### PR TITLE
[CONS-6393] Fix the Unix rights checker on the secret backend helper

### DIFF
--- a/comp/core/secrets/secretsimpl/check_rights_nix.go
+++ b/comp/core/secrets/secretsimpl/check_rights_nix.go
@@ -9,8 +9,9 @@ package secretsimpl
 
 import (
 	"fmt"
-	"os/user"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func checkRights(path string, allowGroupExec bool) error {
@@ -19,72 +20,18 @@ func checkRights(path string, allowGroupExec bool) error {
 		return fmt.Errorf("invalid executable '%s': can't stat it: %s", path, err)
 	}
 
-	// get information about current user
-	usr, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("can't query current user's GIDs: %s", err)
-	}
-
-	if !allowGroupExec {
-		return checkUserPermission(&stat, usr, path)
-	}
-
-	userGroups, err := usr.GroupIds()
-	if err != nil {
-		return fmt.Errorf("can't query current user's GIDs: %s", err)
-	}
-	return checkGroupPermission(&stat, usr, userGroups, path)
-}
-
-// checkUserPermission check that only the current User can exec and own the file path
-func checkUserPermission(stat *syscall.Stat_t, usr *user.User, path string) error {
-	if fmt.Sprintf("%d", stat.Uid) != usr.Uid {
-		return fmt.Errorf("invalid executable: '%s' isn't owned by this user: username '%s', UID %s. We can't execute it", path, usr.Username, usr.Uid)
-	}
-
-	// checking that the owner have exec rights
-	if stat.Mode&syscall.S_IXUSR == 0 {
-		return fmt.Errorf("invalid executable: '%s' is not executable", path)
-	}
-
-	// If *user* executable, user can RWX, and nothing else for anyone.
-	if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
-		return fmt.Errorf("invalid executable '%s', 'group' or 'others' have rights on it", path)
-	}
-
-	return nil
-}
-
-// checkGroupPermission check that only the current User or one of his group can exec the path
-func checkGroupPermission(stat *syscall.Stat_t, usr *user.User, userGroups []string, path string) error {
-	var isUserHavePermission bool
-	// checking if the user is the owner and the owner have exec rights
-	if (fmt.Sprintf("%d", stat.Uid) == usr.Uid) && (stat.Mode&syscall.S_IXUSR != 0) {
-		isUserHavePermission = true
-	}
-
-	// If *group* executable, user can RWX, group can RX, and nothing else for anyone.
-	if stat.Mode&(syscall.S_IRWXO|syscall.S_IWGRP) != 0 {
-		return fmt.Errorf("invalid executable '%s', 'others' have rights on it or 'group' has write permissions on it", path)
-	}
-
-	// If the file is not owned by the user, let's check for one of his groups
-	if !isUserHavePermission {
-		var isGroupFile bool
-		for _, userGroup := range userGroups {
-			if fmt.Sprintf("%d", stat.Gid) == userGroup {
-				isGroupFile = true
-				break
-			}
+	if allowGroupExec {
+		if stat.Mode&(syscall.S_IWGRP|syscall.S_IRWXO) != 0 {
+			return fmt.Errorf("invalid executable '%s', 'others' have rights on it or 'group' has write permissions on it", path)
 		}
-		if !isGroupFile {
-			return fmt.Errorf("invalid executable: '%s' isn't owned by this user or one of his group: username '%s', UID %s GUI %s. We can't execute it", path, usr.Username, usr.Uid, usr.Gid)
+	} else {
+		if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
+			return fmt.Errorf("invalid executable '%s', 'group' or 'others' have rights on it", path)
 		}
+	}
 
-		// Check that *group* can at least exec.
-		if stat.Mode&(syscall.S_IXGRP) == 0 {
-			return fmt.Errorf("invalid executable: '%s' is not executable by group", path)
-		}
+	if err := syscall.Access(path, unix.X_OK); err != nil {
+		return fmt.Errorf("invalid executable '%s': can't access it: %s", path, err)
 	}
 
 	return nil

--- a/releasenotes/notes/Fix-secret-backend-rights-helper-cae7851914217a3a.yaml
+++ b/releasenotes/notes/Fix-secret-backend-rights-helper-cae7851914217a3a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes the validation of the permissions of the secret backend helper.
+    Fixes the validation of permissions for the secret backend helper.

--- a/releasenotes/notes/Fix-secret-backend-rights-helper-cae7851914217a3a.yaml
+++ b/releasenotes/notes/Fix-secret-backend-rights-helper-cae7851914217a3a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the validation of the permissions of the secret backend helper.

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
@@ -44,7 +44,7 @@ func (v *linuxSecretSuite) TestAgentSecretChecksExecutablePermissions() {
 
 	assert.Contains(v.T(), output, "=== Checking executable permissions ===")
 	assert.Contains(v.T(), output, "Executable path: /usr/bin/echo")
-	assert.Contains(v.T(), output, "Executable permissions: error: invalid executable: '/usr/bin/echo' isn't owned by this user")
+	assert.Contains(v.T(), output, "Executable permissions: error: invalid executable '/usr/bin/echo', 'group' or 'others' have rights on it")
 	assert.Regexp(v.T(), "Number of secrets .+: 0", output)
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the function that validates the permissions on the secret backend helper executable.

The `checkRights` function was doing two things:
* Ensuring that the permissions of the secret backend helper are restricted:
  * If `allowGroupExec` is `false`, then neither `group` or `other` should have any permission (`read`, `write`, `execute`) on the secret backend helper executable.
  * If `allowGroupExec` is `true`, then `other` should have no permission and `group` shouldn’t have `write` permission on the secret backend helper executable.
* Check if the current user of the agent process has the right to execute the secret backend helper executable.
  * If `allowGroupExec` is `false`, it only checks if the secret backend helper has the `execute` permission for `user` and that it is owned by by the user of the current process.
  * If `allowGroupExec` is `true`, then, it also checks the user’s groups.

#### Ensuring that the permissions of the secret backend helper are restricted

The first point makes sense only if the secret itself is embedded inside the secret backend helper.
But it’s usually not the case. Usually, the secret backend helper is only a kind of proxy that exposes a secret stored elsewhere, like vault for ex., via the API expected by the agent.
In such a case, enforcing a restriction on the permissions of the secret backend helper is as efficient as pretending to secure a secret file like `/etc/shadow` for ex., by restricting who is allowed to execute `cat`.
Although `cat /etc/shadow` would return `Permission denied`, the secret can still be trivially retrieved by using `more` instead of `cat` !

This PR doesn’t touch this first point and its logic has been kept.
However, I’d be happy to get rid of it in another dedicated PR if there’s an agreement on what I described in the above paragraph.

#### Check if the current user of the agent process has the right to execute the secret backend helper executable

This second point is however currently broken because of a confusion between the default groups a user has access to defined in `/etc/groups` and the effective groups of the running process agent.

Here is an example to explain the difference:

I create a file readable only by members of the `ubuntu(1000)` group:
```
lenaic@lenaic-agent-dev:~$ rm flag 
lenaic@lenaic-agent-dev:~$ echo 'Hello world' > flag
lenaic@lenaic-agent-dev:~$ sudo chown 0:1000 flag
lenaic@lenaic-agent-dev:~$ sudo chmod 0640 flag
```
and then, I start a process in group `nogroup`:
```
lenaic@lenaic-agent-dev:~$ docker run -ti -u 1000:65534 -v $PWD/flag:/flag ubuntu /bin/bash
ubuntu@c61b5d0f7a31:/$ id
uid=1000(ubuntu) gid=65534(nogroup) groups=65534(nogroup)
```
If I try to read the file, it fails:
```
ubuntu@c61b5d0f7a31:/$ ls -l /flag 
-rw-r----- 1 root ubuntu 12 May 28 12:29 /flag
ubuntu@c61b5d0f7a31:/$ cat /flag
cat: /flag: Permission denied
```
Yet, if I look at the groups of the current user, it seems to belong to `ubuntu(1000)`:
```
ubuntu@c61b5d0f7a31:/$ id 1000
uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev)
```
But that’s not the case of my current `bash` process.
So, I need to add that `ubuntu(1000)` group to my current process to be able to read the file:
```
ubuntu@c61b5d0f7a31:/$ newgrp ubuntu
ubuntu@c61b5d0f7a31:/$ id
uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),65534(nogroup)
ubuntu@c61b5d0f7a31:/$ cat /flag
Hello world
```

Please note how `id` returns the groups of the current process whereas `id <user>` returns the the groups of the user.

`checkRigths` was using [`(u *User) GroupIds()`](https://pkg.go.dev/os/user#User.GroupIds) which returns the list of groups of the user (equivalent of `id <user>` in my above example).
This was wrong as it can be seen in my previous example: according to the output of `id 1000`, I should have been able to read the file, but it wasn’t the case.

I could have used [`os.Getgroups()`](https://pkg.go.dev/os#Getgroups) instead as this is the fonction to use to get the groups of the current process (equivalent of `id` in my above example).

But it would still not be able to reliably predict if the kernel would allow to execute the secret backend helper executable or not because, for ex:
* The executable might have some POSIX ACLs that allows its execution although it shouldn’t according to the current `checkRights` logic.
* There might be some SELinux rules that are preventing its execution although it should according to the current `checkRigths` logic.
* Same for AppArmor.
* etc.

In the end, it’s extremely fragile to try to re-implement the logic that tells whether or not a process is allowed to execute an executable.
It’s much more robust to ask the kernel itself if it would allow the execution or not thanks to the dedicated [syscall `access(…, X_OK)`](https://man7.org/linux/man-pages/man2/access.2.html).

This is precisely what this PR does.


### Motivation

The current validation function is broken on OpenShift. See [CONS-6393](https://datadoghq.atlassian.net/browse/CONS-6393)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

See [this](https://datadoghq.atlassian.net/browse/CONS-6393?focusedCommentId=1705693).

Deploy the agent on OpenShift with the `DD_SECRET_BACKEND_COMMAND` environment variable set to `/readsecret_multiple_providers.sh` and with:
```
securityContext:
  RunAsGroup: 101
```

With agent `7.54.0`, `agent secret` would tell that `/readsecret_multiple_providers.sh` cannot be executed because its group isn’t one of the current user. Yet, `exec`ing into the container and trying to manually execute `/readsecret_multiple_providers.sh` would have worked.

With this fix, `agent secret` should be fine in all the cases where `/readsecret_multiple_providers.sh` can be manually executed from the agent container by `exec`ing into it.

[CONS-6393]: https://datadoghq.atlassian.net/browse/CONS-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ