### PR TITLE
Use RWMutex in demultiplexer to prevent check delays

### DIFF
--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -46,7 +46,7 @@ type DemultiplexerWithAggregator interface {
 type AgentDemultiplexer struct {
 	log log.Component
 
-	m sync.Mutex
+	m sync.RWMutex
 
 	// stopChan completely stops the flushLoop of the Demultiplexer when receiving
 	// a message, not doing anything else.
@@ -391,8 +391,8 @@ func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSeri
 // - to have an implementation of SendIterableSeries listening on multiple sinks in parallel, or,
 // - to have a thread-safe implementation of the underlying `util.BufferedChan`.
 func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerializer bool) {
-	d.m.Lock()
-	defer d.m.Unlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 
 	if d.aggregator == nil {
 		// NOTE(remy): we could consider flushing only the time samplers
@@ -561,8 +561,8 @@ func (d *AgentDemultiplexer) DumpDogstatsdContexts(dest io.Writer) error {
 // If no error is returned here, DestroySender must be called with the same ID
 // once the sender is not used anymore
 func (d *AgentDemultiplexer) GetSender(id checkid.ID) (sender.Sender, error) {
-	d.m.Lock()
-	defer d.m.Unlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 
 	if d.senders == nil {
 		return nil, errors.New("demultiplexer is stopped")
@@ -574,8 +574,8 @@ func (d *AgentDemultiplexer) GetSender(id checkid.ID) (sender.Sender, error) {
 // SetSender returns the passed sender with the passed ID.
 // This is largely for testing purposes
 func (d *AgentDemultiplexer) SetSender(s sender.Sender, id checkid.ID) error {
-	d.m.Lock()
-	defer d.m.Unlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 	if d.senders == nil {
 		return errors.New("demultiplexer is stopped")
 	}
@@ -587,8 +587,8 @@ func (d *AgentDemultiplexer) SetSender(s sender.Sender, id checkid.ID) error {
 // Should be called when no sender with this ID is used anymore
 // The metrics of this (these) sender(s) that haven't been flushed yet will be lost
 func (d *AgentDemultiplexer) DestroySender(id checkid.ID) {
-	d.m.Lock()
-	defer d.m.Unlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 
 	if d.senders == nil {
 		return
@@ -599,8 +599,8 @@ func (d *AgentDemultiplexer) DestroySender(id checkid.ID) {
 
 // GetDefaultSender returns a default sender.
 func (d *AgentDemultiplexer) GetDefaultSender() (sender.Sender, error) {
-	d.m.Lock()
-	defer d.m.Unlock()
+	d.m.RLock()
+	defer d.m.RUnlock()
 
 	if d.senders == nil {
 		return nil, errors.New("demultiplexer is stopped")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Followup to this PR: https://github.com/DataDog/datadog-agent/pull/25858

Very long running flushes can cause the lock in `demultiplexer_agent` to be held while checks are starting. When checks start they call `GetSender` to acquire their sender instance which shares the same lock as flush. As a result, a very long running flush will block all checks from starting until it completes. 

In order to avoid check execution delays, we can use an RWMutex here since the protected state is only mutated during `Stop`. So `RLock` will never block during normal agent operations allowing checks to start asynchronously of the flush operation.   

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This was deployed in a large staging cluster so QA is done. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
