### PR TITLE
[ASCII-1866] Compute status date when needed

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider.go
+++ b/comp/core/status/statusimpl/common_header_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"runtime"
@@ -28,7 +29,7 @@ var nowFunc = time.Now
 var startTimeProvider = pkgconfigsetup.StartTime
 
 type headerProvider struct {
-	data                   map[string]interface{}
+	constdata              map[string]interface{}
 	name                   string
 	textTemplatesFunctions textTemplate.FuncMap
 	htmlTemplatesFunctions htmlTemplate.FuncMap
@@ -43,7 +44,7 @@ func (h *headerProvider) Name() string {
 }
 
 func (h *headerProvider) JSON(_ bool, stats map[string]interface{}) error {
-	for k, v := range h.data {
+	for k, v := range h.data() {
 		stats[k] = v
 	}
 
@@ -56,7 +57,7 @@ func (h *headerProvider) Text(_ bool, buffer io.Writer) error {
 		return tmplErr
 	}
 	t := textTemplate.Must(textTemplate.New("header").Funcs(h.textTemplatesFunctions).Parse(string(tmpl)))
-	return t.Execute(buffer, h.data)
+	return t.Execute(buffer, h.data())
 }
 
 func (h *headerProvider) HTML(_ bool, buffer io.Writer) error {
@@ -65,7 +66,13 @@ func (h *headerProvider) HTML(_ bool, buffer io.Writer) error {
 		return tmplErr
 	}
 	t := htmlTemplate.Must(htmlTemplate.New("header").Funcs(h.htmlTemplatesFunctions).Parse(string(tmpl)))
-	return t.Execute(buffer, h.data)
+	return t.Execute(buffer, h.data())
+}
+
+func (h *headerProvider) data() map[string]interface{} {
+	data := maps.Clone(h.constdata)
+	data["time_nano"] = nowFunc().UnixNano()
+	return data
 }
 
 func newCommonHeaderProvider(params status.Params, config config.Component) status.HeaderProvider {
@@ -80,11 +87,10 @@ func newCommonHeaderProvider(params status.Params, config config.Component) stat
 	pythonVersion := params.PythonVersionGetFunc()
 	data["python_version"] = strings.Split(pythonVersion, " ")[0]
 	data["build_arch"] = runtime.GOARCH
-	data["time_nano"] = nowFunc().UnixNano()
 	data["config"] = populateConfig(config)
 
 	return &headerProvider{
-		data:                   data,
+		constdata:              data,
 		name:                   fmt.Sprintf("%s (v%s)", flavor.GetHumanReadableFlavor(), data["version"]),
 		textTemplatesFunctions: status.TextFmap(),
 		htmlTemplatesFunctions: status.HTMLFmap(),

--- a/releasenotes/notes/status-fix-date-3449df92774a0dd4.yaml
+++ b/releasenotes/notes/status-fix-date-3449df92774a0dd4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the status date so that it is computed for every request.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Update the status header provider to compute the date on demand rather than once at initialization.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The date was not being updated when querying status.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
