### PR TITLE
usm: http2: Fixed extraction of request method length if method is in  the dynamic table

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-tls.h
@@ -343,7 +343,7 @@ static __always_inline void tls_process_headers(tls_dispatcher_arguments_t *info
             } else if (is_method_index(dynamic_value->original_index)) {
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                current_stream->request_method.length = current_header->new_dynamic_value_size;
+                current_stream->request_method.length = dynamic_value->string_len;
                 current_stream->request_method.finalized = true;
             }
         } else {

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -240,7 +240,7 @@ static __always_inline void process_headers(struct __sk_buff *skb, dynamic_table
             }  else if (is_method_index(dynamic_value->original_index)) {
                 bpf_memcpy(current_stream->request_method.raw_buffer, dynamic_value->buffer, HTTP2_METHOD_MAX_LEN);
                 current_stream->request_method.is_huffman_encoded = dynamic_value->is_huffman_encoded;
-                current_stream->request_method.length = current_header->new_dynamic_value_size;
+                current_stream->request_method.length = dynamic_value->string_len;
                 current_stream->request_method.finalized = true;
             }
         } else {

--- a/pkg/network/protocols/http2/raw_traffic.go
+++ b/pkg/network/protocols/http2/raw_traffic.go
@@ -21,11 +21,8 @@ type HeadersFrameOptions struct {
 	EndStream              bool
 }
 
-// NewHeadersFrameMessage creates a new HTTP2 data frame message with the given header fields.
-func NewHeadersFrameMessage(frameOptions HeadersFrameOptions) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := hpack.NewEncoder(&buf)
-
+// NewHeadersFrameMessageWithEncoder creates a new HTTP2 data frame message with the given header fields. Uses the provided encoder to encode the headers.
+func NewHeadersFrameMessageWithEncoder(enc *hpack.Encoder, frameOptions HeadersFrameOptions) error {
 	if frameOptions.DynamicTableUpdateSize > 0 {
 		// we set the max dynamic table size to 100 to be able to test different cases of literal header parsing.
 		enc.SetMaxDynamicTableSizeLimit(frameOptions.DynamicTableUpdateSize)
@@ -33,8 +30,20 @@ func NewHeadersFrameMessage(frameOptions HeadersFrameOptions) ([]byte, error) {
 
 	for _, value := range frameOptions.Headers {
 		if err := enc.WriteField(value); err != nil {
-			return nil, fmt.Errorf("error encoding field: %w", err)
+			return fmt.Errorf("error encoding field: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// NewHeadersFrameMessage creates a new HTTP2 data frame message with the given header fields.
+func NewHeadersFrameMessage(frameOptions HeadersFrameOptions) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := hpack.NewEncoder(&buf)
+
+	if err := NewHeadersFrameMessageWithEncoder(enc, frameOptions); err != nil {
+		return nil, err
 	}
 
 	return buf.Bytes(), nil

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -796,8 +796,9 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 			name: "validate http methods",
 			// The purpose of this test is to validate that we are able to capture all http methods.
 			messageBuilder: func() [][]byte {
-				httpMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete,
+				httpMethods := []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete,
 					http.MethodPut, http.MethodPatch, http.MethodOptions, http.MethodTrace, http.MethodConnect}
+				// Duplicating the list to have each method appearing twice
 				httpMethods = append(httpMethods, httpMethods...)
 				// Currently, the methods TRACE and CONNECT are not supported by the http.Method package.
 				// Therefore, we mark those requests as incomplete and not expected to be captured.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixing possible wrong length for the request method if it exists in the dynamic table

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Issues surfaced through logs.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
