### PR TITLE
[CWS] Allow suppressing all non-drift rule-based events

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -1384,6 +1384,10 @@ CSM Threats logs have the following JSON schema:
                 "event_in_profile": {
                     "type": "boolean",
                     "description": "True if the corresponding event is part of this profile"
+                },
+                "event_type_state": {
+                    "type": "string",
+                    "description": "State of the event type in this profile"
                 }
             },
             "additionalProperties": false,
@@ -1392,7 +1396,8 @@ CSM Threats logs have the following JSON schema:
                 "name",
                 "version",
                 "tags",
-                "event_in_profile"
+                "event_in_profile",
+                "event_type_state"
             ],
             "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
         },
@@ -3693,6 +3698,10 @@ CSM Threats logs have the following JSON schema:
         "event_in_profile": {
             "type": "boolean",
             "description": "True if the corresponding event is part of this profile"
+        },
+        "event_type_state": {
+            "type": "string",
+            "description": "State of the event type in this profile"
         }
     },
     "additionalProperties": false,
@@ -3701,7 +3710,8 @@ CSM Threats logs have the following JSON schema:
         "name",
         "version",
         "tags",
-        "event_in_profile"
+        "event_in_profile",
+        "event_type_state"
     ],
     "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
 }
@@ -3714,6 +3724,7 @@ CSM Threats logs have the following JSON schema:
 | `version` | Version of the profile in use |
 | `tags` | List of tags associated to this profile |
 | `event_in_profile` | True if the corresponding event is part of this profile |
+| `event_type_state` | State of the event type in this profile |
 
 
 ## `SignalEvent`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -1368,6 +1368,10 @@
         "event_in_profile": {
           "type": "boolean",
           "description": "True if the corresponding event is part of this profile"
+        },
+        "event_type_state": {
+          "type": "string",
+          "description": "State of the event type in this profile"
         }
       },
       "additionalProperties": false,
@@ -1376,7 +1380,8 @@
         "name",
         "version",
         "tags",
-        "event_in_profile"
+        "event_in_profile",
+        "event_type_state"
       ],
       "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
     },

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -280,7 +280,7 @@ func (c *CWSConsumer) sendStats() {
 		if counter > 0 {
 			tags := []string{
 				fmt.Sprintf("rule_id:%s", statsTags.RuleID),
-				fmt.Sprintf("tree_type:%s", statsTags.TreeType),
+				fmt.Sprintf("suppression_type:%s", statsTags.SuppressionType),
 			}
 			_ = c.statsdClient.Count(metrics.MetricRulesSuppressed, counter, tags, 1.0)
 		}

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -30,10 +30,6 @@ func isAllowAutosuppressionRule(rule *rules.Rule) bool {
 	return booleanTagEquals(rule, "allow_autosuppression", true)
 }
 
-func isWorkloadDriftOnlyRule(rule *rules.Rule) bool {
-	return booleanTagEquals(rule, "workload_drift_only", true)
-}
-
 const (
 	securityProfileSuppressionType = "security_profile"
 	activityDumpSuppressionType    = "activity_dump"
@@ -76,7 +72,7 @@ func (as *AutoSuppression) Suppresses(rule *rules.Rule, event *model.Event) bool
 			if event.HasActiveActivityDump() {
 				as.count(rule.ID, activityDumpSuppressionType)
 				return true
-			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState == model.NoProfile {
+			} else if event.SecurityProfileContext.EventTypeState == model.NoProfile {
 				as.count(rule.ID, noWorkloadDriftSuppressionType)
 				return true
 			}

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -73,18 +73,18 @@ func (as *AutoSuppression) Init(opts Opts) {
 // Suppresses returns true if the event should be suppressed for the given rule, false otherwise. It also counts statistics depending on this result
 func (as *AutoSuppression) Suppresses(rule *rules.Rule, event *model.Event) bool {
 	if isAllowAutosuppressionRule(rule) && slices.Contains(as.opts.EventTypes, event.GetEventType()) {
+		if as.opts.ActivityDumpAutoSuppressionEnabled && event.HasActiveActivityDump() {
+			as.count(rule.ID, activityDumpSuppressionType)
+			return true
+		}
 		if as.opts.SecurityProfileAutoSuppressionEnabled {
 			if event.IsInProfile() {
 				as.count(rule.ID, securityProfileSuppressionType)
 				return true
-			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState != secprofModel.StableEventType {
+			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState == secprofModel.NoProfile {
 				as.count(rule.ID, noWorkloadDriftSuppressionType)
 				return true
 			}
-		}
-		if as.opts.ActivityDumpAutoSuppressionEnabled && event.HasActiveActivityDump() {
-			as.count(rule.ID, activityDumpSuppressionType)
-			return true
 		}
 	}
 	return false

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -15,20 +15,30 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 )
 
-// isAllowAutosuppressionRule returns true if the given rule allows auto suppression
-func isAllowAutosuppressionRule(rule *rules.Rule) bool {
-	if val, ok := rule.Definition.GetTag("allow_autosuppression"); ok {
+// booleanTagEquals returns true if the given rule has the given tag set to a boolean and its value matches the given value
+func booleanTagEquals(rule *rules.Rule, tag string, value bool) bool {
+	if val, ok := rule.Definition.GetTag(tag); ok {
 		b, err := strconv.ParseBool(val)
-		return err == nil && b
+		return err == nil && b == value
 	}
 	return false
 }
 
+func isAllowAutosuppressionRule(rule *rules.Rule) bool {
+	return booleanTagEquals(rule, "allow_autosuppression", true)
+}
+
+func isWorkloadDriftOnlyRule(rule *rules.Rule) bool {
+	return booleanTagEquals(rule, "workload_drift_only", true)
+}
+
 const (
-	securityProfileTreeType = "security_profile"
-	activityDumpTreeType    = "activity_dump"
+	securityProfileSuppressionType = "security_profile"
+	activityDumpSuppressionType    = "activity_dump"
+	noWorkloadDriftSuppressionType = "no_workload_drift"
 )
 
 // Opts holds options for auto suppression
@@ -40,17 +50,16 @@ type Opts struct {
 
 // StatsTags holds tags for auto suppression stats
 type StatsTags struct {
-	RuleID   string
-	TreeType string
+	RuleID          string
+	SuppressionType string
 }
 
 // AutoSuppression is a struct that encapsulates the auto suppression logic
 type AutoSuppression struct {
-	once             sync.Once
-	opts             Opts
-	statsLock        sync.RWMutex
-	stats            map[StatsTags]*atomic.Int64
-	enabledTreeTypes []string
+	once      sync.Once
+	opts      Opts
+	statsLock sync.RWMutex
+	stats     map[StatsTags]*atomic.Int64
 }
 
 // Init initializes the auto suppression with the given options
@@ -58,42 +67,47 @@ func (as *AutoSuppression) Init(opts Opts) {
 	as.once.Do(func() {
 		as.opts = opts
 		as.stats = make(map[StatsTags]*atomic.Int64)
-		if opts.SecurityProfileAutoSuppressionEnabled {
-			as.enabledTreeTypes = append(as.enabledTreeTypes, securityProfileTreeType)
-		}
-		if opts.ActivityDumpAutoSuppressionEnabled {
-			as.enabledTreeTypes = append(as.enabledTreeTypes, activityDumpTreeType)
-		}
 	})
 }
 
 // Suppresses returns true if the event should be suppressed for the given rule, false otherwise. It also counts statistics depending on this result
 func (as *AutoSuppression) Suppresses(rule *rules.Rule, event *model.Event) bool {
-	if as.opts.SecurityProfileAutoSuppressionEnabled &&
-		event.IsInProfile() &&
-		slices.Contains(as.opts.EventTypes, event.GetEventType()) &&
-		isAllowAutosuppressionRule(rule) {
-		as.count(rule.ID, securityProfileTreeType)
-		return true
-	} else if as.opts.ActivityDumpAutoSuppressionEnabled &&
-		event.HasActiveActivityDump() &&
-		slices.Contains(as.opts.EventTypes, event.GetEventType()) &&
-		isAllowAutosuppressionRule(rule) {
-		as.count(rule.ID, activityDumpTreeType)
-		return true
+	if isAllowAutosuppressionRule(rule) && slices.Contains(as.opts.EventTypes, event.GetEventType()) {
+		if as.opts.SecurityProfileAutoSuppressionEnabled {
+			if event.IsInProfile() {
+				as.count(rule.ID, securityProfileSuppressionType)
+				return true
+			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState != secprofModel.StableEventType {
+				as.count(rule.ID, noWorkloadDriftSuppressionType)
+				return true
+			}
+		}
+		if as.opts.ActivityDumpAutoSuppressionEnabled && event.HasActiveActivityDump() {
+			as.count(rule.ID, activityDumpSuppressionType)
+			return true
+		}
 	}
 	return false
 }
 
 // Apply resets the auto suppression stats based on the given ruleset
 func (as *AutoSuppression) Apply(ruleSet *rules.RuleSet) {
+	var enabledSuppressionTypes []string
+	if as.opts.SecurityProfileAutoSuppressionEnabled {
+		enabledSuppressionTypes = append(enabledSuppressionTypes, securityProfileSuppressionType)
+		enabledSuppressionTypes = append(enabledSuppressionTypes, noWorkloadDriftSuppressionType)
+	}
+	if as.opts.ActivityDumpAutoSuppressionEnabled {
+		enabledSuppressionTypes = append(enabledSuppressionTypes, activityDumpSuppressionType)
+	}
+
 	tags := StatsTags{}
 	newStats := make(map[StatsTags]*atomic.Int64)
 	for _, rule := range ruleSet.GetRules() {
 		if isAllowAutosuppressionRule(rule) {
 			tags.RuleID = rule.ID
-			for _, treeType := range as.enabledTreeTypes {
-				tags.TreeType = treeType
+			for _, suppressionType := range enabledSuppressionTypes {
+				tags.SuppressionType = suppressionType
 				newStats[tags] = atomic.NewInt64(0)
 			}
 		}
@@ -104,13 +118,13 @@ func (as *AutoSuppression) Apply(ruleSet *rules.RuleSet) {
 	as.statsLock.Unlock()
 }
 
-func (as *AutoSuppression) count(ruleID string, treeType string) {
+func (as *AutoSuppression) count(ruleID string, suppressionType string) {
 	as.statsLock.RLock()
 	defer as.statsLock.RUnlock()
 
 	tags := StatsTags{
-		RuleID:   ruleID,
-		TreeType: treeType,
+		RuleID:          ruleID,
+		SuppressionType: suppressionType,
 	}
 
 	if stat, ok := as.stats[tags]; ok {

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -96,10 +96,10 @@ func (as *AutoSuppression) Apply(ruleSet *rules.RuleSet) {
 	var enabledSuppressionTypes []string
 	if as.opts.SecurityProfileAutoSuppressionEnabled {
 		enabledSuppressionTypes = append(enabledSuppressionTypes, securityProfileSuppressionType)
-		enabledSuppressionTypes = append(enabledSuppressionTypes, noWorkloadDriftSuppressionType)
 	}
 	if as.opts.ActivityDumpAutoSuppressionEnabled {
 		enabledSuppressionTypes = append(enabledSuppressionTypes, activityDumpSuppressionType)
+		enabledSuppressionTypes = append(enabledSuppressionTypes, noWorkloadDriftSuppressionType)
 	}
 
 	tags := StatsTags{}

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 )
 
 // booleanTagEquals returns true if the given rule has the given tag set to a boolean and its value matches the given value
@@ -81,7 +80,7 @@ func (as *AutoSuppression) Suppresses(rule *rules.Rule, event *model.Event) bool
 			if event.IsInProfile() {
 				as.count(rule.ID, securityProfileSuppressionType)
 				return true
-			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState == secprofModel.NoProfile {
+			} else if isWorkloadDriftOnlyRule(rule) && event.SecurityProfileContext.EventTypeState == model.NoProfile {
 				as.count(rule.ID, noWorkloadDriftSuppressionType)
 				return true
 			}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
-	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 )
 
 // Model describes the data model for the runtime security agent events
@@ -88,11 +87,11 @@ type ContainerContext struct {
 
 // SecurityProfileContext holds the security context of the profile
 type SecurityProfileContext struct {
-	Name           string                                  `field:"name"`        // SECLDoc[name] Definition:`Name of the security profile`
-	Version        string                                  `field:"version"`     // SECLDoc[version] Definition:`Version of the security profile`
-	Tags           []string                                `field:"tags"`        // SECLDoc[tags] Definition:`Tags of the security profile`
-	EventTypes     []EventType                             `field:"event_types"` // SECLDoc[event_types] Definition:`Event types enabled for the security profile`
-	EventTypeState secprofModel.EventFilteringProfileState `field:"-"`           // State of the event type in this profile
+	Name           string                     `field:"name"`        // SECLDoc[name] Definition:`Name of the security profile`
+	Version        string                     `field:"version"`     // SECLDoc[version] Definition:`Version of the security profile`
+	Tags           []string                   `field:"tags"`        // SECLDoc[tags] Definition:`Tags of the security profile`
+	EventTypes     []EventType                `field:"event_types"` // SECLDoc[event_types] Definition:`Event types enabled for the security profile`
+	EventTypeState EventFilteringProfileState `field:"-"`           // State of the event type in this profile
 }
 
 // IPPortContext is used to hold an IP and Port

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
+	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 )
 
 // Model describes the data model for the runtime security agent events
@@ -87,10 +88,11 @@ type ContainerContext struct {
 
 // SecurityProfileContext holds the security context of the profile
 type SecurityProfileContext struct {
-	Name       string      `field:"name"`        // SECLDoc[name] Definition:`Name of the security profile`
-	Version    string      `field:"version"`     // SECLDoc[version] Definition:`Version of the security profile`
-	Tags       []string    `field:"tags"`        // SECLDoc[tags] Definition:`Tags of the security profile`
-	EventTypes []EventType `field:"event_types"` // SECLDoc[event_types] Definition:`Event types enabled for the security profile`
+	Name           string                                  `field:"name"`        // SECLDoc[name] Definition:`Name of the security profile`
+	Version        string                                  `field:"version"`     // SECLDoc[version] Definition:`Version of the security profile`
+	Tags           []string                                `field:"tags"`        // SECLDoc[tags] Definition:`Tags of the security profile`
+	EventTypes     []EventType                             `field:"event_types"` // SECLDoc[event_types] Definition:`Event types enabled for the security profile`
+	EventTypeState secprofModel.EventFilteringProfileState `field:"-"`           // State of the event type in this profile
 }
 
 // IPPortContext is used to hold an IP and Port

--- a/pkg/security/secl/model/security_profile.go
+++ b/pkg/security/secl/model/security_profile.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-
 // Package model holds the security profile data model
 package model
 

--- a/pkg/security/secl/model/security_profile.go
+++ b/pkg/security/secl/model/security_profile.go
@@ -54,22 +54,3 @@ func (efr EventFilteringProfileState) String() string {
 func (efr EventFilteringProfileState) ToTag() string {
 	return "profile_state:" + efr.String()
 }
-
-// ToProto convert a profile state to a proto one
-func (efr EventFilteringProfileState) ToProto() proto.EventProfileState {
-	switch efr {
-	case NoProfile:
-		return proto.EventProfileState_NO_PROFILE
-	case ProfileAtMaxSize:
-		return proto.EventProfileState_PROFILE_AT_MAX_SIZE
-	case UnstableEventType:
-		return proto.EventProfileState_UNSTABLE_PROFILE
-	case StableEventType:
-		return proto.EventProfileState_STABLE_PROFILE
-	case AutoLearning:
-		return proto.EventProfileState_AUTO_LEARNING
-	case WorkloadWarmup:
-		return proto.EventProfileState_WORKLOAD_WARMUP
-	}
-	return proto.EventProfileState_NO_PROFILE
-}

--- a/pkg/security/security_profile/model/model.go
+++ b/pkg/security/security_profile/model/model.go
@@ -8,10 +8,6 @@
 // Package model holds the security profile data model
 package model
 
-import (
-	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
-)
-
 // EventFilteringProfileState is used to compute metrics for the event filtering feature
 type EventFilteringProfileState uint8
 

--- a/pkg/security/security_profile/model/model.go
+++ b/pkg/security/security_profile/model/model.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package model holds the security profile data model
+package model
+
+import (
+	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+)
+
+// EventFilteringProfileState is used to compute metrics for the event filtering feature
+type EventFilteringProfileState uint8
+
+const (
+	// NoProfile is used to count the events for which we didn't have a profile
+	NoProfile EventFilteringProfileState = iota
+	// ProfileAtMaxSize is used to count the events that didn't make it into a profile because their matching profile
+	// reached the max size threshold
+	ProfileAtMaxSize
+	// UnstableEventType is used to count the events that didn't make it into a profile because their matching profile was
+	// unstable for their event type
+	UnstableEventType
+	// StableEventType is used to count the events linked to a stable profile for their event type
+	StableEventType
+	// AutoLearning is used to count the event during the auto learning phase
+	AutoLearning
+	// WorkloadWarmup is used to count the learned events due to workload warm up time
+	WorkloadWarmup
+)
+
+// AllEventFilteringProfileState is the list of all EventFilteringProfileState
+var AllEventFilteringProfileState = []EventFilteringProfileState{NoProfile, ProfileAtMaxSize, UnstableEventType, StableEventType, AutoLearning, WorkloadWarmup}
+
+// String returns the string representation of the EventFilteringProfileState
+func (efr EventFilteringProfileState) String() string {
+	switch efr {
+	case NoProfile:
+		return "no_profile"
+	case ProfileAtMaxSize:
+		return "profile_at_max_size"
+	case UnstableEventType:
+		return "unstable_event_type"
+	case StableEventType:
+		return "stable_event_type"
+	case AutoLearning:
+		return "auto_learning"
+	case WorkloadWarmup:
+		return "workload_warmup"
+	}
+	return ""
+}
+
+// ToTag returns the tag representation of the EventFilteringProfileState
+func (efr EventFilteringProfileState) ToTag() string {
+	return "profile_state:" + efr.String()
+}
+
+// ToProto convert a profile state to a proto one
+func (efr EventFilteringProfileState) ToProto() proto.EventProfileState {
+	switch efr {
+	case NoProfile:
+		return proto.EventProfileState_NO_PROFILE
+	case ProfileAtMaxSize:
+		return proto.EventProfileState_PROFILE_AT_MAX_SIZE
+	case UnstableEventType:
+		return proto.EventProfileState_UNSTABLE_PROFILE
+	case StableEventType:
+		return proto.EventProfileState_STABLE_PROFILE
+	case AutoLearning:
+		return proto.EventProfileState_AUTO_LEARNING
+	case WorkloadWarmup:
+		return proto.EventProfileState_WORKLOAD_WARMUP
+	}
+	return proto.EventProfileState_NO_PROFILE
+}

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -35,90 +35,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // DefaultProfileName used as default profile name
 const DefaultProfileName = "default"
-
-// EventFilteringProfileState is used to compute metrics for the event filtering feature
-type EventFilteringProfileState uint8
-
-const (
-	// NoProfile is used to count the events for which we didn't have a profile
-	NoProfile EventFilteringProfileState = iota
-	// ProfileAtMaxSize is used to count the events that didn't make it into a profile because their matching profile
-	// reached the max size threshold
-	ProfileAtMaxSize
-	// UnstableEventType is used to count the events that didn't make it into a profile because their matching profile was
-	// unstable for their event type
-	UnstableEventType
-	// StableEventType is used to count the events linked to a stable profile for their event type
-	StableEventType
-	// AutoLearning is used to count the event during the auto learning phase
-	AutoLearning
-	// WorkloadWarmup is used to count the learned events due to workload warm up time
-	WorkloadWarmup
-)
-
-func (efr EventFilteringProfileState) String() string {
-	switch efr {
-	case NoProfile:
-		return "no_profile"
-	case ProfileAtMaxSize:
-		return "profile_at_max_size"
-	case UnstableEventType:
-		return "unstable_event_type"
-	case StableEventType:
-		return "stable_event_type"
-	case AutoLearning:
-		return "auto_learning"
-	case WorkloadWarmup:
-		return "workload_warmup"
-	}
-	return ""
-}
-
-func (efr EventFilteringProfileState) toTag() string {
-	return "profile_state:" + efr.String()
-}
-
-func (efr EventFilteringProfileState) toProto() proto.EventProfileState {
-	switch efr {
-	case NoProfile:
-		return proto.EventProfileState_NO_PROFILE
-	case ProfileAtMaxSize:
-		return proto.EventProfileState_PROFILE_AT_MAX_SIZE
-	case UnstableEventType:
-		return proto.EventProfileState_UNSTABLE_PROFILE
-	case StableEventType:
-		return proto.EventProfileState_STABLE_PROFILE
-	case AutoLearning:
-		return proto.EventProfileState_AUTO_LEARNING
-	case WorkloadWarmup:
-		return proto.EventProfileState_WORKLOAD_WARMUP
-	}
-	return proto.EventProfileState_NO_PROFILE
-}
-
-// ProtoToState converts a proto state to a profile one
-func ProtoToState(eps proto.EventProfileState) EventFilteringProfileState {
-	switch eps {
-	case proto.EventProfileState_NO_PROFILE:
-		return NoProfile
-	case proto.EventProfileState_PROFILE_AT_MAX_SIZE:
-		return ProfileAtMaxSize
-	case proto.EventProfileState_UNSTABLE_PROFILE:
-		return UnstableEventType
-	case proto.EventProfileState_STABLE_PROFILE:
-		return StableEventType
-	case proto.EventProfileState_AUTO_LEARNING:
-		return AutoLearning
-	case proto.EventProfileState_WORKLOAD_WARMUP:
-		return WorkloadWarmup
-	}
-	return NoProfile
-}
 
 // EventFilteringResult is used to compute metrics for the event filtering feature
 type EventFilteringResult uint8
@@ -144,14 +66,32 @@ func (efr EventFilteringResult) toTag() string {
 	return ""
 }
 
+// ProtoToState converts a proto state to a profile one
+func ProtoToState(eps proto.EventProfileState) secprofModel.EventFilteringProfileState {
+	switch eps {
+	case proto.EventProfileState_NO_PROFILE:
+		return secprofModel.NoProfile
+	case proto.EventProfileState_PROFILE_AT_MAX_SIZE:
+		return secprofModel.ProfileAtMaxSize
+	case proto.EventProfileState_UNSTABLE_PROFILE:
+		return secprofModel.UnstableEventType
+	case proto.EventProfileState_STABLE_PROFILE:
+		return secprofModel.StableEventType
+	case proto.EventProfileState_AUTO_LEARNING:
+		return secprofModel.AutoLearning
+	case proto.EventProfileState_WORKLOAD_WARMUP:
+		return secprofModel.WorkloadWarmup
+	}
+	return secprofModel.NoProfile
+}
+
 var (
-	allEventFilteringProfileState = []EventFilteringProfileState{NoProfile, ProfileAtMaxSize, UnstableEventType, StableEventType, AutoLearning, WorkloadWarmup}
-	allEventFilteringResults      = []EventFilteringResult{InProfile, NotInProfile, NA}
+	allEventFilteringResults = []EventFilteringResult{InProfile, NotInProfile, NA}
 )
 
 type eventFilteringEntry struct {
 	eventType model.EventType
-	state     EventFilteringProfileState
+	state     secprofModel.EventFilteringProfileState
 	result    EventFilteringResult
 }
 
@@ -269,7 +209,7 @@ func (m *SecurityProfileManager) OnLocalStorageCleanup(files []string) {
 
 func (m *SecurityProfileManager) initMetricsMap() {
 	for i := model.EventType(0); i < model.MaxKernelEventType; i++ {
-		for _, state := range allEventFilteringProfileState {
+		for _, state := range secprofModel.AllEventFilteringProfileState {
 			for _, result := range allEventFilteringResults {
 				m.eventFiltering[eventFilteringEntry{
 					eventType: i,
@@ -593,7 +533,7 @@ func (m *SecurityProfileManager) stop() {
 	}
 }
 
-func (m *SecurityProfileManager) incrementEventFilteringStat(eventType model.EventType, state EventFilteringProfileState, result EventFilteringResult) {
+func (m *SecurityProfileManager) incrementEventFilteringStat(eventType model.EventType, state secprofModel.EventFilteringProfileState, result EventFilteringResult) {
 	m.eventFiltering[eventFilteringEntry{eventType, state, result}].Inc()
 }
 
@@ -656,7 +596,7 @@ func (m *SecurityProfileManager) SendStats() error {
 	}
 
 	for entry, count := range m.eventFiltering {
-		tags := []string{fmt.Sprintf("event_type:%s", entry.eventType), entry.state.toTag(), entry.result.toTag()}
+		tags := []string{fmt.Sprintf("event_type:%s", entry.eventType), entry.state.ToTag(), entry.result.toTag()}
 		if value := count.Swap(0); value > 0 {
 			if err := m.statsdClient.Count(metrics.MetricSecurityProfileEventFiltering, int64(value), tags, 1.0); err != nil {
 				return fmt.Errorf("couldn't send MetricSecurityProfileEventFiltering metric: %w", err)
@@ -791,11 +731,11 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 	// lookup profile
 	profile := m.GetProfile(selector)
 	if profile == nil || profile.ActivityTree == nil {
-		m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
+		m.incrementEventFilteringStat(event.GetEventType(), secprofModel.NoProfile, NA)
 		return
 	}
 	if !profile.IsEventTypeValid(event.GetEventType()) || !profile.loadedInKernel {
-		m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
+		m.incrementEventFilteringStat(event.GetEventType(), secprofModel.NoProfile, NA)
 		return
 	}
 
@@ -828,39 +768,39 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 
 	// if we have one version of the profile in unstable for this event type, just skip the whole process
 	globalEventTypeProfilState := profile.GetGlobalEventTypeState(event.GetEventType())
-	if globalEventTypeProfilState == UnstableEventType {
-		m.incrementEventFilteringStat(event.GetEventType(), UnstableEventType, NA)
+	if globalEventTypeProfilState == secprofModel.UnstableEventType {
+		m.incrementEventFilteringStat(event.GetEventType(), secprofModel.UnstableEventType, NA)
 		return
 	}
 
 	profileState := m.tryAutolearn(profile, ctx, event, imageTag)
-	if profileState != NoProfile {
+	if profileState != secprofModel.NoProfile {
 		ctx.eventTypeState[event.GetEventType()].state = profileState
 	}
 	switch profileState {
-	case NoProfile, ProfileAtMaxSize, UnstableEventType:
+	case secprofModel.NoProfile, secprofModel.ProfileAtMaxSize, secprofModel.UnstableEventType:
 		// an error occurred or we are in unstable state
 		// do not link the profile to avoid sending anomalies
 		return
-	case AutoLearning, WorkloadWarmup:
+	case secprofModel.AutoLearning, secprofModel.WorkloadWarmup:
 		// the event was either already in the profile, or has just been inserted
 		FillProfileContextFromProfile(&event.SecurityProfileContext, profile, imageTag)
 		event.AddToFlags(model.EventFlagsSecurityProfileInProfile)
 
 		return
-	case StableEventType:
+	case secprofModel.StableEventType:
 		// check if the event is in its profile
 		// and if this is not an exec event, check if we can benefit of the occasion to add missing processes
 		insertMissingProcesses := false
 		if event.GetEventType() != model.ExecEventType {
-			if execState := m.getEventTypeState(profile, ctx, event, model.ExecEventType, imageTag); execState == AutoLearning || execState == WorkloadWarmup {
+			if execState := m.getEventTypeState(profile, ctx, event, model.ExecEventType, imageTag); execState == secprofModel.AutoLearning || execState == secprofModel.WorkloadWarmup {
 				insertMissingProcesses = true
 			}
 		}
 		found, err := profile.ActivityTree.Contains(event, insertMissingProcesses, imageTag, activity_tree.ProfileDrift, m.resolvers)
 		if err != nil {
 			// ignore, evaluation failed
-			m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
+			m.incrementEventFilteringStat(event.GetEventType(), secprofModel.NoProfile, NA)
 			return
 		}
 		FillProfileContextFromProfile(&event.SecurityProfileContext, profile, imageTag)
@@ -877,12 +817,12 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 }
 
 // tryAutolearn tries to autolearn the input event. It returns the profile state: stable, unstable, autolearning or workloadwarmup
-func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, ctx *VersionContext, event *model.Event, imageTag string) EventFilteringProfileState {
+func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, ctx *VersionContext, event *model.Event, imageTag string) secprofModel.EventFilteringProfileState {
 	profileState := m.getEventTypeState(profile, ctx, event, event.GetEventType(), imageTag)
 	var nodeType activity_tree.NodeGenerationType
-	if profileState == AutoLearning {
+	if profileState == secprofModel.AutoLearning {
 		nodeType = activity_tree.ProfileDrift
-	} else if profileState == WorkloadWarmup {
+	} else if profileState == secprofModel.WorkloadWarmup {
 		nodeType = activity_tree.WorkloadWarmup
 	} else { // Stable or Unstable state
 		return profileState
@@ -895,14 +835,14 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, ctx *Ver
 	insertMissingProcesses := false
 	if event.GetEventType() == model.ExecEventType {
 		insertMissingProcesses = true
-	} else if execState := m.getEventTypeState(profile, ctx, event, model.ExecEventType, imageTag); execState == AutoLearning || execState == WorkloadWarmup {
+	} else if execState := m.getEventTypeState(profile, ctx, event, model.ExecEventType, imageTag); execState == secprofModel.AutoLearning || execState == secprofModel.WorkloadWarmup {
 		insertMissingProcesses = true
 	}
 
 	newEntry, err := profile.ActivityTree.Insert(event, insertMissingProcesses, imageTag, nodeType, m.resolvers)
 	if err != nil {
-		m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
-		return NoProfile
+		m.incrementEventFilteringStat(event.GetEventType(), secprofModel.NoProfile, NA)
+		return secprofModel.NoProfile
 	} else if newEntry {
 		eventState, ok := ctx.eventTypeState[event.GetEventType()]
 		if ok { // should always be the case
@@ -912,7 +852,7 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, ctx *Ver
 		// if a previous version of this profile was stable for this event type,
 		// and a new entry was added, trigger an anomaly detection
 		globalEventTypeState := profile.GetGlobalEventTypeState(event.GetEventType())
-		if globalEventTypeState == StableEventType && m.canGenerateAnomaliesFor(event) {
+		if globalEventTypeState == secprofModel.StableEventType && m.canGenerateAnomaliesFor(event) {
 			event.AddToFlags(model.EventFlagsAnomalyDetectionEvent)
 		}
 
@@ -1013,57 +953,57 @@ func (m *SecurityProfileManager) FetchSilentWorkloads() map[cgroupModel.Workload
 	return out
 }
 
-func (m *SecurityProfileManager) getEventTypeState(profile *SecurityProfile, pctx *VersionContext, event *model.Event, eventType model.EventType, imageTag string) EventFilteringProfileState {
+func (m *SecurityProfileManager) getEventTypeState(profile *SecurityProfile, pctx *VersionContext, event *model.Event, eventType model.EventType, imageTag string) secprofModel.EventFilteringProfileState {
 	eventState, ok := pctx.eventTypeState[event.GetEventType()]
 	if !ok {
 		eventState = &EventTypeState{
 			lastAnomalyNano: pctx.firstSeenNano,
-			state:           AutoLearning,
+			state:           secprofModel.AutoLearning,
 		}
 		pctx.eventTypeState[eventType] = eventState
-	} else if eventState.state == UnstableEventType {
+	} else if eventState.state == secprofModel.UnstableEventType {
 		// If for the given event type we already are on UnstableEventType, just return
 		// (once reached, this state is immutable)
 		if eventType == event.GetEventType() { // increment stat only once for each event
-			m.incrementEventFilteringStat(eventType, UnstableEventType, NA)
+			m.incrementEventFilteringStat(eventType, secprofModel.UnstableEventType, NA)
 		}
-		return UnstableEventType
+		return secprofModel.UnstableEventType
 	}
 
 	var nodeType activity_tree.NodeGenerationType
-	var profileState EventFilteringProfileState
+	var profileState secprofModel.EventFilteringProfileState
 	// check if we are at the beginning of a workload lifetime
 	if event.ResolveEventTime().Sub(time.Unix(0, int64(event.ContainerContext.CreatedAt))) < m.config.RuntimeSecurity.AnomalyDetectionWorkloadWarmupPeriod {
 		nodeType = activity_tree.WorkloadWarmup
-		profileState = WorkloadWarmup
+		profileState = secprofModel.WorkloadWarmup
 	} else {
 		// If for the given event type we already are on StableEventType (and outside of the warmup period), just return
-		if eventState.state == StableEventType {
-			return StableEventType
+		if eventState.state == secprofModel.StableEventType {
+			return secprofModel.StableEventType
 		}
 
 		if eventType == event.GetEventType() { // update the stable/unstable states only for the event event type
 			// did we reached the stable state time limit ?
 			if time.Duration(event.TimestampRaw-eventState.lastAnomalyNano) >= m.config.RuntimeSecurity.GetAnomalyDetectionMinimumStablePeriod(eventType) {
-				eventState.state = StableEventType
+				eventState.state = secprofModel.StableEventType
 				// call the activity dump manager to stop dumping workloads from the current profile selector
 				if m.activityDumpManager != nil {
 					uniqueImageTagSeclector := profile.selector
 					uniqueImageTagSeclector.Tag = imageTag
 					m.activityDumpManager.StopDumpsWithSelector(uniqueImageTagSeclector)
 				}
-				return StableEventType
+				return secprofModel.StableEventType
 			}
 
 			// did we reached the unstable time limit ?
 			if time.Duration(event.TimestampRaw-profile.loadedNano) >= m.config.RuntimeSecurity.AnomalyDetectionUnstableProfileTimeThreshold {
-				eventState.state = UnstableEventType
-				return UnstableEventType
+				eventState.state = secprofModel.UnstableEventType
+				return secprofModel.UnstableEventType
 			}
 		}
 
 		nodeType = activity_tree.ProfileDrift
-		profileState = AutoLearning
+		profileState = secprofModel.AutoLearning
 	}
 
 	// check if the unstable size limit was reached, but only for the event event type
@@ -1073,16 +1013,16 @@ func (m *SecurityProfileManager) getEventTypeState(profile *SecurityProfile, pct
 		// rearming the lastAnomalyNano timer based on if it's something new or not.
 		found, err := profile.ActivityTree.Contains(event, false /*insertMissingProcesses*/, imageTag, nodeType, m.resolvers)
 		if err != nil {
-			m.incrementEventFilteringStat(eventType, NoProfile, NA)
-			return NoProfile
+			m.incrementEventFilteringStat(eventType, secprofModel.NoProfile, NA)
+			return secprofModel.NoProfile
 		} else if !found {
 			eventState.lastAnomalyNano = event.TimestampRaw
-		} else if profileState == WorkloadWarmup {
+		} else if profileState == secprofModel.WorkloadWarmup {
 			// if it's NOT something's new AND we are on container warmup period, just pretend
 			// we are in learning/warmup phase (as we know, this event is already present on the profile)
-			return WorkloadWarmup
+			return secprofModel.WorkloadWarmup
 		}
-		return ProfileAtMaxSize
+		return secprofModel.ProfileAtMaxSize
 	}
 	return profileState
 }

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -23,21 +23,20 @@ import (
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
-	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 )
 
 type testIteration struct {
-	name                string                                  // test name
-	result              secprofModel.EventFilteringProfileState // expected result
-	newProfile          bool                                    // true if a new profile have to be generated for this test
-	containerCreatedAt  time.Duration                           // time diff from t0
-	addFakeProcessNodes int64                                   // number of fake process nodes to add (adds 1024 to approx size)
-	eventTimestampRaw   time.Duration                           // time diff from t0
-	eventType           model.EventType                         // only exec for now, TODO: add dns
-	eventProcessPath    string                                  // exec path
-	eventDNSReq         string                                  // dns request name (only for eventType == DNSEventType)
-	loopUntil           time.Duration                           // if not 0, will loop until the given duration is reached
-	loopIncrement       time.Duration                           // if loopUntil is not 0, will increment this duration at each loop
+	name                string                           // test name
+	result              model.EventFilteringProfileState // expected result
+	newProfile          bool                             // true if a new profile have to be generated for this test
+	containerCreatedAt  time.Duration                    // time diff from t0
+	addFakeProcessNodes int64                            // number of fake process nodes to add (adds 1024 to approx size)
+	eventTimestampRaw   time.Duration                    // time diff from t0
+	eventType           model.EventType                  // only exec for now, TODO: add dns
+	eventProcessPath    string                           // exec path
+	eventDNSReq         string                           // dns request name (only for eventType == DNSEventType)
+	loopUntil           time.Duration                    // if not 0, will loop until the given duration is reached
+	loopIncrement       time.Duration                    // if loopUntil is not 0, will increment this duration at each loop
 }
 
 func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) *model.Event {
@@ -85,7 +84,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// checking warmup period for exec:
 		{
 			name:                "warmup-exec/not-warmup",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -95,7 +94,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "warmup-exec/warmup",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod + time.Second,
 			addFakeProcessNodes: 0,
@@ -106,7 +105,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "warmup-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -116,7 +115,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "warmup-dns/not-warmup",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -127,7 +126,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "warmup-dns/insert-dns-process2",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -137,7 +136,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "warmup-dns/warmup",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          false,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod + time.Second,
 			addFakeProcessNodes: 0,
@@ -150,7 +149,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// dont insert dns process if not already present:
 		{
 			name:                "dont-insert-dns-process/add-first-exec-event",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -160,7 +159,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "dont-insert-dns-process/wait-stable-period",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -170,7 +169,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "dont-insert-dns-process/reject-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -183,7 +182,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// checking stable period for exec:
 		{
 			name:                "stable-exec/add-first-event",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -193,7 +192,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-exec/add-second-event",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -203,7 +202,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-exec/wait-stable-period",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -213,7 +212,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-exec/still-stable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -223,7 +222,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-exec/dont-get-unstable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -233,7 +232,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-exec/meanwhile-dns-still-learning",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -245,7 +244,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "stable-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -255,7 +254,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/add-first-event",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -266,7 +265,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/add-second-event",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -277,7 +276,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/wait-stable-period",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -288,7 +287,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/still-stable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -299,7 +298,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/dont-get-unstable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -310,7 +309,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "stable-dns/meanwhile-exec-still-learning",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -322,7 +321,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// checking unstable period for exec:
 		{
 			name:                "unstable-exec/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -332,7 +331,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-exec/wait-unstable-period",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -344,7 +343,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-exec/still-unstable",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -354,7 +353,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-exec/still-unstable-after-stable-period",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -364,7 +363,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-exec/meanwhile-dns-still-learning",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -376,7 +375,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "unstable-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -386,7 +385,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-dns/wait-unstable-period",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -399,7 +398,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-dns/still-unstable",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -410,7 +409,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-dns/still-unstable-after-stable-period",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -421,7 +420,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "unstable-dns/meanwhile-exec-still-learning",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -433,7 +432,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// checking max size threshold different cases for exec:
 		{
 			name:                "profile-at-max-size-exec/add-first-event",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          true,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: 0,
@@ -443,7 +442,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/warmup-stable",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess,
@@ -453,7 +452,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/warmup-unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess,
@@ -463,7 +462,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/stable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -473,7 +472,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -483,7 +482,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/warmup-NOT-at-max-size",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          true,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess - 1,
@@ -493,7 +492,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-exec/NOT-at-max-size",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess - 1,
@@ -504,7 +503,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "profile-at-max-size-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -514,7 +513,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/add-first-event",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: 0,
@@ -525,7 +524,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/warmup-stable",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess,
@@ -536,7 +535,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/warmup-unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess,
@@ -547,7 +546,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/stable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -558,7 +557,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -569,7 +568,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/insert-dns-process2",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -579,7 +578,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/warmup-NOT-at-max-size",
-			result:              secprofModel.WorkloadWarmup,
+			result:              model.WorkloadWarmup,
 			newProfile:          false,
 			containerCreatedAt:  0,
 			addFakeProcessNodes: MaxNbProcess - 2,
@@ -590,7 +589,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/insert-dns-process3",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -600,7 +599,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-dns/NOT-at-max-size",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess - 2,
@@ -613,7 +612,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// checking from max-size to stable, for exec:
 		{
 			name:                "profile-at-max-size-to-stable-exec/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -623,7 +622,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-exec/max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -633,7 +632,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-exec/stable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -643,7 +642,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-exec/meanwhile-dns-still-at-max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -655,7 +654,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "profile-at-max-size-to-stable-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -665,7 +664,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-dns/max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -676,7 +675,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-dns/stable",
-			result:              secprofModel.StableEventType,
+			result:              model.StableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -687,7 +686,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-stable-dns/meanwhile-exec-still-at-max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -699,7 +698,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// from checking max-size to unstable for exec:
 		{
 			name:                "profile-at-max-size-to-unstable-exec/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -709,7 +708,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-exec/max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -719,7 +718,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-exec/unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -731,7 +730,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-exec/unstable",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -741,7 +740,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-exec/meanwhile-dns-still-at-max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -753,7 +752,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		// and for dns:
 		{
 			name:                "profile-at-max-size-to-unstable-dns/insert-dns-process",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          true,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -763,7 +762,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-dns/insert-dns-process2",
-			result:              secprofModel.AutoLearning,
+			result:              model.AutoLearning,
 			newProfile:          false,
 			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
 			addFakeProcessNodes: 0,
@@ -773,7 +772,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-dns/max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: MaxNbProcess,
@@ -784,7 +783,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-dns/unstable",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -797,7 +796,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-dns/unstable",
-			result:              secprofModel.UnstableEventType,
+			result:              model.UnstableEventType,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,
@@ -808,7 +807,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		},
 		{
 			name:                "profile-at-max-size-to-unstable-dns/meanwhile-exec-still-at-max-size",
-			result:              secprofModel.ProfileAtMaxSize,
+			result:              model.ProfileAtMaxSize,
 			newProfile:          false,
 			containerCreatedAt:  time.Minute * -5,
 			addFakeProcessNodes: 0,

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -27,14 +27,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
-	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // EventTypeState defines an event type state
 type EventTypeState struct {
 	lastAnomalyNano uint64
-	state           secprofModel.EventFilteringProfileState
+	state           model.EventFilteringProfileState
 }
 
 // VersionContext holds the context of one version (defined by its image tag)
@@ -282,61 +281,61 @@ func (p *SecurityProfile) ToSecurityProfileMessage() *api.SecurityProfileMessage
 }
 
 // GetState returns the state of a profile for a given imageTag
-func (p *SecurityProfile) GetState(imageTag string) secprofModel.EventFilteringProfileState {
+func (p *SecurityProfile) GetState(imageTag string) model.EventFilteringProfileState {
 	pCtx, ok := p.versionContexts[imageTag]
 	if !ok {
-		return secprofModel.NoProfile
+		return model.NoProfile
 	}
 	if len(pCtx.eventTypeState) == 0 {
-		return secprofModel.AutoLearning
+		return model.AutoLearning
 	}
-	state := secprofModel.StableEventType
+	state := model.StableEventType
 	for _, et := range p.eventTypes {
 		s, ok := pCtx.eventTypeState[et]
 		if !ok {
 			continue
 		}
-		if s.state == secprofModel.UnstableEventType {
-			return secprofModel.UnstableEventType
-		} else if s.state != secprofModel.StableEventType {
-			state = secprofModel.AutoLearning
+		if s.state == model.UnstableEventType {
+			return model.UnstableEventType
+		} else if s.state != model.StableEventType {
+			state = model.AutoLearning
 		}
 	}
 	return state
 }
 
-func (p *SecurityProfile) getGlobalState() secprofModel.EventFilteringProfileState {
-	globalState := secprofModel.AutoLearning
+func (p *SecurityProfile) getGlobalState() model.EventFilteringProfileState {
+	globalState := model.AutoLearning
 	for imageTag := range p.versionContexts {
 		state := p.GetState(imageTag)
-		if state == secprofModel.UnstableEventType {
-			return secprofModel.UnstableEventType
-		} else if state == secprofModel.StableEventType {
-			globalState = secprofModel.StableEventType
+		if state == model.UnstableEventType {
+			return model.UnstableEventType
+		} else if state == model.StableEventType {
+			globalState = model.StableEventType
 		}
 	}
 	return globalState // AutoLearning or StableEventType
 }
 
 // GetGlobalState returns the global state of a profile: AutoLearning, StableEventType or UnstableEventType
-func (p *SecurityProfile) GetGlobalState() secprofModel.EventFilteringProfileState {
+func (p *SecurityProfile) GetGlobalState() model.EventFilteringProfileState {
 	p.versionContextsLock.Lock()
 	defer p.versionContextsLock.Unlock()
 	return p.getGlobalState()
 }
 
 // GetGlobalEventTypeState returns the global state of a profile for a given event type: AutoLearning, StableEventType or UnstableEventType
-func (p *SecurityProfile) GetGlobalEventTypeState(et model.EventType) secprofModel.EventFilteringProfileState {
-	globalState := secprofModel.AutoLearning
+func (p *SecurityProfile) GetGlobalEventTypeState(et model.EventType) model.EventFilteringProfileState {
+	globalState := model.AutoLearning
 	for _, ctx := range p.versionContexts {
 		s, ok := ctx.eventTypeState[et]
 		if !ok {
 			continue
 		}
-		if s.state == secprofModel.UnstableEventType {
-			return secprofModel.UnstableEventType
-		} else if s.state == secprofModel.StableEventType {
-			globalState = secprofModel.StableEventType
+		if s.state == model.UnstableEventType {
+			return model.UnstableEventType
+		} else if s.state == model.StableEventType {
+			globalState = model.StableEventType
 		}
 	}
 	return globalState // AutoLearning or StableEventType
@@ -456,7 +455,7 @@ func (p *SecurityProfile) ListAllVersionStates() {
 }
 
 // SetVersionState force a state for a given version (debug purpose only)
-func (p *SecurityProfile) SetVersionState(imageTag string, state secprofModel.EventFilteringProfileState) error {
+func (p *SecurityProfile) SetVersionState(imageTag string, state model.EventFilteringProfileState) error {
 	p.versionContextsLock.Lock()
 	defer p.versionContextsLock.Unlock()
 

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -27,13 +27,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
+	secprofModel "github.com/DataDog/datadog-agent/pkg/security/security_profile/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // EventTypeState defines an event type state
 type EventTypeState struct {
 	lastAnomalyNano uint64
-	state           EventFilteringProfileState
+	state           secprofModel.EventFilteringProfileState
 }
 
 // VersionContext holds the context of one version (defined by its image tag)
@@ -281,61 +282,61 @@ func (p *SecurityProfile) ToSecurityProfileMessage() *api.SecurityProfileMessage
 }
 
 // GetState returns the state of a profile for a given imageTag
-func (p *SecurityProfile) GetState(imageTag string) EventFilteringProfileState {
+func (p *SecurityProfile) GetState(imageTag string) secprofModel.EventFilteringProfileState {
 	pCtx, ok := p.versionContexts[imageTag]
 	if !ok {
-		return NoProfile
+		return secprofModel.NoProfile
 	}
 	if len(pCtx.eventTypeState) == 0 {
-		return AutoLearning
+		return secprofModel.AutoLearning
 	}
-	state := StableEventType
+	state := secprofModel.StableEventType
 	for _, et := range p.eventTypes {
 		s, ok := pCtx.eventTypeState[et]
 		if !ok {
 			continue
 		}
-		if s.state == UnstableEventType {
-			return UnstableEventType
-		} else if s.state != StableEventType {
-			state = AutoLearning
+		if s.state == secprofModel.UnstableEventType {
+			return secprofModel.UnstableEventType
+		} else if s.state != secprofModel.StableEventType {
+			state = secprofModel.AutoLearning
 		}
 	}
 	return state
 }
 
-func (p *SecurityProfile) getGlobalState() EventFilteringProfileState {
-	globalState := AutoLearning
+func (p *SecurityProfile) getGlobalState() secprofModel.EventFilteringProfileState {
+	globalState := secprofModel.AutoLearning
 	for imageTag := range p.versionContexts {
 		state := p.GetState(imageTag)
-		if state == UnstableEventType {
-			return UnstableEventType
-		} else if state == StableEventType {
-			globalState = StableEventType
+		if state == secprofModel.UnstableEventType {
+			return secprofModel.UnstableEventType
+		} else if state == secprofModel.StableEventType {
+			globalState = secprofModel.StableEventType
 		}
 	}
 	return globalState // AutoLearning or StableEventType
 }
 
 // GetGlobalState returns the global state of a profile: AutoLearning, StableEventType or UnstableEventType
-func (p *SecurityProfile) GetGlobalState() EventFilteringProfileState {
+func (p *SecurityProfile) GetGlobalState() secprofModel.EventFilteringProfileState {
 	p.versionContextsLock.Lock()
 	defer p.versionContextsLock.Unlock()
 	return p.getGlobalState()
 }
 
 // GetGlobalEventTypeState returns the global state of a profile for a given event type: AutoLearning, StableEventType or UnstableEventType
-func (p *SecurityProfile) GetGlobalEventTypeState(et model.EventType) EventFilteringProfileState {
-	globalState := AutoLearning
+func (p *SecurityProfile) GetGlobalEventTypeState(et model.EventType) secprofModel.EventFilteringProfileState {
+	globalState := secprofModel.AutoLearning
 	for _, ctx := range p.versionContexts {
 		s, ok := ctx.eventTypeState[et]
 		if !ok {
 			continue
 		}
-		if s.state == UnstableEventType {
-			return UnstableEventType
-		} else if s.state == StableEventType {
-			globalState = StableEventType
+		if s.state == secprofModel.UnstableEventType {
+			return secprofModel.UnstableEventType
+		} else if s.state == secprofModel.StableEventType {
+			globalState = secprofModel.StableEventType
 		}
 	}
 	return globalState // AutoLearning or StableEventType
@@ -455,7 +456,7 @@ func (p *SecurityProfile) ListAllVersionStates() {
 }
 
 // SetVersionState force a state for a given version (debug purpose only)
-func (p *SecurityProfile) SetVersionState(imageTag string, state EventFilteringProfileState) error {
+func (p *SecurityProfile) SetVersionState(imageTag string, state secprofModel.EventFilteringProfileState) error {
 	p.versionContextsLock.Lock()
 	defer p.versionContextsLock.Unlock()
 

--- a/pkg/security/security_profile/profile/profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_enc_v1.go
@@ -12,9 +12,29 @@ import (
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
+
+// EventFilteringProfileStateToProto convert a profile state to a proto one
+func EventFilteringProfileStateToProto(efr model.EventFilteringProfileState) proto.EventProfileState {
+	switch efr {
+	case model.NoProfile:
+		return proto.EventProfileState_NO_PROFILE
+	case model.ProfileAtMaxSize:
+		return proto.EventProfileState_PROFILE_AT_MAX_SIZE
+	case model.UnstableEventType:
+		return proto.EventProfileState_UNSTABLE_PROFILE
+	case model.StableEventType:
+		return proto.EventProfileState_STABLE_PROFILE
+	case model.AutoLearning:
+		return proto.EventProfileState_AUTO_LEARNING
+	case model.WorkloadWarmup:
+		return proto.EventProfileState_WORKLOAD_WARMUP
+	}
+	return proto.EventProfileState_NO_PROFILE
+}
 
 // SecurityProfileToProto incode a Security Profile to its protobuf representation
 func SecurityProfileToProto(input *SecurityProfile) *proto.SecurityProfile {
@@ -40,7 +60,7 @@ func SecurityProfileToProto(input *SecurityProfile) *proto.SecurityProfile {
 		for evtType, evtState := range ctx.eventTypeState {
 			outCtx.EventTypeState[uint32(evtType)] = &proto.EventTypeState{
 				LastAnomalyNano:   evtState.lastAnomalyNano,
-				EventProfileState: evtState.state.ToProto(),
+				EventProfileState: EventFilteringProfileStateToProto(evtState.state),
 			}
 		}
 		copy(outCtx.Syscalls, ctx.Syscalls)

--- a/pkg/security/security_profile/profile/profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_enc_v1.go
@@ -40,7 +40,7 @@ func SecurityProfileToProto(input *SecurityProfile) *proto.SecurityProfile {
 		for evtType, evtState := range ctx.eventTypeState {
 			outCtx.EventTypeState[uint32(evtType)] = &proto.EventTypeState{
 				LastAnomalyNano:   evtState.lastAnomalyNano,
-				EventProfileState: evtState.state.toProto(),
+				EventProfileState: evtState.state.ToProto(),
 			}
 		}
 		copy(outCtx.Syscalls, ctx.Syscalls)

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -466,6 +466,8 @@ type SecurityProfileContextSerializer struct {
 	Tags []string `json:"tags"`
 	// True if the corresponding event is part of this profile
 	EventInProfile bool `json:"event_in_profile"`
+	// State of the event type in this profile
+	EventTypeState string `json:"event_type_state"`
 }
 
 // SyscallSerializer serializes a syscall
@@ -1020,6 +1022,7 @@ func newSecurityProfileContextSerializer(event *model.Event, e *model.SecurityPr
 		Version:        e.Version,
 		Tags:           tags,
 		EventInProfile: event.IsInProfile(),
+		EventTypeState: e.EventTypeState.String(),
 	}
 }
 

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -814,6 +814,8 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers8(i
 			}
 		case "event_in_profile":
 			out.EventInProfile = bool(in.Bool())
+		case "event_type_state":
+			out.EventTypeState = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -858,6 +860,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers8(o
 		const prefix string = ",\"event_in_profile\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.EventInProfile))
+	}
+	{
+		const prefix string = ",\"event_type_state\":"
+		out.RawString(prefix)
+		out.String(string(in.EventTypeState))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -10,12 +10,13 @@ package tests
 
 import (
 	"fmt"
-	imdsutils "github.com/DataDog/datadog-agent/pkg/security/tests/imds_utils"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	imdsutils "github.com/DataDog/datadog-agent/pkg/security/tests/imds_utils"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -635,4 +636,114 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNodeForAD() {
+		t.Skip("Skip test when not run in dedicated env")
+	}
+
+	var expectedFormats = []string{"profile", "protobuf"}
+	var testActivityDumpTracedEventTypes = []string{"exec", "open", "syscalls", "dns", "bind"}
+
+	outputDir := t.TempDir()
+	os.MkdirAll(outputDir, 0755)
+	defer os.RemoveAll(outputDir)
+
+	rulesDef := []*rules.RuleDefinition{
+		{
+			ID:         "test_autosuppression_exec",
+			Expression: `exec.file.name == "getconf"`,
+			Tags:       map[string]string{"allow_autosuppression": "true", "workload_drift_only": "true"},
+		},
+		{
+			ID:         "test_autosuppression_dns",
+			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
+			Tags:       map[string]string{"allow_autosuppression": "true", "workload_drift_only": "true"},
+		},
+	}
+
+	test, err := newTestModule(t, nil, rulesDef, withStaticOpts(testOpts{
+		enableActivityDump:                  true,
+		activityDumpRateLimiter:             testActivityDumpRateLimiter,
+		activityDumpTracedCgroupsCount:      1,
+		activityDumpDuration:                testActivityDumpDuration,
+		activityDumpLocalStorageDirectory:   outputDir,
+		activityDumpLocalStorageCompression: false,
+		activityDumpLocalStorageFormats:     expectedFormats,
+		activityDumpTracedEventTypes:        testActivityDumpTracedEventTypes,
+		activityDumpAutoSuppressionEnabled:  true,
+		autoSuppressionEventTypes:           []string{"exec", "dns"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	dockerInstance1, err := test.StartADocker()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dockerInstance1.stop()
+
+	dockerInstance2, err := test.StartADocker()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dockerInstance2.stop()
+
+	// dockerInstance2 should not be traced
+	_, err = test.GetDumpFromDocker(dockerInstance2)
+	if err == nil {
+		t.Fatal("second docker instance should not have an active dump")
+	}
+
+	time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
+	t.Run("auto-suppression-process-suppression", func(t *testing.T) {
+		// check we autosuppress signals during the activity dump duration
+		err = test.GetEventSent(t, func() error {
+			cmd := dockerInstance2.Command("getconf", []string{"-a"}, []string{})
+			_, err := cmd.CombinedOutput()
+			return err
+		}, func(rule *rules.Rule, event *model.Event) bool {
+			if event.ProcessContext.ContainerID == dockerInstance2.containerID {
+				t.Fatal("Got a signal that should have been suppressed")
+			}
+			return false
+		}, time.Second*3, "test_autosuppression_exec")
+		if err != nil {
+			if otherErr, ok := err.(ErrTimeout); !ok {
+				t.Fatal(otherErr)
+			}
+		}
+	})
+
+	t.Run("auto-suppression-dns-suppression", func(t *testing.T) {
+		// check we autosuppress signals during the activity dump duration
+		err = test.GetEventSent(t, func() error {
+			cmd := dockerInstance2.Command("nslookup", []string{"foo.bar"}, []string{})
+			_, err = cmd.CombinedOutput()
+			return err
+		}, func(rule *rules.Rule, event *model.Event) bool {
+			if event.ProcessContext.ContainerID == dockerInstance2.containerID {
+				t.Fatal("Got a signal that should have been suppressed")
+			}
+			return false
+		}, time.Second*3, "test_autosuppression_dns")
+		if err != nil {
+			if otherErr, ok := err.(ErrTimeout); !ok {
+				t.Fatal(otherErr)
+			}
+		}
+	})
+
 }

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -601,41 +601,6 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			}
 		}
 	})
-
-	err = test.StopActivityDump(dump.Name, "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("auto-suppression-process-signal", func(t *testing.T) {
-		// check that we generate an event during profile learning phase
-		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
-			_, err = cmd.CombinedOutput()
-			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
-			return assertTriggeredRule(t, rule, "test_autosuppression_exec") &&
-				assert.Equal(t, "getconf", event.ProcessContext.FileEvent.BasenameStr, "wrong exec file")
-		}, time.Second*3, "test_autosuppression_exec")
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("auto-suppression-dns-signal", func(t *testing.T) {
-		// check that we generate an event during profile learning phase
-		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
-			_, err = cmd.CombinedOutput()
-			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
-			return assertTriggeredRule(t, rule, "test_autosuppression_dns") &&
-				assert.Equal(t, "nslookup", event.ProcessContext.Argv0, "wrong exec file")
-		}, time.Second*3, "test_autosuppression_dns")
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
 }
 
 func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
@@ -663,12 +628,12 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 		{
 			ID:         "test_autosuppression_exec",
 			Expression: `exec.file.name == "getconf"`,
-			Tags:       map[string]string{"allow_autosuppression": "true", "workload_drift_only": "true"},
+			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 		{
 			ID:         "test_autosuppression_dns",
 			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
-			Tags:       map[string]string{"allow_autosuppression": "true", "workload_drift_only": "true"},
+			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 	}
 

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1301,12 +1301,10 @@ func (tm *testModule) StartADocker() (*dockerCmdWrapper, error) {
 func (tm *testModule) GetDumpFromDocker(dockerInstance *dockerCmdWrapper) (*activityDumpIdentifier, error) {
 	dumps, err := tm.ListActivityDumps()
 	if err != nil {
-		_, _ = dockerInstance.stop()
 		return nil, err
 	}
 	dump := findLearningContainerID(dumps, dockerInstance.containerID)
 	if dump == nil {
-		_, _ = dockerInstance.stop()
 		return nil, errors.New("ContainerID not found on activity dump list")
 	}
 	return dump, nil
@@ -1319,6 +1317,7 @@ func (tm *testModule) StartADockerGetDump() (*dockerCmdWrapper, *activityDumpIde
 	}
 	dump, err := tm.GetDumpFromDocker(dockerInstance)
 	if err != nil {
+		_, _ = dockerInstance.stop()
 		return nil, nil, err
 	}
 	return dockerInstance, dump, nil

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1751,7 +1751,7 @@ func (tm *testModule) ListAllProfiles() {
 	spm.ListAllProfileStates()
 }
 
-func (tm *testModule) SetProfileVersionState(selector *cgroupModel.WorkloadSelector, imageTag string, state profile.EventFilteringProfileState) error {
+func (tm *testModule) SetProfileVersionState(selector *cgroupModel.WorkloadSelector, imageTag string, state model.EventFilteringProfileState) error {
 	p, ok := tm.probe.PlatformProbe.(*sprobe.EBPFProbe)
 	if !ok {
 		return errors.New("no ebpf probe")

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -1131,7 +1131,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.StableEventType); err != nil {
+	}, selector.Tag, model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1202,7 +1202,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.UnstableEventType); err != nil {
+	}, selector.Tag, model.UnstableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1376,7 +1376,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.UnstableEventType); err != nil {
+	}, selector.Tag, model.UnstableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1482,7 +1482,7 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.StableEventType); err != nil {
+	}, selector.Tag, model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1554,7 +1554,7 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag+"v3", profile.StableEventType); err != nil {
+	}, selector.Tag+"v3", model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1663,7 +1663,7 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.StableEventType); err != nil {
+	}, selector.Tag, model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1735,7 +1735,7 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag+"v3", profile.StableEventType); err != nil {
+	}, selector.Tag+"v3", model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1844,7 +1844,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag, profile.UnstableEventType); err != nil {
+	}, selector.Tag, model.UnstableEventType); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1910,7 +1910,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
 		Image: selector.Image,
 		Tag:   "*",
-	}, selector.Tag+"v3", profile.StableEventType); err != nil {
+	}, selector.Tag+"v3", model.StableEventType); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR modify the auto-suppression behavior.

To be suppressed:
* the matching rule has to have the `allow_autosuppression=true` tag.
* the event type should be defined in `runtime_security_config.security_profile.auto_suppression.event_types`
* the event should have an associated containerID
* if the workload have an active dump: we should have the `runtime_security_config.activity_dump.auto_suppression.enabled` config set to true.
* if the workload has an active security profile (either in learning, or in stable with the event already present): we should have the `runtime_security_config.security_profile.auto_suppression.enabled` config set to true.

And now if a workload has no active security profile, and neither an active activity dump (this happens when a new workload starts while we already reached the maximum of concurrent active dump), we can allow events to be suppressed if `runtime_security_config.activity_dump.auto_suppression.enabled` config is set to true.

### Motivation

Events could be suppressed while an activity dump is running, most of the remaining noise comes from workloads that are in wait list to be dumped. This change should allow to remove most of the remaining noise.

### Additional Notes


### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
