### PR TITLE
[kubernetes/apiserver] Initialize metadata controller properly

### DIFF
--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -52,38 +52,6 @@ func newMetadataController(endpointsInformer coreinformers.EndpointsInformer, wm
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "endpoints"),
 	}
 
-	go func() {
-		wmetaFilterParams := workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesNode},
-			Source:    workloadmeta.SourceAll,
-			EventType: workloadmeta.EventTypeAll,
-		}
-
-		wmetaEventsCh := wmeta.Subscribe(
-			"metadata-controller",
-			workloadmeta.NormalPriority,
-			workloadmeta.NewFilter(&wmetaFilterParams),
-		)
-		defer wmeta.Unsubscribe(wmetaEventsCh)
-
-		for eventBundle := range wmetaEventsCh {
-			eventBundle.Acknowledge()
-
-			for _, event := range eventBundle.Events {
-				node := event.Entity.(*workloadmeta.KubernetesNode)
-
-				switch event.Type {
-				case workloadmeta.EventTypeSet:
-					m.addNode(node.Name)
-				case workloadmeta.EventTypeUnset:
-					m.deleteNode(node.Name)
-				default:
-					log.Warnf("Unknown event type %v", event.Type)
-				}
-			}
-		}
-	}()
-
 	if _, err := endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    m.addEndpoints,
 		UpdateFunc: m.updateEndpoints,
@@ -110,6 +78,20 @@ func (m *metadataController) run(stopCh <-chan struct{}) {
 		return
 	}
 
+	wmetaFilterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesNode},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeAll,
+	}
+
+	wmetaEventsCh := m.wmeta.Subscribe(
+		"metadata-controller",
+		workloadmeta.NormalPriority,
+		workloadmeta.NewFilter(&wmetaFilterParams),
+	)
+	defer m.wmeta.Unsubscribe(wmetaEventsCh)
+
+	go m.processWorkloadmetaNodeEvents(wmetaEventsCh)
 	go wait.Until(m.worker, time.Second, stopCh)
 	<-stopCh
 }
@@ -132,6 +114,25 @@ func (m *metadataController) processNextWorkItem() bool {
 	}
 
 	return true
+}
+
+func (m *metadataController) processWorkloadmetaNodeEvents(wmetaEventsCh chan workloadmeta.EventBundle) {
+	for eventBundle := range wmetaEventsCh {
+		eventBundle.Acknowledge()
+
+		for _, event := range eventBundle.Events {
+			node := event.Entity.(*workloadmeta.KubernetesNode)
+
+			switch event.Type {
+			case workloadmeta.EventTypeSet:
+				m.addNode(node.Name)
+			case workloadmeta.EventTypeUnset:
+				m.deleteNode(node.Name)
+			default:
+				log.Warnf("Unknown event type %v", event.Type)
+			}
+		}
+	}
 }
 
 func (m *metadataController) addNode(name string) {


### PR DESCRIPTION
### What does this PR do?

Fixes a panic that happen sometimes when initializing the metadata controller.

The reason is that the agent was processing workloadmeta events before it was supposed to. Moving the code from the constructor to the run function should fix the issue.


### Describe how to test/QA your changes

Skip and test https://github.com/DataDog/datadog-agent/pull/25615 instead.
