### PR TITLE
[cluster-agent][admission_controller] Enable label selector for CWS Instrumentation command webhook

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -601,7 +601,15 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
-					nil,
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      cwsinstrumentation.PodLabelEnabled,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
 					nil,
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
@@ -638,7 +646,11 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
-					nil,
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							cwsinstrumentation.PodLabelEnabled: "true",
+						},
+					},
 					nil,
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
@@ -680,7 +692,15 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
 					nil,
-					nil,
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      cwsinstrumentation.PodLabelEnabled,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
 				)
@@ -717,7 +737,11 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
 					nil,
-					nil,
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							cwsinstrumentation.PodLabelEnabled: "true",
+						},
+					},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
 				)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -594,7 +594,15 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
-					nil,
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      cwsinstrumentation.PodLabelEnabled,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
 					nil,
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
@@ -631,7 +639,11 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
-					nil,
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							cwsinstrumentation.PodLabelEnabled: "true",
+						},
+					},
 					nil,
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
@@ -673,7 +685,15 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
 					nil,
-					nil,
+					&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      cwsinstrumentation.PodLabelEnabled,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"false"},
+							},
+						},
+					},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
 				)
@@ -710,7 +730,11 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					"datadog.webhook.cws.exec.instrumentation",
 					"/inject-command-cws",
 					nil,
-					nil,
+					&metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							cwsinstrumentation.PodLabelEnabled: "true",
+						},
+					},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
 				)

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -190,8 +190,8 @@ func (w *WebhookForCommands) Operations() []admiv1.OperationType {
 
 // LabelSelectors returns the label selectors that specify when the webhook
 // should be invoked
-func (w *WebhookForCommands) LabelSelectors(_ bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
-	return nil, nil
+func (w *WebhookForCommands) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
+	return labelSelectors(useNamespaceSelector)
 }
 
 // MutateFunc returns the function that mutates the resources


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR enables the webhook label selector for the "command" webhook. Originally, it was only enabled for the "pod" webhook because the "command" webhook would automatically exit if the "pod" webhook had not been called first. With the new "remote_copy" mode for CWS Instrumentation, the "pod" webhook is no longer required (as long as `admission_controller.cws_instrumentation.remote_copy.mount_volume: false`).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The motivation for this PR is to allow for a pod to be excluded from the CWS Instrumentation when `admission_controller.cws_instrumentation.mode: remote_copy` and `admission_controller.cws_instrumentation.remote_copy.mount_volume: false` with a simple label.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Start a cluster agent with the following configuration:
```yaml
admission_controller:
  enabled: true
  cws_instrumentation:
    enabled: true
    mutate_unlabelled: true
    mode: remote_copy
    remote_copy:
      mount_volume: false
```
- Add the `admission.datadoghq.com/cws-instrumentation.enabled: false` to a test pod
- Exec into the pod, and make sure that the session isn't tracked (i.e. look for `cws-instrumentation` at the root of the container)