### PR TITLE
Change Agent token storage path to always writable folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
           command: inv -e agent.build --flavor iot
       - run:
           name: test iot agent
-          command: DD_HOSTNAME=test-circleci-hostname ./bin/agent/agent -c ./bin/agent/dist check cpu
+          command: mkdir -p /opt/datadog-agent/run && DD_HOSTNAME=test-circleci-hostname ./bin/agent/agent -c ./bin/agent/dist check cpu
 
   documentation_generation:
     <<: *job_template

--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -56,7 +56,8 @@ type SubcommandFactory func(globalParams *GlobalParams) []*cobra.Command
 func GetDefaultCoreBundleParams(globalParams *GlobalParams) core.BundleParams {
 	return core.BundleParams{
 		ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
-		LogParams:    logimpl.ForOneShot(LoggerName, "off", true)}
+		LogParams:    logimpl.ForOneShot(LoggerName, "off", true),
+	}
 }
 
 // MakeCommand makes the top-level Cobra command for this app.

--- a/cmd/agent/subcommands/run/command_test.go
+++ b/cmd/agent/subcommands/run/command_test.go
@@ -6,6 +6,7 @@
 package run
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -43,13 +44,19 @@ func TestCommandPidfile(t *testing.T) {
 func newGlobalParamsTest(t *testing.T) *command.GlobalParams {
 	// Because getSharedFxOption uses fx.Invoke, demultiplexer component is built
 	// which lead to build:
-	//   - config.Component which requires a valid datadog.yaml
+	//   - configPath.Component which requires a valid datadog.yaml
 	//   - hostname.Component which requires a valid hostname
-	config := path.Join(t.TempDir(), "datadog.yaml")
-	err := os.WriteFile(config, []byte("hostname: test"), 0644)
+	tempDirPath := t.TempDir()
+	configPath := path.Join(tempDirPath, "datadog.yaml")
+	configContent := fmt.Sprintf(`
+hostname: test
+run_path: %s
+`, tempDirPath)
+
+	err := os.WriteFile(configPath, []byte(configContent), 0o644)
 	require.NoError(t, err)
 
 	return &command.GlobalParams{
-		ConfFilePath: config,
+		ConfFilePath: configPath,
 	}
 }

--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -5,6 +5,7 @@
 # .deb: STEP 1 of 5
 
 INSTALL_DIR=/opt/datadog-agent
+ETC_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 
 stop_agent()
@@ -158,6 +159,22 @@ remove_apm_remote_config()
     fi
 }
 
+remove_auth_token()
+{
+    # Since Agent 7.56, Agent stores its token file in /opt/datadog-agent/run/auth_token.
+    # This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/auth_token" ]; then
+        echo "Removing auth_token file"
+        rm "$INSTALL_DIR/run/auth_token" || true
+    fi
+    if [ -f "$ETC_DIR/auth_token" ]; then
+        echo "Removing old auth_token file"
+        rm "$ETC_DIR/auth_token" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 remove_custom_integrations
@@ -169,6 +186,7 @@ case "$1" in
         remove_version_history
         remove_sysprobe_secagent_files
         remove_remote_config_db
+        remove_auth_token
     ;;
     upgrade)
         # We're upgrading.

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -5,6 +5,7 @@
 # .rpm: STEP 4 of 6
 
 INSTALL_DIR=/opt/datadog-agent
+ETC_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 
 stop_agent()
@@ -142,6 +143,22 @@ remove_apm_remote_config()
     fi
 }
 
+remove_auth_token()
+{
+    # Since Agent 7.56, Agent stores its token file in /opt/datadog-agent/run/auth_token.
+    # This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/auth_token" ]; then
+        echo "Removing auth_token file"
+        rm "$INSTALL_DIR/run/auth_token" || true
+    fi
+    if [ -f "$ETC_DIR/auth_token" ]; then
+        echo "Removing old auth_token file"
+        rm "$ETC_DIR/auth_token" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -153,6 +170,7 @@ case "$*" in
         remove_version_history
         remove_sysprobe_secagent_files
         remove_remote_config_db
+        remove_auth_token
     ;;
     1)
         # We're upgrading.

--- a/omnibus/package-scripts/iot-agent-deb/prerm
+++ b/omnibus/package-scripts/iot-agent-deb/prerm
@@ -5,6 +5,7 @@
 # .deb: STEP 1 of 5
 
 INSTALL_DIR=/opt/datadog-agent
+ETC_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 
 stop_agent()
@@ -60,6 +61,22 @@ remove_remote_config_db()
     fi
 }
 
+remove_auth_token()
+{
+    # Since Agent 7.56, Agent stores its token file in /opt/datadog-agent/run/auth_token.
+    # This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/auth_token" ]; then
+        echo "Removing auth_token file"
+        rm "$INSTALL_DIR/run/auth_token" || true
+    fi
+    if [ -f "$ETC_DIR/auth_token" ]; then
+        echo "Removing old auth_token file"
+        rm "$ETC_DIR/auth_token" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -68,6 +85,7 @@ case "$1" in
         # We're uninstalling.
         remove_version_history
         remove_remote_config_db
+        remove_auth_token
     ;;
     upgrade)
         # We're upgrading.

--- a/omnibus/package-scripts/iot-agent-rpm/prerm
+++ b/omnibus/package-scripts/iot-agent-rpm/prerm
@@ -5,6 +5,7 @@
 # .rpm: STEP 4 of 6
 
 INSTALL_DIR=/opt/datadog-agent
+ETC_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 
 stop_agent()
@@ -60,6 +61,22 @@ remove_remote_config_db()
     fi
 }
 
+remove_auth_token()
+{
+    # Since Agent 7.56, Agent stores its token file in /opt/datadog-agent/run/auth_token.
+    # This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/auth_token" ]; then
+        echo "Removing auth_token file"
+        rm "$INSTALL_DIR/run/auth_token" || true
+    fi
+    if [ -f "$ETC_DIR/auth_token" ]; then
+        echo "Removing old auth_token file"
+        rm "$ETC_DIR/auth_token" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -68,6 +85,7 @@ case "$*" in
         # We're uninstalling.
         remove_version_history
         remove_remote_config_db
+        remove_auth_token
     ;;
     1)
         # We're upgrading.

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -36,7 +36,6 @@ replace (
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/model v0.55.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/system v0.55.0-rc.3
@@ -59,7 +58,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.55.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.55.0-rc.3 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	configModel "github.com/DataDog/datadog-agent/pkg/config/model"
-	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -117,7 +116,7 @@ func GetAuthTokenFilepath(config configModel.Reader) string {
 	if config.GetString("auth_token_file_path") != "" {
 		return config.GetString("auth_token_file_path")
 	}
-	return filepath.Join(filepath.Dir(config.ConfigFileUsed()), authTokenName)
+	return filepath.Join(config.GetString("run_path"), authTokenName)
 }
 
 // FetchAuthToken gets the authentication token from the auth token file & creates one if it doesn't exist
@@ -196,7 +195,7 @@ func getClusterAgentAuthToken(config configModel.Reader, tokenCreationAllowed bo
 	}
 
 	// load the cluster agent auth token from filesystem
-	tokenAbsPath := filepath.Join(configUtils.ConfFileDirectory(config), clusterAgentAuthTokenFilename)
+	tokenAbsPath := filepath.Join(config.GetString("run_path"), clusterAgentAuthTokenFilename)
 	log.Debugf("Empty cluster_agent.auth_token, loading from %s", tokenAbsPath)
 
 	// Create a new token if it doesn't exist

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -30,7 +30,7 @@ func initMockConf(t *testing.T) (model.Config, string) {
 	})
 
 	mockConfig := model.NewConfig("datadog", "fake-datadog-yaml", strings.NewReplacer(".", "_"))
-	mockConfig.SetConfigFile(f.Name())
+	mockConfig.SetWithoutSource("run_path", testDir)
 	mockConfig.SetWithoutSource("auth_token", "")
 
 	return mockConfig, filepath.Join(testDir, "auth_token")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -948,6 +948,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	config.BindEnvAndSetDefault("conf_path", ".")
 	config.BindEnvAndSetDefault("confd_path", defaultConfdPath)
+	config.BindEnvAndSetDefault("run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)
 	config.BindEnvAndSetDefault("jmx_log_file", "")
 	// If enabling log_payloads, ensure the log level is set to at least DEBUG to be able to see the logs
@@ -1124,7 +1125,6 @@ func debugging(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("tracemalloc_exclude", "")
 	config.BindEnvAndSetDefault("tracemalloc_whitelist", "") // deprecated
 	config.BindEnvAndSetDefault("tracemalloc_blacklist", "") // deprecated
-	config.BindEnvAndSetDefault("run_path", defaultRunPath)
 	config.BindEnv("no_proxy_nonexact_match")
 }
 

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -730,6 +731,7 @@ func TestClusterAgentSuite(t *testing.T) {
 
 	s := &clusterAgentSuite{}
 	config.Datadog().SetConfigFile(f.Name())
+	config.Datadog().Set("run_path", fakeDir, model.SourceDefault)
 	s.authTokenPath = filepath.Join(fakeDir, clusterAgentAuthTokenFilename)
 	_, err = os.Stat(s.authTokenPath)
 	require.NotNil(t, err, fmt.Sprintf("%v", err))

--- a/test/new-e2e/pkg/utils/e2e/client/agentclientparams/agent_client_params.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclientparams/agent_client_params.go
@@ -150,11 +150,11 @@ func WithWaitForTick(d time.Duration) Option {
 func defaultAuthTokenPath(osfam osComp.Family) string {
 	switch osfam {
 	case osComp.LinuxFamily:
-		return "/etc/datadog-agent/auth_token"
+		return "/opt/datadog-agent/run/auth_token"
 	case osComp.WindowsFamily:
-		return "C:\\ProgramData\\Datadog\\auth_token"
+		return "C:\\ProgramData\\Datadog\\run\\auth_token"
 	case osComp.MacOSFamily:
-		return "/opt/datadog-agent/etc/auth_token"
+		return "/opt/datadog-agent/run/auth_token"
 	}
 	panic(fmt.Sprintf("unsupported OS family %d", osfam))
 }

--- a/test/new-e2e/tests/agent-shared-components/api/api_test.go
+++ b/test/new-e2e/tests/agent-shared-components/api/api_test.go
@@ -415,7 +415,7 @@ func (v *apiSuite) TestDefaultAgentAPIEndpoints() {
 		},
 	}
 
-	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	authTokenFilePath := "/opt/datadog-agent/run/auth_token"
 	authtokenContent := v.Env().RemoteHost.MustExecute("sudo cat " + authTokenFilePath)
 	authtoken := strings.TrimSpace(authtokenContent)
 
@@ -468,7 +468,7 @@ hostname: ENC[hostname]`
 		),
 	))
 
-	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	authTokenFilePath := "/opt/datadog-agent/run/auth_token"
 	authtokenContent := v.Env().RemoteHost.MustExecute("sudo cat " + authTokenFilePath)
 	authtoken := strings.TrimSpace(authtokenContent)
 
@@ -508,7 +508,7 @@ log_level: debug
 		),
 	))
 
-	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	authTokenFilePath := "/opt/datadog-agent/run/auth_token"
 	authtokenContent := v.Env().RemoteHost.MustExecute("sudo cat " + authTokenFilePath)
 	authtoken := strings.TrimSpace(authtokenContent)
 

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_nix_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_nix_test.go
@@ -36,7 +36,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 	rootDir := "/tmp/" + v.T().Name()
 	v.Env().RemoteHost.MkdirAll(rootDir)
 
-	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	authTokenFilePath := "/opt/datadog-agent/run/auth_token"
 	secretResolverPath := filepath.Join(rootDir, "secret-resolver.py")
 
 	v.T().Log("Setting up the secret resolver and the initial api key file")

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
@@ -76,6 +76,6 @@ func (v *linuxFlareSuite) TestzzzFlareWithAllConfiguration() {
 	assertFileContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
 	assertFileContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
 
-	filesRegistredInPermissionsLog := append(systemProbeDummyFiles, "/etc/datadog-agent/auth_token")
+	filesRegistredInPermissionsLog := append(systemProbeDummyFiles, "/opt/datadog-agent/run/auth_token")
 	assertFileContains(v.T(), flare, "permissions.log", filesRegistredInPermissionsLog...)
 }


### PR DESCRIPTION
### What does this PR do?

Agent token is currently stored alongside `dataog.yaml` in `/etc/datadog-agent`.
However `/etc/datadog-agent` is perhaps not suited for this:
- Content of `/etc/datadog-agent` is read by the Agent but not written to or modified.
- There is no guarantee `/etc/datadog-agent` to be writable (actually, the Agent should probably not have the permissions to write there).

However, we do have a `run` path, dedicated to file being written by the Agent: `/opt/datadog-agent/run`, which **has** to be writable (sys probe socket, log pointer, etc.).
Storing the token there seems more suited as the token cannot be passed in and is always generated at runtime.

### Motivation

Fix issues with read-only filesystem in Cluster Agent.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

QA-ing this change means ensuring Agent commands requiring API access (like `agent status`) still work properly and cross-agent communication works correctly as well.
Agent commands (like `agent status`) must also be tested in the Cluster Agent.

This has some E2E coverage as some Agent commands or API calls are made in some tests, but I let owners decide the parts that could warrant manual QA.

In containerized environments, this has been already validated to be working for Agent and Cluster Agent with Helm and Operator.