### PR TITLE
[CONTINT-4216] Make the `oom_kill` check capture the `oom_score`

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
@@ -17,6 +17,8 @@ struct oom_stats {
     char fcomm[TASK_COMM_LEN];
     // Name of killed process
     char tcomm[TASK_COMM_LEN];
+    // OOM score of killed process
+    __s64 score;
     // Total number of pages
     __u64 pages;
     // Tracks if the OOM kill was triggered by a cgroup

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
@@ -19,6 +19,8 @@ struct oom_stats {
     char tcomm[TASK_COMM_LEN];
     // OOM score of killed process
     __s64 score;
+    // OOM score adjustment of killed process
+    __s16 score_adj;
     // Total number of pages
     __u64 pages;
     // Tracks if the OOM kill was triggered by a cgroup

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -51,6 +51,7 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
         return 0;
     }
     BPF_CORE_READ_INTO(&new.tpid, p, pid);
+    BPF_CORE_READ_INTO(&new.score, oc, chosen_points);
 
     if (bpf_helper_exists(BPF_FUNC_get_current_comm)) {
         bpf_get_current_comm(new.fcomm, sizeof(new.fcomm));

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -52,7 +52,15 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     }
     BPF_CORE_READ_INTO(&new.tpid, p, pid);
     BPF_CORE_READ_INTO(&new.score, oc, chosen_points);
-
+#ifdef COMPILE_CORE
+    if (bpf_core_field_exists(p->signal->oom_score_adj)) {
+        BPF_CORE_READ_INTO(&new.score_adj, p, signal, oom_score_adj);
+    }
+#else
+    struct signal_struct *sig;
+    bpf_probe_read_kernel(&sig, sizeof(s), &p->signal);
+    bpf_probe_read_kernel(&new.score_adj, sizeof(new.score_adj), &sig->oom_score_adj);
+#endif
     if (bpf_helper_exists(BPF_FUNC_get_current_comm)) {
         bpf_get_current_comm(new.fcomm, sizeof(new.fcomm));
     }

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -151,10 +151,14 @@ func (m *OOMKillCheck) Run() error {
 
 		var b strings.Builder
 		b.WriteString("%%% \n")
+		var oomScoreAdj string
+		if line.ScoreAdj != 0 {
+			oomScoreAdj = fmt.Sprintf(", oom_score_adj: %d", line.ScoreAdj)
+		}
 		if line.Pid == line.TPid {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d) triggered an OOM kill on itself.", line.FComm, line.Pid, line.Score)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.FComm, line.Pid, line.Score, oomScoreAdj)
 		} else {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d).", line.FComm, line.Pid, line.TComm, line.TPid, line.Score)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.FComm, line.Pid, line.TComm, line.TPid, line.Score, oomScoreAdj)
 		}
 		fmt.Fprintf(&b, "\n The process had reached %d pages in size. \n\n", line.Pages)
 		b.WriteString(triggerTypeText)

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -152,9 +152,9 @@ func (m *OOMKillCheck) Run() error {
 		var b strings.Builder
 		b.WriteString("%%% \n")
 		if line.Pid == line.TPid {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on itself.", line.FComm, line.Pid)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d) triggered an OOM kill on itself.", line.FComm, line.Pid, line.Score)
 		} else {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d).", line.FComm, line.Pid, line.TComm, line.TPid)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d).", line.FComm, line.Pid, line.TComm, line.TPid, line.Score)
 		}
 		fmt.Fprintf(&b, "\n The process had reached %d pages in size. \n\n", line.Pages)
 		b.WriteString(triggerTypeText)

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
@@ -13,6 +13,7 @@ type OOMKillStats struct {
 	TPid       uint32 `json:"tpid"`
 	FComm      string `json:"fcomm"`
 	TComm      string `json:"tcomm"`
+	Score      int64  `json:"score"`
 	Pages      uint64 `json:"pages"`
 	MemCgOOM   uint32 `json:"memcgoom"`
 }

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
@@ -14,6 +14,7 @@ type OOMKillStats struct {
 	FComm      string `json:"fcomm"`
 	TComm      string `json:"tcomm"`
 	Score      int64  `json:"score"`
+	ScoreAdj   int16  `json:"scoreAdj"`
 	Pages      uint64 `json:"pages"`
 	MemCgOOM   uint32 `json:"memcgoom"`
 }

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -171,6 +171,7 @@ func convertStats(in C.struct_oom_stats) (out model.OOMKillStats) {
 	out.CgroupName = C.GoString(&in.cgroup_name[0])
 	out.Pid = uint32(in.pid)
 	out.TPid = uint32(in.tpid)
+	out.Score = int64(in.score)
 	out.FComm = C.GoString(&in.fcomm[0])
 	out.TComm = C.GoString(&in.tcomm[0])
 	out.Pages = uint64(in.pages)

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -172,6 +172,7 @@ func convertStats(in C.struct_oom_stats) (out model.OOMKillStats) {
 	out.Pid = uint32(in.pid)
 	out.TPid = uint32(in.tpid)
 	out.Score = int64(in.score)
+	out.ScoreAdj = int16(in.score_adj)
 	out.FComm = C.GoString(&in.fcomm[0])
 	out.TComm = C.GoString(&in.tcomm[0])
 	out.Pages = uint64(in.pages)

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -99,6 +99,7 @@ func TestOOMKillProbe(t *testing.T) {
 
 		assert.Regexp(t, regexp.MustCompile("run-([0-9|a-z]*).scope"), result.CgroupName, "cgroup name")
 		assert.Equal(t, result.TPid, result.Pid, "tpid == pid")
+		assert.NotZero(t, result.Score, "score")
 		assert.Equal(t, "dd", result.FComm, "fcomm")
 		assert.Equal(t, "dd", result.TComm, "tcomm")
 		assert.NotZero(t, result.Pages, "pages")

--- a/releasenotes/notes/oom_score-384c6e7f13906123.yaml
+++ b/releasenotes/notes/oom_score-384c6e7f13906123.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make the `oom_kill` check capture the OOM score of the process being killed.

--- a/releasenotes/notes/oom_score-384c6e7f13906123.yaml
+++ b/releasenotes/notes/oom_score-384c6e7f13906123.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Make the `oom_kill` check capture the OOM score of the process being killed.
+    Make the `oom_kill` check capture the OOM score and the OOM score adjustment of the process being killed.


### PR DESCRIPTION
### What does this PR do?

Make the `oom_kill` check capture the OOM score of the victim.

### Motivation

Provide as much information as possible in the OOM kill events.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Validate that the extra informations are visible in the OOM kill events.
![image](https://github.com/DataDog/datadog-agent/assets/1437785/3b7f34c8-bf6d-4119-99c2-d006c8b1b5b7)
On Kubernetes, [the `oom_score_adj` is set according to the QoS](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#node-out-of-memory-behavior).