### PR TITLE
[CONTP-142] Remove GetVersion method from DCAClientInterface interface

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -156,10 +156,6 @@ func (f *FakeDCAClient) ClusterAgentAPIEndpoint() string {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetVersion() (version.Version, error) {
-	panic("implement me")
-}
-
 func (f *FakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) {
 	panic("implement me")
 }

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -148,7 +148,7 @@ type FakeDCAClient struct {
 	ClusterIDErr error
 }
 
-func (f *FakeDCAClient) Version() version.Version {
+func (f *FakeDCAClient) Version(_ bool) version.Version {
 	panic("implement me")
 }
 

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -188,18 +188,21 @@ func (c *collector) parsePods(
 
 	var err error
 	var metadataByNsPods apiv1.NamespacesPodsStringsSet
-	if c.isDCAEnabled() && c.dcaClient.Version().Major >= 1 && c.dcaClient.Version().Minor >= 3 {
-		var nodeName string
-		nodeName, err = c.kubeUtil.GetNodename(ctx)
-		if err != nil {
-			log.Errorf("Could not retrieve the Nodename, err: %v", err)
-			return events, err
-		}
+	if c.isDCAEnabled() {
+		dcaVersion := c.dcaClient.Version(false)
+		if dcaVersion.Major >= 1 && dcaVersion.Minor >= 3 {
+			var nodeName string
+			nodeName, err = c.kubeUtil.GetNodename(ctx)
+			if err != nil {
+				log.Errorf("Could not retrieve the Nodename, err: %v", err)
+				return events, err
+			}
 
-		metadataByNsPods, err = c.dcaClient.GetPodsMetadataForNode(nodeName)
-		if err != nil {
-			log.Debugf("Could not pull the metadata map of pods on node %s from the Datadog Cluster Agent: %s", nodeName, err.Error())
-			return events, err
+			metadataByNsPods, err = c.dcaClient.GetPodsMetadataForNode(nodeName)
+			if err != nil {
+				log.Debugf("Could not pull the metadata map of pods on node %s from the Datadog Cluster Agent: %s", nodeName, err.Error())
+				return events, err
+			}
 		}
 	}
 
@@ -341,7 +344,7 @@ func (c *collector) getNamespaceMetadata(ns string) (*clusteragent.Metadata, err
 
 func (c *collector) isDCAEnabled() bool {
 	if c.dcaEnabled && c.dcaClient != nil {
-		v := c.dcaClient.Version()
+		v := c.dcaClient.Version(false)
 		if v.String() != "0.0.0" { // means not initialized
 			return true
 		}

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -75,10 +75,6 @@ func (f *FakeDCAClient) ClusterAgentAPIEndpoint() string {
 	return f.LocalClusterAgentAPIEndpoint
 }
 
-func (f *FakeDCAClient) GetVersion() (version.Version, error) {
-	return f.LocalVersion, f.VersionErr
-}
-
 func (f *FakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) {
 	return f.NodeLabels, f.NodeLabelsErr
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -67,7 +67,7 @@ type FakeDCAClient struct {
 	ClusterIDErr error
 }
 
-func (f *FakeDCAClient) Version() version.Version {
+func (f *FakeDCAClient) Version(_ bool) version.Version {
 	return f.LocalVersion
 }
 

--- a/pkg/status/clusteragent/status_apiserver.go
+++ b/pkg/status/clusteragent/status_apiserver.go
@@ -29,11 +29,7 @@ func GetDCAStatus(stats map[string]interface{}) {
 	}
 	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint()
 
-	ver, err := dcaCl.GetVersion()
-	if err != nil {
-		clusterAgentDetails["ConnectionError"] = err.Error()
-		return
-	}
+	ver := dcaCl.Version()
 	clusterAgentDetails["Version"] = ver.String()
 }
 

--- a/pkg/status/clusteragent/status_apiserver.go
+++ b/pkg/status/clusteragent/status_apiserver.go
@@ -29,7 +29,7 @@ func GetDCAStatus(stats map[string]interface{}) {
 	}
 	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint()
 
-	ver := dcaCl.Version()
+	ver := dcaCl.Version(true)
 	clusterAgentDetails["Version"] = ver.String()
 }
 

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -61,7 +61,6 @@ type DCAClientInterface interface {
 	Version() version.Version
 	ClusterAgentAPIEndpoint() string
 
-	GetVersion() (version.Version, error)
 	GetNodeLabels(nodeName string) (map[string]string, error)
 	GetNodeAnnotations(nodeName string) (map[string]string, error)
 	GetNamespaceLabels(nsName string) (map[string]string, error)
@@ -192,7 +191,7 @@ func (c *DCAClient) initHTTPClient() error {
 	}
 
 	// Validate the cluster-agent client by checking the version
-	clusterAgentVersion, err := c.GetVersion()
+	clusterAgentVersion, err := c.getVersion()
 	if err != nil {
 		return err
 	}
@@ -384,8 +383,8 @@ func (c *DCAClient) doJSONQueryToLeader(ctx context.Context, path, method string
 	return err
 }
 
-// GetVersion fetches the version of the Cluster Agent. Used in the agent status command.
-func (c *DCAClient) GetVersion() (version.Version, error) {
+// getVersion fetches the version of the Cluster Agent
+func (c *DCAClient) getVersion() (version.Version, error) {
 	var version version.Version
 	err := c.doJSONQuery(context.TODO(), "version", "GET", nil, &version, false)
 	return version, err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removes `GetVersion` method from the `DCAClientInterface`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We already have the method `Version` that is required by the interface. Having two methods doing the same thing on the same interface violates the single-responsibility-principle. 

While checking the code, I noticed that `GetVersion` sends an API request to the cluster agent to get the version, and it is used at the initialisation of the cluster agent client in order to get the version and *cache it*.

`Version` method returns the cached value of the version.

Therefore, `GetVersion` should be only a helper method as part of the implementation of the interface, and not as part of the interface definition. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- This is a non-functional change (although it will reduce the number of times we make an API call to the cluster agent to get the status, but this remains a minor improvement as this operation is not done very often).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure the `agent status` command still gets the version of the cluster agent correctly, even directly after rolling out the cluster agent:

Example:

```
=====================
Datadog Cluster Agent
=====================

    - Datadog Cluster Agent endpoint detected: https://10.96.186.204:5005
    Successfully connected to the Datadog Cluster Agent.
    - Running: 7.54.0-dbm-mongo-0.1+git.62.36fb866.commit.36fb86660b
```

Now rollout the cluster agent deployment to a different version, and then run `agent status` command on the agent pod. You should instantly see the DCA status updated:

```
=====================
Datadog Cluster Agent
=====================

    - Datadog Cluster Agent endpoint detected: https://10.96.237.15:5005
    Successfully connected to the Datadog Cluster Agent.
    - Running: 7.52.0+commit.4a6318a
```
