### PR TITLE
[workloadmeta] Remove dedicated namespace collection config

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -67,7 +67,11 @@ func metadataCollectionGVRs(cfg model.Reader, discoveryClient discovery.Discover
 
 	requestedResources := cfg.GetStringSlice("cluster_agent.kube_metadata_collection.resources")
 
-	discoveredResourcesGVs, err := discoverGVRs(discoveryClient, requestedResources)
+	// TODO: Remove this after implementing collector factory which specifies which collector should be registered for each specific resource type
+	// Adding this now as a quick work around to avoid having 2 collectors collecting the same data
+	excludedResources := []string{"namespaces"}
+
+	discoveredResourcesGVs, err := discoverGVRs(discoveryClient, requestedResources, excludedResources)
 	return discoveredResourcesGVs, err
 }
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -46,8 +46,15 @@ func storeGenerators(cfg model.Reader) []storeGenerator {
 		generators = append(generators, newDeploymentStore)
 	}
 
-	if cfg.GetBool("kubernetes_namespace_collection_enabled") {
-		generators = append(generators, newNamespaceStore)
+	// TODO: Remove this once we migrate references to the namespace store to use generic collection
+	if cfg.GetBool("cluster_agent.kube_metadata_collection.enabled") {
+		resources := cfg.GetStringSlice("cluster_agent.kube_metadata_collection.resources")
+		for _, resource := range resources {
+			if resource == "namespaces" {
+				generators = append(generators, newNamespaceStore)
+				break
+			}
+		}
 	}
 
 	return generators

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -10,6 +10,7 @@ package kubeapiserver
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
@@ -49,11 +50,8 @@ func storeGenerators(cfg model.Reader) []storeGenerator {
 	// TODO: Remove this once we migrate references to the namespace store to use generic collection
 	if cfg.GetBool("cluster_agent.kube_metadata_collection.enabled") {
 		resources := cfg.GetStringSlice("cluster_agent.kube_metadata_collection.resources")
-		for _, resource := range resources {
-			if resource == "namespaces" {
-				generators = append(generators, newNamespaceStore)
-				break
-			}
+		if slices.Contains(resources, "namespaces") {
+			generators = append(generators, newNamespaceStore)
 		}
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -26,12 +26,12 @@ func TestStoreGenerators(t *testing.T) {
 	// Define tests
 	tests := []struct {
 		name                    string
-		cfg                     map[string]bool
+		cfg                     map[string]interface{}
 		expectedStoresGenerator []storeGenerator
 	}{
 		{
 			name: "All configurations disabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  false,
 				"language_detection.enabled":            false,
@@ -40,7 +40,7 @@ func TestStoreGenerators(t *testing.T) {
 		},
 		{
 			name: "All configurations disabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  false,
 				"language_detection.enabled":            true,
@@ -49,7 +49,7 @@ func TestStoreGenerators(t *testing.T) {
 		},
 		{
 			name: "Kubernetes tags enabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": true,
 				"language_detection.reporting.enabled":  false,
 				"language_detection.enabled":            true,
@@ -58,7 +58,7 @@ func TestStoreGenerators(t *testing.T) {
 		},
 		{
 			name: "Language detection enabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  true,
 				"language_detection.enabled":            true,
@@ -67,7 +67,7 @@ func TestStoreGenerators(t *testing.T) {
 		},
 		{
 			name: "Language detection enabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": false,
 				"language_detection.reporting.enabled":  true,
 				"language_detection.enabled":            false,
@@ -76,14 +76,15 @@ func TestStoreGenerators(t *testing.T) {
 		},
 		{
 			name: "Kube namespace collection enabled",
-			cfg: map[string]bool{
-				"kubernetes_namespace_collection_enabled": true,
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "namespaces",
 			},
 			expectedStoresGenerator: []storeGenerator{newNodeStore, newNamespaceStore},
 		},
 		{
 			name: "All configurations enabled",
-			cfg: map[string]bool{
+			cfg: map[string]interface{}{
 				"cluster_agent.collect_kubernetes_tags": true,
 				"language_detection.reporting.enabled":  true,
 				"language_detection.enabled":            true,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -346,7 +346,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_namespace_annotations_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
-	config.BindEnvAndSetDefault("kubernetes_namespace_collection_enabled", false) // Enables collection of kubernetes namespace information
 
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Remove the config to enable collection of namespace information in workloadmeta in favor of the generic config introduced in https://github.com/DataDog/datadog-agent/pull/25901.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We will be migrating references to the namespace-specific store to use the generic kubernetes metadata collection types. In the meantime, to avoid exposing temporary configurations, we want to configure namespace collection using the generic kubernetes metadata collection config.  

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Deploy the agent and cluster agent with namespace resource collection enabled
```
...
clusterAgent:
  enabled: true
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "namespaces daemonsets"
```

2. Check the content of workloadmeta of the DCA using `agent workload-list -v`; daemonsets metadata are collected as `kubernetes_metadata` entities (all `kubernetes_metadata` entities should only be daemonset metadata)
```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: daemonsets/default/datadog-agent ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: daemonsets/default/datadog-agent

----------- Entity Meta -----------
Name: datadog-agent
Namespace: default
Annotations: meta.helm.sh/release-name:datadog-agent meta.helm.sh/release-namespace:default 
Labels: app.kubernetes.io/component:agent app.kubernetes.io/instance:datadog-agent app.kubernetes.io/managed-by:Helm app.kubernetes.io/name:datadog-agent app.kubernetes.io/version:7 helm.sh/chart:datadog-3.59.5 
----------- Resource -----------
apps/v1, Resource=daemonsets===
```

Namespace metadata are collected as `kubernetes_namespace` entities only
```
=== Entity kubernetes_namespace sources(merged):[kubeapiserver] id: annotated-namespace ===
----------- Entity ID -----------
Kind: kubernetes_namespace ID: annotated-namespace

----------- Entity Meta -----------
Name: annotated-namespace
Namespace: 
Annotations: kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"related_email":"express@sunday"},"labels":{"injectSidecarNs":"true","related_team":"contp"},"name":"annotated-namespace"}} related_email:express@sunday 
Labels: injectSidecarNs:true kubernetes.io/metadata.name:annotated-namespace related_team:contp 
===
```
