### PR TITLE
installer - reenable suse tests

### DIFF
--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -39,12 +39,6 @@ type testPackageConfig struct {
 	auth           string
 }
 
-const suse15Arm = e2eos.Descriptor{
-	Flavor:       e2eos.Suse,
-	Version:      e2eos.Suse15.Version,
-	Architecture: e2eos.ARM64Arch,
-}
-
 var (
 	amd64Flavors = []e2eos.Descriptor{
 		e2eos.Ubuntu2204,
@@ -59,6 +53,11 @@ var (
 		e2eos.Ubuntu2204,
 		e2eos.AmazonLinux2,
 		e2eos.Suse15,
+	}
+	suse15Arm = e2eos.Descriptor{
+		Flavor:       e2eos.Suse,
+		Version:      e2eos.Suse15.Version,
+		Architecture: e2eos.ARM64Arch,
 	}
 	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -47,12 +47,12 @@ var (
 		e2eos.RedHat9,
 		e2eos.Fedora37,
 		e2eos.CentOS7,
-		// e2eos.Suse15,
+		e2eos.Suse15,
 	}
 	arm64Flavors = []e2eos.Descriptor{
 		e2eos.Ubuntu2204,
 		e2eos.AmazonLinux2,
-		// e2eos.Suse15,
+		e2eos.Suse15,
 	}
 	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -161,7 +161,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 		s.Env().RemoteHost.MustExecute("sudo systemctl daemon-reexec")
 	}
 	err := s.RunInstallScriptWithError(params...)
-	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log"))
+	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log"))
 }
 
 func envForceInstall(pkg string) string {

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -173,7 +173,7 @@ func envForceNoInstall(pkg string) string {
 }
 
 func (s *packageBaseSuite) Purge() {
-	s.Env().RemoteHost.MustExecute("sudo apt-get remove -y --purge datadog-installer || sudo yum remove -y datadog-installer")
+	s.Env().RemoteHost.MustExecute("sudo apt-get remove -y --purge datadog-installer || sudo yum remove -y datadog-installer || sudo zypper remove -y datadog-installer")
 }
 
 // setupFakeIntake sets up the fake intake for the agent and trace agent.

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"slices"
 	"strings"
 	"testing"
 
@@ -54,15 +53,10 @@ var (
 		e2eos.AmazonLinux2,
 		e2eos.Suse15,
 	}
-	suse15Arm = e2eos.Descriptor{
-		Flavor:       e2eos.Suse,
-		Version:      e2eos.Suse15.Version,
-		Architecture: e2eos.ARM64Arch,
-	}
 	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15, suse15Arm}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15}},
 	}
 )
 
@@ -75,6 +69,15 @@ var packagesConfig = []testPackageConfig{
 	{name: "datadog-apm-library-js", defaultVersion: "latest"},
 	{name: "datadog-apm-library-dotnet", defaultVersion: "latest"},
 	{name: "datadog-apm-library-python", defaultVersion: "latest"},
+}
+
+func shouldSkip(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool {
+	for _, f := range flavors {
+		if f.Flavor == flavor.Flavor && f.Version == flavor.Version {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPackages(t *testing.T) {
@@ -90,7 +93,7 @@ func TestPackages(t *testing.T) {
 	for _, f := range flavors {
 		for _, test := range packagesTestsWithSkipedFlavors {
 			flavor := f // capture range variable for parallel tests closure
-			if slices.Contains(test.skippedFlavors, flavor) {
+			if shouldSkip(test.skippedFlavors, flavor) {
 				continue
 			}
 			suite := test.t(flavor, flavor.Architecture)

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -57,7 +57,7 @@ var (
 	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15}},
 	}
 )
 
@@ -161,7 +161,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 		s.Env().RemoteHost.MustExecute("sudo systemctl daemon-reexec")
 	}
 	err := s.RunInstallScriptWithError(params...)
-	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log"))
+	require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log"))
 }
 
 func envForceInstall(pkg string) string {

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -39,6 +39,12 @@ type testPackageConfig struct {
 	auth           string
 }
 
+const suse15Arm = e2eos.Descriptor{
+	Flavor:       e2eos.Suse,
+	Version:      e2eos.Suse15.Version,
+	Architecture: e2eos.ARM64Arch,
+}
+
 var (
 	amd64Flavors = []e2eos.Descriptor{
 		e2eos.Ubuntu2204,
@@ -57,7 +63,7 @@ var (
 	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15, suse15Arm}},
 	}
 )
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -51,9 +51,11 @@ func New(t *testing.T, remote *components.RemoteHost, os e2eos.Descriptor, arch 
 	host.uploadFixtures()
 	host.setSystemdVersion()
 	if _, err := host.remote.Execute("command -v dpkg-query"); err == nil {
-		host.pkgManager = "dpkg"
-	} else if _, err := host.remote.Execute("command -v rpm"); err == nil {
-		host.pkgManager = "rpm"
+		host.pkgManager = "apt"
+	} else if _, err := host.remote.Execute("command -v zypper"); err == nil {
+		host.pkgManager = "zypper"
+	} else if _, err := host.remote.Execute("command -v yum"); err == nil {
+		host.pkgManager = "yum"
 	} else {
 		t.Fatal("no package manager found")
 	}
@@ -153,9 +155,9 @@ func (h *Host) AssertPackageInstalledByInstaller(pkgs ...string) {
 func (h *Host) AssertPackageInstalledByPackageManager(pkgs ...string) {
 	for _, pkg := range pkgs {
 		switch h.pkgManager {
-		case "dpkg":
+		case "apt":
 			h.remote.MustExecute("dpkg-query -l " + pkg)
-		case "rpm":
+		case "yum", "zypper":
 			h.remote.MustExecute("rpm -q " + pkg)
 		default:
 			h.t.Fatal("unsupported package manager")
@@ -167,9 +169,9 @@ func (h *Host) AssertPackageInstalledByPackageManager(pkgs ...string) {
 func (h *Host) AssertPackageNotInstalledByPackageManager(pkgs ...string) {
 	for _, pkg := range pkgs {
 		switch h.pkgManager {
-		case "dpkg":
+		case "apt":
 			h.remote.MustExecute("! dpkg-query -l " + pkg)
-		case "rpm":
+		case "yum", "zypper":
 			h.remote.MustExecute("! rpm -q " + pkg)
 		default:
 			h.t.Fatal("unsupported package manager")

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -61,9 +61,9 @@ func (s *packageAgentSuite) assertUnits(state host.State, oldUnits bool) {
 	if oldUnits {
 		pkgManager := s.host.GetPkgManager()
 		switch pkgManager {
-		case "dpkg":
+		case "apt":
 			systemdPath = "/lib/systemd/system"
-		case "rpm":
+		case "yum", "zypper":
 			systemdPath = "/usr/lib/systemd/system"
 		default:
 			s.T().Fatalf("unsupported package manager: %s", pkgManager)
@@ -372,10 +372,12 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 func (s *packageAgentSuite) purgeAgentDebInstall() {
 	pkgManager := s.host.GetPkgManager()
 	switch pkgManager {
-	case "dpkg":
+	case "apt":
 		s.Env().RemoteHost.Execute("sudo apt-get remove -y --purge datadog-agent")
-	case "rpm":
+	case "yum":
 		s.Env().RemoteHost.Execute("sudo yum remove -y datadog-agent")
+	case "zypper":
+		s.Env().RemoteHost.Execute("sudo zypper remove -y datadog-agent")
 	default:
 		s.T().Fatalf("unsupported package manager: %s", pkgManager)
 	}
@@ -384,10 +386,12 @@ func (s *packageAgentSuite) purgeAgentDebInstall() {
 func (s *packageAgentSuite) installDebRPMAgent() {
 	pkgManager := s.host.GetPkgManager()
 	switch pkgManager {
-	case "dpkg":
+	case "apt":
 		s.Env().RemoteHost.Execute("sudo apt-get install -y --force-yes datadog-agent")
-	case "rpm":
+	case "yum":
 		s.Env().RemoteHost.Execute("sudo yum -y install datadog-agent")
+	case "zypper":
+		s.Env().RemoteHost.Execute("sudo zypper install -y datadog-agent")
 	default:
 		s.T().Fatalf("unsupported package manager: %s", pkgManager)
 	}


### PR DESCRIPTION
Reenable suse tests. Testing both arm and amd for 100% coverage as a different package manager is used.
Skipped injection tests as APM single steps does not support Suse and the install script errs https://github.com/DataDog/agent-linux-install-script/blob/main/install_script.sh.template#L1517