### PR TITLE
Disable zypper repos on suse step-by-step e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -258,6 +258,10 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 	fileManager := VMclient.FileManager
 	var err error
 
+	// Disable all existing non-datadog repos to avoid issues during refresh (which is hard to prevent zypper from doing spontaneously);
+	// we don't need them to install the Agent anyway
+	ExecuteWithoutError(nil, VMclient, "sudo rm /etc/zypp/repos.d/*.repo")
+
 	fileContent := fmt.Sprintf("[datadog]\n"+
 		"name = Datadog, Inc.\n"+
 		"baseurl = %s\n"+


### PR DESCRIPTION

### What does this PR do?

Deletes all repo files for step-by-step installation e2e tests on Suse, effectively disabling any repos not under our control

### Motivation

Addressing this type of failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/540198262

### Additional Notes

`zypper` doesn't seem to honor `--no-refresh` and still goes ahead and tries to refresh a bunch of repositories that we don't really care about. This approach is heavy-handed but it's the most direct and I see no potential drawbacks.

I launched the test from my machine and it does pass, while it fails pretty consistently without this change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
