### PR TITLE
fix(release): Get only tags that are on the current branch

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 from invoke.exceptions import Exit
 
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.git import check_local_branch, check_uncommitted_changes, get_commit_sha
+from tasks.libs.common.git import check_local_branch, check_uncommitted_changes, get_commit_sha, get_current_branch
 from tasks.libs.owners.parsing import search_owners
 
 # constants
@@ -480,7 +480,7 @@ def get_matching_pattern(ctx, major_version, release=False):
     pattern = rf"{major_version}\.*"
     if release or is_allowed_repo_nightly_branch(os.getenv("BUCKET_BRANCH")):
         pattern = ctx.run(
-            rf"git tag --list --merged {get_git_branch_name()} | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
+            rf"git tag --list --merged {get_current_branch(ctx)} | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
             hide=True,
         ).stdout.strip()
     return pattern

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -480,7 +480,7 @@ def get_matching_pattern(ctx, major_version, release=False):
     pattern = rf"{major_version}\.*"
     if release or is_allowed_repo_nightly_branch(os.getenv("BUCKET_BRANCH")):
         pattern = ctx.run(
-            rf"git tag --list | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
+            rf"git tag --list --merged {get_git_branch_name()} | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
             hide=True,
         ).stdout.strip()
     return pattern

--- a/tasks/unit-tests/utils_tests.py
+++ b/tasks/unit-tests/utils_tests.py
@@ -88,11 +88,12 @@ class TestQueryVersion(unittest.TestCase):
         self.assertEqual(g, "315e3a2")
 
     @patch.dict(os.environ, {"BUCKET_BRANCH": "nightly"}, clear=True)
+    @patch("tasks.libs.common.utils.get_git_branch_name", new=MagicMock(return_value="main"))
     def test_on_nightly_bucket(self):
         major_version = "7"
         c = MockContext(
             run={
-                rf"git tag --list | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
+                rf"git tag --list --merged main | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
                     "7.55.0-devel"
                 ),
                 'git describe --tags --candidates=50 --match "7.55.0-devel" --abbrev=7': Result(
@@ -106,11 +107,12 @@ class TestQueryVersion(unittest.TestCase):
         self.assertEqual(c, 543)
         self.assertEqual(g, "315e3a2")
 
+    @patch("tasks.libs.common.utils.get_git_branch_name", new=MagicMock(return_value="7.55.x"))
     def test_on_release(self):
         major_version = "7"
         c = MockContext(
             run={
-                rf"git tag --list | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
+                rf"git tag --list --merged 7.55.x | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
                     "7.55.0-devel"
                 ),
                 'git describe --tags --candidates=50 --match "7.55.0-devel" --abbrev=7': Result(

--- a/tasks/unit-tests/utils_tests.py
+++ b/tasks/unit-tests/utils_tests.py
@@ -88,11 +88,11 @@ class TestQueryVersion(unittest.TestCase):
         self.assertEqual(g, "315e3a2")
 
     @patch.dict(os.environ, {"BUCKET_BRANCH": "nightly"}, clear=True)
-    @patch("tasks.libs.common.utils.get_git_branch_name", new=MagicMock(return_value="main"))
     def test_on_nightly_bucket(self):
         major_version = "7"
         c = MockContext(
             run={
+                "git rev-parse --abbrev-ref HEAD": Result("main"),
                 rf"git tag --list --merged main | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
                     "7.55.0-devel"
                 ),
@@ -107,11 +107,11 @@ class TestQueryVersion(unittest.TestCase):
         self.assertEqual(c, 543)
         self.assertEqual(g, "315e3a2")
 
-    @patch("tasks.libs.common.utils.get_git_branch_name", new=MagicMock(return_value="7.55.x"))
     def test_on_release(self):
         major_version = "7"
         c = MockContext(
             run={
+                "git rev-parse --abbrev-ref HEAD": Result("7.55.x"),
                 rf"git tag --list --merged 7.55.x | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
                     "7.55.0-devel"
                 ),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Enhance the way to retrieve tags to focus only on tags we can find on current branch

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix behaviour in release where we can branch out without having the tag being set on the branch:
- branch out
- set the devel tag on main
- create next rc: the last `release` tag will be the devel one which is not on the release branch so the `git describe` fails, like [here](https://github.com/DataDog/datadog-agent/actions/runs/9449812384/job/26026979420)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Follow-up of #26144 

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
