### PR TITLE
[CWS] Do not warn user if only the 'hash' action of a rule is specified

### DIFF
--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -38,8 +38,8 @@ type ActionDefinition struct {
 
 // Check returns an error if the action in invalid
 func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
-	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil {
-		return errors.New("either 'set' or 'kill' section of an action must be specified")
+	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil && a.Hash == nil {
+		return errors.New("either 'set', 'kill' or 'hash' section of an action must be specified")
 	}
 
 	if a.Set != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Stop displaying the following error in case a 'hash' action is defined:

`2024-06-06 09:57:55 CEST | SYS-PROBE | ERROR | (pkg/security/rules/engine.go:567 in logLoadingErrors) | error while loading policies: invalid action: either 'set' or 'kill' section of an action must be specified`


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
