### PR TITLE
fix(installer): Properly stop installer unit at experiment stop

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -348,7 +348,7 @@ func (i *installerImpl) stopExperiment(ctx context.Context, pkg string) error {
 	switch pkg {
 	case packageDatadogAgent:
 		return service.StopAgentExperiment(ctx)
-	case packageAPMInjector:
+	case packageDatadogInstaller:
 		return service.StopInstallerExperiment(ctx)
 	default:
 		return nil


### PR DESCRIPTION
### What does this PR do?
When the installer upgrades itself it starts an experiment. Before that PR when the experiment is stopped by the backend, the experimental binary was removed but the experimental daemon kept running instead of falling back to the stable one. As the daemon requires the binary to execute privileged actions, the installer as a whole was broken.

This PR fixes that.

### Motivation
No bugs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
