### PR TITLE
conductor env to targets migration

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -10,7 +10,7 @@ extensions:
       schedule: "0 3 * * 1-5"
       options:
         disable_bia: true
-      env:
+      targets:
         - name: "staging"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
   datadoghq.com/change-detection:


### PR DESCRIPTION
change conductor `env` to `targets` migration as we are deprecating the old config.

