### PR TITLE
[CWS] windows: skip write with empty path

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -49,6 +49,7 @@ type fileObjectPointer uint64
 
 var (
 	errDiscardedPath = errors.New("discarded path")
+	errEmptyPath     = errors.New("empty device path")
 )
 
 /*
@@ -541,6 +542,11 @@ func (wp *WindowsProbe) parseReadArgs(e *etw.DDEventRecord) (*readArgs, error) {
 		ra.fileName = s.fileName
 		ra.userFileName = s.userFileName
 	}
+
+	if ra.fileName == "" {
+		return nil, errEmptyPath
+	}
+
 	return ra, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

We currently receive a lot of write events from ETW with un-mappable path. The goal of this PR is to simply drop those events.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
