### PR TITLE
[CWS] ensure IMDS rules are not loaded if network ingress is disabled

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -396,6 +396,11 @@ func (p *Probe) IsNetworkEnabled() bool {
 	return p.Config.Probe.NetworkEnabled
 }
 
+// IsNetworkIngressEnabled returns whether network ingress is enabled
+func (p *Probe) IsNetworkIngressEnabled() bool {
+	return p.Config.Probe.NetworkIngressEnabled
+}
+
 // IsActivityDumpEnabled returns whether activity dump is enabled
 func (p *Probe) IsActivityDumpEnabled() bool {
 	return p.Config.RuntimeSecurity.ActivityDumpEnabled

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -85,6 +85,11 @@ func (p *Probe) IsNetworkEnabled() bool {
 	return p.Config.Probe.NetworkEnabled
 }
 
+// IsNetworkIngressEnabled returns whether network is enabled
+func (p *Probe) IsNetworkIngressEnabled() bool {
+	return p.Config.Probe.NetworkIngressEnabled
+}
+
 // IsActivityDumpEnabled returns whether activity dump is enabled
 func (p *Probe) IsActivityDumpEnabled() bool {
 	return p.Config.RuntimeSecurity.ActivityDumpEnabled

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -483,7 +483,10 @@ func (e *RuleEngine) getEventTypeEnabled() map[eval.EventType]bool {
 	if e.probe.IsNetworkEnabled() {
 		if eventTypes, exists := categories[model.NetworkCategory]; exists {
 			for _, eventType := range eventTypes {
-				enabled[eventType] = true
+				// imds is a special event type in that it requires network ingress
+				if eventType != "imds" || e.probe.IsNetworkIngressEnabled() {
+					enabled[eventType] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that we are not loading imds rules if network ingress is disabled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
