### PR TITLE
[oracle] Test case for the problem with multibyte character sets (SDBM-978)

### DIFF
--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sijms/go-ora/v2/converters"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActivity(t *testing.T) {
+	// include_all_sessions is set to true because the session executing the test query
+	// won't be active during sampling
+	config := `dbm: true
+query_samples:
+  include_all_sessions: true`
+	c, _ := newDefaultCheck(t, config, "")
+	defer c.Teardown()
+
+	var err error
+	err = c.Run()
+	assert.NoError(t, err, "check run activity")
+
+	_ = converters.NewStringConverter(846)
+	largeMultibyteString := strings.Repeat("안녕하세요", 200)
+	filter := fmt.Sprintf("user='%s'", largeMultibyteString)
+	andClause := strings.Repeat(fmt.Sprintf(" and %s", filter), 100)
+	filter = filter + andClause
+	statement := fmt.Sprintf("select 14 from dual where %s", filter)
+	// we aren't scanning rows to force the session keep the cursor open, so
+	// the test query sql_id will be stored in prev_sql_id
+	rows, err := c.db.Query(statement)
+	defer rows.Close()
+	assert.NoError(t, err, "long query didn't run")
+
+	err = c.SampleSession()
+	assert.NoError(t, err, "activity run - multibyte characters")
+}

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sijms/go-ora/v2/converters"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +28,6 @@ query_samples:
 	err = c.Run()
 	assert.NoError(t, err, "check run activity")
 
-	_ = converters.NewStringConverter(846)
 	largeMultibyteString := strings.Repeat("안녕하세요", 200)
 	filter := fmt.Sprintf("user='%s'", largeMultibyteString)
 	andClause := strings.Repeat(fmt.Sprintf(" and %s", filter), 100)


### PR DESCRIPTION
### What does this PR do?

Adding test case for the problem with sampling on databases with multi-byte charactersets.

### Motivation

Provide a test case for more advanced, adaptive solution.

### Additional Notes

We are substringing the query where the length is specified in characters. But the text won't fit in varchar2 if there are many special characters in query text taking multiple bytes. The test case works on any multibyte characterset database, i.e. we don't need an Asian characterset to execute it.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
