### PR TITLE
Remove redundant warning

### DIFF
--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -1,9 +1,8 @@
-import os
 import sys
 
 from invoke import Exit, task
 
-from tasks.libs.common.utils import collapsed_section, color_message, environ
+from tasks.libs.common.utils import collapsed_section, environ
 
 TOOL_LIST = [
     'github.com/frapposelli/wwhrd',

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -43,21 +43,6 @@ def download_tools(ctx):
 @task
 def install_tools(ctx):
     """Install all Go tools for testing."""
-    if os.path.isfile("go.work") or os.path.isfile("go.work.sum"):
-        # Someone reported issues with this command when using a go.work but other people
-        # use a go.work and don't have any issue, so the root cause is unclear.
-        # Printing a warning because it might help someone but not enforcing anything.
-
-        # The issue which was reported was that `go install` would fail with the following error:
-        ### no required module provides package <package>; to add it:
-        ### go get <package>
-        print(
-            color_message(
-                "WARNING: In case of issue, you might want to try disabling go workspaces by setting the environment variable GOWORK=off, or even deleting go.work and go.work.sum",
-                "orange",
-            )
-        )
-
     with collapsed_section("Installing Go tools"):
         with environ({'GO111MODULE': 'on'}):
             for path, tools in TOOLS.items():


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove a redundant warning from `install_tools` invoke task.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
`GOWORK` is now disabled by default, and there is another higher level warning about it anyway, so this one has become redundant:

```
Disabling GOWORK to avoid failures or weird behavior.
It can be enabled by setting the GOWORK environment variable to the empty string, or to the absolute path of a go.work file.

WARNING: In case of issue, you might want to try disabling go workspaces by setting the environment variable GOWORK=off, or even deleting go.work and go.work.sum
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
