### PR TITLE
fix(upload): Handle case when the archive already contains a folder

### DIFF
--- a/tasks/unit-tests/junit_tests.py
+++ b/tasks/unit-tests/junit_tests.py
@@ -52,14 +52,14 @@ class TestSplitJUnitXML(unittest.TestCase):
     def test_without_split(self):
         xml_file = Path("./tasks/unit-tests/testdata/secret.tar.gz/kitchen-rspec-win2016-azure-x86_64.xml")
         owners = read_owners(".github/CODEOWNERS")
-        self.assertEqual(junit.split_junitxml(xml_file, owners, []), 1)
+        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, []), 1)
         generated_folder = xml_file.parent / "windows-agent_base"
         self.assertTrue(generated_folder.exists())
 
     def test_with_split(self):
         xml_file = Path("./tasks/unit-tests/testdata/secret.tar.gz/-go-src-datadog-agent-junit-out-base.xml")
         owners = read_owners(".github/CODEOWNERS")
-        self.assertEqual(junit.split_junitxml(xml_file, owners, []), 29)
+        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, []), 29)
 
 
 class TestGroupPerTag(unittest.TestCase):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Ignore the initial folder which contains xml files if any. This is the case on some kitchen situations, see [this failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/531507612)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Stability

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Thanks @paulcacheux for the notification

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
