### PR TITLE
usm: ssl: Ignore containerd tempmounts

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -572,6 +572,10 @@ var (
 	}
 )
 
+func isContainerdTmpMount(path string) bool {
+	return strings.Contains(path, "tmpmounts/containerd-mount")
+}
+
 func isBuildKit(procRoot string, pid uint32) bool {
 	filePath := filepath.Join(procRoot, strconv.Itoa(int(pid)), "comm")
 
@@ -602,6 +606,8 @@ func addHooks(m *manager.Manager, procRoot string, probes []manager.ProbesSelect
 	return func(fpath utils.FilePath) error {
 		if isBuildKit(procRoot, fpath.PID) {
 			return fmt.Errorf("process %d is buildkitd, skipping", fpath.PID)
+		} else if isContainerdTmpMount(fpath.HostPath) {
+			return fmt.Errorf("path %s from process %d is tempmount of containerd, skipping", fpath.HostPath, fpath.PID)
 		}
 
 		uid := getUID(fpath.ID)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

USM should not hook paths in containerd tmpmounts

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Containerd uses the tmpmounts for copying files. Containerd unmounts the device when it finishes the setup, but the process still lives, which means we didn't unhook `openssl.so` file, which can result in error in containerd.
While we're trying to have a more robust solution, we keep a quick workaround

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
