### PR TITLE
[OASIS-12] Fix datadog exporter default configs

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -107,7 +107,7 @@ func getDDExporterConfig(cfg *confmap.Conf) (*datadogexporter.Config, error) {
 		}
 		for k, v := range exporters {
 			if strings.HasPrefix(k, "datadog") {
-				var datadogConfig *datadogexporter.Config
+				datadogConfig := datadogexporter.CreateDefaultConfig().(*datadogexporter.Config)
 				m, ok := v.(map[string]any)
 				if !ok {
 					return nil, fmt.Errorf("invalid datadog exporter config")

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -19,8 +19,18 @@ func TestAgentConfig(t *testing.T) {
 		t.Errorf("Failed to load agent config: %v", err)
 	}
 	assert.Equal(t, "DATADOG_API_KEY", c.Get("api_key"))
-	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "datadoghq.eu", c.Get("site"))
 	assert.Equal(t, "debug", c.Get("log_level"))
+}
+
+func TestAgentConfigDefaults(t *testing.T) {
+	fileName := "testdata/config_default.yaml"
+	c, err := NewConfigComponent(context.Background(), []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+	assert.Equal(t, "DATADOG_API_KEY", c.Get("api_key"))
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
 }
 
 func TestNoDDExporter(t *testing.T) {

--- a/cmd/otel-agent/config/testdata/config.yaml
+++ b/cmd/otel-agent/config/testdata/config.yaml
@@ -13,7 +13,7 @@ exporters:
   datadog/exp1:
     api:
       key: DATADOG_API_KEY
-      site: datadoghq.com
+      site: datadoghq.eu
 processors:
   batch:
     timeout: 10s

--- a/cmd/otel-agent/config/testdata/config_default.yaml
+++ b/cmd/otel-agent/config/testdata/config_default.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api:
+      key: DATADOG_API_KEY
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
@@ -63,7 +63,7 @@ func newFactoryWithRegistry(registry *featuregate.Registry, s serializer.MetricS
 
 	return exporter.NewFactory(
 		Type,
-		f.createDefaultConfig,
+		CreateDefaultConfig,
 		exporter.WithMetrics(f.createMetricsExporter, MetricsStability),
 		exporter.WithTraces(f.createTracesExporter, TracesStability),
 		exporter.WithLogs(f.createLogsExporter, LogsStability),
@@ -96,8 +96,8 @@ func defaultClientConfig() confighttp.ClientConfig {
 	}
 }
 
-// createDefaultConfig creates the default exporter configuration
-func (f *factory) createDefaultConfig() component.Config {
+// CreateDefaultConfig creates the default exporter configuration
+func CreateDefaultConfig() component.Config {
 	return &Config{
 		ClientConfig:  defaultClientConfig(),
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),


### PR DESCRIPTION
### What does this PR do?

Fix datadog exporter default configs in OTel agent

### Motivation

Datadog exporter should set default config values properly if some fields are left empty.