### PR TITLE
Bump memory limits for go mod tidy check and otel agent builds

### DIFF
--- a/.gitlab/binary_build/otel_agent.yml
+++ b/.gitlab/binary_build/otel_agent.yml
@@ -10,8 +10,8 @@
     - inv -e otel-agent.build
   needs: ["go_deps"]
   variables:
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
   artifacts:
     expire_in: 1 day
     paths:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -239,8 +239,8 @@ go_mod_tidy_check:
     - inv -e check-mod-tidy
     - inv -e check-go-mod-replaces
   variables:
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
 
 new-e2e-unit-tests:
   extends: .linux_tests_with_upload


### PR DESCRIPTION
### What does this PR do?

Bumps the required memory for go mod tidy check and otel agent build jobs.

### Motivation

We're still getting OOM killed in these jobs due to some heavy dependencies.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
