### PR TITLE
Add windows installer permissions E2E tests

### DIFF
--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -245,7 +245,7 @@ func (r AuditRule) AuditSuccess() bool {
 	return (r.AuditFlags & AuditFlagsSuccess) == AuditFlagsSuccess
 }
 
-// IsFailure returns true if failed access attempts are audited
+// AuditFailure returns true if failed access attempts are audited
 func (r AuditRule) AuditFailure() bool {
 	return (r.AuditFlags & AuditFlagsFailure) == AuditFlagsFailure
 }

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -287,6 +287,9 @@ var aclHelpersPs1Fixture []byte
 var aclHelpersPath = `C:\Windows\Temp\acl_helpers.ps1`
 
 func placeACLHelpers(host *components.RemoteHost) error {
+	if exists, _ := host.FileExists(aclHelpersPath); exists {
+		return nil
+	}
 	_, err := host.WriteFile(aclHelpersPath, aclHelpersPs1Fixture)
 	return err
 }

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -139,6 +139,15 @@ const (
 	AccessControlTypeDeny  = 1
 )
 
+// Audit flags
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.auditflags?view=net-8.0
+const (
+	AuditFlagsNone    = 0
+	AuditFlagsSuccess = 1
+	AuditFlagsFailure = 2
+)
+
 //revive:enable:var-naming
 
 // AuthorizationRuleWithRights is an interface for an authorization rule with rights
@@ -210,14 +219,14 @@ func (r AuditRule) Equal(other AuditRule) bool {
 		r.AuthorizationRule.Equal(other.AuthorizationRule)
 }
 
-// IsSuccess returns true if the audit rule is a success rule
-func (r AuditRule) IsSuccess() bool {
-	return r.AuditFlags == 0
+// AuditSuccess returns true if successful access attempts are audited
+func (r AuditRule) AuditSuccess() bool {
+	return (r.AuditFlags & AuditFlagsSuccess) == AuditFlagsSuccess
 }
 
-// IsFailure returns true if the audit rule is a failure rule
-func (r AuditRule) IsFailure() bool {
-	return r.AuditFlags == 1
+// IsFailure returns true if failed access attempts are audited
+func (r AuditRule) AuditFailure() bool {
+	return (r.AuditFlags & AuditFlagsFailure) == AuditFlagsFailure
 }
 
 // GetRights returns the rights for the audit rule

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -412,7 +412,7 @@ func AssertEqualAccessSecurity(t *testing.T, path string, expected, actual Objec
 	t.Helper()
 
 	AssertEqualableElementsMatch(t, expected.Access, actual.Access, "%s access rules should match", path)
-	assert.Equal(t, expected.Owner, actual.Owner, "%s owner should match", path)
-	assert.Equal(t, expected.Group, actual.Group, "%s group should match", path)
+	assert.True(t, expected.Owner.Equal(actual.Owner), "%s owner %s should match %s", path, actual.Owner, expected.Owner)
+	assert.True(t, expected.Group.Equal(actual.Group), "%s group %s should match %s", path, actual.Group, expected.Group)
 	assert.Equal(t, expected.AreAccessRulesProtected, actual.AreAccessRulesProtected, "%s access rules protection should match", path)
 }

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -213,7 +213,7 @@ type ObjectSecurity struct {
 	Group                   Identity
 	Access                  []AccessRule
 	Audit                   []AuditRule
-	SDDL                    string `json:"Sddl"`
+	SDDL                    string
 	AreAccessRulesProtected bool
 	AreAuditRulesProtected  bool
 }

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -151,7 +151,7 @@ type AuthorizationRuleWithRights interface {
 //
 // https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.authorizationrule
 type AuthorizationRule struct {
-	Identity         Identity `json:"IdentityReference"`
+	Identity         Identity
 	InheritanceFlags int
 	PropagationFlags int
 	IsInherited      bool

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -1,0 +1,333 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package common
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//revive:disable:var-naming These names are intended to match the Windows API names
+
+// SECURITY_DESCRIPTOR_CONTROL flags
+//
+// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-control
+const (
+	DELETE                   = 0x00010000
+	READ_CONTROL             = 0x00020000
+	WRITE_DAC                = 0x00040000
+	WRITE_OWNER              = 0x00080000
+	SYNCHRONIZE              = 0x00100000
+	STANDARD_RIGHTS_REQUIRED = 0x000F0000
+	STANDARD_RIGHTS_READ     = READ_CONTROL
+	STANDARD_RIGHTS_WRITE    = READ_CONTROL
+	STANDARD_RIGHTS_EXECUTE  = READ_CONTROL
+	STANDARD_RIGHTS_ALL      = 0x001F0000
+	SPECIFIC_RIGHTS_ALL      = 0x0000FFFF
+	ACCESS_SYSTEM_SECURITY   = 0x01000000
+	MAXIMUM_ALLOWED          = 0x02000000
+	GENERIC_READ             = 0x80000000
+	GENERIC_WRITE            = 0x40000000
+	GENERIC_EXECUTE          = 0x20000000
+	GENERIC_ALL              = 0x10000000
+)
+
+// Filesystem access rights
+//
+// https://learn.microsoft.com/en-us/windows/win32/wmisdk/file-and-directory-access-rights-constants
+// https://learn.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
+const (
+	FILE_READ_DATA        = 0x00000001
+	FILE_READ_ATTRIBUTES  = 0x00000080
+	FILE_READ_EA          = 0x00000008
+	FILE_WRITE_DATA       = 0x00000002
+	FILE_WRITE_ATTRIBUTES = 0x00000100
+	FILE_WRITE_EA         = 0x00000010
+	FILE_APPEND_DATA      = 0x00000004
+	FILE_EXECUTE          = 0x00000020
+
+	FILE_GENERIC_READ    = STANDARD_RIGHTS_READ | FILE_READ_DATA | FILE_READ_ATTRIBUTES | FILE_READ_EA | SYNCHRONIZE
+	FILE_GENERIC_WRITE   = STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | SYNCHRONIZE
+	FILE_GENERIC_EXECUTE = STANDARD_RIGHTS_EXECUTE | FILE_READ_ATTRIBUTES | FILE_EXECUTE | SYNCHRONIZE
+
+	FILE_LIST_DIRECTORY   = FILE_READ_DATA
+	FILE_CREATE_FILES     = FILE_WRITE_DATA
+	FILE_ADD_SUBDIRECTORY = FILE_APPEND_DATA
+	FILE_TRAVERSE         = FILE_EXECUTE
+	FILE_DELETE_CHILD     = 0x00000040
+)
+
+// Filesystem access rights
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemrights
+const (
+	ChangePermissions            = WRITE_DAC
+	ReadPermissions              = READ_CONTROL
+	TakeOwnership                = WRITE_OWNER
+	DeleteSubdirectoriesAndFiles = FILE_DELETE_CHILD
+
+	// FileFullControl = 0x001F01FF
+	FileFullControl = SYNCHRONIZE | TakeOwnership | ChangePermissions | ReadPermissions | DELETE | FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES | DeleteSubdirectoriesAndFiles | FILE_TRAVERSE | FILE_WRITE_EA | FILE_READ_EA | FILE_ADD_SUBDIRECTORY | FILE_CREATE_FILES | FILE_LIST_DIRECTORY
+	// FileRead = 0x00020089
+	FileRead = ReadPermissions | FILE_READ_ATTRIBUTES | FILE_READ_EA | FILE_LIST_DIRECTORY
+	// ReadAndExecute = // 0x000200A9
+	FileReadAndExecute = FileRead | FILE_TRAVERSE
+	// Write = 0x00000116
+	FileWrite = FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_ADD_SUBDIRECTORY | FILE_CREATE_FILES
+	// Modify = 0x000301BF
+	FileModify = FileWrite | FileReadAndExecute | DELETE
+)
+
+// Inheritance flags
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.inheritanceflags
+const (
+	InheritanceFlagsNone      = 0
+	InheritanceFlagsContainer = 1
+	InheritanceFlagsObject    = 2
+)
+
+// Propagation flags
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.propagationflags
+const (
+	PropagationFlagsNone        = 0
+	PropagationFlagsInherit     = 1
+	PropagationFlagsNoPropagate = 2
+)
+
+// Access control types
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.accesscontroltype
+const (
+	AccessControlTypeAllow = 0
+	AccessControlTypeDeny  = 1
+)
+
+//revive:enable:var-naming
+
+// AuthorizationRuleWithRights is an interface for an authorization rule with rights
+type AuthorizationRuleWithRights interface {
+	GetAuthorizationRule() AuthorizationRule
+	GetRights() int
+}
+
+// AuthorizationRule represents the identity and inheritance flags for a Windows ACE
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.authorizationrule
+type AuthorizationRule struct {
+	Identity         Identity `json:"IdentityReference"`
+	InheritanceFlags int
+	PropagationFlags int
+	IsInherited      bool
+}
+
+// AccessRule represents a Windows access rule ACE
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.accessrule
+type AccessRule struct {
+	AuthorizationRule
+	Rights            int
+	AccessControlType int
+}
+
+// AuditRule represents Windows audit rule ACE
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.auditrule
+type AuditRule struct {
+	AuthorizationRule
+	Rights     int
+	AuditFlags int
+}
+
+// ObjectSecurity represents the security information for a Windows Object (e.g. file, directory, registry key)
+//
+// https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.nativeobjectsecurity
+type ObjectSecurity struct {
+	Owner                   Identity
+	Group                   Identity
+	Access                  []AccessRule
+	Audit                   []AuditRule
+	SDDL                    string `json:"Sddl"`
+	AreAccessRulesProtected bool
+	AreAuditRulesProtected  bool
+}
+
+// GetAuthorizationRule returns the authorization rule, used to satisfy interfces when embedding in other structs
+func (r AuthorizationRule) GetAuthorizationRule() AuthorizationRule {
+	return r
+}
+
+// Equal returns true if the rules are equal.
+//
+// See Identity.Equal for more information on how it is compared.
+func (r AuthorizationRule) Equal(other AuthorizationRule) bool {
+	return r.InheritanceFlags == other.InheritanceFlags &&
+		r.PropagationFlags == other.PropagationFlags &&
+		r.IsInherited == other.IsInherited &&
+		r.Identity.Equal(other.Identity)
+}
+
+// Equal returns true if the rules are equal.
+func (r AuditRule) Equal(other AuditRule) bool {
+	return r.Rights == other.Rights &&
+		r.AuditFlags == other.AuditFlags &&
+		r.AuthorizationRule.Equal(other.AuthorizationRule)
+}
+
+// IsSuccess returns true if the audit rule is a success rule
+func (r AuditRule) IsSuccess() bool {
+	return r.AuditFlags == 0
+}
+
+// IsFailure returns true if the audit rule is a failure rule
+func (r AuditRule) IsFailure() bool {
+	return r.AuditFlags == 1
+}
+
+// GetRights returns the rights for the audit rule
+func (r AuditRule) GetRights() int {
+	return r.Rights
+}
+
+// Equal returns true if the rules are equal.
+func (r AccessRule) Equal(other AccessRule) bool {
+	return r.Rights == other.Rights &&
+		r.AccessControlType == other.AccessControlType &&
+		r.AuthorizationRule.Equal(other.AuthorizationRule)
+}
+
+// IsAllow returns true if the access rule is an allow rule
+func (r AccessRule) IsAllow() bool {
+	return r.AccessControlType == AccessControlTypeAllow
+}
+
+// IsDeny returns true if the access rule is a deny rule
+func (r AccessRule) IsDeny() bool {
+	return r.AccessControlType == AccessControlTypeDeny
+}
+
+// GetRights returns the rights for the access rule
+func (r AccessRule) GetRights() int {
+	return r.Rights
+}
+
+// NewExplicitAccessRule creates a new explicit AccessRule for a file or directory
+//
+// Flags default to no inheritance, no no propagation
+func NewExplicitAccessRule(identity Identity, rights int, accessControlType int) AccessRule {
+	return NewExplicitAccessRuleWithFlags(identity, rights, accessControlType, InheritanceFlagsNone, PropagationFlagsNone)
+}
+
+// NewInheritedAccessRule creates a new inherited AccessRule for a file or directory
+func NewInheritedAccessRule(identity Identity, rights int, accessControlType int) AccessRule {
+	return NewInheritedAccessRuleWithFlags(identity, rights, accessControlType, InheritanceFlagsNone, PropagationFlagsNone)
+}
+
+// NewExplicitAccessRuleWithFlags creates a new AccessRule for a file or directory with the given flags
+func NewExplicitAccessRuleWithFlags(identity Identity, rights int, accessControlType int, inheritanceFlags int, propagationFlags int) AccessRule {
+	return newAccessRuleWithFlags(identity, rights, accessControlType, inheritanceFlags, propagationFlags, false)
+}
+
+// NewInheritedAccessRuleWithFlags creates a new inherited AccessRule for a file or directory with the given flags
+func NewInheritedAccessRuleWithFlags(identity Identity, rights int, accessControlType int, inheritanceFlags int, propagationFlags int) AccessRule {
+	return newAccessRuleWithFlags(identity, rights, accessControlType, inheritanceFlags, propagationFlags, true)
+}
+
+func newAccessRuleWithFlags(identity Identity, rights int, accessControlType int, inheritanceFlags int, propagationFlags int, isInherited bool) AccessRule {
+	return AccessRule{
+		AuthorizationRule: AuthorizationRule{
+			Identity:         identity,
+			InheritanceFlags: inheritanceFlags,
+			PropagationFlags: propagationFlags,
+			IsInherited:      isInherited,
+		},
+		Rights:            rights,
+		AccessControlType: accessControlType,
+	}
+}
+
+//go:embed fixtures/get-acl-helpers.ps1
+var aclHelpersPs1Fixture []byte
+var aclHelpersPath = `C:\Windows\Temp\acl_helpers.ps1`
+
+func placeACLHelpers(host *components.RemoteHost) error {
+	_, err := host.WriteFile(aclHelpersPath, aclHelpersPs1Fixture)
+	return err
+}
+
+// GetFileSystemSecurityInfo returns the security information for the given file or directory path using Get-ACL
+func GetFileSystemSecurityInfo(host *components.RemoteHost, path string) (ObjectSecurity, error) {
+	var s ObjectSecurity
+
+	err := placeACLHelpers(host)
+	if err != nil {
+		return s, err
+	}
+
+	// Get the ACL information
+	cmd := fmt.Sprintf(`. %s; Get-Acl -Audit -Path '%s' | ConvertTo-ACLDTO`, aclHelpersPath, path)
+	output, err := host.Execute(cmd)
+	if err != nil {
+		return s, err
+	}
+
+	err = json.Unmarshal([]byte(output), &s)
+	if err != nil {
+		return s, err
+	}
+
+	return s, nil
+}
+
+// NewProtectedFileSystemSecurityInfo creates a new ObjectSecurity with protected access rules (i.e. inheritance is disabled)
+func NewProtectedFileSystemSecurityInfo(owner Identity, group Identity, access []AccessRule) ObjectSecurity {
+	return ObjectSecurity{
+		Owner:                   owner,
+		Group:                   group,
+		Access:                  access,
+		AreAccessRulesProtected: true,
+	}
+}
+
+// NewInheritFileSystemSecurityInfo creates a new ObjectSecurity that can inherit access rules
+func NewInheritFileSystemSecurityInfo(owner Identity, group Identity, access []AccessRule) ObjectSecurity {
+	return ObjectSecurity{
+		Owner:                   owner,
+		Group:                   group,
+		Access:                  access,
+		AreAccessRulesProtected: false,
+	}
+}
+
+// ContainsRuleForIdentity returns true if the list contains a rule for the given identity
+func ContainsRuleForIdentity[T AuthorizationRuleWithRights](acl []T, identity Identity) bool {
+	return slices.ContainsFunc(acl, func(rule T) bool {
+		return rule.GetAuthorizationRule().Identity.Equal(identity)
+	})
+}
+
+// AssertEqualAccessSecurity asserts that the access control settings for the expected and actual are equal.
+//
+// Compares the owner, group, and access rules. Note that the order of the access rules is relevant when
+// multiple rules apply to the same identity, but since this is not relevant for our use cases, we do not
+// enforce the order of the rules in this function.
+func AssertEqualAccessSecurity(t *testing.T, path string, expected, actual ObjectSecurity) {
+	t.Helper()
+
+	AssertEqualableElementsMatch(t, expected.Access, actual.Access, "%s access rules should match", path)
+	assert.Equal(t, expected.Owner, actual.Owner, "%s owner should match", path)
+	assert.Equal(t, expected.Group, actual.Group, "%s group should match", path)
+	assert.Equal(t, expected.AreAccessRulesProtected, actual.AreAccessRulesProtected, "%s access rules protection should match", path)
+}

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -317,7 +317,7 @@ func GetSecurityInfoForPath(host *components.RemoteHost, path string) (ObjectSec
 	}
 
 	// Get the ACL information
-	cmd := fmt.Sprintf(`. %s; Get-Acl -Audit -Path '%s' | ConvertTo-ACLDTO`, aclHelpersPath, path)
+	cmd := fmt.Sprintf(`$ErrorActionPreference = 'Stop'; . %s; Get-Acl -Audit -Path '%s' | ConvertTo-ACLDTO`, aclHelpersPath, path)
 	output, err := host.Execute(cmd)
 	if err != nil {
 		return s, err

--- a/test/new-e2e/tests/windows/common/assert.go
+++ b/test/new-e2e/tests/windows/common/assert.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package common
+
+import (
+	"bytes"
+	"slices"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+// diffListsFunc compares two lists and returns the elements that are in the first list but not in the second, and vice versa,
+// using a custom comparison function.
+func diffListsFunc[T any](a []T, b []T, comp func(a, b T) bool) ([]T, []T) {
+	extraA := []T{}
+	extraB := []T{}
+	inBoth := make([]bool, len(b))
+	for _, aVal := range a {
+		found := false
+		for j, bVal := range b {
+			if inBoth[j] {
+				continue
+			}
+			if comp(aVal, bVal) {
+				inBoth[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			extraA = append(extraA, aVal)
+		}
+	}
+	for j, bVal := range b {
+		if inBoth[j] {
+			continue
+		}
+		extraB = append(extraB, bVal)
+	}
+	return extraA, extraB
+}
+
+// formatListDiff returns a string representation of the differences between two lists
+func formatListDiff[T any](expected, actual, extraExpected, extraActual []T) string {
+	var msg bytes.Buffer
+
+	msg.WriteString("list elements differ")
+	if len(extraExpected) > 0 {
+		msg.WriteString("\n\nextra elements in expected:\n")
+		spewConfig.Fdump(&msg, extraExpected)
+	}
+	if len(extraActual) > 0 {
+		msg.WriteString("\n\nextra elements in actual:\n")
+		spewConfig.Fdump(&msg, extraActual)
+	}
+	msg.WriteString("\n\nexpected:\n")
+	spewConfig.Fdump(&msg, expected)
+	msg.WriteString("\n\nactual:\n")
+	spewConfig.Fdump(&msg, actual)
+
+	return msg.String()
+}
+
+func formatElementNotFound[T any](elem T, list []T) string {
+	var msg bytes.Buffer
+
+	msg.WriteString("element not found")
+	msg.WriteString("\n\nexpected element:\n")
+	spewConfig.Fdump(&msg, elem)
+	msg.WriteString("\n\nactual list:\n")
+	spewConfig.Fdump(&msg, list)
+
+	return msg.String()
+}
+
+// AssertElementsMatchFunc is similar to the assert.ElementsMatch function, but it allows for a custom comparison function
+func AssertElementsMatchFunc[T any](t *testing.T, expected, actual []T, comp func(a, b T) bool, msgAndArgs ...any) bool {
+	t.Helper()
+
+	extraA, extraB := diffListsFunc(expected, actual, comp)
+	if len(extraA) == 0 && len(extraB) == 0 {
+		return true
+	}
+
+	return assert.Fail(t, formatListDiff(expected, actual, extraA, extraB), msgAndArgs...)
+}
+
+// AssertContainsFunc is similar to the assert.Contains function, but it allows for a custom comparison function.
+// It is also similar to slices.ContainsFunc, which it uses internally, but also provides a helpful error message
+// in the style of the testify assert functions.
+func AssertContainsFunc[T any](t *testing.T, list []T, elem T, comp func(a, b T) bool, msgAndArgs ...any) bool {
+	t.Helper()
+	if slices.ContainsFunc(list, func(e T) bool {
+		return comp(e, elem)
+	}) {
+		return true
+	}
+	return assert.Fail(t, formatElementNotFound(elem, list), msgAndArgs...)
+}
+
+type equalable[T any] interface {
+	Equal(other T) bool
+}
+
+// AssertEqualableElementsMatch is a helper for AssertElementsMatchFunc that works with types that implement the Equal method
+func AssertEqualableElementsMatch[T equalable[T]](t *testing.T, expected, actual []T, msgAndArgs ...any) bool {
+	t.Helper()
+	return AssertElementsMatchFunc(t, expected, actual, func(a, b T) bool {
+		return a.Equal(b)
+	}, msgAndArgs...)
+}
+
+// AssertContainsEqualable is a helper for AssertContainsFunc that works with types that implement the Equal method
+func AssertContainsEqualable[T equalable[T]](t *testing.T, list []T, elem T, msgAndArgs ...any) bool {
+	t.Helper()
+	return AssertContainsFunc(t, list, elem, func(a, b T) bool {
+		return a.Equal(b)
+	}, msgAndArgs...)
+}

--- a/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
+++ b/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
@@ -84,7 +84,7 @@ function ConvertTo-ACLDTO {
             $modifiedAccess = @{
                 Rights = Get-RuleRights($access)
                 AccessControlType = $access.AccessControlType
-                IdentityReference = @{
+                Identity = @{
                     Name = $accessName
                     SID = $accessSid
                 }
@@ -102,7 +102,7 @@ function ConvertTo-ACLDTO {
             $modifiedAccess = @{
                 Rights = Get-RuleRights($audit)
                 AuditFlags = $audit.AuditFlags
-                IdentityReference = @{
+                Identity = @{
                     Name = $auditName
                     SID = $auditSid
                 }

--- a/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
+++ b/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
@@ -1,0 +1,106 @@
+# Function to translate identity to SID
+function Format-IdentityAsSID($identity) {
+    if ($identity -is [System.Security.Principal.SecurityIdentifier]) {
+        return $identity.Value
+    }
+    try {
+        # Try it directly, first
+        if ($identity -is [System.Security.Principal.NTAccount]) {
+            return $identity.Translate([System.Security.Principal.SecurityIdentifier]).Value
+        }
+        if ($identity -is [String]) {
+            return (New-Object System.Security.Principal.NTAccount($identity)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        }
+    } catch {
+        # Some names (e.g. APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES) only work if the latter half is provided
+        $name = $identity
+        if ($name -is [System.Security.Principal.NTAccount]) {
+            $name = $identity.Value
+        }
+        $name = $name.Split('\')[-1]
+        return (New-Object System.Security.Principal.NTAccount($name)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        # We must either return a value or throw an error, all accounts/identities have SIDs
+    }
+}
+
+# Function to translate identity to name
+function Format-IdentityAsName($identity) {
+    if ($identity -is [String]) {
+        return $identity
+    }
+    if ($identity -is [System.Security.Principal.NTAccount]) {
+        return $identity.Value
+    }
+    try {
+        return $identity.Translate([System.Security.Principal.NTAccount]).Value
+    } catch {
+        # Don't throw an error if we can't resolve the name, some SIDs don't have names
+        return ""
+    }
+}
+
+# Retrieves the ACL for $path and returns it as a JSON object that can be unmarshalled by the test
+function ConvertTo-ACLDTO {
+    # process block to support pipeline input
+    process {
+        $aclObject = $_
+        # Create a new object to store modified ACL
+        $newAclObject = @{
+            Owner = @{
+                Name = Format-IdentityAsName($aclObject.Owner)
+                SID = Format-IdentityAsSID($aclObject.Owner)
+            }
+            Group = @{
+                Name = Format-IdentityAsName($aclObject.Group)
+                SID = Format-IdentityAsSID($aclObject.Group)
+            }
+            Access = @()
+            Audit = @()
+            Sddl = $aclObject.Sddl
+            AreAccessRulesProtected = $aclObject.AreAccessRulesProtected
+            AreAuditRulesProtected = $aclObject.AreAuditRulesProtected
+        }
+
+        # Modify Access IdentityReferences and add to new ACL object
+        foreach ($access in $aclObject.Access) {
+            $accessSid = Format-IdentityAsSID($access.IdentityReference)
+            $accessName = Format-IdentityAsName($access.IdentityReference)
+            $modifiedAccess = @{
+                Rights = $access.FileSystemRights
+                AccessControlType = $access.AccessControlType
+                IdentityReference = @{
+                    Name = $accessName
+                    SID = $accessSid
+                }
+                IsInherited = $access.IsInherited
+                InheritanceFlags = $access.InheritanceFlags
+                PropagationFlags = $access.PropagationFlags
+            }
+            $newAclObject.Access += $modifiedAccess
+        }
+
+        # Modify Audit IdentityReferences and add to new ACL object
+        foreach ($audit in $aclObject.Audit) {
+            $auditSid = Format-IdentityAsSID($audit.IdentityReference.Value)
+            $auditName = Format-IdentityAsName($audit.IdentityReference.Value)
+            $modifiedAccess = @{
+                Rights = $audit.FileSystemRights
+                AuditFlags = $audit.AuditFlags
+                IdentityReference = @{
+                    Name = $auditName
+                    SID = $auditSid
+                }
+                IsInherited = $audit.IsInherited
+                InheritanceFlags = $audit.InheritanceFlags
+                PropagationFlags = $audit.PropagationFlags
+            }
+            $newAclObject.Audit += $modifiedAccess
+        }
+
+        # Convert new ACL object to JSON
+        $newAclJson = $newAclObject | ConvertTo-Json -Depth 5
+
+        # Output modified JSON
+        Write-Output $newAclJson
+    }
+}

--- a/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
+++ b/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
@@ -74,7 +74,7 @@ function ConvertTo-ACLDTO {
             }
             Access = @()
             Audit = @()
-            Sddl = $aclObject.Sddl
+            SDDL = $aclObject.Sddl
             AreAccessRulesProtected = $aclObject.AreAccessRulesProtected
             AreAuditRulesProtected = $aclObject.AreAuditRulesProtected
         }
@@ -127,7 +127,7 @@ function ConvertTo-ServiceSecurityDTO {
         $newObject = @{
             Access = @()
             Audit = @()
-            Sddl = $sddl
+            SDDL = $sddl
         }
 
         # Modify Access IdentityReferences and add to new ACL object

--- a/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
+++ b/test/new-e2e/tests/windows/common/fixtures/get-acl-helpers.ps1
@@ -48,11 +48,13 @@ function Get-RuleRights($rule) {
     } else {
         throw "Could not determine rights for rule"
     }
-    # convert to unsigned int 32
+    # Make sure to cast to int to get the real value from the Enum
+    # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum
+    $rights = [int]$rights
     if ($rights -lt 0) {
         $rights = [uint32]::MaxValue + 1 + $rights
     }
-    return $rights
+    return [uint32]($rights -band 0xffffffffL)
 }
 
 # Retrieves the ACL for $path and returns it as a JSON object that can be unmarshalled by the test

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -43,18 +43,6 @@ func (i Identity) Equal(other SecurityIdentifier) bool {
 	return SecurityIdentifierEqual(i, other)
 }
 
-// UnmarshalJSON unmarshals an Identity from JSON
-func (i *Identity) UnmarshalJSON(data []byte) error {
-	var v map[string]string
-	err := json.Unmarshal(data, &v)
-	if err != nil {
-		return err
-	}
-	i.Name = v["Name"]
-	i.SID = v["SID"]
-	return nil
-}
-
 // SecurityIdentifier is an interface for objects that have a name and SID
 type SecurityIdentifier interface {
 	GetName() string

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -19,6 +19,7 @@ import (
 const (
 	LocalSystemSID    = "S-1-5-18"
 	AdministratorsSID = "S-1-5-32-544"
+	EveryoneSID       = "S-1-1-0"
 )
 
 // Identity contains the name and SID of an identity (user or group)

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -102,20 +102,6 @@ func GetIdentityForSID(host *components.RemoteHost, sid string) (Identity, error
 	return Identity{Name: name, SID: sid}, nil
 }
 
-// GetSystemIdentity returns the Identity for the SYSTEM account
-//
-// A lookup by SID is performed because the name may be localized.
-func GetSystemIdentity(host *components.RemoteHost) (Identity, error) {
-	return GetIdentityForSID(host, LocalSystemSID)
-}
-
-// GetAdministratorsIdentity returns the Identity for the Administrators group
-//
-// A lookup by SID is performed because the name may be localized.
-func GetAdministratorsIdentity(host *components.RemoteHost) (Identity, error) {
-	return GetIdentityForSID(host, AdministratorsSID)
-}
-
 // GetUserForSID returns the username for the given SID.
 func GetUserForSID(host *components.RemoteHost, sid string) (string, error) {
 	cmd := fmt.Sprintf(`(New-Object System.Security.Principal.SecurityIdentifier('%s')).Translate([System.Security.Principal.NTAccount]).Value`, sid)

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -94,8 +94,15 @@ func GetIdentityForUser(host *components.RemoteHost, user string) (Identity, err
 	return Identity{Name: user, SID: sid}, nil
 }
 
-// GetIdentityForSID returns the Identity for the given SID.
-func GetIdentityForSID(host *components.RemoteHost, sid string) (Identity, error) {
+// GetIdentityForSID returns an Identity for the given SID. Does not fetch the name, see GetIdentityForSIDWithName.
+func GetIdentityForSID(sid string) Identity {
+	return Identity{SID: sid}
+}
+
+// GetIdentityForSIDWithName returns an Identity for the given SID with the name fetched from the host.
+//
+// This is useful when the name is needed for display purposes. The name may be localized or ambiguous, and may not be unique.
+func GetIdentityForSIDWithName(host *components.RemoteHost, sid string) (Identity, error) {
 	name, err := GetUserForSID(host, sid)
 	if err != nil {
 		return Identity{}, err
@@ -294,5 +301,5 @@ func RemoveLocalUser(host *components.RemoteHost, user string) error {
 // IsIdentityLocalSystem Returns true if the identity is the local SYSTEM account
 func IsIdentityLocalSystem(i Identity) bool {
 	// We don't need to fetch a full identity with name from the host, we can just compare the SIDs
-	return SecurityIdentifierEqual(i, Identity{SID: LocalSystemSID})
+	return SecurityIdentifierEqual(i, GetIdentityForSID(LocalSystemSID))
 }

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -13,6 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 )
 
+// Well Known SIDs
+//
+// https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
+const (
+	LocalSystemSID    = "S-1-5-18"
+	AdministratorsSID = "S-1-5-32-544"
+)
+
 // Identity contains the name and SID of an identity (user or group)
 type Identity struct {
 	Name string
@@ -98,14 +106,14 @@ func GetIdentityForSID(host *components.RemoteHost, sid string) (Identity, error
 //
 // A lookup by SID is performed because the name may be localized.
 func GetSystemIdentity(host *components.RemoteHost) (Identity, error) {
-	return GetIdentityForSID(host, "S-1-5-18")
+	return GetIdentityForSID(host, LocalSystemSID)
 }
 
 // GetAdministratorsIdentity returns the Identity for the Administrators group
 //
 // A lookup by SID is performed because the name may be localized.
 func GetAdministratorsIdentity(host *components.RemoteHost) (Identity, error) {
-	return GetIdentityForSID(host, "S-1-5-32-544")
+	return GetIdentityForSID(host, AdministratorsSID)
 }
 
 // GetUserForSID returns the username for the given SID.
@@ -294,4 +302,10 @@ func RemoveLocalUser(host *components.RemoteHost, user string) error {
 	cmd := fmt.Sprintf(`Remove-LocalUser -Name "%s"`, user)
 	_, err := host.Execute(cmd)
 	return err
+}
+
+// IsIdentityLocalSystem Returns true if the identity is the local SYSTEM account
+func IsIdentityLocalSystem(i Identity) bool {
+	// We don't need to fetch a full identity with name from the host, we can just compare the SIDs
+	return SecurityIdentifierEqual(i, Identity{SID: LocalSystemSID})
 }

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -376,17 +376,13 @@ func getExpectedInheritedConfigDirSecurityWithAgent(host *components.RemoteHost,
 // addAgentUserAccessRule is a helper to add an access rule for the agent user to the security settings
 // except when the agent user is SYSTEM, in which case no additional ACE is needed.
 func addAgentUserAccessRule(host *components.RemoteHost, security *windows.ObjectSecurity, agentUserName string, ruleProvider func(agentUser windows.Identity) windows.AccessRule) error {
-	// Get identities from host
-	systemIdentity, err := windows.GetSystemIdentity(host)
-	if err != nil {
-		return err
-	}
+	// Get agent user identity from host
 	ddagentUserIdentity, err := windows.GetIdentityForUser(host, agentUserName)
 	if err != nil {
 		return err
 	}
 
-	if ddagentUserIdentity.Equal(systemIdentity) {
+	if windows.IsIdentityLocalSystem(ddagentUserIdentity) {
 		return nil
 	}
 

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -204,18 +204,18 @@ func ExpectPython2Installed(majorVersion string) bool {
 func getBaseConfigRootSecurity() (windows.ObjectSecurity, error) {
 	// SYSTEM and Administrators have full control
 	return windows.NewProtectedSecurityInfo(
-		windows.Identity{SID: windows.LocalSystemSID},
-		windows.Identity{SID: windows.LocalSystemSID},
+		windows.GetIdentityForSID(windows.LocalSystemSID),
+		windows.GetIdentityForSID(windows.LocalSystemSID),
 		[]windows.AccessRule{
 			windows.NewExplicitAccessRuleWithFlags(
-				windows.Identity{SID: windows.LocalSystemSID},
+				windows.GetIdentityForSID(windows.LocalSystemSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 				windows.InheritanceFlagsContainer|windows.InheritanceFlagsObject,
 				windows.PropagationFlagsNone,
 			),
 			windows.NewExplicitAccessRuleWithFlags(
-				windows.Identity{SID: windows.AdministratorsSID},
+				windows.GetIdentityForSID(windows.AdministratorsSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 				windows.InheritanceFlagsContainer|windows.InheritanceFlagsObject,
@@ -254,16 +254,16 @@ func getExpectedConfigRootSecurityWithAgent(ddAgentUserIdentity windows.Identity
 func getBaseInheritedConfigFileSecurity() (windows.ObjectSecurity, error) {
 	// SYSTEM and Administrators have full control
 	return windows.NewInheritSecurityInfo(
-		windows.Identity{SID: windows.LocalSystemSID},
-		windows.Identity{SID: windows.LocalSystemSID},
+		windows.GetIdentityForSID(windows.LocalSystemSID),
+		windows.GetIdentityForSID(windows.LocalSystemSID),
 		[]windows.AccessRule{
 			windows.NewInheritedAccessRule(
-				windows.Identity{SID: windows.LocalSystemSID},
+				windows.GetIdentityForSID(windows.LocalSystemSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 			),
 			windows.NewInheritedAccessRule(
-				windows.Identity{SID: windows.AdministratorsSID},
+				windows.GetIdentityForSID(windows.AdministratorsSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 			),
@@ -297,18 +297,18 @@ func getExpectedInheritedConfigFileSecurityWithAgent(ddAgentUserIdentity windows
 func getBaseInheritedConfigDirSecurity() (windows.ObjectSecurity, error) {
 	// SYSTEM and Administrators have full control
 	return windows.NewInheritSecurityInfo(
-		windows.Identity{SID: windows.LocalSystemSID},
-		windows.Identity{SID: windows.LocalSystemSID},
+		windows.GetIdentityForSID(windows.LocalSystemSID),
+		windows.GetIdentityForSID(windows.LocalSystemSID),
 		[]windows.AccessRule{
 			windows.NewInheritedAccessRuleWithFlags(
-				windows.Identity{SID: windows.LocalSystemSID},
+				windows.GetIdentityForSID(windows.LocalSystemSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 				windows.InheritanceFlagsContainer|windows.InheritanceFlagsObject,
 				windows.PropagationFlagsNone,
 			),
 			windows.NewInheritedAccessRuleWithFlags(
-				windows.Identity{SID: windows.AdministratorsSID},
+				windows.GetIdentityForSID(windows.AdministratorsSID),
 				windows.FileFullControl,
 				windows.AccessControlTypeAllow,
 				windows.InheritanceFlagsContainer|windows.InheritanceFlagsObject,

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -214,7 +214,7 @@ func getBaseConfigRootSecurity(host *components.RemoteHost) (windows.ObjectSecur
 		return expected, err
 	}
 	// SYSTEM and Administrators have full control
-	return windows.NewProtectedFileSystemSecurityInfo(
+	return windows.NewProtectedSecurityInfo(
 		systemIdentity,
 		systemIdentity,
 		[]windows.AccessRule{
@@ -275,7 +275,7 @@ func getBaseInheritedConfigFileSecurity(host *components.RemoteHost) (windows.Ob
 		return expected, err
 	}
 	// SYSTEM and Administrators have full control
-	return windows.NewInheritFileSystemSecurityInfo(
+	return windows.NewInheritSecurityInfo(
 		systemIdentity,
 		systemIdentity,
 		[]windows.AccessRule{
@@ -329,7 +329,7 @@ func getBaseInheritedConfigDirSecurity(host *components.RemoteHost) (windows.Obj
 		return expected, err
 	}
 	// SYSTEM and Administrators have full control
-	return windows.NewInheritFileSystemSecurityInfo(
+	return windows.NewInheritSecurityInfo(
 		systemIdentity,
 		systemIdentity,
 		[]windows.AccessRule{

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -248,7 +248,7 @@ func getExpectedConfigRootSecurityWithAgent(ddAgentUserIdentity windows.Identity
 	return expected, nil
 }
 
-// getBaseConfigFileSecurity returns the base security settings for a config file that inherits permissions from the config root
+// getBaseInheritedConfigFileSecurity returns the base security settings for a config file that inherits permissions from the config root
 //   - (inherited) SYSTEM full control, owner and group
 //   - (inherited) Administrators full control
 func getBaseInheritedConfigFileSecurity() (windows.ObjectSecurity, error) {
@@ -271,7 +271,7 @@ func getBaseInheritedConfigFileSecurity() (windows.ObjectSecurity, error) {
 	), nil
 }
 
-// getExpectedConfigFileSecurityWithAgent adds a rule for the agent user to getBaseConfigFileSecurity
+// getExpectedInheritedConfigFileSecurityWithAgent adds a rule for the agent user to getBaseInheritedConfigFileSecurity
 //   - (inherited) ddagentuser full control
 func getExpectedInheritedConfigFileSecurityWithAgent(ddAgentUserIdentity windows.Identity) (windows.ObjectSecurity, error) {
 	expected, err := getBaseInheritedConfigFileSecurity()
@@ -291,7 +291,7 @@ func getExpectedInheritedConfigFileSecurityWithAgent(ddAgentUserIdentity windows
 	return expected, nil
 }
 
-// getBaseConfigDirSecurity returns the base security settings for a config dir that inherits permissions from the config root
+// getBaseInheritedConfigDirSecurity returns the base security settings for a config dir that inherits permissions from the config root
 //   - (inherited) SYSTEM full control, owner and group
 //   - (inherited) Administrators full control
 func getBaseInheritedConfigDirSecurity() (windows.ObjectSecurity, error) {
@@ -318,7 +318,7 @@ func getBaseInheritedConfigDirSecurity() (windows.ObjectSecurity, error) {
 	), nil
 }
 
-// getExpectedConfigDirSecurityWithAgent adds a rule for the agent user to getBaseConfigDirSecurity
+// getExpectedInheritedConfigDirSecurityWithAgent adds a rule for the agent user to getBaseInheritedConfigDirSecurity
 //   - (inherited) ddagentuser full control
 func getExpectedInheritedConfigDirSecurityWithAgent(ddAgentUserIdentity windows.Identity) (windows.ObjectSecurity, error) {
 	expected, err := getBaseInheritedConfigDirSecurity()

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -410,7 +410,7 @@ func (t *Tester) testUninstalledFilePermissions(tt *testing.T) {
 			name: "ConfigRoot",
 			path: t.expectedConfigRoot,
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getBaseConfigRootSecurity(t.host)
+				s, err := getBaseConfigRootSecurity()
 				require.NoError(tt, err)
 				return s
 			},
@@ -419,7 +419,7 @@ func (t *Tester) testUninstalledFilePermissions(tt *testing.T) {
 			name: "datadog.yaml",
 			path: filepath.Join(t.expectedConfigRoot, "datadog.yaml"),
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getBaseInheritedConfigFileSecurity(t.host)
+				s, err := getBaseInheritedConfigFileSecurity()
 				require.NoError(tt, err)
 				return s
 			},
@@ -428,7 +428,7 @@ func (t *Tester) testUninstalledFilePermissions(tt *testing.T) {
 			name: "conf.d",
 			path: filepath.Join(t.expectedConfigRoot, "conf.d"),
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getBaseInheritedConfigDirSecurity(t.host)
+				s, err := getBaseInheritedConfigDirSecurity()
 				require.NoError(tt, err)
 				return s
 			},
@@ -461,9 +461,7 @@ func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
 			name: "ConfigRoot",
 			path: t.expectedConfigRoot,
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getExpectedConfigRootSecurityWithAgent(t.host,
-					windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
-				)
+				s, err := getExpectedConfigRootSecurityWithAgent(ddagentUserIdentity)
 				require.NoError(tt, err)
 				return s
 			},
@@ -472,9 +470,7 @@ func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
 			name: "datadog.yaml",
 			path: filepath.Join(t.expectedConfigRoot, "datadog.yaml"),
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getExpectedInheritedConfigFileSecurityWithAgent(t.host,
-					windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
-				)
+				s, err := getExpectedInheritedConfigFileSecurityWithAgent(ddagentUserIdentity)
 				require.NoError(tt, err)
 				return s
 			},
@@ -483,9 +479,7 @@ func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
 			name: "conf.d",
 			path: filepath.Join(t.expectedConfigRoot, "conf.d"),
 			expectedSecurity: func(tt *testing.T) windows.ObjectSecurity {
-				s, err := getExpectedInheritedConfigDirSecurityWithAgent(t.host,
-					windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
-				)
+				s, err := getExpectedInheritedConfigDirSecurityWithAgent(ddagentUserIdentity)
 				require.NoError(tt, err)
 				return s
 			},

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -349,7 +349,7 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 			}
 			// [7.47 - 7.50) added an ACE for Everyone, make sure it isn't there
 			expected := windows.NewExplicitAccessRule(
-				windows.Identity{SID: windows.EveryoneSID},
+				windows.GetIdentityForSID(windows.EveryoneSID),
 				windows.SERVICE_ALL_ACCESS,
 				windows.AccessControlTypeAllow,
 			)

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -250,6 +250,10 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	// don't need to check registry key permissions because the key is removed
 
 	tt.Run("file permissions", func(tt *testing.T) {
+		if strings.HasPrefix(tt.Name(), "TestInstallFail/") {
+			// TODO WINA-852: install rollback leaves different permissions behind
+			tt.Skip("WINA-852: skipping known failure, install rollback leaves different permissions behind")
+		}
 		t.testUninstalledFilePermissions(tt)
 	})
 }

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -385,7 +385,7 @@ func (t *Tester) testUninstalledFilePermissions(tt *testing.T) {
 	}
 	for _, tc := range tc {
 		tt.Run(tc.name, func(tt *testing.T) {
-			out, err := windows.GetFileSystemSecurityInfo(t.host, tc.path)
+			out, err := windows.GetSecurityInfoForPath(t.host, tc.path)
 			require.NoError(tt, err)
 			windows.AssertEqualAccessSecurity(tt, tc.path, tc.expectedSecurity(tt), out)
 		})
@@ -396,7 +396,9 @@ func (t *Tester) testUninstalledFilePermissions(tt *testing.T) {
 }
 
 func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
-	ddagentUserIdentity, err := windows.GetIdentityForUser(t.host, windowsAgent.DefaultAgentUserName)
+	ddagentUserIdentity, err := windows.GetIdentityForUser(t.host,
+		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
+	)
 	require.NoError(tt, err)
 
 	tc := []struct {
@@ -440,7 +442,7 @@ func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
 	}
 	for _, tc := range tc {
 		tt.Run(tc.name, func(tt *testing.T) {
-			out, err := windows.GetFileSystemSecurityInfo(t.host, tc.path)
+			out, err := windows.GetSecurityInfoForPath(t.host, tc.path)
 			require.NoError(tt, err)
 			windows.AssertEqualAccessSecurity(tt, tc.path, tc.expectedSecurity(tt), out)
 		})
@@ -463,7 +465,7 @@ func (t *Tester) testInstalledFilePermissions(tt *testing.T) {
 		windows.PropagationFlagsNone,
 	)
 	for _, path := range embeddedPaths {
-		out, err := windows.GetFileSystemSecurityInfo(t.host, path)
+		out, err := windows.GetSecurityInfoForPath(t.host, path)
 		require.NoError(tt, err)
 		windows.AssertContainsEqualable(tt, out.Access, agentUserFullAccessDirRule, "%s should have full access rule for %s", path, ddagentUserIdentity)
 		assert.False(tt, out.AreAccessRulesProtected, "%s should inherit access rules", path)

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -267,8 +267,6 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 		windows.MakeDownLevelLogonName(t.expectedUserDomain, t.expectedUserName),
 	)
 	require.NoError(tt, err)
-	everyoneIdentity, err := windows.GetIdentityForSID(t.host, "S-1-1-0")
-	require.NoError(tt, err)
 
 	// If install paths differ from default ensure the defaults don't exist
 	if t.expectedInstallPath != windowsAgent.DefaultInstallPath {
@@ -351,11 +349,11 @@ func (t *Tester) testCurrentVersionExpectations(tt *testing.T) {
 			}
 			// [7.47 - 7.50) added an ACE for Everyone, make sure it isn't there
 			expected := windows.NewExplicitAccessRule(
-				everyoneIdentity,
+				windows.Identity{SID: windows.EveryoneSID},
 				windows.SERVICE_ALL_ACCESS,
 				windows.AccessControlTypeAllow,
 			)
-			windows.AssertNotContainsEqualable(tt, security.Access, expected, "%s should not have access rule for %s", serviceName, everyoneIdentity)
+			windows.AssertNotContainsEqualable(tt, security.Access, expected, "%s should not have access rule for Everyone", serviceName)
 		}
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add common utils for collecting and comparing Windows ACLs in E2E tests

Add file, registry, and service, permissions checks to installer E2E test

Add assertion helpers to give experience like `assert.ElementsMatch` and `assert.Contains` for custom objects.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507
replace kitchen test code: https://github.com/DataDog/datadog-agent/blob/main/test/kitchen/test/integration/win-user/rspec_datadog/win-user_spec.rb

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
