### PR TITLE
[CWS] windows multi approvers

### DIFF
--- a/pkg/security/probe/kfilters/capabilities_windows.go
+++ b/pkg/security/probe/kfilters/capabilities_windows.go
@@ -16,4 +16,22 @@ func init() {
 			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
 		},
 	}
+	allCapabilities["rename"] = Capabilities{
+		"rename.file.name": {
+			PolicyFlags:     PolicyFlagBasename,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+		},
+	}
+	allCapabilities["delete"] = Capabilities{
+		"delete.file.name": {
+			PolicyFlags:     PolicyFlagBasename,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+		},
+	}
+	allCapabilities["write"] = Capabilities{
+		"write.file.name": {
+			PolicyFlags:     PolicyFlagBasename,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+		},
+	}
 }

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -166,7 +166,7 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	// not amazing to double compute the basename..
 	basename := filepath.Base(ca.fileName)
 
-	if !wp.approve("create.file.name", basename) {
+	if !wp.approveFimBasename(basename) {
 		wp.discardedFileHandles.Add(fileObjectPointer(ca.fileObject), struct{}{})
 		wp.stats.createFileApproverRejects++
 		return nil, errDiscardedPath

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -538,6 +538,7 @@ func TestETWFileNotifications(t *testing.T) {
 	testfilerename := ex + ".testfilerename"
 
 	wp, err := createTestProbe()
+	wp.disableApprovers = true
 	require.NoError(t, err)
 
 	// teardownTestProe calls the stop function on etw, which will

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1022,6 +1022,7 @@ func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 		return nil, err
 	}
 
+	clear(p.approvers) // remove old approvers
 	for eventType, report := range ars.Policies {
 		if err := p.SetApprovers(eventType, report.Approvers); err != nil {
 			return nil, err

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -319,6 +319,17 @@ func (p *WindowsProbe) Stop() {
 	}
 }
 
+func (p *WindowsProbe) approveFimBasename(value string) bool {
+	fields := []string{"create.file.name", "rename.file.name", "delete.file.name", "write.file.name"}
+
+	for _, field := range fields {
+		if p.approve(field, value) {
+			return true
+		}
+	}
+	return false
+}
+
 // currently support only string base approver for now
 func (p *WindowsProbe) approve(field eval.Field, value string) bool {
 	approvers, exists := p.approvers[field]

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -105,6 +105,7 @@ type WindowsProbe struct {
 	blockonchannelsend bool
 
 	// approvers
+	disableApprovers  bool
 	currentEventTypes []string
 	approvers         map[eval.Field][]approver
 }
@@ -337,6 +338,10 @@ func (p *WindowsProbe) approveFimBasename(value string) bool {
 
 // currently support only string base approver for now
 func (p *WindowsProbe) approve(field eval.Field, eventType string, value string) bool {
+	if p.disableApprovers {
+		return true
+	}
+
 	approvers, exists := p.approvers[field]
 	if !exists {
 		// no approvers, so no filtering for this field, except if no rule for this event type

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -164,7 +164,55 @@ func TestWriteFileEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.Run(t, "delete", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "write", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		test.WaitSignal(t, func() error {
+			f, err := os.OpenFile("C:\\Temp\\test.bad", os.O_WRONLY, 0755)
+			if err != nil {
+				return err
+			}
+			if _, err := f.WriteString("test"); err != nil {
+				return err
+			}
+			return f.Close()
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			assertFieldEqualCaseInsensitve(t, event, "write.file.name", "test.bad", event, "write.file.name file didn't match")
+		}))
+	})
+}
+
+func TestWriteFileEventWithCreate(t *testing.T) {
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_create_polute",
+			Expression: `create.file.name =~ "*.dll"`,
+		},
+		{
+			ID:         "test_write_file",
+			Expression: `write.file.name =~ "test.bad" && write.file.path =~ "C:\Temp\**"`,
+		},
+	}
+	opts := testOpts{
+		enableFIM: true,
+	}
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
+	// so wait around for it to start
+	time.Sleep(5 * time.Second)
+
+	os.MkdirAll("C:\\Temp", 0755)
+	f, err := os.Create("C:\\Temp\\test.bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	test.Run(t, "write", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile("C:\\Temp\\test.bad", os.O_WRONLY, 0755)
 			if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Similarly to what we did for discarders https://github.com/DataDog/datadog-agent/pull/24221, approvers need to be aware of all the FRIM event types to correctly make the decision of approving a file path or not. To fix this, this PR adds new capabilities for the other missing event type basenames, and ensure the approving is checked across all the event types instead of just `create.file.name`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
