### PR TITLE
CI: don't rely on a workflow to force DEPLOY_AGENT for conductor runs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -272,7 +272,7 @@ variables:
   if: $RELEASE_VERSION_7 == ""
 
 .if_deploy: &if_deploy
-  if: $DEPLOY_AGENT == "true"
+  if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
 .if_not_deploy: &if_not_deploy
   if: $DEPLOY_AGENT != "true"
@@ -399,9 +399,6 @@ workflow:
       variables:
         USE_CACHING_PROXY_PYTHON: "false"
         USE_CACHING_PROXY_RUBY: "false"
-    - if: $DDR_WORKFLOW_ID != null
-      variables:
-        DEPLOY_AGENT: "true"
 
 #
 # List of rule blocks used in the pipeline

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -13,6 +13,7 @@ extensions:
       targets:
         - name: "staging"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
+          branch: "main"
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Attempts to fix the CI configuration when running through conductor

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I missed this note in the gitlab doc:
You can use some predefined CI/CD variables in workflow configuration, but not variables that are only defined when jobs start.

This should fix conductor runs systematically failing because no artifacts were deployed, as we should now create the deployment jobs 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

BARX-263

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
