### PR TITLE
[OASIS-12] Add missing DefaultOTelAgentLogFile on darwin

### DIFF
--- a/pkg/config/setup/config_darwin.go
+++ b/pkg/config/setup/config_darwin.go
@@ -16,6 +16,8 @@ const (
 	DefaultSecurityAgentLogFile = "/opt/datadog-agent/logs/security-agent.log"
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "/opt/datadog-agent/logs/process-agent.log"
+	// DefaultOTelAgentLogFile is the default otel-agent log file
+	DefaultOTelAgentLogFile = "/var/log/datadog/otel-agent.log"
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
 	// defaultEventMonitorAddress is the default unix socket path to be used for connecting to the event monitor

--- a/pkg/config/setup/config_darwin.go
+++ b/pkg/config/setup/config_darwin.go
@@ -17,7 +17,7 @@ const (
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "/opt/datadog-agent/logs/process-agent.log"
 	// DefaultOTelAgentLogFile is the default otel-agent log file
-	DefaultOTelAgentLogFile = "/var/log/datadog/otel-agent.log"
+	DefaultOTelAgentLogFile = "/opt/datadog-agent/logs/otel-agent.log"
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
 	// defaultEventMonitorAddress is the default unix socket path to be used for connecting to the event monitor


### PR DESCRIPTION
### What does this PR do?

Add missing DefaultOTelAgentLogFile on config_darwin

config_nix and config_windows already have it

### Motivation

Fix OTel agent build on Darwin.