### PR TITLE
[workloadmeta/collectors/remote] Make filter configurable

### DIFF
--- a/comp/core/workloadmeta/filter.go
+++ b/comp/core/workloadmeta/filter.go
@@ -82,6 +82,20 @@ func (f *Filter) MatchEventType(eventType EventType) bool {
 	return f.EventType() == EventTypeAll || f.EventType() == eventType
 }
 
+// Kinds returns the kinds this filter is filtering by.
+func (f *Filter) Kinds() []Kind {
+	if f == nil || len(f.kinds) == 0 {
+		return nil
+	}
+
+	kinds := make([]Kind, 0, len(f.kinds))
+	for kind := range f.kinds {
+		kinds = append(kinds, kind)
+	}
+
+	return kinds
+}
+
 // Source returns the source this filter is filtering by. If the filter is nil,
 // returns SourceAll.
 func (f *Filter) Source() Source {

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -75,6 +75,40 @@ func ProtobufEventFromWorkloadmetaEvent(event workloadmeta.Event) (*pb.Workloadm
 	return nil, fmt.Errorf("unknown kind: %s", entityID.Kind)
 }
 
+// ProtobufFilterFromWorkloadmetaFilter converts the given workloadmeta.Filter into protobuf
+func ProtobufFilterFromWorkloadmetaFilter(filter *workloadmeta.Filter) (*pb.WorkloadmetaFilter, error) {
+	if filter == nil {
+		return nil, nil
+	}
+
+	kinds := filter.Kinds()
+	protoKinds := make([]pb.WorkloadmetaKind, 0, len(kinds))
+	for _, kind := range kinds {
+		protoKind, err := toProtoKind(kind)
+		if err != nil {
+			return nil, err
+		}
+
+		protoKinds = append(protoKinds, protoKind)
+	}
+
+	protoSource, err := toProtoSource(filter.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	protoEventType, err := toProtoEventType(filter.EventType())
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadmetaFilter{
+		Kinds:     protoKinds,
+		Source:    protoSource,
+		EventType: protoEventType,
+	}, nil
+}
+
 func protoContainerFromWorkloadmetaContainer(container *workloadmeta.Container) (*pb.Container, error) {
 	var pbContainerPorts []*pb.ContainerPort
 	for _, port := range container.Ports {
@@ -122,6 +156,21 @@ func toProtoEventType(eventType workloadmeta.EventType) (pb.WorkloadmetaEventTyp
 	}
 
 	return pb.WorkloadmetaEventType_EVENT_TYPE_ALL, fmt.Errorf("unknown event type: %d", eventType)
+}
+
+func toProtoSource(source workloadmeta.Source) (pb.WorkloadmetaSource, error) {
+	switch source {
+	case workloadmeta.SourceAll:
+		return pb.WorkloadmetaSource_ALL, nil
+	case workloadmeta.SourceRuntime:
+		return pb.WorkloadmetaSource_RUNTIME, nil
+	case workloadmeta.SourceNodeOrchestrator:
+		return pb.WorkloadmetaSource_NODE_ORCHESTRATOR, nil
+	case workloadmeta.SourceClusterOrchestrator:
+		return pb.WorkloadmetaSource_CLUSTER_ORCHESTRATOR, nil
+	}
+
+	return pb.WorkloadmetaSource_ALL, fmt.Errorf("unknown source: %s", source)
 }
 
 func toProtoEntityIDFromContainer(container *workloadmeta.Container) (*pb.WorkloadmetaEntityId, error) {

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
@@ -377,6 +378,23 @@ func TestConversions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProtobufFilterFromWorkloadmetaFilter(t *testing.T) {
+	filter := workloadmeta.NewFilter(
+		&workloadmeta.FilterParams{
+			Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
+			Source:    workloadmeta.SourceRuntime,
+			EventType: workloadmeta.EventTypeSet,
+		},
+	)
+
+	protoFilter, err := ProtobufFilterFromWorkloadmetaFilter(filter)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []pb.WorkloadmetaKind{pb.WorkloadmetaKind_CONTAINER}, protoFilter.Kinds)
+	assert.Equal(t, pb.WorkloadmetaSource_RUNTIME, protoFilter.Source)
+	assert.Equal(t, pb.WorkloadmetaEventType_EVENT_TYPE_SET, protoFilter.EventType)
 }
 
 func TestWorkloadmetaFilterFromProtoFilter(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR makes the filter used by the remote workloadmeta collector configurable.

Now the security-agent subscribes only to Containers. The security-agent doesn't need the other kinds, so this should reduced memory consumption a bit.

cc @DataDog/agent-security 

### Describe how to test/QA your changes

Configure the security-agent to use remote workloadmeta and check with `security-agent workload-list` (added in this PR: https://github.com/DataDog/datadog-agent/pull/25905) that there are only containers.
