### PR TITLE
feat(telemetry): Adding APM telemetry to auto_instrumentation webhook / POC

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -9,7 +9,6 @@ package webhook
 
 import (
 	"context"
-	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -62,7 +62,7 @@ func NewControllerV1(
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
+	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa, telemetryCollector)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -9,6 +9,7 @@ package webhook
 
 import (
 	"context"
+	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"strings"
 	"time"
 
@@ -49,6 +50,7 @@ func NewControllerV1(
 	config Config,
 	wmeta workloadmeta.Component,
 	pa workload.PODPatcher,
+	telemetryCollector telemetry.TelemetryCollector,
 ) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -9,7 +9,6 @@ package webhook
 
 import (
 	"context"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -9,6 +9,7 @@ package webhook
 
 import (
 	"context"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
 	"strings"
 	"time"
 
@@ -40,7 +41,7 @@ type ControllerV1beta1 struct {
 }
 
 // NewControllerV1beta1 returns a new Webhook Controller using admissionregistration/v1beta1.
-func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PODPatcher) *ControllerV1beta1 {
+func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PODPatcher, telemetryCollector telemetry.TelemetryCollector) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
 	controller.config = config

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -31,12 +31,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	apiServerCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 )
 
 const (
@@ -616,6 +616,7 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 		langStr := string(lib.lang)
 		defer func() {
 			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
+			// w.telemetryCollector.SendLibInjectionAttempted(telemetry.LibInjectionMetadata{ })
 		}()
 
 		_ = mutatecommon.InjectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -36,7 +37,7 @@ type ControllerContext struct {
 }
 
 // StartControllers starts the secret and webhook controllers
-func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa workload.PODPatcher) ([]webhook.MutatingWebhook, error) {
+func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa workload.PODPatcher, telemetryCollector telemetry.TelemetryCollector) ([]webhook.MutatingWebhook, error) {
 	if !config.Datadog().GetBool("admission_controller.enabled") {
 		log.Info("Admission controller is disabled")
 		return nil, nil
@@ -78,6 +79,7 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa wo
 		webhookConfig,
 		wmeta,
 		pa,
+		telemetryCollector,
 	)
 
 	go secretController.Run(ctx.StopCh)

--- a/pkg/trace/telemetry/collector.go
+++ b/pkg/trace/telemetry/collector.go
@@ -95,6 +95,7 @@ type TelemetryCollector interface {
 	SendStartupError(code int, err error)
 	SentFirstTrace() bool
 	SendFirstTrace()
+	SendLibInjectionAttempted(metadata LibInjectionMetadata)
 }
 
 type telemetryCollector struct {
@@ -137,11 +138,6 @@ func NewCollector(cfg *config.AgentConfig) TelemetryCollector {
 		collectedFirstTrace:   &atomic.Bool{},
 		firstTraceFailures:    &atomic.Int32{},
 	}
-}
-
-// NewNoopCollector returns a noop collector
-func NewNoopCollector() TelemetryCollector {
-	return &noopTelemetryCollector{}
 }
 
 func (f *telemetryCollector) sendEvent(event *OnboardingEvent) (err error) {
@@ -292,11 +288,16 @@ func (f *telemetryCollector) sendEventPayload(option ...onboardingEventOption) e
 	return f.sendEvent(&ev)
 }
 
+// NewNoopCollector returns a noop collector
+func NewNoopCollector() TelemetryCollector {
+	return &noopTelemetryCollector{}
+}
+
 type noopTelemetryCollector struct{}
 
-func (*noopTelemetryCollector) SendStartupSuccess() {}
-
 //nolint:revive // TODO(TEL) Fix revive linter
-func (*noopTelemetryCollector) SendStartupError(code int, err error) {}
-func (*noopTelemetryCollector) SendFirstTrace()                      {}
-func (*noopTelemetryCollector) SentFirstTrace() bool                 { return true }
+func (*noopTelemetryCollector) SendStartupSuccess()                                     {}
+func (*noopTelemetryCollector) SendStartupError(code int, err error)                    {}
+func (*noopTelemetryCollector) SendFirstTrace()                                         {}
+func (*noopTelemetryCollector) SentFirstTrace() bool                                    { return true }
+func (*noopTelemetryCollector) SendLibInjectionAttempted(metadata LibInjectionMetadata) {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?



This PR adds the `trace/telemetry` package as a dependency to the auto_instrumentation webhook.

This is not _yet_ the complete implementation of triggering the actual telemetry events, just wiring up the webhook code so that it can be used in place.

If this approach is _ok_ I can keep going to add the telemetry calls, ie: `Send...()`


### Motivation

https://datadoghq.atlassian.net/browse/APMON-1043

### Additional Notes



<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Something I'm not sure of is if we want to have the cluster-agent depend on 
tracing or if we would rather push this via a proxy to the trace-agent which
would be responsible for things like this.

It feels a little gross to instantiate a full tracing agent configuration this
way-- but wanted to bring this up as a possibility/straw-man/POC.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
