### PR TITLE
[windows][CWS] consolidate windows probe initialization.

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -37,39 +37,9 @@ func createTestProbe() (*WindowsProbe, error) {
 	}
 	cfg.RuntimeSecurity.FIMEnabled = true
 
-	discardedPaths, err := lru.New[string, struct{}](1 << 10)
+	wp, err := initializeWindowsProbe(cfg, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	discardedBasenames, err := lru.New[string, struct{}](1 << 10)
-	if err != nil {
-		return nil, err
-	}
-	fc, err := lru.New[fileObjectPointer, fileCache](1024)
-	if err != nil {
-		return nil, err
-	}
-	rc, err := lru.New[regObjectPointer, string](1024)
-	if err != nil {
-		return nil, err
-	}
-
-	// probe and config are provided as null.  During the tests, it is assumed
-	// that we will not access those values.
-	wp := &WindowsProbe{
-		opts:               opts,
-		config:             cfg,
-		filePathResolver:   fc,
-		regPathResolver:    rc,
-		discardedPaths:     discardedPaths,
-		discardedBasenames: discardedBasenames,
-
-		isRenameEnabled: true,
-		isWriteEnabled:  true,
-		isDeleteEnabled: true,
-
-		volumeMap: make(map[string]string),
 	}
 	err = wp.Init()
 

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -40,6 +40,10 @@ func createTestProbe() (*WindowsProbe, error) {
 	if err != nil {
 		return nil, err
 	}
+	wp.isRenameEnabled = true
+	wp.isDeleteEnabled = true
+	wp.isWriteEnabled = true
+
 	err = wp.Init()
 
 	// do not call Start(), as start assumes we can load the driver.  these tests


### PR DESCRIPTION
Refactor initialization of windows probe.

Solves problem that each time we add new structure member, needed to remember to copy/paste the initialization to the tests, too.

### Motivation

not copy paste code

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Existing tests.