### PR TITLE
[CONTP-219] Populating missing container id field in remote process collector

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -58,7 +58,7 @@ type StreamHandler interface {
 	// NewClient returns a client to connect to a remote gRPC server.
 	NewClient(cc grpc.ClientConnInterface) GrpcClient
 	// HandleResponse handles a response from the remote gRPC server.
-	HandleResponse(response interface{}) ([]workloadmeta.CollectorEvent, error)
+	HandleResponse(store workloadmeta.Component, response interface{}) ([]workloadmeta.CollectorEvent, error)
 	// HandleResync is called on resynchronization.
 	HandleResync(store workloadmeta.Component, events []workloadmeta.CollectorEvent)
 }
@@ -230,7 +230,7 @@ func (c *GenericCollector) Run() {
 			continue
 		}
 
-		collectorEvents, err := c.StreamHandler.HandleResponse(response)
+		collectorEvents, err := c.StreamHandler.HandleResponse(c.store, response)
 		if err != nil {
 			log.Warnf("error processing event received from remote workloadmeta: %s", err)
 			continue

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -139,7 +139,7 @@ func (s *streamHandler) IsEnabled() bool {
 	return true
 }
 
-func (s *streamHandler) HandleResponse(resp interface{}) ([]workloadmeta.CollectorEvent, error) {
+func (s *streamHandler) HandleResponse(_ workloadmeta.Component, resp interface{}) ([]workloadmeta.CollectorEvent, error) {
 	response, ok := resp.(*pb.WorkloadmetaStreamResponse)
 	if !ok {
 		return nil, fmt.Errorf("incorrect response type")

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -167,6 +167,14 @@ func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 			},
 		},
 	}
+	// workloadmeta client store
+	mockClientStore := fxutil.Test[workloadmeta.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(workloadmeta.Params{
+			AgentType: workloadmeta.Remote,
+		}),
+		workloadmeta.MockModuleV2(),
+	))
 
 	expectedEvent, err := proto.WorkloadmetaEventFromProtoEvent(protoWorkloadmetaEvent)
 	require.NoError(t, err)
@@ -176,7 +184,7 @@ func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 	}
 
 	streamhandler := &streamHandler{}
-	collectorEvents, err := streamhandler.HandleResponse(mockResponse)
+	collectorEvents, err := streamhandler.HandleResponse(mockClientStore, mockResponse)
 
 	require.NoError(t, err)
 	assert.Len(t, collectorEvents, 1)

--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -59,6 +59,7 @@ var (
 // ContainerProvider defines the interface for a container metrics provider
 type ContainerProvider interface {
 	GetContainers(cacheValidity time.Duration, previousContainers map[string]*ContainerRateMetrics) ([]*model.Container, map[string]*ContainerRateMetrics, map[int]string, error)
+	GetProcessToContainerMapping(cacheValidity time.Duration) (map[int]string, error)
 }
 
 // GetSharedContainerProvider returns a shared ContainerProvider
@@ -96,6 +97,24 @@ func NewDefaultContainerProvider(wmeta workloadmeta.Component) ContainerProvider
 	return NewContainerProvider(metrics.GetProvider(optional.NewOption(wmeta)), wmeta, containerFilter)
 }
 
+func (p *containerProvider) shouldSkipContainer(container *workloadmeta.Container) bool {
+	var annotations map[string]string
+	if pod, err := p.metadataStore.GetKubernetesPodForContainer(container.ID); err == nil {
+		annotations = pod.Annotations
+	}
+
+	if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
+		return true
+	}
+
+	if container.Runtime == workloadmeta.ContainerRuntimeGarden && len(container.CollectorTags) == 0 {
+		log.Debugf("No tags found for garden container: %s, skipping", container.ID)
+		return true
+	}
+
+	return false
+}
+
 // GetContainers returns containers found on the machine
 func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousContainers map[string]*ContainerRateMetrics) ([]*model.Container, map[string]*ContainerRateMetrics, map[int]string, error) {
 	containersMetadata := p.metadataStore.ListContainersWithFilter(workloadmeta.GetRunningContainers)
@@ -104,17 +123,8 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 	rateStats := make(map[string]*ContainerRateMetrics)
 	pidToCid := make(map[int]string)
 	for _, container := range containersMetadata {
-		var annotations map[string]string
-		if pod, err := p.metadataStore.GetKubernetesPodForContainer(container.ID); err == nil {
-			annotations = pod.Annotations
-		}
 
-		if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
-			continue
-		}
-
-		if container.Runtime == workloadmeta.ContainerRuntimeGarden && len(container.CollectorTags) == 0 {
-			log.Debugf("No tags found for garden container: %s, skipping", container.ID)
+		if p.shouldSkipContainer(container) {
 			continue
 		}
 
@@ -186,6 +196,40 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 	}
 
 	return processContainers, rateStats, pidToCid, nil
+}
+
+// GetProcessToContainerMapping returns a mapping from process ID to container ID
+func (p *containerProvider) GetProcessToContainerMapping(cacheValidity time.Duration) (map[int]string, error) {
+	containersMetadata := p.metadataStore.ListContainersWithFilter(workloadmeta.GetRunningContainers)
+
+	pidToCid := make(map[int]string)
+	for _, container := range containersMetadata {
+
+		if p.shouldSkipContainer(container) {
+			continue
+		}
+
+		collector := p.metricsProvider.GetCollector(provider.NewRuntimeMetadata(
+			string(container.Runtime),
+			string(container.RuntimeFlavor),
+		))
+		if collector == nil {
+			log.Infof("No metrics collector available for runtime: %s, skipping container: %s", container.Runtime, container.ID)
+			continue
+		}
+
+		// Building PID to CID mapping for NPM
+		pids, err := collector.GetPIDs(container.Namespace, container.ID, cacheValidity)
+		if err == nil && pids != nil {
+			for _, pid := range pids {
+				pidToCid[pid] = container.ID
+			}
+		} else {
+			log.Debugf("PIDs for: %+v not available, err: %v", container, err)
+		}
+	}
+
+	return pidToCid, nil
 }
 
 func computeContainerStats(container *workloadmeta.Container, inStats *metrics.ContainerStats, previousStats, outPreviousStats *ContainerRateMetrics, outStats *model.Container) {

--- a/pkg/util/containers/metrics/docker/collector_test.go
+++ b/pkg/util/containers/metrics/docker/collector_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -87,7 +86,6 @@ func TestGetContainerIDForPID(t *testing.T) {
 	mockStore := fxutil.Test[workloadmeta.Mock](t, fx.Options(
 		config.MockModule(),
 		logimpl.MockModule(),
-		collectors.GetCatalog(),
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmeta.MockModuleV2(),
 	))


### PR DESCRIPTION
### ATTENTION: DO NOT REVIEW THIS PR COMMIT BY COMMIT. REVIEW IT AS A WHOLE

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR updates the stream handler of the remote process collector in workloadmeta of the core agent to populate the container ID of received process entity set events when the field is empty, and whenever it is possible to fetch the container ID.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


The process agent has two methods to discover processes metadata to send them as a stream to the core agent:
- Process Check
  - Requires live process collection to be enabled
  - [Fetches processes by PID](https://github.com/DataDog/datadog-agent/blob/c435f967d9d52981a9edbfc86a1c1fd24f67f84a/pkg/process/checks/process.go#L244)
  - [Gets the container ID](https://github.com/DataDog/datadog-agent/blob/34c6de12a0623c4a4f9bca542f56b96fed22c3f3/pkg/process/checks/process.go#L267) of the container associated for each process and [assigns it](https://github.com/DataDog/datadog-agent/blob/c435f967d9d52981a9edbfc86a1c1fd24f67f84a/pkg/process/metadata/workloadmeta/extractor.go#L136) to the entity before sending it via the stream.
- Process Collector
  - doesn't require live process collection to be enabled
  - [Fetches processes by PID ](https://github.com/DataDog/datadog-agent/blob/e1fc869376d3eb0c366883dd2284f695c584796c/pkg/process/checks/process_data.go#L31-L42)
  - **DOES NOT POPULATE THE CONTAINER ID BEFORE SENDING THE COLLECTED DATA ON THE STREAM**.

Consequently, if live process collection is disabled, the stream handler of the remote process collector in the core agent will receive empty container ID field in all received processes. 

This is not good because it cause Language Detection for APM SSI to fail because, although we know which language is used in each process, it is not possible to correlate this data with containers, and subsequently with pods and deployments. 

Live process collection should not be enabled by default because it is a premium paid feature. 

This is why we need a way to populate the container ID in order not to break APM SSI language detection when live process collection is disabled.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

- This is implemented on the core agent side because the process check and process collector will finally be migrated to run in the core agent instead of the process agent.
- This should not increase memory or cpu because container metadata are already fetched and cached in the core agent.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the agent and cluster agent with APM SSI enabled and language detection enabled, but override the live process collection option by disabling it on the process agent. Then make sure that the container ID field is populated in workloadmeta of the core agent and that language detection is still working as expected for APM SSI.

Example helm:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false

  logLevel: DEBUG

  apm:
    enabled: true
    instrumentation:
      enabled: true
      language_detection:
        enabled: true

agents:
  telemetry: enabled
  containers:
    processAgent:
      env:
        - name: DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED
          value: "false"
        - name: DD_LANGUAGE_DETECTION_ENABLED
          value: "true"
clusterAgent:
  enabled: true
  admissionController:
    enabled: true
    mutateUnlabelled: true
```

Deploy a dummy python app:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: python-process-deployment
  labels:
    app: python-process-app
spec:
  replicas: 3
  selector:
    matchLabels:
      app: python-process-app
  template:
    metadata:
      labels:
        app: python-process-app
    spec:
      containers:
        - name: python-process-container
          image: python:3.7 # Replace with your Python image
          command: ["python3", "-u", "your-python-script.py"]
          volumeMounts:
            - name: python-script-volume
              mountPath: /your-python-script.py
              subPath: your-python-script.py
      volumes:
        - name: python-script-volume
          configMap:
            name: python-script-configmap
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: python-script-configmap
data:
  your-python-script.py: |
    while True:
      pass
```

Wait for some time (normally less than a minute), and then check the content of workloadmeta of the core agent:

```
kubectl exec <datadog-agent>  -- agent workload-list

=== Entity process sources(merged):[remote_process_collector] id: 942019 ===
----------- Entity ID -----------
PID: 942019
Namespace PID: 1
Container ID: 46712d45a62d3ea72f81e20796f66bb6e6a3f3714d7e001ccab5da7930ce6c2d
Creation time: 2024-05-30 06:17:00 +0000 UTC
Language: python
===
```

Now after some time, you the python deployment should be patched with a language detection annotation indicating that python language was detected:


If we had done the same test without the change of this PR, then when inspecting the content of workloadmeta, we will find that the container ID is missing:

```
=== Entity process sources(merged):[remote_process_collector] id: 960174 ===
----------- Entity ID -----------
PID: 960174
Namespace PID: 1
Container ID: 
Creation time: 2024-05-30 06:40:44 +0000 UTC
Language: python
===
```

