### PR TITLE
[CWS] ensure `EnableApprovers` and `EnableDiscarders` are respected on windows

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -538,8 +538,8 @@ func TestETWFileNotifications(t *testing.T) {
 	testfilerename := ex + ".testfilerename"
 
 	wp, err := createTestProbe()
-	wp.disableApprovers = true
 	require.NoError(t, err)
+	wp.config.Probe.EnableApprovers = false
 
 	// teardownTestProe calls the stop function on etw, which will
 	// in turn wait on wp.fimgw

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -112,7 +112,6 @@ type WindowsProbe struct {
 	blockonchannelsend bool
 
 	// approvers
-	disableApprovers  bool
 	currentEventTypes []string
 	approvers         map[eval.Field][]approver
 }
@@ -403,7 +402,7 @@ func (p *WindowsProbe) approveFimBasename(value string) bool {
 
 // currently support only string base approver for now
 func (p *WindowsProbe) approve(field eval.Field, eventType string, value string) bool {
-	if p.disableApprovers {
+	if !p.config.Probe.EnableApprovers {
 		return true
 	}
 
@@ -1265,6 +1264,10 @@ func (p *WindowsProbe) FlushDiscarders() error {
 
 // OnNewDiscarder handles discarders
 func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field eval.Field, evalType eval.EventType) {
+	if !p.config.Probe.EnableDiscarders {
+		return
+	}
+
 	if evalType != "create" {
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a small issue with the windows probe that was not correctly respecting the enable approvers and discarders config flags.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
