### PR TITLE
[CI] Fix XCode version detection

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 
 from invoke.exceptions import Exit
 
-from tasks.libs.common.color import color_message
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import check_local_branch, check_uncommitted_changes, get_commit_sha
 from tasks.libs.owners.parsing import search_owners
 
@@ -301,7 +301,10 @@ def get_build_flags(
                 extldflags += ",-no_warn_duplicate_libraries "
         except ValueError:
             print(
-                "Warning: Could not determine XCode version, not adding -no_warn_duplicate_libraries to extldflags",
+                color_message(
+                    "Warning: Could not determine XCode version, not adding -no_warn_duplicate_libraries to extldflags",
+                    Color.ORANGE,
+                ),
                 file=sys.stderr,
             )
 

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -180,7 +180,7 @@ def get_xcode_version(ctx):
         xcode_version = ctx.run("pkgutil --pkg-info=com.apple.pkg.CLTools_Executables", hide=True).stdout.strip()
         xcode_version = re.search(r"version: ([0-9.]+)", xcode_version).group(1)
         xcode_version = re.search(r"([0-9]+.[0-9]+)", xcode_version).group(1)
-    elif xcode_path.startswith("/Applications/Xcode.app"):
+    elif xcode_path.startswith("/Applications/Xcode"):
         xcode_version = ctx.run(
             "xcodebuild -version | grep -Eo 'Xcode [0-9.]+' | awk '{print $2}'", hide=True
         ).stdout.strip()
@@ -301,7 +301,7 @@ def get_build_flags(
                 extldflags += ",-no_warn_duplicate_libraries "
         except ValueError:
             print(
-                "Could not determine XCode version, not adding -no_warn_duplicate_libraries to extldflags",
+                "Warning: Could not determine XCode version, not adding -no_warn_duplicate_libraries to extldflags",
                 file=sys.stderr,
             )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes the `get_xcode_version` function responsible for the XCode version detection in the macOS jobs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It's broken for some macOS runners and is printing a lot of warnings:
```
Could not determine XCode version, not adding -no_warn_duplicate_libraries to extldflags
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-220

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
