### PR TITLE
Adding a new metadata payload for system-probe

### DIFF
--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -90,7 +90,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
-					LogParams:    logimpl.ForOneShot("CORE", "off", true)}),
+					LogParams:    logimpl.ForOneShot("CORE", "off", true),
+				}),
 				core.Bundle(),
 				// workloadmeta setup
 				collectors.GetCatalog(),
@@ -142,7 +143,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	payloadV5Cmd := &cobra.Command{
 		Use:   "v5",
-		Short: "Print the metadata payload for the agent.",
+		Short: "[internal] Print the metadata payload for the agent.",
 		Long: `
 This command print the V5 metadata payload for the Agent. This payload is used to populate the infra list and host map in Datadog. It's called 'V5' because it's the same payload sent since Agent V5. This payload is mandatory in order to create a new host in Datadog.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -156,7 +157,7 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 
 	payloadGohaiCmd := &cobra.Command{
 		Use:   "gohai",
-		Short: "Print the gohai payload for the agent.",
+		Short: "[internal] Print the gohai payload for the agent.",
 		Long: `
 This command prints the gohai data sent by the Agent, including current processes running on the machine.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -170,7 +171,7 @@ This command prints the gohai data sent by the Agent, including current processe
 
 	payloadInventoriesAgentCmd := &cobra.Command{
 		Use:   "inventory-agent",
-		Short: "Print the Inventory agent metadata payload.",
+		Short: "[internal] Print the Inventory agent metadata payload.",
 		Long: `
 This command print the inventory-agent metadata payload. This payload is used by the 'inventories/sql' product.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -184,7 +185,7 @@ This command print the inventory-agent metadata payload. This payload is used by
 
 	payloadInventoriesHostCmd := &cobra.Command{
 		Use:   "inventory-host",
-		Short: "Print the Inventory host metadata payload.",
+		Short: "[internal] Print the Inventory host metadata payload.",
 		Long: `
 This command print the inventory-host metadata payload. This payload is used by the 'inventories/sql' product.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -198,7 +199,7 @@ This command print the inventory-host metadata payload. This payload is used by 
 
 	payloadInventoriesChecksCmd := &cobra.Command{
 		Use:   "inventory-checks",
-		Short: "Print the Inventory checks metadata payload.",
+		Short: "[internal] Print the Inventory checks metadata payload.",
 		Long: `
 This command print the inventory-checks metadata payload. This payload is used by the 'inventories/sql' product.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -212,12 +213,26 @@ This command print the inventory-checks metadata payload. This payload is used b
 
 	payloadInventoriesPkgSigningCmd := &cobra.Command{
 		Use:   "package-signing",
-		Short: "Print the Inventory package signing payload.",
+		Short: "[internal] Print the Inventory package signing payload.",
 		Long: `
 This command print the package-signing metadata payload. This payload is used by the 'fleet automation' product.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(printPayload,
 				fx.Supply(payloadName("package-signing")),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
+				core.Bundle(),
+			)
+		},
+	}
+
+	payloadSystemProbeCmd := &cobra.Command{
+		Use:   "system-probe",
+		Short: "[internal] Print the inventory systemprobe metadata payload.",
+		Long: `
+This command print the system-probe metadata payload. This payload is used by the 'fleet automation' product.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(printPayload,
+				fx.Supply(payloadName("system-probe")),
 				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle(),
 			)
@@ -230,6 +245,7 @@ This command print the package-signing metadata payload. This payload is used by
 	showPayloadCommand.AddCommand(payloadInventoriesHostCmd)
 	showPayloadCommand.AddCommand(payloadInventoriesChecksCmd)
 	showPayloadCommand.AddCommand(payloadInventoriesPkgSigningCmd)
+	showPayloadCommand.AddCommand(payloadSystemProbeCmd)
 	diagnoseCommand.AddCommand(showPayloadCommand)
 
 	return []*cobra.Command{diagnoseCommand}
@@ -239,7 +255,8 @@ func cmdDiagnose(cliParams *cliParams,
 	senderManager diagnosesendermanager.Component,
 	wmeta optional.Option[workloadmeta.Component],
 	ac autodiscovery.Component,
-	secretResolver secrets.Component) error {
+	secretResolver secrets.Component,
+) error {
 	diagCfg := diagnosis.Config{
 		Verbose:  cliParams.verbose,
 		RunLocal: cliParams.runLocal,

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -85,3 +85,13 @@ func TestShowMetadataPkgSigningCommand(t *testing.T) {
 			require.Equal(t, false, secretParams.Enabled)
 		})
 }
+
+func TestShowMetadataSystemProbeCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"diagnose", "show-metadata", "system-probe"},
+		printPayload,
+		func(coreParams core.BundleParams, secretParams secrets.Params) {
+			require.Equal(t, false, secretParams.Enabled)
+		})
+}

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -101,6 +101,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
 	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner"
+	systemprobemetadata "github.com/DataDog/datadog-agent/comp/metadata/systemprobe/def"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp"
 	"github.com/DataDog/datadog-agent/comp/netflow"
 	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
@@ -231,6 +232,7 @@ func run(log log.Component,
 	_ langDetectionCl.Component,
 	agentAPI internalAPI.Component,
 	_ packagesigning.Component,
+	_ systemprobemetadata.Component,
 	statusComponent status.Component,
 	collector collector.Component,
 	cloudfoundrycontainer cloudfoundrycontainer.Component,

--- a/comp/README.md
+++ b/comp/README.md
@@ -309,6 +309,10 @@ Package resources implements a component to generate the 'resources' metadata pa
 
 Package runner implements a component to generate metadata payload at the right interval.
 
+### [comp/metadata/systemprobe](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/metadata/systemprobe)
+
+Package def is the metadata provider for system-probe process
+
 ## [comp/ndmtmp](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/ndmtmp) (Component Bundle)
 
 *Datadog Team*: network-device-monitoring

--- a/comp/core/settings/settingsimpl/settingsimpl.go
+++ b/comp/core/settings/settingsimpl/settingsimpl.go
@@ -144,8 +144,9 @@ func (s *settingsRegistry) GetFullConfig(namespaces ...string) http.HandlerFunc 
 
 func (s *settingsRegistry) GetFullConfigBySource() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		settings := s.config.AllSettingsBySource()
 		w.Header().Set("Content-Type", "application/json")
+
+		settings := s.config.AllSettingsBySource()
 
 		jsonData, err := json.Marshal(settings)
 		if err != nil {

--- a/comp/metadata/bundle.go
+++ b/comp/metadata/bundle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning/packagesigningimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
+	systemprobe "github.com/DataDog/datadog-agent/comp/metadata/systemprobe/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -30,6 +31,7 @@ func Bundle() fxutil.BundleOptions {
 		inventoryhostimpl.Module(),
 		inventorychecksimpl.Module(),
 		packagesigningimpl.Module(),
+		systemprobe.Module(),
 	)
 }
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -432,15 +432,15 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 		}
 
 		for source, conf := range layers {
-			if json, err := ia.marshalAndScrub(conf); err == nil {
-				data[layersName[source]] = json
+			if yaml, err := ia.marshalAndScrub(conf); err == nil {
+				data[layersName[source]] = yaml
 			}
 		}
-		if json, err := ia.marshalAndScrub(ia.conf.AllSettings()); err == nil {
-			data["full_configuration"] = json
+		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettings()); err == nil {
+			data["full_configuration"] = yaml
 		}
-		if json, err := ia.marshalAndScrub(ia.conf.AllSettingsWithoutDefault()); err == nil {
-			data["provided_configuration"] = json
+		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettingsWithoutDefault()); err == nil {
+			data["provided_configuration"] = yaml
 		}
 	}
 

--- a/comp/metadata/systemprobe/README.md
+++ b/comp/metadata/systemprobe/README.md
@@ -1,0 +1,69 @@
+# System-probe metadata Payload
+
+This package populates some of the system-probe related fields in the `inventories` product in DataDog. More specifically the
+`system-probe` table.
+
+This is enabled by default but can be turned off using `inventories_enabled` config.
+
+The payload is sent every 10min (see `inventories_max_interval` in the config).
+
+## System-probe Configuration
+
+System-probe configurations are scrubbed from any sensitive information (same logic than for the flare).
+This include the following:
+`full_configuration`
+`provided_configuration`
+`file_configuration`
+`environment_variable_configuration`
+`agent_runtime_configuration`
+`remote_configuration`
+`cli_configuration`
+`source_local_configuration`
+
+Sending System-Probe configuration can be disabled using `inventories_configuration_enabled`.
+
+# Format
+
+The payload is a JSON dict with the following fields
+
+- `hostname` - **string**: the hostname of the agent as shown on the status page.
+- `timestamp` - **int**: the timestamp when the payload was created.
+- `system_probe_metadata` - **dict of string to JSON type**:
+  - `agent_version` - **string**: the version of the Agent sending this payload.
+  - `full_configuration` - **string**: the current System-Probe configuration scrubbed, including all the defaults, as a YAML
+    string.
+  - `provided_configuration` - **string**: the current System-Probe configuration (scrubbed), without the defaults, as a YAML
+    string. This includes the settings configured by the user (throuh the configuration file, the environment, CLI...).
+  - `file_configuration` - **string**: the System-Probe configuration specified by the configuration file (scrubbed), as a YAML string.
+    Only the settings written in the configuration file are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+  - `environment_variable_configuration` - **string**: the System-Probe configuration specified by the environment variables (scrubbed), as a YAML string.
+    Only the settings written in the environment variables are included, and their value might not match what's applyed by the agent somce they can be overriden by other sources.
+  - `agent_runtime_configuration` - **string**: the System-Probe configuration set by the agent itself (scrubbed), as a YAML string.
+    Only the settings set by the agent itself are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+  - `remote_configuration` - **string**: the System-Probe configuration specified by the Remote Configuration (scrubbed), as a YAML string.
+    Only the settings currently used by Remote Configuration are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+  - `cli_configuration` - **string**: the System-Probe configuration specified by the CLI (scrubbed), as a YAML string.
+    Only the settings set in the CLI are included.
+  - `source_local_configuration` - **string**: the System-Probe configuration synchronized from the local Agent process, as a YAML string.
+
+("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
+
+## Example Payload
+
+Here an example of an inventory payload:
+
+```
+{
+    "system_probe_metadata": {
+        "agent_version": "7.55.0",
+        "full_configuration": "<entire yaml configuration for system-probe>",
+        "provided_configuration": "system_probe_config:\n  sysprobe_socket: /tmp/sysprobe.sock",
+        "file_configuration": "system_probe_config:\n  sysprobe_socket: /tmp/sysprobe.sock",
+        "environment_variable_configuration": "{}",
+        "remote_configuration": "{}",
+        "cli_configuration": "{}"
+    }
+    "hostname": "my-host",
+    "timestamp": 1631281754507358895
+}
+```

--- a/comp/metadata/systemprobe/def/component.go
+++ b/comp/metadata/systemprobe/def/component.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package def is the metadata provider for system-probe process
+package def
+
+// team: agent-shared-components
+
+// Component is the component type.
+type Component interface{}

--- a/comp/metadata/systemprobe/fx/fx.go
+++ b/comp/metadata/systemprobe/fx/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the systemprobe metadata component
+package fx
+
+import (
+	systemprobeimpl "github.com/DataDog/datadog-agent/comp/metadata/systemprobe/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			systemprobeimpl.NewComponent,
+		),
+	)
+}

--- a/comp/metadata/systemprobe/impl/system_probe.go
+++ b/comp/metadata/systemprobe/impl/system_probe.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package impl implements the systemprobe metadata providers interface
+package impl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/api/api"
+	"github.com/DataDog/datadog-agent/comp/api/api/utils"
+	"github.com/DataDog/datadog-agent/comp/api/authtoken"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
+	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
+	"github.com/DataDog/datadog-agent/comp/metadata/systemprobe/def"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	// for testing
+	fetchSystemProbeConfig         = configFetcher.SystemProbeConfig
+	fetchSystemProbeConfigBySource = configFetcher.SystemProbeConfigBySource
+)
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	Hostname  string                 `json:"hostname"`
+	Timestamp int64                  `json:"timestamp"`
+	Metadata  map[string]interface{} `json:"system_probe_metadata"`
+}
+
+// MarshalJSON serialization a Payload to JSON
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	type PayloadAlias Payload
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+// SplitPayload implements marshaler.AbstractMarshaler#SplitPayload.
+//
+// In this case, the payload can't be split any further.
+func (p *Payload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
+	return nil, fmt.Errorf("could not split inventories agent payload any more, payload is too big for intake")
+}
+
+type systemprobe struct {
+	util.InventoryPayload
+
+	log          log.Component
+	conf         config.Component
+	sysprobeConf optional.Option[sysprobeconfig.Component]
+	hostname     string
+}
+
+// Requires defines the dependencies for the systemprobe metadata component
+type Requires struct {
+	Log        log.Component
+	Config     config.Component
+	Serializer serializer.MetricSerializer
+	// We need the authtoken to be created so we requires the comp. It will be used by configFetcher.
+	AuthToken      authtoken.Component
+	SysProbeConfig optional.Option[sysprobeconfig.Component]
+}
+
+// Provides defines the output of the systemprobe metadatacomponent
+type Provides struct {
+	Comp             def.Component
+	MetadataProvider runnerimpl.Provider
+	FlareProvider    flaretypes.Provider
+	Endpoint         api.AgentEndpointProvider
+}
+
+// NewComponent creates a new systemprobe metadata Component
+func NewComponent(deps Requires) Provides {
+	hname, _ := hostname.Get(context.Background())
+	sb := &systemprobe{
+		log:          deps.Log,
+		conf:         deps.Config,
+		hostname:     hname,
+		sysprobeConf: deps.SysProbeConfig,
+	}
+	sb.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, sb.getPayload, "system-probe.json")
+
+	return Provides{
+		Comp:             sb,
+		MetadataProvider: sb.MetadataProvider(),
+		FlareProvider:    sb.FlareProvider(),
+		Endpoint:         api.NewAgentEndpointProvider(sb.writePayloadAsJSON, "/metadata/system-probe", "GET"),
+	}
+}
+
+func (sb *systemprobe) writePayloadAsJSON(w http.ResponseWriter, _ *http.Request) {
+	// GetAsJSON calls getPayload which already scrub the data
+	scrubbed, err := sb.GetAsJSON()
+	if err != nil {
+		utils.SetJSONError(w, err, 500)
+		return
+	}
+	w.Write(scrubbed)
+}
+
+func (sb *systemprobe) getConfigLayers() map[string]interface{} {
+	metadata := map[string]interface{}{
+		"agent_version": version.AgentVersion,
+	}
+
+	if !sb.conf.GetBool("inventories_configuration_enabled") {
+		return metadata
+	}
+
+	sysprobeConf, isSet := sb.sysprobeConf.Get()
+	if !isSet {
+		sb.log.Debugf("system-probe config not available: disabling systemprobe metadata")
+		return metadata
+	}
+
+	rawLayers, err := fetchSystemProbeConfigBySource(sysprobeConf)
+	if err != nil {
+		sb.log.Debugf("error fetching system-probe config layers: %s", err)
+		return metadata
+	}
+
+	configBySources := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(rawLayers), &configBySources); err != nil {
+		sb.log.Debugf("error unmarshalling systemprobe config by source: %s", err)
+		return metadata
+	}
+
+	layersName := map[model.Source]string{
+		model.SourceFile:               "file_configuration",
+		model.SourceEnvVar:             "environment_variable_configuration",
+		model.SourceAgentRuntime:       "agent_runtime_configuration",
+		model.SourceLocalConfigProcess: "source_local_configuration",
+		model.SourceRC:                 "remote_configuration",
+		model.SourceCLI:                "cli_configuration",
+		model.SourceProvided:           "provided_configuration",
+	}
+	for source, conf := range configBySources {
+		if layer, ok := layersName[model.Source(source)]; ok {
+			if yamlStr, err := yaml.Marshal(conf); err == nil {
+				metadata[layer] = string(yamlStr)
+			} else {
+				sb.log.Debugf("error serializing systemprobe '%s' config layer: %s", source, err)
+			}
+		} else {
+			sb.log.Debugf("error unknown config layer from system-probe '%s'", source)
+		}
+	}
+
+	if str, err := fetchSystemProbeConfig(sysprobeConf); err == nil {
+		metadata["full_configuration"] = str
+	} else {
+		sb.log.Debugf("error fetching system-probe config: %s", err)
+	}
+
+	return metadata
+}
+
+func (sb *systemprobe) getPayload() marshaler.JSONMarshaler {
+	return &Payload{
+		Hostname:  sb.hostname,
+		Timestamp: time.Now().UnixNano(),
+		Metadata:  sb.getConfigLayers(),
+	}
+}

--- a/comp/metadata/systemprobe/impl/system_probe_test.go
+++ b/comp/metadata/systemprobe/impl/system_probe_test.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package impl implements the systemprobe metadata providers interface
+package impl
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/api/authtoken"
+	authtokenimpl "github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+func setupFecther(t *testing.T) {
+	t.Cleanup(func() {
+		fetchSystemProbeConfig = configFetcher.SystemProbeConfig
+		fetchSystemProbeConfigBySource = configFetcher.SystemProbeConfigBySource
+	})
+
+	fetchSystemProbeConfig = func(_ model.Reader) (string, error) { return "full config", nil }
+	fetchSystemProbeConfigBySource = func(_ model.Reader) (string, error) {
+		data, err := json.Marshal(map[string]interface{}{
+			string(model.SourceFile):               map[string]bool{"file": true},
+			string(model.SourceEnvVar):             map[string]bool{"env": true},
+			string(model.SourceAgentRuntime):       map[string]bool{"runtime": true},
+			string(model.SourceLocalConfigProcess): map[string]bool{"local": true},
+			string(model.SourceRC):                 map[string]bool{"rc": true},
+			string(model.SourceCLI):                map[string]bool{"cli": true},
+			string(model.SourceProvided):           map[string]bool{"provided": true},
+		})
+		return string(data), err
+	}
+}
+
+func getSystemProbeComp(t *testing.T, enableConfig bool) *systemprobe {
+	l := fxutil.Test[log.Component](t, logimpl.MockModule())
+
+	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg.Set("inventories_configuration_enabled", enableConfig, model.SourceUnknown)
+
+	r := Requires{
+		Log:        l,
+		Config:     cfg,
+		Serializer: &serializer.MockSerializer{},
+		AuthToken: fxutil.Test[authtoken.Component](t,
+			authtokenimpl.Module(),
+			fx.Provide(func() log.Component { return l }),
+			fx.Provide(func() config.Component { return cfg }),
+		),
+		SysProbeConfig: fxutil.Test[optional.Option[sysprobeconfig.Component]](t, sysprobeconfigimpl.MockModule()),
+	}
+
+	comp := NewComponent(r).Comp
+	return comp.(*systemprobe)
+}
+
+func assertPayload(t *testing.T, p *Payload) {
+	assert.Equal(t, "test hostname", p.Hostname)
+	assert.True(t, p.Timestamp < time.Now().UnixNano())
+	assert.Equal(t,
+		map[string]interface{}{
+			"agent_runtime_configuration":        "runtime: true\n",
+			"cli_configuration":                  "cli: true\n",
+			"environment_variable_configuration": "env: true\n",
+			"file_configuration":                 "file: true\n",
+			"full_configuration":                 "full config",
+			"provided_configuration":             "provided: true\n",
+			"remote_configuration":               "rc: true\n",
+			"source_local_configuration":         "local: true\n",
+			"agent_version":                      version.AgentVersion,
+		},
+		p.Metadata)
+}
+
+func TestGetPayload(t *testing.T) {
+	setupFecther(t)
+	sb := getSystemProbeComp(t, true)
+
+	sb.hostname = "test hostname"
+
+	p := sb.getPayload().(*Payload)
+	assertPayload(t, p)
+}
+
+func TestGetPayloadNoConfig(t *testing.T) {
+	setupFecther(t)
+	sb := getSystemProbeComp(t, false)
+
+	sb.hostname = "test hostname"
+
+	p := sb.getPayload().(*Payload)
+	assert.Equal(t, "test hostname", p.Hostname)
+	assert.True(t, p.Timestamp <= time.Now().UnixNano())
+	assert.Equal(t,
+		map[string]interface{}{
+			"agent_version": version.AgentVersion,
+		},
+		p.Metadata)
+}
+
+func TestWritePayload(t *testing.T) {
+	setupFecther(t)
+	sb := getSystemProbeComp(t, true)
+
+	sb.hostname = "test hostname"
+
+	req := httptest.NewRequest("GET", "http://fake_url.com", nil)
+	w := httptest.NewRecorder()
+
+	sb.writePayloadAsJSON(w, req)
+
+	resp := w.Result()
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+
+	p := Payload{}
+	err = json.Unmarshal(body, &p)
+	require.NoError(t, err)
+
+	assertPayload(t, &p)
+}

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -95,3 +95,11 @@ func SystemProbeConfig(config config.Reader) (string, error) {
 	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 	return c.FullConfig()
 }
+
+// SystemProbeConfigBySource fetch the all configuration layers from the system-probe process by querying its API
+func SystemProbeConfigBySource(config config.Reader) (string, error) {
+	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
+
+	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
+	return c.FullConfigBySource()
+}

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -29,14 +29,28 @@ type Source string
 
 // Declare every known Source
 const (
-	SourceDefault            Source = "default"
-	SourceUnknown            Source = "unknown"
-	SourceFile               Source = "file"
-	SourceEnvVar             Source = "environment-variable"
-	SourceAgentRuntime       Source = "agent-runtime"
+	// SourceDefault are the values from defaults.
+	SourceDefault Source = "default"
+	// SourceUnknown are the values from unknown source. This should only be used in tests when calling
+	// SetWithoutSource.
+	SourceUnknown Source = "unknown"
+	// SourceFile are the values loaded from configuration file.
+	SourceFile Source = "file"
+	// SourceEnvVar are the values loaded from the environment variables.
+	SourceEnvVar Source = "environment-variable"
+	// SourceAgentRuntime are the values configured by the agent itself. The agent can dynamically compute the best
+	// value for some settings when not set by the user.
+	SourceAgentRuntime Source = "agent-runtime"
+	// SourceLocalConfigProcess are the values mirrored from the config process. The config process is the
+	// core-agent. This is used when side process like security-agent or trace-agent pull their configuration from
+	// the core-agent.
 	SourceLocalConfigProcess Source = "local-config-process"
-	SourceRC                 Source = "remote-config"
-	SourceCLI                Source = "cli"
+	// SourceRC are the values loaded from remote-config (aka Datadog backend)
+	SourceRC Source = "remote-config"
+	// SourceCLI are the values set by the user at runtime through the CLI.
+	SourceCLI Source = "cli"
+	// SourceProvided are all values set by any source but default.
+	SourceProvided Source = "provided" // everything but defaults
 )
 
 // sources list the known sources, following the order of hierarchy between them
@@ -644,6 +658,7 @@ func (c *safeConfig) AllSettingsBySource() map[Source]interface{} {
 	for _, source := range sources {
 		res[source] = c.configSources[source].AllSettingsWithoutDefault()
 	}
+	res[SourceProvided] = c.AllSettingsWithoutDefault()
 	return res
 }
 


### PR DESCRIPTION
### What does this PR do?

For now the payload only contains the agent version and the different layers of configuration for system-probe.

### Describe how to test/QA your changes

Check that:
- Configuration from system-probe is accurate in the payload
- the `diagnose show-metadata sytem-probe` cli command works
- The system-probe.yaml file is correctly added to the flare