### PR TITLE
[CONTP-222] fix check-cmd

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -15,6 +15,7 @@ import (
 	utilserror "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
@@ -278,7 +279,7 @@ func waitForConfigsFromAD(ctx context.Context,
 	stopChan := make(chan struct{})
 	// add the scheduler in a goroutine, since it will schedule any "catch-up" immediately,
 	// placing items in configChan
-	go ac.AddScheduler("check-cmd", schedulerFunc(func(configs []integration.Config) {
+	go ac.AddScheduler(adtypes.CheckCmdName, schedulerFunc(func(configs []integration.Config) {
 		var errorList []error
 		for _, cfg := range configs {
 			if instanceFilter != "" {

--- a/comp/core/autodiscovery/common/types/consts.go
+++ b/comp/core/autodiscovery/common/types/consts.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package types
+
+const (
+	// CheckCmdName is the check name for autodiscovery component, used by cli mode.
+	CheckCmdName = "check-cmd"
+)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
[CONTP-222](https://datadoghq.atlassian.net/browse/CONTP-222)
Fix agent check xxx failure after previous [PR](https://github.com/DataDog/datadog-agent/pull/26474)
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The config scheduler in autodiscovery is now async after this [pr](https://github.com/DataDog/datadog-agent/pull/24350). However, `agent check xxx` in cli mode is expecting the configs returns from AD immediately after addScheduler (see comment [here](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/common/autodiscovery.go#L279)). 

Race conditions:
- A scheduler named ["check-cmd"](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/common/autodiscovery.go#L281) is registered in a go routine, which is assumed to catch up all scheduled configs immediately 	`go ac.AddScheduler("check-cmd", schedulerFunc(func(configs []integration.Config) {`

- On the other hand, in controller, configs to be scheduled might not be actually scheduled [here](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/scheduler/controller.go#L88) yet
- If no scheduled config is found, an [error](https://github.com/DataDog/datadog-agent/blob/4dd3f74a0c3f2d7ae3b7284c26184f80adcd7dd8/pkg/cli/subcommands/check/command.go#L474) is reported 

```
2024-06-10 05:11:10 UTC | CORE | INFO | (pkg/aggregator/aggregator.go:744 in run) | Stopping aggregator
Error: no valid check found
```

Fix:
Retrieve all the configs whose desirable state is scheduled from configStateStore (source of truth). 


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Getting all configs from configStateStore might cause double scheduling issue. But we limit the usage to agent check cli only (exit after checks are found), so no side affect on running agent. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Run `agent check disk`, no error is reported and metrics like system.disk.utilized should be dumped


[CONTP-222]: https://datadoghq.atlassian.net/browse/CONTP-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ