### PR TITLE
[USMON-934] postgres tls classification

### DIFF
--- a/pkg/network/protocols/postgres/server.go
+++ b/pkg/network/protocols/postgres/server.go
@@ -9,23 +9,81 @@
 package postgres
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
+const (
+	// TLSDisabled is used to indicate that the server should be started without TLS
+	TLSDisabled = false
+	// TLSEnabled is used to indicate that the server should be started with TLS
+	TLSEnabled = true
+)
+
 // RunServer runs a postgres server in a docker container
-func RunServer(t testing.TB, serverAddr, serverPort string) error {
+func RunServer(t testing.TB, serverAddr, serverPort string, enableTLS bool) error {
 	t.Helper()
 
+	encryptionMode := "off"
+	if enableTLS {
+		encryptionMode = "on"
+	}
+
+	cert, key, err := testutil.GetCertsPaths()
+	require.NoError(t, err)
+
+	dir, _ := testutil.CurDir()
+	testDataDir := filepath.Join(dir, "testdata")
+	if err := linkFile(t, key, filepath.Join(testDataDir, "server.key")); err != nil {
+		return err
+	}
+	if err := linkFile(t, cert, filepath.Join(testDataDir, "server.crt")); err != nil {
+		return err
+	}
 	env := []string{
 		"POSTGRES_ADDR=" + serverAddr,
 		"POSTGRES_PORT=" + serverPort,
+		"ENCRYPTION_MODE=" + encryptionMode,
+		"TESTDIR=" + testDataDir,
 	}
 
-	dir, _ := testutil.CurDir()
+	return protocolsUtils.RunDockerServer(t, "postgres", filepath.Join(testDataDir, "docker-compose.yml"), env, regexp.MustCompile(fmt.Sprintf(".*listening on IPv4 address \"0.0.0.0\", port %s", serverPort)), protocolsUtils.DefaultTimeout, 3)
+}
 
-	return protocolsUtils.RunDockerServer(t, "postgres", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(`.*\[1].*database system is ready to accept connections`), protocolsUtils.DefaultTimeout, 3)
+// copyFile copies a file from src to dst
+func copyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+// linkFile copies a file from src to dst, and sets up a cleanup function to remove the file when the test is done.
+func linkFile(t testing.TB, src, dst string) error {
+	t.Helper()
+	_ = os.Remove(dst)
+	if err := copyFile(src, dst); err != nil {
+		return err
+	}
+	t.Cleanup(func() { os.Remove(dst) })
+	return nil
 }

--- a/pkg/network/protocols/postgres/testdata/.gitignore
+++ b/pkg/network/protocols/postgres/testdata/.gitignore
@@ -1,0 +1,2 @@
+server.crt
+server.key

--- a/pkg/network/protocols/postgres/testdata/docker-compose.yml
+++ b/pkg/network/protocols/postgres/testdata/docker-compose.yml
@@ -2,11 +2,18 @@ version: '3.1'
 name: postgres
 services:
   postgres:
-   image: postgres:15-alpine
-   restart: always
-   ports:
-     - ${POSTGRES_ADDR:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432
-   environment:
-     POSTGRES_USER: admin
-     POSTGRES_PASSWORD: password
-     POSTGRES_DB: testdb
+    image: postgres:15-alpine
+    restart: always
+    entrypoint: /v/runner.sh
+    command: postgres -l -c ssl=${ENCRYPTION_MODE} -c ssl_cert_file=/postgres-test/server.crt -c ssl_key_file=/postgres-test/server.key -c config_file=/postgres-test/postgres.conf
+    ports:
+      - ${POSTGRES_ADDR:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432
+    environment:
+      ENCRYPTION_MODE: ${ENCRYPTION_MODE:-off}
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: testdb
+    volumes:
+      - ${TESTDIR}/server.key:/v/server.key
+      - ${TESTDIR}/server.crt:/v/server.crt
+      - ${TESTDIR}/runner.sh:/v/runner.sh

--- a/pkg/network/protocols/postgres/testdata/runner.sh
+++ b/pkg/network/protocols/postgres/testdata/runner.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Log the commands and their output for better debugging.
+set -x
+
+# Create a directory to store the configuration files
+mkdir -p /postgres-test
+
+# Define the paths to the configuration files
+PG_HBA_CONF="/postgres-test/pg_hba.conf"
+POSTGRES_CONF="/postgres-test/postgres.conf"
+
+# If the ENCRYPTION_MODE is set to on, then we force TLS traffic.
+# If the ENCRYPTION_MODE is set to off, then we force non-TLS traffic.
+# See more details in the documentation: https://www.postgresql.org/docs/15/auth-pg-hba-conf.html
+if [ "$ENCRYPTION_MODE" == "on" ]; then
+  cat > "$PG_HBA_CONF" <<EOL
+local   all             all                                     trust
+hostssl  all  all  0.0.0.0/0  md5
+EOL
+else
+  cat > "$PG_HBA_CONF" <<EOL
+local   all             all                                     trust
+hostnossl  all  all  0.0.0.0/0  md5
+EOL
+fi
+
+# Write the configuration to postgres.conf
+# We modify the listen_addresses to listen on all interfaces (appears in the original configuration) and
+# we set the hba_file to the path of the pg_hba.conf file.
+cat > "$POSTGRES_CONF" <<EOL
+hba_file = '$PG_HBA_CONF'
+listen_addresses = '*'
+EOL
+
+# Copying the server key and certificate to the test directory, as we change the permissions of the files (required for postgres to run)
+cp /v/server.* /postgres-test/
+chown -R postgres:postgres /postgres-test
+chmod 755 /postgres-test
+chmod 600 /postgres-test/server.*
+chmod 666 /postgres-test/postgres.conf
+
+# Call the original entrypoint script
+/usr/local/bin/docker-entrypoint.sh "$@"

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -108,6 +108,7 @@ func skipIfUsingNAT(t *testing.T, ctx testContext) {
 	}
 }
 
+// skipIfGoTLSNotSupported skips the test if GoTLS is not supported.
 func skipIfGoTLSNotSupported(t *testing.T, _ testContext) {
 	if !gotlstestutil.GoTLSSupported(t, config.New()) {
 		t.Skip("GoTLS is not supported")
@@ -2111,12 +2112,16 @@ func testProtocolClassificationLinux(t *testing.T, tr *Tracer, clientHost, targe
 	}
 }
 
+// goTLSAttachPID attaches the Go-TLS monitoring to the given PID.
+// Wraps the call to the Go-TLS attach function and waits for the program to be traced.
 func goTLSAttachPID(t *testing.T, pid int) {
 	t.Helper()
 	require.NoError(t, usm.GoTLSAttachPID(uint32(pid)))
 	utils.WaitForProgramsToBeTraced(t, "go-tls", pid)
 }
 
+// goTLSDetachPID detaches the Go-TLS monitoring from the given PID.
+// Wraps the call to the Go-TLS detach function and waits for the program to be untraced.
 func goTLSDetachPID(t *testing.T, pid int) {
 	t.Helper()
 

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -1149,7 +1149,7 @@ func testPostgresProtocolClassification(t *testing.T, tr *Tracer, clientHost, ta
 	// Setting one instance of postgres server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, postgresPort)
 	targetAddress := net.JoinHostPort(targetHost, postgresPort)
-	require.NoError(t, pgutils.RunServer(t, serverHost, postgresPort))
+	require.NoError(t, pgutils.RunServer(t, serverHost, postgresPort, pgutils.TLSDisabled))
 
 	tests := []protocolClassificationAttributes{
 		{

--- a/pkg/network/usm/ebpf_gotls_testutils.go
+++ b/pkg/network/usm/ebpf_gotls_testutils.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package usm
+
+import (
+	"errors"
+)
+
+// SetGoTLSExcludeSelf sets the GoTLSExcludeSelf configuration.
+func SetGoTLSExcludeSelf(value bool) error {
+	if goTLSSpec.Instance == nil {
+		return errors.New("GoTLS is not enabled")
+	}
+
+	goTLSSpec.Instance.(*goTLSProgram).cfg.GoTLSExcludeSelf = value
+	return nil
+}

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -76,7 +76,7 @@ func (s *postgresProtocolParsingSuite) TestDecoding() {
 	serverHost := "127.0.0.1"
 
 	serverAddress := net.JoinHostPort(serverHost, postgresPort)
-	require.NoError(t, postgres.RunServer(t, serverHost, postgresPort))
+	require.NoError(t, postgres.RunServer(t, serverHost, postgresPort, postgres.TLSDisabled))
 
 	tests := []postgresParsingTestAttributes{
 		{

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -326,7 +326,7 @@ func (s *postgresProtocolParsingSuite) TestCleanupEBPFEntriesOnTermination() {
 	wg := sync.WaitGroup{}
 
 	// Spinning the TCP server
-	const serverAddress = "127.0.0.1:5432"
+	const serverAddress = "127.0.0.1:5433" // Using a different port than 5432 to avoid errors like "address already in use"
 	srv := testutil.NewTCPServer(serverAddress, func(conn net.Conn) {
 		defer conn.Close()
 		defer wg.Done()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implements postgres TLS classification and covers its by tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

As a preliminary step for Postgres TLS monitoring, we need classification of postgres protocol on top of TLS probes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The tests run the test server (postgres instance) inside a docker container, and the client runs within the test binary.
Since the postgres instance is not supported by our TLS hooks, we apply go-tls hooks on the test binary to capture the traffic.
Recently we found out that `Pause` and `Resume` methods of the eBPF manager, which are used to stop (temporarily) the eBPF hooks from running and allowing us to isolate the relevant parts of the test to be traced, do not work on uprobes. To workaround the issue, we detach and attach from the go-binary we trace. That's the reason why this PR exports a method to modify the configuration (ExcludeSelf) of go-tls, detaches and re-attaches the test binary before the relevant parts of the tests

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
