### PR TITLE
fix TLS classification version tests

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/tls.h
@@ -58,7 +58,7 @@ static __always_inline bool is_valid_tls_version(__u16 version) {
 // - the payload length + the size of the record header is less than the size
 //   of the skb
 static __always_inline bool is_valid_tls_app_data(tls_record_header_t *hdr, __u32 buf_size, __u32 skb_len) {
-    if (!is_valid_tls_version(hdr->version)) {
+    if (!is_valid_tls_version(bpf_ntohs(hdr->version))) {
         return false;
     }
 
@@ -78,7 +78,7 @@ static __always_inline bool is_tls_handshake(tls_hello_message_t *msg) {
     switch (msg->handshake_type) {
     case TLS_HANDSHAKE_CLIENT_HELLO:
     case TLS_HANDSHAKE_SERVER_HELLO:
-        return is_valid_tls_version(msg->version);
+        return is_valid_tls_version(bpf_ntohs(msg->version));
     }
 
     return false;

--- a/pkg/network/protocols/tls/openssl/openssl.go
+++ b/pkg/network/protocols/tls/openssl/openssl.go
@@ -9,6 +9,7 @@ package openssl
 import (
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
@@ -22,7 +23,7 @@ func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...
 		"CLIENTS=" + strconv.Itoa(clientCount),
 	}
 	if len(args) > 0 {
-		env = append(env, "OPENSSL_ARGS="+args[0])
+		env = append(env, "OPENSSL_ARGS="+strings.Join(args, " "))
 	}
 
 	t.Helper()
@@ -31,10 +32,11 @@ func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...
 }
 
 // RunClientOpenssl launches an openssl client.
-func RunClientOpenssl(t *testing.T, addr, port, args string) bool {
+func RunClientOpenssl(t *testing.T, addr, port string, args ...string) bool {
 	command := []string{
 		"docker", "run", "--network=host", "menci/archlinuxarm:base",
-		"openssl", "s_client", "-connect", addr + ":" + port, args,
+		"openssl", "s_client", "-connect", addr + ":" + port,
 	}
+	command = append(command, args...)
 	return protocolsUtils.RunHostServer(t, command, []string{}, regexp.MustCompile("Verify return code"))
 }

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -276,7 +276,7 @@ func testProtocolConnectionProtocolMapCleanup(t *testing.T, tr *Tracer, clientHo
 
 type tlsTestCommand struct {
 	version        string
-	openSSLCommand string
+	openSSLCommand []string
 }
 
 func getFreePort() (port uint16, err error) {
@@ -307,26 +307,25 @@ func (s *USMSuite) TestTLSClassification() {
 	scenarios := []tlsTestCommand{
 		{
 			version:        "1.0",
-			openSSLCommand: "-tls1",
+			openSSLCommand: []string{"-tls1", "-cipher=DEFAULT@SECLEVEL=0"},
 		},
 		{
 			version:        "1.1",
-			openSSLCommand: "-tls1_1",
+			openSSLCommand: []string{"-tls1_1", "-cipher=DEFAULT@SECLEVEL=0"},
 		},
 		{
 			version:        "1.2",
-			openSSLCommand: "-tls1_2",
+			openSSLCommand: []string{"-tls1_2"},
 		},
 		{
 			version:        "1.3",
-			openSSLCommand: "-tls1_3",
+			openSSLCommand: []string{"-tls1_3"},
 		},
 	}
 
 	port, err := getFreePort()
 	require.NoError(t, err)
 	portAsString := strconv.Itoa(int(port))
-	require.NoError(t, prototls.RunServerOpenssl(t, portAsString, len(scenarios), "-www"))
 
 	tr := setupTracer(t, cfg)
 
@@ -337,10 +336,12 @@ func (s *USMSuite) TestTLSClassification() {
 	}
 	tests := make([]tlsTest, 0, len(scenarios))
 	for _, scenario := range scenarios {
+		scenario := scenario
 		tests = append(tests, tlsTest{
 			name: "TLS-" + scenario.version + "_docker",
 			postTracerSetup: func(t *testing.T) {
-				require.True(t, prototls.RunClientOpenssl(t, "localhost", portAsString, scenario.openSSLCommand))
+				require.NoError(t, prototls.RunServerOpenssl(t, portAsString, len(scenarios), append([]string{"-www"}, scenario.openSSLCommand...)...))
+				require.True(t, prototls.RunClientOpenssl(t, "localhost", portAsString, scenario.openSSLCommand...))
 			},
 			validation: func(t *testing.T, tr *Tracer) {
 				// Iterate through active connections until we find connection created above


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- Correctly sets up the docker openssl servers to use the intended TLS version, by capturing the loop variable (fix on both Go 1.21 and 1.22)
- Fixes TLS version comparison by converting from network to host byte order. 

### Motivation

- Go 1.22 exposed that this test loop suffers from the "for loop gotcha". Go 1.21 was using TLS 1.3 for all version tests, rather than the desired versions.
- Once above was fixed, TLS 1.0 and TLS 1.1 tests were still failing which was traced to the TLS version bug.

### Additional Notes

From TLS spec:
> This byte ordering for multi-byte values is the commonplace network byte order or big endian format

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
