### PR TITLE
Change on `agent.version` task for nightly builds

### DIFF
--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -5,7 +5,7 @@ setup_agent_version:
   tags: ["arch:amd64"]
   script:
     - source /root/.bashrc
-    - inv -e agent.version --version-cached
+    - inv -e agent.version --cache-version
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache
   needs: []
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -21,7 +21,7 @@ from tasks.go import deps
 from tasks.libs.common.utils import (
     REPO_PATH,
     bin_name,
-    cache_version,
+    create_version_json,
     get_build_flags,
     get_embedded_path,
     get_goenv,
@@ -730,7 +730,7 @@ def version(
     omnibus_format=False,
     git_sha_length=7,
     major_version='7',
-    version_cached=False,
+    cache_version=False,
     pipeline_id=None,
     include_git=True,
     include_pre=True,
@@ -746,8 +746,8 @@ def version(
     version_cached: save the version inside a "agent-version.cache" that will be reused
                     by each next call of version.
     """
-    if version_cached:
-        cache_version(ctx, git_sha_length=git_sha_length)
+    if cache_version:
+        create_version_json(ctx, git_sha_length=git_sha_length)
 
     version = get_version(
         ctx,

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -433,9 +433,9 @@ def query_version(ctx, major_version, git_sha_length=7):
     # The describe string format is <tag>-<number of commits since the tag>-g<commit hash>
     # e.g. 6.0.0-beta.0-1-g4f19118
     #   - tag is 6.0.0-beta.0
-    #   - it has been one commit since the tag
+    #   - it has been one commit since the tag creation
     #   - that commit hash is g4f19118
-    cmd = rf"git describe --tags --candidates=50 --match {get_matching_pattern(ctx, major_version)}"
+    cmd = rf'git describe --tags --candidates=50 --match "{get_matching_pattern(ctx, major_version)}"'
     if git_sha_length and isinstance(git_sha_length, int):
         cmd += f" --abbrev={git_sha_length}"
     described_version = ctx.run(cmd, hide=True).stdout.strip()
@@ -479,7 +479,7 @@ def query_version(ctx, major_version, git_sha_length=7):
 
 def get_matching_pattern(ctx, major_version):
     """
-    We need to used
+    We need to used specific patterns (official release tags) for nightly builds as they are used to install agent versions.
     """
     pattern = rf"{major_version}\.*"
     if is_allowed_repo_nightly_branch(os.getenv("BUCKET_BRANCH")):
@@ -487,7 +487,7 @@ def get_matching_pattern(ctx, major_version):
             rf"git tag --list | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
             hide=True,
         ).stdout.strip()
-    return f'"{pattern}"'
+    return pattern
 
 
 def create_version_json(ctx, git_sha_length=7):

--- a/tasks/unit-tests/utils_tests.py
+++ b/tasks/unit-tests/utils_tests.py
@@ -1,7 +1,10 @@
+import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from tasks.libs.common.utils import clean_nested_paths, guess_from_keywords, guess_from_labels
+from invoke import MockContext, Result
+
+from tasks.libs.common.utils import clean_nested_paths, guess_from_keywords, guess_from_labels, query_version
 
 
 class TestUtils(unittest.TestCase):
@@ -65,3 +68,40 @@ class TestGuessFromKeywords(unittest.TestCase):
     def test_no_match(self):
         issue = MagicMock(title="fix bug", body="It comes from the file... hm I don't know.")
         self.assertEqual(guess_from_keywords(issue), "triage")
+
+
+class TestQueryVersion(unittest.TestCase):
+    @patch.dict(os.environ, {"BUCKET_BRANCH": "dev"}, clear=True)
+    def test_on_dev_bucket(self):
+        major_version = "7"
+        c = MockContext(
+            run={
+                r'git describe --tags --candidates=50 --match "7\.*" --abbrev=7': Result(
+                    "7.54.0-dbm-mongo-0.1-163-g315e3a2"
+                )
+            }
+        )
+        v, p, c, g, _ = query_version(c, major_version)
+        self.assertEqual(v, "7.54.0")
+        self.assertEqual(p, "dbm-mongo-0.1")
+        self.assertEqual(c, 163)
+        self.assertEqual(g, "315e3a2")
+
+    @patch.dict(os.environ, {"BUCKET_BRANCH": "nightly"}, clear=True)
+    def test_on_nightly_bucket(self):
+        major_version = "7"
+        c = MockContext(
+            run={
+                rf"git tag --list | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
+                    "7.55.0-devel"
+                ),
+                'git describe --tags --candidates=50 --match "7.55.0-devel" --abbrev=7': Result(
+                    "7.55.0-devel-543-g315e3a2"
+                ),
+            }
+        )
+        v, p, c, g, _ = query_version(c, major_version)
+        self.assertEqual(v, "7.55.0")
+        self.assertEqual(p, "devel")
+        self.assertEqual(c, 543)
+        self.assertEqual(g, "315e3a2")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
On nightly builds we filter the tag handled to save only valid versions, according to release nomenclature. Otherwise, manually created tags can be used and create side effects like preventing agent update on windows.
While new [recommendation](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/1568966971/How+to+create+custom+Agent+builds#2.-%5BOptional%2C-Recommended%5D-Tag-your-branch) is to prevent addition of "test tags" on main branch we will filter on nightlies to circumvent the issue

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Stability

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The first commit is refactoring, you can review them independently

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
