### PR TITLE
feat(opentelemetry): implement unified service tagging

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -28,6 +28,7 @@ import (
 func TestHandleKubePod(t *testing.T) {
 	const (
 		fullyFleshedContainerID = "foobarquux"
+		otelEnvContainerID      = "otelcontainer"
 		noEnvContainerID        = "foobarbaz"
 		containerName           = "agent"
 		runtimeContainerName    = "k8s_datadog-agent_agent"
@@ -82,6 +83,20 @@ func TestHandleKubePod(t *testing.T) {
 			"DD_ENV":     env,
 			"DD_SERVICE": svc,
 			"DD_VERSION": version,
+		},
+	})
+	store.Set(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   otelEnvContainerID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: runtimeContainerName,
+		},
+		Image: image,
+		EnvVars: map[string]string{
+			"OTEL_SERVICE_NAME":        svc,
+			"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("service.name=%s,service.version=%s,deployment.environment=%s", svc, version, env),
 		},
 	})
 	store.Set(&workloadmeta.Container{
@@ -262,6 +277,57 @@ func TestHandleKubePod(t *testing.T) {
 					Entity: fullyFleshedContainerTaggerEntityID,
 					HighCardTags: []string{
 						fmt.Sprintf("container_id:%s", fullyFleshedContainerID),
+						fmt.Sprintf("display_container_name:%s_%s", runtimeContainerName, podName),
+					},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: append([]string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						fmt.Sprintf("kube_container_name:%s", containerName),
+						"image_id:datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
+						"image_name:datadog/agent",
+						"image_tag:latest",
+						"short_image:agent",
+					}, standardTags...),
+					StandardTags: standardTags,
+				},
+			},
+		},
+		{
+			name: "pod with fully formed container, standard tags from env with opentelemetry sdk",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:    otelEnvContainerID,
+						Name:  containerName,
+						Image: image,
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+					},
+					StandardTags: []string{},
+				},
+				{
+					Source: podSource,
+					Entity: fmt.Sprintf("container_id://%s", otelEnvContainerID),
+					HighCardTags: []string{
+						fmt.Sprintf("container_id:%s", otelEnvContainerID),
 						fmt.Sprintf("display_container_name:%s_%s", runtimeContainerName, podName),
 					},
 					OrchestratorCardTags: []string{
@@ -969,6 +1035,42 @@ func TestHandleContainer(t *testing.T) {
 					"DD_ENV":     env,
 					"DD_SERVICE": svc,
 					"DD_VERSION": version,
+				},
+			},
+			envAsTags: map[string]string{
+				"team": "owner_team",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						"owner_team:container-integrations",
+					}, standardTags...),
+					StandardTags: standardTags,
+				},
+			},
+		},
+		{
+			name: "tags from environment with opentelemetry sdk",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				EnvVars: map[string]string{
+					// env as tags
+					"TEAM": "container-integrations",
+					"TIER": "node",
+
+					// otel standard tags
+					"OTEL_SERVICE_NAME":        svc,
+					"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("service.name=%s,service.version=%s,deployment.environment=%s", svc, version, env),
 				},
 			},
 			envAsTags: map[string]string{

--- a/pkg/util/containers/env_vars_filter.go
+++ b/pkg/util/containers/env_vars_filter.go
@@ -14,22 +14,23 @@ import (
 
 var (
 	defaultEnvVarsIncludeList = []string{
-		"DD_ENV",
-		"DD_VERSION",
-		"DD_SERVICE",
 		"CHRONOS_JOB_NAME",
 		"CHRONOS_JOB_OWNER",
-		"NOMAD_TASK_NAME",
-		"NOMAD_JOB_NAME",
-		"NOMAD_GROUP_NAME",
-		"NOMAD_NAMESPACE",
-		"NOMAD_DC",
-		"MESOS_TASK_ID",
+		"DD_ENV",
+		"DD_SERVICE",
+		"DD_VERSION",
+		"DOCKER_DD_AGENT", // included to be able to detect agent containers
 		"ECS_CONTAINER_METADATA_URI",
 		"ECS_CONTAINER_METADATA_URI_V4",
-		"DOCKER_DD_AGENT", // included to be able to detect agent containers
-		// Included to ease unit tests without requiring a mock
-		"TEST_ENV",
+		"MESOS_TASK_ID",
+		"NOMAD_DC",
+		"NOMAD_GROUP_NAME",
+		"NOMAD_JOB_NAME",
+		"NOMAD_NAMESPACE",
+		"NOMAD_TASK_NAME",
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"OTEL_SERVICE_NAME",
+		"TEST_ENV", // Included to ease unit tests without requiring a mock
 	}
 
 	envFilterOnce       sync.Once

--- a/releasenotes/notes/opentelemetry-resource-attributes-ust-e379136c3a5c8046.yaml
+++ b/releasenotes/notes/opentelemetry-resource-attributes-ust-e379136c3a5c8046.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Implement OpenTelemetry SDK Resource Attributes as Unified Service Tags.
+

--- a/releasenotes/notes/opentelemetry-resource-attributes-ust-e379136c3a5c8046.yaml
+++ b/releasenotes/notes/opentelemetry-resource-attributes-ust-e379136c3a5c8046.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Implement OpenTelemetry SDK Resource Attributes as Unified Service Tags.
+    Implement OpenTelemetry SDK resource attributes as unified service rags.
 


### PR DESCRIPTION
### What does this PR do?

OpenTelemetry [implements](https://opentelemetry.io/docs/languages/sdk-configuration/general) an equivalent to [Datadog's Unified Service Tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging)

We want to support the OpenTelemetry SDK resource attributes the same as Unified Service Tags.

### Motivation

This is needed to improve feature parity between Datadog and OpenTelemetry.

### Additional notes

Note that OpenTelemetry SDK resource attributes are incompatible with pod/deployment level Unified Service Tags since they are applied at the container level.

### Describe how to test/QA your changes

* Deploy the following manifest:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-nginx-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-nginx-app
  template:
    metadata:
      labels:
        app: dummy-nginx-app
        admission.datadoghq.com/enabled: "false"
    spec:
      containers:
      - name: dummy-nginx-app
        image: nginx
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: OTEL_SERVICE_NAME
          value: "Service from environment variable"
        - name: OTEL_RESOURCE_ATTRIBUTES
          value: "service.name=Service from resource attributes,service.version=0.0.1,deployment.environment=Development"
```

* When running the `tagger-list` command, you should see Unified Service Tags for your container in both the Agent and Process Agent.
```
➜  kubectl exec -it daemonsets/datadog-agent -c agent -- agent tagger-list | grep dummy-nginx-app
=Tags: [kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-f8dd44f76 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-f8dd44f76 pod_name:dummy-nginx-app-f8dd44f76-np9q9 pod_phase:running]
=Tags: [container_id:ec02cca65cb13a23d409a4463124e6d8a541d2edae41f30b827c0b80dd5d22a4 container_name:dummy-nginx-app docker_image:nginx:latest env:Development image_id:nginx@sha256:a484819eb60211f5299034ac80f6a681b06f89e65866ce91f356ed7c72af059c image_name:nginx image_tag:latest service:Service from environment variable service:Service from resource attributes short_image:nginx version:0.0.1]
=Tags: [container_id:ec02cca65cb13a23d409a4463124e6d8a541d2edae41f30b827c0b80dd5d22a4 display_container_name:dummy-nginx-app_dummy-nginx-app-f8dd44f76-np9q9 env:Development image_id:nginx@sha256:a484819eb60211f5299034ac80f6a681b06f89e65866ce91f356ed7c72af059c image_name:nginx image_tag:latest kube_container_name:dummy-nginx-app kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-f8dd44f76 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-f8dd44f76 pod_name:dummy-nginx-app-f8dd44f76-np9q9 pod_phase:running service:Service from environment variable service:Service from resource attributes short_image:nginx version:0.0.1]
```

```
➜  kubectl exec -it daemonsets/datadog-agent -c process-agent -- process-agent tagger-list | grep dummy-nginx-app
=Tags: [kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-f8dd44f76 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-f8dd44f76 pod_name:dummy-nginx-app-f8dd44f76-np9q9 pod_phase:running]
=Tags: [container_id:ec02cca65cb13a23d409a4463124e6d8a541d2edae41f30b827c0b80dd5d22a4 container_name:dummy-nginx-app docker_image:nginx:latest env:Development image_id:nginx@sha256:a484819eb60211f5299034ac80f6a681b06f89e65866ce91f356ed7c72af059c image_name:nginx image_tag:latest service:Service from environment variable service:Service from resource attributes short_image:nginx version:0.0.1]
=Tags: [container_id:ec02cca65cb13a23d409a4463124e6d8a541d2edae41f30b827c0b80dd5d22a4 display_container_name:dummy-nginx-app_dummy-nginx-app-f8dd44f76-np9q9 env:Development image_id:nginx@sha256:a484819eb60211f5299034ac80f6a681b06f89e65866ce91f356ed7c72af059c image_name:nginx image_tag:latest kube_container_name:dummy-nginx-app kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-f8dd44f76 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-f8dd44f76 pod_name:dummy-nginx-app-f8dd44f76-np9q9 pod_phase:running service:Service from environment variable service:Service from resource attributes short_image:nginx version:0.0.1]
```

* You can also see Unified Service Tags on metrics
![image](https://github.com/DataDog/datadog-agent/assets/5231539/2fe4a7e4-654f-4e40-97d7-0ed1eb7d3dec)
