### PR TITLE
usm: Don't run USM is it is disabled or not supported

### DIFF
--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -143,8 +143,6 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 				return nil, fmt.Errorf(errStr)
 			}
 			log.Warnf("%s. NPM is explicitly enabled, so system-probe will continue with only NPM features enabled.", errStr)
-			cfg.EnableHTTPMonitoring = false
-			cfg.EnableNativeTLSMonitoring = false
 		}
 	}
 
@@ -843,6 +841,12 @@ func (t *Tracer) DebugDumpProcessCache(ctx context.Context) (interface{}, error)
 }
 
 func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
+	if !http.Supported() || !c.ServiceMonitoringEnabled {
+		// http.Supported is misleading, it should be named usm.Supported.
+		// If USM is not supported, or if USM is not enabled, we should not start the USM monitor.
+		return nil
+	}
+
 	// Shared with the USM program
 	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
 

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -146,6 +146,25 @@ func (s *USMSuite) TestEnableHTTPMonitoring() {
 	_ = setupTracer(t, cfg)
 }
 
+func (s *USMSuite) TestDisableUSM() {
+	t := s.T()
+
+	cfg := testConfig()
+	cfg.ServiceMonitoringEnabled = false
+	// Enabling all features, to ensure nothing is forcing USM enablement.
+	cfg.EnableHTTPMonitoring = true
+	cfg.EnableHTTP2Monitoring = true
+	cfg.EnableKafkaMonitoring = true
+	cfg.EnablePostgresMonitoring = true
+	cfg.EnableGoTLSSupport = true
+	cfg.EnableNodeJSMonitoring = true
+	cfg.EnableIstioMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
+
+	tr := setupTracer(t, cfg)
+	require.Nil(t, tr.usmMonitor)
+}
+
 func (s *USMSuite) TestProtocolClassification() {
 	t := s.T()
 	cfg := testConfig()
@@ -153,6 +172,7 @@ func (s *USMSuite) TestProtocolClassification() {
 		t.Skip("Classification is not supported")
 	}
 
+	cfg.ServiceMonitoringEnabled = true
 	cfg.EnableNativeTLSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 	cfg.EnablePostgresMonitoring = true
@@ -275,6 +295,7 @@ func getFreePort() (port uint16, err error) {
 func (s *USMSuite) TestTLSClassification() {
 	t := s.T()
 	cfg := testConfig()
+	cfg.ServiceMonitoringEnabled = true
 	cfg.ProtocolClassificationEnabled = true
 	cfg.CollectTCPv4Conns = true
 	cfg.CollectTCPv6Conns = true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Don't create USM instance if it disabled or not supported

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing an edge case where USM is disabled, but a protocol (different than HTTP) or a TLS mode (different than Native) is enabled, which made USM to run, collect information, but the data were dropped in the network-intake pipeline since USM is disabled

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
