### PR TITLE
upgrade(installer): Add installer commands to instrument / uninstrument host & docker

### DIFF
--- a/cmd/installer/command/command.go
+++ b/cmd/installer/command/command.go
@@ -71,6 +71,10 @@ Datadog Installer installs datadog-packages based on your commands.`,
 			ID:    "bootstrap",
 			Title: "Bootstrap Commands",
 		},
+		&cobra.Group{
+			ID:    "apm",
+			Title: "APM Commands",
+		},
 	)
 
 	agentCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "cfgpath", "c", "", "path to directory containing installer.yaml")

--- a/cmd/installer/subcommands/installer/apm.go
+++ b/cmd/installer/subcommands/installer/apm.go
@@ -21,8 +21,8 @@ func apmCommands() *cobra.Command {
 
 func apmInstrumentCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "instrument [all|host|container]",
-		Short: "Instrument APM auto-injection for a host or container. Defaults to both.",
+		Use:   "instrument [all|host|docker]",
+		Short: "Instrument APM auto-injection for a host or docker. Defaults to both.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("apm_instrument")
@@ -42,8 +42,8 @@ func apmInstrumentCommand() *cobra.Command {
 
 func apmUninstrumentCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "uninstrument [all|host|container]",
-		Short: "Uninstrument APM auto-injection for a host or container. Defaults to both.",
+		Use:   "uninstrument [all|host|docker]",
+		Short: "Uninstrument APM auto-injection for a host or docker. Defaults to both.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			i, err := newInstallerCmd("apm_uninstrument")

--- a/cmd/installer/subcommands/installer/apm.go
+++ b/cmd/installer/subcommands/installer/apm.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func apmCommands() *cobra.Command {
+	ctlCmd := &cobra.Command{
+		Use:     "apm [command]",
+		Short:   "Interact with the APM auto-injector",
+		GroupID: "apm",
+	}
+	ctlCmd.AddCommand(apmInstrumentCommand(), apmUninstrumentCommand())
+	return ctlCmd
+}
+
+func apmInstrumentCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "instrument [all|host|container]",
+		Short: "Instrument APM auto-injection for a host or container. Defaults to both.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) (err error) {
+			i, err := newInstallerCmd("apm_instrument")
+			if err != nil {
+				return err
+			}
+			defer func() { i.Stop(err) }()
+			if len(args) == 0 {
+				args = []string{"not_set"}
+			}
+			i.span.SetTag("params.instrument", args[0])
+			return i.InstrumentAPMInjector(i.ctx, args[0])
+		},
+	}
+	return cmd
+}
+
+func apmUninstrumentCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstrument [all|host|container]",
+		Short: "Uninstrument APM auto-injection for a host or container. Defaults to both.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) (err error) {
+			i, err := newInstallerCmd("apm_uninstrument")
+			if err != nil {
+				return err
+			}
+			defer func() { i.Stop(err) }()
+			if len(args) == 0 {
+				args = []string{"not_set"}
+			}
+			i.span.SetTag("params.instrument", args[0])
+			return i.UninstrumentAPMInjector(i.ctx, args[0])
+		},
+	}
+	return cmd
+}

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -46,7 +46,18 @@ const (
 
 // Commands returns the installer subcommands.
 func Commands(_ *command.GlobalParams) []*cobra.Command {
-	return []*cobra.Command{bootstrapCommand(), installCommand(), removeCommand(), installExperimentCommand(), removeExperimentCommand(), promoteExperimentCommand(), garbageCollectCommand(), purgeCommand(), isInstalledCommand()}
+	return []*cobra.Command{
+		bootstrapCommand(),
+		installCommand(),
+		removeCommand(),
+		installExperimentCommand(),
+		removeExperimentCommand(),
+		promoteExperimentCommand(),
+		garbageCollectCommand(),
+		purgeCommand(),
+		isInstalledCommand(),
+		apmCommands(),
+	}
 }
 
 // UnprivilegedCommands returns the unprivileged installer subcommands.

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -76,6 +76,16 @@ func (m *testPackageManager) GarbageCollect(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (m *testPackageManager) InstrumentAPMInjector(ctx context.Context, method string) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *testPackageManager) UninstrumentAPMInjector(ctx context.Context, method string) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 type testRemoteConfigClient struct {
 	listeners map[string][]client.Handler
 }

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -77,12 +77,12 @@ func (m *testPackageManager) GarbageCollect(ctx context.Context) error {
 }
 
 func (m *testPackageManager) InstrumentAPMInjector(ctx context.Context, method string) error {
-	args := m.Called(ctx)
+	args := m.Called(ctx, method)
 	return args.Error(0)
 }
 
 func (m *testPackageManager) UninstrumentAPMInjector(ctx context.Context, method string) error {
-	args := m.Called(ctx)
+	args := m.Called(ctx, method)
 	return args.Error(0)
 }
 

--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -87,10 +87,7 @@ type apmInjectorInstaller struct {
 
 // Setup sets up the APM injector
 func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
-	err := a.Instrument(ctx)
-	if err != nil {
-		return err
-	}
+	var err error
 
 	// Set up defaults for agent sockets
 	if err := configureSocketsEnv(ctx); err != nil {
@@ -120,7 +117,7 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 		return fmt.Errorf("error changing permissions on /var/log/datadog/dotnet: %w", err)
 	}
 
-	return nil
+	return a.Instrument(ctx)
 }
 
 // Instrument instruments the APM injector

--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"go.uber.org/multierr"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -42,7 +43,7 @@ func RemoveAPMInjector(ctx context.Context) error {
 	span, ctx := tracer.StartSpanFromContext(ctx, "remove_injector")
 	defer span.Finish()
 	installer := newAPMInjectorInstaller(injectorPath)
-	return installer.Remove(ctx)
+	return installer.Uninstrument(ctx)
 }
 
 func newAPMInjectorInstaller(path string) *apmInjectorInstaller {
@@ -65,9 +66,31 @@ type apmInjectorInstaller struct {
 }
 
 // Setup sets up the APM injector
-func (a *apmInjectorInstaller) Setup(ctx context.Context) (retErr error) {
+func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
+	err := a.Instrument(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Set up defaults for agent sockets
+	if err := configureSocketsEnv(ctx); err != nil {
+		return err
+	}
+	if err := addSystemDEnvOverrides(ctx, agentUnit); err != nil {
+		return err
+	}
+	if err := addSystemDEnvOverrides(ctx, agentExp); err != nil {
+		return err
+	}
+	if err := addSystemDEnvOverrides(ctx, traceAgentUnit); err != nil {
+		return err
+	}
+	if err := addSystemDEnvOverrides(ctx, traceAgentExp); err != nil {
+		return err
+	}
+
 	// /var/log/datadog is created by default with datadog-installer install
-	err := os.Mkdir("/var/log/datadog/dotnet", 0777)
+	err = os.Mkdir("/var/log/datadog/dotnet", 0777)
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("error creating /var/log/datadog/dotnet: %w", err)
 	}
@@ -76,7 +99,13 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("error changing permissions on /var/log/datadog/dotnet: %w", err)
 	}
-	// Check if the shared library is working before adding it to the preload
+
+	return nil
+}
+
+// Instrument instruments the APM injector
+func (a *apmInjectorInstaller) Instrument(ctx context.Context) (retErr error) {
+	// Check if the shared library is working before any instrumentation
 	if err := a.verifySharedLib(ctx, path.Join(a.installPath, "inject", "launcher.preload.so")); err != nil {
 		return err
 	}
@@ -88,9 +117,9 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) (retErr error) {
 			return err
 		}
 		defer func() {
-			if retErr != nil && rollbackLDPreload != nil {
+			if retErr != nil {
 				if err := rollbackLDPreload(); err != nil {
-					log.Warnf("Failed to rollback agent config: %v", err)
+					log.Warnf("Failed to rollback host instrumentation: %v", err)
 				}
 			}
 		}()
@@ -101,14 +130,14 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) (retErr error) {
 		return fmt.Errorf("DD_APM_INSTRUMENTATION_ENABLED is set to docker but docker is not installed")
 	}
 	if shouldInstrumentDocker(envs) && dockerIsInstalled {
-		rollbackDockerConfig, err := a.setupDocker(ctx)
+		rollbackDocker, err := a.instrumentDocker(ctx)
 		if err != nil {
 			return err
 		}
 		defer func() {
-			if retErr != nil && rollbackDockerConfig != nil {
-				if err := rollbackDockerConfig(); err != nil {
-					log.Warnf("Failed to rollback agent config: %v", err)
+			if retErr != nil {
+				if err := rollbackDocker(); err != nil {
+					log.Warnf("Failed to rollback docker instrumentation: %v", err)
 				}
 			}
 		}()
@@ -119,31 +148,14 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) (retErr error) {
 		}
 	}
 
-	// Set up defaults for agent sockets
-	if err = configureSocketsEnv(ctx); err != nil {
-		return err
-	}
-	if err = addSystemDEnvOverrides(ctx, agentUnit); err != nil {
-		return err
-	}
-	if err = addSystemDEnvOverrides(ctx, agentExp); err != nil {
-		return err
-	}
-	if err = addSystemDEnvOverrides(ctx, traceAgentUnit); err != nil {
-		return err
-	}
-	return addSystemDEnvOverrides(ctx, traceAgentExp)
+	return nil
 }
 
-func (a *apmInjectorInstaller) Remove(ctx context.Context) error {
-	if _, err := a.ldPreloadFileUninstrument.mutate(ctx); err != nil {
-		log.Warnf("Failed to remove ld preload config: %v", err)
-	}
-	if err := a.uninstallDocker(ctx); err != nil {
-		log.Warnf("Failed to remove docker config: %v", err)
-	}
-	// TODO: return error to caller?
-	return nil
+// Uninstrument uninstruments the APM injector
+func (a *apmInjectorInstaller) Uninstrument(ctx context.Context) error {
+	dockerErr := a.uninstrumentDocker(ctx)
+	_, hostErr := a.ldPreloadFileUninstrument.mutate(ctx)
+	return multierr.Combine(dockerErr, hostErr)
 }
 
 // setLDPreloadConfigContent sets the content of the LD preload configuration

--- a/pkg/fleet/installer/service/apm_inject_windows.go
+++ b/pkg/fleet/installer/service/apm_inject_windows.go
@@ -17,3 +17,9 @@ func SetupAPMInjector(_ context.Context) error {
 
 // RemoveAPMInjector noop
 func RemoveAPMInjector(_ context.Context) error { return nil }
+
+// InstrumentAPMInjector noop
+func InstrumentAPMInjector(_ context.Context, _ string) error { return nil }
+
+// UninstrumentAPMInjector noop
+func UninstrumentAPMInjector(_ context.Context, _ string) error { return nil }

--- a/pkg/fleet/installer/service/file.go
+++ b/pkg/fleet/installer/service/file.go
@@ -20,6 +20,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
+var rollbackNoop = func() error { return nil }
+
 // fileMutator is a struct used to transform a file
 // creating backups, replacing original files and setting permissions
 // default permissions are root:root 0644
@@ -80,7 +82,7 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 
 	// no changes needed
 	if bytes.Equal(data, res) {
-		return nil, nil
+		return rollbackNoop, nil
 	}
 
 	if err := writeFile(ft.pathTmp, res); err != nil {

--- a/pkg/fleet/installer/service/file_test.go
+++ b/pkg/fleet/installer/service/file_test.go
@@ -63,7 +63,7 @@ func TestNoChangesNeeded(t *testing.T) {
 	}, nil, nil)
 
 	rollback, err := mutator.mutate(context.TODO())
-	require.Nil(t, rollback)
+	require.Nil(t, rollback())
 	require.NoError(t, err)
 	assertFile(t, originalPath, originalContent, mode)
 }

--- a/pkg/fleet/internal/exec/installer_exec.go
+++ b/pkg/fleet/internal/exec/installer_exec.go
@@ -108,6 +108,20 @@ func (i *InstallerExec) GarbageCollect(ctx context.Context) (err error) {
 	return cmd.Run()
 }
 
+// InstrumentAPMInjector instruments the APM auto-injector.
+func (i *InstallerExec) InstrumentAPMInjector(ctx context.Context, method string) (err error) {
+	cmd := i.newInstallerCmd(ctx, "apm instrument", method)
+	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	return cmd.Run()
+}
+
+// UninstrumentAPMInjector uninstruments the APM auto-injector.
+func (i *InstallerExec) UninstrumentAPMInjector(ctx context.Context, method string) (err error) {
+	cmd := i.newInstallerCmd(ctx, "apm uninstrument", method)
+	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	return cmd.Run()
+}
+
 // IsInstalled checks if a package is installed.
 func (i *InstallerExec) IsInstalled(ctx context.Context, pkg string) (_ bool, err error) {
 	cmd := i.newInstallerCmd(ctx, "is-installed", pkg)

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -53,7 +53,7 @@ var (
 		e2eos.AmazonLinux2,
 		e2eos.Suse15,
 	}
-	packagesTestsWithSkipedFlavors = []packageTestsWithSkipedFlavors{
+	packagesTestsWithSkippedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
 		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15}},
@@ -91,7 +91,7 @@ func TestPackages(t *testing.T) {
 		flavors = append(flavors, flavor)
 	}
 	for _, f := range flavors {
-		for _, test := range packagesTestsWithSkipedFlavors {
+		for _, test := range packagesTestsWithSkippedFlavors {
 			flavor := f // capture range variable for parallel tests closure
 			if shouldSkip(test.skippedFlavors, flavor) {
 				continue

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -90,6 +90,10 @@ func (h *Host) InstallDocker() {
 
 // GetDockerRuntimePath returns the runtime path of a docker runtime
 func (h *Host) GetDockerRuntimePath(runtime string) string {
+	if _, err := h.remote.Execute("command -v docker"); err != nil {
+		return ""
+	}
+
 	var cmd string
 	switch h.os.Flavor {
 	case e2eos.AmazonLinux:


### PR DESCRIPTION
### What does this PR do?
- Refactors a bit the injector setup to extract the `Instrument` & `Uninstrument` methods
- Create `datadog-installer` commands for these methods

<ins>In the next PR</ins> I'll make the install replace the deb injector install scripts to execute these new commands instead.

### Motivation


### Additional Notes
Corresponding system-tests PR (needs an installer staging release): TODO


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

