### PR TITLE
Bump the ulimit when running the `tidy` task if needed

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -8,6 +8,7 @@ import glob
 import os
 import posixpath
 import re
+import resource
 import shutil
 import sys
 import textwrap
@@ -411,6 +412,13 @@ def tidy_all(ctx):
 
 @task
 def tidy(ctx):
+    # Some people might face ulimit issues, so we bump it up if needed.
+    # It won't change it globally, only for this process and child processes.
+    # TODO: if this is working fine, let's do it during the init so all tasks can benefit from it if needed.
+    current_ulimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if current_ulimit[0] < 1024:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (1024, current_ulimit[1]))
+
     # Note: It's currently faster to tidy everything than looking for exactly what we should tidy
     promises = []
     for mod in DEFAULT_MODULES.values():

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -8,7 +8,6 @@ import glob
 import os
 import posixpath
 import re
-import resource
 import shutil
 import sys
 import textwrap
@@ -412,12 +411,15 @@ def tidy_all(ctx):
 
 @task
 def tidy(ctx):
-    # Some people might face ulimit issues, so we bump it up if needed.
-    # It won't change it globally, only for this process and child processes.
-    # TODO: if this is working fine, let's do it during the init so all tasks can benefit from it if needed.
-    current_ulimit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    if current_ulimit[0] < 1024:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (1024, current_ulimit[1]))
+    if os.name != 'nt':
+        import resource
+
+        # Some people might face ulimit issues, so we bump it up if needed.
+        # It won't change it globally, only for this process and child processes.
+        # TODO: if this is working fine, let's do it during the init so all tasks can benefit from it if needed.
+        current_ulimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if current_ulimit[0] < 1024:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (1024, current_ulimit[1]))
 
     # Note: It's currently faster to tidy everything than looking for exactly what we should tidy
     promises = []

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -411,7 +411,7 @@ def tidy_all(ctx):
 
 @task
 def tidy(ctx):
-    if os.name != 'nt':
+    if os.name != 'nt':  # not windows
         import resource
 
         # Some people might face ulimit issues, so we bump it up if needed.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Bump the ulimit when running the `tidy` task if needed

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Depending on the terminal emulator, people can have various values for the max number of files open. On iterm2 it seems to be 256, which is pretty low for the `tidy` task. 

We bump it for the current process so people don't face the issue and don't need to tweak their own config.

We might move it to the init section so all task can benefit from it if it works well enough but let's keep it for just this one for now.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
