### PR TITLE
chore(opentelemetry): add malformed OTEL_RESOURCE_ATTRIBUTES unit test

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -1129,6 +1129,41 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "tags from environment with malformed OTEL_RESOURCE_ATTRIBUTES",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				EnvVars: map[string]string{
+					// env as tags
+					"TEAM": "container-integrations",
+					"TIER": "node",
+
+					// otel standard tags
+					"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("service.name=,  =  , =%s", env),
+				},
+			},
+			envAsTags: map[string]string{
+				"team": "owner_team",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"owner_team:container-integrations",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "tags from labels",
 			container: workloadmeta.Container{
 				EntityID: entityID,


### PR DESCRIPTION
### What does this PR do?

Adds a unit test to validate OTEL_RESOURCE_ATTRIBUTES key/pair check as implemented in #26427.

### Motivation

This is needed to make sure that we don't break the key/pair check.

### Describe how to test/QA your changes

None as this is a unit test.