### PR TITLE
[EBPF] Avoid rebuilds and improve kmt.prepare speed

### DIFF
--- a/tasks/kernel_matrix_testing/tool.py
+++ b/tasks/kernel_matrix_testing/tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import platform
+import sys
 from typing import TYPE_CHECKING
 
 import invoke.exceptions as ie
@@ -20,24 +21,28 @@ except ImportError:
         return text
 
 
+def _logprint(msg: str):
+    print(msg, flush=True, file=sys.stderr)
+
+
 def ask(question: str) -> str:
     return input(colored(question, "blue"))
 
 
 def debug(msg: str):
-    print(colored(msg, "white"))
+    _logprint(colored(msg, "white"))
 
 
 def info(msg: str):
-    print(colored(msg, "green"))
+    _logprint(colored(msg, "green"))
 
 
 def warn(msg: str):
-    print(colored(msg, "yellow"))
+    _logprint(colored(msg, "yellow"))
 
 
 def error(msg: str):
-    print(colored(msg, "red"))
+    _logprint(colored(msg, "red"))
 
 
 def Exit(msg: str):

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -726,8 +726,12 @@ def compute_package_dependencies(ctx: Context, packages: list[str]) -> dict[str,
         deps = [d.strip() for d in deps.split(" ")]
         dd_deps = [d[len(dd_pkg_name) :] for d in deps if d.startswith(dd_pkg_name)]
 
-        # Test packages might be named path/to/pkg [path/to/pkg.test] or
-        # path/to/pkg.test. Control for both cases and get the package name
+        # The import path printed by "go list" is usually path/to/pkg  (e.g., pkg/ebpf/verifier).
+        # However, for test packages it might be either:
+        # - path/to/pkg.test
+        # - path/to/pkg [path/to/pkg.test]
+        # In any case all variants refer to the same variant. This code controls for that
+        # so that we keep the usual package name.
         pkg = pkg.split(" ")[0].removeprefix(dd_pkg_name).removesuffix(".test")
         pkg_deps[pkg].update(dd_deps)
 

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -775,17 +775,16 @@ def kmt_sysprobe_prepare(
 
             go_files = [os.path.abspath(i) for i in glob(f"{pkg}/*.go")]
 
-            # We delete the output file to force ninja to rebuild the testsuite everytime
-            # because it cannot track go dependencies correctly.
-            ctx.run(f"rm -f {output_path}")
-            nw.build(
-                inputs=[pkg],
-                outputs=[output_path],
-                implicit=go_files,
-                rule="gotestsuite",
-                pool="gobuild",
-                variables=variables,
-            )
+            # skip packages without test files
+            if any(x.endswith("_test.go") for x in go_files):
+                nw.build(
+                    inputs=[pkg],
+                    outputs=[output_path],
+                    implicit=go_files,
+                    rule="gotestsuite",
+                    pool="gobuild",
+                    variables=variables,
+                )
 
             if pkg.endswith("java"):
                 nw.build(

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -757,7 +757,6 @@ def kmt_sysprobe_prepare(
     if packages:
         filter_pkgs = [os.path.relpath(p) for p in packages.split(",")]
 
-    target_packages = build_target_packages(filter_pkgs)
     kmt_paths = KMTPaths(stack, arch)
     nf_path = os.path.join(kmt_paths.arch_dir, "kmt-sysprobe.ninja")
 
@@ -772,6 +771,7 @@ def kmt_sysprobe_prepare(
     build_object_files(ctx, f"{kmt_paths.arch_dir}/kmt-object-files.ninja")
 
     info("[+] Computing Go dependencies for test packages...")
+    target_packages = build_target_packages(filter_pkgs)
     pkg_deps = compute_package_dependencies(ctx, target_packages)
 
     info("[+] Generating build instructions..")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -811,7 +811,7 @@ def kmt_sysprobe_prepare(
                 variables["extra_arguments"] = extra_arguments
 
             go_files = set(glob(f"{pkg}/*.go"))
-            has_test_files = any(x.endswith("_test.go") for x in go_files)
+            has_test_files = any(x.lower().endswith("_test.go") for x in go_files)
 
             # skip packages without test files
             if has_test_files:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -787,21 +787,13 @@ def go_package_dirs(packages, build_tags):
     """
 
     target_packages = []
-    for pkg in packages:
-        dirs = (
-            check_output(
-                f"go list -find -f \"{{{{ .Dir }}}}\" -mod=mod -tags \"{','.join(build_tags)}\" {pkg}",
-                shell=True,
-            )
-            .decode('utf-8')
-            .strip()
-            .split("\n")
-        )
-        # Some packages may not be available on all architectures, ignore them
-        # instead of reporting empty path names
-        target_packages += [dir for dir in dirs if len(dir) > 0]
+    format_arg = '{{ .Dir }}'
+    buildtags_arg = ",".join(build_tags)
+    packages_arg = " ".join(packages)
+    cmd = f"go list -find -f \"{format_arg}\" -mod=mod -tags \"{buildtags_arg}\" {packages_arg}"
 
-    return target_packages
+    target_packages = [p.strip() for p in check_output(cmd, shell=True, encoding='utf-8').split("\n")]
+    return [p for p in target_packages if len(p) > 0]
 
 
 BUILD_COMMIT = os.path.join(KITCHEN_ARTIFACT_DIR, "build.commit")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR improves the `kmt.prepare` task to avoid unnecessary rebuilds and improve speed:

* The `go_package_dirs` is changed to use a single invocation of `go list`, which makes that call slightly faster (it takes several seconds usually).
* Calculate the dependencies of Go test binaries using `go list`, and communicate that to Ninja so that tests are only rebuilt when needed.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
