### PR TITLE
[CWS] allow approver report display when validating windows model

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -492,17 +492,15 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 		return err
 	}
 
-	if !args.windowsModel {
-		report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
-		if err != nil {
-			return err
-		}
+	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
+	if err != nil {
+		return err
+	}
 
-		content, _ := json.MarshalIndent(report, "", "\t")
-		_, err = fmt.Fprintf(writer, "%s\n", string(content))
-		if err != nil {
-			return fmt.Errorf("unable to write out report: %w", err)
-		}
+	content, _ := json.MarshalIndent(report, "", "\t")
+	_, err = fmt.Fprintf(writer, "%s\n", string(content))
+	if err != nil {
+		return fmt.Errorf("unable to write out report: %w", err)
 	}
 
 	return nil

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -584,7 +584,7 @@ func (rs *RuleSet) GetEventApprovers(eventType eval.EventType, fieldCaps FieldCa
 		return nil, ErrNoEventTypeBucket{EventType: eventType}
 	}
 
-	return GetApprovers(bucket.rules, model.NewFakeEvent(), fieldCaps)
+	return GetApprovers(bucket.rules, rs.eventCtor(), fieldCaps)
 }
 
 // GetFieldValues returns all the values of the given field


### PR DESCRIPTION
### What does this PR do?

Currently we only report the kfilter/approver report when the model is the same as the running OS. This PR fixes this limitation by ensuring the approver computation is done using `eventCtor` instead of creating a fake event from scratch.
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
