### PR TITLE
USM: test: HTTP protocol classification: attach server binary

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -10,6 +10,7 @@ package usm
 import (
 	"bytes"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -762,4 +763,24 @@ func getUID(lib utils.PathIdentifier) string {
 // IsBuildModeSupported returns always true, as tls module is supported by all modes.
 func (*sslProgram) IsBuildModeSupported(buildmode.Type) bool {
 	return true
+}
+
+// OpenSSLAttachPID attaches Shared Libraries TLS hooks on the binary of process with
+// provided PID.
+func OpenSSLAttachPID(pid pid) error {
+	if opensslSpec.Instance == nil {
+		return errors.New("Shared Libaries TLS monitoring is not enabled")
+	}
+
+	return opensslSpec.Instance.(*sslProgram).watcher.AttachPID(pid)
+}
+
+// OpenSSLDetachPID detaches Shared Libraries TLS hooks on the binary of process with
+// provided PID.
+func OpenSSLDetachPID(pid pid) error {
+	if opensslSpec.Instance == nil {
+		return errors.New("Shared Libaries TLS monitoring is not enabled")
+	}
+
+	return opensslSpec.Instance.(*sslProgram).watcher.DetachPID(pid)
 }


### PR DESCRIPTION
Manually attaching the test binary should be more reliable than relying on the process monitor to attach the test server in time.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Makes the the test for HTTP+TLS protocol classification explicitly attach the test binary with TLS hooks, instead of relying on the process monitor to hook the server process.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

It sometimes happens that the server binary does not get hooked in time, causing the test to fail in the CI. This commit aims to make this more deterministic in hope to make this test more reliable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
