### PR TITLE
[workloadmeta/types] Add missing newline in KubernetesMetadata.String()

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -821,7 +821,7 @@ func (m *KubernetesMetadata) String(verbose bool) string {
 
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "----------- Resource -----------")
-		_, _ = fmt.Fprint(&sb, m.GVR.String())
+		_, _ = fmt.Fprintln(&sb, m.GVR.String())
 	}
 
 	return sb.String()


### PR DESCRIPTION

### What does this PR do?

Fixes the output of `agent workload-list --verbose` for `KubernetesMetadata` objects.
There was a missing newline at the end.

Before:
```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: namespaces//default ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: namespaces//default

----------- Entity Meta -----------
Name: default
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:default
----------- Resource -----------
/v1, Resource=namespaces===
```

After:
```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: namespaces//default ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: namespaces//default

----------- Entity Meta -----------
Name: default
Namespace:
Annotations:
Labels: kubernetes.io/metadata.name:default
----------- Resource -----------
/v1, Resource=namespaces
===
```

### Describe how to test/QA your changes

- Deploy the agent with some metadata collection enabled. For example, using the helm chart:
```yaml
clusterAgent:
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: true
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "namespaces"
```
- Run `agent workload-list --verbose` and check that the output is correct as described above. Notice that `--verbose` is needed, because otherwise the `Resource` section is not shown.