### PR TITLE
[EBPF] Fix flakiness in TestLogParsing

### DIFF
--- a/pkg/ebpf/verifier/verifier_log_parser_test.go
+++ b/pkg/ebpf/verifier/verifier_log_parser_test.go
@@ -7,6 +7,7 @@ package verifier
 
 import (
 	"math"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -230,6 +231,14 @@ func TestLogParsingWith(t *testing.T) {
 			vlp := newVerifierLogParser(tt.progSourceMap)
 			_, err := vlp.parseVerifierLog(tt.input)
 			require.NoError(t, err)
+
+			// Fix to avoid flakiness, sort the assembly instructions
+			// as they might be in a different order, due to dict iteration
+			// order being random.
+			for _, lineData := range vlp.complexity.SourceMap {
+				sort.Ints(lineData.AssemblyInsns)
+			}
+
 			require.Equal(t, tt.expected, vlp.complexity)
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes a flaky test, that was failing sometimes due to random dictionary iteration order. The `AssemblyInsns` list is generated by iterating through a dictionary, to avoid that we sort it after in tests (we don't care about the order when exporting that list).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
