### PR TITLE
[CWS] ensure device and user path are serialized for windows fim events

### DIFF
--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -19,6 +19,8 @@ import (
 type FileSerializer struct {
 	// File path
 	Path string `json:"path,omitempty"`
+	// File device path
+	DevicePath string `json:"device_path,omitempty"`
 	// File basename
 	Name string `json:"name,omitempty"`
 }
@@ -115,8 +117,9 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, _ ...uint64) *FileSe
 
 func newFimFileSerializer(fe *model.FimFileEvent, e *model.Event, _ ...uint64) *FileSerializer {
 	return &FileSerializer{
-		Path: e.FieldHandlers.ResolveFimFilePath(e, fe),
-		Name: e.FieldHandlers.ResolveFimFileBasename(e, fe),
+		Path:       e.FieldHandlers.ResolveFileUserPath(e, fe),
+		DevicePath: e.FieldHandlers.ResolveFimFilePath(e, fe),
+		Name:       e.FieldHandlers.ResolveFimFileBasename(e, fe),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the serialization of windows fim events (the backend payload) making sure both the device path and the mapped user path are available.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
