### PR TITLE
[OASIS-48] Fix agent config in OTel agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -58,8 +58,12 @@ func NewConfigComponent(ctx context.Context, uris []string) (config.Component, e
 	}
 	site := ddc.API.Site
 	apiKey := string(ddc.API.Key)
-	// Create a new config
-	pkgconfig := pkgconfigmodel.NewConfig("OTel", "DD", strings.NewReplacer(".", "_"))
+	// Set the global agent config
+	pkgconfig := pkgconfigsetup.Datadog()
+	pkgconfig.SetConfigName("OTel")
+	pkgconfig.SetEnvPrefix("DD")
+	pkgconfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
 	// Set Default values
 	pkgconfigsetup.InitConfig(pkgconfig)
 	pkgconfig.Set("api_key", apiKey, pkgconfigmodel.SourceLocalConfigProcess)

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -144,7 +144,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Invoke(func(_ collectordef.Component, _ defaultforwarder.Forwarder, _ optional.Option[logsagentpipeline.Component]) {
 		}),
 
-		fx.Provide(tagger.NewTaggerParams()),
+		fx.Supply(tagger.NewTaggerParams()),
 		taggerimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -144,7 +144,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Invoke(func(_ collectordef.Component, _ defaultforwarder.Forwarder, _ optional.Option[logsagentpipeline.Component]) {
 		}),
 
-		fx.Provide(func() tagger.Params { return tagger.NewTaggerParams() }),
+		fx.Provide(tagger.NewTaggerParams()),
 		taggerimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -144,12 +144,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Invoke(func(_ collectordef.Component, _ defaultforwarder.Forwarder, _ optional.Option[logsagentpipeline.Component]) {
 		}),
 
-		fx.Provide(func(coreConfig coreconfig.Component) tagger.Params {
-			if coreConfig.GetBool("apm_config.remote_tagger") {
-				return tagger.NewNodeRemoteTaggerParamsWithFallback()
-			}
-			return tagger.NewTaggerParams()
-		}),
+		fx.Provide(func() tagger.Params { return tagger.NewTaggerParams() }),
 		taggerimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -144,7 +144,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Invoke(func(_ collectordef.Component, _ defaultforwarder.Forwarder, _ optional.Option[logsagentpipeline.Component]) {
 		}),
 
-		fx.Supply(tagger.NewTaggerParams()),
+		fx.Provide(tagger.NewTaggerParams),
 		taggerimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())


### PR DESCRIPTION
### What does this PR do?

Fix agent config initialization in OTel agent. 
Also remove an unused tagger param that leads to lots of spam logs.

### Motivation

Set the global config so that trace agent component can properly access it.

### Describe how to test/QA your changes

Already done with building & running OTel agent binary.
