### PR TITLE
Follow Agent RC staging deployment pipeline inside the build pipeline

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -25,7 +25,6 @@ rc_kubernetes_deploy:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $GITLAB_SCHEDULER_TOKEN_SSM_NAME)
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main
-      --no-follow
       --variable OPTION_AUTOMATIC_ROLLOUT
       --variable EXPLICIT_WORKFLOWS
       --variable OPTION_PRE_SCRIPT


### PR DESCRIPTION
### What does this PR do?

This PR removes` --no-follow` flag from the Agent RC staging deployment job trigger.

### Motivation

In the past we set the job this way as the mechanism for Agent RC builds deployment was fresh and not reliable. At the moment there is more benefit to fail the original job and pipeline so we can quickly get feedback about potential issues, as without it, user has to manually look up the child pipeline and check its status.

Additional thing - this job is at the very end of the pipeline so in case of the failure the worst case is that there will be no success notification in slack.

### Describe how to test/QA your changes

To be properly tested with the next RC build.
