### PR TITLE
autoinstrumentation.ShouldInject simplification

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -27,6 +27,7 @@ import (
 	agentsidecar "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/agent_sidecar"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
@@ -79,21 +80,31 @@ type MutatingWebhook interface {
 	MutateFunc() admission.WebhookFunc
 }
 
+func getInjectionFilter() common.InjectionFilter {
+	return common.InjectionFilter{
+		NSFilter: autoinstrumentation.GetInjectionFilter(),
+	}
+}
+
 // mutatingWebhooks returns the list of mutating webhooks. Notice that the order
 // of the webhooks returned is the order in which they will be executed. For
 // now, the only restriction is that the agent sidecar webhook needs to go after
 // the config one. The reason is that the volume mount for the APM socket added
 // by the config webhook doesn't always work on Fargate (one of the envs where
 // we use an agent sidecar), and the agent sidecar webhook needs to remove it.
-func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher) []MutatingWebhook {
+//
+// Note: the auto_instrumentation pod injection filter is used across
+//       multiple mutating webhooks, so we add it as a hard dependency to each
+//       of the components that use it.
+func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, injectionFilter common.InjectionFilter) []MutatingWebhook {
 	webhooks := []MutatingWebhook{
-		config.NewWebhook(wmeta),
-		tagsfromlabels.NewWebhook(wmeta),
+		config.NewWebhook(wmeta, injectionFilter),
+		tagsfromlabels.NewWebhook(wmeta, injectionFilter),
 		agentsidecar.NewWebhook(),
 		autoscaling.NewWebhook(pa),
 	}
 
-	apm, err := autoinstrumentation.GetWebhook(wmeta)
+	apm, err := autoinstrumentation.NewWebhook(wmeta, injectionFilter)
 	if err == nil {
 		webhooks = append(webhooks, apm)
 	} else {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -94,8 +94,8 @@ func getInjectionFilter() common.InjectionFilter {
 // we use an agent sidecar), and the agent sidecar webhook needs to remove it.
 //
 // Note: the auto_instrumentation pod injection filter is used across
-//       multiple mutating webhooks, so we add it as a hard dependency to each
-//       of the components that use it.
+// multiple mutating webhooks, so we add it as a hard dependency to each
+// of the components that use it via the injectionFilter parameter.
 func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, injectionFilter common.InjectionFilter) []MutatingWebhook {
 	webhooks := []MutatingWebhook{
 		config.NewWebhook(wmeta, injectionFilter),

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -60,7 +60,7 @@ func NewControllerV1(
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
+	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa, getInjectionFilter())
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -959,12 +959,10 @@ func TestGenerateTemplatesV1(t *testing.T) {
 			mockConfig := config.Mock(t)
 			mockConfig.SetWithoutSource("kube_resources_namespace", "nsfoo")
 			tt.setupConfig(mockConfig)
-			autoinstrumentation.UnsetWebhook()       // Ensure that the webhook uses the config set above
-			defer autoinstrumentation.UnsetWebhook() // So other tests are not impacted
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()
-			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
+			c.mutatingWebhooks = autoinstrumentation.WithResetInjectionFilter2(wmeta, nil, mutatingWebhooks)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.webhookTemplates)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -51,7 +51,7 @@ func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinform
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
+	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa, getInjectionFilter())
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -951,14 +951,11 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := config.Mock(t)
 			mockConfig.SetWithoutSource("kube_resources_namespace", "nsfoo")
-
 			tt.setupConfig(mockConfig)
-			autoinstrumentation.UnsetWebhook()       // Ensure that the webhook uses the config set above
-			defer autoinstrumentation.UnsetWebhook() // So other tests are not impacted
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc()
-			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
+			c.mutatingWebhooks = autoinstrumentation.WithResetInjectionFilter2(wmeta, nil, mutatingWebhooks)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.webhookTemplates)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -17,7 +17,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 
 	admiv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,9 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
-	apiServerCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
@@ -122,16 +119,6 @@ var (
 		Name:  instrumentationInstallTypeEnvVarName,
 		Value: localLibraryInstrumentationInstallType,
 	}
-
-	// We need a global variable to store the APMInstrumentationWebhook instance
-	// because other webhooks depend on it. The "config" and the "tags" webhooks
-	// depend on the "auto_instrumentation" webhook to decide if a pod should be
-	// injected. They first check if the pod has the label to enable mutations.
-	// If it doesn't, they mutate the pod if the option to mutate unlabeled is
-	// set to true or if APM SSI is enabled in the namespace.
-	apmInstrumentationWebhook *Webhook
-	errInitAPMInstrumentation error
-	initOnce                  sync.Once
 )
 
 // Webhook is the auto instrumentation webhook
@@ -141,101 +128,35 @@ type Webhook struct {
 	endpoint          string
 	resources         []string
 	operations        []admiv1.OperationType
-	filter            *containers.Filter
 	containerRegistry string
+	injectionFilter   mutatecommon.InjectionFilter
 	pinnedLibraries   []libInfo
 	wmeta             workloadmeta.Component
 }
 
-// NewWebhook returns a new Webhook
-func NewWebhook(wmeta workloadmeta.Component) (*Webhook, error) {
-	filter, err := apmSSINamespaceFilter()
-	if err != nil {
+// NewWebhook returns a new Webhook dependent on the injection filter.
+func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilter) (*Webhook, error) {
+	// Note: the webhook is not functional with the filter being disabled--
+	//       and the filter is _global_! so we need to make sure that it was
+	//       initialized as it validates the configuration itself.
+	if filter.NSFilter == nil {
+		return nil, errors.New("filter required for auto_instrumentation webhook")
+	} else if err := filter.NSFilter.Err(); err != nil {
 		return nil, err
 	}
 
 	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.auto_instrumentation.container_registry")
-
 	return &Webhook{
 		name:              webhookName,
 		isEnabled:         config.Datadog().GetBool("admission_controller.auto_instrumentation.enabled"),
 		endpoint:          config.Datadog().GetString("admission_controller.auto_instrumentation.endpoint"),
 		resources:         []string{"pods"},
 		operations:        []admiv1.OperationType{admiv1.Create},
-		filter:            filter,
 		containerRegistry: containerRegistry,
+		injectionFilter:   filter,
 		pinnedLibraries:   getPinnedLibraries(containerRegistry),
 		wmeta:             wmeta,
 	}, nil
-}
-
-// GetWebhook returns the Webhook instance, creating it if it doesn't exist
-func GetWebhook(wmeta workloadmeta.Component) (*Webhook, error) {
-	initOnce.Do(func() {
-		if apmInstrumentationWebhook == nil {
-			apmInstrumentationWebhook, errInitAPMInstrumentation = NewWebhook(wmeta)
-		}
-	})
-
-	return apmInstrumentationWebhook, errInitAPMInstrumentation
-}
-
-// UnsetWebhook unsets the webhook. For testing only.
-func UnsetWebhook() {
-	initOnce = sync.Once{}
-	apmInstrumentationWebhook = nil
-	errInitAPMInstrumentation = nil
-}
-
-// apmSSINamespaceFilter returns the filter used by APM SSI to filter namespaces.
-// The filter excludes two namespaces by default: "kube-system" and the
-// namespace where datadog is installed.
-// Cases:
-// - No enabled namespaces and no disabled namespaces: inject in all namespaces
-// except the 2 namespaces excluded by default.
-// - Enabled namespaces and no disabled namespaces: inject only in the
-// namespaces specified in the list of enabled namespaces. If one of the
-// namespaces excluded by default is included in the list, it will be injected.
-// - Disabled namespaces and no enabled namespaces: inject only in the
-// namespaces that are not included in the list of disabled namespaces and that
-// are not one of the ones disabled by default.
-// - Enabled and disabled namespaces: return error.
-func apmSSINamespaceFilter() (*containers.Filter, error) {
-	apmEnabledNamespaces := config.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")
-	apmDisabledNamespaces := config.Datadog().GetStringSlice("apm_config.instrumentation.disabled_namespaces")
-
-	if len(apmEnabledNamespaces) > 0 && len(apmDisabledNamespaces) > 0 {
-		return nil, fmt.Errorf("apm.instrumentation.enabled_namespaces and apm.instrumentation.disabled_namespaces configuration cannot be set together")
-	}
-
-	// Prefix the namespaces as needed by the containers.Filter.
-	prefix := containers.KubeNamespaceFilterPrefix
-	apmEnabledNamespacesWithPrefix := make([]string, len(apmEnabledNamespaces))
-	apmDisabledNamespacesWithPrefix := make([]string, len(apmDisabledNamespaces))
-
-	for i := range apmEnabledNamespaces {
-		apmEnabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmEnabledNamespaces[i])
-	}
-	for i := range apmDisabledNamespaces {
-		apmDisabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmDisabledNamespaces[i])
-	}
-
-	disabledByDefault := []string{
-		prefix + "^kube-system$",
-		prefix + fmt.Sprintf("^%s$", apiServerCommon.GetResourcesNamespace()),
-	}
-
-	var filterExcludeList []string
-	if len(apmEnabledNamespacesWithPrefix) > 0 && len(apmDisabledNamespacesWithPrefix) == 0 {
-		// In this case, we want to include only the namespaces in the enabled list.
-		// In the containers.Filter, the include list is checked before the
-		// exclude list, that's why we set the exclude list to all namespaces.
-		filterExcludeList = []string{prefix + ".*"}
-	} else {
-		filterExcludeList = append(apmDisabledNamespacesWithPrefix, disabledByDefault...)
-	}
-
-	return containers.NewFilter(containers.GlobalFilter, apmEnabledNamespacesWithPrefix, filterExcludeList)
 }
 
 // Name returns the name of the webhook
@@ -291,42 +212,41 @@ func libImageName(registry string, lang language, tag string) string {
 }
 
 func (w *Webhook) isPodEligible(pod *corev1.Pod) bool {
-	if w.isEnabledInNamespace(pod.Namespace) {
-		// if Single Step Instrumentation is enabled, pods can still opt out using the label
-		if pod.GetLabels()[common.EnabledLabelKey] == "false" {
-			log.Debugf("Skipping single step instrumentation of pod %q due to label", mutatecommon.PodString(pod))
-			return false
-		}
-	} else if !mutatecommon.ShouldMutatePod(pod) {
-		log.Debugf("Skipping auto instrumentation of pod %q because pod mutation is not allowed", mutatecommon.PodString(pod))
-		return false
-	}
+	return w.injectionFilter.ShouldMutatePod(pod)
+}
 
-	return true
+func (w *Webhook) isEnabledInNamespace(namespace string) bool {
+	return w.injectionFilter.NSFilter.IsNamespaceEligible(namespace)
 }
 
 func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
 		return false, errors.New(metrics.InvalidInput)
 	}
+
 	injectApmTelemetryConfig(pod)
 
 	if !w.isPodEligible(pod) {
 		return false, nil
 	}
+
+	// 1. we check to see if we've already done injection,
+	//    if so, we abort.
 	for _, lang := range supportedLanguages {
 		if containsInitContainer(pod, initContainerName(lang)) {
-			// The admission can be reinvocated for the same pod
+			// The admission can be re-run for the same pod
 			// Fast return if we injected the library already
 			log.Debugf("Init container %q already exists in pod %q", initContainerName(lang), mutatecommon.PodString(pod))
 			return false, nil
 		}
 	}
 
+	// 3. If we have nothing to inject we bail out, otherwise we do _work_!
 	libsToInject, autoDetected := w.extractLibInfo(pod)
 	if len(libsToInject) == 0 {
 		return false, nil
 	}
+
 	injectSecurityClientLibraryConfig(pod)
 	// Inject env variables used for Onboarding KPIs propagation
 	var injectionType string
@@ -413,12 +333,12 @@ func getPinnedLibraries(registry string) []libInfo {
 // getLibrariesLanguageDetection runs process language auto-detection and returns languages to inject for APM Instrumentation.
 // The languages information is available in workloadmeta-store and attached on the pod's owner.
 func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) []libInfo {
-	if config.Datadog().GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries") {
-		// Use libraries returned by language detection for APM Instrumentation
-		return w.getAutoDetectedLibraries(pod)
+	if !config.Datadog().GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries") {
+		return nil
 	}
 
-	return nil
+	// Use libraries returned by language detection for APM Instrumentation
+	return w.getAutoDetectedLibraries(pod)
 }
 
 // getAllLatestLibraries returns all supported by APM Instrumentation tracing libraries
@@ -441,20 +361,19 @@ type libInfo struct {
 // extractLibInfo returns the language, the image,
 // and a boolean indicating whether the library should be injected into the pod
 func (w *Webhook) extractLibInfo(pod *corev1.Pod) ([]libInfo, bool) {
-	// If the pod is "injectable" and annotated with libraries to inject, use those.
-	if ShouldInject(pod, w.wmeta) {
-		libs := w.extractLibrariesFromAnnotations(pod)
-		if len(libs) > 0 {
-			return libs, false
+
+	if w.isPodEligible(pod) {
+		// The library version specified via annotation on the Pod takes precedence
+		// over libraries injected with Single Step Instrumentation
+		anns := w.extractLibrariesFromAnnotations(pod)
+		if len(anns) > 0 {
+			return anns, false
 		}
 	}
 
-	// If auto-instrumentation is enabled in the namespace and nothing has been overridden,
-	//
-	// 1. We check for pinned libraries in the config
-	// 2. We check for language detection (if enabled)
-	// 3. We fall back to "latest"
 	if w.isEnabledInNamespace(pod.Namespace) {
+		// if the user has pinned libraries, and they weren't overridden
+		// by annotations, we use those.
 		if len(w.pinnedLibraries) > 0 {
 			return w.pinnedLibraries, false
 		}
@@ -553,41 +472,6 @@ func (w *Webhook) extractLibrariesFromAnnotations(pod *corev1.Pod) []libInfo {
 	}
 
 	return libList
-}
-
-// ShouldInject returns true if Admission Controller should inject standard tags, APM configs and APM libraries
-func ShouldInject(pod *corev1.Pod, wmeta workloadmeta.Component) bool {
-	// If a pod explicitly sets the label admission.datadoghq.com/enabled, make a decision based on its value
-	if val, found := pod.GetLabels()[common.EnabledLabelKey]; found {
-		switch val {
-		case "true":
-			return true
-		case "false":
-			return false
-		default:
-			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it", common.EnabledLabelKey, val, mutatecommon.PodString(pod))
-		}
-	}
-
-	apmWebhook, err := GetWebhook(wmeta)
-	if err != nil {
-		return config.Datadog().GetBool("admission_controller.mutate_unlabelled")
-	}
-
-	return apmWebhook.isEnabledInNamespace(pod.Namespace) || config.Datadog().GetBool("admission_controller.mutate_unlabelled")
-}
-
-// isEnabledInNamespace indicates if Single Step Instrumentation is enabled for
-// the namespace in the cluster
-func (w *Webhook) isEnabledInNamespace(namespace string) bool {
-	apmInstrumentationEnabled := config.Datadog().GetBool("apm_config.instrumentation.enabled")
-
-	if !apmInstrumentationEnabled {
-		log.Debugf("APM Instrumentation is disabled")
-		return false
-	}
-
-	return !w.filter.IsExcluded(nil, "", "", namespace)
 }
 
 func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetected bool, injectionType string) error {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -36,7 +36,7 @@ import (
 
 const commonRegistry = "gcr.io/datadoghq"
 
-func TestInjectAutoInstrumentationConfig(t *testing.T) {
+func TestInjectAutoInstruConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		pod            *corev1.Pod
@@ -245,19 +245,18 @@ func TestInjectAutoInstrumentationConfig(t *testing.T) {
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			webhook, err := NewWebhook(wmeta, common.InjectionFilter{})
-			require.NoError(t, err)
-
-			err = webhook.injectAutoInstruConfig(tt.pod, tt.libsToInject, false, "")
+			webhook := WithResetInjectionFilter1(wmeta, mustWebhook(t))
+			err := webhook.injectAutoInstruConfig(tt.pod, tt.libsToInject, false, "")
 			if tt.wantErr {
-				require.Error(t, err)
+				require.Error(t, err, "expected injectAutoInstruConfig to error")
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, "expected injectAutoInstruConfig to succeed")
 			}
 
 			if err != nil {
 				return
 			}
+
 			assertLibReq(t, tt.pod, tt.libsToInject[0].lang, tt.libsToInject[0].image, tt.expectedEnvKey, tt.expectedEnvVal)
 		})
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2401,11 +2401,8 @@ func TestShouldInject(t *testing.T) {
 			mockConfig = config.Mock(nil)
 			tt.setupConfig()
 
-			// Need to create a new instance of the webhook account for config changes.
 			webhook := WithResetInjectionFilter1(wmeta, mustWebhook(t))
-			if got := webhook.isPodEligible(tt.pod); got != tt.want {
-				t.Errorf("shouldInject() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, webhook.isPodEligible(tt.pod), "expected webhook.isPodEligible() to be %t", tt.want)
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -36,7 +36,7 @@ import (
 
 const commonRegistry = "gcr.io/datadoghq"
 
-func TestInjectAutoInstruConfig(t *testing.T) {
+func TestInjectAutoInstrumentationConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		pod            *corev1.Pod
@@ -245,7 +245,7 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			webhook, err := GetWebhook(wmeta)
+			webhook, err := NewWebhook(wmeta, common.InjectionFilter{})
 			require.NoError(t, err)
 
 			err = webhook.injectAutoInstruConfig(tt.pod, tt.libsToInject, false, "")
@@ -541,6 +541,35 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 		},
 		{
+			name:                 "all with mutate_unlabelled off",
+			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "latest"),
+			containerRegistry:    "registry",
+			expectedPodEligible:  pointer.Ptr(false),
+			expectedLibsToInject: allLatestLibs,
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
+			},
+		},
+		{
+			name: "all with mutate_unlabelled off, but labelled admission enabled",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"admission.datadoghq.com/all-lib.version": "latest",
+					},
+					Labels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+				},
+			},
+			containerRegistry:    "registry",
+			expectedPodEligible:  pointer.Ptr(true),
+			expectedLibsToInject: allLatestLibs,
+			setupConfig: func() {
+				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
+			},
+		},
+		{
 			name: "java + all",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -625,8 +654,8 @@ func TestExtractLibInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Fix me: since comp-config and pkg-config don't work together yet we have to set settings
-			// twice
+			// Fix me: since comp-config and pkg-config don't work together,
+			// we have to set settings twice
 			overrides := map[string]interface{}{
 				"admission_controller.mutate_unlabelled":  true,
 				"admission_controller.container_registry": commonRegistry,
@@ -650,17 +679,14 @@ func TestExtractLibInfo(t *testing.T) {
 				tt.setupConfig()
 			}
 
-			// Need to create a new instance of the webhook to take into account
-			// the config changes.
-			UnsetWebhook()
-			apmInstrumentationWebhook, errInitAPMInstrumentation := GetWebhook(wmeta)
-			require.NoError(t, errInitAPMInstrumentation)
+			// Need to create a new instance of the webhook account of config changes.
+			webhook := WithResetInjectionFilter1(wmeta, mustWebhook(t))
 
 			if tt.expectedPodEligible != nil {
-				require.Equal(t, *tt.expectedPodEligible, apmInstrumentationWebhook.isPodEligible(tt.pod))
+				require.Equal(t, *tt.expectedPodEligible, webhook.isPodEligible(tt.pod))
 			}
 
-			libsToInject, _ := apmInstrumentationWebhook.extractLibInfo(tt.pod)
+			libsToInject, _ := webhook.extractLibInfo(tt.pod)
 			require.ElementsMatch(t, tt.expectedLibsToInject, libsToInject)
 		})
 	}
@@ -2134,13 +2160,9 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 				}
 			}
 
-			// Need to create a new instance of the webhook to take into account
-			// the config changes.
-			UnsetWebhook()
-			apmInstrumentationWebhook, errInitAPMInstrumentation := GetWebhook(wmeta)
-			require.NoError(t, errInitAPMInstrumentation)
+			webhook := WithResetInjectionFilter1(wmeta, mustWebhook(t))
 
-			_, err := apmInstrumentationWebhook.inject(tt.pod, "", fake.NewSimpleDynamicClient(scheme.Scheme))
+			_, err := webhook.inject(tt.pod, "", fake.NewSimpleDynamicClient(scheme.Scheme))
 			require.False(t, (err != nil) != tt.wantErr)
 
 			container := tt.pod.Spec.Containers[0]
@@ -2380,14 +2402,20 @@ func TestShouldInject(t *testing.T) {
 			mockConfig = config.Mock(nil)
 			tt.setupConfig()
 
-			// Need to create a new instance of the webhook to take into account
-			// the config changes.
-			UnsetWebhook()
-			webhook, errInitAPMInstrumentation := GetWebhook(wmeta)
-			require.NoError(t, errInitAPMInstrumentation)
-
-			require.Equal(t, tt.want, ShouldInject(tt.pod, webhook.wmeta), "expected ShouldInject() to be %t", tt.want)
-			require.Equal(t, tt.want, webhook.isPodEligible(tt.pod), "expected webhook.isPodEligible() to be %t", tt.want)
+			// Need to create a new instance of the webhook account for config changes.
+			webhook := WithResetInjectionFilter1(wmeta, mustWebhook(t))
+			if got := webhook.isPodEligible(tt.pod); got != tt.want {
+				t.Errorf("shouldInject() = %v, want %v", got, tt.want)
+			}
 		})
+	}
+}
+
+func mustWebhook(t *testing.T) func(workloadmeta.Component, common.InjectionFilter) *Webhook {
+	t.Helper()
+	return func(wmeta workloadmeta.Component, f common.InjectionFilter) *Webhook {
+		webhook, err := NewWebhook(wmeta, f)
+		require.NoError(t, err)
+		return webhook
 	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+	"sync"
+
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	apiServerCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	// We need a global variable to store the filter instance
+	// because other webhooks depend on it.
+	//
+	// The "config" and the "tags" webhooks depend on the "auto_instrumentation"
+	// configuration to decide if a pod should be injected.
+	//
+	// They first check if the pod has the label to enable mutations.
+	// If it doesn't, they mutate the pod if the option to "mutate_unlabeled" is
+	// set to true or if APM SSI is enabled in the namespace.
+	autoInstrumentationFilter = &injectionFilter{}
+)
+
+var _ mutatecommon.NamespaceInjectionFilter = &injectionFilter{}
+
+type injectionFilter struct {
+	once   sync.Once
+	filter *containers.Filter
+	err    error
+}
+
+// IsNamespaceEligible returns true of APM Single Step Instrumentation
+// is enabled and enabled for this namespace.
+//
+// There could be an error in configuration which would imply that
+// APM is disabled.
+//
+// This DOES NOT respect `mutate_unlabelled` since it is a namespace
+// specific check.
+func (f *injectionFilter) IsNamespaceEligible(ns string) bool {
+	apmInstrumentationEnabled := config.Datadog().GetBool("apm_config.instrumentation.enabled")
+
+	if !apmInstrumentationEnabled {
+		log.Debugf("APM Instrumentation is disabled")
+		return false
+	}
+
+	filter, err := f.get()
+	if err != nil {
+		return false
+	}
+
+	return !filter.IsExcluded(nil, "", "", ns)
+}
+
+// Err returns an error if the namespace filter failed to initialize.
+//
+// This is safe to ignore for most uses, except for in auto_instrumentation itself.
+func (f *injectionFilter) Err() error {
+	_, err := f.get()
+	return err
+}
+
+func (f *injectionFilter) get() (*containers.Filter, error) {
+	f.once.Do(func() {
+		if f.filter == nil {
+			f.filter, f.err = makeAPMSSINamespaceFilter()
+		}
+	})
+
+	return f.filter, f.err
+}
+
+// makeAPMSSINamespaceFilter returns the filter used by APM SSI to filter namespaces.
+// The filter excludes two namespaces by default: "kube-system" and the
+// namespace where datadog is installed.
+//
+// Cases:
+//   - No enabled namespaces and no disabled namespaces: inject in all namespaces
+//     except the 2 namespaces excluded by default.
+//   - Enabled namespaces and no disabled namespaces: inject only in the
+//     namespaces specified in the list of enabled namespaces. If one of the
+//     namespaces excluded by default is included in the list, it will be injected.
+//   - Disabled namespaces and no enabled namespaces: inject only in the
+//     namespaces that are not included in the list of disabled namespaces and that
+//     are not one of the ones disabled by default.
+//   - Enabled and disabled namespaces: return error.
+func makeAPMSSINamespaceFilter() (*containers.Filter, error) {
+	apmEnabledNamespaces := config.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")
+	apmDisabledNamespaces := config.Datadog().GetStringSlice("apm_config.instrumentation.disabled_namespaces")
+
+	if len(apmEnabledNamespaces) > 0 && len(apmDisabledNamespaces) > 0 {
+		return nil, fmt.Errorf("apm.instrumentation.enabled_namespaces and apm.instrumentation.disabled_namespaces configuration cannot be set together")
+	}
+
+	// Prefix the namespaces as needed by the containers.Filter.
+	prefix := containers.KubeNamespaceFilterPrefix
+	apmEnabledNamespacesWithPrefix := make([]string, len(apmEnabledNamespaces))
+	apmDisabledNamespacesWithPrefix := make([]string, len(apmDisabledNamespaces))
+
+	for i := range apmEnabledNamespaces {
+		apmEnabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmEnabledNamespaces[i])
+	}
+	for i := range apmDisabledNamespaces {
+		apmDisabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", apmDisabledNamespaces[i])
+	}
+
+	disabledByDefault := []string{
+		prefix + "^kube-system$",
+		prefix + fmt.Sprintf("^%s$", apiServerCommon.GetResourcesNamespace()),
+	}
+
+	var filterExcludeList []string
+	if len(apmEnabledNamespacesWithPrefix) > 0 && len(apmDisabledNamespacesWithPrefix) == 0 {
+		// In this case, we want to include only the namespaces in the enabled list.
+		// In the containers.Filter, the include list is checked before the
+		// exclude list, that's why we set the exclude list to all namespaces.
+		filterExcludeList = []string{prefix + ".*"}
+	} else {
+		filterExcludeList = append(apmDisabledNamespacesWithPrefix, disabledByDefault...)
+	}
+
+	return containers.NewFilter(containers.GlobalFilter, apmEnabledNamespacesWithPrefix, filterExcludeList)
+}
+
+// GetInjectionFilter is an accessor for the autoInstrumentationFilter
+func GetInjectionFilter() mutatecommon.NamespaceInjectionFilter {
+	return autoInstrumentationFilter
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailingInjectionConfig(t *testing.T) {
+	tests := []struct {
+		name string
+
+		instrumentationEnabled                bool
+		enabledNamespaces, disabledNamespaces []string
+
+		expectedFilterError, expectedWebhookError bool
+		expectedNamespaces                        map[string]bool
+	}{
+		{
+			name: "disabled",
+			expectedNamespaces: map[string]bool{
+				"enabled-ns":   false,
+				"disabled-ns":  false,
+				"any-other-ns": false,
+			},
+		},
+		{
+			name:                   "enabled no namespaces",
+			instrumentationEnabled: true,
+			expectedNamespaces: map[string]bool{
+				"enabled-ns":   true,
+				"disabled-ns":  true,
+				"any-other-ns": true,
+			},
+		},
+		{
+			name:                   "enabled with enabled namespace",
+			instrumentationEnabled: true,
+			enabledNamespaces:      []string{"enabled-ns"},
+			expectedNamespaces: map[string]bool{
+				"enabled-ns":   true,
+				"disabled-ns":  false,
+				"any-other-ns": false,
+			},
+		},
+		{
+			name:                   "enabled with disabled namespace",
+			instrumentationEnabled: true,
+			disabledNamespaces:     []string{"disabled-ns"},
+			expectedNamespaces: map[string]bool{
+				"enabled-ns":   true,
+				"disabled-ns":  false,
+				"any-other-ns": true,
+			},
+		},
+		{
+			name:                   "both enabled and disabled errors, fail closed",
+			instrumentationEnabled: true,
+			enabledNamespaces:      []string{"enabled-ns"},
+			disabledNamespaces:     []string{"disabled-ns"},
+			expectedFilterError:    true,
+			expectedWebhookError:   true,
+			expectedNamespaces: map[string]bool{
+				"enabled-ns":   false,
+				"disabled-ns":  false,
+				"any-other-ns": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			wmeta := common.FakeStoreWithDeployment(t, nil)
+
+			c := config.Mock(t)
+			c.SetWithoutSource("apm_config.instrumentation.enabled", tt.instrumentationEnabled)
+			c.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", tt.enabledNamespaces)
+			c.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", tt.disabledNamespaces)
+
+			resetInjectionFilter()
+			_, err := autoInstrumentationFilter.get()
+			if tt.expectedFilterError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			_, err = NewWebhook(wmeta, common.InjectionFilter{
+				NSFilter: GetInjectionFilter(),
+			})
+			if tt.expectedWebhookError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			filter := GetInjectionFilter()
+			require.NotNil(t, filter, "we should always get a filter")
+
+			checkedNamespaces := map[string]bool{}
+
+			for ns := range tt.expectedNamespaces {
+				checkedNamespaces[ns] = filter.IsNamespaceEligible(ns)
+			}
+
+			require.Equal(t, tt.expectedNamespaces, checkedNamespaces)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test_util.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test_util.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package autoinstrumentation
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+)
+
+// WithResetInjectionFilter is useful for testing when you want to make sure
+// that you're getting a fresh instance based on configuration changes.
+//
+// The injection filter is reset before and after `do` runs.
+func WithResetInjectionFilter[T any](do func(f common.InjectionFilter) T) T {
+	resetInjectionFilter()
+	defer resetInjectionFilter()
+	return do(common.InjectionFilter{NSFilter: GetInjectionFilter()})
+}
+
+// WithResetInjectionFilter1 reflects the structure of NewWebhook constructors (2 arguments),
+// that depend on workloadmeta.Component, but this is generic instead of depending on it directly.
+func WithResetInjectionFilter1[C, T any](c C, do func(C, common.InjectionFilter) T) T {
+	return WithResetInjectionFilter(func(f common.InjectionFilter) T { return do(c, f) })
+}
+
+// WithResetInjectionFilter2 reflects the structure of constructors (3 arguments),
+// that depend on workloadmeta.Component, but this is generic instead of depending on it directly.
+func WithResetInjectionFilter2[C1, C2, T any](c1 C1, c2 C2, do func(C1, C2, common.InjectionFilter) T) T {
+	return WithResetInjectionFilter(func(f common.InjectionFilter) T { return do(c1, c2, f) })
+}
+
+// resetInjectionFilter resets the singleton autoInstrumentationFilter.
+func resetInjectionFilter() {
+	autoInstrumentationFilter = &injectionFilter{}
+}

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -177,9 +177,9 @@ func IsExplicitPodMutationEnabled(pod *corev1.Pod) (bool, bool) {
 	// make a decision based on its value.
 	if val, found := pod.GetLabels()[admCommon.EnabledLabelKey]; found {
 		switch val {
-		case "true", "TRUE":
+		case "true":
 			return true, true
-		case "false", "FALSE":
+		case "false":
 			return false, true
 		default:
 			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it", admCommon.EnabledLabelKey, val, PodString(pod))

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -189,20 +189,6 @@ func IsExplicitPodMutationEnabled(pod *corev1.Pod) (bool, bool) {
 	return false, false
 }
 
-// ShouldMutatePod checks if a pod is mutable per explicit rules and/or
-// a NamespaceInjectionFilter.
-func ShouldMutatePod(pod *corev1.Pod, f NamespaceInjectionFilter) bool {
-	if val, ok := IsExplicitPodMutationEnabled(pod); ok {
-		return val
-	}
-
-	if f != nil && f.IsNamespaceEligible(pod.Namespace) {
-		return true
-	}
-
-	return ShouldMutateUnlabelledPods()
-}
-
 // ContainerRegistry gets the container registry config using the specified
 // config option, and falls back to the default container registry if no
 // webhook-specific container registry is set.

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -203,7 +203,6 @@ func ShouldMutatePod(pod *corev1.Pod, f NamespaceInjectionFilter) bool {
 	return ShouldMutateUnlabelledPods()
 }
 
-
 // ContainerRegistry gets the container registry config using the specified
 // config option, and falls back to the default container registry if no
 // webhook-specific container registry is set.

--- a/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type InjectionFilter struct {
+	NSFilter NamespaceInjectionFilter
+}
+
+func (f InjectionFilter) ShouldMutatePod(pod *corev1.Pod) bool {
+	return ShouldMutatePod(pod, f.NSFilter)
+}
+
+// NamespaceInjectionFilter represents a contract to be able to filter out which pods are
+// eligible for mutation/injection.
+//
+// See [autoinstrumentation.GetInjectionFilter].
+type NamespaceInjectionFilter interface {
+	IsNamespaceEligible(ns string) bool
+	Err() error
+}

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -24,7 +24,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -94,29 +93,31 @@ type conf struct {
 
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod
 type Webhook struct {
-	name       string
-	config     conf
-	isEnabled  bool
-	endpoint   string
-	resources  []string
-	operations []admiv1.OperationType
-	mode       string
-	wmeta      workloadmeta.Component
+	name            string
+	config          conf
+	isEnabled       bool
+	endpoint        string
+	resources       []string
+	operations      []admiv1.OperationType
+	mode            string
+	wmeta           workloadmeta.Component
+	injectionFilter common.InjectionFilter
 }
 
 // NewWebhook returns a new Webhook
-func NewWebhook(wmeta workloadmeta.Component) *Webhook {
+func NewWebhook(wmeta workloadmeta.Component, injectionFilter common.InjectionFilter) *Webhook {
 	return &Webhook{
 		name: webhookName,
 		config: conf{
 			injectContName: config.Datadog().GetBool("admission_controller.inject_config.inject_container_name"),
 		},
-		isEnabled:  config.Datadog().GetBool("admission_controller.inject_config.enabled"),
-		endpoint:   config.Datadog().GetString("admission_controller.inject_config.endpoint"),
-		resources:  []string{"pods"},
-		operations: []admiv1.OperationType{admiv1.Create},
-		mode:       config.Datadog().GetString("admission_controller.inject_config.mode"),
-		wmeta:      wmeta,
+		isEnabled:       config.Datadog().GetBool("admission_controller.inject_config.enabled"),
+		endpoint:        config.Datadog().GetString("admission_controller.inject_config.endpoint"),
+		resources:       []string{"pods"},
+		operations:      []admiv1.OperationType{admiv1.Create},
+		mode:            config.Datadog().GetString("admission_controller.inject_config.mode"),
+		wmeta:           wmeta,
+		injectionFilter: injectionFilter,
 	}
 }
 
@@ -172,7 +173,7 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, 
 
 	}
 
-	if !autoinstrumentation.ShouldInject(pod, w.wmeta) {
+	if !w.injectionFilter.ShouldMutatePod(pod) {
 		return false, nil
 	}
 

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -26,6 +26,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -75,7 +76,7 @@ func TestInjectHostIP(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta)
+	webhook := NewWebhook(wmeta, mutatecommon.InjectionFilter{})
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -86,7 +87,7 @@ func TestInjectService(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "service"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta)
+	webhook := NewWebhook(wmeta, mutatecommon.InjectionFilter{})
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -123,7 +124,7 @@ func TestInjectEntityID(t *testing.T) {
 				fx.Supply(workloadmeta.NewParams()),
 				fx.Replace(config.MockParams{Overrides: tt.configOverrides}),
 			)
-			webhook := NewWebhook(wmeta)
+			webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -230,7 +231,7 @@ func TestInjectSocket(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta)
+	webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -285,7 +286,7 @@ func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
 	}
 
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta)
+	webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.True(t, injected)
 	assert.Nil(t, err)
@@ -328,7 +329,7 @@ func TestJSONPatchCorrectness(t *testing.T) {
 				fx.Supply(workloadmeta.NewParams()),
 				fx.Replace(config.MockParams{Overrides: tt.overrides}),
 			)
-			webhook := NewWebhook(wmeta)
+			webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 			request := admission.MutateRequest{
 				Raw:       podJSON,
 				Namespace: "bar",
@@ -359,7 +360,7 @@ func BenchmarkJSONPatch(b *testing.B) {
 	}
 
 	wmeta := fxutil.Test[workloadmeta.Component](b, core.MockBundle())
-	webhook := NewWebhook(wmeta)
+	webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 	podJSON := obj.(*admiv1.AdmissionReview).Request.Object.Raw
 
 	b.ResetTimer()

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -43,25 +42,27 @@ const webhookName = "standard_tags"
 
 // Webhook is the webhook that injects DD_ENV, DD_VERSION, DD_SERVICE env vars
 type Webhook struct {
-	name          string
-	isEnabled     bool
-	endpoint      string
-	resources     []string
-	operations    []admiv1.OperationType
-	ownerCacheTTL time.Duration
-	wmeta         workloadmeta.Component
+	name            string
+	isEnabled       bool
+	endpoint        string
+	resources       []string
+	operations      []admiv1.OperationType
+	ownerCacheTTL   time.Duration
+	wmeta           workloadmeta.Component
+	injectionFilter common.InjectionFilter
 }
 
 // NewWebhook returns a new Webhook
-func NewWebhook(wmeta workloadmeta.Component) *Webhook {
+func NewWebhook(wmeta workloadmeta.Component, injectionFilter common.InjectionFilter) *Webhook {
 	return &Webhook{
-		name:          webhookName,
-		isEnabled:     config.Datadog().GetBool("admission_controller.inject_tags.enabled"),
-		endpoint:      config.Datadog().GetString("admission_controller.inject_tags.endpoint"),
-		resources:     []string{"pods"},
-		operations:    []admiv1.OperationType{admiv1.Create},
-		ownerCacheTTL: ownerCacheTTL(),
-		wmeta:         wmeta,
+		name:            webhookName,
+		isEnabled:       config.Datadog().GetBool("admission_controller.inject_tags.enabled"),
+		endpoint:        config.Datadog().GetString("admission_controller.inject_tags.endpoint"),
+		resources:       []string{"pods"},
+		operations:      []admiv1.OperationType{admiv1.Create},
+		ownerCacheTTL:   ownerCacheTTL(),
+		wmeta:           wmeta,
+		injectionFilter: injectionFilter,
 	}
 }
 
@@ -139,8 +140,9 @@ func (w *Webhook) injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) (
 		return false, errors.New(metrics.InvalidInput)
 	}
 
-	if !autoinstrumentation.ShouldInject(pod, w.wmeta) {
-		// Ignore pod if it has the label admission.datadoghq.com/enabled=false or Single step configuration is disabled
+	if !w.injectionFilter.ShouldMutatePod(pod) {
+		// Ignore pod if it has the label admission.datadoghq.com/enabled=false
+		// or Single step configuration is disabled
 		return false, nil
 	}
 

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -173,7 +174,7 @@ func Test_injectTags(t *testing.T) {
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			webhook := NewWebhook(wmeta)
+			webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 			_, err := webhook.injectTags(tt.pod, "ns", nil)
 			assert.NoError(t, err)
 			assert.Len(t, tt.pod.Spec.Containers, 1)
@@ -273,7 +274,7 @@ func TestGetAndCacheOwner(t *testing.T) {
 	kubeObj := newUnstructuredWithSpec(map[string]interface{}{"foo": "bar"})
 	owner := newOwner(kubeObj)
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(), fx.Supply(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta)
+	webhook := autoinstrumentation.WithResetInjectionFilter1(wmeta, NewWebhook)
 
 	// Cache hit
 	cache.Cache.Set(ownerInfo.buildID(testNamespace), owner, webhook.ownerCacheTTL)


### PR DESCRIPTION
## Related PRs

These PRs are extracted parts of this full implementation that should make this easier to ship.

- [x] https://github.com/DataDog/datadog-agent/pull/26854
- [x] https://github.com/DataDog/datadog-agent/pull/26856

## Motivation

This is a step in decoupling the singleton dependencies in both autoinstrumentation eligibility checks as well as the other webhooks that rely on `autoinstrumentation.ShouldInject`. 

Originally, I wanted to understand what the intended behavior of the feature was during instrumentation so that I could clean it up and extend it later on (like in #25914).

Changes:

1. I added more test cases to disambiguate some of the behaviors in autoinstrumentation (both lib detection and eligibility) in the first commit.
2. Noticed that the global `ShouldInject` had no real dependency on the webhook itself, but on the namespace filter and configuration for auto_instrumentation, so I factored that out-- moving the relevant pieces elsewhere. 
3. `ShouldInject` also no longer needs `wmeta` because it doesn't need the it for the webhook.
4. Because we did _some checks_ at the beginning of `inject`  and some later on in `extractLibInfo` this was all really complicated to reason about, so I kept the 2x checks so that all of the tests pass and are consistent, but the function itself is a bit simpler and we don't do as many sentinel values, just early returns.


#### More notes

Factoring out the `isPodEligible` function to be able to test this as a separate piece from injection since these tests only cover `extractLibInfo`.

It's important to know the difference between the two... the second one only gets called _after_ the first and the test cases cover particular outcomes which might not happen because of the eligibility check at the beginning of `Webhook.inject` -- now also being tested here.

We can see in the added test cases that disabling mutate_unlabelled changes the libs that are output and is generally congruent with eligibility.

However! in the case of `all-lib.version` -- expected to add all of the latest libraries, it will only work if the feature flag if `mutate_unabelled` is on and instrumentation is off.

_This was confusing!_

<img width="977" alt="Screenshot 2024-06-12 at 4 03 30 PM" src="https://github.com/DataDog/datadog-agent/assets/66807/53f177b6-edbf-430b-818d-006580c1f9f6">

### Testing

- This is leveraging unit test coverage (which we've increased) for eligibility and library/language extraction to make sure we aren't introducing any breaking changes to the `inject` codepath. 
- Also adding more coverage for `isPodEligible` which is a wrapper for `ShouldInject` (the code used by the other controllers). 



