### PR TITLE
Mark `TestECSSuite/TestCPU` e2e test as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -7,6 +7,7 @@
 #   - "TestInstallScript/test_install_script_on_centos-79_x86_64_datadog-agent_agent_7"
 
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
-test/new-e2e/tests/containers:  
+test/new-e2e/tests/containers:
+  - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}


### PR DESCRIPTION
### What does this PR do?

Mark `TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}` as flaky.

### Motivation

For an unknown reason, since recently, sometimes, `stress-ng` is consuming significantly less CPU than expected:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/8872c05a-ac4c-4469-9cf6-948cedad8f87)

### Additional Notes

[Investigation notebook](https://dddev.datadoghq.com/notebook/8407492/container-cpu-usage-shaky-on-ecs)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
