### PR TITLE
[CWS] copy clang-bpf and llc-bpf inside docker test container

### DIFF
--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
@@ -174,6 +174,9 @@ if not ['redhat', 'suse', 'opensuseleap', 'rocky'].include?(node[:platform])
       content <<-EOF
       FROM ghcr.io/paulcacheux/cws-centos7@sha256:b16587f1cc7caebc1a18868b9fbd3823e79457065513e591352c4d929b14c426
 
+      COPY clang-bpf /opt/datadog-agent/embedded/bin/
+      COPY llc-bpf /opt/datadog-agent/embedded/bin/
+
       CMD sleep 7200
       EOF
       action :create


### PR DESCRIPTION
### What does this PR do?

This PR fixes https://github.com/DataDog/datadog-agent/pull/25917 re-adding the `COPY clang/llc-bpf` lines that had been removed by mistake.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
