### PR TITLE
[CONTP-223] Allow entity level filtering for workloadmetadata subscribers

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/util.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util.go
@@ -189,13 +189,14 @@ func (ownersLanguages *OwnersLanguages) handleKubeAPIServerUnsetEvents(events []
 // This method is blocking, and should be called within a goroutine
 // This method is thread-safe.
 func (ownersLanguages *OwnersLanguages) cleanRemovedOwners(wlm workloadmeta.Component) {
-	evBundle := wlm.Subscribe("language-detection-handler", workloadmeta.NormalPriority, workloadmeta.NewFilter(
-		&workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesDeployment},
-			Source:    "kubeapiserver",
-			EventType: workloadmeta.EventTypeUnset,
-		},
-	))
+
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource("kubeapiserver").
+		SetEventType(workloadmeta.EventTypeUnset).
+		AddKind(workloadmeta.KindKubernetesDeployment).
+		Build()
+
+	evBundle := wlm.Subscribe("language-detection-handler", workloadmeta.NormalPriority, filter)
 	defer wlm.Unsubscribe(evBundle)
 
 	for evChan := range evBundle {

--- a/cmd/cluster-agent/api/v1/languagedetection/util_test.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util_test.go
@@ -596,13 +596,13 @@ func TestHandleKubeAPIServerUnsetEvents(t *testing.T) {
 		},
 	}
 
-	evBundle := mockStore.Subscribe("language-detection-handler", workloadmeta.NormalPriority, workloadmeta.NewFilter(
-		&workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesDeployment},
-			Source:    "kubeapiserver",
-			EventType: workloadmeta.EventTypeUnset,
-		},
-	))
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource("kubeapiserver").
+		SetEventType(workloadmeta.EventTypeUnset).
+		AddKind(workloadmeta.KindKubernetesDeployment).
+		Build()
+
+	evBundle := mockStore.Subscribe("language-detection-handler", workloadmeta.NormalPriority, filter)
 	defer mockStore.Unsubscribe(evBundle)
 
 	go func() {

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -37,19 +37,16 @@ type ContainerListener struct {
 func NewContainerListener(_ Config, wmeta optional.Option[workloadmeta.Component]) (ServiceListener, error) {
 	const name = "ad-containerlistener"
 	l := &ContainerListener{}
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-		Source:    workloadmeta.SourceRuntime,
-		EventType: workloadmeta.EventTypeAll,
-	}
-	f := workloadmeta.NewFilter(&filterParams)
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceRuntime).
+		AddKind(workloadmeta.KindContainer).Build()
 
 	wmetaInstance, ok := wmeta.Get()
 	if !ok {
 		return nil, errors.New("workloadmeta store is not initialized")
 	}
 	var err error
-	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.createContainerService, wmetaInstance)
+	l.workloadmetaListener, err = newWorkloadmetaListener(name, filter, l.createContainerService, wmetaInstance)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -32,19 +32,17 @@ func NewKubeletListener(_ Config, wmeta optional.Option[workloadmeta.Component])
 	const name = "ad-kubeletlistener"
 
 	l := &KubeletListener{}
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-		Source:    workloadmeta.SourceNodeOrchestrator,
-		EventType: workloadmeta.EventTypeAll,
-	}
-	f := workloadmeta.NewFilter(&filterParams)
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceNodeOrchestrator).
+		AddKind(workloadmeta.KindKubernetesPod).
+		Build()
 
 	wmetaInstance, ok := wmeta.Get()
 	if !ok {
 		return nil, errors.New("workloadmeta store is not initialized")
 	}
 	var err error
-	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.processPod, wmetaInstance)
+	l.workloadmetaListener, err = newWorkloadmetaListener(name, filter, l.processPod, wmetaInstance)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/autodiscovery/providers/container.go
+++ b/comp/core/autodiscovery/providers/container.go
@@ -56,13 +56,11 @@ func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration
 	// need to be generated before any associated services.
 	outCh := make(chan integration.ConfigChanges)
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
-
-	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(&filterParams))
+	filter := workloadmeta.NewFilterBuilder().
+		AddKind(workloadmeta.KindContainer).
+		AddKind(workloadmeta.KindKubernetesPod).
+		Build()
+	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, filter)
 
 	go func() {
 		for {

--- a/comp/core/workloadmeta/collectors/collectors.go
+++ b/comp/core/workloadmeta/collectors/collectors.go
@@ -62,13 +62,7 @@ func remoteWorkloadmetaParams() fx.Option {
 
 	// Security Agent is only interested in containers
 	if flavor.GetFlavor() == flavor.SecurityAgent {
-		filter = workloadmeta.NewFilter(
-			&workloadmeta.FilterParams{
-				Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-				Source:    workloadmeta.SourceAll,
-				EventType: workloadmeta.EventTypeAll,
-			},
-		)
+		filter = workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
 	}
 
 	return fx.Provide(func() remoteworkloadmeta.Params {

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -36,15 +36,15 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		return fmt.Errorf("error retrieving global SBOM scanner")
 	}
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeSet,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		SetEventType(workloadmeta.EventTypeSet).
+		AddKind(workloadmeta.KindContainerImageMetadata).
+		Build()
+
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 	scanner := collectors.GetContainerdScanner()
 	if scanner == nil {

--- a/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -41,15 +41,15 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		return fmt.Errorf("error retrieving global SBOM scanner")
 	}
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeSet,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		AddKind(workloadmeta.KindContainerImageMetadata).
+		SetEventType(workloadmeta.EventTypeSet).
+		Build()
+
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 
 	scanner := collectors.GetDockerScanner()

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -75,22 +75,18 @@ func TestNewCollector(t *testing.T) {
 		},
 		{
 			name: "filter with only supported kinds",
-			filter: workloadmeta.NewFilter(&workloadmeta.FilterParams{
-				Kinds: []workloadmeta.Kind{
-					workloadmeta.KindContainer,
-					workloadmeta.KindKubernetesPod,
-				},
-			}),
+			filter: workloadmeta.NewFilterBuilder().
+				AddKind(workloadmeta.KindContainer).
+				AddKind(workloadmeta.KindKubernetesPod).
+				Build(),
 			expectsError: false,
 		},
 		{
 			name: "filter with unsupported kinds",
-			filter: workloadmeta.NewFilter(&workloadmeta.FilterParams{
-				Kinds: []workloadmeta.Kind{
-					workloadmeta.KindContainer,
-					workloadmeta.KindContainerImageMetadata, // Not supported
-				},
-			}),
+			filter: workloadmeta.NewFilterBuilder().
+				AddKind(workloadmeta.KindContainer).
+				AddKind(workloadmeta.KindContainerImageMetadata /* No Supported */).
+				Build(),
 			expectsError: true,
 		},
 	}

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -43,7 +43,7 @@ type Component interface {
 
 	// ListContainersWithFilter returns all the containers for which the passed
 	// filter evaluates to true.
-	ListContainersWithFilter(filter ContainerFilterFunc) []*Container
+	ListContainersWithFilter(filter EntityFilterFunc[*Container]) []*Container
 
 	// GetKubernetesPod returns metadata about a Kubernetes pod.  It fetches
 	// the entity with kind KindKubernetesPod and the given ID.
@@ -105,7 +105,7 @@ type Component interface {
 
 	// ListProcessesWithFilter returns all the processes for which the passed
 	// filter evaluates to true.
-	ListProcessesWithFilter(filterFunc ProcessFilterFunc) []*Process
+	ListProcessesWithFilter(filterFunc EntityFilterFunc[*Process]) []*Process
 
 	// Notify notifies the store with a slice of events.  It should only be
 	// used by workloadmeta collectors.

--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -11,6 +11,8 @@ package workloadmeta
 // included in the output, and false if it should be filtered out.
 type EntityFilterFunc[T Entity] func(T) bool
 
+// GenericEntityFilterFunc is a filter function applicable to any object
+// of a struct implementing the Entity interface
 type GenericEntityFilterFunc EntityFilterFunc[Entity]
 
 // EntityFilterFuncAcceptAll is an entity filter function that accepts

--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -5,27 +5,38 @@
 
 package workloadmeta
 
+// EntityFilterFunc provides a filter on the entity object level
+//
+// Given an entity instance, it returns true if the object should be
+// included in the output, and false if it should be filtered out.
+type EntityFilterFunc func(*Entity) bool
+
+// EntityFilterFuncAcceptAll is an entity filter function that accepts
+// any entity.
+func EntityFilterFuncAcceptAll(_ *Entity) bool { return true }
+
 // Filter allows a subscriber to filter events by entity kind, event source, and
 // event type.
 //
 // A nil filter matches all events.
 type Filter struct {
-	kinds     map[Kind]struct{}
+	kinds     map[Kind]EntityFilterFunc
 	source    Source
 	eventType EventType
 }
 
-// FilterParams are the parameters used to create a Filter
-type FilterParams struct {
-	Kinds     []Kind
-	Source    Source
-	EventType EventType
+// FilterBuilder is used to build a filter object for subscribers.
+type FilterBuilder struct {
+	filter *Filter
 }
 
-// NewFilter creates a new filter for subscribing to workloadmeta events.
+// NewFilterBuilder creates and returns a new filter builder for a given
+// event type for subscribing to workloadmeta events.
 //
-// Only events for entities with one of the given kinds will be delivered.  If
-// kinds is nil or empty, events for entities of any kind will be delivered.
+// Only events for entities with one of the added kinds and matching the
+// associated entity filter function will be delivered.
+//
+// If no kind is added, events for entities of any kind will be delivered.
 //
 // Similarly, only events for entities collected from the given source will be
 // delivered, and the entities in the events will contain data only from that
@@ -36,38 +47,65 @@ type FilterParams struct {
 //
 // Only events of the given type will be delivered. Use EventTypeAll to collect
 // data from all the event types. EventTypeAll is the default.
-func NewFilter(filterParams *FilterParams) *Filter {
-	var kindSet map[Kind]struct{}
-	kinds := filterParams.Kinds
-	if len(kinds) > 0 {
-		kindSet = make(map[Kind]struct{})
-		for _, k := range kinds {
-			kindSet[k] = struct{}{}
-		}
-	}
-
-	// This is enforced in the matching functions, but putting here for clarity
-	if filterParams.Source == "" {
-		filterParams.Source = SourceAll
-	}
-
-	return &Filter{
-		kinds:     kindSet,
-		source:    filterParams.Source,
-		eventType: filterParams.EventType,
+func NewFilterBuilder() *FilterBuilder {
+	return &FilterBuilder{
+		filter: &Filter{
+			source:    SourceAll,
+			eventType: EventTypeAll,
+			kinds:     map[Kind]EntityFilterFunc{},
+		},
 	}
 }
 
-// MatchKind returns true if the filter matches the passed Kind. If the filter
-// is nil, or has no kinds, it always matches.
-func (f *Filter) MatchKind(k Kind) bool {
+// Build builds the filter and returns it.
+func (fb *FilterBuilder) Build() *Filter {
+	return fb.filter
+}
+
+// AddKind adds a specific kind to the built filter.
+// The built filter will match any entity of the added kind.
+func (fb *FilterBuilder) AddKind(kind Kind) *FilterBuilder {
+	fb.filter.kinds[kind] = EntityFilterFuncAcceptAll
+	return fb
+}
+
+// AddKindWithEntityFilter adds an entity kind with an associated entity filter function.
+// The built filter will match all entities of the added kind for which the entity filter function returns true.
+func (fb *FilterBuilder) AddKindWithEntityFilter(kind Kind, entityFilterFunc EntityFilterFunc) *FilterBuilder {
+	fb.filter.kinds[kind] = entityFilterFunc
+	return fb
+}
+
+// SetSource sets the source for the filter.
+func (fb *FilterBuilder) SetSource(source Source) *FilterBuilder {
+	fb.filter.source = source
+	return fb
+}
+
+// SetEventType sets the event type for the filter
+func (fb *FilterBuilder) SetEventType(eventType EventType) *FilterBuilder {
+	fb.filter.eventType = eventType
+	return fb
+}
+
+// MatchEntity returns true if the filter matches the passed entity.
+// If the filter is nil, or has no kinds, it always matches.
+func (f *Filter) MatchEntity(entity *Entity) bool {
 	if f == nil || len(f.kinds) == 0 {
 		return true
 	}
 
-	_, ok := f.kinds[k]
+	if entity == nil {
+		return false
+	}
 
-	return ok
+	entityKind := (*entity).GetID().Kind
+
+	if entityFilterFunc, found := f.kinds[entityKind]; found {
+		return entityFilterFunc(entity)
+	}
+
+	return false
 }
 
 // MatchSource returns true if the filter matches the passed source. If the
@@ -80,6 +118,18 @@ func (f *Filter) MatchSource(source Source) bool {
 // the filter is nil, or has EventTypeAll, it always matches.
 func (f *Filter) MatchEventType(eventType EventType) bool {
 	return f.EventType() == EventTypeAll || f.EventType() == eventType
+}
+
+// MatchKind returns false if the filter can never match entities
+// of the specified kind.
+func (f *Filter) MatchKind(kind Kind) bool {
+	if f == nil || len(f.kinds) == 0 {
+		return true
+	}
+
+	_, found := f.kinds[kind]
+
+	return found
 }
 
 // Kinds returns the kinds this filter is filtering by.

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -305,7 +305,7 @@ func TestFilter_MatchEntity(t *testing.T) {
 			if test.expectMatch {
 				assert.True(tt, test.filter.MatchEntity(&test.entity))
 			} else {
-				assert.False(tt, !test.filter.MatchEntity(&test.entity))
+				assert.False(tt, test.filter.MatchEntity(&test.entity))
 			}
 		})
 	}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -655,14 +655,8 @@ type SeccompProfile struct {
 
 var _ Entity = &Container{}
 
-// ContainerFilterFunc is a function used to filter containers.
-type ContainerFilterFunc func(container *Container) bool
-
-// ProcessFilterFunc is a function used to filter processes.
-type ProcessFilterFunc func(process *Process) bool
-
 // GetRunningContainers is a function that evaluates to true for running containers.
-var GetRunningContainers ContainerFilterFunc = func(container *Container) bool { return container.State.Running }
+var GetRunningContainers EntityFilterFunc[*Container] = func(container *Container) bool { return container.State.Running }
 
 // KubernetesPod is an Entity representing a Kubernetes Pod.
 type KubernetesPod struct {

--- a/comp/core/workloadmeta/filter_test.go
+++ b/comp/core/workloadmeta/filter_test.go
@@ -1,0 +1,349 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterBuilder_Build(t *testing.T) {
+	dummyEntityFilterFunc := func(entity Entity) bool {
+		return len(entity.GetID().ID) == 5
+	}
+
+	tests := []struct {
+		name           string
+		builderFunc    func() *FilterBuilder
+		expectedFilter *Filter
+	}{
+		{
+			name:        "filter with default options",
+			builderFunc: NewFilterBuilder,
+			expectedFilter: &Filter{
+				source:    SourceAll,
+				kinds:     map[Kind]GenericEntityFilterFunc{},
+				eventType: EventTypeAll,
+			},
+		},
+		{
+			name: "filter with custom values",
+			builderFunc: func() *FilterBuilder {
+				return NewFilterBuilder().
+					AddKind(KindContainer).
+					AddKindWithEntityFilter(KindKubernetesPod, dummyEntityFilterFunc).
+					SetSource(SourceRuntime).
+					SetEventType(EventTypeSet)
+			},
+			expectedFilter: &Filter{
+				source: SourceRuntime,
+				kinds: map[Kind]GenericEntityFilterFunc{
+					KindContainer:     EntityFilterFuncAcceptAll,
+					KindKubernetesPod: dummyEntityFilterFunc,
+				},
+				eventType: EventTypeSet,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			filterBuilder := test.builderFunc()
+			filter := filterBuilder.Build()
+			assert.Equal(tt, filter.source, test.expectedFilter.source)
+			assert.Equal(tt, filter.eventType, test.expectedFilter.eventType)
+
+			assert.Equal(tt, len(filter.kinds), len(test.expectedFilter.kinds))
+			for kind, entityFilter := range test.expectedFilter.kinds {
+				expectedEntityFilter, found := filter.kinds[kind]
+				assert.True(tt, found)
+				assert.Equal(tt, fmt.Sprintf("%v", entityFilter), fmt.Sprintf("%v", expectedEntityFilter))
+			}
+		})
+	}
+}
+
+func TestFilter_MatchSource(t *testing.T) {
+	tests := []struct {
+		name              string
+		filter            *Filter
+		source            Source
+		expectMatchSource bool
+	}{
+		{
+			name:              "matched due to nil filter",
+			filter:            nil,
+			source:            "foo",
+			expectMatchSource: true,
+		},
+		{
+			name:              "matched exact source",
+			filter:            &Filter{source: "foo"},
+			source:            "foo",
+			expectMatchSource: true,
+		},
+		{
+			name:              "unmatched source",
+			filter:            &Filter{source: "foo"},
+			source:            "bar",
+			expectMatchSource: false,
+		},
+		{
+			name:              "any source should match SourceAll",
+			filter:            &Filter{source: SourceAll},
+			source:            "foo",
+			expectMatchSource: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.expectMatchSource {
+				assert.True(tt, test.filter.MatchSource(test.source))
+			} else {
+				assert.False(tt, test.filter.MatchSource(test.source))
+			}
+
+		})
+	}
+}
+
+func TestFilter_MatchEventType(t *testing.T) {
+	tests := []struct {
+		name                 string
+		filter               *Filter
+		eventType            EventType
+		expectMatchEventType bool
+	}{
+		{
+			name:                 "any event type should match nil filter",
+			filter:               nil,
+			eventType:            EventTypeSet,
+			expectMatchEventType: true,
+		},
+		{
+			name:                 "matched exact event type",
+			filter:               &Filter{eventType: EventTypeSet},
+			eventType:            EventTypeSet,
+			expectMatchEventType: true,
+		},
+		{
+			name:                 "unmatched event type",
+			filter:               &Filter{eventType: EventTypeSet},
+			eventType:            EventTypeUnset,
+			expectMatchEventType: false,
+		},
+		{
+			name:                 "any event type should match EventTypeAll",
+			filter:               &Filter{eventType: EventTypeAll},
+			eventType:            EventTypeSet,
+			expectMatchEventType: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.expectMatchEventType {
+				assert.True(tt, test.filter.MatchEventType(test.eventType))
+			} else {
+				assert.False(tt, test.filter.MatchEventType(test.eventType))
+			}
+
+		})
+	}
+}
+
+func TestFilter_MatchKind(t *testing.T) {
+	tests := []struct {
+		name            string
+		filter          *Filter
+		kind            Kind
+		expectMatchKind bool
+	}{
+		{
+			name:            "any kind should match nil filter",
+			filter:          nil,
+			kind:            KindContainer,
+			expectMatchKind: true,
+		},
+		{
+			name:            "matched exact kind",
+			filter:          &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: EntityFilterFuncAcceptAll}},
+			kind:            KindContainer,
+			expectMatchKind: true,
+		},
+		{
+			name:            "matched kind due to empty kinds map",
+			filter:          &Filter{kinds: map[Kind]GenericEntityFilterFunc{}},
+			kind:            KindContainer,
+			expectMatchKind: true,
+		},
+		{
+			name:            "matched kind due uninitialised kinds map",
+			filter:          &Filter{},
+			kind:            KindContainer,
+			expectMatchKind: true,
+		},
+		{
+			name:            "unmatched kind",
+			filter:          &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: EntityFilterFuncAcceptAll}},
+			kind:            KindKubernetesPod,
+			expectMatchKind: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.expectMatchKind {
+				assert.True(tt, test.filter.MatchKind(test.kind))
+			} else {
+				assert.False(tt, test.filter.MatchKind(test.kind))
+			}
+
+		})
+	}
+}
+
+func TestFilter_MatchEntity(t *testing.T) {
+	tests := []struct {
+		name        string
+		filter      *Filter
+		entity      Entity
+		expectMatch bool
+	}{
+		{
+			name:   "nil filter should match any entity",
+			filter: nil,
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name:   "matched entity with match all entity filter func",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: EntityFilterFuncAcceptAll}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name:   "unmatched entity due to missing key from map",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindKubernetesPod: EntityFilterFuncAcceptAll}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "unmatched entity due to entity filter func returning false",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: func(entity Entity) bool {
+				return false
+			}}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "matched container entity based on container id",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: func(entity Entity) bool {
+				contEntity, ok := entity.(*Container)
+				if !ok {
+					return false
+				}
+
+				return contEntity.ID == "cont-d"
+			}}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "unmatched container entity based on container id",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: func(entity Entity) bool {
+				contEntity, ok := entity.(*Container)
+				if !ok {
+					return false
+				}
+
+				return contEntity.ID == "cont-a"
+			}}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.expectMatch {
+				assert.True(tt, test.filter.MatchEntity(&test.entity))
+			} else {
+				assert.False(tt, !test.filter.MatchEntity(&test.entity))
+			}
+		})
+	}
+}
+
+func TestFilter_Kinds(t *testing.T) {
+	tests := []struct {
+		name          string
+		filter        *Filter
+		expectedKinds []Kind
+	}{
+		{
+			name:          "nil filter",
+			filter:        nil,
+			expectedKinds: nil,
+		},
+		{
+			name:          "filter with no kinds",
+			filter:        &Filter{},
+			expectedKinds: nil,
+		},
+		{
+			name: "matched kind due uninitialised kinds map",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{
+				KindContainer:     EntityFilterFuncAcceptAll,
+				KindKubernetesPod: EntityFilterFuncAcceptAll,
+			},
+			},
+			expectedKinds: []Kind{KindContainer, KindKubernetesPod},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(tt, len(test.filter.Kinds()), len(test.expectedKinds))
+			for _, item := range test.filter.Kinds() {
+				assert.Contains(tt, test.expectedKinds, item)
+			}
+		})
+	}
+}

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -132,7 +132,7 @@ func (w *workloadmeta) Subscribe(name string, priority wmdef.SubscriberPriority,
 
 			for _, cachedEntity := range entitiesOfKind {
 				entity := cachedEntity.get(sub.filter.Source())
-				if entity != nil {
+				if entity != nil && sub.filter.MatchEntity(&entity) {
 					events = append(events, wmdef.Event{
 						Type:   wmdef.EventTypeSet,
 						Entity: entity,
@@ -705,7 +705,7 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 
 		for _, sub := range w.subscribers {
 			filter := sub.filter
-			if !filter.MatchKind(entityID.Kind) || !filter.MatchSource(ev.Source) || !filter.MatchEventType(ev.Type) {
+			if !filter.MatchEntity(&ev.Entity) || !filter.MatchSource(ev.Source) || !filter.MatchEventType(ev.Type) {
 				// event should be filtered out because it
 				// doesn't match the filter
 				continue

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -202,7 +202,7 @@ func (w *workloadmeta) ListContainers() []*wmdef.Container {
 }
 
 // ListContainersWithFilter implements Store#ListContainersWithFilter
-func (w *workloadmeta) ListContainersWithFilter(filter wmdef.ContainerFilterFunc) []*wmdef.Container {
+func (w *workloadmeta) ListContainersWithFilter(filter wmdef.EntityFilterFunc[*wmdef.Container]) []*wmdef.Container {
 	entities := w.listEntitiesByKind(wmdef.KindContainer)
 
 	// Not very efficient
@@ -271,7 +271,7 @@ func (w *workloadmeta) ListProcesses() []*wmdef.Process {
 }
 
 // ListProcessesWithFilter implements Store#ListProcessesWithFilter
-func (w *workloadmeta) ListProcessesWithFilter(filter wmdef.ProcessFilterFunc) []*wmdef.Process {
+func (w *workloadmeta) ListProcessesWithFilter(filter wmdef.EntityFilterFunc[*wmdef.Process]) []*wmdef.Process {
 	entities := w.listEntitiesByKind(wmdef.KindProcess)
 
 	processes := make([]*wmdef.Process, 0, len(entities))

--- a/comp/core/workloadmeta/impl/store_example_test.go
+++ b/comp/core/workloadmeta/impl/store_example_test.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"testing"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 func TestExampleStoreSubscribe(t *testing.T) {
@@ -26,13 +27,7 @@ func TestExampleStoreSubscribe(t *testing.T) {
 
 	s := newWorkloadmetaObject(deps)
 
-	filterParams := wmdef.FilterParams{
-		Kinds:     []wmdef.Kind{wmdef.KindContainer},
-		Source:    wmdef.SourceRuntime,
-		EventType: wmdef.EventTypeAll,
-	}
-	filter := wmdef.NewFilter(&filterParams)
-
+	filter := wmdef.NewFilterBuilder().SetSource(wmdef.SourceRuntime).AddKind(wmdef.KindContainer).Build()
 	ch := s.Subscribe("test", wmdef.NormalPriority, filter)
 
 	go func() {

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -171,8 +171,8 @@ func TestSubscribe(t *testing.T) {
 			// if the filter has type "wmdef.EventTypeUnset", it does not receive
 			// events for entities that are currently in the store.
 			name:   "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
-			filter: NewFilterBuilder().SetSource(fooSource).SetEventType(EventTypeUnset).Build(),
-			preEvents: []CollectorEvent{
+			filter: wmdef.NewFilterBuilder().SetSource(fooSource).SetEventType(wmdef.EventTypeUnset).Build(),
+			preEvents: []wmdef.CollectorEvent{
 				{
 					Type:   wmdef.EventTypeSet,
 					Source: fooSource,
@@ -189,8 +189,8 @@ func TestSubscribe(t *testing.T) {
 			// that don't match the filter at all should not
 			// generate an event.
 			name:   "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilterBuilder().SetSource(fooSource).Build(),
-			preEvents: []CollectorEvent{
+			filter: wmdef.NewFilterBuilder().SetSource(fooSource).Build(),
+			preEvents: []wmdef.CollectorEvent{
 				// set container with two sources, delete one source
 				{
 					Type:   wmdef.EventTypeSet,
@@ -353,8 +353,8 @@ func TestSubscribe(t *testing.T) {
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
 			name:   "sets and unsets an entity with source filters",
-			filter: NewFilterBuilder().SetSource(fooSource).Build(),
-			postEvents: [][]CollectorEvent{
+			filter: wmdef.NewFilterBuilder().SetSource(fooSource).Build(),
+			postEvents: [][]wmdef.CollectorEvent{
 				{
 					{
 						Type:   wmdef.EventTypeSet,
@@ -517,8 +517,8 @@ func TestSubscribe(t *testing.T) {
 		},
 		{
 			name:   "filters by event type",
-			filter: NewFilterBuilder().SetEventType(EventTypeUnset).Build(),
-			postEvents: [][]CollectorEvent{
+			filter: wmdef.NewFilterBuilder().SetEventType(wmdef.EventTypeUnset).Build(),
+			postEvents: [][]wmdef.CollectorEvent{
 				{
 					{
 						Type:   wmdef.EventTypeSet,

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -170,12 +170,9 @@ func TestSubscribe(t *testing.T) {
 		{
 			// if the filter has type "wmdef.EventTypeUnset", it does not receive
 			// events for entities that are currently in the store.
-			name: "do not receive events for entities in the store pre-subscription if filter type is wmdef.EventTypeUnset",
-			filter: wmdef.NewFilter(&wmdef.FilterParams{
-				Source:    fooSource,
-				EventType: wmdef.EventTypeUnset,
-			}),
-			preEvents: []wmdef.CollectorEvent{
+			name:   "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
+			filter: NewFilterBuilder().SetSource(fooSource).SetEventType(EventTypeUnset).Build(),
+			preEvents: []CollectorEvent{
 				{
 					Type:   wmdef.EventTypeSet,
 					Source: fooSource,
@@ -191,12 +188,9 @@ func TestSubscribe(t *testing.T) {
 			// in the store, and match a filter by source. entities
 			// that don't match the filter at all should not
 			// generate an event.
-			name: "receive events for entities in the store pre-subscription with filter",
-			filter: wmdef.NewFilter(&wmdef.FilterParams{
-				Source:    fooSource,
-				EventType: wmdef.EventTypeAll,
-			}),
-			preEvents: []wmdef.CollectorEvent{
+			name:   "receive events for entities in the store pre-subscription with filter",
+			filter: NewFilterBuilder().SetSource(fooSource).Build(),
+			preEvents: []CollectorEvent{
 				// set container with two sources, delete one source
 				{
 					Type:   wmdef.EventTypeSet,
@@ -358,12 +352,9 @@ func TestSubscribe(t *testing.T) {
 			// setting an entity from two different sources, but
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
-			name: "sets and unsets an entity with source filters",
-			filter: wmdef.NewFilter(&wmdef.FilterParams{
-				Source:    fooSource,
-				EventType: wmdef.EventTypeAll,
-			}),
-			postEvents: [][]wmdef.CollectorEvent{
+			name:   "sets and unsets an entity with source filters",
+			filter: NewFilterBuilder().SetSource(fooSource).Build(),
+			postEvents: [][]CollectorEvent{
 				{
 					{
 						Type:   wmdef.EventTypeSet,
@@ -525,12 +516,9 @@ func TestSubscribe(t *testing.T) {
 			},
 		},
 		{
-			name: "filters by event type",
-			filter: wmdef.NewFilter(&wmdef.FilterParams{
-				Source:    wmdef.SourceAll,
-				EventType: wmdef.EventTypeUnset,
-			}),
-			postEvents: [][]wmdef.CollectorEvent{
+			name:   "filters by event type",
+			filter: NewFilterBuilder().SetEventType(EventTypeUnset).Build(),
+			postEvents: [][]CollectorEvent{
 				{
 					{
 						Type:   wmdef.EventTypeSet,

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -83,7 +83,7 @@ func (w *workloadMetaMock) ListContainers() []*wmdef.Container {
 }
 
 // ListContainersWithFilter returns metadata about the containers that pass the given filter.
-func (w *workloadMetaMock) ListContainersWithFilter(filter wmdef.ContainerFilterFunc) []*wmdef.Container {
+func (w *workloadMetaMock) ListContainersWithFilter(filter wmdef.EntityFilterFunc[*wmdef.Container]) []*wmdef.Container {
 	var res []*wmdef.Container
 
 	for _, container := range w.ListContainers() {
@@ -119,7 +119,7 @@ func (w *workloadMetaMock) ListProcesses() []*wmdef.Process {
 }
 
 // ListProcessesWithFilter implements workloadMetaMock#ListProcessesWithFilter.
-func (w *workloadMetaMock) ListProcessesWithFilter(filter wmdef.ProcessFilterFunc) []*wmdef.Process {
+func (w *workloadMetaMock) ListProcessesWithFilter(filter wmdef.EntityFilterFunc[*wmdef.Process]) []*wmdef.Process {
 	var res []*wmdef.Process
 
 	for _, process := range w.ListProcesses() {

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -455,22 +455,17 @@ func toProtoLaunchType(launchType workloadmeta.ECSLaunchType) (pb.ECSLaunchType,
 func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*workloadmeta.Filter, error) {
 	if protoFilter == nil {
 		// Return filter that subscribes to everything
-		filterParams := workloadmeta.FilterParams{
-			Source:    workloadmeta.SourceAll,
-			EventType: workloadmeta.EventTypeAll,
-		}
-		return workloadmeta.NewFilter(&filterParams), nil
+		return workloadmeta.NewFilterBuilder().Build(), nil
 	}
 
-	var kinds []workloadmeta.Kind
+	filterBuilder := workloadmeta.NewFilterBuilder()
 
 	for _, protoKind := range protoFilter.Kinds {
 		kind, err := toWorkloadmetaKind(protoKind)
 		if err != nil {
 			return nil, err
 		}
-
-		kinds = append(kinds, kind)
+		filterBuilder = filterBuilder.AddKind(kind)
 	}
 
 	source, err := toWorkloadmetaSource(protoFilter.Source)
@@ -483,12 +478,11 @@ func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*wor
 		return nil, err
 	}
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     kinds,
-		Source:    source,
-		EventType: eventType,
-	}
-	return workloadmeta.NewFilter(&filterParams), nil
+	filter := filterBuilder.
+		SetEventType(eventType).
+		SetSource(source).Build()
+
+	return filter, nil
 }
 
 // WorkloadmetaEventFromProtoEvent converts the given protobuf workloadmeta event into a workloadmeta.Event

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -381,13 +381,12 @@ func TestConversions(t *testing.T) {
 }
 
 func TestProtobufFilterFromWorkloadmetaFilter(t *testing.T) {
-	filter := workloadmeta.NewFilter(
-		&workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-			Source:    workloadmeta.SourceRuntime,
-			EventType: workloadmeta.EventTypeSet,
-		},
-	)
+
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceRuntime).
+		SetEventType(workloadmeta.EventTypeSet).
+		AddKind(workloadmeta.KindContainer).
+		Build()
 
 	protoFilter, err := ProtobufFilterFromWorkloadmetaFilter(filter)
 	require.NoError(t, err)

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -150,19 +150,15 @@ func (c *client) stop(_ context.Context) error {
 func (c *client) run() {
 	defer c.logger.Info("Shutting down language detection client")
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds: []workloadmeta.Kind{
-			workloadmeta.KindKubernetesPod, // Subscribe to pod events to clean up the current batch when a pod is deleted
-			workloadmeta.KindProcess,       // Subscribe to process events to populate the current batch
-		},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		AddKind(workloadmeta.KindProcess).
+		AddKind(workloadmeta.KindKubernetesPod).
+		Build()
 
 	eventCh := c.store.Subscribe(
 		subscriber,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 	defer c.store.Unsubscribe(eventCh)
 

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -65,12 +65,10 @@ func NewContainerTagger(wmeta workloadmeta.Component) (*ContainerTagger, error) 
 // Cancel the context to stop the container tagger.
 func (c *ContainerTagger) Start(ctx context.Context) {
 	go func() {
-		filterParams := workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-			Source:    workloadmeta.SourceClusterOrchestrator,
-			EventType: workloadmeta.EventTypeAll,
-		}
-		filter := workloadmeta.NewFilter(&filterParams)
+		filter := workloadmeta.NewFilterBuilder().
+			SetSource(workloadmeta.SourceClusterOrchestrator).
+			AddKind(workloadmeta.KindContainer).
+			Build()
 
 		ch := c.store.Subscribe(componentName, workloadmeta.NormalPriority, filter)
 		defer c.store.Unsubscribe(ch)

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher.go
@@ -75,15 +75,12 @@ func (pw *podWatcherImpl) GetPodsForOwner(owner NamespacedPodOwner) []*workloadm
 // Start subscribes to workloadmeta events and indexes pods by their owner.
 func (pw *podWatcherImpl) Run(ctx context.Context) {
 	log.Debug("Starting PodWatcher")
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
+
+	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindKubernetesPod).Build()
 	ch := pw.wlm.Subscribe(
 		"app-autoscaler-pod-watcher",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 	defer pw.wlm.Unsubscribe(ch)
 

--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -122,19 +122,15 @@ func (lp *languagePatcher) run(ctx context.Context) {
 	lp.startProcessingPatchingRequests(ctx)
 
 	// Capture all set events
-	filterParams := workloadmeta.FilterParams{
-		Kinds: []workloadmeta.Kind{
-			// Currently only deployments are supported
-			workloadmeta.KindKubernetesDeployment,
-		},
-		Source:    workloadmeta.SourceLanguageDetectionServer,
-		EventType: workloadmeta.EventTypeAll,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceLanguageDetectionServer).
+		AddKind(workloadmeta.KindKubernetesDeployment).
+		Build()
 
 	eventCh := lp.store.Subscribe(
 		subscriber,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 	defer lp.store.Unsubscribe(eventCh)
 

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -133,15 +133,15 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeSet, // We don’t care about images removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		SetEventType(workloadmeta.EventTypeSet).
+		AddKind(workloadmeta.KindContainerImageMetadata).
+		Build()
+
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		CheckName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 
 	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -134,7 +134,7 @@ func (c *Check) Run() error {
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
 	filter := workloadmeta.NewFilterBuilder().
-		SetEventType(workloadmeta.EventTypeSet).
+		SetEventType(workloadmeta.EventTypeSet). // We don’t care about images removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
 		AddKind(workloadmeta.KindContainerImageMetadata).
 		Build()
 

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -91,39 +91,43 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
-	containerFilterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-		Source:    workloadmeta.SourceRuntime,
-		EventType: workloadmeta.EventTypeUnset,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceRuntime).
+		SetEventType(workloadmeta.EventTypeUnset).
+		AddKind(workloadmeta.KindContainer).
+		Build()
+
 	contEventsCh := c.workloadmetaStore.Subscribe(
 		CheckName+"-cont",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&containerFilterParams),
+		filter,
 	)
 
-	podFilterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-		Source:    workloadmeta.SourceNodeOrchestrator,
-		EventType: workloadmeta.EventTypeUnset,
-	}
+	podFilter := workloadmeta.NewFilterBuilder().
+		SetSource(workloadmeta.SourceNodeOrchestrator).
+		SetEventType(workloadmeta.EventTypeUnset).
+		AddKind(workloadmeta.KindKubernetesPod).
+		Build()
+
 	podEventsCh := c.workloadmetaStore.Subscribe(
 		CheckName+"-pod",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&podFilterParams),
+		podFilter,
 	)
 
 	var taskEventsCh chan workloadmeta.EventBundle
 	if ddConfig.Datadog().GetBool("container_lifecycle.ecs_task_event.enabled") {
-		taskFilterParams := workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindECSTask},
-			Source:    workloadmeta.SourceNodeOrchestrator,
-			EventType: workloadmeta.EventTypeUnset,
-		}
+
+		taskFilter := workloadmeta.NewFilterBuilder().
+			SetSource(workloadmeta.SourceNodeOrchestrator).
+			SetEventType(workloadmeta.EventTypeUnset).
+			AddKind(workloadmeta.KindECSTask).
+			Build()
+
 		taskEventsCh = c.workloadmetaStore.Subscribe(
 			CheckName+"-task",
 			workloadmeta.NormalPriority,
-			workloadmeta.NewFilter(&taskFilterParams),
+			taskFilter,
 		)
 	}
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -167,19 +167,15 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds: []workloadmeta.Kind{
-			workloadmeta.KindContainerImageMetadata,
-			workloadmeta.KindContainer,
-		},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
+	filter := workloadmeta.NewFilterBuilder().
+		AddKind(workloadmeta.KindContainer).
+		AddKind(workloadmeta.KindContainerImageMetadata).
+		Build()
 
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		CheckName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&filterParams),
+		filter,
 	)
 
 	// Trigger an initial scan on host. This channel is buffered to avoid blocking the scanner

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -63,12 +63,7 @@ func (c *Collector) Start(ctx context.Context, store workloadmeta.Component) err
 		c.ddConfig.GetDuration("workloadmeta.local_process_collector.collection_interval"),
 	)
 
-	filterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
-	filter := workloadmeta.NewFilter(&filterParams)
+	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
 	containerEvt := store.Subscribe(collectorId, workloadmeta.NormalPriority, filter)
 
 	go c.run(ctx, store, containerEvt, collectionTicker)

--- a/pkg/util/containers/metrics/system/filter_container.go
+++ b/pkg/util/containers/metrics/system/filter_container.go
@@ -40,13 +40,9 @@ func (cf *containerFilter) start() {
 	if cf.wlm == nil {
 		return
 	}
-	evBundle := cf.wlm.Subscribe("cid-mapper", workloadmeta.NormalPriority, workloadmeta.NewFilter(
-		&workloadmeta.FilterParams{
-			Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
-			Source:    workloadmeta.SourceAll,
-			EventType: workloadmeta.EventTypeAll,
-		},
-	))
+	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
+
+	evBundle := cf.wlm.Subscribe("cid-mapper", workloadmeta.NormalPriority, filter)
 	for evs := range evBundle {
 		evs.Acknowledge()
 		cf.mutex.Lock()

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -78,16 +78,12 @@ func (m *metadataController) run(stopCh <-chan struct{}) {
 		return
 	}
 
-	wmetaFilterParams := workloadmeta.FilterParams{
-		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesNode},
-		Source:    workloadmeta.SourceAll,
-		EventType: workloadmeta.EventTypeAll,
-	}
+	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindKubernetesNode).Build()
 
 	wmetaEventsCh := m.wmeta.Subscribe(
 		"metadata-controller",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(&wmetaFilterParams),
+		filter,
 	)
 	defer m.wmeta.Unsubscribe(wmetaEventsCh)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR allows components to subscribe to workloadmeta with entity level filtering. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Currently, a subscriber to workloadmeta needs to provide a filter that includes the following:
- Source
- Event Type
- List of kinds

In some scenarios, we have a need to subscribe to workloadmeta with a filter on the entity level, not only on the event and kind level. For example, a component might need to subscribe to metadata events for namespaces. Metadata are stored in the `KubernetesMetadata` entity. To subscribe only to namespace metadata updates, we need to specify to workloadmeta that the subscriber wants to receive events on `KubernetesMetadata` entity kind that has the GVR field equal to that of namespaces. 

This PR adds this capability by allowing subscribers to provide an entity filter function for each kind so that only events matching the following conditions are received by the subscriber:
- Event type matches the filter event type
- Event Source matches the filter event source
- The entity filter function of the entity kind returns true when applied to the entity instances.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- To improve design, I refactored workloadmeta filter to use the builder pattern.
- We can use this generic filtering for all exposed Listing methods of workloadmeta. I will open a new PR to include this.

### Possible Drawbacks / Trade-offs
- None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No specific QA is needed. Generic QA and E2E should be enough.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
