### PR TITLE
[EBPF] Cancel KMT test jobs too when cancelling pipelines

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -183,15 +183,25 @@ def auto_cancel_previous_pipelines(ctx):
     repo = get_gitlab_repo()
     pipelines = get_running_pipelines_on_same_ref(repo, git_ref)
     pipelines_without_current = [p for p in pipelines if p.sha != git_sha]
+    force_cancel_stages = [
+        "package_build",
+        # We want to cancel all KMT jobs to ensure proper cleanup of the KMT EC2 instances.
+        # If some jobs are canceled, the cleanup jobs will not run automatically, which means
+        # we must trigger the manual cleanup jobs (done in gracefully_cancel_pipeline) below.
+        # But if we trigger the cleanup manually and there are test jobs still running, those
+        # will be practically canceled (the instance they run on gets shut down) but will appear
+        # as a fail in the pipeline.
+        "kernel_matrix_testing_prepare",
+        "kernel_matrix_testing_system_probe",
+        "kernel_matrix_testing_security_agent",
+    ]
 
     for pipeline in pipelines_without_current:
         # We cancel pipeline only if it correspond to a commit that is an ancestor of the current commit
         is_ancestor = ctx.run(f'git merge-base --is-ancestor {pipeline.sha} {git_sha}', warn=True, hide="both")
         if is_ancestor.exited == 0:
             print(f'Gracefully canceling jobs that are not canceled on pipeline {pipeline.id} ({pipeline.web_url})')
-            gracefully_cancel_pipeline(
-                repo, pipeline, force_cancel_stages=["package_build", "kernel_matrix_testing_prepare"]
-            )
+            gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
         elif is_ancestor.exited == 1:
             print(f'{pipeline.sha} is not an ancestor of {git_sha}, not cancelling pipeline {pipeline.id}')
         elif is_ancestor.exited == 128:
@@ -205,9 +215,7 @@ def auto_cancel_previous_pipelines(ctx):
                 print(
                     f'Pipeline started earlier than {min_time_before_cancel} minutes ago, gracefully canceling pipeline {pipeline.id}'
                 )
-                gracefully_cancel_pipeline(
-                    repo, pipeline, force_cancel_stages=["package_build", "kernel_matrix_testing_prepare"]
-                )
+                gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
         else:
             print(is_ancestor.stderr)
             raise Exit(1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds the KMT test jobs to the list of jobs that will be force canceled when canceling a previous pipeline.

### Motivation

In https://github.com/DataDog/datadog-agent/pull/26126 we forced a manual cleanup of KMT instances when canceling pipelines. This causes the test jobs to end early, as the instance they run on is terminated, with a failure error code. This PR will change the state of those jobs to "canceled" removing false failures from our monitoring.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested while re-running pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/543501757

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
