### PR TITLE
feat(tagger): add kubernetes_persistent_volume_claims_as_tags configuration

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -588,9 +588,11 @@ func (c *WorkloadMetaCollector) extractTagsFromPodOwner(pod *workloadmeta.Kubern
 
 	case kubernetes.StatefulSetKind:
 		tagList.AddLow(tags.KubeStatefulSet, owner.Name)
-		for _, pvc := range pod.PersistentVolumeClaimNames {
-			if pvc != "" {
-				tagList.AddLow(tags.KubePersistentVolumeClaim, pvc)
+		if c.collectPersistentVolumeClaimsTags {
+			for _, pvc := range pod.PersistentVolumeClaimNames {
+				if pvc != "" {
+					tagList.AddLow(tags.KubePersistentVolumeClaim, pvc)
+				}
 			}
 		}
 

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
@@ -67,7 +67,8 @@ type WorkloadMetaCollector struct {
 	globContainerLabels    map[string]glob.Glob
 	globContainerEnvLabels map[string]glob.Glob
 
-	collectEC2ResourceTags bool
+	collectEC2ResourceTags            bool
+	collectPersistentVolumeClaimsTags bool
 }
 
 func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags map[string]string) {
@@ -159,10 +160,11 @@ func (c *WorkloadMetaCollector) stream(ctx context.Context) {
 // NewWorkloadMetaCollector returns a new WorkloadMetaCollector.
 func NewWorkloadMetaCollector(_ context.Context, store workloadmeta.Component, p processor) *WorkloadMetaCollector {
 	c := &WorkloadMetaCollector{
-		tagProcessor:           p,
-		store:                  store,
-		children:               make(map[string]map[string]struct{}),
-		collectEC2ResourceTags: config.Datadog().GetBool("ecs_collect_resource_tags_ec2"),
+		tagProcessor:                      p,
+		store:                             store,
+		children:                          make(map[string]map[string]struct{}),
+		collectEC2ResourceTags:            config.Datadog().GetBool("ecs_collect_resource_tags_ec2"),
+		collectPersistentVolumeClaimsTags: config.Datadog().GetBool("kubernetes_persistent_volume_claims_as_tags"),
 	}
 
 	containerLabelsAsTags := mergeMaps(

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -345,6 +345,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_namespace_annotations_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_persistent_volume_claims_as_tags", true)
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider

--- a/releasenotes/notes/tagger-kubernetes_pvc_tags-configuration-bd3746df3af77bf3.yaml
+++ b/releasenotes/notes/tagger-kubernetes_pvc_tags-configuration-bd3746df3af77bf3.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Implement the kubernetes_persistent_volume_claims_as_tags configuration that allows
+    users to disable PersistentVolumeClaim for Kubernetes resources.
+


### PR DESCRIPTION
### What does this PR do?

Implement the `kubernetes_persistent_volume_claims_as_tags` configuration that allow users to disable `persistentvolumeclaim` for Kubernetes resources.

### Describe how to test/QA your changes

* Deploy the following manifest
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: python-pv
  labels:
    type: local
spec:
  storageClassName: manual
  capacity:
    storage: 10Mi
  accessModes:
    - ReadWriteOnce
  hostPath:
    path: "/mnt/data"
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: python-pvc
spec:
  storageClassName: manual
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Mi
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: python
  labels:
    environment: testing
    user: wassim
spec:
  replicas: 1
  selector:
    matchLabels:
      app: python
  template:
    metadata:
      labels:
        app: python
    spec:
      volumes:
        - name: python-pv
          persistentVolumeClaim:
            claimName: python-pvc
      containers:
        - name: python
          image: python
          imagePullPolicy: Always
          env:
          - name: DD_AGENT_HOST
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
          command: ["python", "-c"]
          args: ['while True: pass']
          volumeMounts:
            - mountPath: "/tmp"
              name: python-pv
```

* Using the following command
```
kubectl exec -it daemonsets/datadog-agent -- agent tagger-list | grep persistentvolumeclaim
```
* Make sure that you have `persistentvolumeclaim` tags using the default configuration.
* Make sure that you still have `persistentvolumeclaim` tags when setting the `DD_KUBERNETES_PERSISTENT_VOLUME_CLAIMS_AS_TAGS` as `true`.
* Make sure that you don't have `persistentvolumeclaim` tags when setting the `DD_KUBERNETES_PERSISTENT_VOLUME_CLAIMS_AS_TAGS` as `true`.