### PR TITLE
[PROCS-1194] Add docker end to end tests for process-agent

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -251,6 +251,7 @@ qa_agent:
     - !reference [.on_container_or_e2e_changes]
     - !reference [.on_apm_or_e2e_changes]
     - !reference [.on_npm_or_e2e_changes]
+    - !reference [.on_process_or_e2e_changes]
     - !reference [.manual]
   needs:
     - docker_build_agent7

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -279,7 +279,11 @@ new-e2e-cws:
   allow_failure: true
 
 new-e2e-process:
-  extends: .new_e2e_template_needs_deb_windows_x64
+  extends: .new_e2e_template
+  needs:
+    - deploy_deb_testing-a7_x64
+    - deploy_windows_testing-a7
+    - qa_agent
   rules: 
     - !reference [.on_process_or_e2e_changes]
     - !reference [.manual]

--- a/test/new-e2e/tests/process/compose/fake-process-compose.yaml
+++ b/test/new-e2e/tests/process/compose/fake-process-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM alpine:3.20
+        FROM 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20
 
         # generates a synthetic process that consumes CPU and memory
         ENTRYPOINT ["dd", "if=/dev/zero", "of=/tmp/test-process.txt"]

--- a/test/new-e2e/tests/process/compose/fake-process-compose.yaml
+++ b/test/new-e2e/tests/process/compose/fake-process-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  fake-process:
+    container_name: fake-process
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM alpine:3.20
+
+        # generates a synthetic process that consumes CPU and memory
+        ENTRYPOINT ["dd", "if=/dev/zero", "of=/tmp/test-process.txt"]

--- a/test/new-e2e/tests/process/compose/fake-process-compose.yaml
+++ b/test/new-e2e/tests/process/compose/fake-process-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/alpine:3.20
+        FROM public.ecr.aws/docker/library/alpine:3.20
 
         # generates a synthetic process that consumes CPU and memory
         ENTRYPOINT ["dd", "if=/dev/zero", "of=/tmp/test-process.txt"]

--- a/test/new-e2e/tests/process/compose/stress-compose.yaml
+++ b/test/new-e2e/tests/process/compose/stress-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  stress:
+    image: polinux/stress
+    container_name: stress
+    command:
+      - "stress"
+      - "-d"
+      - "1"

--- a/test/new-e2e/tests/process/compose/stress-compose.yaml
+++ b/test/new-e2e/tests/process/compose/stress-compose.yaml
@@ -1,8 +1,0 @@
-services:
-  stress:
-    image: polinux/stress
-    container_name: stress
-    command:
-      - "stress"
-      - "-d"
-      - "1"

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -26,6 +26,7 @@ type dockerTestSuite struct {
 }
 
 func TestDockerTestSuite(t *testing.T) {
+	t.Parallel()
 	agentOpts := []dockeragentparams.Option{
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -166,10 +166,13 @@ func (s *dockerTestSuite) TestProcessChecksInCoreAgent() {
 
 	// Verify that the process agent is not running
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		status := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName,
-			"process-agent", "status")
+		status := s.Env().Docker.Client.ExecuteCommand(
+			s.Env().Agent.ContainerName, "process-agent", "status")
 		assert.Contains(t, status, "The Process Agent is not running")
 	}, 1*time.Minute, 5*time.Second)
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -199,6 +202,9 @@ func (s *dockerTestSuite) TestProcessChecksInCoreAgentWithNPM() {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, s.Env().Agent.Client, []string{"connections"}, false)
 	}, 1*time.Minute, 5*time.Second)
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package process
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
+)
+
+type dockerTestSuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestDockerTestSuite(t *testing.T) {
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("false")),
+
+		dockeragentparams.WithExtraComposeManifest("stress", pulumi.String(stressCompose)),
+	}
+
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(awsdocker.Provisioner(
+			awsdocker.WithAgentOptions(agentOpts...),
+		)),
+	}
+
+	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
+	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
+		options = append(options, e2e.WithDevMode())
+	}
+
+	e2e.Run(t, &dockerTestSuite{}, options...)
+}
+
+func (s *dockerTestSuite) TestDockerProcessCheck() {
+	t := s.T()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, false)
+	}, 2*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress")
+
+	// TODO: assert containers collected
+}
+
+func (s *dockerTestSuite) TestProcessDiscoveryCheck() {
+	t := s.T()
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("false")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("true")),
+
+		dockeragentparams.WithExtraComposeManifest("stress", pulumi.String(stressCompose)),
+	}
+
+	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process_discovery"}, false)
+	}, 1*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessDiscoveryPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcessDiscoveries()
+		assert.NoError(c, err, "failed to get process discovery payloads from fakeintake")
+		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessDiscoveryCollected(t, payloads, "stress")
+}
+
+//
+//func (s *dockerTestSuite) TestProcessCheckWithIO() {
+//	t := s.T()
+//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
+//
+//	// Flush fake intake to remove payloads that won't have IO stats
+//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+//
+//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, true, "sudo datadog-agent status --json")
+//	}, 1*time.Minute, 5*time.Second)
+//
+//	var payloads []*aggregator.ProcessPayload
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		var err error
+//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+//
+//		// Wait for two payloads, as processes must be detected in two check runs to be returned
+//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+//	}, 2*time.Minute, 10*time.Second)
+//
+//	assertProcessCollected(t, payloads, true, "stress")
+//}
+//
+//func (s *dockerTestSuite) TestProcessChecksInCoreAgent() {
+//	t := s.T()
+//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
+//
+//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+//		assertRunningChecks(collect, s.Env().RemoteHost, []string{}, false, "sudo datadog-agent status --json")
+//	}, 1*time.Minute, 5*time.Second)
+//
+//	// Verify that the process agent is not running
+//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+//		status := s.Env().RemoteHost.MustExecute("/opt/datadog-agent/embedded/bin/process-agent status")
+//		assert.Contains(t, status, "The Process Agent is not running")
+//	}, 1*time.Minute, 5*time.Second)
+//
+//	// Flush fake intake to remove any payloads which may have
+//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+//
+//	var payloads []*aggregator.ProcessPayload
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		var err error
+//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+//
+//		// Wait for two payloads, as processes must be detected in two check runs to be returned
+//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+//	}, 2*time.Minute, 10*time.Second)
+//
+//	assertProcessCollected(t, payloads, false, "stress")
+//
+//	// check that the process agent is not collected as it should not be running
+//	requireProcessNotCollected(t, payloads, "process-agent")
+//}
+//
+//func (s *dockerTestSuite) TestProcessChecksInCoreAgentWithNPM() {
+//	t := s.T()
+//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
+//
+//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"connections"}, false, "sudo datadog-agent status --json")
+//	}, 1*time.Minute, 5*time.Second)
+//
+//	// Flush fake intake to remove any payloads which may have
+//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+//
+//	var payloads []*aggregator.ProcessPayload
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		var err error
+//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+//
+//		// Wait for two payloads, as processes must be detected in two check runs to be returned
+//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+//	}, 2*time.Minute, 10*time.Second)
+//
+//	assertProcessCollected(t, payloads, false, "stress")
+//}
+//
+//func (s *dockerTestSuite) TestProcessChecksWithNPM() {
+//	t := s.T()
+//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
+//
+//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess", "connections"}, false, "sudo datadog-agent status --json")
+//	}, 1*time.Minute, 5*time.Second)
+//
+//	// Flush fake intake to remove any payloads which may have
+//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+//
+//	var payloads []*aggregator.ProcessPayload
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		var err error
+//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+//
+//		// Wait for two payloads, as processes must be detected in two check runs to be returned
+//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+//	}, 2*time.Minute, 10*time.Second)
+//
+//	assertProcessCollected(t, payloads, false, "stress")
+//}
+//
+//func (s *dockerTestSuite) TestManualProcessCheck() {
+//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
+//
+//	assertManualProcessCheck(s.T(), check, false, "stress")
+//}
+//
+//func (s *dockerTestSuite) TestManualProcessDiscoveryCheck() {
+//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")
+//
+//	assertManualProcessDiscoveryCheck(s.T(), check, "stress")
+//}
+//
+//func (s *dockerTestSuite) TestManualProcessCheckWithIO() {
+//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
+//
+//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
+//
+//	assertManualProcessCheck(s.T(), check, true, "stress")
+//}

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -31,7 +31,7 @@ func TestDockerTestSuite(t *testing.T) {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("false")),
 
-		dockeragentparams.WithExtraComposeManifest("stress", pulumi.String(stressCompose)),
+		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}
 
 	options := []e2e.SuiteOption{
@@ -65,9 +65,8 @@ func (s *dockerTestSuite) TestDockerProcessCheck() {
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertProcessCollected(t, payloads, false, "stress")
-
-	// TODO: assert containers collected
+	assertProcessCollected(t, payloads, false, "dd")
+	assertContainersCollected(t, payloads, []string{"fake-process"})
 }
 
 func (s *dockerTestSuite) TestProcessDiscoveryCheck() {
@@ -77,7 +76,7 @@ func (s *dockerTestSuite) TestProcessDiscoveryCheck() {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("true")),
 
-		dockeragentparams.WithExtraComposeManifest("stress", pulumi.String(stressCompose)),
+		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}
 
 	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
@@ -94,131 +93,90 @@ func (s *dockerTestSuite) TestProcessDiscoveryCheck() {
 		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
 	}, 2*time.Minute, 10*time.Second)
 
-	assertProcessDiscoveryCollected(t, payloads, "stress")
+	assertProcessDiscoveryCollected(t, payloads, "dd")
 }
 
-//
-//func (s *dockerTestSuite) TestProcessCheckWithIO() {
-//	t := s.T()
-//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
-//
-//	// Flush fake intake to remove payloads that won't have IO stats
-//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-//
-//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, true, "sudo datadog-agent status --json")
-//	}, 1*time.Minute, 5*time.Second)
-//
-//	var payloads []*aggregator.ProcessPayload
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-//		var err error
-//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
-//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-//
-//		// Wait for two payloads, as processes must be detected in two check runs to be returned
-//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-//	}, 2*time.Minute, 10*time.Second)
-//
-//	assertProcessCollected(t, payloads, true, "stress")
-//}
-//
-//func (s *dockerTestSuite) TestProcessChecksInCoreAgent() {
-//	t := s.T()
-//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
-//
-//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-//		assertRunningChecks(collect, s.Env().RemoteHost, []string{}, false, "sudo datadog-agent status --json")
-//	}, 1*time.Minute, 5*time.Second)
-//
-//	// Verify that the process agent is not running
-//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-//		status := s.Env().RemoteHost.MustExecute("/opt/datadog-agent/embedded/bin/process-agent status")
-//		assert.Contains(t, status, "The Process Agent is not running")
-//	}, 1*time.Minute, 5*time.Second)
-//
-//	// Flush fake intake to remove any payloads which may have
-//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-//
-//	var payloads []*aggregator.ProcessPayload
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-//		var err error
-//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
-//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-//
-//		// Wait for two payloads, as processes must be detected in two check runs to be returned
-//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-//	}, 2*time.Minute, 10*time.Second)
-//
-//	assertProcessCollected(t, payloads, false, "stress")
-//
-//	// check that the process agent is not collected as it should not be running
-//	requireProcessNotCollected(t, payloads, "process-agent")
-//}
-//
-//func (s *dockerTestSuite) TestProcessChecksInCoreAgentWithNPM() {
-//	t := s.T()
-//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
-//
-//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"connections"}, false, "sudo datadog-agent status --json")
-//	}, 1*time.Minute, 5*time.Second)
-//
-//	// Flush fake intake to remove any payloads which may have
-//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-//
-//	var payloads []*aggregator.ProcessPayload
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-//		var err error
-//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
-//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-//
-//		// Wait for two payloads, as processes must be detected in two check runs to be returned
-//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-//	}, 2*time.Minute, 10*time.Second)
-//
-//	assertProcessCollected(t, payloads, false, "stress")
-//}
-//
-//func (s *dockerTestSuite) TestProcessChecksWithNPM() {
-//	t := s.T()
-//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
-//
-//	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-//		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess", "connections"}, false, "sudo datadog-agent status --json")
-//	}, 1*time.Minute, 5*time.Second)
-//
-//	// Flush fake intake to remove any payloads which may have
-//	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-//
-//	var payloads []*aggregator.ProcessPayload
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-//		var err error
-//		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
-//		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-//
-//		// Wait for two payloads, as processes must be detected in two check runs to be returned
-//		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-//	}, 2*time.Minute, 10*time.Second)
-//
-//	assertProcessCollected(t, payloads, false, "stress")
-//}
-//
-//func (s *dockerTestSuite) TestManualProcessCheck() {
-//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
-//
-//	assertManualProcessCheck(s.T(), check, false, "stress")
-//}
-//
-//func (s *dockerTestSuite) TestManualProcessDiscoveryCheck() {
-//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")
-//
-//	assertManualProcessDiscoveryCheck(s.T(), check, "stress")
-//}
-//
-//func (s *dockerTestSuite) TestManualProcessCheckWithIO() {
-//	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
-//
-//	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
-//
-//	assertManualProcessCheck(s.T(), check, true, "stress")
-//}
+func (s *dockerTestSuite) TestProcessCheckWithIO() {
+	t := s.T()
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_PROCESS_ENABLED", pulumi.StringPtr("true")),
+	}
+	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
+
+	// Flush fake intake to remove payloads that won't have IO stats
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
+	}, 1*time.Minute, 5*time.Second)
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, true, "dd")
+}
+
+func (s *dockerTestSuite) TestProcessChecksWithNPM() {
+	t := s.T()
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
+	}
+	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "connections"}, false)
+	}, 1*time.Minute, 5*time.Second)
+
+	// Flush fake intake to ensure a clean slate
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "dd")
+	assertContainersCollected(t, payloads, []string{"fake-process"})
+}
+
+func (s *dockerTestSuite) TestManualProcessCheck() {
+	check := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName,
+		"process-agent", "check", "process", "--json")
+
+	assertManualProcessCheck(s.T(), check, false, "dd", "fake-process")
+}
+
+func (s *dockerTestSuite) TestManualProcessDiscoveryCheck() {
+	check := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName,
+		"process-agent", "check", "process_discovery", "--json")
+
+	assertManualProcessDiscoveryCheck(s.T(), check, "dd")
+}
+
+func (s *dockerTestSuite) TestManualProcessCheckWithIO() {
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_PROCESS_ENABLED", pulumi.StringPtr("true")),
+	}
+	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
+
+	check := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName,
+		"process-agent", "check", "process", "--json")
+
+	assertManualProcessCheck(s.T(), check, true, "dd")
+}

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -54,7 +54,7 @@ func (s *linuxTestSuite) TestProcessCheck() {
 	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, false, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, false)
 	}, 2*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -75,7 +75,7 @@ func (s *linuxTestSuite) TestProcessDiscoveryCheck() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processDiscoveryCheckConfigStr))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process_discovery"}, false, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process_discovery"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessDiscoveryPayload
@@ -97,7 +97,7 @@ func (s *linuxTestSuite) TestProcessCheckWithIO() {
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, true, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -118,7 +118,7 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{}, false, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	// Verify that the process agent is not running
@@ -151,7 +151,7 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgentWithNPM() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"connections"}, false, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"connections"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	// Flush fake intake to remove any payloads which may have
@@ -175,7 +175,7 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess", "connections"}, false, "sudo datadog-agent status --json")
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "connections"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	// Flush fake intake to remove any payloads which may have

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -207,7 +207,9 @@ func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
-	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(
+		agentparams.WithAgentConfig(processCheckConfigStr),
+		agentparams.WithSystemProbeConfig(systemProbeConfigStr))))
 
 	check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process --json")
 

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -34,6 +34,9 @@ var systemProbeConfigStr string
 //go:embed config/npm.yaml
 var systemProbeNPMConfigStr string
 
+//go:embed compose/stress-compose.yaml
+var stressCompose string
+
 // assertRunningChecks asserts that the given process agent checks are running on the given VM
 func assertRunningChecks(t *assert.CollectT, client agentclient.Agent, checks []string, withSystemProbe bool) {
 	status := client.Status(agentclient.WithArgs([]string{"--json"}))

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -34,8 +34,8 @@ var systemProbeConfigStr string
 //go:embed config/npm.yaml
 var systemProbeNPMConfigStr string
 
-//go:embed compose/stress-compose.yaml
-var stressCompose string
+//go:embed compose/fake-process-compose.yaml
+var fakeProcessCompose string
 
 // assertRunningChecks asserts that the given process agent checks are running on the given VM
 func assertRunningChecks(t *assert.CollectT, client agentclient.Agent, checks []string, withSystemProbe bool) {

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -45,8 +45,7 @@ func (s *windowsTestSuite) SetupSuite() {
 func (s *windowsTestSuite) TestProcessCheck() {
 	t := s.T()
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, false, command)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -70,8 +69,7 @@ func (s *windowsTestSuite) TestProcessDiscoveryCheck() {
 	))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process_discovery"}, false, command)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process_discovery"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessDiscoveryPayload
@@ -96,8 +94,7 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		command := "& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe\" status --json"
-		assertRunningChecks(collect, s.Env().RemoteHost, []string{"process", "rtprocess"}, true, command)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
 	}, 1*time.Minute, 5*time.Second)
 
 	// s.Env().VM.Execute("Start-MpScan -ScanType FullScan")


### PR DESCRIPTION
### What does this PR do?
- Add a new E2E tests for the process-agent running in a docker environment
  - Adds a new docker compose file which generates a containerized process for simulating cpu/mem/io load.
- Update process-agent e2e tests to use the `agentclient.Agent` to simplify core agent interactions
- Add the process-agent changes as a trigger for publishing the agent to ECR agent so the process e2e tests have an agent image to against
- Add dependency for the process-agent e2e tests on the the agent image publishing job

### Motivation
Add additional e2e tests for the `process-agent` for building a more consistent and rigorous QA suite.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
