### PR TITLE
Enable to set the buffering config of Lambda Logs API via env vars

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -356,10 +356,11 @@ func handleTerminationSignals(serverlessDaemon *daemon.Daemon, stopCh chan struc
 
 func envVarToInt(envVar string, defaultValue int) int {
 	if value, ok := os.LookupEnv(envVar); ok {
-		if intValue, err := strconv.Atoi(value); err == nil {
-			log.Warnf("%s must be int type, got %s: %s", envVar, value, err)
+		intValue, err := strconv.Atoi(value)
+		if err == nil {
 			return intValue
 		}
+		log.Warnf("%s must be int type, got %s: %s", envVar, value, err)
 	}
 	return defaultValue
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -43,9 +43,12 @@ import (
 )
 
 var (
-	logLevelEnvVar         = "DD_LOG_LEVEL"
-	flushStrategyEnvVar    = "DD_SERVERLESS_FLUSH_STRATEGY"
-	logsLogsTypeSubscribed = "DD_LOGS_CONFIG_LAMBDA_LOGS_TYPE"
+	logLevelEnvVar             = "DD_LOG_LEVEL"
+	flushStrategyEnvVar        = "DD_SERVERLESS_FLUSH_STRATEGY"
+	logsLogsTypeSubscribed     = "DD_LOGS_CONFIG_LAMBDA_LOGS_TYPE"
+	logsLogsBufferingTimeoutMs = "DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_TIMEOUT_MS"
+	logsLogsBufferingMaxBytes  = "DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_BYTES"
+	logsLogsBufferingMaxItesm  = "DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_ITEMS"
 
 	// AWS Lambda is writing the Lambda function files in /var/task, we want the
 	// configuration file to be at the root of this directory.
@@ -233,9 +236,9 @@ func runAgent() {
 				LogsType:            os.Getenv(logsLogsTypeSubscribed),
 				Port:                logsAPIHttpServerPort,
 				CollectionRoute:     logsAPICollectionRoute,
-				Timeout:             logsAPITimeout,
-				MaxBytes:            logsAPIMaxBytes,
-				MaxItems:            logsAPIMaxItems,
+				Timeout:             envVarToInt(logsLogsBufferingTimeoutMs, logsAPITimeout),
+				MaxBytes:            envVarToInt(logsLogsBufferingMaxBytes, logsAPIMaxBytes),
+				MaxItems:            envVarToInt(logsLogsBufferingMaxItesm, logsAPIMaxItems),
 			})
 
 		if logRegistrationError != nil {
@@ -349,4 +352,14 @@ func handleTerminationSignals(serverlessDaemon *daemon.Daemon, stopCh chan struc
 	log.Infof("Received signal '%s', shutting down...", signo)
 	serverlessDaemon.Stop()
 	stopCh <- struct{}{}
+}
+
+func envVarToInt(envVar string, defaultValue int) int {
+	if value, ok := os.LookupEnv(envVar); ok {
+		if intValue, err := strconv.Atoi(value); err == nil {
+			log.Warnf("%s must be int type, got %s: %s", envVar, value, err)
+			return intValue
+		}
+	}
+	return defaultValue
 }

--- a/pkg/serverless/registration/telemetry_api.go
+++ b/pkg/serverless/registration/telemetry_api.go
@@ -72,7 +72,7 @@ func subscribeTelemetry(id ID, url string, timeout time.Duration, payload json.M
 
 func buildLogRegistrationPayload(callBackURI string, logsType string, timeoutMs int, maxBytes int, maxItems int) *TelemetrySubscriptionPayload {
 	logsTypeArray := getLogTypesToSubscribe(logsType)
-	log.Debug("Subscribing to Telemetry for types:", logsTypeArray)
+	log.Debugf("Subscribing to Telemetry for %v with buffering timeoutMs=%d, maxBytes=%d, maxItems=%d", logsTypeArray, timeoutMs, maxBytes, maxItems)
 	destination := &destination{
 		URI:      callBackURI,
 		Protocol: "HTTP",

--- a/releasenotes/notes/add-lambda-logs-api-buffering-configs-ba8b5ad40eb6a62d.yaml
+++ b/releasenotes/notes/add-lambda-logs-api-buffering-configs-ba8b5ad40eb6a62d.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable to set the buffering configuration of Lambda Logs API
+    via ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_TIMEOUT_MS``,
+    ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_BYTES`` and
+    ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_ITEMS``.

--- a/releasenotes/notes/add-lambda-logs-api-buffering-configs-ba8b5ad40eb6a62d.yaml
+++ b/releasenotes/notes/add-lambda-logs-api-buffering-configs-ba8b5ad40eb6a62d.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    Enable to set the buffering configuration of Lambda Logs API
-    via ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_TIMEOUT_MS``,
-    ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_BYTES`` and
+    You can now set the buffering configuration of Lambda Logs API
+    using ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_TIMEOUT_MS``,
+    ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_BYTES``, and
     ``DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_ITEMS``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Enable set the buffering config of Lambda Logs API via env vars such as
- `DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_TIMEOUT_MS`
- `DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_BYTES`
- `DD_LOGS_CONFIG_LAMBDA_LOGS_BUFFERING_MAX_ITEMS`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- SLES-1598
- Currently the buffering configs are hardcode.
- Current maxBytes and maxItems are set to minimum value.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The default behavior will not change.

Min and Max values are defined here.
https://docs.aws.amazon.com/lambda/latest/dg/runtimes-logs-api.html#runtimes-logs-api-buffering

<img width="1334" alt="2024-05-25_11-19-24" src="https://github.com/DataDog/datadog-agent/assets/41987730/bbabbfc5-c381-414c-8dd7-8109f9c44678">

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

After setting env vars, we can see this debug log.

```
2024-05-25 06:25:57 UTC | DD_EXTENSION | DEBUG | Subscribing to Telemetry for [platform function extension] with buffering timeoutMs=30, maxBytes=1048576, maxItems=10000
```

<img width="1796" alt="2024-05-25_15-27-17" src="https://github.com/DataDog/datadog-agent/assets/41987730/acdf40c8-236e-4071-bc02-db7859328fcc">

```dockerfile
FROM golang:1.22 as app-builder
# ..skip...

FROM golang:1.22 as datadog-lambda-extension-builder
WORKDIR /build
ARG AGENT_BRANCH=main
RUN git clone --branch ${AGENT_BRANCH} --depth=1 https://github.com/DataDog/datadog-agent.git
WORKDIR /build/datadog-agent
RUN go build -o datadog-agent -tags serverless,otlp ./cmd/serverless

FROM public.ecr.aws/lambda/provided:al2023
RUN dnf update -y \
    && dnf install -y ca-certificates
COPY --from=app-builder /build/app /app
COPY --from=datadog-lambda-extension-builder /build/datadog-agent/datadog-agent /opt/extensions/datadog-agent
ENTRYPOINT [ "/app" ]

```