### PR TITLE
[ASCII-1823] Remove unnecessary fx Provide blocks to populate API component dependencies

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -50,7 +50,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
@@ -150,7 +149,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Provide(func() dogstatsdServer.Component { return nil }),
 			fx.Provide(func() pidmap.Component { return nil }),
 			fx.Provide(func() replay.Component { return nil }),
-			fx.Provide(func() serverdebug.Component { return nil }),
 			fx.Provide(func() status.Component { return nil }),
 
 			fx.Provide(tagger.NewTaggerParamsForCoreAgent),

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger/jmxloggerimpl"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl"
 	internalAPI "github.com/DataDog/datadog-agent/comp/api/api"
@@ -39,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -53,12 +51,6 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
-	"github.com/DataDog/datadog-agent/comp/metadata/host"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
@@ -147,26 +139,20 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			// still, we need to pass it to ensure the API server is proprely initialized
 			settingsimpl.Module(),
 			fx.Supply(settings.Params{}),
+
 			// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
 			// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
 			// in others commands such as run.
-			fx.Provide(func() flare.Component { return nil }),
-			fx.Provide(func() dogstatsdServer.Component { return nil }),
-			fx.Provide(func() replay.Component { return nil }),
-			fx.Provide(func() pidmap.Component { return nil }),
-			fx.Provide(func() serverdebug.Component { return nil }),
-			fx.Provide(func() host.Component { return nil }),
-			fx.Provide(func() inventoryagent.Component { return nil }),
-			fx.Provide(func() inventoryhost.Component { return nil }),
-			fx.Provide(func() demultiplexer.Component { return nil }),
-			fx.Provide(func() inventorychecks.Component { return nil }),
-			fx.Provide(func() packagesigning.Component { return nil }),
 			fx.Supply(optional.NewNoneOption[rcservice.Component]()),
 			fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
-			fx.Provide(func() status.Component { return nil }),
-			fx.Provide(func() eventplatformreceiver.Component { return nil }),
 			fx.Supply(optional.NewNoneOption[collector.Component]()),
 			fx.Supply(optional.NewNoneOption[logsAgent.Component]()),
+			fx.Provide(func() dogstatsdServer.Component { return nil }),
+			fx.Provide(func() pidmap.Component { return nil }),
+			fx.Provide(func() replay.Component { return nil }),
+			fx.Provide(func() serverdebug.Component { return nil }),
+			fx.Provide(func() status.Component { return nil }),
+
 			fx.Provide(tagger.NewTaggerParamsForCoreAgent),
 			taggerimpl.Module(),
 			autodiscoveryimpl.Module(),

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -23,7 +23,6 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -42,7 +41,6 @@ type apiServer struct {
 	capture           replay.Component
 	pidMap            pidmap.Component
 	secretResolver    secrets.Component
-	pkgSigning        packagesigning.Component
 	statusComponent   status.Component
 	rcService         optional.Option[rcservice.Component]
 	rcServiceMRF      optional.Option[rcservicemrf.Component]
@@ -62,7 +60,6 @@ type dependencies struct {
 	Capture           replay.Component
 	PidMap            pidmap.Component
 	SecretResolver    secrets.Component
-	PkgSigning        packagesigning.Component
 	StatusComponent   status.Component
 	RcService         optional.Option[rcservice.Component]
 	RcServiceMRF      optional.Option[rcservicemrf.Component]
@@ -83,7 +80,6 @@ func newAPIServer(deps dependencies) api.Component {
 		capture:           deps.Capture,
 		pidMap:            deps.PidMap,
 		secretResolver:    deps.SecretResolver,
-		pkgSigning:        deps.PkgSigning,
 		statusComponent:   deps.StatusComponent,
 		rcService:         deps.RcService,
 		rcServiceMRF:      deps.RcServiceMRF,

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -40,8 +40,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/inventoryhostimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning/packagesigningimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 
@@ -67,7 +65,6 @@ type testdeps struct {
 	ServerDebug           dogstatsddebug.Component
 	Demux                 demultiplexer.Component
 	SecretResolver        secrets.Component
-	PkgSigning            packagesigning.Component
 	StatusComponent       status.Mock
 	EventPlatformReceiver eventplatformreceiver.Component
 	RcService             optional.Option[rcservice.Component]
@@ -100,7 +97,6 @@ func getComponentDependencies(t *testing.T) testdeps {
 			return component
 		}),
 		inventorychecksimpl.MockModule(),
-		packagesigningimpl.MockModule(),
 		statusimpl.MockModule(),
 		eventplatformreceiverimpl.MockModule(),
 		fx.Supply(optional.NewNoneOption[rcservice.Component]()),
@@ -131,7 +127,6 @@ func getTestAPIServer(deps testdeps) api.Component {
 		DogstatsdServer:   deps.DogstatsdServer,
 		Capture:           deps.Capture,
 		SecretResolver:    deps.SecretResolver,
-		PkgSigning:        deps.PkgSigning,
 		StatusComponent:   deps.StatusComponent,
 		RcService:         deps.RcService,
 		RcServiceMRF:      deps.RcServiceMRF,

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -10,19 +10,15 @@ import (
 	"testing"
 
 	// component dependencies
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+
 	"github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
-	"github.com/DataDog/datadog-agent/comp/core/flare/flareimpl"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
-	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -31,13 +27,7 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
-	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/inventoryhostimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 
@@ -58,43 +48,33 @@ type testdeps struct {
 	//
 	// TODO: remove these in the next PR once StartServer component arguments
 	//       are part of the api component dependency struct
-	DogstatsdServer       dogstatsdServer.Component
-	Capture               replay.Component
-	Demux                 demultiplexer.Component
-	SecretResolver        secrets.Component
-	StatusComponent       status.Mock
-	EventPlatformReceiver eventplatformreceiver.Component
-	RcService             optional.Option[rcservice.Component]
-	RcServiceMRF          optional.Option[rcservicemrf.Component]
-	AuthToken             authtoken.Component
-	WorkloadMeta          workloadmeta.Component
-	Tagger                tagger.Mock
-	Autodiscovery         autodiscovery.Mock
-	Logs                  optional.Option[logsAgent.Component]
-	Collector             optional.Option[collector.Component]
-	EndpointProviders     []api.EndpointProvider `group:"agent_endpoint"`
+	DogstatsdServer   dogstatsdServer.Component
+	Capture           replay.Component
+	SecretResolver    secrets.Component
+	StatusComponent   status.Mock
+	RcService         optional.Option[rcservice.Component]
+	RcServiceMRF      optional.Option[rcservicemrf.Component]
+	AuthToken         authtoken.Component
+	WorkloadMeta      workloadmeta.Component
+	Tagger            tagger.Mock
+	Autodiscovery     autodiscovery.Mock
+	Logs              optional.Option[logsAgent.Component]
+	Collector         optional.Option[collector.Component]
+	EndpointProviders []api.EndpointProvider `group:"agent_endpoint"`
 }
 
 func getComponentDependencies(t *testing.T) testdeps {
 	// TODO: this fxutil.Test[T] can take a component and return the component
 	return fxutil.Test[testdeps](
 		t,
-		hostnameimpl.MockModule(),
-		flareimpl.MockModule(),
 		dogstatsdServer.MockModule(),
 		replaymock.MockModule(),
-		hostimpl.MockModule(),
-		inventoryagentimpl.MockModule(),
-		demultiplexerimpl.MockModule(),
-		inventoryhostimpl.MockModule(),
 		secretsimpl.MockModule(),
 		fx.Provide(func(secretMock secrets.Mock) secrets.Component {
 			component := secretMock.(secrets.Component)
 			return component
 		}),
-		inventorychecksimpl.MockModule(),
 		statusimpl.MockModule(),
-		eventplatformreceiverimpl.MockModule(),
 		fx.Supply(optional.NewNoneOption[rcservice.Component]()),
 		fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
 		fetchonlyimpl.MockModule(),
@@ -102,13 +82,8 @@ func getComponentDependencies(t *testing.T) testdeps {
 		taggerimpl.MockModule(),
 		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
 		autodiscoveryimpl.MockModule(),
-		fx.Provide(func() optional.Option[logsAgent.Component] {
-			return optional.NewNoneOption[logsAgent.Component]()
-		}),
-		fx.Provide(func() optional.Option[collector.Component] {
-			return optional.NewNoneOption[collector.Component]()
-		}),
-		settingsimpl.MockModule(),
+		fx.Supply(optional.NewNoneOption[logsAgent.Component]()),
+		fx.Supply(optional.NewNoneOption[collector.Component]()),
 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
 		fx.Provide(func() api.AgentEndpointProvider {
 			return api.AgentEndpointProvider{

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -31,8 +31,6 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	dogstatsddebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -62,7 +60,6 @@ type testdeps struct {
 	//       are part of the api component dependency struct
 	DogstatsdServer       dogstatsdServer.Component
 	Capture               replay.Component
-	ServerDebug           dogstatsddebug.Component
 	Demux                 demultiplexer.Component
 	SecretResolver        secrets.Component
 	StatusComponent       status.Mock
@@ -86,7 +83,6 @@ func getComponentDependencies(t *testing.T) testdeps {
 		flareimpl.MockModule(),
 		dogstatsdServer.MockModule(),
 		replaymock.MockModule(),
-		serverdebugimpl.MockModule(),
 		hostimpl.MockModule(),
 		inventoryagentimpl.MockModule(),
 		demultiplexerimpl.MockModule(),

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -39,8 +39,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
-	"github.com/DataDog/datadog-agent/comp/core/gui"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -63,12 +61,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	logagent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/metadata/host"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryhost"
-	"github.com/DataDog/datadog-agent/comp/metadata/packagesigning"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
@@ -180,10 +174,6 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				// Here we just want to collect metadata to be displayed, so we don't need a collector.
 				collector.NoneModule(),
 				fx.Supply(status.NewInformationProvider(statuscollector.Provider{})),
-				fx.Provide(func() optional.Option[logagent.Component] {
-					return optional.NewNoneOption[logagent.Component]()
-
-				}),
 				fx.Provide(func() serializer.MetricSerializer { return nil }),
 				fx.Supply(defaultforwarder.Params{UseNoopForwarder: true}),
 				compressionimpl.Module(),
@@ -217,18 +207,14 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
 				// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
 				// in others commands such as run.
-				fx.Provide(func() flare.Component { return nil }),
+				fx.Supply(optional.NewNoneOption[rcservice.Component]()),
+				fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
+				fx.Supply(optional.NewNoneOption[logagent.Component]()),
 				fx.Provide(func() server.Component { return nil }),
 				fx.Provide(func() replay.Component { return nil }),
 				fx.Provide(func() pidmap.Component { return nil }),
 				fx.Provide(func() serverdebug.Component { return nil }),
-				fx.Provide(func() host.Component { return nil }),
-				fx.Provide(func() inventoryagent.Component { return nil }),
-				fx.Provide(func() inventoryhost.Component { return nil }),
-				fx.Provide(func() packagesigning.Component { return nil }),
-				fx.Supply(optional.NewNoneOption[rcservice.Component]()),
-				fx.Supply(optional.NewNoneOption[rcservicemrf.Component]()),
-				fx.Supply(optional.NewNoneOption[gui.Component]()),
+
 				getPlatformModules(),
 				jmxloggerimpl.Module(),
 				fx.Supply(jmxloggerimpl.NewDisabledParams()),

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -54,7 +54,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -213,7 +212,6 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				fx.Provide(func() server.Component { return nil }),
 				fx.Provide(func() replay.Component { return nil }),
 				fx.Provide(func() pidmap.Component { return nil }),
-				fx.Provide(func() serverdebug.Component { return nil }),
 
 				getPlatformModules(),
 				jmxloggerimpl.Module(),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removed unnecessary `fx.Provide` and dependencies from the API component.

We no longer need this dependencies because their endpoint are being register via value groups 🎉 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
