### PR TITLE
[windows][cws] Add filter to only run tests for the current process

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -173,6 +174,12 @@ type stats struct {
 	totalEtwNotifications uint64
 }
 
+var (
+	// ProbeETWFilterOnlyMyPID is exported so that it can be set to true for testing.
+	// should never be set at runtime
+	ProbeETWFilterOnlyMyPID = false
+)
+
 /*
  * callback function for every etw notification, after it's been parsed.
  * pid is provided for testing purposes, to allow filtering on pid.  it is
@@ -226,7 +233,10 @@ func (p *WindowsProbe) initEtwFIM() error {
 		return err
 	}
 
-	pidsList := make([]uint32, 0)
+	pidsList := make([]uint32, 1)
+	if ProbeETWFilterOnlyMyPID {
+		pidsList[0] = uint32(os.Getpid())
+	}
 
 	p.fimSession.ConfigureProvider(p.fileguid, func(cfg *etw.ProviderConfiguration) {
 		cfg.TraceLevel = etw.TRACE_LEVEL_VERBOSE

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -213,6 +213,9 @@ var commonCfgDir string
 
 func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition, fopts ...optFunc) (*testModule, error) {
 
+	// this sets the windows ETW probe to filter only on messages from our own PID
+	sprobe.ProbeETWFilterOnlyMyPID = true
+
 	var opts tmOpts
 	for _, opt := range fopts {
 		opt(&opts)


### PR DESCRIPTION
The tests in the security module were currently flakey because the ETW subsystem can be overloaded, and drop notifications.

By filtering down to only the test process pid, then we should slow the flow enough that the tests won't be flakey

### Motivation

make tests reliable

### Possible Drawbacks / Trade-offs

Intentionally not made a config option, but a compile-time decision.  However, now exists the possibility of introducing a bug where we only filter on the system-probe pid

### Describe how to test/QA your changes

change is test-code only