### PR TITLE
Fix old e2e tests

### DIFF
--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -173,7 +173,8 @@ class App(common.App):
         api_key = os.environ["DD_API_KEY"]
         app_key = os.environ["DD_APP_KEY"]
 
-        url = f"https://api.{site}/api/v2/remote_config/products/cws/policy/download"
+        url = f"https://api.{site}/api/v2/security/cloud_workload/policy/download"
+
         with requests.get(
             url,
             headers={


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR aims to fix CWS old e2e tests by reverting to the old endpoint for downloading policies. No need to update to the latest, as these tests will be dropped in the future once the new-e2e tests are up and running.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
