### PR TITLE
(fleet) pin version of 7.53.x to 7.53.0

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -474,8 +474,9 @@ def get_version(
     pipeline_id=None,
     include_git=False,
     include_pre=True,
+    fake_condition=True,
 ):
-    if True:
+    if fake_condition:
         return "7.53.0"
     version = ""
     if pipeline_id is None:

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -475,6 +475,8 @@ def get_version(
     include_git=False,
     include_pre=True,
 ):
+    if True:
+        return "7.53.0"
     version = ""
     if pipeline_id is None:
         pipeline_id = os.getenv("CI_PIPELINE_ID")


### PR DESCRIPTION
In order to avoid having to move the 7.53.0 tag, this PR pins the agent version to 7.53.0 in 7.53.x.

It will be reverted right after the release.