### PR TITLE
[CONTP-261] add kubemetadata entity id generator and parser utils

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -67,7 +68,8 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	var dataBytes []byte
 	nodeName := vars["nodeName"]
 
-	nodeMetadata, err := wmeta.GetKubernetesMetadata(fmt.Sprintf("nodes//%s", nodeName))
+	entityID := util.GenerateKubeMetadataEntityID("nodes", "", nodeName)
+	nodeMetadata, err := wmeta.GetKubernetesMetadata(entityID)
 	if err != nil {
 		log.Errorf("Could not retrieve the node %s of %s: %v", what, nodeName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -118,7 +118,7 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	vars := mux.Vars(r)
 	var metadataBytes []byte
 	nsName := vars["ns"]
-	namespaceMetadata, err := wmeta.GetKubernetesMetadata(fmt.Sprintf("namespaces//%s", nsName))
+	namespaceMetadata, err := wmeta.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("namespaces", "", nsName))
 	if err != nil {
 		log.Debugf("Could not retrieve the %s of namespace %s: %v", what, nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -9,7 +9,6 @@ package kubeapiserver
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -71,16 +71,9 @@ func newMetadataParser(gvr schema.GroupVersionResource, annotationsExclude []str
 	return metadataParser{gvr: gvr, annotationsFilter: filters}, nil
 }
 
-// generateEntityID generates and returns a unique entity id for KubernetesMetadata entity
-// for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
-// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. node//master-node)
-func (p metadataParser) generateEntityID(resource, namespace, name string) string {
-	return fmt.Sprintf("%s/%s/%s", resource, namespace, name)
-}
-
 func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 	partialObjectMetadata := obj.(*metav1.PartialObjectMetadata)
-	id := p.generateEntityID(p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
+	id := util.GenerateKubeMetadataEntityID(p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
 
 	return &workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -78,7 +78,7 @@ func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 	return &workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   id,
+			ID:   string(id),
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Name:        partialObjectMetadata.Name,

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
@@ -82,7 +83,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   "namespaces//test-namespace",
+					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",
@@ -116,7 +117,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   "namespaces//test-namespace",
+					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",
@@ -152,7 +153,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   "namespaces//test-namespace",
+					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",

--- a/comp/core/workloadmeta/collectors/util/doc.go
+++ b/comp/core/workloadmeta/collectors/util/doc.go
@@ -3,15 +3,5 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build !trivy
-
+// Package util contains utility functions for workload metadata collectors
 package util
-
-import (
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-)
-
-// UpdateSBOMRepoMetadata does nothing
-func UpdateSBOMRepoMetadata(sbom *workloadmeta.SBOM, _, _ []string) *workloadmeta.SBOM {
-	return sbom
-}

--- a/comp/core/workloadmeta/collectors/util/image_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_metadata_util.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_metadata_util.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_metadata_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_metadata_util_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_metadata_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_metadata_util_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -5,7 +5,7 @@
 
 //go:build trivy
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_util.go
+++ b/comp/core/workloadmeta/collectors/util/image_util.go
@@ -5,7 +5,6 @@
 
 //go:build trivy
 
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_util_stub.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_stub.go
@@ -5,7 +5,7 @@
 
 //go:build !trivy
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -5,7 +5,7 @@
 
 //go:build trivy
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (
@@ -14,9 +14,10 @@ import (
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	trivycore "github.com/aquasecurity/trivy/pkg/sbom/core"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 func Test_UpdateSBOMRepoMetadata(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -5,7 +5,6 @@
 
 //go:build trivy
 
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package util contains utility functions for image metadata collection
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GenerateKubeMetadataEntityID generates and returns a unique entity id for KubernetesMetadata entity
+// for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
+// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. node//master-node)
+func GenerateKubeMetadataEntityID(resource, namespace, name string) string {
+	return fmt.Sprintf("%s/%s/%s", resource, namespace, name)
+}
+
+// ParseKubeMetadataEntityID parses a metadata entity ID and returns the resource type, namespace and resource name.
+// The parsed id should be in the following format: <resourceType>/<namespace>/<name>
+// The namespace field is left empty for cluster-scoped objects.
+// Examples:
+// - deployments/default/app
+// - namespaces//default
+// If the parsed id is malformatted, this function will return empty strings
+func ParseKubeMetadataEntityID(id string) (string, string, string) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 3 {
+		log.Errorf("malformatted metadata entity id: %s", id)
+		return "", "", ""
+	}
+
+	return parts[0], parts[1], parts[2]
+}

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
@@ -5,21 +5,21 @@
 
 //go:build kubeapiserver
 
-// Package util contains utility functions for image metadata collection
+// Package util contains utility functions for workload metadata collectors
 package util
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 // GenerateKubeMetadataEntityID generates and returns a unique entity id for KubernetesMetadata entity
 // for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
 // for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. node//master-node)
-func GenerateKubeMetadataEntityID(resource, namespace, name string) string {
-	return fmt.Sprintf("%s/%s/%s", resource, namespace, name)
+func GenerateKubeMetadataEntityID(resource, namespace, name string) workloadmeta.KubeMetadataEntityID {
+	return workloadmeta.KubeMetadataEntityID(fmt.Sprintf("%s/%s/%s", resource, namespace, name))
 }
 
 // ParseKubeMetadataEntityID parses a metadata entity ID and returns the resource type, namespace and resource name.
@@ -28,13 +28,13 @@ func GenerateKubeMetadataEntityID(resource, namespace, name string) string {
 // Examples:
 // - deployments/default/app
 // - namespaces//default
-// If the parsed id is malformatted, this function will return empty strings
-func ParseKubeMetadataEntityID(id string) (string, string, string) {
-	parts := strings.Split(id, "/")
+// If the parsed id is malformatted, this function will return empty strings and a non nil error
+func ParseKubeMetadataEntityID(id workloadmeta.KubeMetadataEntityID) (resource, namespace, name string, err error) {
+	parts := strings.Split(string(id), "/")
 	if len(parts) != 3 {
-		log.Errorf("malformatted metadata entity id: %s", id)
-		return "", "", ""
+		err := fmt.Errorf("malformatted metadata entity id: %s", id)
+		return "", "", "", err
 	}
 
-	return parts[0], parts[1], parts[2]
+	return parts[0], parts[1], parts[2], nil
 }

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build kubeapiserver
-
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (
@@ -17,7 +14,7 @@ import (
 
 // GenerateKubeMetadataEntityID generates and returns a unique entity id for KubernetesMetadata entity
 // for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
-// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. node//master-node)
+// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. nodes//master-node)
 func GenerateKubeMetadataEntityID(resource, namespace, name string) workloadmeta.KubeMetadataEntityID {
 	return workloadmeta.KubeMetadataEntityID(fmt.Sprintf("%s/%s/%s", resource, namespace, name))
 }

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package util contains utility functions for image metadata collection
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateKubeMetadataEntityID(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		resourceType string
+		resourceName string
+		expectedID   string
+	}{
+		{
+			name:         "namespace scoped resource",
+			namespace:    "default",
+			resourceType: "deployments",
+			resourceName: "app",
+			expectedID:   "deployments/default/app",
+		},
+		{
+			name:         "cluster scoped resource",
+			namespace:    "",
+			resourceType: "nodes",
+			resourceName: "foo-node",
+			expectedID:   "nodes//foo-node",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(tt, GenerateKubeMetadataEntityID(test.resourceType, test.namespace, test.resourceName), test.expectedID)
+		})
+	}
+
+}
+
+func TestParseKubeMetadataEntityID(t *testing.T) {
+	tests := []struct {
+		name              string
+		entityID          string
+		expectedName      string
+		expectedNamespace string
+		expectedResource  string
+	}{
+		{
+			name:              "namespace scoped resource",
+			expectedNamespace: "default",
+			expectedResource:  "deployments",
+			expectedName:      "app",
+			entityID:          "deployments/default/app",
+		},
+		{
+			name:              "cluster scoped resource",
+			expectedNamespace: "",
+			expectedResource:  "nodes",
+			expectedName:      "foo-node",
+			entityID:          "nodes//foo-node",
+		},
+		{
+			name:              "malformatted id",
+			expectedNamespace: "",
+			expectedResource:  "",
+			expectedName:      "",
+			entityID:          "mal//formatted//id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			resource, namespace, name := ParseKubeMetadataEntityID(test.entityID)
+			assert.Equal(tt, test.expectedName, name)
+			assert.Equal(tt, test.expectedNamespace, namespace)
+			assert.Equal(tt, test.expectedResource, resource)
+		})
+	}
+
+}

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
@@ -5,7 +5,6 @@
 
 //go:build kubeapiserver
 
-// Package util contains utility functions for workload metadata collectors
 package util
 
 import (
@@ -42,7 +41,7 @@ func TestGenerateKubeMetadataEntityID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			assert.Equal(tt, GenerateKubeMetadataEntityID(test.resourceType, test.namespace, test.resourceName), test.expectedID)
+			assert.Equal(tt, test.expectedID, GenerateKubeMetadataEntityID(test.resourceType, test.namespace, test.resourceName))
 		})
 	}
 

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -66,7 +66,7 @@ type Component interface {
 
 	// GetKubernetesMetadata returns metadata about a Kubernetes resource. It fetches
 	// the entity with kind KubernetesMetadata and the given ID.
-	GetKubernetesMetadata(id string) (*KubernetesMetadata, error)
+	GetKubernetesMetadata(id KubeMetadataEntityID) (*KubernetesMetadata, error)
 
 	// ListKubernetesMetadata returns all the kubernetes metadata objects for
 	// which the passed filter evaluates to true.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -780,6 +780,9 @@ func (o KubernetesPodOwner) String(verbose bool) string {
 	return sb.String()
 }
 
+// KubeMetadataEntityID is a unique ID for Kube Metadata Entity
+type KubeMetadataEntityID string
+
 // KubernetesMetadata is an Entity representing kubernetes resource metadata
 type KubernetesMetadata struct {
 	EntityID

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -376,8 +376,8 @@ func (w *workloadmeta) GetImage(id string) (*wmdef.ContainerImageMetadata, error
 }
 
 // GetKubernetesMetadata implements Store#GetKubernetesMetadata.
-func (w *workloadmeta) GetKubernetesMetadata(id string) (*wmdef.KubernetesMetadata, error) {
-	entity, err := w.getEntityByKind(wmdef.KindKubernetesMetadata, id)
+func (w *workloadmeta) GetKubernetesMetadata(id wmdef.KubeMetadataEntityID) (*wmdef.KubernetesMetadata, error) {
+	entity, err := w.getEntityByKind(wmdef.KindKubernetesMetadata, string(id))
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
@@ -1382,7 +1383,7 @@ func TestListKubernetesMetadata(t *testing.T) {
 	nodeMetadata := wmdef.KubernetesMetadata{
 		EntityID: wmdef.EntityID{
 			Kind: wmdef.KindKubernetesMetadata,
-			ID:   "nodes//node1",
+			ID:   string(util.GenerateKubeMetadataEntityID("nodes", "", "node1")),
 		},
 		EntityMeta: wmdef.EntityMeta{
 			Name:        "node1",

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -60,8 +60,8 @@ func (w *workloadMetaMock) GetContainer(id string) (*wmdef.Container, error) {
 }
 
 // GetKubernetesMetadata implements workloadMetaMock#GetKubernetesMetadata.
-func (w *workloadMetaMock) GetKubernetesMetadata(id string) (*wmdef.KubernetesMetadata, error) {
-	entity, err := w.getEntityByKind(wmdef.KindKubernetesMetadata, id)
+func (w *workloadMetaMock) GetKubernetesMetadata(id wmdef.KubeMetadataEntityID) (*wmdef.KubernetesMetadata, error) {
+	entity, err := w.getEntityByKind(wmdef.KindKubernetesMetadata, string(id))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -357,7 +358,9 @@ func (ci *CWSInstrumentation) injectForCommand(request *admission.MutateRequest)
 func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kubernetes.Interface) (string, error) {
 	var arch string
 	// try with the wmeta
-	out, err := ci.wmeta.GetKubernetesMetadata(fmt.Sprintf("nodes//%s", nodeName))
+	entityID := util.GenerateKubeMetadataEntityID("nodes", "", nodeName)
+
+	out, err := ci.wmeta.GetKubernetesMetadata(entityID)
 	if err == nil && out != nil {
 		arch = out.Labels["kubernetes.io/arch"]
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds utility functions to make it easy for developers to generate and parse kube metadata id's of kubemetadata workloadmeta entity.

No functional change is done in this PR.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Improve code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No QA is needed. This is only a code improvement PR and requires no specific QA.
Generic QA and Sanity check should be enough.