### PR TITLE
pkg/trace: add e2e benchmark

### DIFF
--- a/comp/trace/agent/agent_mock.go
+++ b/comp/trace/agent/agent_mock.go
@@ -19,6 +19,22 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
+type noopTraceWriter struct{}
+
+func (n *noopTraceWriter) Run() {}
+
+func (n *noopTraceWriter) Stop() {}
+
+func (n *noopTraceWriter) WriteChunks(_ *writer.SampledChunks) {}
+
+func (n *noopTraceWriter) FlushSync() error { return nil }
+
+type noopConcentrator struct{}
+
+func (c *noopConcentrator) Start()            {}
+func (c *noopConcentrator) Stop()             {}
+func (c *noopConcentrator) Add(_ stats.Input) {}
+
 func newMock(deps dependencies, t testing.TB) Component { //nolint:revive // TODO fix revive unused-parameter
 	telemetryCollector := telemetry.NewCollector(deps.Config.Object())
 
@@ -40,8 +56,8 @@ func newMock(deps dependencies, t testing.TB) Component { //nolint:revive // TOD
 	}
 
 	// Temporary copy of pkg/trace/agent.NewTestAgent
-	ag.TraceWriter.In = make(chan *writer.SampledChunks, 1000)
-	ag.Concentrator.In = make(chan stats.Input, 1000)
+	ag.TraceWriter = &noopTraceWriter{}
+	ag.Concentrator = &noopConcentrator{}
 
 	return component{}
 }

--- a/pkg/serverless/trace/span_modifer_test.go
+++ b/pkg/serverless/trace/span_modifer_test.go
@@ -10,6 +10,7 @@ package trace
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,9 +24,31 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/writer"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
+
+type mockTraceWriter struct {
+	mu       sync.Mutex
+	payloads []*writer.SampledChunks
+}
+
+func (m *mockTraceWriter) Stop() {
+	//TODO implement me
+	panic("not implemented")
+}
+
+func (m *mockTraceWriter) WriteChunks(pkg *writer.SampledChunks) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.payloads = append(m.payloads, pkg)
+}
+
+func (m *mockTraceWriter) FlushSync() error {
+	//TODO implement me
+	panic("not implemented")
+}
 
 func TestServerlessServiceRewrite(t *testing.T) {
 	cfg := config.New()
@@ -39,24 +62,20 @@ func TestServerlessServiceRewrite(t *testing.T) {
 		tags: cfg.GlobalTags,
 	}
 	agnt.ModifySpan = spanModifier.ModifySpan
+	agnt.TraceWriter = &mockTraceWriter{}
 	defer cancel()
 
 	tc := testutil.RandomTraceChunk(1, 1)
 	tc.Priority = 1 // ensure trace is never sampled out
 	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Service = "aws.lambda"
-	go agnt.Process(&api.Payload{
+	agnt.Process(&api.Payload{
 		TracerPayload: tp,
 		Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 	})
-	timeout := time.After(2 * time.Second)
-	var span *pb.Span
-	select {
-	case ss := <-agnt.TraceWriter.In:
-		span = ss.TracerPayload.Chunks[0].Spans[0]
-	case <-timeout:
-		t.Fatal("timed out")
-	}
+	payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+	assert.NotEmpty(t, payloads, "no payloads were written")
+	span := payloads[0].TracerPayload.Chunks[0].Spans[0]
 	assert.Equal(t, "myTestService", span.Service)
 }
 
@@ -70,6 +89,7 @@ func TestInferredSpanFunctionTagFiltering(t *testing.T) {
 		tags: cfg.GlobalTags,
 	}
 	agnt.ModifySpan = spanModifier.ModifySpan
+	agnt.TraceWriter = &mockTraceWriter{}
 	defer cancel()
 
 	tc := testutil.RandomTraceChunk(2, 1)
@@ -77,17 +97,13 @@ func TestInferredSpanFunctionTagFiltering(t *testing.T) {
 	tp := testutil.TracerPayloadWithChunk(tc)
 	tp.Chunks[0].Spans[0].Meta["_inferred_span.tag_source"] = "self"
 	tp.Chunks[0].Spans[1].Meta["_dd_origin"] = "lambda"
-	go agnt.Process(&api.Payload{
+	agnt.Process(&api.Payload{
 		TracerPayload: tp,
 		Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 	})
-	timeout := time.After(2 * time.Second)
-	select {
-	case ss := <-agnt.TraceWriter.In:
-		tp = ss.TracerPayload
-	case <-timeout:
-		t.Fatal("timed out")
-	}
+	payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+	assert.NotEmpty(t, payloads, "no payloads were written")
+	tp = payloads[0].TracerPayload
 
 	_, lambdaSpanHasGlobalTags := tp.Chunks[0].Spans[1].GetMeta()["function_arn"]
 	assert.True(t, lambdaSpanHasGlobalTags, "The regular span should get global tags")
@@ -107,6 +123,7 @@ func TestSpanModifierAddsOriginToAllSpans(t *testing.T) {
 		if withModifier {
 			agnt.ModifySpan = (&spanModifier{tags: cfg.GlobalTags, ddOrigin: getDDOrigin()}).ModifySpan
 		}
+		agnt.TraceWriter = &mockTraceWriter{}
 		tc := testutil.RandomTraceChunk(2, 1)
 		tc.Priority = 1 // ensure trace is never sampled out
 		tp := testutil.TracerPayloadWithChunk(tc)
@@ -115,13 +132,9 @@ func TestSpanModifierAddsOriginToAllSpans(t *testing.T) {
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
-
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			tp = ss.TracerPayload
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		tp = payloads[0].TracerPayload
 
 		for _, chunk := range tp.Chunks {
 			if chunk.Origin != "lambda" {
@@ -156,6 +169,7 @@ func TestSpanModifierDetectsCloudService(t *testing.T) {
 		if withModifier {
 			agnt.ModifySpan = (&spanModifier{ddOrigin: getDDOrigin()}).ModifySpan
 		}
+		agnt.TraceWriter = &mockTraceWriter{}
 		tc := testutil.RandomTraceChunk(2, 1)
 		tc.Priority = 1 // ensure trace is never sampled out
 		tp := testutil.TracerPayloadWithChunk(tc)
@@ -165,12 +179,9 @@ func TestSpanModifierDetectsCloudService(t *testing.T) {
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
 
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			tp = ss.TracerPayload
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		tp = payloads[0].TracerPayload
 
 		for _, chunk := range tp.Chunks {
 			if chunk.Origin != expectedOrigin {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -177,15 +177,16 @@ func (a *Agent) Run() {
 
 	go a.StatsWriter.Run()
 
-	// Having GOMAXPROCS/2 processor threads is
-	// enough to keep the downstream writer busy.
+	// Having GOMAXPROCS processor threads is
+	// enough to keep the agent busy.
 	// Having more processor threads would not speed
 	// up processing, but just expand memory.
-	workers := runtime.GOMAXPROCS(0) / 2
+	workers := runtime.GOMAXPROCS(0)
 	if workers < 1 {
 		workers = 1
 	}
 
+	log.Infof("Processing Pipeline configured with %d workers", workers)
 	for i := 0; i < workers; i++ {
 		go a.work()
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -54,11 +54,28 @@ const (
 	tagDecisionMaker = "_dd.p.dm"
 )
 
+type traceWriter interface {
+	// Stop stops the traceWriter and attempts to flush whatever is left in the senders buffers.
+	Stop()
+
+	// WriteChunks to be written
+	WriteChunks(pkg *writer.SampledChunks)
+
+	// FlushSync blocks and sends pending payloads when syncMode is true
+	FlushSync() error
+}
+
+type concentrator interface {
+	Start()
+	Stop()
+	Add(t stats.Input)
+}
+
 // Agent struct holds all the sub-routines structs and make the data flow between them
 type Agent struct {
 	Receiver              *api.HTTPReceiver
 	OTLPReceiver          *api.OTLPReceiver
-	Concentrator          *stats.Concentrator
+	Concentrator          concentrator
 	ClientStatsAggregator *stats.ClientStatsAggregator
 	Blacklister           *filters.Blacklister
 	Replacer              *filters.Replacer
@@ -68,7 +85,7 @@ type Agent struct {
 	NoPrioritySampler     *sampler.NoPrioritySampler
 	ProbabilisticSampler  *sampler.ProbabilisticSampler
 	EventProcessor        *event.Processor
-	TraceWriter           *writer.TraceWriter
+	TraceWriter           traceWriter
 	StatsWriter           *writer.StatsWriter
 	RemoteConfigHandler   *remoteconfighandler.RemoteConfigHandler
 	TelemetryCollector    telemetry.TelemetryCollector
@@ -105,15 +122,15 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 	dynConf := sampler.NewDynamicConfig()
 	log.Infof("Starting Agent with processor trace buffer of size %d", conf.TraceBuffer)
 	in := make(chan *api.Payload, conf.TraceBuffer)
-	statsChan := make(chan *pb.StatsPayload, 1)
 	oconf := conf.Obfuscation.Export(conf)
 	if oconf.Statsd == nil {
 		oconf.Statsd = statsd
 	}
 	timing := timing.New(statsd)
+	statsWriter := writer.NewStatsWriter(conf, telemetryCollector, statsd, timing)
 	agnt := &Agent{
-		Concentrator:          stats.NewConcentrator(conf, statsChan, time.Now(), statsd),
-		ClientStatsAggregator: stats.NewClientStatsAggregator(conf, statsChan, statsd),
+		Concentrator:          stats.NewConcentrator(conf, statsWriter, time.Now(), statsd),
+		ClientStatsAggregator: stats.NewClientStatsAggregator(conf, statsWriter, statsd),
 		Blacklister:           filters.NewBlacklister(conf.Ignore["resource"]),
 		Replacer:              filters.NewReplacer(conf.ReplaceTags),
 		PrioritySampler:       sampler.NewPrioritySampler(conf, dynConf, statsd),
@@ -122,7 +139,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 		NoPrioritySampler:     sampler.NewNoPrioritySampler(conf, statsd),
 		ProbabilisticSampler:  sampler.NewProbabilisticSampler(conf, statsd),
 		EventProcessor:        newEventProcessor(conf, statsd),
-		StatsWriter:           writer.NewStatsWriter(conf, statsChan, telemetryCollector, statsd, timing),
+		StatsWriter:           statsWriter,
 		obfuscator:            obfuscate.NewObfuscator(oconf),
 		In:                    in,
 		conf:                  conf,
@@ -158,7 +175,6 @@ func (a *Agent) Run() {
 		starter.Start()
 	}
 
-	go a.TraceWriter.Run()
 	go a.StatsWriter.Run()
 
 	// Having GOMAXPROCS/2 processor threads is
@@ -177,7 +193,7 @@ func (a *Agent) Run() {
 	a.loop()
 }
 
-// FlushSync flushes traces sychronously. This method only works when the agent is configured in synchronous flushing
+// FlushSync flushes traces synchronously. This method only works when the agent is configured in synchronous flushing
 // mode via the apm_config.sync_flush option.
 func (a *Agent) FlushSync() {
 	if !a.conf.SynchronousFlushing {
@@ -336,7 +352,7 @@ func (a *Agent) Process(p *api.Payload) {
 		a.setRootSpanTags(root)
 		if !p.ClientComputedTopLevel {
 			// Figure out the top-level spans now as it involves modifying the Metrics map
-			// which is not thread-safe while samplers and Concentrator might modify it too.
+			// which is not thread-safe while samplers and concentrator might modify it too.
 			traceutil.ComputeTopLevel(chunk.Spans)
 		}
 
@@ -372,17 +388,17 @@ func (a *Agent) Process(p *api.Payload) {
 			sampledChunks.TracerPayload = p.TracerPayload.Cut(i)
 			i = 0
 			sampledChunks.TracerPayload.Chunks = newChunksArray(sampledChunks.TracerPayload.Chunks)
-			a.TraceWriter.In <- sampledChunks
+			a.TraceWriter.WriteChunks(sampledChunks)
 			sampledChunks = new(writer.SampledChunks)
 		}
 	}
 	sampledChunks.TracerPayload = p.TracerPayload
 	sampledChunks.TracerPayload.Chunks = newChunksArray(p.TracerPayload.Chunks)
 	if sampledChunks.Size > 0 {
-		a.TraceWriter.In <- sampledChunks
+		a.TraceWriter.WriteChunks(sampledChunks)
 	}
 	if len(statsInput.Traces) > 0 {
-		a.Concentrator.In <- statsInput
+		a.Concentrator.Add(statsInput)
 	}
 }
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
@@ -39,19 +42,53 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 func NewTestAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector telemetry.TelemetryCollector) *Agent {
 	a := NewAgent(ctx, conf, telemetryCollector, &statsd.NoOpClient{})
-	a.TraceWriter.In = make(chan *writer.SampledChunks, 1000)
-	a.Concentrator.In = make(chan stats.Input, 1000)
+	a.Concentrator = &mockConcentrator{}
+	a.TraceWriter = &mockTraceWriter{}
 	return a
+}
+
+type mockTraceWriter struct {
+	mu       sync.Mutex
+	payloads []*writer.SampledChunks
+}
+
+func (m *mockTraceWriter) Stop() {}
+
+func (m *mockTraceWriter) WriteChunks(pkg *writer.SampledChunks) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.payloads = append(m.payloads, pkg)
+}
+
+func (m *mockTraceWriter) FlushSync() error {
+	panic("not implemented")
+}
+
+type mockConcentrator struct {
+	stats []stats.Input
+	mu    sync.Mutex
+}
+
+func (c *mockConcentrator) Start() {}
+func (c *mockConcentrator) Stop()  {}
+func (c *mockConcentrator) Add(t stats.Input) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stats = append(c.stats, t)
+}
+func (c *mockConcentrator) Reset() []stats.Input {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := c.stats
+	c.stats = nil
+	return ret
 }
 
 // Test to make sure that the joined effort of the quantizer and truncator, in that order, produce the
@@ -292,13 +329,9 @@ func TestProcess(t *testing.T) {
 		})
 		assert.EqualValues(1, want.TracesFiltered.Load())
 		assert.EqualValues(2, want.SpansFiltered.Load())
-		var span *pb.Span
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			span = ss.TracerPayload.Chunks[0].Spans[0]
-		case <-time.After(2 * time.Second):
-			t.Fatal("timeout: Expected one valid trace, but none were received.")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(payloads, "no payloads were written")
+		span := payloads[0].TracerPayload.Chunks[0].Spans[0]
 		assert.Equal("unnamed_operation", span.Name)
 	})
 
@@ -369,18 +402,13 @@ func TestProcess(t *testing.T) {
 			Start:    time.Now().Add(-time.Second).UnixNano(),
 			Duration: (500 * time.Millisecond).Nanoseconds(),
 		}, 2))
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
-		timeout := time.After(2 * time.Second)
-		var span *pb.Span
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			span = ss.TracerPayload.Chunks[0].Spans[0]
-		case <-timeout:
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		span := payloads[0].TracerPayload.Chunks[0].Spans[0]
 		assert.Equal(t, "unnamed_operation", span.Name)
 		assert.Equal(t, "something_that_should_be_a_metric", span.Service)
 	})
@@ -395,17 +423,13 @@ func TestProcess(t *testing.T) {
 		tp := testutil.TracerPayloadWithChunk(testutil.RandomTraceChunk(1, 1))
 		tp.Chunks[0].Priority = int32(sampler.PriorityUserKeep)
 		tp.Chunks[0].Spans[0].Meta["_dd.hostname"] = "tracer-hostname"
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
-		timeout := time.After(2 * time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			tp = ss.TracerPayload
-		case <-timeout:
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		tp = payloads[0].TracerPayload
 		assert.Equal(t, "tracer-hostname", tp.Hostname)
 	})
 
@@ -416,21 +440,18 @@ func TestProcess(t *testing.T) {
 		cfg.Endpoints[0].APIKey = "test"
 		ctx, cancel := context.WithCancel(context.Background())
 		agnt := NewAgent(ctx, cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{})
+		agnt.TraceWriter = &mockTraceWriter{}
 		defer cancel()
 
 		tp := testutil.TracerPayloadWithChunk(testutil.RandomTraceChunk(1, 1))
 		tp.Chunks[0].Priority = int32(sampler.PriorityUserKeep)
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
-		timeout := time.After(2 * time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			tp = ss.TracerPayload
-		case <-timeout:
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		tp = payloads[0].TracerPayload
 
 		for _, chunk := range tp.Chunks {
 			for _, span := range chunk.Spans {
@@ -468,20 +489,16 @@ func TestProcess(t *testing.T) {
 		c.Priority = 1
 		tp := testutil.TracerPayloadWithChunk(c)
 
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
-
-		timeout := time.After(2 * time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			assert.Equal(t, 2, int(ss.SpanCount))
-			assert.NotContains(t, ss.TracerPayload.Chunks[0].Spans[0].Meta, "irrelevant")
-			assert.NotContains(t, ss.TracerPayload.Chunks[0].Spans[1].Meta, "irrelevant")
-		case <-timeout:
-			t.Fatal("timed out")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		payload := payloads[0]
+		assert.Equal(t, 2, int(payload.SpanCount))
+		assert.NotContains(t, payload.TracerPayload.Chunks[0].Spans[0].Meta, "irrelevant")
+		assert.NotContains(t, payload.TracerPayload.Chunks[0].Spans[1].Meta, "irrelevant")
 	})
 
 	t.Run("chunking", func(t *testing.T) {
@@ -507,26 +524,14 @@ func TestProcess(t *testing.T) {
 		defer func(oldSize int) { writer.MaxPayloadSize = oldSize }(writer.MaxPayloadSize)
 		//minChunkSize := int(math.Min(math.Min(float64(tp.Chunks[0].Msgsize()), float64(tp.Chunks[1].Msgsize())), float64(tp.Chunks[2].Msgsize())))
 		writer.MaxPayloadSize = 1
-		// and expecting it to result in 3 payloads
-		expectedPayloads := 3
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload: tp,
 			Source:        agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 		})
 
-		var gotCount int
-		timeout := time.After(3 * time.Second)
-		// expect multiple payloads
-		for i := 0; i < expectedPayloads; i++ {
-			select {
-			case ss := <-agnt.TraceWriter.In:
-				gotCount += int(ss.SpanCount)
-			case <-timeout:
-				t.Fatal("timed out")
-			}
-		}
-		// without missing a trace
-		assert.Equal(t, gotCount, 3)
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		// and expecting it to result in 3 payloads
+		assert.Len(t, payloads, 3)
 	})
 }
 
@@ -732,18 +737,19 @@ func TestConcentratorInput(t *testing.T) {
 			agent := NewTestAgent(context.TODO(), cfg, telemetry.NewNoopCollector())
 			tc.in.Source = agent.Receiver.Stats.GetTagStats(info.Tags{})
 			agent.Process(tc.in)
+			mco := agent.Concentrator.(*mockConcentrator)
 
 			if len(tc.expected.Traces) == 0 {
-				assert.Len(t, agent.Concentrator.In, 0)
+				assert.Len(t, mco.stats, 0)
 				return
 			}
-			require.Len(t, agent.Concentrator.In, 1)
-			assert.Equal(t, tc.expected, <-agent.Concentrator.In)
+			require.Len(t, mco.stats, 1)
+			assert.Equal(t, tc.expected, mco.stats[0])
 
 			if tc.expectedSampled != nil && len(tc.expectedSampled.Chunks) > 0 {
-				require.Len(t, agent.TraceWriter.In, 1)
-				ss := <-agent.TraceWriter.In
-				assert.Equal(t, tc.expectedSampled, ss.TracerPayload)
+				payloads := agent.TraceWriter.(*mockTraceWriter).payloads
+				assert.NotEmpty(t, payloads, "no payloads were written")
+				assert.Equal(t, tc.expectedSampled, payloads[0].TracerPayload)
 			}
 		})
 	}
@@ -753,50 +759,42 @@ func TestClientComputedTopLevel(t *testing.T) {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
 	ctx, cancel := context.WithCancel(context.Background())
-	agnt := NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())
 	defer cancel()
 
 	t.Run("onNotTop", func(t *testing.T) {
+		agnt := NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())
 		chunk := testutil.TraceChunkWithSpan(testutil.RandomSpan())
 		chunk.Priority = 2
 		tp := testutil.TracerPayloadWithChunk(chunk)
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload:          tp,
 			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedTopLevel: true,
 		})
-		timeout := time.After(time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			_, ok := ss.TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
-			assert.False(t, ok)
-			return
-		case <-timeout:
-			t.Fatal("timed out waiting for input")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		_, ok := payloads[0].TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
+		assert.False(t, ok)
 	})
 
 	t.Run("off", func(t *testing.T) {
+		agnt := NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())
 		chunk := testutil.TraceChunkWithSpan(testutil.RandomSpan())
 		chunk.Priority = 2
 		tp := testutil.TracerPayloadWithChunk(chunk)
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload:          tp,
 			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedTopLevel: false,
 		})
-		timeout := time.After(time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			_, ok := ss.TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
-			assert.True(t, ok)
-			return
-		case <-timeout:
-			t.Fatal("timed out waiting for input")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		_, ok := payloads[0].TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
+		assert.True(t, ok)
 	})
 
 	t.Run("onTop", func(t *testing.T) {
+		agnt := NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())
 		span := testutil.RandomSpan()
 		span.Metrics = map[string]float64{
 			"_dd.top_level": 1,
@@ -804,22 +802,17 @@ func TestClientComputedTopLevel(t *testing.T) {
 		chunk := testutil.TraceChunkWithSpan(span)
 		chunk.Priority = 2
 		tp := testutil.TracerPayloadWithChunk(chunk)
-		go agnt.Process(&api.Payload{
+		agnt.Process(&api.Payload{
 			TracerPayload:          tp,
 			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedTopLevel: true,
 		})
-		timeout := time.After(time.Second)
-		select {
-		case ss := <-agnt.TraceWriter.In:
-			_, ok := ss.TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
-			assert.True(t, ok)
-			_, ok = ss.TracerPayload.Chunks[0].Spans[0].Metrics["_dd.top_level"]
-			assert.True(t, ok)
-			return
-		case <-timeout:
-			t.Fatal("timed out waiting for input")
-		}
+		payloads := agnt.TraceWriter.(*mockTraceWriter).payloads
+		assert.NotEmpty(t, payloads, "no payloads were written")
+		_, ok := payloads[0].TracerPayload.Chunks[0].Spans[0].Metrics["_top_level"]
+		assert.True(t, ok)
+		_, ok = payloads[0].TracerPayload.Chunks[0].Spans[0].Metrics["_dd.top_level"]
+		assert.True(t, ok)
 	})
 }
 
@@ -1033,7 +1026,8 @@ func TestClientComputedStats(t *testing.T) {
 			Source:              agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedStats: true,
 		})
-		assert.Len(t, agnt.Concentrator.In, 0)
+		mco := agnt.Concentrator.(*mockConcentrator)
+		assert.Len(t, mco.stats, 0)
 	})
 
 	t.Run("off", func(t *testing.T) {
@@ -1042,7 +1036,8 @@ func TestClientComputedStats(t *testing.T) {
 			Source:              agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedStats: false,
 		})
-		assert.Len(t, agnt.Concentrator.In, 1)
+		mco := agnt.Concentrator.(*mockConcentrator)
+		assert.Len(t, mco.stats, 1)
 	})
 }
 
@@ -1384,13 +1379,11 @@ func TestSampleManualUserDropNoAnalyticsEvents(t *testing.T) {
 
 func TestPartialSamplingFree(t *testing.T) {
 	cfg := &config.AgentConfig{RareSamplerEnabled: false, BucketInterval: 10 * time.Second}
-	statsChan := make(chan *pb.StatsPayload, 100)
-	writerChan := make(chan *writer.SampledChunks, 100)
 	dynConf := sampler.NewDynamicConfig()
 	in := make(chan *api.Payload, 1000)
 	statsd := &statsd.NoOpClient{}
 	agnt := &Agent{
-		Concentrator:      stats.NewConcentrator(cfg, statsChan, time.Now(), statsd),
+		Concentrator:      &mockConcentrator{},
 		Blacklister:       filters.NewBlacklister(cfg.Ignore["resource"]),
 		Replacer:          filters.NewReplacer(cfg.ReplaceTags),
 		NoPrioritySampler: sampler.NewNoPrioritySampler(cfg, statsd),
@@ -1398,7 +1391,7 @@ func TestPartialSamplingFree(t *testing.T) {
 		PrioritySampler:   sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}, statsd),
 		EventProcessor:    newEventProcessor(cfg, statsd),
 		RareSampler:       sampler.NewRareSampler(config.New(), statsd),
-		TraceWriter:       &writer.TraceWriter{In: writerChan},
+		TraceWriter:       &mockTraceWriter{},
 		conf:              cfg,
 		Timing:            &timing.NoopReporter{},
 	}
@@ -1452,14 +1445,13 @@ func TestPartialSamplingFree(t *testing.T) {
 	runtime.ReadMemStats(&m)
 	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
 
-	<-agnt.Concentrator.In
+	agnt.Concentrator.(*mockConcentrator).Reset()
 	// big chunk should be cleaned as unsampled and passed through stats
 	runtime.GC()
 	runtime.ReadMemStats(&m)
 	assert.Less(t, m.HeapInuse, uint64(50*1e6))
 
-	p := <-agnt.TraceWriter.In
-	assert.Len(t, p.TracerPayload.Chunks, 1)
+	assert.Len(t, agnt.TraceWriter.(*mockTraceWriter).payloads, 1)
 }
 
 func TestEventProcessorFromConf(t *testing.T) {
@@ -1573,6 +1565,7 @@ func testEventProcessorFromConf(t *testing.T, conf *config.AgentConfig, testCase
 // second). These spans will all have the provided service and operation names and be set as extractable/sampled
 // based on the associated rate/%. This traffic generation will run for the specified `duration`.
 func generateTraffic(processor *event.Processor, serviceName string, operationName string, extractionRate float64,
+
 	duration time.Duration, intakeSPS float64, priority sampler.SamplingPriority) float64 {
 	tickerInterval := 100 * time.Millisecond
 	totalSampled := 0
@@ -1583,6 +1576,7 @@ func generateTraffic(processor *event.Processor, serviceName string, operationNa
 	spansPerTick := int(math.Round(intakeSPS / numTicksInSecond))
 
 Loop:
+
 	for {
 		spans := make([]*pb.Span, spansPerTick)
 		for i := range spans {
@@ -1634,6 +1628,7 @@ func BenchmarkAgentTraceProcessingWithFiltering(b *testing.B) {
 
 // worst case scenario: spans are tested against multiple rules without any match.
 // this means we won't compesate the overhead of TestFilteredByTagsing by dropping traces
+
 func BenchmarkAgentTraceProcessingWithWorstCaseFiltering(b *testing.B) {
 	c := config.New()
 	c.Endpoints[0].APIKey = "test"
@@ -1695,6 +1690,20 @@ func BenchmarkThroughput(b *testing.B) {
 	})
 }
 
+type noopTraceWriter struct {
+	count int
+}
+
+func (n *noopTraceWriter) Run() {}
+
+func (n *noopTraceWriter) Stop() {}
+
+func (n *noopTraceWriter) WriteChunks(_ *writer.SampledChunks) {
+	n.count++
+}
+
+func (n *noopTraceWriter) FlushSync() error { return nil }
+
 func benchThroughput(file string) func(*testing.B) {
 	return func(b *testing.B) {
 		data, count, err := tracesFromFile(file)
@@ -1712,7 +1721,8 @@ func benchThroughput(file string) func(*testing.B) {
 		// start the agent without the trace and stats writers; we will be draining
 		// these channels ourselves in the benchmarks, plus we don't want the writers
 		// resource usage to show up in the results.
-		agnt.TraceWriter.In = make(chan *writer.SampledChunks)
+		noopWriter := &noopTraceWriter{}
+		agnt.TraceWriter = noopWriter
 		go agnt.Run()
 
 		// wait for receiver to start:
@@ -1727,19 +1737,6 @@ func benchThroughput(file string) func(*testing.B) {
 				break
 			}
 		}
-
-		// drain every other channel to avoid blockage.
-		exit := make(chan bool)
-		go func() {
-			defer close(exit)
-			for {
-				select {
-				case <-agnt.Concentrator.Out:
-				case <-exit:
-					return
-				}
-			}
-		}()
 
 		b.ResetTimer()
 		b.SetBytes(int64(len(data)))
@@ -1766,22 +1763,17 @@ func benchThroughput(file string) func(*testing.B) {
 		loop:
 			for {
 				select {
-				case <-agnt.TraceWriter.In:
-					got++
-					if got == count {
+				default:
+					if noopWriter.count == count {
 						// processed everything!
 						break loop
 					}
 				case <-timeout:
 					// taking too long...
 					b.Fatalf("time out at %d/%d", got, count)
-					break loop
 				}
 			}
 		}
-
-		exit <- true
-		<-exit
 	}
 }
 
@@ -2308,10 +2300,12 @@ func TestSpanSampling(t *testing.T) {
 				// a nil Source would trigger a panic
 				Source: traceAgent.Receiver.Stats.GetTagStats(info.Tags{}),
 			})
-			assert.Len(t, traceAgent.TraceWriter.In, 1)
-			sampledChunks := <-traceAgent.TraceWriter.In
+			assert.Len(t, traceAgent.TraceWriter.(*mockTraceWriter).payloads, 1)
+			sampledChunks := traceAgent.TraceWriter.(*mockTraceWriter).payloads[0]
 			tc.checks(t, tc.payload, sampledChunks.TracerPayload.Chunks)
-			stats := <-traceAgent.Concentrator.In
+			mco := traceAgent.Concentrator.(*mockConcentrator)
+			require.Len(t, mco.stats, 1)
+			stats := mco.stats[0]
 			assert.Equal(t, len(tc.payload.Chunks[0].Spans), len(stats.Traces[0].TraceChunk.Spans))
 		})
 	}

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -6,11 +6,13 @@
 package stats
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/runtime/protoiface"
 
 	proto "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -27,10 +29,33 @@ func newTestAggregator() *ClientStatsAggregator {
 		DefaultEnv: "agentEnv",
 		Hostname:   "agentHostname",
 	}
-	a := NewClientStatsAggregator(conf, make(chan *proto.StatsPayload, 100), &statsd.NoOpClient{})
+	a := NewClientStatsAggregator(conf, noopStatsWriter{}, &statsd.NoOpClient{})
 	a.Start()
 	a.flushTicker.Stop()
 	return a
+}
+
+type noopStatsWriter struct{}
+
+func (noopStatsWriter) Add(*proto.StatsPayload) {}
+
+type mockStatsWriter struct {
+	payloads []*proto.StatsPayload
+	mu       sync.Mutex
+}
+
+func (w *mockStatsWriter) Add(p *proto.StatsPayload) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.payloads = append(w.payloads, p)
+}
+
+func (w *mockStatsWriter) Reset() []*proto.StatsPayload {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	ret := w.payloads
+	w.payloads = nil
+	return ret
 }
 
 func wrapPayload(p *proto.ClientStatsPayload) *proto.StatsPayload {
@@ -150,17 +175,20 @@ func agg2Counts(insertionTime time.Time, p *proto.ClientStatsPayload) *proto.Cli
 func TestAggregatorFlushTime(t *testing.T) {
 	assert := assert.New(t)
 	a := newTestAggregator()
+	msw := &mockStatsWriter{}
+	a.out = msw
 	testTime := time.Now()
 	a.flushOnTime(testTime)
-	assert.Len(a.out, 0)
+	assert.Len(msw.payloads, 0)
 	testPayload := getTestStatsWithStart(testTime)
 	a.add(testTime, deepCopy(testPayload))
 	a.flushOnTime(testTime)
-	assert.Len(a.out, 0)
+	assert.Len(msw.payloads, 0)
 	a.flushOnTime(testTime.Add(oldestBucketStart - bucketDuration))
-	assert.Len(a.out, 0)
+	assert.Len(msw.payloads, 0)
 	a.flushOnTime(testTime.Add(oldestBucketStart))
-	s := <-a.out
+	require.NotEmpty(t, msw.payloads)
+	s := msw.payloads[0]
 	assert.Equal(s.String(), wrapPayload(testPayload).String())
 	assert.Len(a.buckets, 0)
 }
@@ -169,6 +197,8 @@ func TestMergeMany(t *testing.T) {
 	assert := assert.New(t)
 	for i := 0; i < 10; i++ {
 		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.out = msw
 		payloadTime := time.Now().Truncate(bucketDuration)
 		merge1 := getTestStatsWithStart(payloadTime)
 		merge2 := getTestStatsWithStart(payloadTime.Add(time.Nanosecond))
@@ -180,16 +210,16 @@ func TestMergeMany(t *testing.T) {
 		a.add(insertionTime, deepCopy(merge2))
 		a.add(insertionTime, deepCopy(other))
 		a.add(insertionTime, deepCopy(merge3))
-		assert.Len(a.out, 2)
+		assert.Len(msw.payloads, 2)
 		a.flushOnTime(payloadTime.Add(oldestBucketStart - time.Nanosecond))
-		assert.Len(a.out, 3)
+		assert.Len(msw.payloads, 3)
 		a.flushOnTime(payloadTime.Add(oldestBucketStart))
-		assert.Len(a.out, 4)
-		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{merge1, merge2}), <-a.out)
-		assertDistribPayload(t, wrapPayload(merge3), <-a.out)
-		s := <-a.out
+		assert.Len(msw.payloads, 4)
+		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{merge1, merge2}), msw.payloads[0])
+		assertDistribPayload(t, wrapPayload(merge3), msw.payloads[1])
+		s := msw.payloads[2]
 		assert.Equal(wrapPayload(other).String(), s.String())
-		assertAggCountsPayload(t, <-a.out)
+		assertAggCountsPayload(t, msw.payloads[3])
 		assert.Len(a.buckets, 0)
 	}
 }
@@ -227,18 +257,20 @@ func TestTimeShifts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 			a := newTestAggregator()
+			msw := &mockStatsWriter{}
+			a.out = msw
 			agentTime := alignAggTs(time.Now())
 			payloadTime := agentTime.Add(tc.shift)
 
 			stats := getTestStatsWithStart(payloadTime)
 			a.add(agentTime, deepCopy(stats))
 			a.flushOnTime(agentTime)
-			assert.Len(a.out, 0)
+			assert.Len(msw.payloads, 0)
 			a.flushOnTime(agentTime.Add(oldestBucketStart + time.Nanosecond))
-			assert.Len(a.out, 1)
+			require.Len(t, msw.payloads, 1)
 			stats.Stats[0].AgentTimeShift = -tc.expectedShift.Nanoseconds()
 			stats.Stats[0].Start -= uint64(tc.expectedShift.Nanoseconds())
-			s := <-a.out
+			s := msw.payloads[0]
 			assert.Equal(wrapPayload(stats).String(), s.String())
 		})
 	}
@@ -248,6 +280,8 @@ func TestFuzzCountFields(t *testing.T) {
 	assert := assert.New(t)
 	for i := 0; i < 30; i++ {
 		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.out = msw
 		// Ensure that peer tags aggregation is on. Some tests may expect non-empty values the peer tags.
 		a.peerTagsAggregation = true
 		payloadTime := time.Now().Truncate(bucketDuration)
@@ -256,11 +290,11 @@ func TestFuzzCountFields(t *testing.T) {
 		insertionTime := payloadTime.Add(time.Second)
 		a.add(insertionTime, deepCopy(merge1))
 		a.add(insertionTime, deepCopy(merge1))
-		assert.Len(a.out, 1)
+		assert.Len(msw.payloads, 1)
 		a.flushOnTime(payloadTime.Add(oldestBucketStart))
-		assert.Len(a.out, 2)
-		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{deepCopy(merge1), deepCopy(merge1)}), <-a.out)
-		aggCounts := <-a.out
+		require.Len(t, msw.payloads, 2)
+		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{deepCopy(merge1), deepCopy(merge1)}), msw.payloads[0])
+		aggCounts := msw.payloads[1]
 		expectedAggCounts := wrapPayload(agg2Counts(insertionTime, merge1))
 
 		// map gives random orders post aggregation
@@ -330,6 +364,8 @@ func TestCountAggregation(t *testing.T) {
 	for _, tc := range tts {
 		t.Run(tc.name, func(t *testing.T) {
 			a := newTestAggregator()
+			msw := &mockStatsWriter{}
+			a.out = msw
 			testTime := time.Unix(time.Now().Unix(), 0)
 
 			c1 := payloadWithCounts(testTime, tc.k, "", "test-version", "", "", 11, 7, 100)
@@ -338,19 +374,19 @@ func TestCountAggregation(t *testing.T) {
 			keyDefault := BucketsAggregationKey{}
 			cDefault := payloadWithCounts(testTime, keyDefault, "", "test-version", "", "", 0, 2, 4)
 
-			assert.Len(a.out, 0)
+			assert.Len(msw.payloads, 0)
 			a.add(testTime, deepCopy(c1))
 			a.add(testTime, deepCopy(c2))
 			a.add(testTime, deepCopy(c3))
 			a.add(testTime, deepCopy(cDefault))
-			assert.Len(a.out, 3)
+			assert.Len(msw.payloads, 3)
 			a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
-			assert.Len(a.out, 4)
+			require.Len(t, msw.payloads, 4)
 
-			assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), <-a.out)
-			assertDistribPayload(t, wrapPayload(c3), <-a.out)
-			assertDistribPayload(t, wrapPayload(cDefault), <-a.out)
-			aggCounts := <-a.out
+			assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), msw.payloads[0])
+			assertDistribPayload(t, wrapPayload(c3), msw.payloads[1])
+			assertDistribPayload(t, wrapPayload(cDefault), msw.payloads[2])
+			aggCounts := msw.payloads[3]
 			assertAggCountsPayload(t, aggCounts)
 
 			tc.res.Hits = 43
@@ -399,6 +435,8 @@ func TestCountAggregationPeerTags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 			a := newTestAggregator()
+			msw := &mockStatsWriter{}
+			a.out = msw
 			a.peerTagsAggregation = tc.enablePeerTagsAgg
 			testTime := time.Unix(time.Now().Unix(), 0)
 
@@ -411,19 +449,19 @@ func TestCountAggregationPeerTags(t *testing.T) {
 			keyDefault := BucketsAggregationKey{}
 			cDefault := payloadWithCounts(testTime, keyDefault, "", "test-version", "", "", 0, 2, 4)
 
-			assert.Len(a.out, 0)
+			assert.Len(msw.payloads, 0)
 			a.add(testTime, deepCopy(c1))
 			a.add(testTime, deepCopy(c2))
 			a.add(testTime, deepCopy(c3))
 			a.add(testTime, deepCopy(cDefault))
-			assert.Len(a.out, 3)
+			assert.Len(msw.payloads, 3)
 			a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
-			assert.Len(a.out, 4)
+			require.Len(t, msw.payloads, 4)
 
-			assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), <-a.out)
-			assertDistribPayload(t, wrapPayload(c3), <-a.out)
-			assertDistribPayload(t, wrapPayload(cDefault), <-a.out)
-			aggCounts := <-a.out
+			assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), msw.payloads[0])
+			assertDistribPayload(t, wrapPayload(c3), msw.payloads[1])
+			assertDistribPayload(t, wrapPayload(cDefault), msw.payloads[2])
+			aggCounts := msw.payloads[3]
 			assertAggCountsPayload(t, aggCounts)
 
 			tc.res.Hits = 43
@@ -449,6 +487,8 @@ func TestAggregationVersionData(t *testing.T) {
 	t.Run("all version data provided in payload", func(t *testing.T) {
 		assert := assert.New(t)
 		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.out = msw
 		testTime := time.Unix(time.Now().Unix(), 0)
 
 		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
@@ -458,19 +498,19 @@ func TestAggregationVersionData(t *testing.T) {
 		keyDefault := BucketsAggregationKey{}
 		cDefault := payloadWithCounts(testTime, keyDefault, "1", "test-version", "abc", "abc123", 0, 2, 4)
 
-		assert.Len(a.out, 0)
+		assert.Len(msw.payloads, 0)
 		a.add(testTime, deepCopy(c1))
 		a.add(testTime, deepCopy(c2))
 		a.add(testTime, deepCopy(c3))
 		a.add(testTime, deepCopy(cDefault))
-		assert.Len(a.out, 3)
+		assert.Len(msw.payloads, 3)
 		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
-		assert.Len(a.out, 4)
+		require.Len(t, msw.payloads, 4)
 
-		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), <-a.out)
-		assertDistribPayload(t, wrapPayload(c3), <-a.out)
-		assertDistribPayload(t, wrapPayload(cDefault), <-a.out)
-		aggCounts := <-a.out
+		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), msw.payloads[0])
+		assertDistribPayload(t, wrapPayload(c3), msw.payloads[1])
+		assertDistribPayload(t, wrapPayload(cDefault), msw.payloads[2])
+		aggCounts := msw.payloads[3]
 		assertAggCountsPayload(t, aggCounts)
 
 		expectedRes := &proto.ClientGroupedStats{
@@ -499,6 +539,8 @@ func TestAggregationVersionData(t *testing.T) {
 	t.Run("git commit sha and image tag come from container tags", func(t *testing.T) {
 		assert := assert.New(t)
 		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.out = msw
 		cfg := config.New()
 		cfg.ContainerTags = func(cid string) ([]string, error) {
 			return []string{"git.commit.sha:sha-from-container-tags", "image_tag:image-tag-from-container-tags"}, nil
@@ -513,14 +555,14 @@ func TestAggregationVersionData(t *testing.T) {
 		keyDefault := BucketsAggregationKey{}
 		cDefault := payloadWithCounts(testTime, keyDefault, "1", "", "", "", 0, 2, 4)
 
-		assert.Len(a.out, 0)
+		assert.Len(msw.payloads, 0)
 		a.add(testTime, deepCopy(c1))
 		a.add(testTime, deepCopy(c2))
 		a.add(testTime, deepCopy(c3))
 		a.add(testTime, deepCopy(cDefault))
-		assert.Len(a.out, 3)
+		assert.Len(msw.payloads, 3)
 		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
-		assert.Len(a.out, 4)
+		require.Len(t, msw.payloads, 4)
 
 		// Add the expected gitCommitSha and imageTag on c1, c2, c3, and cDefault for these assertions.
 		c1.GitCommitSha = "sha-from-container-tags"
@@ -531,10 +573,10 @@ func TestAggregationVersionData(t *testing.T) {
 		c3.ImageTag = "image-tag-from-container-tags"
 		cDefault.GitCommitSha = "sha-from-container-tags"
 		cDefault.ImageTag = "image-tag-from-container-tags"
-		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), <-a.out)
-		assertDistribPayload(t, wrapPayload(c3), <-a.out)
-		assertDistribPayload(t, wrapPayload(cDefault), <-a.out)
-		aggCounts := <-a.out
+		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), msw.payloads[0])
+		assertDistribPayload(t, wrapPayload(c3), msw.payloads[1])
+		assertDistribPayload(t, wrapPayload(cDefault), msw.payloads[2])
+		aggCounts := msw.payloads[3]
 		assertAggCountsPayload(t, aggCounts)
 
 		expectedRes := &proto.ClientGroupedStats{
@@ -563,6 +605,8 @@ func TestAggregationVersionData(t *testing.T) {
 	t.Run("payload git commit sha and image tag override container tags", func(t *testing.T) {
 		assert := assert.New(t)
 		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.out = msw
 		cfg := config.New()
 		cfg.ContainerTags = func(cid string) ([]string, error) {
 			return []string{"git.commit.sha:overrideThisSha", "image_tag:overrideThisImageTag"}, nil
@@ -577,19 +621,19 @@ func TestAggregationVersionData(t *testing.T) {
 		keyDefault := BucketsAggregationKey{}
 		cDefault := payloadWithCounts(testTime, keyDefault, "1", "test-version", "abc", "abc123", 0, 2, 4)
 
-		assert.Len(a.out, 0)
+		assert.Len(msw.payloads, 0)
 		a.add(testTime, deepCopy(c1))
 		a.add(testTime, deepCopy(c2))
 		a.add(testTime, deepCopy(c3))
 		a.add(testTime, deepCopy(cDefault))
-		assert.Len(a.out, 3)
+		assert.Len(msw.payloads, 3)
 		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
-		assert.Len(a.out, 4)
+		require.Len(t, msw.payloads, 4)
 
-		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), <-a.out)
-		assertDistribPayload(t, wrapPayload(c3), <-a.out)
-		assertDistribPayload(t, wrapPayload(cDefault), <-a.out)
-		aggCounts := <-a.out
+		assertDistribPayload(t, wrapPayloads([]*proto.ClientStatsPayload{c1, c2}), msw.payloads[0])
+		assertDistribPayload(t, wrapPayload(c3), msw.payloads[1])
+		assertDistribPayload(t, wrapPayload(cDefault), msw.payloads[2])
+		aggCounts := msw.payloads[3]
 		assertAggCountsPayload(t, aggCounts)
 
 		expectedRes := &proto.ClientGroupedStats{

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -29,14 +30,13 @@ var (
 )
 
 func NewTestConcentrator(now time.Time) *Concentrator {
-	statsChan := make(chan *pb.StatsPayload)
 	cfg := config.AgentConfig{
 		BucketInterval: time.Duration(testBucketInterval),
 		AgentVersion:   "0.99.0",
 		DefaultEnv:     "env",
 		Hostname:       "hostname",
 	}
-	return NewConcentrator(&cfg, statsChan, now, &statsd.NoOpClient{})
+	return NewConcentrator(&cfg, noopStatsWriter{}, now, &statsd.NoOpClient{})
 }
 
 // getTsInBucket gives a timestamp in ns which is `offset` buckets late

--- a/pkg/trace/testutil/span.go
+++ b/pkg/trace/testutil/span.go
@@ -362,7 +362,7 @@ func RandomSpan() *pb.Span {
 }
 
 // GetTestSpan returns a Span with different fields set
-func GetTestSpan() *pb.Span {
+func GetTestSpan(metacount, metanamesize, metavalsize int) *pb.Span {
 	span := &pb.Span{
 		TraceID:  42,
 		SpanID:   52,
@@ -389,9 +389,21 @@ func GetTestSpan() *pb.Span {
 			},
 		},
 	}
+	for i := 0; i < metacount; i++ {
+		span.Meta[randString(metanamesize)] = randString(metavalsize)
+		span.Metrics[randString(metanamesize)] = rand.Float64()
+	}
 	trace := pb.Trace{span}
 	traceutil.ComputeTopLevel(trace)
 	return trace[0]
+}
+
+func randString(n int) string {
+	bs := make([]rune, n)
+	for i := 0; i < n; i++ {
+		bs[i] = rune(rand.Intn(94) + 33) // interval [33, 127), printable ascii characters
+	}
+	return string(bs)
 }
 
 // TestSpan returns a fix span with hardcoded info, useful for reproducible tests

--- a/pkg/trace/testutil/trace.go
+++ b/pkg/trace/testutil/trace.go
@@ -100,6 +100,10 @@ func RandomTraceChunk(maxLevels, maxSpans int) *pb.TraceChunk {
 // GetTestTraces returns a []Trace that is composed by “traceN“ number
 // of traces, each one composed by “size“ number of spans.
 func GetTestTraces(traceN, size int, realisticIDs bool) pb.Traces {
+	return GetTestTracesWithMeta(traceN, size, 0, 0, 0, realisticIDs)
+}
+
+func GetTestTracesWithMeta(traceN, size, metacount, metanamesize, metavalsize int, realisticIDs bool) pb.Traces {
 	traces := pb.Traces{}
 
 	r := rand.New(rand.NewSource(42))
@@ -112,7 +116,7 @@ func GetTestTraces(traceN, size int, realisticIDs bool) pb.Traces {
 
 		trace := pb.Trace{}
 		for j := 0; j < size; j++ {
-			span := GetTestSpan()
+			span := GetTestSpan(metacount, metanamesize, metavalsize)
 			if realisticIDs {
 				// Need to have different span IDs else traces are rejected
 				// because they are not correct (indeed, a trace with several

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -63,7 +63,7 @@ func assertPayload(assert *assert.Assertions, testSets []*pb.StatsPayload, paylo
 func TestStatsWriter(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		assert := assert.New(t)
-		sw, statsChannel, srv := testStatsWriter()
+		sw, srv := testStatsWriter()
 		go sw.Run()
 
 		testSets := []*pb.StatsPayload{
@@ -96,15 +96,15 @@ func TestStatsWriter(t *testing.T) {
 				}},
 			},
 		}
-		statsChannel <- testSets[0]
-		statsChannel <- testSets[1]
+		sw.Add(testSets[0])
+		sw.Add(testSets[1])
 		sw.Stop()
 		assertPayload(assert, testSets, srv.Payloads())
 	})
 
 	t.Run("buildPayloads", func(t *testing.T) {
 		assert := assert.New(t)
-		sw, _, _ := testStatsWriter()
+		sw, _ := testStatsWriter()
 		// This gives us a total of 45 entries. 3 per span, 5
 		// spans per stat bucket. Each buckets have the same
 		// time window (start: 0, duration 1e9).
@@ -177,7 +177,7 @@ func TestStatsWriter(t *testing.T) {
 		rand.Seed(1)
 		assert := assert.New(t)
 
-		sw, _, _ := testStatsWriter()
+		sw, _ := testStatsWriter()
 		// This gives us a tota of 45 entries. 3 per span, 5 spans per
 		// stat bucket. Each buckets have the same time window (start:
 		// 0, duration 1e9).
@@ -203,7 +203,7 @@ func TestStatsWriter(t *testing.T) {
 
 	t.Run("container-tags", func(t *testing.T) {
 		assert := assert.New(t)
-		sw, _, _ := testStatsWriter()
+		sw, _ := testStatsWriter()
 		stats := &pb.StatsPayload{
 			AgentHostname: "agenthost",
 			AgentEnv:      "agentenv",
@@ -236,7 +236,7 @@ func TestStatsWriter(t *testing.T) {
 }
 
 func TestStatsResetBuffer(t *testing.T) {
-	w, _, _ := testStatsSyncWriter()
+	w, _ := testStatsSyncWriter()
 
 	runtime.GC()
 	var m runtime.MemStats
@@ -262,7 +262,7 @@ func TestStatsResetBuffer(t *testing.T) {
 func TestStatsSyncWriter(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		assert := assert.New(t)
-		sw, statsChannel, srv := testStatsSyncWriter()
+		sw, srv := testStatsSyncWriter()
 		go sw.Run()
 		testSets := []*pb.StatsPayload{
 			{
@@ -288,8 +288,8 @@ func TestStatsSyncWriter(t *testing.T) {
 				}},
 			},
 		}
-		statsChannel <- testSets[0]
-		statsChannel <- testSets[1]
+		sw.Add(testSets[0])
+		sw.Add(testSets[1])
 		err := sw.FlushSync()
 		assert.Nil(err)
 		assertPayload(assert, testSets, srv.Payloads())
@@ -297,7 +297,7 @@ func TestStatsSyncWriter(t *testing.T) {
 
 	t.Run("stop", func(t *testing.T) {
 		assert := assert.New(t)
-		sw, statsChannel, srv := testStatsSyncWriter()
+		sw, srv := testStatsSyncWriter()
 		go sw.Run()
 
 		testSets := []*pb.StatsPayload{
@@ -324,37 +324,31 @@ func TestStatsSyncWriter(t *testing.T) {
 				}},
 			},
 		}
-		statsChannel <- testSets[0]
-		statsChannel <- testSets[1]
+		sw.Add(testSets[0])
+		sw.Add(testSets[1])
 		sw.Stop()
 		assertPayload(assert, testSets, srv.Payloads())
 	})
 }
 
-func testStatsWriter() (*StatsWriter, chan *pb.StatsPayload, *testServer) {
+func testStatsWriter() (*StatsWriter, *testServer) {
 	srv := newTestServer()
-	// We use a blocking channel to make sure that sends get received on the
-	// other end.
-	in := make(chan *pb.StatsPayload)
 	cfg := &config.AgentConfig{
 		Endpoints:     []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
 		StatsWriter:   &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
 		ContainerTags: func(cid string) ([]string, error) { return nil, nil },
 	}
-	return NewStatsWriter(cfg, in, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}), in, srv
+	return NewStatsWriter(cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}), srv
 }
 
-func testStatsSyncWriter() (*StatsWriter, chan *pb.StatsPayload, *testServer) {
+func testStatsSyncWriter() (*StatsWriter, *testServer) {
 	srv := newTestServer()
-	// We use a blocking channel to make sure that sends get received on the
-	// other end.
-	in := make(chan *pb.StatsPayload)
 	cfg := &config.AgentConfig{
 		Endpoints:           []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
 		StatsWriter:         &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
 		SynchronousFlushing: true,
 	}
-	return NewStatsWriter(cfg, in, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}), in, srv
+	return NewStatsWriter(cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{}), srv
 }
 
 type key struct {

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -171,6 +171,8 @@ func (w *TraceWriter) Stop() {
 	// Wait for encoding/compression to complete on each payload,
 	// and submission to senders
 	w.wg.Wait()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.flush()
 	stopSenders(w.senders)
 }
@@ -188,24 +190,37 @@ func (w *TraceWriter) FlushSync() error {
 	return nil
 }
 
-// WriteChunks writes and serializes the provided chunks
-func (w *TraceWriter) WriteChunks(pkg *SampledChunks) {
-	w.stats.Spans.Add(pkg.SpanCount)
-	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
-	w.stats.Events.Add(pkg.EventCount)
-
+// appendChunks adds sampled chunks to the current payload, and in the case the payload
+// is full, returns a finished payload which needs to be written out.
+func (w *TraceWriter) appendChunks(pkg *SampledChunks) []*pb.TracerPayload {
+	var toflush []*pb.TracerPayload
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	size := pkg.Size
 	if size+w.bufferedSize > MaxPayloadSize {
 		// reached maximum allowed buffered size
-		w.flush()
+		// reset the buffer so we can add our payload and defer a flush.
+		toflush = w.tracerPayloads
+		w.resetBuffer()
 	}
 	if len(pkg.TracerPayload.Chunks) > 0 {
 		log.Tracef("Writer: handling new tracer payload with %d spans: %v", pkg.SpanCount, pkg.TracerPayload)
 		w.tracerPayloads = append(w.tracerPayloads, pkg.TracerPayload)
 	}
 	w.bufferedSize += size
+	return toflush
+}
+
+// WriteChunks writes and serializes the provided chunks
+func (w *TraceWriter) WriteChunks(pkg *SampledChunks) {
+	w.stats.Spans.Add(pkg.SpanCount)
+	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
+	w.stats.Events.Add(pkg.EventCount)
+
+	toflush := w.appendChunks(pkg)
+	if toflush != nil {
+		w.flushPayloads(toflush)
+	}
 }
 
 func (w *TraceWriter) resetBuffer() {
@@ -215,17 +230,23 @@ func (w *TraceWriter) resetBuffer() {
 
 const headerLanguages = "X-Datadog-Reported-Languages"
 
+// w must be locked for a flush.
 func (w *TraceWriter) flush() {
+	defer w.resetBuffer()
+	w.flushPayloads(w.tracerPayloads)
+}
+
+// w does not need to be locked during flushPayloads.
+func (w *TraceWriter) flushPayloads(payloads []*pb.TracerPayload) {
 	w.flushTicker.Reset(w.tick) // reset the flush timer whenever we flush
-	if len(w.tracerPayloads) == 0 {
+	if len(payloads) == 0 {
 		// nothing to do
 		return
 	}
 
 	defer w.timing.Since("datadog.trace_agent.trace_writer.encode_ms", time.Now())
-	defer w.resetBuffer()
 
-	log.Debugf("Serializing %d tracer payloads.", len(w.tracerPayloads))
+	log.Debugf("Serializing %d tracer payloads.", len(payloads))
 	p := pb.AgentPayload{
 		AgentVersion:       w.agentVersion,
 		HostName:           w.hostname,
@@ -233,7 +254,7 @@ func (w *TraceWriter) flush() {
 		TargetTPS:          w.prioritySampler.GetTargetTPS(),
 		ErrorTPS:           w.errorsSampler.GetTargetTPS(),
 		RareSamplerEnabled: w.rareSampler.IsEnabled(),
-		TracerPayloads:     w.tracerPayloads,
+		TracerPayloads:     payloads,
 	}
 	log.Debugf("Reported agent rates: target_tps=%v errors_tps=%v rare_sampling=%v", p.TargetTPS, p.ErrorTPS, p.RareSamplerEnabled)
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -8,7 +8,6 @@ package writer
 import (
 	"compress/gzip"
 	"errors"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -50,15 +49,9 @@ type SampledChunks struct {
 	EventCount int64
 }
 
-// TraceWriter buffers traces and APM events, flushing them to the Datadog API.
+// TraceWriter buffers traces and APM events, flushing them to the Datadog API implements TraceWriter
 type TraceWriter struct {
-	// In receives sampled spans to be processed by the trace writer.
-	// Channel should only be received from when testing.
-	In        chan *SampledChunks
-	Serialize chan *pb.AgentPayload
-	// used to keep track of payloads currently being flushed
-	// only useful for tests
-	swg sync.WaitGroup
+	flushTicker *time.Ticker
 
 	prioritySampler samplerTPSReader
 	errorsSampler   samplerTPSReader
@@ -69,7 +62,7 @@ type TraceWriter struct {
 	senders      []*sender
 	stop         chan struct{}
 	stats        *info.TraceWriterInfo
-	wg           sync.WaitGroup // waits for gzippers
+	wg           sync.WaitGroup // waits flusher + reporter
 	tick         time.Duration  // flush frequency
 	agentVersion string
 
@@ -85,6 +78,7 @@ type TraceWriter struct {
 	easylog *log.ThrottledLogger
 	statsd  statsd.ClientInterface
 	timing  timing.Reporter
+	mu      sync.Mutex
 }
 
 // NewTraceWriter returns a new TraceWriter. It is created for the given agent configuration and
@@ -98,8 +92,6 @@ func NewTraceWriter(
 	statsd statsd.ClientInterface,
 	timing timing.Reporter) *TraceWriter {
 	tw := &TraceWriter{
-		In:                 make(chan *SampledChunks, 1),
-		Serialize:          make(chan *pb.AgentPayload, 1),
 		prioritySampler:    prioritySampler,
 		errorsSampler:      errorsSampler,
 		rareSampler:        rareSampler,
@@ -127,71 +119,60 @@ func NewTraceWriter(
 	if s := cfg.TraceWriter.FlushPeriodSeconds; s != 0 {
 		tw.tick = time.Duration(s*1000) * time.Millisecond
 	}
+	tw.flushTicker = time.NewTicker(tw.tick)
+
 	qsize := 1
 	log.Infof("Trace writer initialized (climit=%d qsize=%d)", climit, qsize)
 	tw.senders = newSenders(cfg, tw, pathTraces, climit, qsize, telemetryCollector, statsd)
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
-		tw.wg.Add(1)
-		go tw.serializer()
-	}
+	//for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+	//	tw.wg.Add(1)
+	//	go tw.serializer()
+	//}
+	tw.wg.Add(1)
+	go tw.timeFlush()
+	tw.wg.Add(1)
+	go tw.reporter()
 	return tw
+}
+
+func (w *TraceWriter) reporter() {
+	tck := time.NewTicker(w.tick)
+	defer w.wg.Done()
+	for {
+		select {
+		case <-tck.C:
+			w.report()
+		case <-w.stop:
+			return
+		}
+	}
+}
+
+func (w *TraceWriter) timeFlush() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.flushTicker.C:
+			func() {
+				w.mu.Lock()
+				defer w.mu.Unlock()
+				w.flush()
+			}()
+		case <-w.stop:
+			return
+		}
+	}
 }
 
 // Stop stops the TraceWriter and attempts to flush whatever is left in the senders buffers.
 func (w *TraceWriter) Stop() {
 	log.Debug("Exiting trace writer. Trying to flush whatever is left...")
-	w.stop <- struct{}{}
-	<-w.stop
+	close(w.stop)
 	// Wait for encoding/compression to complete on each payload,
 	// and submission to senders
 	w.wg.Wait()
+	w.flush()
 	stopSenders(w.senders)
-}
-
-// Run starts the TraceWriter.
-func (w *TraceWriter) Run() {
-	if w.syncMode {
-		w.runSync()
-	} else {
-		w.runAsync()
-	}
-}
-
-func (w *TraceWriter) runAsync() {
-	t := time.NewTicker(w.tick)
-	defer t.Stop()
-	defer close(w.Serialize)
-	defer close(w.stop)
-	for {
-		select {
-		case pkg := <-w.In:
-			w.addSpans(pkg)
-		case <-w.stop:
-			w.drainAndFlush()
-			return
-		case <-t.C:
-			w.report()
-			w.flush()
-		}
-	}
-}
-
-func (w *TraceWriter) runSync() {
-	defer close(w.Serialize)
-	defer close(w.stop)
-	defer close(w.flushChan)
-	for {
-		select {
-		case pkg := <-w.In:
-			w.addSpans(pkg)
-		case notify := <-w.flushChan:
-			w.drainAndFlush()
-			notify <- struct{}{}
-		case <-w.stop:
-			w.drainAndFlush()
-			return
-		}
-	}
 }
 
 // FlushSync blocks and sends pending payloads when syncMode is true
@@ -201,17 +182,20 @@ func (w *TraceWriter) FlushSync() error {
 	}
 	defer w.report()
 
-	notify := make(chan struct{}, 1)
-	w.flushChan <- notify
-	<-notify
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.flush()
 	return nil
 }
 
-func (w *TraceWriter) addSpans(pkg *SampledChunks) {
+// WriteChunks writes and serializes the provided chunks
+func (w *TraceWriter) WriteChunks(pkg *SampledChunks) {
 	w.stats.Spans.Add(pkg.SpanCount)
 	w.stats.Traces.Add(int64(len(pkg.TracerPayload.Chunks)))
 	w.stats.Events.Add(pkg.EventCount)
 
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	size := pkg.Size
 	if size+w.bufferedSize > MaxPayloadSize {
 		// reached maximum allowed buffered size
@@ -224,20 +208,6 @@ func (w *TraceWriter) addSpans(pkg *SampledChunks) {
 	w.bufferedSize += size
 }
 
-func (w *TraceWriter) drainAndFlush() {
-outer:
-	for {
-		select {
-		case pkg := <-w.In:
-			w.addSpans(pkg)
-		default:
-			break outer
-		}
-	}
-	w.flush()
-	w.swg.Wait()
-}
-
 func (w *TraceWriter) resetBuffer() {
 	w.bufferedSize = 0
 	w.tracerPayloads = make([]*pb.TracerPayload, 0, len(w.tracerPayloads))
@@ -246,6 +216,7 @@ func (w *TraceWriter) resetBuffer() {
 const headerLanguages = "X-Datadog-Reported-Languages"
 
 func (w *TraceWriter) flush() {
+	w.flushTicker.Reset(w.tick) // reset the flush timer whenever we flush
 	if len(w.tracerPayloads) == 0 {
 		// nothing to do
 		return
@@ -266,44 +237,38 @@ func (w *TraceWriter) flush() {
 	}
 	log.Debugf("Reported agent rates: target_tps=%v errors_tps=%v rare_sampling=%v", p.TargetTPS, p.ErrorTPS, p.RareSamplerEnabled)
 
-	w.swg.Add(1)
-	w.Serialize <- &p
+	w.serialize(&p)
 }
 
-func (w *TraceWriter) serializer() {
-	defer w.wg.Done()
-	for pl := range w.Serialize {
-		func() {
-			defer w.swg.Done()
-			b, err := pl.MarshalVT()
-			if err != nil {
-				log.Errorf("Failed to serialize payload, data dropped: %v", err)
-				return
-			}
-
-			w.stats.BytesUncompressed.Add(int64(len(b)))
-			p := newPayload(map[string]string{
-				"Content-Type":     "application/x-protobuf",
-				"Content-Encoding": "gzip",
-				headerLanguages:    strings.Join(info.Languages(), "|"),
-			})
-			p.body.Grow(len(b) / 2)
-			gzipw, err := gzip.NewWriterLevel(p.body, gzip.BestSpeed)
-			if err != nil {
-				// it will never happen, unless an invalid compression is chosen;
-				// we know gzip.BestSpeed is valid.
-				log.Errorf("gzip.NewWriterLevel: %d", err)
-				return
-			}
-			if _, err := gzipw.Write(b); err != nil {
-				log.Errorf("Error gzipping trace payload: %v", err)
-			}
-			if err := gzipw.Close(); err != nil {
-				log.Errorf("Error closing gzip stream when writing trace payload: %v", err)
-			}
-			sendPayloads(w.senders, p, w.syncMode)
-		}()
+func (w *TraceWriter) serialize(pl *pb.AgentPayload) {
+	b, err := pl.MarshalVT()
+	if err != nil {
+		log.Errorf("Failed to serialize payload, data dropped: %v", err)
+		return
 	}
+
+	w.stats.BytesUncompressed.Add(int64(len(b)))
+	p := newPayload(map[string]string{
+		"Content-Type":     "application/x-protobuf",
+		"Content-Encoding": "gzip",
+		headerLanguages:    strings.Join(info.Languages(), "|"),
+	})
+	p.body.Grow(len(b) / 2)
+	gzipw, err := gzip.NewWriterLevel(p.body, gzip.BestSpeed)
+	if err != nil {
+		// it will never happen, unless an invalid compression is chosen;
+		// we know gzip.BestSpeed is valid.
+		log.Errorf("gzip.NewWriterLevel: %d", err)
+		return
+	}
+	if _, err := gzipw.Write(b); err != nil {
+		log.Errorf("Error gzipping trace payload: %v", err)
+	}
+	if err := gzipw.Close(); err != nil {
+		log.Errorf("Error closing gzip stream when writing trace payload: %v", err)
+	}
+	sendPayloads(w.senders, p, w.syncMode)
+
 }
 
 func (w *TraceWriter) report() {

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -63,10 +63,8 @@ func TestTraceWriter(t *testing.T) {
 		// but overflow on the third.
 		defer useFlushThreshold(testSpans[0].Size + testSpans[1].Size + 10)()
 		tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		tw.In = make(chan *SampledChunks)
-		go tw.Run()
 		for _, ss := range testSpans {
-			tw.In <- ss
+			tw.WriteChunks(ss)
 		}
 		tw.Stop()
 		// One payload flushes due to overflowing the threshold, and the second one
@@ -104,8 +102,6 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 		randomSampledSpans(40, 5),
 	}
 	tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-	tw.In = make(chan *SampledChunks, 100)
-	go tw.Run()
 
 	var wg sync.WaitGroup
 	for i := 0; i < numWorkers; i++ {
@@ -114,7 +110,7 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numOpsPerWorker; j++ {
 				for _, ss := range testSpans {
-					tw.In <- ss
+					tw.WriteChunks(ss)
 				}
 			}
 		}()
@@ -197,9 +193,8 @@ func TestTraceWriterFlushSync(t *testing.T) {
 			randomSampledSpans(40, 5),
 		}
 		tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		go tw.Run()
 		for _, ss := range testSpans {
-			tw.In <- ss
+			tw.WriteChunks(ss)
 		}
 
 		// No payloads should be sent before flushing
@@ -266,9 +261,8 @@ func TestTraceWriterSyncStop(t *testing.T) {
 			randomSampledSpans(40, 5),
 		}
 		tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		go tw.Run()
 		for _, ss := range testSpans {
-			tw.In <- ss
+			tw.WriteChunks(ss)
 		}
 
 		// No payloads should be sent before flushing
@@ -315,7 +309,7 @@ func TestTraceWriterAgentPayload(t *testing.T) {
 
 	// helper function to send a chunk to the writer and force a synchronous flush
 	sendRandomSpanAndFlush := func(t *testing.T, tw *TraceWriter) {
-		tw.In <- randomSampledSpans(20, 8)
+		tw.WriteChunks(randomSampledSpans(20, 8))
 		err := tw.FlushSync()
 		assert.Nil(t, err)
 	}
@@ -332,7 +326,6 @@ func TestTraceWriterAgentPayload(t *testing.T) {
 
 	t.Run("static TPS config", func(t *testing.T) {
 		tw := NewTraceWriter(cfg, mockSampler, mockSampler, mockSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		go tw.Run()
 		defer tw.Stop()
 		sendRandomSpanAndFlush(t, tw)
 		assertExpectedTps(t, 5, 5, true)
@@ -344,7 +337,6 @@ func TestTraceWriterAgentPayload(t *testing.T) {
 		rareSampler := &MockSampler{Enabled: false}
 
 		tw := NewTraceWriter(cfg, prioritySampler, errorSampler, rareSampler, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
-		go tw.Run()
 		defer tw.Stop()
 		sendRandomSpanAndFlush(t, tw)
 		assertExpectedTps(t, 5, 6, false)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds an e2e benchmark suite for the Trace Agent. It sets up a live agent and runs generated traces through the receiver and out of the senders to a dumb intake.

### Motivation

These tests might provide high-level insight into the effects of changes that aren't covered by more specific benchmarks. It fills a minor gap between the micro benchmarks here and the full-scale benchmarks run against the trace agent binary.

### Additional Notes

There are a lot of benchmarks here and probably not all of them are useful. It would be nice to have a subset run on PRs and possibly delete the ones we don't think are useful, or mark them as skip so they could be run manually if we think they still have some value.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
 
Run the benchmarks locally and compare with benchstat. This is already complete.