### PR TITLE
AMLII-1839 Fix bug when user remove the streamlog file and the flare maker does not attach the file again. 

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -340,6 +340,14 @@ func makeFlare(flareComp flare.Component,
 		return err
 	}
 
+	if streamLogParams.Duration > 0 {
+		fmt.Fprintln(color.Output, color.GreenString((fmt.Sprintf("Asking the agent to stream logs for %s", streamLogParams.Duration))))
+		err := streamlogs.StreamLogs(lc, config, &streamLogParams)
+		if err != nil {
+			fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error streaming logs: %s", err)))
+		}
+	}
+
 	var filePath string
 	if cliParams.forceLocal {
 		filePath, err = createArchive(flareComp, profile, nil)
@@ -355,14 +363,6 @@ func makeFlare(flareComp flare.Component,
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("The flare zipfile \"%s\" does not exist.", filePath)))
 		fmt.Fprintln(color.Output, color.RedString("If the agent running in a different container try the '--local' option to generate the flare locally"))
 		return err
-	}
-
-	if streamLogParams.Duration > 0 {
-		fmt.Fprintln(color.Output, color.GreenString((fmt.Sprintf("Asking the agent to stream logs for %s", streamLogParams.Duration))))
-		err := streamlogs.StreamLogs(lc, config, &streamLogParams)
-		if err != nil {
-			fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error streaming logs: %s", err)))
-		}
 	}
 
 	fmt.Fprintf(color.Output, "%s is going to be uploaded to Datadog\n", color.YellowString(filePath))


### PR DESCRIPTION
### What does this PR do?
- This PR fix an issue where if a user remove the default streamlogs folder that contains the `streamlogs.log` output then the flare will fail to attach the output next time they run the flare command with streamlog output.

### Describe how to test/QA your changes
- Generate a flare with streamlog
```
datad-agent flare -L 10s
```
- Check the flare that it has the streamlog_info folder and log file
- Remove the log file/folder in:
```
/var/log/datadog
```
- Rerun the flare command:
```
datad-agent flare -L 10s
```
- Check the flare that it still has the log file attached. 
