### PR TITLE
[NDM][NDMII-2815] use the cache container for netflow test

### DIFF
--- a/test/new-e2e/tests/ndm/netflow/compose/netflowCompose.yaml
+++ b/test/new-e2e/tests/ndm/netflow/compose/netflowCompose.yaml
@@ -15,4 +15,4 @@ services:
     depends_on:
       agent:
         condition: service_healthy
-    image: ghcr.io/datadog/apps-netflow-generator:main
+    image: 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/networkstatic/nflow-generator


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Application of [this doc](https://datadoghq.atlassian.net/wiki/spaces/ADX/pages/3740697756/E2E+-+Use+our+Dockerhub+mirror+registry+on+AWS#Use-our-private-ECR-with-pull-through-cache)

### Motivation

Following [this commit](https://github.com/DataDog/datadog-agent/pull/26003/commits/114b9cb88ebd9c10a54bdd1bd821952036daf794), we want to be consistent and to use the same registry for netflow and snmp


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
