### PR TITLE
[gitlab] add links to CI Visibility from e2e jobs

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -111,6 +111,10 @@ k8s-e2e-otlp-main:
     - touch $E2E_PRIVATE_KEY_PATH && chmod 600 $E2E_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $SSH_KEY_RSA_SSM_NAME > $E2E_PRIVATE_KEY_PATH
     # Use S3 backend
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
+    - cp .gitlab/e2e/external_links.json.template external_links_$CI_JOB_ID.json
+    - sed -i "s|{{CI_JOB_ID}}|$CI_JOB_ID|g" external_links_$CI_JOB_ID.json
+    - sed -i "s|{{CI_JOB_NAME}}|$CI_JOB_NAME|g" external_links_$CI_JOB_ID.json
   variables:
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
@@ -133,6 +137,9 @@ k8s-e2e-otlp-main:
       - $E2E_OUTPUT_DIR
       # junit tarball, kept for investigations
       - junit-*.tgz
+    reports:
+      annotations:
+        - external_links_$CI_JOB_ID.json
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template

--- a/.gitlab/e2e/external_links.json.template
+++ b/.gitlab/e2e/external_links.json.template
@@ -1,0 +1,16 @@
+{
+  "CI Visibility": [
+    {
+      "external_link": {
+        "label": "🔗 CI Visibility: This job instance",
+        "url": "https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.job.id%3A{{CI_JOB_ID}}&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline"
+      }
+    },
+    {
+      "external_link": {
+        "label": "🔗 CI Visibility: This job on main",
+        "url": "https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.job.name%3A%22{{CI_JOB_NAME}}%22%20%40git.branch%3Amain"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add links to CI Visibility for e2e jobs, with links to the current job instance and the same job name on main.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This will help investigations on failing jobs: with a quick link to main's job execution, we can quickly determine if a failure is a flake or it is due to the branch changes

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Links are available after the job ends - they are artifacts

![image](https://github.com/DataDog/datadog-agent/assets/45568537/383aaf45-f041-46f5-80a3-e543581355b1)

Example on [e2e_pre_test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/526049414)

Will iterate adding it to other jobs

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
