### PR TITLE
[CONTP-220] default annotations exclusion for generic metadata collection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -178,7 +178,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			if test.requireErrorInitailisingParser {
 				require.Errorf(tt, err, "should have failed to create parser")
 			} else {
-				require.NoErrorf(tt, err, "shoud have not failed to create parser")
+				require.NoErrorf(tt, err, "should have not failed to create parser")
 				entity := parser.Parse(test.partialObjectMetadata)
 				storedMetadata, ok := entity.(*workloadmeta.KubernetesMetadata)
 				require.True(t, ok)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -471,6 +471,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.cleanup.period", "10m")
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.enabled", false)
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resources", []string{})
+	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resource_annotations_exclude", []string{})
 
 	// Metadata endpoints
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR allows excluding non-useful (or custom) annotations from generic k8s metadata collection in workload meta.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Avoid having lengthy and non useful annotations collected in workloadmetadata (more memory consumption for no use, and less readable inspection of workloadmeta store).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- This is similar to what we do for pod collection [here](https://github.com/DataDog/datadog-agent/blob/344ecd725ed39019a4b04c212934cf98ca5f9427/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go#L112)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Same QA as [this](https://github.com/DataDog/datadog-agent/pull/25901) PR, but verify that excluded annotations don't get collected. 

For example, when setting the following env var on the cluster agent:

`DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCE_ANNOTATIONS_EXCLUDE: ^kubectl\.kubernetes\.io\/last-applied-configuration$`

the following annotation should not be collected:
```
kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"local-path-provisioner","namespace":"local-path-storage"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"local-path-provisioner"}},"template":{"metadata":{"labels":{"app":"local-path-provisioner"}},"spec":{"containers":[{"command":["local-path-provisioner","--debug","start","--helper-image","docker.io/kindest/local-path-helper:v20230510-486859a6","--config","/etc/config/config.json"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"image":"docker.io/kindest/local-path-provisioner:v20230511-dc714da8","imagePullPolicy":"IfNotPresent","name":"local-path-provisioner","volumeMounts":[{"mountPath":"/etc/config/","name":"config-volume"}]}],"nodeSelector":{"kubernetes.io/os":"linux"},"serviceAccountName":"local-path-provisioner-service-account","tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Equal"}],"volumes":[{"configMap":{"name":"local-path-config"},"name":"config-volume"}]}}}} 
```

Previously it was collected, for example see this from the output of the [previous PR](https://github.com/DataDog/datadog-agent/pull/25901) QA:
```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/local-path-storage/local-path-provisioner ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/local-path-storage/local-path-provisioner

----------- Entity Meta -----------
Name: local-path-provisioner
Namespace: local-path-storage
Annotations: deployment.kubernetes.io/revision:1 kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"local-path-provisioner","namespace":"local-path-storage"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"local-path-provisioner"}},"template":{"metadata":{"labels":{"app":"local-path-provisioner"}},"spec":{"containers":[{"command":["local-path-provisioner","--debug","start","--helper-image","docker.io/kindest/local-path-helper:v20230510-486859a6","--config","/etc/config/config.json"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"image":"docker.io/kindest/local-path-provisioner:v20230511-dc714da8","imagePullPolicy":"IfNotPresent","name":"local-path-provisioner","volumeMounts":[{"mountPath":"/etc/config/","name":"config-volume"}]}],"nodeSelector":{"kubernetes.io/os":"linux"},"serviceAccountName":"local-path-provisioner-service-account","tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Equal"}],"volumes":[{"configMap":{"name":"local-path-config"},"name":"config-volume"}]}}}} 
Labels: 
----------- Resource -----------
```
