### PR TITLE
[USM] Added traced programs to the USM status

### DIFF
--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -40,7 +40,7 @@ const (
 var (
 	state        = disabled
 	startupError error
-	tlsPrograms  = []string{"go-tls", "native-tls", "java-tls", "istio-tls", "nodejs-tls", "shared_libraries"}
+	tlsPrograms  = []string{"go-tls", "native-tls", "java-tls", "istio-tls", "shared_libraries"}
 )
 
 // Monitor is responsible for:

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -158,9 +158,7 @@ func (m *Monitor) GetUSMStats() map[string]interface{} {
 	}
 
 	tracedPrograms := utils.GetTracedProgramList()
-	if len(tracedPrograms) > 0 {
-		response["traced_programs"] = tracedPrograms
-	}
+	response["traced_programs"] = tracedPrograms
 
 	if m != nil {
 		response["last_check"] = m.lastUpdateTime

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -40,7 +40,6 @@ const (
 var (
 	state        = disabled
 	startupError error
-	tlsPrograms  = []string{"go-tls", "native-tls", "java-tls", "istio-tls", "shared_libraries"}
 )
 
 // Monitor is responsible for:
@@ -158,11 +157,9 @@ func (m *Monitor) GetUSMStats() map[string]interface{} {
 		response["error"] = startupError.Error()
 	}
 
-	for _, tlsProgram := range tlsPrograms {
-		tracedPrograms := utils.GetTracedPrograms(tlsProgram)
-		if len(tracedPrograms) > 0 {
-			response[tlsProgram] = tracedPrograms
-		}
+	tracedPrograms := utils.GetTracedProgramList()
+	if len(tracedPrograms) > 0 {
+		response["traced_programs"] = tracedPrograms
 	}
 
 	if m != nil {

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -24,6 +24,7 @@ import (
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -39,6 +40,7 @@ const (
 var (
 	state        = disabled
 	startupError error
+	tlsPrograms  = []string{"go-tls", "native-tls", "java-tls", "istio-tls", "nodejs-tls", "shared_libraries"}
 )
 
 // Monitor is responsible for:
@@ -154,6 +156,13 @@ func (m *Monitor) GetUSMStats() map[string]interface{} {
 
 	if startupError != nil {
 		response["error"] = startupError.Error()
+	}
+
+	for _, tlsProgram := range tlsPrograms {
+		tracedPrograms := utils.GetTracedPrograms(tlsProgram)
+		if len(tracedPrograms) > 0 {
+			response[tlsProgram] = tracedPrograms
+		}
 	}
 
 	if m != nil {

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -216,3 +216,11 @@ func init() {
 		attachers: make(map[string]Attacher),
 	}
 }
+
+// GetTracedProgramList returns a list of traced programs.
+func GetTracedProgramList() []TracedProgram {
+	if debugger == nil {
+		return nil
+	}
+	return debugger.GetTracedPrograms()
+}

--- a/pkg/network/usm/utils/debugger_testutils.go
+++ b/pkg/network/usm/utils/debugger_testutils.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && test
+//go:build linux
 
 package utils
 

--- a/pkg/network/usm/utils/debugger_testutils.go
+++ b/pkg/network/usm/utils/debugger_testutils.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && test
 
 package utils
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adding USM traced programs to the USM status will be reflected in the flare file as well.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve USM debugging tools.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The flare/status check after the change:

```
  universal_service_monitoring:
    last_check: 1.717513387e+09
    state: running
    traced_programs:
    - FilePath: /usr/lib/aarch64-linux-gnu/libcrypto.so.3
      PIDs:
      - 732
      - 1648
      - 1711
      - 37852
      - 38905
      - 39486
      - 451
      - 38291
      - 38909
      - 40059
      - 40703
      - 716
      - 1652
      - 1715
      - 37856
      - 38740
      - 39482
      - 39944
      - 494
      - 1660
      - 774
      - 734
      - 792
      - 1714
      - 38295
      - 39344
      - 40402
      - 1
      - 38744
      - 39940
      - 40707
      - 40796
      - 40890
      - 1651
      - 39340
      - 40055
      - 779
      - 40406
      ProgramType: shared_libraries
    - FilePath: /usr/lib/aarch64-linux-gnu/libgnutls.so.30.31.0
      PIDs:
      - 734
      ProgramType: shared_libraries
    - FilePath: /usr/bin/dockerd
      PIDs:
      - 1008
      ProgramType: go-tls
```
Example whiteout any traced programs:

```
network_tracer:
  tracer:
    last_check: 1.717569736e+09
  universal_service_monitoring:
    state: disabled
    traced_programs: null
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
