### PR TITLE
[workloadmeta/store_test] Delete nolint comment that no longer applies

### DIFF
--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -1614,7 +1614,7 @@ func TestReset(t *testing.T) {
 	}
 }
 
-func TestNoDataRace(t *testing.T) { //nolint:revive // TODO fix revive unused-parameter
+func TestNoDataRace(t *testing.T) {
 	// This test ensures that no race conditions are encountered when the "--race" flag is passed
 	// to the test process and an entity is accessed in a different thread than the one handling events
 	deps := fxutil.Test[dependencies](t, fx.Options(


### PR DESCRIPTION
### What does this PR do?

Deletes a `nolint` comment that no longer applies in `comp/core/workloadmeta/impl/store_test.go`.

### Describe how to test/QA your changes

Skip.
