### PR TITLE
AMLII-1818 Skip jmx checks in the collector

### DIFF
--- a/releasenotes/notes/fix-jmx-integration-10ce3c8d9b709aac.yaml
+++ b/releasenotes/notes/fix-jmx-integration-10ce3c8d9b709aac.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Fix an issue where the Agent incorrectly reports JMX integrations as having issues.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This patch makes collector skip loading jmxfetch checks.

### Motivation
JMX integrations are now handled in a separate component, but collector still tries to load them as python and core checks. When the loading fails, collector reports a misleading error message about the integration, which is in fact working fine.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Without running kafka, run the agent with a kafka check configuration (`/etc/datadog-agent/conf.d/kafka.yaml`):

```
init_config: {}
instances:
  - {}
```

Check that the jmx fetch section contains entry for the check, and kafka is not mentioned under 'Loading errors'.

Check that kafka integration does not show in the 'Integration issues' on the host in `Host list` page.