### PR TITLE
[workloadmeta/cached_entity] Avoid deep copy when there's 1 source

### DIFF
--- a/comp/core/workloadmeta/impl/cached_entity.go
+++ b/comp/core/workloadmeta/impl/cached_entity.go
@@ -75,6 +75,12 @@ func (e *cachedEntity) computeCache() {
 
 	e.sortedSources = sources
 
+	// Avoid deep-copying if there's only 1 source
+	if len(e.sortedSources) == 1 {
+		e.cached = e.sources[wmdef.Source(e.sortedSources[0])]
+		return
+	}
+
 	var merged wmdef.Entity
 	for _, source := range e.sortedSources {
 		if e, ok := e.sources[wmdef.Source(source)]; ok {


### PR DESCRIPTION
### What does this PR do?

This PR reduces memory usage in workloadmeta by avoiding a deep-copy for entities that are reported only by one source.

This is more important for the cluster-agent than for the node-agent because the cluster-agent needs to store way more entities than the node agent (when the options to collect them are enabled). And also because all the entities in the cluster-agent come from a single source (the kubeapiserver collector). The only exception are deployments that can also come from the language detection components.


### Describe how to test/QA your changes

This should be covered by end to end tests and monitors.