### PR TITLE
[CWS] do not run CWS kmt tests on opensuse 15.3 on arm64

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -179,7 +179,6 @@ kmt_run_secagent_tests_arm64:
           - "oracle_9.3"
           - "rocky_8.5"
           - "rocky_9.3"
-          - "opensuse_15.3"
           - "opensuse_15.5"
         TEST_SET: ["all_tests"]
   after_script:


### PR DESCRIPTION
### What does this PR do?

This kernel version is buggy and does not offer a working `bpf_probe_read` that allows reading user space memory. [More detail about the bug](https://lore.kernel.org/bpf/20230522203352.738576-1-jolsa@kernel.org/). Since we don't really support this OS version anyway, this PR removes it from the CI (but keeps it for x64 of course).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
