### PR TITLE
[process-agent] Only report "datadog.process.agent" on Process Agent

### DIFF
--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util/api"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -212,7 +213,12 @@ func (s *CheckSubmitter) Start() error {
 		defer s.wg.Done()
 
 		heartbeat := time.NewTicker(15 * time.Second)
-		defer heartbeat.Stop()
+		// We only want to send heartbeats for the process agent
+		if flavor.GetFlavor() == flavor.DefaultAgent {
+			heartbeat.Stop()
+		} else {
+			defer heartbeat.Stop()
+		}
 
 		queueSizeTicker := time.NewTicker(10 * time.Second)
 		defer queueSizeTicker.Stop()

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -217,7 +217,7 @@ func (s *CheckSubmitter) Start() error {
 	}()
 
 	if flavor.GetFlavor() == flavor.ProcessAgent {
-		heartbeatTicker := s.clock.Ticker(15 * time.Minute)
+		heartbeatTicker := s.clock.Ticker(15 * time.Second)
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -220,6 +220,7 @@ func (s *CheckSubmitter) Start() error {
 		heartbeatTicker := s.clock.Ticker(15 * time.Second)
 		s.wg.Add(1)
 		go func() {
+			defer heartbeatTicker.Stop()
 			defer s.wg.Done()
 			s.heartbeat(heartbeatTicker)
 		}()
@@ -471,8 +472,6 @@ func (s *CheckSubmitter) shouldDropPayload(check string) bool {
 }
 
 func (s *CheckSubmitter) heartbeat(heartbeatTicker *clock.Ticker) {
-	defer heartbeatTicker.Stop()
-
 	agentVersion, _ := version.Agent()
 	tags := []string{
 		fmt.Sprintf("version:%s", agentVersion.GetNumberAndPre()),

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -213,11 +213,11 @@ func (s *CheckSubmitter) Start() error {
 		defer s.wg.Done()
 
 		heartbeat := time.NewTicker(15 * time.Second)
-		// We only want to send heartbeats for the process agent
-		if flavor.GetFlavor() == flavor.DefaultAgent {
-			heartbeat.Stop()
-		} else {
+		// We only want to send heartbeats for the process agent process
+		if flavor.GetFlavor() == flavor.ProcessAgent {
 			defer heartbeat.Stop()
+		} else {
+			heartbeat.Stop()
 		}
 
 		queueSizeTicker := time.NewTicker(10 * time.Second)

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -344,7 +344,7 @@ func TestSubmitterHeartbeatProcess(t *testing.T) {
 	mockedClock := clock.NewMock()
 	s.clock = mockedClock
 	s.Start()
-	mockedClock.Add(15 * time.Minute)
+	mockedClock.Add(15 * time.Second)
 	s.Stop()
 }
 
@@ -364,7 +364,7 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	mockedClock := clock.NewMock()
 	s.clock = mockedClock
 	s.Start()
-	mockedClock.Add(15 * time.Minute)
+	mockedClock.Add(15 * time.Second)
 	s.Stop()
 }
 

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
@@ -340,9 +341,10 @@ func TestSubmitterHeartbeatProcess(t *testing.T) {
 	deps := newSubmitterDeps(t)
 	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, testHostName)
 	assert.NoError(t, err)
-	s.heartbeatTime = 5 * time.Millisecond
+	mockedClock := clock.NewMock()
+	s.clock = mockedClock
 	s.Start()
-	time.Sleep(10 * time.Millisecond)
+	mockedClock.Add(15 * time.Minute)
 	s.Stop()
 }
 
@@ -359,9 +361,10 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	deps := newSubmitterDeps(t)
 	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, testHostName)
 	assert.NoError(t, err)
-	s.heartbeatTime = 5 * time.Millisecond
+	mockedClock := clock.NewMock()
+	s.clock = mockedClock
 	s.Start()
-	time.Sleep(10 * time.Millisecond)
+	mockedClock.Add(16 * time.Minute)
 	s.Stop()
 }
 

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/benbjohnson/clock"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -364,7 +364,7 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	mockedClock := clock.NewMock()
 	s.clock = mockedClock
 	s.Start()
-	mockedClock.Add(16 * time.Minute)
+	mockedClock.Add(15 * time.Minute)
 	s.Stop()
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR makes it so that the "datadog.process.agent" metric is only reported when the process agent runs as a separate process. Otherwise, its usage and liveness can be tracked through other [metrics](https://github.com/DataDog/datadog-agent/blob/aa3b2b0448f8555c4ed54cba4e1f730ab3d09fcd/pkg/process/checks/process.go#L345).

### Motivation

Bug fix: This metric was being double-reported when the process agent was up and the process checks were running in the core agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the process checks on the core agent and the connections check on the process agent. Verify `datadog.process.agent`  is not reported twice for the host on Datadog.

```
# datadog.yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
```
```
# system-probe.yaml
system_probe_config:
  enabled: true
```
