### PR TITLE
Set the standard `org.opencontainers.image.*` labels on the docker images.

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -18,7 +18,7 @@
     - DOCKER_REGISTRY_LOGIN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DOCKER_REGISTRY_LOGIN_SSM_KEY)
     - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $DOCKER_REGISTRY_PWD_SSM_KEY | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Build image
-    - docker buildx build --no-cache --push --pull --platform linux/$ARCH --build-arg CIBUILD=true --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} $BUILD_ARG --file $BUILD_CONTEXT/Dockerfile --tag ${TARGET_TAG} $BUILD_CONTEXT
+    - docker buildx build --no-cache --push --pull --platform linux/$ARCH --build-arg CIBUILD=true --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} $BUILD_ARG --file $BUILD_CONTEXT/Dockerfile --tag ${TARGET_TAG} --label "org.opencontainers.image.created=$(date --rfc-3339=seconds)" --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>" --label "org.opencontainers.image.source=https://github.com/DataDog/datadog-agent" --label "org.opencontainers.image.version=$(inv agent.version)" --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}" --label "org.opencontainers.image.vendor=Datadog, Inc." $BUILD_CONTEXT
     # Squash image
     - crane flatten -t ${TARGET_TAG} ${TARGET_TAG}
   # Workaround for temporary network failures

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -1,10 +1,12 @@
 ARG BASE_IMAGE_UBUNTU_VERSION=23.10
 ARG BASE_IMAGE_UBUNTU_NAME=mantic
 FROM ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS baseimage
+ARG BASE_IMAGE_UBUNTU_VERSION
+ARG BASE_IMAGE_UBUNTU_NAME
 LABEL baseimage.os "ubuntu ${BASE_IMAGE_UBUNTU_NAME}"
 LABEL baseimage.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
-# Can be used by Dependabot
-LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
+LABEL org.opencontainers.image.base.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
+LABEL org.opencontainers.image.title "Datadog Agent"
 
 ARG CIBUILD
 # NOTE about APT mirrorlists:

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -5,10 +5,12 @@ ARG BASE_IMAGE_UBUNTU_VERSION=23.10
 ARG BASE_IMAGE_UBUNTU_NAME=mantic
 FROM ubuntu:$BASE_IMAGE_UBUNTU_VERSION as builder
 ARG TARGETARCH
+ARG BASE_IMAGE_UBUNTU_VERSION
+ARG BASE_IMAGE_UBUNTU_NAME
 LABEL baseimage.os "ubuntu ${BASE_IMAGE_UBUNTU_NAME}"
 LABEL baseimage.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
-# Can be used by Dependabot
-LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
+LABEL org.opencontainers.image.base.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
+LABEL org.opencontainers.image.title "Datadog Cluster Agent"
 
 WORKDIR /output
 

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -1,12 +1,13 @@
 ARG BASE_IMAGE_ALPINE_VERSION=3.18
 FROM alpine:$BASE_IMAGE_ALPINE_VERSION
 ARG TARGETARCH
+ARG BASE_IMAGE_ALPINE_VERSION
 
 LABEL baseimage.os "alpine"
 LABEL baseimage.name "alpine:${BASE_IMAGE_ALPINE_VERSION}"
 LABEL maintainer "Datadog <package@datadoghq.com>"
-# Can be used by Dependabot
-LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
+LABEL org.opencontainers.image.base.name "alpine:${BASE_IMAGE_ALPINE_VERSION}"
+LABEL org.opencontainers.image.title "Datadog Dogstatsd Agent"
 
 ENV DOCKER_DD_AGENT=true
 


### PR DESCRIPTION
### What does this PR do?

Set [the standard `org.opencontainers.image.`-prefixed labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) on the docker images.

### Motivation

We should at least set the labels that are used by the [Datadog source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration) and captured by the agent here: https://github.com/DataDog/datadog-agent/blob/9f39b073d65f4b201d2c7f940b6470949537aa31/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go#L115-L119

Although `org.opencontainers.image.source` was already set, `org.opencontainers.image.revision` was missing and `org.opencontainers.image.version` had a bad value because it was inherited from the base image:
```
$ docker inspect gcr.io/datadoghq/agent:7.54.0-rc.5  --format '{{ range $k, $v := .Config.Labels }}{{ $k }}={{ $v }}{{ "\n" }}{{ end }}'
baseimage.name=ubuntu:
baseimage.os=ubuntu 
maintainer=Datadog <package@datadoghq.com>
org.opencontainers.image.ref.name=ubuntu
org.opencontainers.image.source=https://github.com/DataDog/datadog-agent
org.opencontainers.image.version=23.10
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that the [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration) is working fine with the agent.

The set of labels of agent docker image should now be more complete:
```
$ docker inspect docker.io/datadog/agent-dev:lenaic-docker-images-std-labels-py3  --format '{{ range $k, $v := .Config.Labels }}{{ $k }}={{ $v }}{{ "\n" }}{{ end }}'
baseimage.name=ubuntu:23.10
baseimage.os=ubuntu mantic
maintainer=Datadog <package@datadoghq.com>
org.opencontainers.image.authors=Datadog <package@datadoghq.com>
org.opencontainers.image.base.name=ubuntu:23.10
org.opencontainers.image.created=2024-05-31 08:30:53+00:00
org.opencontainers.image.ref.name=ubuntu
org.opencontainers.image.revision=6e9e4a54168fb91bb01e1f682aeb24be1101f460
org.opencontainers.image.source=https://github.com/DataDog/datadog-agent
org.opencontainers.image.title=Datadog Agent
org.opencontainers.image.vendor=Datadog, Inc.
org.opencontainers.image.version=7.55.0-devel+git.586.6e9e4a5.pipeline.35547510
```