### PR TITLE
[PROCS-4045] Move process agent statsd client initialization into process agent component

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -82,6 +82,7 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	dogstatsdStatusimpl "github.com/DataDog/datadog-agent/comp/dogstatsd/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -218,6 +219,7 @@ func run(log log.Component,
 	demultiplexer demultiplexer.Component,
 	sharedSerializer serializer.MetricSerializer,
 	logsAgent optional.Option[logsAgent.Component],
+	_ statsd.Component,
 	processAgent processAgent.Component,
 	otelcollector otelcollector.Component,
 	_ host.Component,
@@ -364,6 +366,7 @@ func getSharedFxOption() fx.Option {
 		traceagentStatusImpl.Module(),
 		processagentStatusImpl.Module(),
 		dogstatsdStatusimpl.Module(),
+		statsd.Module(),
 		statusimpl.Module(),
 		authtokenimpl.Module(),
 		apiimpl.Module(),

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -54,7 +54,6 @@ import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta/collector"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	ddutil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -303,7 +302,6 @@ type miscDeps struct {
 	Lc fx.Lifecycle
 
 	Config       config.Component
-	Statsd       compstatsd.Component
 	Syscfg       sysprobeconfig.Component
 	HostInfo     hostinfo.Component
 	WorkloadMeta workloadmeta.Component
@@ -311,13 +309,9 @@ type miscDeps struct {
 }
 
 // initMisc initializes modules that cannot, or have not yet been componetized.
-// Todo: (Components) WorkloadMeta, remoteTagger, statsd
+// Todo: (Components) WorkloadMeta, remoteTagger
 // Todo: move metadata/workloadmeta/collector to workloadmeta
 func initMisc(deps miscDeps) error {
-	if err := statsd.Configure(ddconfig.GetBindHost(), deps.Config.GetInt("dogstatsd_port"), deps.Statsd.CreateForHostPort); err != nil {
-		deps.Logger.Criticalf("Error configuring statsd: %s", err)
-		return err
-	}
 
 	if err := ddutil.SetupCoreDump(deps.Config); err != nil {
 		deps.Logger.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/submitter/submitterimpl"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	checkMocks "github.com/DataDog/datadog-agent/pkg/process/checks/mocks"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -117,6 +118,7 @@ func TestProcessAgentComponentOnLinux(t *testing.T) {
 				submitterimpl.MockModule(),
 				taggerimpl.MockModule(),
 				telemetryimpl.Module(),
+				statsd.MockModule(),
 				Module(),
 
 				fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
@@ -178,6 +180,7 @@ func TestStatusProvider(t *testing.T) {
 				submitterimpl.MockModule(),
 				taggerimpl.MockModule(),
 				telemetryimpl.Module(),
+				statsd.MockModule(),
 				Module(),
 				fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
 					"process_config.run_in_core_agent.enabled": true,
@@ -215,6 +218,7 @@ func TestTelemetryCoreAgent(t *testing.T) {
 		hostinfoimpl.MockModule(),
 		submitterimpl.MockModule(),
 		taggerimpl.MockModule(),
+		statsd.MockModule(),
 		Module(),
 		fx.Replace(configComp.MockParams{Overrides: map[string]interface{}{
 			"process_config.run_in_core_agent.enabled": true,

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -199,8 +199,9 @@ func TestStatusProvider(t *testing.T) {
 					}
 				}),
 			))
-			provides := newProcessAgent(deps)
+			provides, err := newProcessAgent(deps)
 			assert.IsType(t, tc.expected, provides.StatusProvider.Provider)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -238,7 +239,8 @@ func TestTelemetryCoreAgent(t *testing.T) {
 			}
 		}),
 	))
-	_ = newProcessAgent(deps)
+	_, err := newProcessAgent(deps)
+	assert.NoError(t, err)
 
 	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	tel.Reset()

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo/hostinfoimpl"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck/processcheckimpl"
@@ -26,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/submitter/submitterimpl"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	checkMocks "github.com/DataDog/datadog-agent/pkg/process/checks/mocks"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )

--- a/comp/process/agent/agentimpl/agent_test.go
+++ b/comp/process/agent/agentimpl/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	"github.com/DataDog/datadog-agent/comp/process/agent"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo/hostinfoimpl"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck/processcheckimpl"
 	"github.com/DataDog/datadog-agent/comp/process/runner/runnerimpl"
@@ -65,6 +66,7 @@ func TestProcessAgentComponent(t *testing.T) {
 				submitterimpl.MockModule(),
 				telemetryimpl.Module(),
 				taggerimpl.MockModule(),
+				statsd.MockModule(),
 				Module(),
 			}
 

--- a/comp/process/agent/agentimpl/agent_test.go
+++ b/comp/process/agent/agentimpl/agent_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
+	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo/hostinfoimpl"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck/processcheckimpl"
 	"github.com/DataDog/datadog-agent/comp/process/runner/runnerimpl"

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl"
@@ -54,6 +55,7 @@ func TestBundleDependencies(t *testing.T) {
 		),
 		fx.Provide(func() context.Context { return context.TODO() }),
 		npcollectorimpl.MockModule(),
+		statsd.MockModule(),
 	)
 }
 
@@ -94,6 +96,7 @@ func TestBundleOneShot(t *testing.T) {
 		eventplatformimpl.Module(),
 		fx.Supply(eventplatformimpl.NewDefaultParams()),
 		npcollectorimpl.Module(),
+		statsd.MockModule(),
 		Bundle(),
 	)
 	require.NoError(t, err)

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -7,6 +7,7 @@ package checks
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -134,7 +135,8 @@ func (c *ContainerCheck) Run(nextGroupID func() int32, options *RunOptions) (Run
 	}
 
 	numContainers := float64(len(containers))
-	statsd.Client.Gauge("datadog.process.containers.host_count", numContainers, []string{}, 1) //nolint:errcheck
+	agentNameTag := fmt.Sprintf("agent:%s", flavor.GetFlavor())
+	statsd.Client.Gauge("datadog.process.containers.host_count", numContainers, []string{agentNameTag}, 1) //nolint:errcheck
 	log.Debugf("collected %d containers in %s", int(numContainers), time.Since(startTime))
 	return StandardRunResult(messages), nil
 }

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -340,8 +341,9 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 		p.realtimeLastRun = p.lastRun
 	}
 
-	statsd.Client.Gauge("datadog.process.containers.host_count", float64(totalContainers), []string{}, 1) //nolint:errcheck
-	statsd.Client.Gauge("datadog.process.processes.host_count", float64(totalProcs), []string{}, 1)       //nolint:errcheck
+	agentNameTag := fmt.Sprintf("agent:%s", flavor.GetFlavor())
+	statsd.Client.Gauge("datadog.process.containers.host_count", float64(totalContainers), []string{agentNameTag}, 1) //nolint:errcheck
+	statsd.Client.Gauge("datadog.process.processes.host_count", float64(totalProcs), []string{agentNameTag}, 1)       //nolint:errcheck
 	log.Debugf("collected processes in %s", time.Since(start))
 
 	return result, nil

--- a/releasenotes/notes/process-statsd-client-fix-66b11cc991a9f6be.yaml
+++ b/releasenotes/notes/process-statsd-client-fix-66b11cc991a9f6be.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix metric reporting for process checks on the core agent.

--- a/releasenotes/notes/process-statsd-client-fix-66b11cc991a9f6be.yaml
+++ b/releasenotes/notes/process-statsd-client-fix-66b11cc991a9f6be.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix metric reporting for process checks on the core agent.
+    Fix metric reporting for process checks on the core Agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR moves process agent statsd client initialization into the process agent component constructor. 

### Motivation

This helps to ensure the statsd client is configured before the checks are run and so that the statsd client can be used when the checks are running on the core agent. Otherwise, the client would be noop and no metrics could be reported from the checks.

### Additional Notes

While this does result in redundant network calls, the alternative for maintaining the same functionality is to convert the process checks into a collector check which is not easily done at the moment.

### Possible Drawbacks / Trade-offs

Redundant network calls on the core agent.

### Describe how to test/QA your changes

Run the process checks on the core agent and verify metrics (`datadog.process.processes.host_count`) are reported with correct tags.
```
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```