### PR TITLE
Create leader engine when running check command in DCA

### DIFF
--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -11,12 +11,21 @@ package check
 import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgcommon "github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
 	"github.com/spf13/cobra"
 )
 
 // Commands returns a slice of subcommands for the 'cluster-agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	ctx, _ := pkgcommon.GetMainCtxCancel()
+	// Create the Leader election engine without initializing it
+	if pkgconfig.Datadog().GetBool("leader_election") {
+		leaderelection.CreateGlobalLeaderEngine(ctx)
+	}
+
 	cmd := check.MakeCommand(func() check.GlobalParams {
 		return check.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,

--- a/releasenotes/notes/fix-manual-check-run-dca-cb3415a653d359ea.yaml
+++ b/releasenotes/notes/fix-manual-check-run-dca-cb3415a653d359ea.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fix leader election error when running checks manually from the
-    cluster agent.
+    Cluster Agent.

--- a/releasenotes/notes/fix-manual-check-run-dca-cb3415a653d359ea.yaml
+++ b/releasenotes/notes/fix-manual-check-run-dca-cb3415a653d359ea.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix leader election error when running checks manually from the
+    cluster agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Make a call to create the leader election engine when running `agent check <check>` command in the cluster agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This command does not work in the cluster agent currently due to a leader election error, e.g.:
```
$ agent check -r kubernetes_state_core
...

  Running Checks
  ==============

    kubernetes_state_core
    ---------------------
      Instance ID: kubernetes_state_core:f0ece86b2bc4e82e [WARNING]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.yaml.default
      Total Runs: 2
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2024-05-30 20:10:44 UTC (1717099844000)
      Last Successful Execution Date : 2024-05-30 20:10:44 UTC (1717099844000)

      Warning: Leader Election error. Not running the kube-state-metrics core check.
```

This change allows users to run checks in the DCA manually.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Deploy an agent and cluster agent
```
datadog:
  clusterName: test-cluster-agent-check-command
agents:
  replicas: 1
clusterAgent:
  enabled: true
```
2. Check that the kubernetes state core check is scheduled on the cluster agent properly, and that running `agent check -r kubernetes_state_core` works properly
```
  Running Checks
  ==============

    kubernetes_state_core
    ---------------------
      Instance ID: kubernetes_state_core:f0ece86b2bc4e82e [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.yaml.default
      Total Runs: 2
      Metric Samples: Last Run: 339, Total: 678
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 3, Total: 6
      Average Execution Time : 517ms
      Last Execution Date : 2024-05-30 20:32:05 UTC (1717101125000)
      Last Successful Execution Date : 2024-05-30 20:32:05 UTC (1717101125000)
```