### PR TITLE
populate PID for container entity on containerd runtime

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -57,6 +57,16 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 		}
 	}
 
+	// Get Container PID
+	var pid int
+	task, err := container.Task(ctx, nil)
+	if err == nil {
+		pid = int(task.Pid())
+	} else {
+		pid = 0
+		log.Debugf("cannot get container %s's process PID: %v", container.ID(), err)
+	}
+
 	image, err := workloadmeta.NewContainerImage(imageID, info.Image)
 	if err != nil {
 		log.Debugf("cannot split image name %q: %s", info.Image, err)
@@ -118,7 +128,7 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 			FinishedAt: time.Time{},    // Not available
 		},
 		NetworkIPs: networkIPs,
-		PID:        0, // Not available
+		PID:        pid, // PID will be 0 for non-running containers
 	}
 
 	// Spec retrieval is slow if large due to JSON parsing

--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -9,11 +9,13 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -32,6 +34,7 @@ type mockedContainer struct {
 	containerd.Container
 	mockID    func() string
 	mockImage func() (containerd.Image, error)
+	mockTask  func() (containerd.Task, error)
 }
 
 func (m *mockedContainer) ID() string {
@@ -41,6 +44,20 @@ func (m *mockedContainer) ID() string {
 // Image is from the containerd.Container interface
 func (m *mockedContainer) Image(context.Context) (containerd.Image, error) {
 	return m.mockImage()
+}
+
+// Task is from the containerd.Container interface
+func (m *mockedContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	return m.mockTask()
+}
+
+type mockedTask struct {
+	containerd.Task
+	mockPid func() uint32
+}
+
+func (t *mockedTask) Pid() uint32 {
+	return t.mockPid()
 }
 
 type mockedImage struct {
@@ -88,12 +105,111 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 			return ocispec.Descriptor{Digest: "my_repo_digest"}
 		},
 	}
-	container := mockedContainer{
-		mockID: func() string {
-			return containerID
+
+	task := &mockedTask{
+		mockPid: func() uint32 {
+			return 12345
 		},
-		mockImage: func() (containerd.Image, error) {
-			return image, nil
+	}
+
+	tests := []struct {
+		name      string
+		container mockedContainer
+		expected  workloadmeta.Container
+	}{
+		{
+			name: "container in running state",
+			container: mockedContainer{
+				mockID: func() string {
+					return containerID
+				},
+				mockImage: func() (containerd.Image, error) {
+					return image, nil
+				},
+				mockTask: func() (containerd.Task, error) {
+					return task, nil
+				},
+			},
+			expected: workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   containerID,
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:   "", // Not available
+					Labels: labels,
+				},
+				Image: workloadmeta.ContainerImage{
+					RawName:    "datadog/agent:7",
+					Name:       "datadog/agent",
+					ShortName:  "agent",
+					Tag:        "7",
+					ID:         "my_image_id",
+					RepoDigest: "sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+				},
+				EnvVars:       envVars,
+				Ports:         nil, // Not available
+				Runtime:       workloadmeta.ContainerRuntimeContainerd,
+				RuntimeFlavor: workloadmeta.ContainerRuntimeFlavorKata,
+				State: workloadmeta.ContainerState{
+					Running:    true,
+					Status:     workloadmeta.ContainerStatusRunning,
+					StartedAt:  createdAt,
+					CreatedAt:  createdAt,
+					FinishedAt: time.Time{}, // Not available
+				},
+				NetworkIPs: make(map[string]string), // Not available
+				Hostname:   hostName,
+				PID:        12345,
+				CgroupPath: "kubelet-kubepods-burstable-pod99dcb84d2a34f7e338778606703258c4.slice/cri-containerd-ec9ea0ad54dd0d96142d5dbe11eb3f1509e12ba9af739620c7b5ad377ce94602.scope",
+			},
+		},
+		{
+			name: "container not in running state",
+			container: mockedContainer{
+				mockID: func() string {
+					return containerID
+				},
+				mockImage: func() (containerd.Image, error) {
+					return image, nil
+				},
+				mockTask: func() (containerd.Task, error) {
+					return nil, fmt.Errorf("no task found")
+				},
+			},
+			expected: workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   containerID,
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:   "", // Not available
+					Labels: labels,
+				},
+				Image: workloadmeta.ContainerImage{
+					RawName:    "datadog/agent:7",
+					Name:       "datadog/agent",
+					ShortName:  "agent",
+					Tag:        "7",
+					ID:         "my_image_id",
+					RepoDigest: "sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+				},
+				EnvVars:       envVars,
+				Ports:         nil, // Not available
+				Runtime:       workloadmeta.ContainerRuntimeContainerd,
+				RuntimeFlavor: workloadmeta.ContainerRuntimeFlavorKata,
+				State: workloadmeta.ContainerState{
+					Running:    true,
+					Status:     workloadmeta.ContainerStatusRunning,
+					StartedAt:  createdAt,
+					CreatedAt:  createdAt,
+					FinishedAt: time.Time{}, // Not available
+				},
+				NetworkIPs: make(map[string]string), // Not available
+				Hostname:   hostName,
+				PID:        0,
+				CgroupPath: "kubelet-kubepods-burstable-pod99dcb84d2a34f7e338778606703258c4.slice/cri-containerd-ec9ea0ad54dd0d96142d5dbe11eb3f1509e12ba9af739620c7b5ad377ce94602.scope",
+			},
 		},
 	}
 
@@ -129,6 +245,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmeta.MockModuleV2(),
 	))
+
 	imageMetadata := &workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindContainerImageMetadata,
@@ -141,47 +258,20 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 			"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 		},
 	}
+
 	workloadmetaStore.Set(imageMetadata)
 
-	result, err := buildWorkloadMetaContainer(namespace, &container, &client, workloadmetaStore)
-	assert.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			result, err := buildWorkloadMetaContainer(namespace, &test.container, &client, workloadmetaStore)
+			assert.NoError(t, err)
 
-	expected := workloadmeta.Container{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindContainer,
-			ID:   containerID,
-		},
-		EntityMeta: workloadmeta.EntityMeta{
-			Name:   "", // Not available
-			Labels: labels,
-		},
-		Image: workloadmeta.ContainerImage{
-			RawName:    "datadog/agent:7",
-			Name:       "datadog/agent",
-			ShortName:  "agent",
-			Tag:        "7",
-			ID:         "my_image_id",
-			RepoDigest: "sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-		},
-		EnvVars:       envVars,
-		Ports:         nil, // Not available
-		Runtime:       workloadmeta.ContainerRuntimeContainerd,
-		RuntimeFlavor: workloadmeta.ContainerRuntimeFlavorKata,
-		State: workloadmeta.ContainerState{
-			Running:    true,
-			Status:     workloadmeta.ContainerStatusRunning,
-			StartedAt:  createdAt,
-			CreatedAt:  createdAt,
-			FinishedAt: time.Time{}, // Not available
-		},
-		NetworkIPs: make(map[string]string), // Not available
-		Hostname:   hostName,
-		PID:        0, // Not available
-		CgroupPath: "kubelet-kubepods-burstable-pod99dcb84d2a34f7e338778606703258c4.slice/cri-containerd-ec9ea0ad54dd0d96142d5dbe11eb3f1509e12ba9af739620c7b5ad377ce94602.scope",
+			assert.Equal(t, test.expected, result)
+		})
 	}
-	assert.Equal(t, expected, result)
 }
 
+/*
 func TestExtractCgroupPath(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -249,3 +339,4 @@ func TestExtractRuntimeFlavor(t *testing.T) {
 		})
 	}
 }
+*/

--- a/comp/core/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -43,12 +43,21 @@ func TestBuildCollectorEvent(t *testing.T) {
 		},
 	}
 
+	task := &mockedTask{
+		mockPid: func() uint32 {
+			return 12345
+		},
+	}
+
 	container := mockedContainer{
 		mockID: func() string {
 			return containerID
 		},
 		mockImage: func() (containerd.Image, error) {
 			return image, nil
+		},
+		mockTask: func() (containerd.Task, error) {
+			return task, nil
 		},
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Populates the PID field of container entity of workloadmeta in containerd runtime. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Currently, the containerd collector sets PID field to 0 by default for all container entities that it generates.
We should be able to populate this field.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- For containers that are not in the running state, the PID field will be 0.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the agent in containerd runtime environment (example, on kind cluster), and verify that container entities of running containers get the PID field correctly populated.

Ensure that PID is 0 for non running containers, and non zero for running containers.

Example:

```
agent workload-list

=== Entity container sources(merged):[node_orchestrator runtime] id: f4a6cadb8c218e6bcc665de99a50050f31018aa4213d4daec27017ba355004b2 ===
----------- Entity ID -----------
Kind: container ID: f4a6cadb8c218e6bcc665de99a50050f31018aa4213d4daec27017ba355004b2
----------- Entity Meta -----------
Name: coredns
Namespace: k8s.io
Annotations: 
Labels: io.cri-containerd.kind:container io.kubernetes.container.name:coredns io.kubernetes.pod.name:coredns-5d78c9869d-zqwzh io.kubernetes.pod.uid:ba28258a-b68d-4f3b-ae07-dbc677af1dee io.kubernetes.pod.namespace:kube-system 
----------- Image -----------
Name: registry.k8s.io/coredns/coredns
Tag: v1.10.1
ID: sha256:97e04611ad43405a2e5863ae17c6f1bc9181bdefdaa78627c432ef754a4eb108
Raw Name: registry.k8s.io/coredns/coredns:v1.10.1
Short Name: coredns
Repo Digest: sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e
----------- Container Info -----------
Runtime: containerd
RuntimeFlavor: 
Running: true
Status: running
Health: 
Created At: 2024-06-03 08:55:32.257184715 +0000 UTC
Started At: 2024-06-03 08:55:32.257184715 +0000 UTC
Finished At: 0001-01-01 00:00:00 +0000 UTC
----------- Resources -----------
TargetCPUUsage: 10
TargetMemoryUsage: 73400320
Allowed env variables: 
Hostname: 
Network IPs: :10.244.0.3 
PID: 1628
Cgroup path: kubelet-kubepods-burstable-podba28258a_b68d_4f3b_ae07_dbc677af1dee.slice/cri-containerd-f4a6cadb8c218e6bcc665de99a50050f31018aa4213d4daec27017ba355004b2.scope
----------- Ports -----------
Port: 53
Name: dns
Protocol: UDP
Host Port: 0
Port: 53
Name: dns-tcp
Protocol: TCP
Host Port: 0
Port: 9153
Name: metrics
Protocol: TCP
Host Port: 0
----------- Security Context -----------
----------- Capabilities -----------
Add: [NET_BIND_SERVICE]
Drop: [all]
Privileged: false
===

=== Entity container sources(merged):[runtime] id: 28ef5afd89655116febe6fea719cace2c2d8f14a8f1897445c10be14852221b9 ===
----------- Entity ID -----------
Kind: container ID: 28ef5afd89655116febe6fea719cace2c2d8f14a8f1897445c10be14852221b9
----------- Entity Meta -----------
Name: 
Namespace: k8s.io
Annotations: 
Labels: io.kubernetes.pod.uid:***************************e78ae maintainers:Kubernetes Authors description:go based runner for distroless scenarios io.cri-containerd.kind:container io.kubernetes.container.name:kube-apiserver io.kubernetes.pod.name:kube-apiserver-kind-control-plane io.kubernetes.pod.namespace:kube-system 
----------- Image -----------
Name: registry.k8s.io/kube-apiserver
Tag: v1.27.3
ID: sha256:634c53edb5c14785aa9360617dcf173dc8f56081eff42a0d0da8ad823cc7773f
Raw Name: registry.k8s.io/kube-apiserver:v1.27.3
Short Name: kube-apiserver
Repo Digest: sha256:024134bb4e61a4975c5c15db76a7e3571eea74eff90c12a730781bf9c9daedd0
----------- Container Info -----------
Runtime: containerd
RuntimeFlavor: 
Running: false
Status: unknown
Health: 
Created At: 2024-05-30 13:29:06.768518043 +0000 UTC
Started At: 2024-05-30 13:29:06.768518043 +0000 UTC
Finished At: 0001-01-01 00:00:00 +0000 UTC
----------- Resources -----------
Allowed env variables: 
Hostname: 
Network IPs: 
PID: 0
Cgroup path: kubelet-kubepods-burstable-podb97232df7635c1e88c7bd9309b8e78ae.slice/cri-containerd-28ef5afd89655116febe6fea719cace2c2d8f14a8f1897445c10be14852221b9.scope
===
```

We can see that PID is set to 1628 for the running container, and 0 for the second container which has a status `UNKNOWN`
