### PR TITLE
Fix timestamp issue in unbundled events tests

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -8,6 +8,7 @@
 package kubernetesapiserver
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ import (
 )
 
 func TestUnbundledEventsTransform(t *testing.T) {
-	ts := metav1.Time{Time: time.Date(2024, 5, 29, 6, 0, 51, 0, time.UTC)}
+	ts := metav1.Time{Time: time.Date(2024, 5, 29, 6, 0, 51, 0, time.Now().Location())}
 
 	incomingEvents := []*v1.Event{
 		{
@@ -132,12 +133,12 @@ func TestUnbundledEventsTransform(t *testing.T) {
 			expected: []event.Event{
 				{
 					Title: "Events from the PodDisruptionBudget default/otel-demo-opensearch-pdb",
-					Text: `%%% 
+					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **CalculateExpectedPodCountFailed**: Failed to calculate the number of expected pods: found no controllers for pod "otel-demo-opensearch-0"
- 
- _Events emitted by the kubelet seen at 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ 
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
 
- %%%`,
+ %%%%%%`, " ", ts.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Tags: []string{
@@ -156,13 +157,13 @@ func TestUnbundledEventsTransform(t *testing.T) {
 				},
 				{
 					Title: "Events from the ReplicaSet default/blastoise-759fd559f7",
-					Text: `%%% 
+					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **Killing**: Stopping container blastoise
  1 **SuccessfulDelete**: Deleted pod: blastoise-759fd559f7-5wtqr
- 
- _Events emitted by the kubelet seen at 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ 
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
 
- %%%`,
+ %%%%%%`, " ", ts.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Host:     "",
@@ -291,12 +292,12 @@ func TestUnbundledEventsTransform(t *testing.T) {
 			expected: []event.Event{
 				{
 					Title: "Events from the Pod default/squirtle-8fff95dbb-tsc7v",
-					Text: `%%% 
+					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **Pulled**: Successfully pulled image "pokemon/squirtle:latest" in 1.263s (1.263s including waiting)
- 
- _Events emitted by the kubelet seen at 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ 
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
 
- %%%`,
+ %%%%%%`, " ", ts.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Tags: []string{
@@ -317,12 +318,12 @@ func TestUnbundledEventsTransform(t *testing.T) {
 				},
 				{
 					Title: "Events from the Pod default/wartortle-8fff95dbb-tsc7v",
-					Text: `%%% 
+					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **Failed**: All containers terminated
- 
- _Events emitted by the kubelet seen at 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ 
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
 
- %%%`,
+ %%%%%%`, " ", ts.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Tags: []string{
@@ -343,12 +344,12 @@ func TestUnbundledEventsTransform(t *testing.T) {
 				},
 				{
 					Title: "Events from the PodDisruptionBudget default/otel-demo-opensearch-pdb",
-					Text: `%%% 
+					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **CalculateExpectedPodCountFailed**: Failed to calculate the number of expected pods: found no controllers for pod "otel-demo-opensearch-0"
- 
- _Events emitted by the kubelet seen at 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ 
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
 
- %%%`,
+ %%%%%%`, " ", ts.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Tags: []string{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change expected event message timestamp in unbundled events tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Tests were failing when run locally due to a timestamp issue:
```
Diff:
--- Expected
+++ Actual
@@ -3,3 +3,3 @@
 Title: (string) (len=52) "Events from the Pod default/squirtle-8fff95dbb-tsc7v",
-  Text: (string) (len=223) "<snip> 2024-05-29 06:00:51 +0000 UTC since 2024-05-29 06:00:51 +0000 UTC_ \n\n %%%",
+  Text: (string) (len=223) "<snip> 2024-05-29 02:00:51 -0400 EDT since 2024-05-29 02:00:51 -0400 EDT_ \n\n %%%",
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Run `TestUnbundledEventsTransform` tests locally and verify they pass