### PR TITLE
Use a separate ReceiverTimeout value for EVPProxy handlers

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -641,6 +641,9 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "evp_proxy_config.max_payload_size"; core.IsSet(k) {
 		c.EVPProxy.MaxPayloadSize = core.GetInt64(k)
 	}
+	if k := "evp_proxy_config.receiver_timeout"; core.IsSet(k) {
+		c.EVPProxy.ReceiverTimeout = core.GetInt(k)
+	}
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	return nil
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -863,6 +863,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnv("evp_proxy_config.api_key")
 	config.BindEnv("evp_proxy_config.additional_endpoints")
 	config.BindEnv("evp_proxy_config.max_payload_size")
+	config.BindEnv("evp_proxy_config.receiver_timeout")
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -7,6 +7,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
@@ -22,6 +23,10 @@ type Endpoint struct {
 	// Hidden reports whether this endpoint should be hidden in the /info
 	// discovery endpoint.
 	Hidden bool
+
+	// TimeoutOverride lets you specify a timeout for this endpoint that will be used
+	// instead of the default one from conf.ReceiverTimeout
+	TimeoutOverride func(conf *config.AgentConfig) time.Duration
 
 	// IsEnabled specifies a function which reports whether this endpoint should be enabled
 	// based on the given config conf.
@@ -109,20 +114,24 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.pipelineStatsProxyHandler() },
 	},
 	{
-		Pattern: "/evp_proxy/v1/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(1) },
+		Pattern:         "/evp_proxy/v1/",
+		Handler:         func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(1) },
+		TimeoutOverride: getConfiguredEVPRequestTimeoutDuration,
 	},
 	{
-		Pattern: "/evp_proxy/v2/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
+		Pattern:         "/evp_proxy/v2/",
+		Handler:         func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
+		TimeoutOverride: getConfiguredEVPRequestTimeoutDuration,
 	},
 	{
-		Pattern: "/evp_proxy/v3/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(3) },
+		Pattern:         "/evp_proxy/v3/",
+		Handler:         func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(3) },
+		TimeoutOverride: getConfiguredEVPRequestTimeoutDuration,
 	},
 	{
-		Pattern: "/evp_proxy/v4/",
-		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(4) },
+		Pattern:         "/evp_proxy/v4/",
+		Handler:         func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(4) },
+		TimeoutOverride: getConfiguredEVPRequestTimeoutDuration,
 	},
 	{
 		Pattern: "/debugger/v1/input",

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -13,6 +13,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
 	"strings"
 	"time"
 
@@ -177,6 +178,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 
 	// Timeout: Our outbound request(s) can't take longer than the WriteTimeout of the server
 	timeout := getConfiguredEVPRequestTimeoutDuration(t.conf)
+	req.Header.Set("X-Datadog-Timeout", strconv.Itoa((int(timeout.Seconds()))))
 	deadline := time.Now().Add(timeout)
 	ctx, ctxCancel := context.WithDeadline(req.Context(), deadline)
 	req = req.WithContext(ctx)

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -176,7 +176,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	}
 
 	// Timeout: Our outbound request(s) can't take longer than the WriteTimeout of the server
-	timeout := getConfiguredRequestTimeoutDuration(t.conf)
+	timeout := getConfiguredEVPRequestTimeoutDuration(t.conf)
 	deadline := time.Now().Add(timeout)
 	ctx, ctxCancel := context.WithDeadline(req.Context(), deadline)
 	req = req.WithContext(ctx)

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -469,7 +469,7 @@ func TestE2E(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
-		conf.ReceiverTimeout = 1 // in seconds
+		conf.EVPProxy.ReceiverTimeout = 1 // in seconds
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(2 * time.Second)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -224,6 +224,8 @@ type EVPProxy struct {
 	AdditionalEndpoints map[string][]string
 	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes.
 	MaxPayloadSize int64
+	// ReceiverTimeout indicates the maximum time an EVPProxy request can take. Value in seconds.
+	ReceiverTimeout int
 }
 
 // InstallSignatureConfig contains the information on how the agent was installed


### PR DESCRIPTION
### What does this PR do?

Allows configuring the timeout per-handler instead of it being set at the Server level, and sets a different value with a higher default for EVPProxy requests.

### Motivation

CI Visibility's Intelligent Test Runner makes requests that take can ~10 seconds.

### Describe how to test/QA your changes

Set a low EVP timeout value (eg: 1 sec), eg:
```
evp_proxy_config:
    receiver_timeout: 1
```

Check that connections that take longer than 1 second are aborted with an error. You might need an endpoint that takes a bit to respond, for example (assuming the trace-agent is listening on the port 8126): 

Failed request:
```
$ time curl  -w "\nStatus: %{http_code}"   --location 'http://127.0.0.1:8126/evp_proxy/v1/api/v2/ci/tests/skippable' --header 'Content-Type: application/json' --header 'X-Datadog-EVP-Subdomain: api' --data '{
    "data": {
        "type": "test_params",
        "attributes": {
            "configurations": {
                "os.platform": "linux",
                "os.version": "6.5.0-azure",
                "os.architecture": "x64",
                "runtime.name": "node",
                "runtime.version": "v16.20.2"
            },
            "env": "ci",
            "repository_url": "https://github.com/DataDog/datadog-ci.git",
            "service": "datadog-ci-tests",
            "test_level": "test",
            "sha": "bff12e212215133d0eb59ae1814d052a2ee886c2"
        }
    }
}'

Status: 502
real	0m1.033s
user	0m0.007s
sys	0m0.012s
```

Successful request:
```
$ time curl  -w "\nStatus: %{http_code}"   --location 'http://127.0.0.1:8126/evp_proxy/v1/api/v2/ci/tests/skippable' --header 'Content-Type: application/json' --header 'X-Datadog-EVP-Subdomain: api' --data '{
    "data": {
        "type": "test_params",
        "attributes": {
            "configurations": {
                "os.platform": "linux",
                "os.version": "6.5.0-azure",
                "os.architecture": "x64",
                "runtime.name": "node",
                "runtime.version": "v16.20.2"
            },
            "env": "ci",
            "repository_url": "https://github.com/DataDog/datadog-ci.git",
            "service": "datadog-ci-tests",
            "test_level": "test",
            "sha": "bff12e212215133d0eb59ae1814d052a2ee886c2"
        }
    }
}'
{"data":[],"meta":{"correlation_id":"16808e3c8b59d60d426a9da406202e74"}}
Status: 200
real	0m0.965s
user	0m0.005s
sys	0m0.008s
```

Note: the backend caches the response based on the commit sha, so the second time you make the same request will be faster (although usually still takes ~1 second). Use a different commit from the datadog-ci repo on each request to avoid the cache.