### PR TITLE
pkg/trace/traceutil: reduce allocations during normalization

### DIFF
--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -267,7 +267,8 @@ func normMetricNameParse(name string) (string, bool) {
 	}
 
 	var i, ptr int
-	res := make([]byte, 0, len(name))
+	var resa [MaxNameLen]byte
+	res := resa[:0]
 
 	// skip non-alphabetic characters
 	for ; i < len(name) && !isAlpha(name[i]); i++ {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

During normalization of metrics names, we make an extra allocation, which can in some cases account for almost 10% of the allocations of the entire agent. Reducing this number should reduce GC pressure and improve memory usage.

```
name              old time/op    new time/op    delta
Normalization-16     858ns ±29%     943ns ±32%     ~     (p=0.393 n=10+10)

name              old alloc/op   new alloc/op   delta
Normalization-16    1.49kB ± 0%    1.46kB ± 0%   -1.88%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
Normalization-16      15.0 ± 0%      13.0 ± 0%  -13.33%  (p=0.000 n=10+10)
```
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
