### PR TITLE
feat(health): implement startup healthcheck

### DIFF
--- a/comp/core/healthprobe/impl/healthprobe.go
+++ b/comp/core/healthprobe/impl/healthprobe.go
@@ -111,6 +111,15 @@ func (rh readyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	healthHandler(rh.logsGoroutines, rh.log, health.GetReadyNonBlocking, w, r)
 }
 
+type startupHandler struct {
+	logsGoroutines bool
+	log            log.Component
+}
+
+func (sh startupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	healthHandler(sh.logsGoroutines, sh.log, health.GetStartupNonBlocking, w, r)
+}
+
 func buildServer(options healthprobeComponent.Options, log log.Component) *http.Server {
 	r := mux.NewRouter()
 
@@ -124,8 +133,14 @@ func buildServer(options healthprobeComponent.Options, log log.Component) *http.
 		log:            log,
 	}
 
+	startupHandler := startupHandler{
+		logsGoroutines: options.LogsGoroutines,
+		log:            log,
+	}
+
 	r.Handle("/live", liveHandler)
 	r.Handle("/ready", readyHandler)
+	r.Handle("/startup", startupHandler)
 	// Default route for backward compatibility
 	r.NewRoute().Handler(liveHandler)
 

--- a/pkg/status/health/README.md
+++ b/pkg/status/health/README.md
@@ -11,6 +11,10 @@ For more information on the context, see the `agent-healthcheck.md` proposal.
 receive a `*health.Handle` to keep. As soon as `Register` is called, you need to start reading
 the channel to be considered healthy.
 
+- If you want to register a component for the `Startup` probe, you need to call `RegisterStartup()`.
+This is useful for components that need to perform some initialization before being considered healthy.
+You will need to first register the component, then do the initialization, and finally read from the channel.
+
 - In your main goroutine, you need to read from the `handle.C` channel, at least every 15 seconds.
 This is accomplished by using a `select` statement in your main goroutine. If the channel is full
 (after two tries), your component will be considered unhealthy, which might result in the agent
@@ -25,6 +29,6 @@ It depends on your component lifecycle, but the check's purpose is to check that
 is able to process new input and act accordingly. For components that read input from a channel,
 you should read the channel from this logic.
 
-This is usually hightly unprobable, but it's exactly the scope of this system: be able to
+This is usually highly unlikely, but it's exactly the scope of this system: be able to
 detect if a component is frozen because of a bug / race condition. This is usually the only
 kind of issue that could be solved by the agent restarting.

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -35,12 +35,14 @@ type catalog struct {
 	sync.RWMutex
 	components map[*Handle]*component
 	latestRun  time.Time
+	startup    bool
 }
 
 func newCatalog() *catalog {
 	return &catalog{
 		components: make(map[*Handle]*component),
 		latestRun:  time.Now(), // Start healthy
+		startup:    false,
 	}
 }
 
@@ -97,6 +99,10 @@ func (c *catalog) pingComponents(healthDeadline time.Time) bool {
 	c.Lock()
 	defer c.Unlock()
 	for _, component := range c.components {
+		// In startup mode, we skip already healthy components.
+		if c.startup && component.healthy {
+			continue
+		}
 		select {
 		case component.healthChan <- healthDeadline:
 			component.healthy = true

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -138,6 +138,12 @@ func TestStartupCatalog(t *testing.T) {
 
 	// Get healthy
 	<-token.C
+	cat.pingComponents(time.Time{}) // First ping will make component healthy and fill the channel again.
+	status = cat.getStatus()
+	assert.Len(t, status.Healthy, 2)
+	assert.Contains(t, status.Healthy, "test1")
+
+	// Make sure that we stay health even if we don't ping.
 	cat.pingComponents(time.Time{})
 	status = cat.getStatus()
 	assert.Len(t, status.Healthy, 2)

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -123,3 +123,23 @@ func TestGetHealthy(t *testing.T) {
 	assert.Len(t, status.Healthy, 2)
 	assert.Len(t, status.Unhealthy, 0)
 }
+
+func TestStartupCatalog(t *testing.T) {
+	cat := newCatalog()
+	cat.startup = true
+	token := cat.register("test1")
+
+	// Start unhealthy
+	status := cat.getStatus()
+	assert.Len(t, status.Healthy, 1)
+	assert.Contains(t, status.Healthy, "healthcheck")
+	assert.Len(t, status.Unhealthy, 1)
+	assert.Contains(t, status.Unhealthy, "test1")
+
+	// Get healthy
+	<-token.C
+	cat.pingComponents(time.Time{})
+	status = cat.getStatus()
+	assert.Len(t, status.Healthy, 2)
+	assert.Contains(t, status.Healthy, "test1")
+}


### PR DESCRIPTION
### What does this PR do?

Implements a startup healthcheck in the `health` component.

### Motivation

This is needed to support newest [Kubernetes Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).

### Describe how to test/QA your changes

Deploy an Agent and check that the `/startup` endpoint is working as intended
```
➜  dddev kubectl exec -it datadog-agent-rjrfl -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":null,"Unhealthy":null}%
```

Since no components are using the Startup healthcheck now, it stays empty.
I've made a test to show that the function does work as intended.

With the following code
```
// Register the startup healthcheck
startup := health.RegisterStartup("tagger-workloadmeta")

// Startup will be unhealthy until we consume the first item from the channel
time.Sleep(10 * time.Second)
// Consume the first item from the channel to make the startup healthcheck healthy
<-startup.C
// Startup is now healthy
time.Sleep(10 * time.Second)

// De-register the startup healthcheck, since we have only one component this will also de-register the "healthcheck" component.
err := startup.Deregister()
if err != nil {
	log.Warnf("error de-registering startup health check: %s", err)
}
```

We get the following results:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":["healthcheck"],"Unhealthy":["tagger-workloadmeta"]}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 500 Internal Server Error
Date: Mon, 27 May 2024 14:52:29 GMT
Content-Length: 63
Content-Type: text/plain; charset=utf-8
```

After 10 seconds:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":["healthcheck","tagger-workloadmeta"],"Unhealthy":null}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 200 OK
Date: Mon, 27 May 2024 14:52:43 GMT
Content-Length: 66
Content-Type: text/plain; charset=utf-8
```

After another 10 seconds, we de-register:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":null,"Unhealthy":null}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 200 OK
Date: Mon, 27 May 2024 14:57:47 GMT
Content-Length: 33
Content-Type: text/plain; charset=utf-8
```