### PR TITLE
[EBPF] Warn the user when PATH variable is not correctly set for KMT

### DIFF
--- a/tasks/kernel_matrix_testing/init_kmt.py
+++ b/tasks/kernel_matrix_testing/init_kmt.py
@@ -72,7 +72,12 @@ def init_kernel_matrix_testing_system(ctx: Context, lite: bool, images):
 
     if not lite:
         if shutil.which("libvirtd") is None:
-            raise Exit("libvirtd not found in $PATH, did you run tasks/kernel_matrix_testing/env-setup.sh?")
+            if Path("/opt/homebrew/sbin/libvirtd").exists():
+                raise Exit(
+                    "libvirtd is installed in /opt/homebrew/sbin/libvirtd, but not in $PATH. /opt/homebrew/sbin should be part of your $PATH variable"
+                )
+            else:
+                raise Exit("libvirtd not found in $PATH, did you run tasks/kernel_matrix_testing/env-setup.sh?")
 
         info("[+] OS-specific setup")
         kmt_os.init_local(ctx)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In some cases, `/opt/homebrew/sbin/` might not be in `$PATH`, this will cause the code to fail to detect `libvirtd`. This PR changes the code so that this situation is detected and the user is warned.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
