### PR TITLE
[EBPF] Add extra stats to KMT jobs

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -49,19 +49,27 @@
   - export AWS_PROFILE=agent-qa-ci
 
 .collect_outcomes_kmt:
-  - MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
+  - export MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
   # Collect setup-ddvm systemd service logs
   - mkdir -p $CI_PROJECT_DIR/logs
   - ssh metal_instance "ssh ${MICRO_VM_IP} \"journalctl -u setup-ddvm.service\"" > $CI_PROJECT_DIR/logs/setup-ddvm.log || true
   - cat $CI_PROJECT_DIR/logs/setup-ddvm.log || true
+  - ssh metal_instance "ssh ${MICRO_VM_IP} \"systemctl is-active setup-ddvm.service\"" | tee $CI_PROJECT_DIR/logs/setup-ddvm.status || true
   # Retrieve the junit generated
-  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz"
-  - scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/
-  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz"
-  - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/
+  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
+  - scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
+  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
+  - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
 
 .upload_junit_kmt:
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"
+
+.tag_kmt_ci_job:
+  - GITLAB_TOKEN="$("$CI_PROJECT_DIR"/tools/ci/aws_ssm_get_wrapper.sh "$GITLAB_READ_API_TOKEN_SSM_NAME")"
+  - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/aws_ssm_get_wrapper.sh "$API_KEY_ORG2_SSM_NAME")"
+  - export DATADOG_API_KEY
+  - export GITLAB_TOKEN
+  - inv kmt.tag-ci-job
 
 # -- Test dependencies
 
@@ -134,6 +142,7 @@
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$INSTANCE_IP:/tmp/ddvm-xml-*" $CI_PROJECT_DIR/libvirt/xml
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$INSTANCE_IP:/tmp/qemu-ddvm-*.log" $CI_PROJECT_DIR/libvirt/qemu
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$INSTANCE_IP:/tmp/dnsmasq/*" $CI_PROJECT_DIR/libvirt/dnsmasq
+    - !reference [.tag_kmt_ci_job]
   artifacts:
     when: always
     paths:
@@ -156,6 +165,8 @@
       if [[ "${INSTANCE_ID}" != "" ]] && [[ "${INSTANCE_ID}" != "null" ]]; then
         aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
       fi
+  after_script:
+    - !reference [.tag_kmt_ci_job]
 
 # Manual cleanup jobs, these will be used to cleanup the instances after the tests
 # if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
@@ -208,6 +219,7 @@
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'CI=true /root/fetch_dependencies.sh ${ARCH} && /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}"
     - ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review'"
+    - !reference [.tag_kmt_ci_job]
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -118,7 +118,7 @@
     INFRA_ENV: "aws/agent-qa"
     PIPELINE_ID: $CI_PIPELINE_ID
     TEAM: "ebpf-platform"
-    RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH},test-component:${TEST_COMPONENT},branch:${CI_COMMIT_REF_NAME}"
+    RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH},test-component:${TEST_COMPONENT},git-branch:${CI_COMMIT_REF_NAME}"
     KUBERNETES_MEMORY_REQUEST: "12Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
     VMCONFIG_FILE: "${CI_PROJECT_DIR}/vmconfig-${CI_PIPELINE_ID}-${ARCH}.json"

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -113,7 +113,7 @@
     INFRA_ENV: "aws/agent-qa"
     PIPELINE_ID: $CI_PIPELINE_ID
     TEAM: "ebpf-platform"
-    RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH},test-component:${TEST_COMPONENT}"
+    RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH},test-component:${TEST_COMPONENT},branch:${CI_COMMIT_REF_NAME}"
     KUBERNETES_MEMORY_REQUEST: "12Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
     VMCONFIG_FILE: "${CI_PROJECT_DIR}/vmconfig-${CI_PIPELINE_ID}-${ARCH}.json"

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -93,6 +93,9 @@
         tar czvf $DD_AGENT_TESTING_DIR/kmt-dockers-$ARCH.tar.gz -C $DD_AGENT_TESTING_DIR kmt-dockers-$ARCH
         scp $DD_AGENT_TESTING_DIR/kmt-dockers-$ARCH.tar.gz metal_instance:/opt/kernel-version-testing
       fi
+  after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - !reference [.tag_kmt_ci_job]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
 

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -72,7 +72,7 @@
 # - In KMT we change the AWS_PROFILE environment variable, and that might cause the ssm wrapper to fail getting the keys. Export
 #   the DD_API_KEY variable before changing the AWS_PROFILE variable.
 .tag_kmt_ci_job:
-  - inv kmt.tag-ci-job
+  - inv -e kmt.tag-ci-job
 
 # -- Test dependencies
 

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -49,6 +49,7 @@
   - export AWS_PROFILE=agent-qa-ci
 
 .collect_outcomes_kmt:
+  - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
   - export MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
   # Collect setup-ddvm systemd service logs
   - mkdir -p $CI_PROJECT_DIR/logs
@@ -65,9 +66,12 @@
 .upload_junit_kmt:
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"
 
+# Important: this job needs DD_API_KEY to be set. Some caveats:
+# - if this command is called in the after_script section, note that variables exported in the before_script and
+#   script sections are not avilable to after_script sections
+# - In KMT we change the AWS_PROFILE environment variable, and that might cause the ssm wrapper to fail getting the keys. Export
+#   the DD_API_KEY variable before changing the AWS_PROFILE variable.
 .tag_kmt_ci_job:
-  - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/aws_ssm_get_wrapper.sh "$API_KEY_ORG2_SSM_NAME")"
-  - export DATADOG_API_KEY
   - inv kmt.tag-ci-job
 
 # -- Test dependencies
@@ -130,6 +134,7 @@
     - jq "." $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
     - export AWS_PROFILE=agent-qa-ci
     - !reference [.shared_filters_and_queries]
     - mkdir -p $CI_PROJECT_DIR/libvirt/log/$ARCH $CI_PROJECT_DIR/libvirt/xml $CI_PROJECT_DIR/libvirt/qemu $CI_PROJECT_DIR/libvirt/dnsmasq

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -60,6 +60,7 @@
   - scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
   - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
   - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
+  - !reference [.tag_kmt_ci_job]
 
 .upload_junit_kmt:
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"
@@ -219,7 +220,6 @@
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'CI=true /root/fetch_dependencies.sh ${ARCH} && /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}"
     - ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review'"
-    - !reference [.tag_kmt_ci_job]
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -66,10 +66,8 @@
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"
 
 .tag_kmt_ci_job:
-  - GITLAB_TOKEN="$("$CI_PROJECT_DIR"/tools/ci/aws_ssm_get_wrapper.sh "$GITLAB_READ_API_TOKEN_SSM_NAME")"
   - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/aws_ssm_get_wrapper.sh "$API_KEY_ORG2_SSM_NAME")"
   - export DATADOG_API_KEY
-  - export GITLAB_TOKEN
   - inv kmt.tag-ci-job
 
 # -- Test dependencies

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -71,6 +71,9 @@ kmt_setup_env_secagent_x64:
     - popd
     # upload connector to metal instance
     - scp $CI_PROJECT_DIR/connector-${ARCH} metal_instance:/home/ubuntu/connector
+  after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - !reference [.tag_kmt_ci_job]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     TEST_COMPONENT: security-agent

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -33,6 +33,9 @@ upload_dependencies_sysprobe_arm64:
     # Pull base images
     - mkdir $KMT_DOCKERS
     - inv -e system-probe.save-test-dockers --use-crane --output-dir $KMT_DOCKERS --arch $ARCH
+  after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - !reference [.tag_kmt_ci_job]
   artifacts:
     expire_in: 1 day
     paths:
@@ -77,6 +80,9 @@ pull_test_dockers_arm64:
     - !reference [.get_instance_ip_by_type]
     - !reference [.setup_ssh_config]
     - scp $CI_PROJECT_DIR/kmt-deps/ci/$ARCH/$ARCHIVE_NAME metal_instance:/opt/kernel-version-testing/
+  after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - !reference [.tag_kmt_ci_job]
   variables:
     DEPENDENCIES: $CI_PROJECT_DIR/kmt-deps/ci/$ARCH/btfs
     BTF_DIR: opt/kmt-ramfs/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf
@@ -153,6 +159,9 @@ kmt_setup_env_sysprobe_x64:
     - popd
     # upload connector to metal instance
     - scp $CI_PROJECT_DIR/connector-${ARCH} metal_instance:/home/ubuntu/connector
+  after_script:
+    - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
+    - !reference [.tag_kmt_ci_job]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     TEST_COMPONENT: system-probe

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1766,7 +1766,7 @@ def tag_ci_job(ctx: Context):
 
     # Get the job type based on the job name
     job_name = os.environ["CI_JOB_NAME"]
-    if "setup_env" in job_name:
+    if "setup_env" in job_name or "upload" in job_name or "pull_test_dockers" in job_name:
         job_type = "setup"
     elif "cleanup" in job_name:
         job_type = "cleanup"
@@ -1803,6 +1803,17 @@ def tag_ci_job(ctx: Context):
             tags["failure_reason"] = "infra_ssh-config"
         else:
             tags["failure_reason"] = "infra-unknown"
+    elif job_type == "setup":
+        if "kmt_setup_env" in job_name:
+            tags["setup_stage"] = "infra-provision"
+        elif "pull_test_dockers" in job_name:
+            tags["setup_stage"] = "docker-images"
+        elif "upload_dependencies" in job_name:
+            tags["setup_stage"] = "dependencies"
+        elif "btfs" in job_name:
+            tags["setup_stage"] = "btfs"
+        elif "upload_secagent_tests" in job_name or "upload_sysprobe_tests" in job_name:
+            tags["setup_stage"] = "tests"
 
     tag_prefix = "kmt."
     tags_str = " ".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1816,6 +1816,6 @@ def tag_ci_job(ctx: Context):
             tags["setup_stage"] = "tests"
 
     tag_prefix = "kmt."
-    tags_str = " ".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())
+    tags_str = " ".join(f"--tags {tag_prefix}{k}:{v}" for k, v in tags.items())
 
-    ctx.run(f"datadog-ci tag --level job --tags {tags_str}")
+    ctx.run(f"datadog-ci tag --level job {tags_str}")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1805,6 +1805,6 @@ def tag_ci_job(ctx: Context):
             tags["failure_reason"] = "infra-unknown"
 
     tag_prefix = "kmt."
-    tags_str = ",".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())
+    tags_str = " ".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())
 
     ctx.run(f"datadog-ci tag --level job --tags {tags_str}")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1748,7 +1748,7 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
 @task
 def tag_ci_job(ctx: Context):
     """Add extra tags to the CI job"""
-    tags: dict[str, str] = {"is_kmt_job": "true"}  # Base tag for easy identification of KMT jobs
+    tags: dict[str, str] = {}
 
     # Retrieve tags from environment variables, with a renaming for convenience
     environment_vars_to_tags = {

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1748,7 +1748,7 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
 @task
 def tag_ci_job(ctx: Context):
     """Add extra tags to the CI job"""
-    tags: dict[str, str] = {}
+    tags: dict[str, str] = {"is_kmt_job": "true"}  # Base tag for easy identification of KMT jobs
 
     # Retrieve tags from environment variables, with a renaming for convenience
     environment_vars_to_tags = {

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shutil
+import tarfile
 import tempfile
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -18,7 +19,7 @@ from invoke.tasks import task
 
 from tasks.kernel_matrix_testing import selftest as selftests
 from tasks.kernel_matrix_testing import stacks, vmconfig
-from tasks.kernel_matrix_testing.ci import KMTTestRunJob, get_all_jobs_for_pipeline
+from tasks.kernel_matrix_testing.ci import KMTTestRunJob, get_all_jobs_for_pipeline, get_test_results_from_tarfile
 from tasks.kernel_matrix_testing.compiler import CONTAINER_AGENT_PATH, all_compilers, get_compiler
 from tasks.kernel_matrix_testing.config import ConfigManager
 from tasks.kernel_matrix_testing.download import arch_mapping, full_arch, update_rootfs
@@ -1742,3 +1743,66 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
 
     print(tabulate(table, headers=["Package"] + vm_list))
     print("\nLegend: Successes/Failures/Skipped")
+
+
+@task
+def tag_ci_job(ctx: Context):
+    """Add extra tags to the CI job"""
+    tags: dict[str, str] = {}
+
+    # Retrieve tags from environment variables, with a renaming for convenience
+    environment_vars_to_tags = {
+        "ARCH": "arch",
+        "TEST_COMPONENT": "component",
+        "TAG": "platform",
+        "TEST_SET": "test_set",
+        "MICRO_VM_IP": "microvm_ip",
+    }
+
+    for env_var, tag in environment_vars_to_tags.items():
+        value = os.getenv(env_var)
+        if value is not None:
+            tags[tag] = value
+
+    # Get the job type based on the job name
+    job_name = os.environ["CI_JOB_NAME"]
+    if "setup_env" in job_name:
+        job_type = "setup"
+    elif "cleanup" in job_name:
+        job_type = "cleanup"
+    elif "kmt_run" in job_name:
+        job_type = "test"
+    tags["job_type"] = job_type
+
+    if job_type == "test":
+        # Retrieve all data for the tests to detect a failure reason
+        agent_testing_dir = Path(os.environ["DD_AGENT_TESTING_DIR"])
+        ci_project_dir = Path(os.environ["CI_PROJECT_DIR"])
+
+        test_jobs_executed, tests_failed = False, False
+        for candidate in agent_testing_dir.glob("junit-*.tar.gz"):
+            tar = tarfile.open(candidate)
+            test_results = get_test_results_from_tarfile(tar)
+            test_jobs_executed = test_jobs_executed or len(test_results) > 0
+            # values can be none, we have to explicitly check for False
+            tests_failed = tests_failed or any(r is False for r in test_results.values())
+
+        tags["tests_executed"] = str(test_jobs_executed).lower()
+        tags["tests_failed"] = str(tests_failed).lower()
+
+        ssh_config_path = Path.home() / ".ssh" / "config"
+        setup_ddvm_status_file = ci_project_dir / "setup-ddvm.status"
+
+        if test_jobs_executed and not tests_failed:
+            tags["failure_reason"] = "none"
+        elif tests_failed:
+            tags["failure_reason"] = "test"
+        elif setup_ddvm_status_file.is_file() and "active" not in setup_ddvm_status_file.read_text():
+            tags["failure_reason"] = "infra_setup-ddvm"
+        elif not ssh_config_path.is_file():
+            tags["failure_reason"] = "infra_ssh-config"
+
+    tag_prefix = "kmt."
+    tags_str = ",".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())
+
+    ctx.run(f"datadog-ci tag --level job --tags {tags_str}")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1816,6 +1816,6 @@ def tag_ci_job(ctx: Context):
             tags["setup_stage"] = "tests"
 
     tag_prefix = "kmt."
-    tags_str = " ".join(f"--tags {tag_prefix}{k}:{v}" for k, v in tags.items())
+    tags_str = " ".join(f"--tags '{tag_prefix}{k}:{v}'" for k, v in tags.items())
 
     ctx.run(f"datadog-ci tag --level job {tags_str}")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1795,12 +1795,14 @@ def tag_ci_job(ctx: Context):
 
         if test_jobs_executed and not tests_failed:
             tags["failure_reason"] = "none"
-        elif tests_failed:
+        elif test_jobs_executed and tests_failed:  # The first condition is redundant but makes the logic clearer
             tags["failure_reason"] = "test"
         elif setup_ddvm_status_file.is_file() and "active" not in setup_ddvm_status_file.read_text():
             tags["failure_reason"] = "infra_setup-ddvm"
         elif not ssh_config_path.is_file():
             tags["failure_reason"] = "infra_ssh-config"
+        else:
+            tags["failure_reason"] = "infra-unknown"
 
     tag_prefix = "kmt."
     tags_str = ",".join(f"{tag_prefix}{k}:{v}" for k, v in tags.items())


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR increases our visibility into KMT pipelines and CI jobs, with the following changes:

- Sends environment variables such as job architecture, test component and similar variables as CI job tags for easier classification of jobs
- Detects test results and generates several tags that can be used to detect whether the job has failed due to infrastructure issues or due to actual test failures.
- Classifies the stage of each job for improved classification  
- Adds a `kmt.tag-ci-job` that centralizes the generation of tasks
- Adds a branch tag to the AWS instances, for easier tracking of per-PR costs. 

### Motivation

Improve visibility into KMT, specially around infrastructure failures, to generate data that will be used to inform development decisions.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The `datadog-ci` standalone binary is not available in ARM64 runners, so those jobs will not get tagged correctly. Right now it seems that the complexity of adding tags to those jobs is greater than the benefit we'd get from it (specially as it seems we don't have a significant difference of outcomes between x64/arm64 jobs) so, for now, the CI will not execute the tagging task if the `datadog-ci` binary is not available.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
