### PR TITLE
Add support for logs to the infra attributes processor

### DIFF
--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
@@ -69,7 +69,7 @@ func (f *factory) createLogsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {
-	iap, err := newInfraAttributesLogsProcessor(set, cfg.(*Config))
+	iap, err := newInfraAttributesLogsProcessor(set, cfg.(*Config), f.tagger)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs.go
@@ -8,24 +8,68 @@ package infraattributesprocessor
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor"
 	"go.uber.org/zap"
 )
 
 type infraAttributesLogProcessor struct {
-	logger *zap.Logger
+	logger      *zap.Logger
+	tagger      tagger.Component
+	cardinality types.TagCardinality
 }
 
-func newInfraAttributesLogsProcessor(set processor.CreateSettings, _ *Config) (*infraAttributesLogProcessor, error) {
+func newInfraAttributesLogsProcessor(set processor.CreateSettings, cfg *Config, tagger tagger.Component) (*infraAttributesLogProcessor, error) {
 	telp := &infraAttributesLogProcessor{
-		logger: set.Logger,
+		logger:      set.Logger,
+		tagger:      tagger,
+		cardinality: cfg.Cardinality,
 	}
 
-	set.Logger.Info("Logs Infra Attributes Processor configured")
+	set.Logger.Info("Logs Infra Attributes configured")
 	return telp, nil
 }
 
-func (telp *infraAttributesLogProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs, error) {
+func (ialp *infraAttributesLogProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs, error) {
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		resourceAttributes := rls.At(i).Resource().Attributes()
+		entityIDs := entityIDsFromAttributes(resourceAttributes)
+		tagMap := make(map[string]string)
+
+		// Get all unique tags from resource attributes and global tags
+		for _, entityID := range entityIDs {
+			entityTags, err := ialp.tagger.Tag(entityID, ialp.cardinality)
+			if err != nil {
+				ialp.logger.Error("Cannot get tags for entity", zap.String("entityID", entityID), zap.Error(err))
+				continue
+			}
+			for _, tag := range entityTags {
+				k, v := splitTag(tag)
+				_, hasTag := tagMap[k]
+				if k != "" && v != "" && !hasTag {
+					tagMap[k] = v
+				}
+			}
+		}
+		globalTags, err := ialp.tagger.GlobalTags(ialp.cardinality)
+		if err != nil {
+			ialp.logger.Error("Cannot get global tags", zap.Error(err))
+		}
+		for _, tag := range globalTags {
+			k, v := splitTag(tag)
+			_, hasTag := tagMap[k]
+			if k != "" && v != "" && !hasTag {
+				tagMap[k] = v
+			}
+		}
+		// Add all tags as resource attributes
+		for k, v := range tagMap {
+			resourceAttributes.PutStr(k, v)
+		}
+	}
 	return ld, nil
 }

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
@@ -10,73 +10,151 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor/processortest"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/collectors"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 )
 
 type logNameTest struct {
-	name   string
-	inLogs plog.Logs
-	outLN  [][]string // output Log names per Resource
+	name                  string
+	inLogs                plog.Logs
+	outResourceAttributes []map[string]any
+}
+
+type logWithResource struct {
+	logNames           []string
+	resourceAttributes map[string]any
 }
 
 var (
+	inLogNames = []string{
+		"full_name_match",
+	}
+
 	standardLogTests = []logNameTest{
 		{
-			name:   "emptyFilterInclude",
-			inLogs: plog.NewLogs(),
-			outLN:  [][]string{},
+			name: "one tag with global",
+			inLogs: testResourceLogs([]logWithResource{{
+				logNames: inLogNames,
+				resourceAttributes: map[string]any{
+					"container.id": "test",
+				},
+			}}),
+			outResourceAttributes: []map[string]any{{
+				"global":       "tag",
+				"container.id": "test",
+				"container":    "id",
+			}},
+		},
+		{
+			name: "two tags with global",
+			inLogs: testResourceLogs([]logWithResource{{
+				logNames: inLogNames,
+				resourceAttributes: map[string]any{
+					"container.id":        "test",
+					"k8s.namespace.name":  "namespace",
+					"k8s.deployment.name": "deployment",
+				},
+			}}),
+			outResourceAttributes: []map[string]any{{
+				"global":              "tag",
+				"container.id":        "test",
+				"k8s.namespace.name":  "namespace",
+				"k8s.deployment.name": "deployment",
+				"container":           "id",
+				"deployment":          "name",
+			}},
+		},
+		{
+			name: "two resource metrics, two tags with global",
+			inLogs: testResourceLogs([]logWithResource{
+				{
+					logNames: inLogNames,
+					resourceAttributes: map[string]any{
+						"container.id": "test",
+					},
+				},
+				{
+					logNames: inLogNames,
+					resourceAttributes: map[string]any{
+						"k8s.namespace.name":  "namespace",
+						"k8s.deployment.name": "deployment",
+					},
+				}}),
+			outResourceAttributes: []map[string]any{
+				{
+					"global":       "tag",
+					"container.id": "test",
+					"container":    "id",
+				},
+				{
+					"global":              "tag",
+					"k8s.namespace.name":  "namespace",
+					"k8s.deployment.name": "deployment",
+					"deployment":          "name",
+				},
+			},
 		},
 	}
 )
 
+func testResourceLogs(lwrs []logWithResource) plog.Logs {
+	ld := plog.NewLogs()
+	for _, lwr := range lwrs {
+		rl := ld.ResourceLogs().AppendEmpty()
+		//nolint:errcheck
+		rl.Resource().Attributes().FromRaw(lwr.resourceAttributes)
+		lr := rl.ScopeLogs().AppendEmpty()
+		for _, name := range lwr.logNames {
+			l := lr.Scope()
+			l.SetName(name)
+		}
+	}
+	return ld
+}
+
 func TestInfraAttributesLogProcessor(t *testing.T) {
 	for _, test := range standardLogTests {
 		t.Run(test.name, func(t *testing.T) {
-			// next stores the results of the filter log processor
 			next := new(consumertest.LogsSink)
 			cfg := &Config{
-				Logs: LogInfraAttributes{},
+				Logs:        LogInfraAttributes{},
+				Cardinality: types.LowCardinality,
 			}
 			fakeTagger := taggerimpl.SetupFakeTagger(t)
 			defer fakeTagger.ResetTagger()
+			fakeTagger.SetTags("container_id://test", "test", []string{"container:id"}, nil, nil, nil)
+			fakeTagger.SetTags("deployment://namespace/deployment", "test", []string{"deployment:name"}, nil, nil, nil)
+			fakeTagger.SetTags(collectors.GlobalEntityID, "test", []string{"global:tag"}, nil, nil, nil)
 			factory := NewFactory(fakeTagger)
-			flp, err := factory.CreateLogsProcessor(
+			fmp, err := factory.CreateLogsProcessor(
 				context.Background(),
 				processortest.NewNopCreateSettings(),
 				cfg,
 				next,
 			)
-			assert.NotNil(t, flp)
+			assert.NotNil(t, fmp)
 			assert.NoError(t, err)
 
-			caps := flp.Capabilities()
+			caps := fmp.Capabilities()
 			assert.True(t, caps.MutatesData)
 			ctx := context.Background()
-			assert.NoError(t, flp.Start(ctx, nil))
+			assert.NoError(t, fmp.Start(ctx, nil))
 
-			cErr := flp.ConsumeLogs(context.Background(), test.inLogs)
+			cErr := fmp.ConsumeLogs(context.Background(), test.inLogs)
 			assert.Nil(t, cErr)
-			got := next.AllLogs()
+			assert.NoError(t, fmp.Shutdown(ctx))
 
-			require.Len(t, got, 1)
-			rLogs := got[0].ResourceLogs()
-			assert.Equal(t, len(test.outLN), rLogs.Len())
-
-			for i, wantOut := range test.outLN {
-				gotLogs := rLogs.At(i).ScopeLogs().At(0).LogRecords()
-				assert.Equal(t, len(wantOut), gotLogs.Len())
-				for idx := range wantOut {
-					val, ok := gotLogs.At(idx).Attributes().Get("name")
-					require.True(t, ok)
-					assert.Equal(t, wantOut[idx], val.AsString())
-				}
+			assert.Len(t, next.AllLogs(), 1)
+			for i, out := range test.outResourceAttributes {
+				rms := next.AllLogs()[0].ResourceLogs().At(i)
+				assert.NotNil(t, rms)
+				assert.EqualValues(t, out, rms.Resource().Attributes().AsRaw())
 			}
-			assert.NoError(t, flp.Shutdown(ctx))
 		})
 	}
 }

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
@@ -131,23 +131,23 @@ func TestInfraAttributesLogProcessor(t *testing.T) {
 			fakeTagger.SetTags("deployment://namespace/deployment", "test", []string{"deployment:name"}, nil, nil, nil)
 			fakeTagger.SetTags(collectors.GlobalEntityID, "test", []string{"global:tag"}, nil, nil, nil)
 			factory := NewFactory(fakeTagger)
-			fmp, err := factory.CreateLogsProcessor(
+			flp, err := factory.CreateLogsProcessor(
 				context.Background(),
 				processortest.NewNopCreateSettings(),
 				cfg,
 				next,
 			)
-			assert.NotNil(t, fmp)
+			assert.NotNil(t, flp)
 			assert.NoError(t, err)
 
-			caps := fmp.Capabilities()
+			caps := flp.Capabilities()
 			assert.True(t, caps.MutatesData)
 			ctx := context.Background()
-			assert.NoError(t, fmp.Start(ctx, nil))
+			assert.NoError(t, flp.Start(ctx, nil))
 
-			cErr := fmp.ConsumeLogs(context.Background(), test.inLogs)
+			cErr := flp.ConsumeLogs(context.Background(), test.inLogs)
 			assert.Nil(t, cErr)
-			assert.NoError(t, fmp.Shutdown(ctx))
+			assert.NoError(t, flp.Shutdown(ctx))
 
 			assert.Len(t, next.AllLogs(), 1)
 			for i, out := range test.outResourceAttributes {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Implements the logs processor for infraattributesprocessor. Gets entities from resource attributes and applies entity tags and global tags as resource attributes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
