### PR TITLE
[windows][cws] restrict ETW message flow

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -226,6 +226,21 @@ func (p *WindowsProbe) initEtwFIM() error {
 		// try masking on create & create_new_file
 		// given the current requirements, I think we can _probably_ just do create_new_file
 		cfg.MatchAnyKeyword = 0x18A0
+
+		fileIds := []uint16{
+			idCreate,
+			idCreateNewFile,
+			idCleanup,
+			idClose,
+			idWrite,
+			idSetDelete,
+			idDeletePath,
+			idRename,
+			idRenamePath,
+			idRename29,
+		}
+
+		cfg.EnabledIDs = fileIds
 	})
 	p.fimSession.ConfigureProvider(p.regguid, func(cfg *etw.ProviderConfiguration) {
 		cfg.TraceLevel = etw.TRACE_LEVEL_VERBOSE


### PR DESCRIPTION
Another performance enhancement, this PR builds on #25875 and limits the messages that ETW will send us to the once we're specifically looking to handle. Significantly reduces load on the system-probe


### Motivation

Better performance

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Unit tests verify no regressions.
Load test environment (manual) has verified improvements.