### PR TITLE
[ASCII-1867][gohai] if all errors are the same then return it directly

### DIFF
--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -93,6 +93,7 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []string, error) {
 
 	values := make(map[string]interface{})
 	warns := []string{}
+	var lastErr error // store an error to return, so that errors.Is can be used
 
 	for i := 0; i < reflVal.NumField(); i++ {
 		fieldTy := reflType.Field(i)
@@ -126,6 +127,7 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []string, error) {
 			// ignore these errors
 			if !errors.Is(err, ErrNotCollectable) {
 				warns = append(warns, err.Error())
+				lastErr = err
 			}
 
 			// if the field is an error and we don't want to print the default value, continue
@@ -149,8 +151,28 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []string, error) {
 
 	// return an error if no field was successfully collected
 	if len(values) == 0 {
+		// if all field errors are the same then use that as error message on top of the generic "no field was collected"
+		if len(warns) != 0 && allEqual(warns) {
+			return nil, nil, fmt.Errorf("%w: %w", ErrNoFieldCollected, lastErr)
+		}
+
 		return nil, warns, ErrNoFieldCollected
 	}
 
 	return values, warns, nil
+}
+
+func allEqual[T comparable](values []T) bool {
+	if len(values) == 0 {
+		return true
+	}
+
+	first := values[0]
+	for _, val := range values {
+		if val != first {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -234,3 +234,27 @@ func TestAsJSONSuffix(t *testing.T) {
 	}`
 	require.JSONEq(t, expected, string(marshalled))
 }
+
+func TestAsJSONSameError(t *testing.T) {
+	info := &struct {
+		FieldOne   Value[int] `json:"field_one"`
+		FieldTwo   Value[int] `json:"field_two"`
+		FieldThree Value[int] `json:"field_three"`
+	}{
+		FieldOne:   NewErrorValue[int](errors.New("this is an error")),
+		FieldTwo:   NewErrorValue[int](errors.New("this is an error")),
+		FieldThree: NewErrorValue[int](ErrNotCollectable),
+	}
+
+	_, warns, err := AsJSON(info, false)
+	require.ErrorIs(t, err, ErrNoFieldCollected)
+	require.ErrorContains(t, err, "this is an error")
+	require.Empty(t, warns)
+}
+
+func TestAllEqual(t *testing.T) {
+	require.True(t, allEqual([]string{}))
+	require.True(t, allEqual([]string{"1"}))
+	require.True(t, allEqual([]string{"1", "1"}))
+	require.False(t, allEqual([]string{"1", "2"}))
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Update `gohai` error handling so that if all fields contain the same error then that error is returned.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://github.com/DataDog/datadog-agent/issues/26244 shows that currently if nothing can be collected we just return `"no field was collected"`, we don't have a more precise error.
This change allows that if a single error prevented collecting anything, that error is returned.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Another PR will print each field's error with a lower log level.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit tested the specific change, and manually tested that the general functionality still works.
