### PR TITLE
[e2e] handle context timeout on pulumi up and destroy

### DIFF
--- a/test/new-e2e/pkg/e2e/pulumi_provisioner.go
+++ b/test/new-e2e/pkg/e2e/pulumi_provisioner.go
@@ -68,16 +68,15 @@ func (pp *PulumiProvisioner[Env]) Provision(ctx context.Context, stackName strin
 
 // ProvisionEnv runs the Pulumi program with a given environment and returns the raw resources.
 func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName string, logger io.Writer, env *Env) (RawResources, error) {
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
-		Context: ctx,
-		Name:    stackName,
-		Config:  pp.configMap,
-		DeployFunc: func(ctx *pulumi.Context) error {
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
+		ctx,
+		stackName,
+		func(ctx *pulumi.Context) error {
 			return pp.runFunc(ctx, env)
 		},
-		FailOnMissing: false,
-		LogWriter:     logger,
-	})
+		infra.WithConfigMap(pp.configMap),
+		infra.WithLogWriter(logger),
+	)
 
 	if err != nil {
 		return nil, err

--- a/test/new-e2e/pkg/e2e/pulumi_provisioner.go
+++ b/test/new-e2e/pkg/e2e/pulumi_provisioner.go
@@ -68,17 +68,17 @@ func (pp *PulumiProvisioner[Env]) Provision(ctx context.Context, stackName strin
 
 // ProvisionEnv runs the Pulumi program with a given environment and returns the raw resources.
 func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName string, logger io.Writer, env *Env) (RawResources, error) {
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
-		ctx,
-		stackName,
-		pp.configMap,
-		func(ctx *pulumi.Context) error {
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
+		Context: ctx,
+		Name:    stackName,
+		Config:  pp.configMap,
+		DeployFunc: func(ctx *pulumi.Context) error {
 			return pp.runFunc(ctx, env)
 		},
-		false,
-		logger,
-		nil,
-	)
+		FailOnMissing: false,
+		LogWriter:     logger,
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -599,7 +599,7 @@ func cancelStack(stack *auto.Stack, cancelTimeout time.Duration) error {
 	// handle timeout
 	ctxCauseErr := context.Cause(cancelCtx)
 	if errors.Is(ctxCauseErr, context.DeadlineExceeded) {
-		return fmt.Errorf("timeout during stack cancel: %v", ctxCauseErr)
+		return fmt.Errorf("timeout during stack cancel: %w", ctxCauseErr)
 	}
 
 	return err

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -73,7 +73,7 @@ func TestStackManager(t *testing.T) {
 		}()
 		require.NotNil(t, result)
 		retryOnErrorLogs := filterRetryOnErrorLogs(mockWriter.logs)
-		assert.Len(t, retryOnErrorLogs, 0)
+		assert.Empty(t, retryOnErrorLogs)
 		assert.Len(t, mockDatadogEventSender.events, 1)
 		assert.Contains(t, mockDatadogEventSender.events[0].Title, fmt.Sprintf("[E2E] Stack %s : success on Pulumi stack up", stackName))
 	})

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -184,9 +184,9 @@ func TestStackManager(t *testing.T) {
 		}
 		stackUpCounter := 0
 		stackName := "test-cancel-retry-timeout"
-		// override stackUpTimeout to 2s
-		// average up time with an dummy run function is 900ms
-		stackUpTimeout := 2 * time.Second
+		// override stackUpTimeout to 10s
+		// average up time with an dummy run function is 5s
+		stackUpTimeout := 10 * time.Second
 		stack, result, err := stackManager.GetStackNoDeleteOnFailure(GetStackArgs{
 			Context:   ctx,
 			Name:      stackName,
@@ -195,7 +195,7 @@ func TestStackManager(t *testing.T) {
 				if stackUpCounter == 0 {
 					// sleep only first time to ensure context is cancelled
 					// on timeout
-					t.Log("Sleeping for 2x stackUpTimeout")
+					t.Logf("Sleeping for %f", 2*stackUpTimeout.Seconds())
 					time.Sleep(2 * stackUpTimeout)
 				}
 				stackUpCounter++

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -252,12 +252,19 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 			config["ddinfra:aws/defaultSubnets"] = auto.ConfigValue{Value: az}
 		}
 
-		pulumiStack, upResult, err = stackManager.GetStackNoDeleteOnFailure(systemProbeTestEnv.context, systemProbeTestEnv.name, config, func(ctx *pulumi.Context) error {
-			if err := microvms.Run(ctx); err != nil {
-				return fmt.Errorf("setup micro-vms in remote instance: %w", err)
-			}
-			return nil
-		}, opts.FailOnMissing, nil, nil)
+		pulumiStack, upResult, err = stackManager.GetStackNoDeleteOnFailure(infra.GetStackArgs{
+			Context: systemProbeTestEnv.context,
+			Name:    systemProbeTestEnv.name,
+			Config:  config,
+			DeployFunc: func(ctx *pulumi.Context) error {
+				if err := microvms.Run(ctx); err != nil {
+					return fmt.Errorf("setup micro-vms in remote instance: %w", err)
+				}
+				return nil
+			},
+			FailOnMissing: opts.FailOnMissing,
+		})
+
 		if err != nil {
 			return handleScenarioFailure(err, func(possibleError handledError) {
 				// handle the following errors by trying in a different availability zone

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -252,18 +252,18 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 			config["ddinfra:aws/defaultSubnets"] = auto.ConfigValue{Value: az}
 		}
 
-		pulumiStack, upResult, err = stackManager.GetStackNoDeleteOnFailure(infra.GetStackArgs{
-			Context: systemProbeTestEnv.context,
-			Name:    systemProbeTestEnv.name,
-			Config:  config,
-			DeployFunc: func(ctx *pulumi.Context) error {
+		pulumiStack, upResult, err = stackManager.GetStackNoDeleteOnFailure(
+			systemProbeTestEnv.context,
+			systemProbeTestEnv.name,
+			func(ctx *pulumi.Context) error {
 				if err := microvms.Run(ctx); err != nil {
 					return fmt.Errorf("setup micro-vms in remote instance: %w", err)
 				}
 				return nil
 			},
-			FailOnMissing: opts.FailOnMissing,
-		})
+			infra.WithFailOnMissing(opts.FailOnMissing),
+			infra.WithConfigMap(config),
+		)
 
 		if err != nil {
 			return handleScenarioFailure(err, func(possibleError handledError) {

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -62,7 +62,13 @@ func (suite *ecsSuite) SetupSuite() {
 		"ddtestworkload:deploy":                      auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "ecs-cluster", stackConfig, ecs.Run, false, nil, nil)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
+		Context:       ctx,
+		Name:          "ecs-cluster",
+		Config:        stackConfig,
+		DeployFunc:    ecs.Run,
+		FailOnMissing: false,
+	})
 	suite.Require().NoError(err)
 
 	fakeintake := &components.FakeIntake{}

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -62,13 +62,12 @@ func (suite *ecsSuite) SetupSuite() {
 		"ddtestworkload:deploy":                      auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
-		Context:       ctx,
-		Name:          "ecs-cluster",
-		Config:        stackConfig,
-		DeployFunc:    ecs.Run,
-		FailOnMissing: false,
-	})
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
+		ctx,
+		"ecs-cluster",
+		ecs.Run,
+		infra.WithConfigMap(stackConfig),
+	)
 	suite.Require().NoError(err)
 
 	fakeintake := &components.FakeIntake{}

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -38,13 +38,13 @@ func (suite *eksSuite) SetupSuite() {
 		"dddogstatsd:deploy":    auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
-		Context:       ctx,
-		Name:          "eks-cluster",
-		Config:        stackConfig,
-		DeployFunc:    eks.Run,
-		FailOnMissing: false,
-	})
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
+		ctx,
+		"eks-cluster",
+		eks.Run,
+		infra.WithConfigMap(stackConfig),
+	)
+
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("eks-cluster")
 		suite.Require().NoError(err)

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -38,7 +38,13 @@ func (suite *eksSuite) SetupSuite() {
 		"dddogstatsd:deploy":    auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "eks-cluster", stackConfig, eks.Run, false, nil, nil)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
+		Context:       ctx,
+		Name:          "eks-cluster",
+		Config:        stackConfig,
+		DeployFunc:    eks.Run,
+		FailOnMissing: false,
+	})
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("eks-cluster")
 		suite.Require().NoError(err)

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -39,13 +39,12 @@ func (suite *kindSuite) SetupSuite() {
 		"dddogstatsd:deploy":              auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
-		Context:       ctx,
-		Name:          "kind-cluster",
-		Config:        stackConfig,
-		DeployFunc:    kindvm.Run,
-		FailOnMissing: false,
-	})
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
+		ctx,
+		"kind-cluster",
+		kindvm.Run,
+		infra.WithConfigMap(stackConfig),
+	)
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("kind-cluster")
 		suite.Require().NoError(err)

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -39,7 +39,13 @@ func (suite *kindSuite) SetupSuite() {
 		"dddogstatsd:deploy":              auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "kind-cluster", stackConfig, kindvm.Run, false, nil, nil)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
+		Context:       ctx,
+		Name:          "kind-cluster",
+		Config:        stackConfig,
+		DeployFunc:    kindvm.Run,
+		FailOnMissing: false,
+	})
 	if !suite.Assert().NoError(err) {
 		stackName, err := infra.GetStackManager().GetPulumiStackName("kind-cluster")
 		suite.Require().NoError(err)

--- a/test/new-e2e/tests/orchestrator/suite_test.go
+++ b/test/new-e2e/tests/orchestrator/suite_test.go
@@ -78,13 +78,12 @@ func (suite *k8sSuite) SetupSuite() {
 			fmt.Fprint(os.Stderr, err.Error())
 		}
 	}
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
-		Context:       ctx,
-		Name:          "orch-kind-cluster",
-		Config:        stackConfig,
-		DeployFunc:    Apply,
-		FailOnMissing: false,
-	})
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
+		ctx,
+		"orch-kind-cluster",
+		Apply,
+		infra.WithConfigMap(stackConfig),
+	)
 
 	suite.printKubeConfig(stackOutput)
 

--- a/test/new-e2e/tests/orchestrator/suite_test.go
+++ b/test/new-e2e/tests/orchestrator/suite_test.go
@@ -78,7 +78,13 @@ func (suite *k8sSuite) SetupSuite() {
 			fmt.Fprint(os.Stderr, err.Error())
 		}
 	}
-	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(ctx, "orch-kind-cluster", stackConfig, Apply, false, nil, nil)
+	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(infra.GetStackArgs{
+		Context:       ctx,
+		Name:          "orch-kind-cluster",
+		Config:        stackConfig,
+		DeployFunc:    Apply,
+		FailOnMissing: false,
+	})
 
 	suite.printKubeConfig(stackOutput)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Handle context cause and attempt to cancel stack's operations on timeout 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In incident-27812 we spotted a weird `killed` message log reported by the stack up command of several e2e tests, within the same time frame. Eventually we realised the stack up operation was cancelled by the context, after a 60 minutes timeout. The following retries fail as the stack is locked. This PR attempts to cancel the stack up operation so that we can retry it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This PR refactors `GetStack` to take a struct of arguments, allowing overriding the default timeouts. This allows unit testing the cancel logic with a dummy pulumi run function

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
