### PR TITLE
trace: fix idle connection timeout for outgoing traffic

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -575,7 +575,7 @@ func (c *AgentConfig) NewHTTPTransport() *http.Transport {
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}

--- a/releasenotes/notes/trace-idle-timeout-20328713b855263d.yaml
+++ b/releasenotes/notes/trace-idle-timeout-20328713b855263d.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    All datadog public endpoints have the maximum requirements to close idle
+    connections after 60s being idle.  If a given client keeps it for longer,
+    the server will close it, and the client will likely see the issue during
+    the next write, leading to a connection reset error.  The idle timeout
+    should be therefore set under a minute.
+    This PR is reducing the timeout from 90 to 30s.


### PR DESCRIPTION
all datadog public endpoints have the maximum requirements to close idle connections after 60s being idle.

if a given client keeps it for longer, the server will close it, and the client will likely see the issue during the next write, leading to a connection reset error.

the idle timeout should be therefore set under a minute.

### Describe how to test/QA your changes

1. Set up a trace-agent, send traces every 35 seconds
2. it should never end up with a request error to Datadog enpoints