### PR TITLE
Handle potential `GitlabJobPlayError` when running a cleanup job

### DIFF
--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -8,10 +8,11 @@ from time import sleep, time
 from typing import cast
 
 from gitlab import GitlabError
+from gitlab.exceptions import GitlabJobPlayError
 from gitlab.v4.objects import Project, ProjectJob, ProjectPipeline
 
 from tasks.libs.ciproviders.gitlab_api import refresh_pipeline
-from tasks.libs.common.color import color_message
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.user_interactions import yes_no_question
 from tasks.libs.common.utils import DEFAULT_BRANCH
 
@@ -102,7 +103,12 @@ def gracefully_cancel_pipeline(repo: Project, pipeline: ProjectPipeline, force_c
         cleanup_job = jobs_by_name.get(cleanup_job_name, None)
         if cleanup_job is not None:
             print(f"Triggering KMT {cleanup_job_name} job")
-            repo.jobs.get(cleanup_job.id, lazy=True).play()
+            try:
+                repo.jobs.get(cleanup_job.id, lazy=True).play()
+            except GitlabJobPlayError:
+                # It can happen if you push two commits in a very short period of time (a few seconds).
+                # Both pipelines will try to play the job and one will fail.
+                print(color_message("The job is unplayable. Was it already replayed by another pipeline?", Color.RED))
         else:
             print(f"Cleanup job {cleanup_job_name} not found, skipping.")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Handle potential `GitlabJobPlayError` when running a cleanup job

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We had a case where someone pushed two commit in a very short period of time and we got a race condition between the two cancel jobs:

- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/36383945
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/36383932

We can't really predict it, so we can handle it when it happens. This error is only thrown when this happens so this should be safe.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
