### PR TITLE
[EBPF] Only check images matching CI when running local VMs

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -802,7 +802,7 @@ def kmt_sysprobe_prepare(
     ctx.run(f"ninja -d explain -v -f {nf_path}")
 
 
-def images_matching_ci(ctx, domains):
+def images_matching_ci(ctx: Context, domains: list[LibvirtDomain]):
     platforms = get_platforms()
     arch = full_arch("local")
     kmt_os = get_kmt_os()
@@ -814,7 +814,7 @@ def images_matching_ci(ctx, domains):
 
         check_tag = False
         for d in domains:
-            if vmid in d.name:
+            if vmid in d.name and d.instance.arch == "local":
                 check_tag = True
                 break
 
@@ -840,10 +840,7 @@ def images_matching_ci(ctx, domains):
     for name in not_matches:
         warn(f"[-] {name} does not match version in CI")
 
-    if len(not_matches) > 0:
-        return False
-
-    return True
+    return len(not_matches) == 0
 
 
 @task(


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Changes the `images_matching_ci` function to only check local domains, as remote VMs will always be the version present in `platforms.json`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
