### PR TITLE
[FA] Reduce inventory payload first run

### DIFF
--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -56,6 +56,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -117,6 +118,14 @@ func CreateInventoryPayload(conf config.Component, l log.Component, s serializer
 		maxInterval = defaultMaxInterval
 	}
 
+	firstRunDelay := conf.GetDuration("inventories_first_run_delay") * time.Second
+
+	// First run delay override per payload config name
+	payloadFirstRunDelayConfigName := fmt.Sprintf("inventories_first_run_delay_%s", strings.TrimSuffix(flareFileName, ".json"))
+	if firstRunDelayOverride := conf.GetDuration(payloadFirstRunDelayConfigName); firstRunDelayOverride > 0 {
+		firstRunDelay = firstRunDelayOverride * time.Second
+	}
+
 	return InventoryPayload{
 		Enabled:       InventoryEnabled(conf),
 		conf:          conf,
@@ -124,7 +133,7 @@ func CreateInventoryPayload(conf config.Component, l log.Component, s serializer
 		serializer:    s,
 		getPayload:    getPayload,
 		createdAt:     time.Now(),
-		firstRunDelay: conf.GetDuration("inventories_first_run_delay") * time.Second,
+		firstRunDelay: firstRunDelay,
 		FlareFileName: flareFileName,
 		MinInterval:   minInterval,
 		MaxInterval:   maxInterval,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -786,7 +786,10 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", 0) // 0 == default interval from inventories
 	config.BindEnvAndSetDefault("inventories_min_interval", 0) // 0 == default interval from inventories
 	// Seconds to wait to sent metadata payload to the backend after startup
-	config.BindEnvAndSetDefault("inventories_first_run_delay", 15)
+	config.BindEnvAndSetDefault("inventories_first_run_delay", 60)
+	config.BindEnvAndSetDefault("inventories_first_run_delay_agent", 5)
+	config.BindEnvAndSetDefault("inventories_first_run_delay_host", 0)
+	config.BindEnvAndSetDefault("inventories_first_run_delay_checks", 0)
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -786,7 +786,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", 0) // 0 == default interval from inventories
 	config.BindEnvAndSetDefault("inventories_min_interval", 0) // 0 == default interval from inventories
 	// Seconds to wait to sent metadata payload to the backend after startup
-	config.BindEnvAndSetDefault("inventories_first_run_delay", 60)
+	config.BindEnvAndSetDefault("inventories_first_run_delay", 15)
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Reduce the default first run of the inventory payload to 15sec.
This metadata payload is used in Fleet Automation to show an agent, so sending them 1min after startup means we have at least 1min latency (+ the backend latency) to show up in Fleet.
The reason we send this payload seconds after startup is to make sure we have host tags, which is also needed when we send metrics payload.

Since the first metrics payload is usually 15sec after startup, let's sync these 2 duration.

This keeps https://github.com/DataDog/datadog-agent/issues/23875

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Enable debug logs
* Start agent
* See in the logs that the datadog_agent metadata payload is sent after 15s
