### PR TITLE
Add a `lint` option to `get_modified_packages`

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -151,6 +151,7 @@ def go(
         headless_mode,
         build_tags=build_tags,
         only_modified_packages=only_modified_packages,
+        lint=True,
     )
 
     lint_results = run_lint_go(

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -150,7 +150,14 @@ def test_core(
 
 
 def process_input_args(
-    ctx, input_module, input_targets, input_flavor, headless_mode=False, only_modified_packages=False, build_tags=None
+    ctx,
+    input_module,
+    input_targets,
+    input_flavor,
+    headless_mode=False,
+    only_modified_packages=False,
+    build_tags=None,
+    lint=False,
 ):
     """
     Takes the input module, targets and flavor arguments from inv test and inv codecov,
@@ -162,7 +169,7 @@ def process_input_args(
         if not build_tags:
             build_tags = []
 
-        modules = get_modified_packages(ctx, build_tags)
+        modules = get_modified_packages(ctx, build_tags, lint=lint)
     elif isinstance(input_module, str):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a `lint` option to `get_modified_packages`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We use the `--only-modified-packages` in the `linter.go` task, but it should use `lint_targets` introduced [here](https://github.com/DataDog/datadog-agent/pull/17905) instead of the default one

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Spotted by @pducolin on https://github.com/DataDog/datadog-agent/pull/25668

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
