### PR TITLE
Add a `vim.set-buildtags` `invoke` task to configure Vim ALE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,9 @@ pkg/network/netlink/testdata/message_dump*
 *~
 .dir-locals.el
 
+# Vim
+.vimrc
+
 # etags
 /TAGS
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -48,6 +48,7 @@ from tasks import (
     system_probe,
     systray,
     trace_agent,
+    vim,
     vscode,
 )
 from tasks.build_tags import audit_tag_impact, print_default_build_tags
@@ -155,6 +156,7 @@ ns.add_collection(docker_tasks, "docker")
 ns.add_collection(dogstatsd)
 ns.add_collection(ebpf)
 ns.add_collection(emacs)
+ns.add_collection(vim)
 ns.add_collection(epforwarder)
 ns.add_collection(go_deps)
 ns.add_collection(linter)

--- a/tasks/vim.py
+++ b/tasks/vim.py
@@ -1,0 +1,45 @@
+"""
+Vim namespaced tags
+
+Helpers for getting Vim set up nicely
+"""
+
+from invoke import task
+
+from tasks.build_tags import (
+    build_tags,
+    filter_incompatible_tags,
+    get_build_tags,
+    get_default_build_tags,
+)
+from tasks.flavor import AgentFlavor
+
+
+@task
+def set_buildtags(
+    _,
+    target="agent",
+    build_include=None,
+    build_exclude=None,
+    flavor=AgentFlavor.base.name,
+):
+    """
+    Create .vimrc settings file for this project to include correct build tags
+    """
+    flavor = AgentFlavor[flavor]
+
+    if target not in build_tags[flavor]:
+        print("Must choose a valid target.  Valid targets are: \n")
+        print(f'{", ".join(build_tags[flavor].keys())} \n')
+        return
+
+    build_include = (
+        get_default_build_tags(build=target, flavor=flavor)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","))
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+    use_tags = get_build_tags(build_include, build_exclude)
+
+    with open(".vimrc", "w") as f:
+        f.write(f"let g:ale_go_gopls_init_options = {{'buildFlags': ['-tags', '{','.join(use_tags)}']}}\n")


### PR DESCRIPTION
### What does this PR do?

Add a `vim.set-buildtags` `invoke` task that does for Vim exactly what the already existing [`vscode.set-buildtags` task](https://github.com/DataDog/datadog-agent/blob/f63ce53fb801732818b9f540522e76d4ba77b0bd/tasks/vscode.py#L28-L66) does for VS Code: configure `gopls` with appropriate build tags.

### Motivation

IDE configuration is usually a matter of personal taste.
As such, their configuration is best located in the home of each user.
There’s however a setting which depends on the `datadog-agent` project rather than on the developers’ personal taste: the list of GO build tags.
That’s why we already have `invoke` tasks to configure the GO build tags for:
* [`VScode`](https://github.com/DataDog/datadog-agent/blob/f63ce53fb801732818b9f540522e76d4ba77b0bd/tasks/vscode.py#L28-L66)
* [`Emacs`](https://github.com/DataDog/datadog-agent/blob/758f7c6e14b70d9f27644f5d8ab634b0df65f608/tasks/emacs.py#L13-L43)
* … and now Vim thanks to this PR.

### Additional Notes

This PR configures the [ALE](https://github.com/dense-analysis/ale) vim plugin.

In order to benefit from the [`gopls` integration in Vim](https://github.com/golang/tools/blob/master/gopls/doc/vim.md#ale) with the GO build tags properly set thanks to `inv vim.set-buildtags`, one must [install ALE](https://github.com/dense-analysis/ale?tab=readme-ov-file#installation) and configure its `~/.vimrc` with:
```vim
packadd! ale
let g:ale_completion_enabled = 1
let g:ale_fix_on_save = 1
let g:ale_linters = {
\  'go':  ['gopls'],
\ }
let g:ale_fixers = {
\ 'go': ['gofmt', 'goimports'],
\ }

set exrc
set secure
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
