### PR TITLE
remote-config: fix update loop error backoff policy

### DIFF
--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -424,13 +424,13 @@ func (c *Client) pollLoop() {
 					}
 				} else {
 					c.lastUpdateError = err
-					c.backoffPolicy.IncError(c.backoffErrorCount)
+					c.backoffErrorCount = c.backoffPolicy.IncError(c.backoffErrorCount)
 					log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
 				}
 			} else {
 				c.lastUpdateError = nil
 				successfulFirstRun = true
-				c.backoffPolicy.DecError(c.backoffErrorCount)
+				c.backoffErrorCount = c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}
 	}


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The `IncError` and `DecError` methods work by returning the new value, we weren't saving this and thus weren't ever executing any backoff in the clients, causing spammy logs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Backoff appropriately when there are errors fetching config updates
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the system-probe, trace-agent, or cluster-agent alongside the core-agent. After
startup of both, shut down the core-agent for a period of time. The secondary agent should
not log an error message every second and eventually settle on a 90 second cadence (the
max backoff delay).
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
