### PR TITLE
Fix panic in etwtracer stop hook

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -214,6 +214,7 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestLinuxSecretSuite
       - EXTRA_PARAMS: --run TestWindowsSecretSuite
       - EXTRA_PARAMS: --run TestLinuxCheckSuite
+      - EXTRA_PARAMS: --run TestLinuxRunSuite
       - EXTRA_PARAMS: --run TestWindowsRunSuite
 
 new-e2e-language-detection:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -214,6 +214,7 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run TestLinuxSecretSuite
       - EXTRA_PARAMS: --run TestWindowsSecretSuite
       - EXTRA_PARAMS: --run TestLinuxCheckSuite
+      - EXTRA_PARAMS: --run TestWindowsRunSuite
 
 new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64

--- a/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
+++ b/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
@@ -421,15 +421,33 @@ func (a *etwtracerimpl) doTrace() {
 
 func (a *etwtracerimpl) stop(_ context.Context) error {
 	a.log.Infof("Stopping Datadog APM ETW tracer component")
-	err := a.session.StopTracing()
-	err = errors.Join(err, a.pipeListener.Close())
+
+	// NOTE: since start can fail but doesn't return an error, stop will be called in cases
+	//       where start exits before fully intializing the object, so we need to check
+	// 	     that each resource is not nil before closing it.
+	var err error
+
+	if a.session != nil {
+		err = a.session.StopTracing()
+		if err != nil {
+			a.log.Errorf("Failed to stop the ETW session: %v", err)
+		}
+	}
+	if a.pipeListener != nil {
+		err = errors.Join(err, a.pipeListener.Close())
+		if err != nil {
+			a.log.Errorf("Failed to stop the ETW session: %v", err)
+		}
+	}
 	// Cancel all active reads
-	a.readCancel()
-	a.pidMutex.Lock()
-	defer a.pidMutex.Unlock()
-	for pid, pidCtx := range a.pids {
-		pidCtx.conn.Close()
-		delete(a.pids, pid)
+	if a.readCtx != nil {
+		a.readCancel()
+		a.pidMutex.Lock()
+		defer a.pidMutex.Unlock()
+		for pid, pidCtx := range a.pids {
+			pidCtx.conn.Close()
+			delete(a.pids, pid)
+		}
 	}
 	return err
 }

--- a/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
+++ b/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
@@ -422,9 +422,10 @@ func (a *etwtracerimpl) doTrace() {
 func (a *etwtracerimpl) stop(_ context.Context) error {
 	a.log.Infof("Stopping Datadog APM ETW tracer component")
 
-	// NOTE: since start can fail but doesn't return an error, stop will be called in cases
-	//       where start exits before fully intializing the object, so we need to check
-	// 	     that each resource is not nil before closing it.
+	// NOTE: since start can fail but doesn't return an error, stop will be
+	//       called in casee where start exits before fully intializing the
+	//       object, so we need to check that each resource is not nil before
+	//       closing it.
 	var err error
 
 	if a.session != nil {

--- a/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
+++ b/comp/trace/etwtracer/etwtracerimpl/etwtracerimpl.go
@@ -423,7 +423,7 @@ func (a *etwtracerimpl) stop(_ context.Context) error {
 	a.log.Infof("Stopping Datadog APM ETW tracer component")
 
 	// NOTE: since start can fail but doesn't return an error, stop will be
-	//       called in casee where start exits before fully intializing the
+	//       called in cases where start exits before fully intializing the
 	//       object, so we need to check that each resource is not nil before
 	//       closing it.
 	var err error

--- a/releasenotes/notes/fix-agent-etwtracer-shutdown-panic-fae2346480bc8427.yaml
+++ b/releasenotes/notes/fix-agent-etwtracer-shutdown-panic-fae2346480bc8427.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an issue introduced in Agent 7.51 for Windows that would cause a panic during Agent shutdown
+    if the etwtracer component failed to initialize.

--- a/test/new-e2e/tests/agent-subcommands/run/run_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_common_test.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package status
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+)
+
+type baseRunSuite struct {
+	e2e.BaseSuite[environments.Host]
+}

--- a/test/new-e2e/tests/agent-subcommands/run/run_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_common_test.go
@@ -6,10 +6,37 @@
 package status
 
 import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 )
 
 type baseRunSuite struct {
 	e2e.BaseSuite[environments.Host]
+}
+
+func (s *baseRunSuite) runTimeout() time.Duration {
+	return 5 * time.Minute
+}
+
+func runCommandWithTimeout(host *components.RemoteHost, cmd string, timeout time.Duration) (string, error) {
+	var out string
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	go func() {
+		out, err = host.Execute(cmd)
+		cancel()
+	}()
+	<-ctx.Done()
+	if errors.Is(ctx.Err(), context.Canceled) {
+		// return the execute error
+		return out, err
+	}
+	// return the timeout error
+	return out, ctx.Err()
 }

--- a/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
@@ -1,32 +1,28 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package status
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
-	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"testing"
 )
 
-type windowsRunSuite struct {
+type linuxRunSuite struct {
 	baseRunSuite
 }
 
-func TestWindowsRunSuite(t *testing.T) {
-	e2e.Run(t, &windowsRunSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
+func TestLinuxRunSuite(t *testing.T) {
+	e2e.Run(t, &linuxRunSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 
-func (s *windowsRunSuite) TestRunWhenAgentAlreadyRunning() {
+func (s *linuxRunSuite) TestRunWhenAgentAlreadyRunning() {
 	host := s.Env().RemoteHost
 	s.T().Log(host.HostOutput)
 
@@ -34,10 +30,7 @@ func (s *windowsRunSuite) TestRunWhenAgentAlreadyRunning() {
 	s.Require().True(s.Env().Agent.Client.IsReady(), "agent should be running")
 
 	// execute the `agent run` subcommand
-	path, err := windowsAgent.GetInstallPathFromRegistry(host)
-	s.Require().NoError(err)
-	agentPath := filepath.Join(path, "bin", "agent.exe")
-	cmd := fmt.Sprintf(`& "%s" run`, agentPath)
+	cmd := `sudo datadog-agent run`
 	// run command with timeout in case it succeeds/hangs
 	out, err := runCommandWithTimeout(host, cmd, s.runTimeout())
 	if err == nil {
@@ -48,6 +41,6 @@ func (s *windowsRunSuite) TestRunWhenAgentAlreadyRunning() {
 	// make sure it didn't panic
 	s.Require().NotContains(err.Error(), "panic: runtime error")
 	// make sure it printed a reasonable human readable error
-	s.Require().ErrorContains(err, "listen tcp 127.0.0.1:5001: bind: Only one usage of each socket address")
+	s.Require().ErrorContains(err, " listen tcp 127.0.0.1:5001: bind: address already in use")
 	// TODO: Once host.Execute is fixed to return the exit code, check that the exit code is ??
 }

--- a/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
@@ -24,7 +24,6 @@ func TestLinuxRunSuite(t *testing.T) {
 
 func (s *linuxRunSuite) TestRunWhenAgentAlreadyRunning() {
 	host := s.Env().RemoteHost
-	s.T().Log(host.HostOutput)
 
 	// Ensure agent is running
 	s.Require().True(s.Env().Agent.Client.IsReady(), "agent should be running")

--- a/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+)
+
+type windowsRunSuite struct {
+	baseRunSuite
+}
+
+func TestWindowsRunSuite(t *testing.T) {
+	e2e.Run(t, &windowsRunSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
+}
+
+func (s *windowsRunSuite) TestRunWhenAgentAlreadyRunning() {
+	host := s.Env().RemoteHost
+	s.T().Log(host.HostOutput)
+
+	// Ensure agent is running
+	s.Require().True(s.Env().Agent.Client.IsReady(), "agent should be running")
+
+	// execute the `agent run` subcommand
+	path, err := windowsAgent.GetInstallPathFromRegistry(host)
+	s.Require().NoError(err)
+	agentPath := filepath.Join(path, "bin", "agent.exe")
+	cmd := fmt.Sprintf(`& "%s" run`, agentPath)
+	// run command with timeout in case it succeeds/hangs
+	var out string
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	go func() {
+		out, err = host.Execute(cmd)
+		cancel()
+	}()
+	<-ctx.Done()
+	s.Require().ErrorIs(ctx.Err(), context.Canceled, "agent run command timed out")
+	if err == nil {
+		s.T().Log(out)
+		s.FailNow("agent run command succeeded when it should have failed")
+	}
+	// make sure it didn't panic
+	s.Require().NotContains(err.Error(), "panic: runtime error")
+	// make sure it printed a reasonable human readable error
+	s.Require().ErrorContains(err, "listen tcp 127.0.0.1:5001: bind: Only one usage of each socket address")
+	// TODO: Once host.Execute is fixed to return the exit code, check that the exit code is ??
+}

--- a/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
@@ -28,7 +28,6 @@ func TestWindowsRunSuite(t *testing.T) {
 
 func (s *windowsRunSuite) TestRunWhenAgentAlreadyRunning() {
 	host := s.Env().RemoteHost
-	s.T().Log(host.HostOutput)
 
 	// Ensure agent is running
 	s.Require().True(s.Env().Agent.Client.IsReady(), "agent should be running")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add initialization checks to etwtracer component `stop` fx lifecycle hook. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-841
The `start` hook can exit early but doesn't return an error so as to not block agent startup. This leaves some struct fields uninitialized. In these cases once its `stop` hook is called it panics.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
easiest way to reproduce this is by running the agent twice. the etwtracer component `start` hook will fail because the named pipe is already in use.

I believe this has been present since the component was added in Agent 7.51.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
e2e test added to cover expected behavior when agent is run twice