### PR TITLE
fix(opentelemetry): add OTEL_RESOURCE_ATTRIBUTES spaces trimming

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -769,6 +769,7 @@ func (c *WorkloadMetaCollector) addOpenTelemetryStandardTags(container *workload
 	if otelResourceAttributes, ok := container.EnvVars[envVarOtelResourceAttributes]; ok {
 		for _, pair := range strings.Split(otelResourceAttributes, ",") {
 			fields := strings.SplitN(pair, "=", 2)
+			fields[0], fields[1] = strings.TrimSpace(fields[0]), strings.TrimSpace(fields[1])
 			if tag, ok := otelResourceAttributesMapping[fields[0]]; ok {
 				tags.AddStandard(tag, fields[1])
 			}

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -1093,6 +1093,42 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "tags from environment with opentelemetry sdk with whitespace",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				EnvVars: map[string]string{
+					// env as tags
+					"TEAM": "container-integrations",
+					"TIER": "node",
+
+					// otel standard tags
+					"OTEL_SERVICE_NAME":        svc,
+					"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("service.name= %s, service.version = %s , deployment.environment =%s", svc, version, env),
+				},
+			},
+			envAsTags: map[string]string{
+				"team": "owner_team",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						"owner_team:container-integrations",
+					}, standardTags...),
+					StandardTags: standardTags,
+				},
+			},
+		},
+		{
 			name: "tags from labels",
 			container: workloadmeta.Container{
 				EntityID: entityID,


### PR DESCRIPTION
### What does this PR do?

Add spaces trimming for `OTEL_RESOURCE_ATTRIBUTES`.

### Motivation

This is needed for customer who have spaces in their `OTEL_RESOURCE_ATTRIBUTES`.

### Describe how to test/QA your changes

QA will be done with this PR: https://github.com/DataDog/datadog-agent/pull/26118