### PR TITLE
[OASIS-12] Allow serializerexporter to consume APM stats

### DIFF
--- a/comp/otelcol/otlp/collector.go
+++ b/comp/otelcol/otlp/collector.go
@@ -104,7 +104,7 @@ func getComponents(s serializer.MetricSerializer, logsAgentChannel chan *message
 
 	exporterFactories := []exporter.Factory{
 		otlpexporter.NewFactory(),
-		serializerexporter.NewFactory(s, &tagEnricher{cardinality: types.LowCardinality}, hostname.Get),
+		serializerexporter.NewFactory(s, &tagEnricher{cardinality: types.LowCardinality}, hostname.Get, nil),
 		loggingexporter.NewFactory(),
 	}
 

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
@@ -8,6 +8,8 @@ package datadogexporter
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -16,7 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	tracepb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	otlpmetrics "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics"
 	"go.opentelemetry.io/collector/component"
@@ -26,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/featuregate"
+	"google.golang.org/protobuf/proto"
 
 	"go.uber.org/zap"
 )
@@ -39,6 +44,8 @@ type factory struct {
 	s         serializer.MetricSerializer
 	logsAgent logsagentpipeline.Component
 	h         hostnameinterface.Component
+
+	wg sync.WaitGroup // waits for agent to exit
 }
 
 func (f *factory) AttributesTranslator(set component.TelemetrySettings) (*attributes.Translator, error) {
@@ -169,7 +176,10 @@ func (f *factory) createMetricsExporter(
 	c component.Config,
 ) (exporter.Metrics, error) {
 	cfg := checkAndCastConfig(c, set.Logger)
-	sf := serializerexporter.NewFactory(f.s, &tagEnricher{}, f.h.Get)
+	statsIn := make(chan []byte, 1000)
+	statsv := set.BuildInfo.Command + set.BuildInfo.Version
+	f.consumeStatsPayload(ctx, statsIn, statsv, fmt.Sprintf("datadogexporter-%s-%s", set.BuildInfo.Command, set.BuildInfo.Version), set.Logger)
+	sf := serializerexporter.NewFactory(f.s, &tagEnricher{}, f.h.Get, statsIn)
 	ex := &serializerexporter.ExporterConfig{
 		Metrics: cfg.Metrics,
 		TimeoutSettings: exporterhelper.TimeoutSettings{
@@ -178,6 +188,38 @@ func (f *factory) createMetricsExporter(
 		QueueSettings: cfg.QueueSettings,
 	}
 	return sf.CreateMetricsExporter(ctx, set, ex)
+}
+
+func (f *factory) consumeStatsPayload(ctx context.Context, statsIn <-chan []byte, tracerVersion string, agentVersion string, logger *zap.Logger) {
+	for i := 0; i < runtime.NumCPU(); i++ {
+		f.wg.Add(1)
+		go func() {
+			defer f.wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-statsIn:
+					sp := &tracepb.StatsPayload{}
+
+					err := proto.Unmarshal(msg, sp)
+					if err != nil {
+						logger.Error("failed to unmarshal stats payload", zap.Error(err))
+						continue
+					}
+					for _, csp := range sp.Stats {
+						if csp.TracerVersion == "" {
+							csp.TracerVersion = tracerVersion
+						}
+					}
+					// The DD Connector doesn't set the agent version, so we'll set it here
+					sp.AgentVersion = agentVersion
+
+					// TODO(OASIS-12): send StatsPayload with trace agent
+				}
+			}
+		}()
+	}
 }
 
 // createLogsExporter creates a logs exporter based on the config.

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/logs/message v0.55.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/proto v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/serializer v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.55.0-rc.3
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.16.1
@@ -101,6 +102,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
 	go.uber.org/zap v1.27.0
+	google.golang.org/protobuf v1.34.1
 )
 
 require (
@@ -135,7 +137,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/metrics v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.55.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/proto v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/tagset v0.55.0-rc.3 // indirect
@@ -268,7 +269,6 @@ require (
 	golang.org/x/tools v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/grpc v1.64.0 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -176,7 +176,7 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			ctx := context.Background()
 			f := NewFactory(rec, &MockTagEnricher{}, func(context.Context) (string, error) {
 				return "", nil
-			})
+			}, nil)
 			cfg := f.CreateDefaultConfig().(*ExporterConfig)
 			cfg.Metrics.Tags = strings.Join(tt.extraTags, ",")
 			exp, err := f.CreateMetricsExporter(

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory_test.go
@@ -36,7 +36,7 @@ func (m *MockTagEnricher) Enrich(_ context.Context, extraTags []string, dimensio
 func newFactory() exp.Factory {
 	return NewFactory(&MockSerializer{}, &MockTagEnricher{}, func(context.Context) (string, error) {
 		return "", nil
-	})
+	}, nil)
 }
 
 func TestNewFactory(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Add stats in channel to serializerexporter to consume APM stats
Split from https://github.com/DataDog/datadog-agent/pull/25759

### Motivation

Consume and send APM stats from DD connector.

### Describe how to test/QA your changes

n/a will be covered in https://github.com/DataDog/datadog-agent/pull/25759
