### PR TITLE
Enforce gitlab check in the merge queue instead of relying on the autodetection

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -7,6 +7,7 @@ workflow_type: speculative_parallel_impact
 speculative_max_depth: 5
 wait_for_check_timeout_in_minutes: 240
 gitlab_jobs_retry_enable: true
+gitlab_check_enable: true
 skip_labels: true
 ---
 schema-version: v1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- Enforce gitlab check inside the merge queue

### Motivation

This parameter used to be `true` by default and we are trying to set up a mechanism to automatically detect if the merge queue needs to check for the Gitlab pipeline or only Github status checks. In some cases, this mechanism can fail and it is harder to find the associated Gitlab pipeline used in the merge queue. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
