### PR TITLE
skip registering generic metadata collector for namespaces

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -67,7 +67,11 @@ func metadataCollectionGVRs(cfg model.Reader, discoveryClient discovery.Discover
 
 	requestedResources := cfg.GetStringSlice("cluster_agent.kube_metadata_collection.resources")
 
-	discoveredResourcesGVs, err := discoverGVRs(discoveryClient, requestedResources)
+	// TODO: Remove this after implementing collector factory which specifies which collector should be registered for each specific resource type
+	// Adding this now as a quick work around to avoid having 2 collectors collecting the same data
+	excludedResources := []string{"namespaces"}
+
+	discoveredResourcesGVs, err := discoverGVRs(discoveryClient, requestedResources, excludedResources)
 	return discoveredResourcesGVs, err
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Skips registering generic metadata collector for namespaces resource.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We already have another collector that collects namespace metadata, we should avoid registering both collectors at the same time because it results in registering 2 informers and in duplicating namespace data in workloadmetadata store.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- This is a quick workaround for now to avoid making a breaking configuration change in the future. Ideally, we should implement a factory which decides which collector should be registered for each kubernetes resource type.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No need for QA. This PR is merged to a feature branch (which has its own QA), not to main.
