### PR TITLE
logs/sds: support not sending logs until an SDS configuration has been received

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1416,6 +1416,8 @@ func logsagent(config pkgconfigmodel.Config) {
 	// Time in seconds
 	config.BindEnvAndSetDefault("logs_config.file_scan_period", 10.0)
 
+	config.BindEnvAndSetDefault("logs_config.sds.wait_for_configuration", false)
+
 	// Controls how wildcard file log source are prioritized when there are more files
 	// that match wildcard log configurations than the `logs_config.open_files_limit`
 	//

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -41,6 +41,9 @@ var (
 	// TlmLogsDropped is the total number of logs dropped per Destination
 	TlmLogsDropped = telemetry.NewCounter("logs", "dropped",
 		[]string{"destination"}, "Total number of logs dropped per Destination")
+	// TlmLogsBlocked is the total number of logs blocked in the pipeline (to not send them).
+	TlmLogsBlocked = telemetry.NewCounter("logs", "blocked",
+		[]string{"reason"}, "Total number of logs blocked and dropped in the pipeline.")
 	// BytesSent is the total number of sent bytes before encoding if any
 	BytesSent = expvar.Int{}
 	// TlmBytesSent is the total number of sent bytes before encoding if any

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -67,7 +67,7 @@ func NewPipeline(outputChan chan *message.Payload,
 	logsSender = sender.NewSender(cfg, senderInput, outputChan, mainDestinations, config.DestinationPayloadChanSize)
 
 	inputChan := make(chan *message.Message, config.ChanSize)
-	processor := processor.New(inputChan, strategyInput, processingRules, encoder, diagnosticMessageReceiver, hostname, pipelineID)
+	processor := processor.New(cfg, inputChan, strategyInput, processingRules, encoder, diagnosticMessageReceiver, hostname, pipelineID)
 
 	return &Pipeline{
 		InputChan: inputChan,

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/DataDog/agent-payload/v5 v5.0.106
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.54.0-rc.2
+	github.com/DataDog/datadog-agent/pkg/config/model v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/logs/message v0.54.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.54.0-rc.2
@@ -60,7 +61,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.55.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.54.0-rc.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.54.0-rc.2 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/model v0.54.0-rc.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.54.0-rc.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.54.0-rc.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.54.0-rc.2 // indirect

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -143,7 +143,7 @@ func (p *Processor) processMessage(msg *message.Message) {
 	// to send the logs to the intake. In this mode, we drop the message if we didn't
 	// receive a valid SDS configuration yet.
 	if p.waitForSDSConfiguration && !p.sds.IsConfigured() {
-		// TODO(remy): telemetry
+		metrics.TlmLogsBlocked.Inc("sds_unconfigured")
 		return
 	}
 

--- a/pkg/logs/sds/scanner_nosds.go
+++ b/pkg/logs/sds/scanner_nosds.go
@@ -44,6 +44,9 @@ func (s *Scanner) GetRuleByIdx(_ uint32) (RuleConfig, error) {
 // IsReady mocks the IsReady function.
 func (s *Scanner) IsReady() bool { return false }
 
+// IsConfigured mocks the IsConfigured function.
+func (s *Scanner) IsConfigured() bool { return true }
+
 // Scan mocks the Scan function.
 func (s *Scanner) Scan(_ []byte, _ *message.Message) (bool, []byte, error) {
 	return false, nil, nil


### PR DESCRIPTION
### What does this PR do?

Adds a mode in the Logs Agent blocking from sending logs until it has received an SDS configuration through RC. These logs are dropped and will never be sent.

### Additional Notes

This is not the ideal solution: the ideal solution would freeze the pipeline until a configuration is received, avoiding unnecessary drops. Until then, this PR provides a mitigation.

### Possible Drawbacks / Trade-offs

The Agent drop logs until it has received any SDS configuration.

### Describe how to test/QA your changes

An unit test validates that the Scanner isn't considered configured until an RC configuration has been processed.
If someone wanted to test this manually:
* agent stopped, configure:
  * SDS in the Agent to process IP and redacts these,
  * the Agent with `logs_config.sds.wait_for_configuration: true` 
* continuously write logs containing an IP into a file collected by the Agent
* start the Agent
* no logs with email should be sent un-redacted to your org
