### PR TITLE
[ASCII-1802] Ensure that API endpoint provider are filter before being use

### DIFF
--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -97,7 +97,7 @@ func newAPIServer(deps dependencies) api.Component {
 		wmeta:             deps.WorkloadMeta,
 		collector:         deps.Collector,
 		gui:               deps.Gui,
-		endpointProviders: deps.EndpointProviders,
+		endpointProviders: fxutil.GetAndFilterGroup(deps.EndpointProviders),
 	}
 }
 

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -117,6 +117,12 @@ func getComponentDependencies(t *testing.T) testdeps {
 			return optional.NewNoneOption[collector.Component]()
 		}),
 		settingsimpl.MockModule(),
+		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
+		fx.Provide(func() api.AgentEndpointProvider {
+			return api.AgentEndpointProvider{
+				Provider: nil,
+			}
+		}),
 	)
 }
 

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -61,9 +61,9 @@ func SetupHandlers(
 ) *mux.Router {
 
 	// Register the handlers from the component providers
-	sort.Slice(providers, func(i, j int) bool { return providers[i].Route < providers[j].Route })
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Route() < providers[j].Route() })
 	for _, p := range providers {
-		r.HandleFunc(p.Route, p.HandlerFunc).Methods(p.Methods...)
+		r.HandleFunc(p.Route(), p.HandlerFunc()).Methods(p.Methods()...)
 	}
 
 	// TODO: move these to a component that is registerable

--- a/comp/api/api/component.go
+++ b/comp/api/api/component.go
@@ -32,11 +32,34 @@ type Component interface {
 }
 
 // EndpointProvider is an interface to register api endpoints
-type EndpointProvider struct {
-	HandlerFunc http.HandlerFunc
+type EndpointProvider interface {
+	HandlerFunc() http.HandlerFunc
 
-	Methods []string
-	Route   string
+	Methods() []string
+	Route() string
+}
+
+// endpointProvider is the implementation of EndpointProvider interface
+type endpointProvider struct {
+	methods []string
+	route   string
+	handler http.HandlerFunc
+}
+
+// Methods returns the methods for the endpoint.
+// e.g.: "GET", "POST", "PUT".
+func (p endpointProvider) Methods() []string {
+	return p.methods
+}
+
+// Route returns the route for the endpoint.
+func (p endpointProvider) Route() string {
+	return p.route
+}
+
+// HandlerFunc returns the handler function for the endpoint.
+func (p endpointProvider) HandlerFunc() http.HandlerFunc {
+	return p.handler
 }
 
 // AgentEndpointProvider is the provider for registering endpoints to the internal agent api server
@@ -49,10 +72,10 @@ type AgentEndpointProvider struct {
 // NewAgentEndpointProvider returns a AgentEndpointProvider to register the endpoint provided to the internal agent api server
 func NewAgentEndpointProvider(handlerFunc http.HandlerFunc, route string, methods ...string) AgentEndpointProvider {
 	return AgentEndpointProvider{
-		Provider: EndpointProvider{
-			HandlerFunc: handlerFunc,
-			Route:       route,
-			Methods:     methods,
+		Provider: endpointProvider{
+			handler: handlerFunc,
+			route:   route,
+			methods: methods,
 		},
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Ensure `nil` API endpoint providers are being filter. 

I had to convert `EndpointProvider` from a struct into an interface. 

This PR would allow for a component to don't declare an empty api endpoint in the case the component is optional. Here we can see an example https://github.com/DataDog/datadog-agent/pull/24800/files#r1615836038

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
