### PR TITLE
[ASCII-1843] Ensure configcheck result is written to stdout

### DIFF
--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -40,6 +40,9 @@ type GlobalParams struct {
 
 	// LogStreamFilePath holds the path to the logstream log path
 	LogStreamFilePath string
+
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
@@ -79,10 +82,9 @@ monitoring and performance data.`,
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when
 	// the value is true.
-	var noColorFlag bool
-	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
+	agentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
-		if noColorFlag {
+		if globalParams.NoColor {
 			color.NoColor = true
 		}
 	}

--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -62,6 +62,12 @@ func run(config config.Component, cliParams *cliParams) error {
 		v.Set("verbose", "true")
 	}
 
+	if cliParams.NoColor {
+		v.Set("nocolor", "true")
+	} else {
+		v.Set("nocolor", "false")
+	}
+
 	endpoint, err := apiutil.NewIPCEndpoint(config, "/agent/config-check")
 	if err != nil {
 		return err

--- a/cmd/cluster-agent-cloudfoundry/command/command.go
+++ b/cmd/cluster-agent-cloudfoundry/command/command.go
@@ -33,6 +33,9 @@ type GlobalParams struct {
 	// ConfFilePath holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line
 	ConfFilePath string
+
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
@@ -74,10 +77,9 @@ once per cluster.`,
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when
 	// the value is true.
-	var noColorFlag bool
-	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
+	agentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
-		if noColorFlag {
+		if globalParams.NoColor {
 			color.NoColor = true
 		}
 	}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -163,7 +163,8 @@ func makeFlare(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 //nolint:revive // TODO(CINT) Fix revive linter
 func getConfigCheck(w http.ResponseWriter, r *http.Request, ac autodiscovery.Component) {
 	verbose := r.URL.Query().Get("verbose") == "true"
-	bytes := ac.GetConfigCheck(verbose)
+	noColor := r.URL.Query().Get("nocolor") == "true"
+	bytes := ac.GetConfigCheck(verbose, noColor)
 
 	w.Write(bytes)
 }

--- a/cmd/cluster-agent/command/command.go
+++ b/cmd/cluster-agent/command/command.go
@@ -31,6 +31,8 @@ type GlobalParams struct {
 	// ConfFilePath holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line
 	ConfFilePath string
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
@@ -56,10 +58,9 @@ metadata for their metrics.`,
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when
 	// the value is true.
-	var noColorFlag bool
-	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
+	agentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
-		if noColorFlag {
+		if globalParams.NoColor {
 			color.NoColor = true
 		}
 	}

--- a/cmd/cluster-agent/subcommands/configcheck/command.go
+++ b/cmd/cluster-agent/subcommands/configcheck/command.go
@@ -20,6 +20,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := dcaconfigcheck.MakeCommand(func() dcaconfigcheck.GlobalParams {
 		return dcaconfigcheck.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
+			NoColor:      globalParams.NoColor,
 		}
 	})
 

--- a/cmd/installer/command/command.go
+++ b/cmd/installer/command/command.go
@@ -10,9 +10,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // common constants for all the updater subcommands.
@@ -39,6 +40,9 @@ type GlobalParams struct {
 
 	// AllowNoRoot is a flag to allow running the installer as non-root.
 	AllowNoRoot bool
+
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
@@ -84,7 +88,7 @@ Datadog Installer installs datadog-packages based on your commands.`,
 	var noColorFlag bool
 	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
 	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
-		if noColorFlag {
+		if globalParams.NoColor {
 			color.NoColor = true
 		}
 	}

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -50,6 +50,9 @@ type GlobalParams struct {
 
 	// WinParams provides windows specific options
 	WinParams WinParams
+
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // WinParams specifies Windows-specific CLI params
@@ -98,10 +101,9 @@ func MakeCommand(subcommandFactories []SubcommandFactory, winParams bool, rootCm
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when
 	// the value is true.
-	var noColorFlag bool
-	rootCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
+	rootCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 	rootCmd.PersistentPreRun = func(*cobra.Command, []string) {
-		if noColorFlag {
+		if globalParams.NoColor {
 			color.NoColor = true
 		}
 	}

--- a/cmd/security-agent/command/command.go
+++ b/cmd/security-agent/command/command.go
@@ -23,6 +23,9 @@ import (
 type GlobalParams struct {
 	ConfigFilePaths      []string
 	SysProbeConfFilePath string
+
+	// NoColor is a flag to disable color output
+	NoColor bool
 }
 
 // SubcommandFactory returns a sub-command factory
@@ -43,7 +46,6 @@ var (
 // MakeCommand makes the top-level Cobra command for this command.
 func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {
 	var globalParams GlobalParams
-	var flagNoColor bool
 
 	SecurityAgentCmd := &cobra.Command{
 		Use:   "datadog-security-agent [command]",
@@ -52,7 +54,7 @@ func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {
 Datadog Security Agent takes care of running compliance and security checks.`,
 		SilenceUsage: true, // don't print usage on errors
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if flagNoColor {
+			if globalParams.NoColor {
 				color.NoColor = true
 			}
 
@@ -65,7 +67,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 
 	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfigFilePaths, "cfgpath", "c", defaultSecurityAgentConfigFilePaths, "paths to yaml configuration files")
 	SecurityAgentCmd.PersistentFlags().StringVar(&globalParams.SysProbeConfFilePath, "sysprobe-config", defaultSysProbeConfPath, "path to system-probe.yaml config")
-	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
+	SecurityAgentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 
 	for _, factory := range subcommandFactories {
 		for _, subcmd := range factory(&globalParams) {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_mock.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_mock.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"testing"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/api/api"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
@@ -19,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"go.uber.org/fx"
 )
 
 // MockParams defines the parameters for the mock component.

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -38,6 +38,6 @@ type Component interface {
 	Start()
 	Stop()
 	// TODO (component): once cluster agent uses the API component remove this function
-	GetConfigCheck(verbose bool) []byte
+	GetConfigCheck(verbose bool, noColor bool) []byte
 	IsStarted() bool
 }

--- a/pkg/cli/subcommands/dcaconfigcheck/command.go
+++ b/pkg/cli/subcommands/dcaconfigcheck/command.go
@@ -66,9 +66,8 @@ func run(_ log.Component, _ config.Component, cliParams *cliParams) error {
 	var b bytes.Buffer
 	color.Output = &b
 
-	err := flare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose)
-	if err != nil {
-		return fmt.Errorf("the agent ran into an error while checking config: %v", err)
+	if err := flare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose); err != nil {
+		return fmt.Errorf("the agent ran into an error while checking config: %w", err)
 	}
 
 	fmt.Println(b.String())

--- a/pkg/cli/subcommands/dcaconfigcheck/command.go
+++ b/pkg/cli/subcommands/dcaconfigcheck/command.go
@@ -7,6 +7,9 @@
 package dcaconfigcheck
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -60,5 +63,14 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 }
 
 func run(_ log.Component, _ config.Component, cliParams *cliParams) error {
-	return flare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose)
+	var b bytes.Buffer
+	color.Output = &b
+
+	err := flare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose)
+	if err != nil {
+		return fmt.Errorf("the agent ran into an error while checking config: %v", err)
+	}
+
+	fmt.Println(b.String())
+	return nil
 }

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -151,7 +151,7 @@ func getClusterAgentConfigCheck(fb flaretypes.FlareBuilder) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)
-	GetClusterAgentConfigCheck(writer, true) //nolint:errcheck
+	GetClusterAgentConfigCheck(writer, true, true) //nolint:errcheck
 	writer.Flush()
 
 	return fb.AddFile("config-check.log", b.Bytes())

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -10,18 +10,12 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/fatih/color"
-
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // GetClusterAgentConfigCheck gets config check from the server
-func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
-	if w != color.Output {
-		color.NoColor = true
-	}
-
+func GetClusterAgentConfigCheck(w io.Writer, noColor bool, withDebug bool) error {
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
@@ -33,6 +27,12 @@ func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
 	v := url.Values{}
 	if withDebug {
 		v.Set("verbose", "true")
+	}
+
+	if noColor {
+		v.Set("nocolor", "true")
+	} else {
+		v.Set("nocolor", "false")
 	}
 
 	targetURL := url.URL{

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -50,5 +50,7 @@ func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
 		return fmt.Errorf("failed to query the agent (running?): %s", err)
 	}
 
-	return nil
+	_, err = w.Write(r)
+
+	return err
 }

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
@@ -89,7 +91,7 @@ func (v *linuxConfigCheckSuite) TestDefaultInstalledChecks() {
 		},
 	}
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 	VerifyDefaultInstalledCheck(v.T(), output, testChecks)
 }
 
@@ -101,7 +103,7 @@ func (v *linuxConfigCheckSuite) TestWithBadConfigCheck() {
 	integration := agentparams.WithIntegration("http_check.d", config)
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(integration)))
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 
 	assert.Contains(v.T(), output, "http_check: yaml: line 2: found character that cannot start any token")
 }
@@ -114,7 +116,7 @@ func (v *linuxConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	integration := agentparams.WithIntegration("http_check.d", config)
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(integration)))
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 
 	result, err := MatchCheckToTemplate("http_check", output)
 	require.NoError(v.T(), err)

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
@@ -86,7 +87,7 @@ func (v *windowsConfigCheckSuite) TestDefaultInstalledChecks() {
 		},
 	}
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 	VerifyDefaultInstalledCheck(v.T(), output, testChecks)
 }
 
@@ -98,7 +99,7 @@ func (v *windowsConfigCheckSuite) TestWithBadConfigCheck() {
 	integration := agentparams.WithIntegration("http_check.d", config)
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(integration)))
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 
 	assert.Contains(v.T(), output, "http_check: yaml: line 2: found character that cannot start any token")
 }
@@ -111,7 +112,7 @@ func (v *windowsConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	integration := agentparams.WithIntegration("http_check.d", config)
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)), awshost.WithAgentOptions(integration)))
 
-	output := v.Env().Agent.Client.ConfigCheck()
+	output := v.Env().Agent.Client.ConfigCheck(agentclient.WithArgs([]string{"-n"}))
 
 	result, err := MatchCheckToTemplate("http_check", output)
 	require.NoError(v.T(), err)

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -257,15 +257,12 @@ func (suite *k8sSuite) TestClusterAgentConfigCheck() {
 			LabelSelector: fields.OneTermEqualSelector("app", appSelector).String(),
 			Limit:         1,
 		})
-		if suite.NoError(err) && len(linuxPods.Items) >= 1 {
-			stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck"})
-			if suite.NoError(err) {
-				suite.Empty(stderr, "Standard error of `agent configcheck` should be empty")
-				suite.Contains(stdout, "=== kubernetes_apiserver check ===")
-			} else {
-				suite.T().Errorf("No cluster agent pod found. %v\n", err)
-			}
-		}
+		suite.Require().NoError(err)
+		suite.Require().Len(linuxPods.Items, 1)
+		stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `agent configcheck` should be empty")
+		suite.Contains(stdout, "=== kubernetes_apiserver check ===")
 	})
 }
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -259,7 +259,7 @@ func (suite *k8sSuite) TestClusterAgentConfigCheck() {
 		})
 		suite.Require().NoError(err)
 		suite.Require().Len(linuxPods.Items, 1)
-		stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck"})
+		stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck", "-n"})
 		suite.Require().NoError(err)
 		suite.Empty(stderr, "Standard error of `agent configcheck` should be empty")
 		suite.Contains(stdout, "=== kubernetes_apiserver check ===")

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/agent-payload/v5/sbom"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
-	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/fatih/color"
 	"github.com/samber/lo"
@@ -245,6 +246,27 @@ func (suite *k8sSuite) TestVersion() {
 			}
 		})
 	}
+}
+
+func (suite *k8sSuite) TestClusterAgentConfigCheck() {
+	ctx := context.Background()
+	suite.Run("cluster agent pods return the right information for the config check command", func() {
+		appSelector := suite.AgentLinuxHelmInstallName + "-datadog-cluster-agent"
+
+		linuxPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+			LabelSelector: fields.OneTermEqualSelector("app", appSelector).String(),
+			Limit:         1,
+		})
+		if suite.NoError(err) && len(linuxPods.Items) >= 1 {
+			stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck"})
+			if suite.NoError(err) {
+				suite.Empty(stderr, "Standard error of `agent configcheck` should be empty")
+				suite.Contains(stdout, "=== kubernetes_apiserver check ===")
+			} else {
+				suite.T().Errorf("No cluster agent pod found. %v\n", err)
+			}
+		}
+	})
 }
 
 func (suite *k8sSuite) TestNginx() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

On the work done on this PR https://github.com/DataDog/datadog-agent/pull/25595 we modified the configcheck command to ensure scrubbing would happen in the server an not in the client. 

On that PR we missed a tiny detail for the cluster agent. We forgot to write the result from communicating with the server 🤦 

In this PR we ensure that we write the result from the server into the writer, and that the CLI flag for color `-n` is respected

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Ensure the main agent flare archive includes the `config-check.log` file with the right information. Ensure the output does not have ANSI color strings
- Ensure the cluster agent flare archive includes the `config-check.log` file with the right information. Ensure the output does not have ANSI color strings
- Ensure CLI command `cluster-agent configcheck` works as expected. The output must include colors 
- Ensure CLI command `cluster-agent configcheck -n` works as expected. The output must not include colors 
- Ensure CLI command `agent configcheck` works as expected. The output must include colors 
- Ensure CLI command `agent configcheck -n` works as expected. The output must not include colors 

