### PR TITLE
Redact container prob http headers and command

### DIFF
--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -82,6 +82,45 @@ func TestScrubPod(t *testing.T) {
 						{Name: "API_KEY", Value: "LkhqmrnfESPrvhyfpephDDokCKvVokxXg"},
 						{Name: "DD_SITE", Value: "datadoghq.com"},
 					},
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+							Exec: &v1.ExecAction{
+								Command: []string{"/hello", "--password", "fOPeWWuFKUxwGLRTNnoM٪YwCExdwUcQBDZMogm"},
+							},
+						},
+					},
+					ReadinessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+						},
+					},
+					StartupProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+						},
+					},
 				},
 				{
 					Name:    "container-2",
@@ -136,6 +175,45 @@ func TestScrubPod(t *testing.T) {
 						{Name: "API_KEY", Value: "********"},
 						{Name: "DD_SITE", Value: "datadoghq.com"},
 					},
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+							Exec: &v1.ExecAction{
+								Command: []string{"/hello", "--password", "********"},
+							},
+						},
+					},
+					ReadinessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+						},
+					},
+					StartupProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+						},
+					},
 				},
 				{
 					Name:    "container-2",
@@ -152,7 +230,7 @@ func TestScrubPod(t *testing.T) {
 	}
 
 	scrubber := NewDefaultDataScrubber()
-	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault"})
+	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault", "authorization"})
 	ScrubPod(pod, scrubber)
 
 	assert.EqualValues(t, expectedPod, pod)
@@ -197,6 +275,45 @@ func TestScrubPodTemplate(t *testing.T) {
 					Env: []v1.EnvVar{
 						{Name: "API_KEY", Value: "LkhqmrnfESPrvhyfpephDDokCKvVokxXg"},
 						{Name: "DD_SITE", Value: "datadoghq.com"},
+					},
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+							Exec: &v1.ExecAction{
+								Command: []string{"/hello", "--password", "fOPeWWuFKUxwGLRTNnoM٪YwCExdwUcQBDZMogm"},
+							},
+						},
+					},
+					ReadinessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+						},
+					},
+					StartupProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "Bearer GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin",
+									},
+								},
+							},
+						},
 					},
 				},
 				{
@@ -249,6 +366,45 @@ func TestScrubPodTemplate(t *testing.T) {
 						{Name: "API_KEY", Value: "********"},
 						{Name: "DD_SITE", Value: "datadoghq.com"},
 					},
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+							Exec: &v1.ExecAction{
+								Command: []string{"/hello", "--password", "********"},
+							},
+						},
+					},
+					ReadinessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+						},
+					},
+					StartupProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							HTTPGet: &v1.HTTPGetAction{
+								HTTPHeaders: []v1.HTTPHeader{
+									{
+										Name:  "Authorization",
+										Value: "********",
+									},
+								},
+							},
+						},
+					},
 				},
 				{
 					Name:    "container-2",
@@ -262,7 +418,7 @@ func TestScrubPodTemplate(t *testing.T) {
 	}
 
 	scrubber := NewDefaultDataScrubber()
-	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault"})
+	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault", "authorization"})
 	ScrubPodTemplateSpec(template, scrubber)
 
 	assert.EqualValues(t, expectedTemplate, template)

--- a/releasenotes-dca/notes/releasenotes-946616ca3ce71d03.yaml
+++ b/releasenotes-dca/notes/releasenotes-946616ca3ce71d03.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The orchestrator check can now scrub sensitive data from probes in pods specifications.

--- a/releasenotes/notes/releasenotes-946616ca3ce71d03.yaml
+++ b/releasenotes/notes/releasenotes-946616ca3ce71d03.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The orchestrator check can now scrub sensitive data from probes in pods specifications.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

https://datadoghq.atlassian.net/jira/software/c/projects/CAP/boards/5274?assignee=712020%3Aaabe9019-10de-41f2-a2be-d5c905ff39e4&selectedIssue=CAP-1728

This pull request scrubs container probes http headers values.

I was able to test this change a new Kubernetes cluster on GKE with the following pod spec:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: liveness-http-header-deployment
  labels:
    app: liveness-http-header-app
spec:
  replicas: 2
  selector:
    matchLabels:
      app: liveness-http-header-app
  template:
    metadata:
      labels:
        app: liveness-http-header-app
    spec:
      containers:
      - name: myapp-container
        image: nginx:latest
        env:
          - name: authorization
            value: test2
          - name: password
            value: test4
        ports:
        - containerPort: 8080
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8080
            httpHeaders:
            - name: X-Custom-Header
              value: Awesome
            - name: authorization
              value: my vearer
            - name: password
              value: te
          initialDelaySeconds: 15
          periodSeconds: 10

```

I verified that both Deployment and Pod manifest data had their `authorization` field scrubbed.

This is the helm chart values used.
Note that both cluster-agent and agent need to be redeployed.

```yaml
clusterAgent:
  image:
    repository: docker.io/datadog/cluster-agent-dev
    digest: sha256:c20cc8329d2061f53491a1336460dede85f7f604bc878e69388fdca6bb42c913
    doNotCheckTag: true
  env:
    - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS
      value: "authorization"
agents:
  image:
    repository: docker.io/datadog/agent-dev
    digest: sha256:37062f83eaef135bf4ae3ccd83322b8f9c4522a51f69cf0a33608a26a19576df
    doNotCheckTag: true
  containers:
    agent:
      env:
        - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS
          value: "authorization"
```

Result:
![image](https://github.com/DataDog/datadog-agent/assets/22493292/506c3909-de4d-46ac-ac07-4ddf1d881793)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
