### PR TITLE
[Bug Fix] Check if cluster agent is enabled before accessing DCA client

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -232,7 +232,7 @@ func (c *collector) parsePods(
 
 		var nsLabels, nsAnnotations map[string]string
 
-		if c.dcaClient.SupportsNamespaceMetadataCollection() {
+		if c.isDCAEnabled() && c.dcaClient.SupportsNamespaceMetadataCollection() {
 			// Cluster agent with version 7.55+
 			var nsMetadata *clusteragent.Metadata
 			nsMetadata, err = c.getNamespaceMetadata(pod.Metadata.Namespace)

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -491,6 +491,43 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "cluster agent not enabled, ns labels enabled, ns annotations enabled",
+			args: args{
+				pods: pods,
+			},
+			fields: fields{
+				kubeUtil:                    kubeUtilFake,
+				dcaEnabled:                  false,
+				collectNamespaceLabels:      true,
+				collectNamespaceAnnotations: true,
+				dcaClient:                   nil,
+			},
+			namespaceLabelsAsTags: map[string]string{
+				"label": "tag",
+			},
+			namespaceAnnotationsAsTags: map[string]string{
+				"annotation": "tag",
+			},
+			want: []workloadmeta.CollectorEvent{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Source: workloadmeta.SourceClusterOrchestrator,
+					Entity: &workloadmeta.KubernetesPod{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindKubernetesPod,
+							ID:   "foouid",
+						},
+						EntityMeta: workloadmeta.EntityMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						KubeServices: []string{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "clusterAgentEnabled enabled, cluster-agent version < 7.55, ns labels enabled, ns annotations enabled",
 			args: args{
 				pods: pods,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes a bug in the kubemetadata workloadmeta collector (which runs in the node agent).
A new feature that adds namespace annotations as tags on related workloads was added in [this](https://github.com/DataDog/datadog-agent/pull/25585) PR.

The implementation of that PR accesses the DCA client without checking if the cluster agent is enabled. In case it is not enabled, it panics because it leads to nil pointer dereference.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix the bug.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- Added a unit test to catch this error.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
- QA is marked as done as this feature will be QA'ed in the initial feature PR.
