### PR TITLE
[NDM][Cisco SD-WAN] Add option to collect hardware statuses

### DIFF
--- a/cmd/agent/dist/conf.d/cisco_sdwan.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/cisco_sdwan.d/conf.yaml.example
@@ -76,3 +76,8 @@ instances:
     ## on the Cisco Manager instance.
     #
     # collect_bfd_session_status: false
+
+    ## @param collect_bfd_session_status - boolean - optional - default: false
+    ## This enable collecting hardware status metrics.
+    #
+    # collect_hardware_status: true

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
@@ -106,6 +106,7 @@ func SetupMockAPIServer() *httptest.Server {
 	mux.HandleFunc("/dataservice/data/device/state/ControlConnection", fixtureHandler(fixtures.GetControlConnectionsState))
 	mux.HandleFunc("/dataservice/data/device/state/OMPPeer", fixtureHandler(fixtures.GetOMPPeersState))
 	mux.HandleFunc("/dataservice/data/device/state/BFDSessions", fixtureHandler(fixtures.GetBFDSessionsState))
+	mux.HandleFunc("/dataservice/data/device/state/HardwareEnvironment", fixtureHandler(fixtures.GetHardwareStates))
 
 	return httptest.NewServer(mux)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -246,7 +246,7 @@ func (ms *SDWanSender) SendHardwareMetrics(hardwareEnvironments []client.Hardwar
 		if entry.Status == "OK" {
 			status = 1
 		}
-		ms.sender.Gauge(ciscoSDWANMetricPrefix+"hardware.status", float64(status), "", tags)
+		ms.sender.Gauge(ciscoSDWANMetricPrefix+"hardware.status_ok", float64(status), "", tags)
 	}
 }
 

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -234,6 +234,22 @@ func (ms *SDWanSender) SendDeviceStatusMetrics(deviceStatus map[string]float64) 
 	}
 }
 
+// SendHardwareMetrics sends hardware metrics
+func (ms *SDWanSender) SendHardwareMetrics(hardwareEnvironments []client.HardwareEnvironment) {
+	for _, entry := range hardwareEnvironments {
+		devIndex := fmt.Sprintf("%d", entry.HwDevIndex)
+
+		tags := ms.getDeviceTags(entry.VmanageSystemIP)
+		tags = append(tags, "status:"+entry.Status, "class:"+entry.HwClass, "item:"+entry.HwItem, "dev_index:"+devIndex)
+
+		status := 0
+		if entry.Status == "OK" {
+			status = 1
+		}
+		ms.sender.Gauge(ciscoSDWANMetricPrefix+"hardware.status", float64(status), "", tags)
+	}
+}
+
 // Commit commits to the sender
 func (ms *SDWanSender) Commit() {
 	ms.sender.Commit()

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
@@ -1132,7 +1132,7 @@ func TestSendHardwareMetrics(t *testing.T) {
 				{
 					method: "Gauge",
 					value:  1,
-					name:   ciscoSDWANMetricPrefix + "hardware.status",
+					name:   ciscoSDWANMetricPrefix + "hardware.status_ok",
 					tags: []string{
 						"device_name:10.0.0.1",
 						"device_namespace:cisco-sdwan",
@@ -1149,7 +1149,7 @@ func TestSendHardwareMetrics(t *testing.T) {
 				{
 					method: "Gauge",
 					value:  0,
-					name:   ciscoSDWANMetricPrefix + "hardware.status",
+					name:   ciscoSDWANMetricPrefix + "hardware.status_ok",
 					tags: []string{
 						"device_name:10.0.0.2",
 						"device_namespace:cisco-sdwan",

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -45,6 +45,7 @@ type checkCfg struct {
 	SendNDMMetadata           *bool  `yaml:"send_ndm_metadata"`
 	MinCollectionInterval     int    `yaml:"min_collection_interval"`
 	CollectBFDSessionStatus   bool   `yaml:"collect_bfd_session_status"`
+	CollectHardwareStatus     bool   `yaml:"collect_hardware_status"`
 }
 
 // CiscoSdwanCheck contains the field for the CiscoSdwanCheck
@@ -135,6 +136,14 @@ func (c *CiscoSdwanCheck) Run() error {
 			log.Warnf("Error getting BFD session states from Cisco SD-WAN API: %s", err)
 		}
 		c.metricsSender.SendBFDSessionMetrics(bfdSessionsState)
+	}
+
+	if c.config.CollectHardwareStatus {
+		hardwareStates, err := client.GetHardwareStates()
+		if err != nil {
+			log.Warnf("Error getting hardware states from Cisco SD-WAN API: %s", err)
+		}
+		c.metricsSender.SendHardwareMetrics(hardwareStates)
 	}
 
 	// Commit

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -69,6 +69,7 @@ use_http: true
 namespace: test
 min_collection_interval: 180
 collect_bfd_session_status: true
+collect_hardware_status: true
 `)
 
 	// Use ID to ensure the mock sender gets registered
@@ -166,6 +167,9 @@ collect_bfd_session_status: true
 
 	// Assert device status metrics
 	sender.AssertMetric(t, "Gauge", "cisco_sdwan.device.reachable", 1, "", []string{"device_vendor:cisco", "device_namespace:test", "hostname:Manager", "system_ip:10.10.1.1", "site_id:101", "type:vmanage"})
+
+	// Assert hardware status metrics
+	sender.AssertMetric(t, "Gauge", "cisco_sdwan.hardware.status", 1, "", []string{"system_ip:10.10.1.11", "status:OK", "class:Fans", "item:Tray 0 fan", "dev_index:1"})
 
 	// Assert metadata
 	// language=json
@@ -284,4 +288,46 @@ namespace: test
 	require.NoError(t, err)
 
 	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.bfd_session.status", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHardwareStatusConfig(t *testing.T) {
+	payload.TimeNow = mockTimeNow
+	report.TimeNow = mockTimeNow
+
+	apiMockServer := client.SetupMockAPIServer()
+	defer apiMockServer.Close()
+
+	deps := createDeps(t)
+	chk := newCheck()
+	senderManager := deps.Demultiplexer
+
+	url := strings.TrimPrefix(apiMockServer.URL, "http://")
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+vmanage_endpoint: ` + url + `
+username: admin
+password: 'test-password'
+use_http: true
+namespace: test
+`)
+
+	// Use ID to ensure the mock sender gets registered
+	id := checkid.BuildID(CheckName, integration.FakeConfigHash, rawInstanceConfig, []byte(``))
+	sender := mocksender.NewMockSenderWithSenderManager(id, senderManager)
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("GaugeWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("CountWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+
+	sender.On("Commit").Return()
+
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	require.NoError(t, err)
+
+	err = chk.Run()
+	require.NoError(t, err)
+
+	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.hardware.status", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -169,7 +169,7 @@ collect_hardware_status: true
 	sender.AssertMetric(t, "Gauge", "cisco_sdwan.device.reachable", 1, "", []string{"device_vendor:cisco", "device_namespace:test", "hostname:Manager", "system_ip:10.10.1.1", "site_id:101", "type:vmanage"})
 
 	// Assert hardware status metrics
-	sender.AssertMetric(t, "Gauge", "cisco_sdwan.hardware.status", 1, "", []string{"system_ip:10.10.1.11", "status:OK", "class:Fans", "item:Tray 0 fan", "dev_index:1"})
+	sender.AssertMetric(t, "Gauge", "cisco_sdwan.hardware.status_ok", 1, "", []string{"system_ip:10.10.1.11", "status:OK", "class:Fans", "item:Tray 0 fan", "dev_index:1"})
 
 	// Assert metadata
 	// language=json

--- a/releasenotes/notes/cisco-sdwan-hardware-status-f90d945c787dbaa4.yaml
+++ b/releasenotes/notes/cisco-sdwan-hardware-status-f90d945c787dbaa4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [NDM] Add option to collect hardware status from Cisco SD-WAN.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add option to collect hardware statuses (fan, power supply, interface modules, ... states)
NDMII-2806

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
