### PR TITLE
[Serverless] Reuse DD_ENHANCED_METRICS for new system enhanced metrics

### DIFF
--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -49,7 +49,6 @@ const (
 	cpuUserTimeMetric     = "aws.lambda.enhanced.cpu_user_time"
 	cpuTotalTimeMetric    = "aws.lambda.enhanced.cpu_total_time"
 	enhancedMetricsEnvVar = "DD_ENHANCED_METRICS"
-	systemMetricsEnvVar   = "DD_SYSTEM_METRICS"
 )
 
 func getOutOfMemorySubstrings() []string {
@@ -256,7 +255,7 @@ type GenerateCPUEnhancedMetricsArgs struct {
 // GenerateCPUEnhancedMetrics generates enhanced metrics for CPU time spent running the function in kernel mode,
 // in user mode, and in total
 func GenerateCPUEnhancedMetrics(args GenerateCPUEnhancedMetricsArgs) {
-	if strings.ToLower(os.Getenv(systemMetricsEnvVar)) == "false" {
+	if strings.ToLower(os.Getenv(enhancedMetricsEnvVar)) == "false" {
 		return
 	}
 	timestamp := float64(args.Time.UnixNano()) / float64(time.Second)

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -507,8 +507,8 @@ func TestGenerateCPUEnhancedMetrics(t *testing.T) {
 }
 
 func TestGenerateCPUEnhancedMetricsDisabled(t *testing.T) {
-	os.Setenv("DD_SYSTEM_METRICS", "false")
-	defer os.Setenv("DD_SYSTEM_METRICS", "true")
+	os.Setenv("DD_ENHANCED_METRICS", "false")
+	defer os.Setenv("DD_ENHANCED_METRICS", "true")
 
 	demux := createDemultiplexer(t)
 	tags := []string{"functionname:test-function"}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR gates new system enhanced metrics behind the existing `DD_ENHANCED_METRICS` environment variable instead of using a separate one.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This change will reduce complexity around enabling/disabling enhanced metrics. There's currently no strong motivation to use a separate variable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
- Unit tests
- Publish extension using this code
- Create a test function and toggle `DD_ENHANCED_METRICS`, should see CPU metrics emitted/not emitted according to this variable
