### PR TITLE
fix(health): add newStartupCatalog method

### DIFF
--- a/pkg/status/health/global.go
+++ b/pkg/status/health/global.go
@@ -12,7 +12,7 @@ import (
 
 var readinessAndLivenessCatalog = newCatalog()
 var readinessOnlyCatalog = newCatalog()
-var startupOnlyCatalog = newCatalog()
+var startupOnlyCatalog = newStartupCatalog()
 
 // RegisterReadiness registers a component for readiness check with the default 30 seconds timeout, returns a token
 func RegisterReadiness(name string) *Handle {
@@ -26,7 +26,6 @@ func RegisterLiveness(name string) *Handle {
 
 // RegisterStartup registers a component for startup check, returns a token
 func RegisterStartup(name string) *Handle {
-	startupOnlyCatalog.startup = true
 	return startupOnlyCatalog.register(name)
 }
 

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -46,6 +46,14 @@ func newCatalog() *catalog {
 	}
 }
 
+func newStartupCatalog() *catalog {
+	return &catalog{
+		components: make(map[*Handle]*component),
+		latestRun:  time.Now(), // Start healthy
+		startup:    true,
+	}
+}
+
 // register a component with the default 30 seconds timeout, returns a token
 func (c *catalog) register(name string) *Handle {
 	c.Lock()

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -125,8 +125,7 @@ func TestGetHealthy(t *testing.T) {
 }
 
 func TestStartupCatalog(t *testing.T) {
-	cat := newCatalog()
-	cat.startup = true
+	cat := newStartupCatalog()
 	token := cat.register("test1")
 
 	// Start unhealthy


### PR DESCRIPTION
### What does this PR do?

Fixes a potential race condition introduced in #25973.

### Describe how to test/QA your changes

Deploy an Agent and check that the `/startup` endpoint is working as intended
```
➜  dddev kubectl exec -it datadog-agent-rjrfl -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":null,"Unhealthy":null}%
```

Since no components are using the Startup healthcheck now, it stays empty.
I've made a test to show that the function does work as intended.

With the following code
```
// Register the startup healthcheck
startup := health.RegisterStartup("tagger-workloadmeta")

// Startup will be unhealthy until we consume the first item from the channel
time.Sleep(10 * time.Second)
// Consume the first item from the channel to make the startup healthcheck healthy
<-startup.C
// Startup is now healthy
time.Sleep(10 * time.Second)

// De-register the startup healthcheck, since we have only one component this will also de-register the "healthcheck" component.
err := startup.Deregister()
if err != nil {
	log.Warnf("error de-registering startup health check: %s", err)
}
```

We get the following results:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":["healthcheck"],"Unhealthy":["tagger-workloadmeta"]}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 500 Internal Server Error
Date: Mon, 27 May 2024 14:52:29 GMT
Content-Length: 63
Content-Type: text/plain; charset=utf-8
```

After 10 seconds:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":["healthcheck","tagger-workloadmeta"],"Unhealthy":null}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 200 OK
Date: Mon, 27 May 2024 14:52:43 GMT
Content-Length: 66
Content-Type: text/plain; charset=utf-8
```

After another 10 seconds, we de-register:
```
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":null,"Unhealthy":null}%
➜  dddev kubectl exec -it datadog-agent-qt58b -- curl -I localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
HTTP/1.1 200 OK
Date: Mon, 27 May 2024 14:57:47 GMT
Content-Length: 33
Content-Type: text/plain; charset=utf-8
```