### PR TITLE
[golang-deps-diff] Explictly export CGO_ENABLED to also include CGO-only deps

### DIFF
--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -108,7 +108,8 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
                             flavor = details.get("flavor", AgentFlavor.base)
                             build = details.get("build", binary)
                             build_tags = get_default_build_tags(build=build, platform=platform, flavor=flavor)
-                            env = {"GOOS": goos, "GOARCH": goarch}
+                            # need to explicitly enable CGO to also include CGO-only deps when checking different platforms
+                            env = {"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "1"}
                             ctx.run(f"{dep_cmd} -tags \"{' '.join(build_tags)}\" > {depsfile}", env=env)
         finally:
             ctx.run(f"git checkout -q {current_branch}")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add `CGO_ENABLED=1` in the environment when running `inv diff.go-deps`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
CGO is disabled by default when cross-compiling, it includes when trying to list dependencies for another platform.
When CGO is disabled, `go list` will not list dependencies that only work with CGO enabled, so the diff can be slightly incorrect.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
