### PR TITLE
[CONTP-221] Workloadmeta: remove redundant image metadata pulling in agent startup

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -276,6 +276,7 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 	if err != nil {
 		return err
 	}
+
 	mergedImages := make(map[workloadmeta.EntityID]*workloadmeta.ContainerImageMetadata)
 	for _, image := range existingImages {
 		wlmImage, err := c.createOrUpdateImageMetadata(ctx, namespace, image, nil, true)
@@ -298,6 +299,7 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 			},
 		})
 	}
+	log.Debugf("%d initial image events sent for namespace %s. total number of images reference is %d", len(mergedImages), namespace, len(existingImages))
 	return nil
 }
 

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -276,10 +276,9 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 	if err != nil {
 		return err
 	}
-
 	mergedImages := make(map[workloadmeta.EntityID]*workloadmeta.ContainerImageMetadata)
 	for _, image := range existingImages {
-		wlmImage, err := c.createOrUpdateImageMetadata(ctx, namespace, image, nil)
+		wlmImage, err := c.createOrUpdateImageMetadata(ctx, namespace, image, nil, true)
 		if err != nil {
 			log.Warnf("error getting information for image with name %q: %s", image.Name(), err.Error())
 			continue


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
[CONTP-221](https://datadoghq.atlassian.net/browse/CONTP-221)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
When new image is found or ListImage is called, multiple image references could be returned from containerd client for the same image. These references could cause multiple events sent to the backend which makes duplicate container image. To resolve this, several PR have been committed to merge image metadata from same image. 
[PR1 ](https://github.com/DataDog/datadog-agent/pull/22355) was committed in 7.52 to consolidate duplicate image metadata entities when all references have been processed [here](https://github.com/DataDog/datadog-agent/blob/57b5fc2e1db2567e7c4e7520ac47fc1880202d9c/comp/core/workloadmeta/collectors/internal/containerd/containerd.go#L292) in the initilization
[PR2](https://github.com/DataDog/datadog-agent/pull/24185) was committed in 7.53 to actively pull all image reference when new image was found.

Both PRs work and fix the issue. However, they cause a redundant image metadata pulling in agent start up. 

#### When agent starts,
-  [ListImage](https://github.com/DataDog/datadog-agent/blob/main/comp/core/workloadmeta/collectors/internal/containerd/containerd.go#L275) was called (first pull)
-  Since all images or new to workloadmeta, a second [pull](https://github.com/DataDog/datadog-agent/blob/57b5fc2e1db2567e7c4e7520ac47fc1880202d9c/comp/core/workloadmeta/collectors/internal/containerd/image.go#L330) is called for each image
-  If number of images is large enough (> 3000), the query time to containerd runtime becomes non-negligible. ListImage could take more than 10s to return result. A redundant pulling can cause timeout in liveness check (30s limit)

Proposed fix:
Remove second pull if createOrUpdateImageMetadata function is called in workloadmeta [init](https://github.com/DataDog/datadog-agent/blob/57b5fc2e1db2567e7c4e7520ac47fc1880202d9c/comp/core/workloadmeta/collectors/internal/containerd/containerd.go#L281) 
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Run `agent workload-list | grep "Entity container_image_metadata sources" | wc -l` 
the count should match in current and new version


[CONTP-221]: https://datadoghq.atlassian.net/browse/CONTP-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ