### PR TITLE
[CWS] dynamic ETW reconfiguration of providers

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -199,6 +199,9 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	if wp.filePathResolver.Add(ca.fileObject, fc) {
 		wp.stats.fileNameCacheEvictions++
 	}
+	// if we get here, we have a new file handle.  Remove it from the discarder cache in case
+	// we missed the close notification
+	wp.discardedFileHandles.Remove(fileObjectPointer(ca.fileObject))
 
 	return ca, nil
 }

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -416,6 +416,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 					p.stats.fileProcessedNotifications[e.EventHeader.EventDescriptor.ID]++
 					ecb(ca, e.EventHeader.ProcessID)
 					// lru is thread safe, has its own locking
+					p.discardedFileHandles.Remove(ca.fileObject)
 					p.filePathResolver.Remove(ca.fileObject)
 				}
 			case idFlush:

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -230,6 +230,10 @@ func (p *WindowsProbe) initEtwFIM() error {
 }
 
 func (p *WindowsProbe) reconfigureProvider() error {
+	if !p.config.RuntimeSecurity.FIMEnabled {
+		return nil
+	}
+
 	pidsList := make([]uint32, 0)
 
 	p.fimSession.ConfigureProvider(p.fileguid, func(cfg *etw.ProviderConfiguration) {


### PR DESCRIPTION
### What does this PR do?

We are currently able to detect if write/rename/delete events are unused by any rule and skip them as soon as they exit the etw channel. With this PR we go one step further and reconfigure the ETW provider to not even look at those kind of events if they are not required.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
