### PR TITLE
Set timeout for requests made by the EVP proxy

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -195,6 +195,14 @@ func replyWithVersion(hash string, version string, h http.Handler) http.Handler 
 	})
 }
 
+func getConfiguredRequestTimeoutDuration(conf *config.AgentConfig) time.Duration {
+	timeout := 5 * time.Second
+	if conf.ReceiverTimeout > 0 {
+		timeout = time.Duration(conf.ReceiverTimeout) * time.Second
+	}
+	return timeout
+}
+
 // Start starts doing the HTTP server and is ready to receive traces
 func (r *HTTPReceiver) Start() {
 	if r.conf.ReceiverPort == 0 &&
@@ -205,10 +213,7 @@ func (r *HTTPReceiver) Start() {
 		return
 	}
 
-	timeout := 5 * time.Second
-	if r.conf.ReceiverTimeout > 0 {
-		timeout = time.Duration(r.conf.ReceiverTimeout) * time.Second
-	}
+	timeout := getConfiguredRequestTimeoutDuration(r.conf)
 	httpLogger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	r.server = &http.Server{
 		ReadTimeout:  timeout,

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -7,6 +7,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -173,6 +174,13 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	if needsAppKey {
 		req.Header.Set("DD-APPLICATION-KEY", t.conf.EVPProxy.ApplicationKey)
 	}
+
+	// Timeout: Our outbound request(s) can't take longer than the WriteTimeout of the server
+	timeout := getConfiguredRequestTimeoutDuration(t.conf)
+	deadline := time.Now().Add(timeout)
+	ctx, ctxCancel := context.WithDeadline(req.Context(), deadline)
+	req = req.WithContext(ctx)
+	defer ctxCancel()
 
 	// Set target URL and API key header (per domain)
 	req.URL.Scheme = "https"

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -180,7 +180,7 @@ def test_list(
                 filename = os.path.join(ctx.cwd, f"dependencies_{goos}_{goarch}.txt")
                 if not os.path.isfile(filename):
                     print(
-                        f"File {filename} does not exist. To execute the dependencies list check for the {binary} binary, please run the task `inv -e go-deps.generate --binaries {binary}"
+                        f"File {filename} does not exist. To execute the dependencies list check for the {binary} binary, please run the task `inv -e go-deps.generate"
                     )
                     continue
 


### PR DESCRIPTION
### Motivation

Despite the trace-agent API server having a timeout (that defaults to 5 seconds), requests to the EVP proxy endpoint could continue running past this timeout because they were not cancelled themselves. In either case we would close the connection with the client without propagating the response from the server, but we would take way longer than intended.

### Describe how to test/QA your changes

Before the patch (and hardcoding the endpoint to a local python server that takes 8 seconds to respond):

```
$ time curl -v 127.0.0.1:8126/evp_proxy/v1/
*   Trying 127.0.0.1:8126...
* Connected to 127.0.0.1 (127.0.0.1) port 8126
> GET /evp_proxy/v1/ HTTP/1.1
> Host: 127.0.0.1:8126
> User-Agent: curl/8.4.0
> Accept: */*
> 
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server

real	0m8.033s
user	0m0.006s
sys	0m0.010s
```

After the patch:

```
$ time curl -v 127.0.0.1:8126/evp_proxy/v1/
*   Trying 127.0.0.1:8126...
* Connected to 127.0.0.1 (127.0.0.1) port 8126
> GET /evp_proxy/v1/ HTTP/1.1
> Host: 127.0.0.1:8126
> User-Agent: curl/8.4.0
> Accept: */*
> 
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server

real	0m5.033s
user	0m0.006s
sys	0m0.010s
```

Both close the connection without response, but the first one goes over the timeout.
