### PR TITLE
[EBPF] Run manual KMT cleanup when cancelling pipelines

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -157,6 +157,14 @@
         aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
       fi
 
+# Manual cleanup jobs, these will be used to cleanup the instances after the tests
+# if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
+# will not run if the dependencies are canceled
+.kmt_cleanup_manual:
+  when: manual
+  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
+  needs: []
+
 # -- Test runners
 .kmt_run_tests:
   retry:

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -144,7 +144,6 @@
 .kmt_cleanup:
   stage: kernel_matrix_testing_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  when: always
   tags: ["arch:amd64"]
   before_script:
     - !reference [.kmt_new_profile]

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -216,6 +216,7 @@ kmt_secagent_cleanup_x64:
 # will not run if the dependencies are canceled
 kmt_secagent_cleanup_arm64_manual:
   when: manual
+  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_secagent_cleanup
   +variables:
@@ -224,6 +225,7 @@ kmt_secagent_cleanup_arm64_manual:
 
 kmt_secagent_cleanup_x64_manual:
   when: manual
+  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_secagent_cleanup
   variables:

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -215,19 +215,17 @@ kmt_secagent_cleanup_x64:
 # if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
 # will not run if the dependencies are canceled
 kmt_secagent_cleanup_arm64_manual:
-  when: manual
-  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_secagent_cleanup
+    - .kmt_cleanup_manual
   variables:
     ARCH: arm64
     INSTANCE_TYPE: "m6gd.metal"
 
 kmt_secagent_cleanup_x64_manual:
-  when: manual
-  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_secagent_cleanup
+    - .kmt_cleanup_manual
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -219,7 +219,7 @@ kmt_secagent_cleanup_arm64_manual:
   allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_secagent_cleanup
-  +variables:
+  variables:
     ARCH: arm64
     INSTANCE_TYPE: "m6gd.metal"
 

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -190,6 +190,7 @@ kmt_run_secagent_tests_arm64:
     TEST_COMPONENT: security-agent
 
 kmt_secagent_cleanup_arm64:
+  when: always
   extends:
     - .kmt_secagent_cleanup
   needs:
@@ -200,11 +201,31 @@ kmt_secagent_cleanup_arm64:
     INSTANCE_TYPE: "m6gd.metal"
 
 kmt_secagent_cleanup_x64:
+  when: always
   extends:
     - .kmt_secagent_cleanup
   needs:
     - kmt_setup_env_secagent_x64
     - kmt_run_secagent_tests_x64
+  variables:
+    ARCH: x86_64
+    INSTANCE_TYPE: "m5d.metal"
+
+# Manual cleanup jobs, these will be used to cleanup the instances after the tests
+# if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
+# will not run if the dependencies are canceled
+kmt_secagent_cleanup_arm64_manual:
+  when: manual
+  extends:
+    - .kmt_secagent_cleanup
+  +variables:
+    ARCH: arm64
+    INSTANCE_TYPE: "m6gd.metal"
+
+kmt_secagent_cleanup_x64_manual:
+  when: manual
+  extends:
+    - .kmt_secagent_cleanup
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -268,6 +268,7 @@ kmt_run_sysprobe_tests_arm64:
     TEST_COMPONENT: system-probe
 
 kmt_sysprobe_cleanup_arm64:
+  when: always
   extends:
     - .kmt_sysprobe_cleanup
   needs:
@@ -278,11 +279,31 @@ kmt_sysprobe_cleanup_arm64:
     INSTANCE_TYPE: "m6gd.metal"
 
 kmt_sysprobe_cleanup_x64:
+  when: always
   extends:
     - .kmt_sysprobe_cleanup
   needs:
     - kmt_setup_env_sysprobe_x64
     - kmt_run_sysprobe_tests_x64
+  variables:
+    ARCH: x86_64
+    INSTANCE_TYPE: "m5d.metal"
+
+# Manual cleanup jobs, these will be used to cleanup the instances after the tests
+# if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
+# will not run if the dependencies are canceled
+kmt_sysprobe_cleanup_arm64_manual:
+  when: manual
+  extends:
+    - .kmt_sysprobe_cleanup
+  variables:
+    ARCH: arm64
+    INSTANCE_TYPE: "m6gd.metal"
+
+kmt_sysprobe_cleanup_x64_manual:
+  when: manual
+  extends:
+    - .kmt_sysprobe_cleanup
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -294,6 +294,7 @@ kmt_sysprobe_cleanup_x64:
 # will not run if the dependencies are canceled
 kmt_sysprobe_cleanup_arm64_manual:
   when: manual
+  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_sysprobe_cleanup
   variables:
@@ -302,6 +303,7 @@ kmt_sysprobe_cleanup_arm64_manual:
 
 kmt_sysprobe_cleanup_x64_manual:
   when: manual
+  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_sysprobe_cleanup
   variables:

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -289,23 +289,19 @@ kmt_sysprobe_cleanup_x64:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"
 
-# Manual cleanup jobs, these will be used to cleanup the instances after the tests
-# if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
-# will not run if the dependencies are canceled
+
 kmt_sysprobe_cleanup_arm64_manual:
-  when: manual
-  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_sysprobe_cleanup
+    - .kmt_cleanup_manual
   variables:
     ARCH: arm64
     INSTANCE_TYPE: "m6gd.metal"
 
 kmt_sysprobe_cleanup_x64_manual:
-  when: manual
-  allow_failure: true  # Don't fail the full pipeline, these can fail if the instances are already cleaned up
   extends:
     - .kmt_sysprobe_cleanup
+    - .kmt_cleanup_manual
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: "m5d.metal"

--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -81,11 +81,11 @@ def gracefully_cancel_pipeline(repo: Project, pipeline: ProjectPipeline, force_c
 
     for job in jobs:
         if job.stage in force_cancel_stages or (
-            job.status not in ["running", "canceled"] and "cleanup" not in job.name
+            job.status not in ["running", "canceled", "success"] and "cleanup" not in job.name
         ):
             repo.jobs.get(job.id, lazy=True).cancel()
 
-            if job.name.startswith("kmt_"):
+            if job.name.startswith("kmt_setup_env") or job.name.startswith("kmt_run"):
                 component = "sysprobe" if "sysprobe" in job.name else "secagent"
                 arch = "x64" if "x64" in job.name else "arm64"
                 cleanup_job = f"kmt_{component}_cleanup_{arch}_manual"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Creates manual cleanup jobs for KMT that are triggered automatically when the CI cancels the previous pipeline. 

### Motivation

The automatic cancellation of jobs does not work correctly for the way KMT is setup. In a lot of cases, the pipeline gets canceled while the setup or upload jobs are running, with the tests jobs still not started. This means that the `kmt_run_*_tests*` jobs get canceled, and therefore the cleanup jobs that depend on them to remove the EC2 instances are skipped, as they depend on these `kmt_run_*` jobs that never run.

This leads to a lot of instances for more time than expected, which represents extra cost. See [this dashboard](https://app.datadoghq.com/dashboard/24a-iqc-2ex/ebpf-platform-kernel-matrix-testing-v2?fromUser=true&refresh_mode=sliding&view=spans&from_ts=1714473097971&to_ts=1717065097971&live=true) for an estimation.

### Additional Notes

Gitlab does not allow jobs to be triggered automatically with the option to be also manually triggered. For this reason we need to duplicate the jobs and create manual variants.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
