### PR TITLE
usm: Introduce a method to move data_off of a pktbuf

### DIFF
--- a/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
+++ b/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
@@ -27,6 +27,20 @@ typedef const struct pktbuf pktbuf_t;
 // Never defined, intended to catch some implementation/usage errors at build-time.
 extern void pktbuf_invalid_operation(void);
 
+static __always_inline __maybe_unused void pktbuf_advance(pktbuf_t pkt, u32 offset)
+{
+    switch (pkt.type) {
+    case PKTBUF_SKB:
+        pkt.skb_info->data_off += offset;
+        return;
+    case PKTBUF_TLS:
+        pkt.tls->data_off += offset;
+        return;
+    }
+
+    pktbuf_invalid_operation();
+}
+
 static __always_inline __maybe_unused u32 pktbuf_data_offset(pktbuf_t pkt)
 {
     switch (pkt.type) {

--- a/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
+++ b/pkg/network/ebpf/c/protocols/helpers/pktbuf.h
@@ -135,7 +135,7 @@ PKTBUF_READ_BIG_ENDIAN(s8)
             read_into_buffer_##name(buffer, pkt.skb, offset);                                            \
             return;                                                                                      \
         case PKTBUF_TLS:                                                                                 \
-            read_into_user_buffer_##name(buffer, pkt.tls->buffer_ptr + pkt.tls->data_off + offset);      \
+            read_into_user_buffer_##name(buffer, pkt.tls->buffer_ptr + offset);                          \
             return;                                                                                      \
         }                                                                                                \
         pktbuf_invalid_operation();                                                                      \


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

* Introduces a method to advance the data_off field
* Fixes a bug in `PKTBUF_READ_INTO_BUFFER` on TLS monitoring (reading from `offset + data_off` instead only from `offset`)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Found while working on #25729

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
