### PR TITLE
[windows][cws] Fix cleaning up discarders

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -199,6 +199,9 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	if wp.filePathResolver.Add(ca.fileObject, fc) {
 		wp.stats.fileNameCacheEvictions++
 	}
+	// if we get here, we have a new file handle.  Remove it from the discarder cache in case
+	// we missed the close notification
+	wp.discardedFileHandles.Remove(fileObjectPointer(ca.fileObject))
 
 	return ca, nil
 }

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -403,6 +403,7 @@ func (p *WindowsProbe) setupEtw(ecb etwCallback) error {
 					p.stats.fileProcessedNotifications[e.EventHeader.EventDescriptor.ID]++
 					ecb(ca, e.EventHeader.ProcessID)
 					// lru is thread safe, has its own locking
+					p.discardedFileHandles.Remove(ca.fileObject)
 					p.filePathResolver.Remove(ca.fileObject)
 				}
 			case idFlush:


### PR DESCRIPTION
This change fixes the issue where we're never removing the file handle from the discarded handles cache.  So, once a file handle is discarded, it stays discarded even if that handle is closed, and then is reused on subsequent file open.

Also, since we could miss the close operation, if we see a new handle, remove it from the discarded cache.
### Describe how to test/QA your changes

Testing in performance environment