### PR TITLE
fix(opentelemetry): add OTEL_RESOURCE_ATTRIBUTES key/pair check

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -769,6 +769,10 @@ func (c *WorkloadMetaCollector) addOpenTelemetryStandardTags(container *workload
 	if otelResourceAttributes, ok := container.EnvVars[envVarOtelResourceAttributes]; ok {
 		for _, pair := range strings.Split(otelResourceAttributes, ",") {
 			fields := strings.SplitN(pair, "=", 2)
+			if len(fields) != 2 {
+				log.Debugf("invalid OpenTelemetry resource attribute: %s", pair)
+				continue
+			}
 			fields[0], fields[1] = strings.TrimSpace(fields[0]), strings.TrimSpace(fields[1])
 			if tag, ok := otelResourceAttributesMapping[fields[0]]; ok {
 				tags.AddStandard(tag, fields[1])


### PR DESCRIPTION
### What does this PR do?

Add a check for `OTEL_RESOURCE_ATTRIBUTES` key/pair.

### Motivation

Fix a panic occurring when `OTEL_RESOURCE_ATTRIBUTES` is malformed.

### Describe how to test/QA your changes

QA will be done with this PR: https://github.com/DataDog/datadog-agent/pull/26118