### PR TITLE
upgrade(installer): Add more telemetry for injector installation

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -108,7 +108,6 @@ func (i *installerImpl) IsInstalled(_ context.Context, pkg string) (bool, error)
 
 // Install installs or updates a package.
 func (i *installerImpl) Install(ctx context.Context, url string, args []string) error {
-	span, _ := tracer.SpanFromContext(ctx)
 	i.m.Lock()
 	defer i.m.Unlock()
 	pkg, err := i.downloader.Download(ctx, url)
@@ -118,13 +117,12 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 	span, ok := tracer.SpanFromContext(ctx)
 	if ok {
 		span.SetTag(ext.ResourceName, pkg.Name)
+		span.SetTag("package_version", pkg.Version)
 	}
 	dbPkg, err := i.db.GetPackage(pkg.Name)
 	if err != nil && !errors.Is(err, db.ErrPackageNotFound) {
 		return fmt.Errorf("could not get package: %w", err)
 	}
-	span.SetTag("package.name", pkg.Name)
-	span.SetTag("package.version", pkg.Version)
 	if dbPkg.Name == pkg.Name && dbPkg.Version == pkg.Version {
 		log.Infof("package %s version %s is already installed", pkg.Name, pkg.Version)
 		return nil

--- a/pkg/fleet/installer/service/apm_inject_test.go
+++ b/pkg/fleet/installer/service/apm_inject_test.go
@@ -9,6 +9,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,7 +53,7 @@ func TestSetLDPreloadConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := a.setLDPreloadConfigContent(tc.input)
+			output, err := a.setLDPreloadConfigContent(context.TODO(), tc.input)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, output)
 			if len(tc.input) > 0 {
@@ -89,14 +90,14 @@ func TestRemoveLDPreloadConfig(t *testing.T) {
 		// File doesn't contain the entry to remove (removed by customer?)
 		"/abc/def/preload.so /def/abc/preload.so": "/abc/def/preload.so /def/abc/preload.so",
 	} {
-		output, err := a.deleteLDPreloadConfigContent([]byte(input))
+		output, err := a.deleteLDPreloadConfigContent(context.TODO(), []byte(input))
 		assert.Nil(t, err)
 		assert.Equal(t, expected, string(output))
 	}
 
 	// File is badly formatted (non-breaking space instead of space)
 	input := "/tmp/stable/inject/launcher.preload.so\u00a0/def/abc/preload.so"
-	output, err := a.deleteLDPreloadConfigContent([]byte(input))
+	output, err := a.deleteLDPreloadConfigContent(context.TODO(), []byte(input))
 	assert.NotNil(t, err)
 	assert.Equal(t, "", string(output))
 	assert.NotEqual(t, input, string(output))

--- a/pkg/fleet/installer/service/apm_sockets.go
+++ b/pkg/fleet/installer/service/apm_sockets.go
@@ -10,12 +10,14 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
 )
 
@@ -72,14 +74,16 @@ func getSocketsPath() (string, string, error) {
 }
 
 // configureSocketsEnv configures the sockets for the agent & injector
-func configureSocketsEnv() error {
+func configureSocketsEnv(ctx context.Context) error {
 	envFile := newFileMutator(envFilePath, setSocketEnvs, nil, nil)
 	defer envFile.cleanup()
-	rollback, err := envFile.mutate()
+	rollback, err := envFile.mutate(ctx)
 	if err != nil {
-		rollbackErr := rollback()
-		if rollbackErr != nil {
-			log.Warnf("Failed to rollback environment file: %v", rollbackErr)
+		if rollback != nil {
+			rollbackErr := rollback()
+			if rollbackErr != nil {
+				log.Warnf("Failed to rollback environment file: %v", rollbackErr)
+			}
 		}
 		return fmt.Errorf("error configuring sockets: %w", err)
 	}
@@ -91,11 +95,18 @@ func configureSocketsEnv() error {
 }
 
 // setSocketEnvs sets the socket environment variables
-func setSocketEnvs(envFile []byte) ([]byte, error) {
+func setSocketEnvs(ctx context.Context, envFile []byte) ([]byte, error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "set_socket_envs")
+	defer span.Finish()
+
 	apmSocket, statsdSocket, err := getSocketsPath()
 	if err != nil {
 		return nil, fmt.Errorf("error getting sockets path: %w", err)
 	}
+
+	span.SetTag("socket_path.apm", apmSocket)
+	span.SetTag("socket_path.dogstatsd", statsdSocket)
+
 	envs := map[string]string{
 		"DD_APM_RECEIVER_SOCKET": apmSocket,
 		"DD_DOGSTATSD_SOCKET":    statsdSocket,
@@ -133,7 +144,11 @@ func addEnvsIfNotSet(envs map[string]string, envFile []byte) ([]byte, error) {
 // The unit should contain the .service suffix (e.g. datadog-agent-exp.service)
 //
 // Reloading systemd & restarting the unit has to be done separately by the caller
-func addSystemDEnvOverrides(unit string) error {
+func addSystemDEnvOverrides(ctx context.Context, unit string) (err error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "add_systemd_env_overrides")
+	defer span.Finish(tracer.WithError(err))
+	span.SetTag("unit", unit)
+
 	// The - is important as it lets the unit start even if the file is missing.
 	content := []byte(fmt.Sprintf("[Service]\nEnvironmentFile=-%s\n", envFilePath))
 
@@ -141,13 +156,15 @@ func addSystemDEnvOverrides(unit string) error {
 	// We don't really need to remove the file either as it'll just be ignored once the
 	// unit is removed.
 	path := filepath.Join(systemdPath, unit+".d", "datadog_environment.conf")
-	err := os.Mkdir(filepath.Dir(path), 0755)
+	err = os.Mkdir(filepath.Dir(path), 0755)
 	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("error creating systemd environment override directory: %w", err)
+		err = fmt.Errorf("error creating systemd environment override directory: %w", err)
+		return err
 	}
 	err = os.WriteFile(path, content, 0644)
 	if err != nil {
-		return fmt.Errorf("error writing systemd environment override: %w", err)
+		err = fmt.Errorf("error writing systemd environment override: %w", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/fleet/installer/service/apm_sockets_test.go
+++ b/pkg/fleet/installer/service/apm_sockets_test.go
@@ -9,6 +9,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ func TestSetSocketEnvs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := setSocketEnvs([]byte(tt.input))
+			res, err := setSocketEnvs(context.TODO(), []byte(tt.input))
 			assert.NoError(t, err)
 			envVarsCount := 0
 			for _, line := range strings.Split(string(res), "\n") {

--- a/pkg/fleet/installer/service/docker.go
+++ b/pkg/fleet/installer/service/docker.go
@@ -38,7 +38,7 @@ func (a *apmInjectorInstaller) setupDocker(ctx context.Context) (rollback func()
 		return nil, err
 	}
 
-	rollbackDockerConfig, err := a.dockerConfigInstrument.mutate()
+	rollbackDockerConfig, err := a.dockerConfigInstrument.mutate(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -60,14 +60,17 @@ func (a *apmInjectorInstaller) uninstallDocker(ctx context.Context) error {
 	if !isDockerInstalled(ctx) {
 		return nil
 	}
-	if _, err := a.dockerConfigUninstrument.mutate(); err != nil {
+	if _, err := a.dockerConfigUninstrument.mutate(ctx); err != nil {
 		return err
 	}
 	return reloadDockerConfig(ctx)
 }
 
 // setDockerConfigContent sets the content of the docker daemon configuration
-func (a *apmInjectorInstaller) setDockerConfigContent(previousContent []byte) ([]byte, error) {
+func (a *apmInjectorInstaller) setDockerConfigContent(ctx context.Context, previousContent []byte) ([]byte, error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "set_docker_config_content")
+	defer span.Finish()
+
 	dockerConfig := dockerDaemonConfig{}
 
 	if len(previousContent) > 0 {
@@ -76,12 +79,13 @@ func (a *apmInjectorInstaller) setDockerConfigContent(previousContent []byte) ([
 			return nil, err
 		}
 	}
-
+	span.SetTag("docker_config.previous.default_runtime", dockerConfig["default-runtime"])
 	dockerConfig["default-runtime"] = "dd-shim"
 	runtimes, ok := dockerConfig["runtimes"].(map[string]interface{})
 	if !ok {
 		runtimes = map[string]interface{}{}
 	}
+	span.SetTag("docker_config.previous.runtimes_count", len(runtimes))
 	runtimes["dd-shim"] = map[string]interface{}{
 		"path": path.Join(a.installPath, "inject", "auto_inject_runc"),
 	}
@@ -96,7 +100,7 @@ func (a *apmInjectorInstaller) setDockerConfigContent(previousContent []byte) ([
 }
 
 // deleteDockerConfigContent restores the content of the docker daemon configuration
-func (a *apmInjectorInstaller) deleteDockerConfigContent(previousContent []byte) ([]byte, error) {
+func (a *apmInjectorInstaller) deleteDockerConfigContent(_ context.Context, previousContent []byte) ([]byte, error) {
 	dockerConfig := dockerDaemonConfig{}
 
 	if len(previousContent) > 0 {
@@ -129,7 +133,9 @@ func (a *apmInjectorInstaller) deleteDockerConfigContent(previousContent []byte)
 // As the reload is eventually consistent we have to retry a few times
 //
 // This method is valid since at least Docker 17.03 (last update 2018-08-30)
-func (a *apmInjectorInstaller) verifyDockerRuntime() (err error) {
+func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "verify_docker_runtime")
+	defer span.Finish(tracer.WithError(err))
 	for i := 0; i < 3; i++ {
 		if i > 0 {
 			time.Sleep(time.Second)
@@ -146,10 +152,12 @@ func (a *apmInjectorInstaller) verifyDockerRuntime() (err error) {
 			}
 		}
 		if strings.TrimSpace(outb.String()) == "dd-shim" {
+			span.SetTag("success", true)
 			return nil
 		}
 	}
-	return fmt.Errorf("docker default runtime has not been set to injector docker runtime")
+	err = fmt.Errorf("docker default runtime has not been set to injector docker runtime")
+	return err
 }
 
 func reloadDockerConfig(ctx context.Context) (err error) {

--- a/pkg/fleet/installer/service/docker.go
+++ b/pkg/fleet/installer/service/docker.go
@@ -152,7 +152,6 @@ func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err err
 			}
 		}
 		if strings.TrimSpace(outb.String()) == "dd-shim" {
-			span.SetTag("success", true)
 			return nil
 		}
 	}

--- a/pkg/fleet/installer/service/docker_test.go
+++ b/pkg/fleet/installer/service/docker_test.go
@@ -9,6 +9,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func TestSetDockerConfig(t *testing.T) {
     }
 }`,
 	} {
-		output, err := a.setDockerConfigContent([]byte(input))
+		output, err := a.setDockerConfigContent(context.TODO(), []byte(input))
 		assert.Nil(t, err)
 		assert.Equal(t, expected, string(output))
 	}
@@ -168,7 +169,7 @@ func TestRemoveDockerConfig(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := a.deleteDockerConfigContent([]byte(tc.input))
+			output, err := a.deleteDockerConfigContent(context.TODO(), []byte(tc.input))
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, string(output))
 		})

--- a/pkg/fleet/installer/service/file_test.go
+++ b/pkg/fleet/installer/service/file_test.go
@@ -9,6 +9,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -25,7 +26,7 @@ const (
 )
 
 var (
-	transformFunc = func(existing []byte) ([]byte, error) {
+	transformFunc = func(ctx context.Context, existing []byte) ([]byte, error) {
 		return []byte(transformedContent), nil
 	}
 	failFunc = func() error { return errors.New("fail") }
@@ -40,7 +41,7 @@ func TestFileTransformWithRollback(t *testing.T) {
 
 	mutator := newFileMutator(originalPath, transformFunc, nil, nil)
 
-	rollback, err := mutator.mutate()
+	rollback, err := mutator.mutate(context.TODO())
 	require.NoError(t, err)
 	require.NotNil(t, rollback)
 
@@ -57,11 +58,11 @@ func TestNoChangesNeeded(t *testing.T) {
 	mode := os.FileMode(0744)
 	require.Nil(t, os.WriteFile(originalPath, []byte(originalContent), mode))
 
-	mutator := newFileMutator(originalPath, func(existing []byte) ([]byte, error) {
+	mutator := newFileMutator(originalPath, func(ctx context.Context, existing []byte) ([]byte, error) {
 		return []byte(originalContent), nil
 	}, nil, nil)
 
-	rollback, err := mutator.mutate()
+	rollback, err := mutator.mutate(context.TODO())
 	require.Nil(t, rollback)
 	require.NoError(t, err)
 	assertFile(t, originalPath, originalContent, mode)
@@ -73,7 +74,7 @@ func TestFileTransformWithRollback_No_original(t *testing.T) {
 
 	mutator := newFileMutator(originalPath, transformFunc, nil, nil)
 
-	rollback, err := mutator.mutate()
+	rollback, err := mutator.mutate(context.TODO())
 	require.NoError(t, err)
 	require.NotNil(t, rollback)
 
@@ -91,7 +92,7 @@ func TestFileMutator_RollbackOnValidation(t *testing.T) {
 
 	mutator := newFileMutator(originalPath, transformFunc, nil, failFunc)
 
-	_, err := mutator.mutate()
+	_, err := mutator.mutate(context.TODO())
 	require.Error(t, err)
 
 	// check already rolled back
@@ -104,7 +105,7 @@ func TestFileTransform_RollbackOnValidation_No_original(t *testing.T) {
 
 	mutator := newFileMutator(originalPath, transformFunc, nil, failFunc)
 
-	_, err := mutator.mutate()
+	_, err := mutator.mutate(context.TODO())
 	require.Error(t, err)
 
 	assertNoExists(t, originalPath)


### PR DESCRIPTION
### What does this PR do?
- Adds a bunch of telemetry spans for injector installation, namely
  - Socket paths in dedicated span
  - Docker previous default runtime
  - Docker previous count of runtimes
  - Which files are mutated
  - Which units are overridden to get the environment
  - Spans on almost each operation for more precise error tracking
- Adds package name/version in top-level installation span

[Example trace](https://dd.datad0g.com/apm/traces?query=%40_top_level%3A1%20env%3Astaging%20service%3Adatadog-installer%20&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&panel_tab=flamegraph&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=4139495949837434142&spanType=service-entry&timeHint=1717417499072&trace=665db61a00000000397271a2673a7d1e4139495949837434142&traceID=665db61a00000000397271a2673a7d1e&traceQuery=&view=spans&viz=stream&start=1717403410302&end=1717417810302&paused=false)

### Motivation
More telemetry

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
N/A