### PR TITLE
[workloadmeta/collectors/remote] Handle unsupported kinds

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -9,6 +9,7 @@ package workloadmeta
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -25,6 +26,22 @@ import (
 const (
 	collectorID = "remote-workloadmeta"
 )
+
+// These are the workloadmeta kinds that are supported by the remote
+// workloadmeta collector.
+//
+// Not all of them are supported because the users of remote workloadmeta
+// (security-agent, process-agent) don't need them, so sending them would be a
+// waste of memory and bandwidth.
+//
+// In order to support a workloadmeta kind, we need to add its protobuf
+// representation and also handle it in the functions that convert workloadmeta
+// types to protobuf and vice versa.
+var supportedKinds = []workloadmeta.Kind{
+	workloadmeta.KindContainer,
+	workloadmeta.KindKubernetesPod,
+	workloadmeta.KindECSTask,
+}
 
 // Params defines the parameters of the remote workloadmeta collector.
 type Params struct {
@@ -76,6 +93,10 @@ type streamHandler struct {
 
 // NewCollector returns a CollectorProvider to build a remote workloadmeta collector, and an error if any.
 func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
+	if filterHasUnsupportedKind(deps.Params.Filter) {
+		return workloadmeta.CollectorProvider{}, fmt.Errorf("the filter specified contains unsupported kinds")
+	}
+
 	return workloadmeta.CollectorProvider{
 		Collector: &remote.GenericCollector{
 			CollectorID: collectorID,
@@ -156,4 +177,13 @@ func (s *streamHandler) HandleResync(store workloadmeta.Component, events []work
 	// entities in the store that match the filters specified (see
 	// workloadmeta.Store#Subscribe).
 	store.Reset(entities, workloadmeta.SourceRemoteWorkloadmeta)
+}
+
+func filterHasUnsupportedKind(filter *workloadmeta.Filter) bool {
+	for _, kind := range filter.Kinds() {
+		if !slices.Contains(supportedKinds, kind) {
+			return true
+		}
+	}
+	return false
 }

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -60,6 +60,58 @@ func (s *serverSecure) WorkloadmetaStreamEntities(in *pbgo.WorkloadmetaStreamReq
 	return s.workloadmetaServer.StreamEntities(in, out)
 }
 
+func TestNewCollector(t *testing.T) {
+	tests := []struct {
+		name         string
+		filter       *workloadmeta.Filter
+		expectsError bool
+	}{
+		{
+			name:         "nil filter",
+			filter:       nil,
+			expectsError: false,
+		},
+		{
+			name: "filter with only supported kinds",
+			filter: workloadmeta.NewFilter(&workloadmeta.FilterParams{
+				Kinds: []workloadmeta.Kind{
+					workloadmeta.KindContainer,
+					workloadmeta.KindKubernetesPod,
+				},
+			}),
+			expectsError: false,
+		},
+		{
+			name: "filter with unsupported kinds",
+			filter: workloadmeta.NewFilter(&workloadmeta.FilterParams{
+				Kinds: []workloadmeta.Kind{
+					workloadmeta.KindContainer,
+					workloadmeta.KindContainerImageMetadata, // Not supported
+				},
+			}),
+			expectsError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deps := dependencies{
+				Params: Params{
+					Filter: test.filter,
+				},
+			}
+
+			_, err := NewCollector(deps)
+
+			if test.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 	protoWorkloadmetaEvent := &pbgo.WorkloadmetaEvent{
 		Type: pbgo.WorkloadmetaEventType_EVENT_TYPE_SET,

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -72,7 +72,11 @@ func ProtobufEventFromWorkloadmetaEvent(event workloadmeta.Event) (*pb.Workloadm
 		}, nil
 	}
 
-	return nil, fmt.Errorf("unknown kind: %s", entityID.Kind)
+	// We have not defined a conversion for the workloadmeta type included in
+	// the given event.
+	// This is not considered to be an error because we only support some
+	// types. The list is defined in the remote workloadmeta collector.
+	return nil, nil
 }
 
 // ProtobufFilterFromWorkloadmetaFilter converts the given workloadmeta.Filter into protobuf


### PR DESCRIPTION

### What does this PR do?

This PR improves the handling of unsupported kinds in the remote workloadmeta collector.

The PR introduces a check to make sure that users of remote workloadmeta (security-agent and process-agent at the moment) cannot subscribe with a filter that uses a workloadmeta kind that it's not supported. This is not the case right now, but this check will allow to catch this issue in the future if it happens.

This PR also deletes a spammy error message for something that it's not really an error.

### Describe how to test/QA your changes

Deploy with remote workloadmeta enabled and verify that this log line does not appear anymore: `unknown kind:` in the core agent.
