### PR TITLE
[ASCII] Remove import in API Component interface definition

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger/jmxloggerimpl"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
@@ -61,6 +60,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -157,7 +157,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Provide(func() host.Component { return nil }),
 			fx.Provide(func() inventoryagent.Component { return nil }),
 			fx.Provide(func() inventoryhost.Component { return nil }),
-			fx.Provide(func() demultiplexer.Component { return nil }),
+			fx.Provide(func() sender.DiagnoseSenderManager { return nil }),
 			fx.Provide(func() inventorychecks.Component { return nil }),
 			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Supply(settings.Params{}),

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger/jmxloggerimpl"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
@@ -39,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -49,16 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
-	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
-	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
-	"github.com/DataDog/datadog-agent/comp/metadata/host"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
@@ -147,20 +136,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			// still, we need to pass it to ensure the API server is proprely initialized
 			settingsimpl.Module(),
 			fx.Supply(settings.Params{}),
-			// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
-			// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
-			// in others commands such as run.
-			fx.Provide(func() flare.Component { return nil }),
-			fx.Provide(func() dogstatsdServer.Component { return nil }),
-			fx.Provide(func() replay.Component { return nil }),
-			fx.Provide(func() pidmap.Component { return nil }),
-			fx.Provide(func() serverdebug.Component { return nil }),
-			fx.Provide(func() host.Component { return nil }),
-			fx.Provide(func() inventoryagent.Component { return nil }),
-			fx.Provide(func() inventoryhost.Component { return nil }),
-			fx.Provide(func() demultiplexer.Component { return nil }),
-			fx.Provide(func() inventorychecks.Component { return nil }),
-			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Supply(optional.NewNoneOption[rcservice.Component]()),
 			fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
 			fx.Provide(func() status.Component { return nil }),
@@ -342,7 +317,7 @@ func runJmxCommandConsole(config config.Component,
 		return err
 	}
 
-	err = standalone.ExecJMXCommandConsole(cliParams.command, cliParams.cliSelectedChecks, cliParams.jmxLogLevel, allConfigs, diagnoseSendermanager, agentAPI, jmxLogger)
+	err = standalone.ExecJMXCommandConsole(cliParams.command, cliParams.cliSelectedChecks, cliParams.jmxLogLevel, allConfigs, agentAPI, jmxLogger)
 
 	if runtime.GOOS == "windows" {
 		standalone.PrintWindowsUserWarning("jmx")

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -24,12 +24,21 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger/jmxloggerimpl"
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
 	authtokenimpl "github.com/DataDog/datadog-agent/comp/api/authtoken/createandfetchimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
+	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
+	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
+	"github.com/DataDog/datadog-agent/comp/metadata/host"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
+	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
+	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl"
@@ -38,6 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -47,6 +57,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
+	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
@@ -135,6 +146,20 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			// The jmx command do not have settings that change are runtime
 			// still, we need to pass it to ensure the API server is proprely initialized
 			settingsimpl.Module(),
+			// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
+			// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
+			// in others commands such as run.
+			fx.Provide(func() flare.Component { return nil }),
+			fx.Provide(func() dogstatsdServer.Component { return nil }),
+			fx.Provide(func() replay.Component { return nil }),
+			fx.Provide(func() pidmap.Component { return nil }),
+			fx.Provide(func() serverdebug.Component { return nil }),
+			fx.Provide(func() host.Component { return nil }),
+			fx.Provide(func() inventoryagent.Component { return nil }),
+			fx.Provide(func() inventoryhost.Component { return nil }),
+			fx.Provide(func() demultiplexer.Component { return nil }),
+			fx.Provide(func() inventorychecks.Component { return nil }),
+			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Supply(settings.Params{}),
 			fx.Supply(optional.NewNoneOption[rcservice.Component]()),
 			fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -244,7 +244,7 @@ func run(log log.Component,
 	_ agenttelemetry.Component,
 ) error {
 	defer func() {
-		stopAgent(agentAPI)
+		stopAgent()
 	}()
 
 	// Setup a channel to catch OS signals
@@ -597,12 +597,12 @@ func startAgent(
 }
 
 // StopAgentWithDefaults is a temporary way for other packages to use stopAgent.
-func StopAgentWithDefaults(agentAPI internalAPI.Component) {
-	stopAgent(agentAPI)
+func StopAgentWithDefaults() {
+	stopAgent()
 }
 
 // stopAgent Tears down the agent process
-func stopAgent(agentAPI internalAPI.Component) {
+func stopAgent() {
 	// retrieve the agent health before stopping the components
 	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
 	health, err := health.GetReadyNonBlocking()
@@ -612,7 +612,6 @@ func stopAgent(agentAPI internalAPI.Component) {
 		pkglog.Warnf("Some components were unhealthy: %v", health.Unhealthy)
 	}
 
-	agentAPI.StopServer()
 	clcrunnerapi.StopCLCRunnerServer()
 	jmxfetch.StopJmxfetch()
 

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -547,13 +547,6 @@ func startAgent(
 		}
 	}
 
-	// start the cmd HTTP server
-	if err = agentAPI.StartServer(
-		demultiplexer,
-	); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
-	}
-
 	// start clc runner server
 	// only start when the cluster agent is enabled and a cluster check runner host is enabled
 	if pkgconfig.Datadog().GetBool("cluster_agent.enabled") && pkgconfig.Datadog().GetBool("clc_runner_enabled") {

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -488,7 +488,7 @@ func startAgent(
 	_ serializer.MetricSerializer,
 	_ otelcollector.Component,
 	demultiplexer demultiplexer.Component,
-	agentAPI internalAPI.Component,
+	_ internalAPI.Component,
 	invChecks inventorychecks.Component,
 	_ status.Component,
 	collector collector.Component,

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -129,7 +129,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			_ optional.Option[gui.Component],
 			_ agenttelemetry.Component,
 		) error {
-			defer StopAgentWithDefaults(agentAPI)
+			defer StopAgentWithDefaults()
 
 			err := startAgent(
 				log,

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer.go
@@ -28,7 +28,10 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fx.Provide(newDemultiplexer))
+		fx.Provide(newDemultiplexer),
+		fx.Provide(func(sender demultiplexerComp.Component) sender.DiagnoseSenderManager {
+			return sender
+		}))
 }
 
 type dependencies struct {

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -12,7 +12,6 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
@@ -37,9 +36,6 @@ import (
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newAPIServer),
-		fx.Provide(func(sender demultiplexer.Component) sender.DiagnoseSenderManager {
-			return sender
-		}),
 	)
 }
 

--- a/comp/api/api/apiimpl/api_mock.go
+++ b/comp/api/api/apiimpl/api_mock.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/api/api"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -30,13 +29,6 @@ func MockModule() fxutil.Module {
 
 func newMock() api.Mock {
 	return &mockAPIServer{}
-}
-
-// StartServer creates the router and starts the HTTP server
-func (mock *mockAPIServer) StartServer(
-	_ sender.DiagnoseSenderManager,
-) error {
-	return nil
 }
 
 // StopServer closes the connection and the server

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -46,12 +46,12 @@ import (
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 
 	// package dependencies
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
 	// third-party dependencies
-	"github.com/stretchr/testify/assert"
+
 	"go.uber.org/fx"
 )
 
@@ -143,18 +143,4 @@ func getTestAPIServer(deps testdeps) api.Component {
 		EndpointProviders: deps.EndpointProviders,
 	}
 	return newAPIServer(apideps)
-}
-
-func TestStartServer(t *testing.T) {
-	deps := getComponentDependencies(t)
-
-	sender := aggregator.NewNoOpSenderManager()
-
-	srv := getTestAPIServer(deps)
-	err := srv.StartServer(
-		sender,
-	)
-	defer srv.StopServer()
-
-	assert.NoError(t, err, "could not start api component servers: %v", err)
 }

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -5,142 +5,144 @@
 
 package apiimpl
 
-import (
-	"context"
-	"testing"
+// TODO impl tests
 
-	// component dependencies
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/api/api"
-	"github.com/DataDog/datadog-agent/comp/api/authtoken"
-	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
-	"github.com/DataDog/datadog-agent/comp/collector/collector"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
-	"github.com/DataDog/datadog-agent/comp/core/flare/flareimpl"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
-	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
-	"github.com/DataDog/datadog-agent/comp/core/status"
-	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
-	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
-	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
-	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/inventoryhostimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning/packagesigningimpl"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
+// import (
+// 	"context"
+// 	"testing"
 
-	// package dependencies
+// 	// component dependencies
+// 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+// 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+// 	"github.com/DataDog/datadog-agent/comp/api/api"
+// 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
+// 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
+// 	"github.com/DataDog/datadog-agent/comp/collector/collector"
+// 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+// 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/flare/flareimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+// 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/status"
+// 	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/tagger"
+// 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
+// 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
+// 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
+// 	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
+// 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
+// 	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
+// 	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
+// 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
+// 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
+// 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/inventoryhostimpl"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
+// 	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning/packagesigningimpl"
+// 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+// 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
+// 	// package dependencies
 
-	// third-party dependencies
+// 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+// 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
-	"go.uber.org/fx"
-)
+// 	// third-party dependencies
 
-type testdeps struct {
-	fx.In
+// 	"go.uber.org/fx"
+// )
 
-	// additional StartServer arguments
-	//
-	// TODO: remove these in the next PR once StartServer component arguments
-	//       are part of the api component dependency struct
-	DogstatsdServer       dogstatsdServer.Component
-	Capture               replay.Component
-	ServerDebug           dogstatsddebug.Component
-	Demux                 demultiplexer.Component
-	SecretResolver        secrets.Component
-	PkgSigning            packagesigning.Component
-	StatusComponent       status.Mock
-	EventPlatformReceiver eventplatformreceiver.Component
-	RcService             optional.Option[rcservice.Component]
-	RcServiceMRF          optional.Option[rcservicemrf.Component]
-	AuthToken             authtoken.Component
-	WorkloadMeta          workloadmeta.Component
-	Tagger                tagger.Mock
-	Autodiscovery         autodiscovery.Mock
-	Logs                  optional.Option[logsAgent.Component]
-	Collector             optional.Option[collector.Component]
-	EndpointProviders     []api.EndpointProvider `group:"agent_endpoint"`
-}
+// type testdeps struct {
+// 	fx.In
 
-func getComponentDependencies(t *testing.T) testdeps {
-	// TODO: this fxutil.Test[T] can take a component and return the component
-	return fxutil.Test[testdeps](
-		t,
-		hostnameimpl.MockModule(),
-		flareimpl.MockModule(),
-		dogstatsdServer.MockModule(),
-		replaymock.MockModule(),
-		serverdebugimpl.MockModule(),
-		hostimpl.MockModule(),
-		inventoryagentimpl.MockModule(),
-		demultiplexerimpl.MockModule(),
-		inventoryhostimpl.MockModule(),
-		secretsimpl.MockModule(),
-		fx.Provide(func(secretMock secrets.Mock) secrets.Component {
-			component := secretMock.(secrets.Component)
-			return component
-		}),
-		inventorychecksimpl.MockModule(),
-		packagesigningimpl.MockModule(),
-		statusimpl.MockModule(),
-		eventplatformreceiverimpl.MockModule(),
-		fx.Supply(optional.NewNoneOption[rcservice.Component]()),
-		fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
-		fetchonlyimpl.MockModule(),
-		fx.Supply(context.Background()),
-		taggerimpl.MockModule(),
-		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
-		autodiscoveryimpl.MockModule(),
-		fx.Provide(func() optional.Option[logsAgent.Component] {
-			return optional.NewNoneOption[logsAgent.Component]()
-		}),
-		fx.Provide(func() optional.Option[collector.Component] {
-			return optional.NewNoneOption[collector.Component]()
-		}),
-		settingsimpl.MockModule(),
-		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
-		fx.Provide(func() api.AgentEndpointProvider {
-			return api.AgentEndpointProvider{
-				Provider: nil,
-			}
-		}),
-	)
-}
+// 	// additional StartServer arguments
+// 	//
+// 	// TODO: remove these in the next PR once StartServer component arguments
+// 	//       are part of the api component dependency struct
+// 	DogstatsdServer       dogstatsdServer.Component
+// 	Capture               replay.Component
+// 	ServerDebug           dogstatsddebug.Component
+// 	Demux                 demultiplexer.Component
+// 	SecretResolver        secrets.Component
+// 	PkgSigning            packagesigning.Component
+// 	StatusComponent       status.Mock
+// 	EventPlatformReceiver eventplatformreceiver.Component
+// 	RcService             optional.Option[rcservice.Component]
+// 	RcServiceMRF          optional.Option[rcservicemrf.Component]
+// 	AuthToken             authtoken.Component
+// 	WorkloadMeta          workloadmeta.Component
+// 	Tagger                tagger.Mock
+// 	Autodiscovery         autodiscovery.Mock
+// 	Logs                  optional.Option[logsAgent.Component]
+// 	Collector             optional.Option[collector.Component]
+// 	EndpointProviders     []api.EndpointProvider `group:"agent_endpoint"`
+// }
 
-func getTestAPIServer(deps testdeps) api.Component {
-	apideps := dependencies{
-		DogstatsdServer:   deps.DogstatsdServer,
-		Capture:           deps.Capture,
-		SecretResolver:    deps.SecretResolver,
-		PkgSigning:        deps.PkgSigning,
-		StatusComponent:   deps.StatusComponent,
-		RcService:         deps.RcService,
-		RcServiceMRF:      deps.RcServiceMRF,
-		AuthToken:         deps.AuthToken,
-		Tagger:            deps.Tagger,
-		LogsAgentComp:     deps.Logs,
-		WorkloadMeta:      deps.WorkloadMeta,
-		Collector:         deps.Collector,
-		EndpointProviders: deps.EndpointProviders,
-	}
-	return newAPIServer(apideps)
-}
+// func getComponentDependencies(t *testing.T) testdeps {
+// 	// TODO: this fxutil.Test[T] can take a component and return the component
+// 	return fxutil.Test[testdeps](
+// 		t,
+// 		hostnameimpl.MockModule(),
+// 		flareimpl.MockModule(),
+// 		dogstatsdServer.MockModule(),
+// 		replaymock.MockModule(),
+// 		serverdebugimpl.MockModule(),
+// 		hostimpl.MockModule(),
+// 		inventoryagentimpl.MockModule(),
+// 		demultiplexerimpl.MockModule(),
+// 		inventoryhostimpl.MockModule(),
+// 		secretsimpl.MockModule(),
+// 		fx.Provide(func(secretMock secrets.Mock) secrets.Component {
+// 			component := secretMock.(secrets.Component)
+// 			return component
+// 		}),
+// 		inventorychecksimpl.MockModule(),
+// 		packagesigningimpl.MockModule(),
+// 		statusimpl.MockModule(),
+// 		eventplatformreceiverimpl.MockModule(),
+// 		fx.Supply(optional.NewNoneOption[rcservice.Component]()),
+// 		fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
+// 		fetchonlyimpl.MockModule(),
+// 		fx.Supply(context.Background()),
+// 		taggerimpl.MockModule(),
+// 		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
+// 		autodiscoveryimpl.MockModule(),
+// 		fx.Provide(func() optional.Option[logsAgent.Component] {
+// 			return optional.NewNoneOption[logsAgent.Component]()
+// 		}),
+// 		fx.Provide(func() optional.Option[collector.Component] {
+// 			return optional.NewNoneOption[collector.Component]()
+// 		}),
+// 		settingsimpl.MockModule(),
+// 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
+// 		fx.Provide(func() api.AgentEndpointProvider {
+// 			return api.AgentEndpointProvider{
+// 				Provider: nil,
+// 			}
+// 		}),
+// 	)
+// }
+
+// func getTestAPIServer(deps testdeps) api.Component {
+// 	apideps := dependencies{
+// 		DogstatsdServer:   deps.DogstatsdServer,
+// 		Capture:           deps.Capture,
+// 		SecretResolver:    deps.SecretResolver,
+// 		PkgSigning:        deps.PkgSigning,
+// 		StatusComponent:   deps.StatusComponent,
+// 		RcService:         deps.RcService,
+// 		RcServiceMRF:      deps.RcServiceMRF,
+// 		AuthToken:         deps.AuthToken,
+// 		Tagger:            deps.Tagger,
+// 		LogsAgentComp:     deps.Logs,
+// 		WorkloadMeta:      deps.WorkloadMeta,
+// 		Collector:         deps.Collector,
+// 		EndpointProviders: deps.EndpointProviders,
+// 	}
+// 	return newAPIServer(apideps)
+// }

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -6,6 +6,7 @@
 package apiimpl
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	stdLog "log"
@@ -14,23 +15,8 @@ import (
 
 	"github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/comp/api/api"
-	"github.com/DataDog/datadog-agent/comp/collector/collector"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	"github.com/DataDog/datadog-agent/comp/core/status"
-	"github.com/DataDog/datadog-agent/comp/core/tagger"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
-	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
-	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func startServer(listener net.Listener, srv *http.Server, name string) {
@@ -57,22 +43,7 @@ func stopServer(listener net.Listener, name string) {
 }
 
 // StartServers creates certificates and starts API + IPC servers
-func StartServers(
-	configService optional.Option[rcservice.Component],
-	configServiceMRF optional.Option[rcservicemrf.Component],
-	dogstatsdServer dogstatsdServer.Component,
-	capture replay.Component,
-	pidMap pidmap.Component,
-	wmeta workloadmeta.Component,
-	taggerComp tagger.Component,
-	logsAgent optional.Option[logsAgent.Component],
-	senderManager sender.DiagnoseSenderManager,
-	secretResolver secrets.Component,
-	statusComponent status.Component,
-	collector optional.Option[collector.Component],
-	ac autodiscovery.Component,
-	providers []api.EndpointProvider,
-) error {
+func (a *apiServer) StartServers(_ context.Context) error {
 	apiAddr, err := getIPCAddressPort()
 	if err != nil {
 		return fmt.Errorf("unable to get IPC address and port: %v", err)
@@ -101,21 +72,20 @@ func StartServers(
 		apiAddr,
 		tlsConfig,
 		tlsCertPool,
-		configService,
-		configServiceMRF,
-		dogstatsdServer,
-		capture,
-		pidMap,
-		wmeta,
-		taggerComp,
-		logsAgent,
-		senderManager,
-		secretResolver,
-		statusComponent,
-		collector,
-		ac,
-		providers,
-	); err != nil {
+		a.rcService,
+		a.rcServiceMRF,
+		a.dogstatsdServer,
+		a.capture,
+		a.pidMap,
+		a.wmeta,
+		a.taggerComp,
+		a.logsAgentComp,
+		a.senderManager,
+		a.secretResolver,
+		a.statusComponent,
+		a.collector,
+		a.autoConfig,
+		a.endpointProviders); err != nil {
 		return fmt.Errorf("unable to start CMD API server: %v", err)
 	}
 

--- a/comp/api/api/component.go
+++ b/comp/api/api/component.go
@@ -10,8 +10,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-
 	"go.uber.org/fx"
 )
 
@@ -24,9 +22,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	StartServer(
-		senderManager sender.DiagnoseSenderManager,
-	) error
 	StopServer()
 	ServerAddress() *net.TCPAddr
 }

--- a/comp/api/api/component.go
+++ b/comp/api/api/component.go
@@ -22,7 +22,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	StopServer()
 	ServerAddress() *net.TCPAddr
 }
 

--- a/pkg/cli/standalone/jmx.go
+++ b/pkg/cli/standalone/jmx.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
 )
@@ -22,32 +21,32 @@ import (
 // ExecJMXCommandConsole runs the provided JMX command name on the selected checks, and
 // reports with the ConsoleReporter to the agent's `log.Info`.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
-	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, jmxLogger.JMXInfo, logLevel, configs, senderManager, agentAPI, jmxLogger)
+func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
+	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, jmxLogger.JMXInfo, logLevel, configs, agentAPI, jmxLogger)
 }
 
 // ExecJmxListWithMetricsJSON runs the JMX command with "with-metrics", reporting
 // the data as a JSON on the console. It is used by the `check jmx` cli command
 // of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
+func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
 	// don't pollute the JSON with the log pattern.
 	out := func(a ...interface{}) {
 		fmt.Println(a...)
 	}
-	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs, senderManager, agentAPI, jmxLogger)
+	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs, agentAPI, jmxLogger)
 }
 
 // ExecJmxListWithRateMetricsJSON runs the JMX command with "with-rate-metrics", reporting
 // the data as a JSON on the console. It is used by the `check jmx --rate` cli command
 // of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
+func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error {
 	// don't pollute the JSON with the log pattern.
 	out := func(a ...interface{}) {
 		fmt.Println(a...)
 	}
-	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs, senderManager, agentAPI, jmxLogger)
+	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs, agentAPI, jmxLogger)
 }
 
 // execJmxCommand runs the provided JMX command name on the selected checks.
@@ -58,13 +57,8 @@ func execJmxCommand(command string,
 	output func(...interface{}),
 	logLevel string,
 	configs []integration.Config,
-	senderManager sender.DiagnoseSenderManager,
 	agentAPI internalAPI.Component,
 	logger jmxlogger.Component) error {
-	// start the cmd HTTP server
-	if err := agentAPI.StartServer(senderManager); err != nil {
-		return fmt.Errorf("Error while starting api server, exiting: %v", err)
-	}
 
 	runner := jmxfetch.NewJMXFetch(logger)
 

--- a/pkg/cli/standalone/jmx_nojmx.go
+++ b/pkg/cli/standalone/jmx_nojmx.go
@@ -13,20 +13,19 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 )
 
 // ExecJMXCommandConsole is not supported when the 'jmx' build tag isn't included
-func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
+func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
 // ExecJmxListWithMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
+func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
 // ExecJmxListWithRateMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, senderManager sender.DiagnoseSenderManager, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
+func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config, agentAPI internalAPI.Component, jmxLogger jmxlogger.Component) error { //nolint:revive // TODO fix revive unused-parameter
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -341,11 +341,11 @@ func run(
 			fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
 			selectedChecks := []string{cliParams.checkName}
 			if cliParams.checkRate {
-				if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, config.GetString("log_level"), allConfigs, demultiplexer, agentAPI, jmxLogger); err != nil {
+				if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, config.GetString("log_level"), allConfigs, agentAPI, jmxLogger); err != nil {
 					return fmt.Errorf("while running the jmx check: %v", err)
 				}
 			} else {
-				if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, config.GetString("log_level"), allConfigs, demultiplexer, agentAPI, jmxLogger); err != nil {
+				if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, config.GetString("log_level"), allConfigs, agentAPI, jmxLogger); err != nil {
 					return fmt.Errorf("while running the jmx check: %v", err)
 				}
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR move the API server start and stop in Fx Lifecycle

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The motiviation is to get rid of the `sender.DiagnoseSenderManager` in the API component interface definition.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
As it is written in [a comment above the API Component interface](https://github.com/DataDog/datadog-agent/pull/26099/files#diff-1fb0edb76ccb9025e023366aa0cb4b485ab8008cff0c153b463a4e30e4e419daR18-R21), some dependencies of the api Component are modified between the Fx initialization and the call to `api.StartServer()`
```
// TODO(components):
// * Lifecycle can't be used atm because:
//     - logsAgent and remoteconfig.Service are modified in `startAgent` in the run subcommand
//     - Same for workloadmeta and senderManager in `execJmxCommand` in the jmx subcommand
```
This PR changes the order of initialization, the API server is started before certain elements are modified :
- **remoteconfig.Service**: depending on some configuration, the rcclient.Component [is modified](https://github.com/DataDog/datadog-agent/blob/a0fd230906038e7b575b14d1d118937b2403a468/cmd/agent/subcommands/run/command.go#L533-L548), maybe we should move this logic in the `rcclient.Component` start lifecycle function because the API component is dependent of it so it will always be executed before.
- **workloadmeta**: [is modified here](https://github.com/DataDog/datadog-agent/blob/a0fd230906038e7b575b14d1d118937b2403a468/cmd/agent/subcommands/jmx/command.go#L323-L324)
I don't think it might break anything, I just think that the related API endpoints can be unreliable during this time interval. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. run the Agent
2. the command `diagnose` must have the same behaviour as before this PR
3. It's important to also compare the behaviour inside the JMX context
