### PR TITLE
fix(installer): Don't execute any nil rollback or cleanup

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -99,6 +99,9 @@ func (a *apmInjectorInstaller) Finish(err error) {
 	if err != nil {
 		// Run rollbacks in reverse order
 		for i := len(a.rollbacks) - 1; i >= 0; i-- {
+			if a.rollbacks[i] == nil {
+				continue
+			}
 			if rollbackErr := a.rollbacks[i](); rollbackErr != nil {
 				log.Warnf("rollback failed: %v", rollbackErr)
 			}
@@ -107,6 +110,9 @@ func (a *apmInjectorInstaller) Finish(err error) {
 
 	// Run cleanups in reverse order
 	for i := len(a.cleanups) - 1; i >= 0; i-- {
+		if a.cleanups[i] == nil {
+			continue
+		}
 		a.cleanups[i]()
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Enforces that we can never panic when executing a rollback or a cleanup during apm injector installation

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
