### PR TITLE
[ASCII-1865] Add an invoke task to compute PR stats

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -6,7 +6,9 @@ import time
 from collections import Counter
 from functools import lru_cache
 
-from invoke import Exit, task
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
 
 from tasks.libs.ciproviders.github_actions_tools import (
     download_artifacts,
@@ -322,3 +324,31 @@ def handle_community_pr(_, repo='', pr_id=-1, labels=''):
     client = WebClient(os.environ['SLACK_API_TOKEN'])
     for channel in channels:
         client.chat_postMessage(channel=channel, text=message)
+
+
+@task
+def milestone_pr_team_stats(_: Context, milestone: str, team: str):
+    """
+    This task prints statistics about the PRs opened by a given team and
+    merged in the given milestone.
+    """
+    from tasks.libs.ciproviders.github_api import GithubAPI
+
+    gh = GithubAPI()
+    team_members = gh.get_team_members(team)
+    authors = ' '.join("author:" + member.login for member in team_members)
+    common_query = f'repo:DataDog/datadog-agent is:pr is:merged milestone:{milestone} {authors}'
+
+    no_code_changes_query = common_query + ' label:qa/no-code-change'
+    no_code_changes = gh.search_issues(no_code_changes_query).totalCount
+
+    qa_done_query = common_query + ' -label:qa/no-code-change label:qa/done'
+    qa_done = gh.search_issues(qa_done_query).totalCount
+
+    with_qa_query = common_query + ' -label:qa/no-code-change -label:qa/done'
+    with_qa = gh.search_issues(with_qa_query).totalCount
+
+    print("no code changes :", no_code_changes)
+    print("qa done :", qa_done)
+    print("with qa :", with_qa)
+    print("proportion of PRs with code changes and QA done :", 100 * qa_done / (qa_done + with_qa), "%")

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -32,8 +32,8 @@ class GithubAPI:
     def __init__(self, repository="DataDog/datadog-agent", public_repo=False):
         self._auth = self._chose_auth(public_repo)
         self._github = Github(auth=self._auth)
-        org, _ = repository.split("/")
-        self._organization = org
+        org = repository.split("/")
+        self._organization = org[0] if len(org) > 1 else None
         self._repository = self._github.get_repo(repository)
 
     @property
@@ -249,6 +249,7 @@ class GithubAPI:
         """
         Get the members of a team.
         """
+        assert self._organization
         org = self._github.get_organization(self._organization)
         team = org.get_team_by_slug(team_slug)
         return team.get_members()

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -5,12 +5,14 @@ import json
 import os
 import platform
 import subprocess
+from collections.abc import Iterable
 from functools import lru_cache
 
 import requests
 
 try:
     from github import Auth, Github, GithubException, GithubIntegration, GithubObject
+    from github.NamedUser import NamedUser
 except ImportError:
     # PyGithub isn't available on some build images, ignore it for now
     # and fail hard if it gets used.
@@ -30,6 +32,8 @@ class GithubAPI:
     def __init__(self, repository="DataDog/datadog-agent", public_repo=False):
         self._auth = self._chose_auth(public_repo)
         self._github = Github(auth=self._auth)
+        org, _ = repository.split("/")
+        self._organization = org
         self._repository = self._github.get_repo(repository)
 
     @property
@@ -240,6 +244,21 @@ class GithubAPI:
         pr = self.get_pr(pr_id)
 
         return [f.filename for f in pr.get_files()]
+
+    def get_team_members(self, team_slug: str) -> Iterable[NamedUser]:
+        """
+        Get the members of a team.
+        """
+        org = self._github.get_organization(self._organization)
+        team = org.get_team_by_slug(team_slug)
+        return team.get_members()
+
+    def search_issues(self, query: str):
+        """
+        Search for issues with the given query.
+        By default this is not scoped to the repository, it is a global Github search.
+        """
+        return self._github.search_issues(query)
 
     def is_organization_member(self, user):
         organization = self._repository.organization

--- a/tasks/unit-tests/github_api_tests.py
+++ b/tasks/unit-tests/github_api_tests.py
@@ -48,3 +48,11 @@ class TestContainsReleaseNote(unittest.TestCase):
             mock_pr = mock_repo.get_pull.return_value
             mock_pr.get_files.return_value = [Myfile("release_notes/notes")]
             self.assertFalse(github.contains_release_note(2))
+
+    @patch("tasks.libs.ciproviders.github_api.Github", autospec=True)
+    def test_org(self, _):
+        github = GithubAPI(repository="test", public_repo=True)
+        self.assertIsNone(github._organization)
+
+        github = GithubAPI(repository="org/test", public_repo=True)
+        self.assertEqual(github._organization, "org")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a `github.milestone-pr-team-stats` invoke task which prints basic statistics about the number of PRs from a given team during a given milestone.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We need those numbers to track some initiatives, and doing it manually is error prone.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Example usage:
```
❯ inv github.milestone-pr-team-stats -m 7.55.0 -t agent-shared-components
no code changes : 35
qa done : 22
with qa : 17
proportion of PRs with code changes and QA done : 56.41025641025641 %
```

The task requires a Github token with org permissions to be able to list team members.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
