### PR TITLE
(fleet) fix the installer run path

### DIFF
--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -32,7 +32,7 @@ build do
   env = with_embedded_path(env)
 
   if linux_target?
-    command "invoke installer.build --rebuild --run-path=/var/run/datadog/installer --install-path=#{install_dir}", env: env
+    command "invoke installer.build --rebuild --run-path=/var/run/datadog-installer --install-path=#{install_dir}", env: env
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
     mkdir "#{install_dir}/systemd/"

--- a/omnibus/config/templates/installer/datadog-installer-exp.service.erb
+++ b/omnibus/config/templates/installer/datadog-installer-exp.service.erb
@@ -7,11 +7,11 @@ JobTimeoutSec=3000 #50 minutes
 
 [Service]
 Type=oneshot
-PIDFile=/var/run/datadog/installer/installer.pid
+PIDFile=/var/run/datadog-installer/installer.pid
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/omnibus/config/templates/installer/datadog-installer.service.erb
+++ b/omnibus/config/templates/installer/datadog-installer.service.erb
@@ -5,10 +5,10 @@ Conflicts=datadog-installer-exp.service
 
 [Service]
 Type=simple
-PIDFile=/var/run/datadog/installer/installer.pid
+PIDFile=/var/run/datadog-installer/installer.pid
 Restart=on-failure
 EnvironmentFile=-<%= etc_dir %>/environment
-ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog/installer/installer.pid
+ExecStart=<%= installer_dir %>/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/omnibus/package-scripts/installer-deb/postrm
+++ b/omnibus/package-scripts/installer-deb/postrm
@@ -6,7 +6,7 @@
 
 PACKAGES_DIR=/opt/datadog-packages
 INSTALL_DIR=/opt/datadog-installer
-RUN_DIR=/var/run/datadog/installer
+RUN_DIR=/var/run/datadog-installer
 
 set -e
 

--- a/omnibus/package-scripts/installer-rpm/postrm
+++ b/omnibus/package-scripts/installer-rpm/postrm
@@ -6,7 +6,7 @@
 
 PACKAGES_DIR=/opt/datadog-packages
 INSTALL_DIR=/opt/datadog-installer
-RUN_DIR=/var/run/datadog/installer
+RUN_DIR=/var/run/datadog-installer
 
 set -e
 

--- a/pkg/fleet/installer/installer_paths.go
+++ b/pkg/fleet/installer/installer_paths.go
@@ -13,7 +13,7 @@ const (
 	// TmpDirPath is the path to the temporary directory used for package installation.
 	TmpDirPath = "/opt/datadog-packages"
 	// LocksPack is the path to the locks directory.
-	LocksPack = "/var/run/datadog-packages"
+	LocksPack = "/var/run/datadog-installer/locks"
 	// DefaultConfigsDir is the default Agent configuration directory
 	DefaultConfigsDir = "/etc"
 )

--- a/pkg/fleet/installer/service/apm_sockets.go
+++ b/pkg/fleet/installer/service/apm_sockets.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	apmInstallerSocket    = "/var/run/datadog/installer/apm.socket"
-	statsdInstallerSocket = "/var/run/datadog/installer/dsd.socket"
+	apmInstallerSocket    = "/var/run/datadog-installer/apm.socket"
+	statsdInstallerSocket = "/var/run/datadog-installer/dsd.socket"
 	apmInjectOldPath      = "/opt/datadog/apm/inject"
-	envFilePath           = "/var/run/datadog/installer/environment"
+	envFilePath           = "/var/run/datadog-installer/environment"
 )
 
 // Overridden in tests

--- a/pkg/fleet/installer/service/apm_sockets_test.go
+++ b/pkg/fleet/installer/service/apm_sockets_test.go
@@ -28,8 +28,8 @@ func TestSetSocketEnvs(t *testing.T) {
 			name:  "file doesn't exist",
 			input: "",
 			expected: map[string]string{
-				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog/installer/apm.socket",
-				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog/installer/dsd.socket",
+				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog-installer/apm.socket",
+				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog-installer/dsd.socket",
 				"DD_USE_DOGSTATSD":       "true",
 			},
 		},
@@ -37,8 +37,8 @@ func TestSetSocketEnvs(t *testing.T) {
 			name:  "keep other envs - missing newline",
 			input: "banana=true",
 			expected: map[string]string{
-				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog/installer/apm.socket",
-				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog/installer/dsd.socket",
+				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog-installer/apm.socket",
+				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog-installer/dsd.socket",
 				"DD_USE_DOGSTATSD":       "true",
 				"banana":                 "true",
 			},
@@ -47,8 +47,8 @@ func TestSetSocketEnvs(t *testing.T) {
 			name:  "keep envs - with newline",
 			input: "apple=false\nat=home\n",
 			expected: map[string]string{
-				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog/installer/apm.socket",
-				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog/installer/dsd.socket",
+				"DD_APM_RECEIVER_SOCKET": "/var/run/datadog-installer/apm.socket",
+				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog-installer/dsd.socket",
 				"DD_USE_DOGSTATSD":       "true",
 				"apple":                  "false",
 				"at":                     "home",
@@ -59,7 +59,7 @@ func TestSetSocketEnvs(t *testing.T) {
 			input: "DD_APM_RECEIVER_SOCKET=/tmp/apm.socket",
 			expected: map[string]string{
 				"DD_APM_RECEIVER_SOCKET": "/tmp/apm.socket",
-				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog/installer/dsd.socket",
+				"DD_DOGSTATSD_SOCKET":    "/var/run/datadog-installer/dsd.socket",
 				"DD_USE_DOGSTATSD":       "true",
 			},
 		},

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -71,18 +71,18 @@ func SetupInstaller(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("error creating /var/log/datadog: %w", err)
 	}
-	err = os.MkdirAll("/var/run/datadog/installer", 0755)
+	err = os.MkdirAll("/var/run/datadog-installer", 0755)
 	if err != nil {
-		return fmt.Errorf("error creating /var/run/datadog/installer: %w", err)
+		return fmt.Errorf("error creating /var/run/datadog-installer: %w", err)
 	}
-	err = os.MkdirAll("/var/run/datadog/installer/locks", 0777)
+	err = os.MkdirAll("/var/run/datadog-installer/locks", 0777)
 	if err != nil {
-		return fmt.Errorf("error creating /var/run/datadog/installer/locks: %w", err)
+		return fmt.Errorf("error creating /var/run/datadog-installer/locks: %w", err)
 	}
 	// Locks directory can already be created by a package install
-	err = os.Chmod("/var/run/datadog/installer/locks", 0777)
+	err = os.Chmod("/var/run/datadog-installer/locks", 0777)
 	if err != nil {
-		return fmt.Errorf("error changing permissions of /var/run/datadog/installer/locks: %w", err)
+		return fmt.Errorf("error changing permissions of /var/run/datadog-installer/locks: %w", err)
 	}
 	err = os.Chown("/etc/datadog-agent", ddAgentUID, ddAgentGID)
 	if err != nil {
@@ -92,13 +92,9 @@ func SetupInstaller(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("error changing owner of /var/log/datadog: %w", err)
 	}
-	err = os.Chown("/var/run/datadog", ddAgentUID, ddAgentGID)
+	err = os.Chown("/var/run/datadog-installer", ddAgentUID, ddAgentGID)
 	if err != nil {
-		return fmt.Errorf("error changing owner of /var/run/datadog: %w", err)
-	}
-	err = os.Chown("/var/run/datadog/installer", ddAgentUID, ddAgentGID)
-	if err != nil {
-		return fmt.Errorf("error changing owner of /var/run/datadog/installer: %w", err)
+		return fmt.Errorf("error changing owner of /var/run/datadog-installer: %w", err)
 	}
 
 	// Create installer path symlink

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -45,11 +45,11 @@ func (s *packageApmInjectSuite) TestInstall() {
 	s.host.AssertPackageInstalledByInstaller("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	state := s.host.State()
-	state.AssertFileExists("/var/run/datadog/installer/environment", 0644, "root", "root")
+	state.AssertFileExists("/var/run/datadog-installer/environment", 0644, "root", "root")
 	state.AssertDirExists("/var/log/datadog/dotnet", 0777, "root", "root")
 	state.AssertFileExists("/etc/ld.so.preload", 0644, "root", "root")
 	s.assertLDPreloadInstrumented(injectOCIPath)
-	s.assertSocketPath("/var/run/datadog/installer/apm.socket")
+	s.assertSocketPath("/var/run/datadog-installer/apm.socket")
 	s.assertDockerdInstrumented(injectOCIPath)
 
 	traceID := rand.Uint64()
@@ -155,7 +155,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 	assert.NoError(s.T(), err)
 
 	s.assertLDPreloadInstrumented(injectOCIPath)
-	s.assertSocketPath("/var/run/datadog/installer/apm.socket")
+	s.assertSocketPath("/var/run/datadog-installer/apm.socket")
 	s.assertDockerdInstrumented(injectOCIPath)
 
 	// Deb install using today's defaults
@@ -176,7 +176,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 
 	// OCI musn't be overridden
 	s.assertLDPreloadInstrumented(injectOCIPath)
-	s.assertSocketPath("/var/run/datadog/installer/apm.socket")
+	s.assertSocketPath("/var/run/datadog-installer/apm.socket")
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
@@ -252,7 +252,7 @@ func (s *packageApmInjectSuite) assertDockerdNotInstrumented() {
 }
 
 func (s *packageApmInjectSuite) purgeInjectorDebInstall() {
-	s.Env().RemoteHost.MustExecute("sudo rm -f /var/run/datadog/installer/environment")
+	s.Env().RemoteHost.MustExecute("sudo rm -f /var/run/datadog-installer/environment")
 	s.Env().RemoteHost.MustExecute("sudo rm -f /etc/datadog-agent/datadog.yaml")
 
 	packageList := []string{

--- a/test/new-e2e/tests/installer/package_installer_test.go
+++ b/test/new-e2e/tests/installer/package_installer_test.go
@@ -36,9 +36,8 @@ func (s *packageInstallerSuite) TestInstall() {
 
 	state.AssertDirExists("/etc/datadog-agent", 0755, "dd-agent", "dd-agent")
 	state.AssertDirExists("/var/log/datadog", 0755, "dd-agent", "dd-agent")
-	state.AssertDirExists("/var/run/datadog", 0755, "dd-agent", "dd-agent")
-	state.AssertDirExists("/var/run/datadog/installer", 0755, "dd-agent", "dd-agent")
-	state.AssertDirExists("/var/run/datadog/installer/locks", 0777, "root", "root")
+	state.AssertDirExists("/var/run/datadog-installer", 0755, "dd-agent", "dd-agent")
+	state.AssertDirExists("/var/run/datadog-installer/locks", 0777, "root", "root")
 
 	state.AssertDirExists("/opt/datadog-installer", 0755, "root", "root")
 	state.AssertDirExists("/opt/datadog-packages", 0755, "root", "root")
@@ -74,11 +73,10 @@ func (s *packageInstallerSuite) TestUninstall() {
 	state.AssertUserHasGroup("dd-agent", "dd-agent")
 
 	state.AssertDirExists("/var/log/datadog", 0755, "dd-agent", "dd-agent")
-	state.AssertDirExists("/var/run/datadog", 0755, "dd-agent", "dd-agent")
 
 	// state that should get removed
 	state.AssertPathDoesNotExist("/opt/datadog-installer")
-	state.AssertPathDoesNotExist("/var/run/datadog/installer")
+	state.AssertPathDoesNotExist("/var/run/datadog-installer")
 	state.AssertPathDoesNotExist("/opt/datadog-packages")
 
 	state.AssertPathDoesNotExist("/usr/bin/datadog-bootstrap")


### PR DESCRIPTION
This PR moves the installer run path from `/var/run/datadog/installer` to `/var/run/datadog-installer`. Unfortunately `/var/run/datadog` gets cleaned up every time the datadog-agent.service unit is stoped because of the `RuntimeDirectory` directive.
