### PR TITLE
remove deadlock in dca client

### DIFF
--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -284,17 +284,19 @@ func GetClusterAgentEndpoint() (string, error) {
 // Version returns ClusterAgentVersion already stored in the DCAClient
 // It refreshes the cached version before returning it if withRefresh is true
 func (c *DCAClient) Version(withRefresh bool) version.Version {
-	c.clusterAgentClientLock.Lock()
-	defer c.clusterAgentClientLock.Unlock()
-
 	if withRefresh {
 		ver, err := c.getVersion()
 		if err != nil {
 			log.Errorf("failed to refresh cluster agent version")
 		} else {
+			c.clusterAgentClientLock.Lock()
 			c.clusterAgentVersion = ver
+			c.clusterAgentClientLock.Unlock()
 		}
 	}
+
+	c.clusterAgentClientLock.RLock()
+	defer c.clusterAgentClientLock.RUnlock()
 
 	return c.clusterAgentVersion
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes acquiring locks in the dca client Version method to avoid deadlock scenario.

The issue is introduced in [this](https://github.com/DataDog/datadog-agent/pull/25960) PR.

`Version` acquires the Read-Write lock, and then nested function calls lead to calling `c.httpClient`, which in turn tries to acquire the read lock, resulting in a deadlock case. This PR fixes this issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix deadlock scenario.



### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

QA should already be done on [this](https://github.com/DataDog/datadog-agent/pull/25960) PR.
