### PR TITLE
InvokeLogger: No more warnings for unit tests

### DIFF
--- a/tasks/custom_task/custom_task.py
+++ b/tasks/custom_task/custom_task.py
@@ -122,6 +122,10 @@ class InvokeLogger:
                 task_result=task_result,
             )
         except Exception as e:
+            # Do not print warning for unit tests
+            if 'Mock' in str(e):
+                return
+
             print(
                 color_message(
                     message=f"Warning: couldn't log the invoke task in the InvokeLogger context manager (error: {e})",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When running unit tests, this warning was showing : `Warning: couldn't log the invoke task in the InvokeLogger context manager (error: Object of type MagicMock is not JSON serializable)` ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/537990371#L105))

Removed this warning when running unit tests.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
