### PR TITLE
Use github.com/json-iterator/go instead of encode/json  for system-probe API

### DIFF
--- a/comp/core/settings/settingsimpl/settingsimpl.go
+++ b/comp/core/settings/settingsimpl/settingsimpl.go
@@ -7,12 +7,12 @@
 package settingsimpl
 
 import (
-	"encoding/json"
 	"html"
 	"net/http"
 	"sync"
 
 	"github.com/gorilla/mux"
+	json "github.com/json-iterator/go"
 	"go.uber.org/fx"
 	"gopkg.in/yaml.v2"
 

--- a/pkg/network/config/replace_rules.go
+++ b/pkg/network/config/replace_rules.go
@@ -21,7 +21,7 @@ type ReplaceRule struct {
 	Pattern string `mapstructure:"pattern"`
 
 	// Re holds the compiled Pattern and is only used internally.
-	Re *regexp.Regexp `mapstructure:"-"`
+	Re *regexp.Regexp `mapstructure:"-" json:"-"`
 
 	// Repl specifies the replacement string to be used when Pattern matches.
 	Repl string `mapstructure:"repl"`


### PR DESCRIPTION
### What does this PR do?

'encode/json' is not capable of marshalling 'map[interface{}]interface{}'.

### Describe how to test/QA your changes

Test that the command `system-probe config by-source` works without returning an error when `service_monitoring_config.http_replace_rules` is configured.