### PR TITLE
docker: Introduce `bundle_unspecified_events` to send bundled/unbundled events

### DIFF
--- a/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
+++ b/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
@@ -12,4 +12,5 @@ instances:
   filtered_event_types: []
   capped_metrics: {}
   unbundle_events: false
+  bundle_unspecified_events: false
   collected_event_types: []

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -20,13 +20,13 @@ instances:
     ## Transforms each collected Docker event into its own Datadog
     ## event, instead of grouping them together by container image.
     #
-    # unbundle_events: true
+    # unbundle_events: false
 
     ## @param bundle_unspecified_events - boolean - optional - default: false
     ## Bundle the events that remain after unbundling with collected_event_types
     ## and filtering with filtered_event_types. Only effective when unbundle_events is true.
     #
-    # bundle_unspecified_events: true
+    # bundle_unspecified_events: false
 
     ## @param collected_event_types - array of strings - optional
     ## Specify which docker events will be collected. Only effective when

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -22,6 +22,12 @@ instances:
     #
     # unbundle_events: true
 
+    ## @param bundle_unspecified_events - boolean - optional - default: false
+    ## Bundle the events that remain after unbundling with collected_event_types
+    ## and filtering with filtered_event_types. Only effective when unbundle_events is true.
+    #
+    # bundle_unspecified_events: true
+
     ## @param collected_event_types - array of strings - optional
     ## Specify which docker events will be collected. Only effective when
     ## unbundle_events is true, otherwise filtered_event_types is used.
@@ -34,7 +40,7 @@ instances:
 
     ## @param filtered_event_types - list of strings - optional - default: ['top', 'exec_start', 'exec_create', 'exec_die']
     ## List of excluded (filtered out) event types. Docker events of this type are not collected.
-    ## Only effective when unbundle_events is true, otherwise filtered_event_types is used.
+    ## Effective when unbundle_events is false or unbundle_events and bundle_unspecified_events are true both.
     ## A list of available types can be found at:
     ## https://docs.docker.com/engine/reference/commandline/events/#object-types
     #

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -49,6 +49,12 @@ type eventTransformer interface {
 	Transform([]*docker.ContainerEvent) ([]event.Event, []error)
 }
 
+type noopEventTransformer struct{}
+
+func (noopEventTransformer) Transform([]*docker.ContainerEvent) ([]event.Event, []error) {
+	return nil, nil
+}
+
 // DockerCheck grabs docker metrics
 type DockerCheck struct {
 	core.CheckBase
@@ -76,6 +82,13 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 	})
 }
 
+var defaultFilteredEventTypes = []string{
+	"top",
+	"exec_create",
+	"exec_start",
+	"exec_die",
+}
+
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
 	err := d.CommonConfigure(senderManager, initConfig, config, source)
@@ -93,19 +106,22 @@ func (d *DockerCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 		log.Warnf("Can't get hostname from docker, events will not have it: %v", err)
 	}
 
-	if d.instance.UnbundleEvents {
-		d.eventTransformer = newUnbundledTransformer(d.dockerHostname, d.instance.CollectedEventTypes)
-	} else {
-		filteredEventTypes := d.instance.FilteredEventType
-		if len(filteredEventTypes) == 0 {
-			filteredEventTypes = []string{
-				"top",
-				"exec_create",
-				"exec_start",
-				"exec_die",
-			}
-		}
+	filteredEventTypes := d.instance.FilteredEventType
+	if len(filteredEventTypes) == 0 {
+		filteredEventTypes = defaultFilteredEventTypes
+	}
 
+	if d.instance.UnbundleEvents {
+		var bundledTransformer eventTransformer = noopEventTransformer{}
+		if d.instance.BundleUnspecifiedEvents {
+			bundledTransformer = newBundledTransformer(
+				d.dockerHostname,
+				// Don't bundle events that are unbundled already.
+				append(filteredEventTypes, d.instance.CollectedEventTypes...),
+			)
+		}
+		d.eventTransformer = newUnbundledTransformer(d.dockerHostname, d.instance.CollectedEventTypes, bundledTransformer)
+	} else {
 		d.eventTransformer = newBundledTransformer(d.dockerHostname, filteredEventTypes)
 	}
 

--- a/pkg/collector/corechecks/containers/docker/config.go
+++ b/pkg/collector/corechecks/containers/docker/config.go
@@ -29,16 +29,15 @@ type DockerConfig struct {
 	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
 
 	// Event collection configuration
-	CollectEvent   bool `yaml:"collect_events"`
-	UnbundleEvents bool `yaml:"unbundle_events"`
+	CollectEvent            bool `yaml:"collect_events"`
+	UnbundleEvents          bool `yaml:"unbundle_events"`
+	BundleUnspecifiedEvents bool `yaml:"bundle_unspecified_events"`
 
 	// FilteredEventTypes is a slice of docker event types that works as a
-	// deny list of events to filter out. Only effective when
-	// UnbundleEvents = false
+	// deny list of events to filter out.
 	FilteredEventType []string `yaml:"filtered_event_types"`
 
 	// CollectedEventTypes is a slice of docker event types to collect.
-	// Only effective when UnbundleEvents = true
 	CollectedEventTypes []string `yaml:"collected_event_types"`
 }
 

--- a/pkg/collector/corechecks/containers/docker/unbundled_events.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events.go
@@ -27,14 +27,14 @@ func newUnbundledTransformer(hostname string, types []string, bundledTransformer
 	return &unbundledTransformer{
 		hostname:            hostname,
 		collectedEventTypes: collectedEventTypes,
-		bundledTransformer: bundledTransformer,
+		bundledTransformer:  bundledTransformer,
 	}
 }
 
 type unbundledTransformer struct {
 	hostname            string
 	collectedEventTypes map[string]struct{}
-	bundledTransformer eventTransformer
+	bundledTransformer  eventTransformer
 }
 
 func (t *unbundledTransformer) Transform(events []*docker.ContainerEvent) ([]event.Event, []error) {

--- a/pkg/collector/corechecks/containers/docker/unbundled_events.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func newUnbundledTransformer(hostname string, types []string, eventTransformer eventTransformer) eventTransformer {
+func newUnbundledTransformer(hostname string, types []string, bundledTransformer eventTransformer) eventTransformer {
 	collectedEventTypes := make(map[string]struct{}, len(types))
 	for _, t := range types {
 		collectedEventTypes[t] = struct{}{}
@@ -27,7 +27,7 @@ func newUnbundledTransformer(hostname string, types []string, eventTransformer e
 	return &unbundledTransformer{
 		hostname:            hostname,
 		collectedEventTypes: collectedEventTypes,
-		eventTransformer:    eventTransformer,
+		eventTransformer:    bundledTransformer,
 	}
 }
 

--- a/pkg/collector/corechecks/containers/docker/unbundled_events.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events.go
@@ -27,14 +27,14 @@ func newUnbundledTransformer(hostname string, types []string, bundledTransformer
 	return &unbundledTransformer{
 		hostname:            hostname,
 		collectedEventTypes: collectedEventTypes,
-		eventTransformer:    bundledTransformer,
+		bundledTransformer: bundledTransformer,
 	}
 }
 
 type unbundledTransformer struct {
 	hostname            string
 	collectedEventTypes map[string]struct{}
-	eventTransformer    eventTransformer
+	bundledTransformer eventTransformer
 }
 
 func (t *unbundledTransformer) Transform(events []*docker.ContainerEvent) ([]event.Event, []error) {
@@ -81,7 +81,7 @@ func (t *unbundledTransformer) Transform(events []*docker.ContainerEvent) ([]eve
 		})
 	}
 
-	bundledEvs, errs := t.eventTransformer.Transform(evsToBundle)
+	bundledEvs, errs := t.bundledTransformer.Transform(evsToBundle)
 
 	return append(datadogEvs, bundledEvs...), append(errors, errs...)
 }

--- a/pkg/collector/corechecks/containers/docker/unbundled_events_test.go
+++ b/pkg/collector/corechecks/containers/docker/unbundled_events_test.go
@@ -8,87 +8,368 @@
 package docker
 
 import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/docker/docker/api/types/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnbundledEventsTransform(t *testing.T) {
-	ts := time.Now()
-	containerID := "foobar"
-	containerName := "foo"
-	containerTags := []string{"image_name:foo", "image_tag:latest"}
-	imageName := "foo:latest"
 	hostname := "test-host"
+	codeBlock := "```"
+	eventBlock := "%%%"
+	incomingEvents := []*docker.ContainerEvent{
+		{
+			ContainerID:   "5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7",
+			ContainerName: "squirtle",
+			ImageName:     "pokemon/squirtle",
+			Action:        events.ActionStart,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"squirtle_attribute1": "value1",
+				"squirtle_attribute2": "value2",
+				"squirtle_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7",
+			ContainerName: "squirtle",
+			ImageName:     "pokemon/squirtle",
+			Action:        events.ActionExecStart,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"squirtle_attribute1": "value1",
+				"squirtle_attribute2": "value2",
+				"squirtle_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7",
+			ContainerName: "squirtle",
+			ImageName:     "pokemon/squirtle",
+			Action:        events.ActionExecCreate,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"squirtle_attribute1": "value1",
+				"squirtle_attribute2": "value2",
+				"squirtle_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "7579e0790f48037c1b49683a751ff2e70bdf93dde9b54fec26371d9e8727edc7",
+			ContainerName: "azurill",
+			ImageName:     "pokemon/azurill",
+			Action:        events.ActionTop,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"azurill_attribute1": "value1",
+				"azurill_attribute2": "value2",
+				"azurill_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "87b6a7785a962622fbdc2634ae69118913e3a4a7844f940a71c7db63532b265b",
+			ContainerName: "bagon",
+			ImageName:     "pokemon/bagon",
+			Action:        events.ActionExecStart,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"bagon_attribute1": "value1",
+				"bagon_attribute2": "value2",
+				"bagon_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "66b6a7785a962622fdbc2634a6e9191831e3aa48744f940a17cd7b36532b2b65",
+			ContainerName: "bagon",
+			ImageName:     "pokemon/bagon",
+			Action:        events.ActionExecDie,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"bagon_attribute1": "value1",
+				"bagon_attribute2": "value2",
+				"bagon_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "66b6a7785a962622fdbc2634a6e9191831e3aa48744f940a17cd7b36532b2b65",
+			ContainerName: "bagon",
+			ImageName:     "pokemon/bagon",
+			Action:        events.ActionCopy,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"bagon_attribute1": "value1",
+				"bagon_attribute2": "value2",
+				"bagon_attribute3": "value3",
+			},
+		},
+		{
+			ContainerID:   "26b6a7785a966222fdbc2364ae69191f13ea3a487449f40a17cd7b356322a6bb",
+			ContainerName: "bagon",
+			ImageName:     "pokemon/bagon",
+			Action:        events.ActionDisable,
+			Timestamp:     time.Now(),
+			Attributes: map[string]string{
+				"bagon_attribute1": "value1",
+				"bagon_attribute2": "value2",
+				"bagon_attribute3": "value3",
+			},
+		},
+	}
 
 	fakeTagger := taggerimpl.SetupFakeTagger(t)
 	defer fakeTagger.ResetTagger()
-
-	fakeTagger.SetTags(
-		containers.BuildTaggerEntityName(containerID), "-",
-		containerTags, []string{}, []string{}, []string{},
-	)
+	for _, ev := range incomingEvents {
+		fakeTagger.SetTags(
+			containers.BuildTaggerEntityName(ev.ContainerID),
+			"docker",
+			[]string{fmt.Sprintf("image_name:%s", ev.ImageName), fmt.Sprintf("container_name:%s", ev.ContainerName)},
+			[]string{},
+			[]string{},
+			[]string{},
+		)
+	}
 
 	tests := []struct {
-		name     string
-		event    *docker.ContainerEvent
-		expected []event.Event
+		name                   string
+		bundleUnspecifedEvents bool
+		filteredEventTypes     []string
+		collectedEventTypes    []string
+		expectedEvents         []event.Event
 	}{
 		{
-			name: "event is filtered out",
-			event: &docker.ContainerEvent{
-				ContainerID:   containerID,
-				ContainerName: containerName,
-				ImageName:     imageName,
-				Action:        "create",
-				Timestamp:     ts,
-			},
-			expected: nil,
+			name:                   "nothing will be unbundled since collectedEventTypes is empty",
+			bundleUnspecifedEvents: false,
+			filteredEventTypes:     []string{},
+			collectedEventTypes:    []string{},
+			expectedEvents:         nil,
 		},
 		{
-			name: "event is filtered out",
-			event: &docker.ContainerEvent{
-				ContainerID:   containerID,
-				ContainerName: containerName,
-				ImageName:     imageName,
-				Action:        "oom",
-				Timestamp:     ts,
-			},
-			expected: []event.Event{
+			name:                   "bundle events with default filtered event types and without collected event types",
+			bundleUnspecifedEvents: true,
+			filteredEventTypes:     defaultFilteredEventTypes,
+			collectedEventTypes:    []string{},
+			expectedEvents: []event.Event{
 				{
-					Title:          "Container foobar: oom",
-					Text:           "Container foobar (running image \"foo:latest\"): oom",
-					AlertType:      event.AlertTypeError,
-					AggregationKey: "docker:foobar",
-					Ts:             ts.Unix(),
+					Title: "pokemon/bagon 1 copy 1 disable on test-host",
+					Text: fmt.Sprintf(`%s 
+pokemon/bagon 1 copy 1 disable on test-host
+%s
+%s
+%s
+%s
+ %s`, eventBlock, codeBlock, "COPY\tbagon", "DISABLE\tbagon", codeBlock, eventBlock),
+					Priority:       "normal",
 					Host:           hostname,
+					AlertType:      "info",
 					SourceTypeName: "docker",
+					AggregationKey: "docker:pokemon/bagon",
 					EventType:      "docker",
-					Priority:       event.PriorityNormal,
 					Tags: []string{
-						"image_name:foo",
-						"image_tag:latest",
-						"event_type:oom",
+						"image_name:pokemon/bagon",
+						"container_name:bagon",
+						"image_name:pokemon/bagon",
+						"container_name:bagon",
+					},
+				},
+				{
+					Title: "pokemon/squirtle 1 start on test-host",
+					Text: fmt.Sprintf(`%s 
+pokemon/squirtle 1 start on test-host
+%s
+%s
+%s
+ %s`, eventBlock, codeBlock, "START\tsquirtle", codeBlock, eventBlock),
+					Priority:       "normal",
+					Host:           hostname,
+					AlertType:      "info",
+					EventType:      "docker",
+					AggregationKey: "docker:pokemon/squirtle",
+					SourceTypeName: "docker",
+					Tags: []string{
+						"image_name:pokemon/squirtle",
+						"container_name:squirtle",
+					},
+				},
+			},
+		},
+		{
+			name:                   "unbundle and bundle events",
+			bundleUnspecifedEvents: true,
+			filteredEventTypes:     []string{"exec_start", "exec_die"},
+			collectedEventTypes: []string{
+				string(events.ActionCopy),
+				string(events.ActionDisable),
+				string(events.ActionStart),
+			},
+			expectedEvents: []event.Event{
+				{
+					Title: "pokemon/squirtle 1 exec_create on test-host",
+					Text: fmt.Sprintf(`%s 
+pokemon/squirtle 1 exec_create on test-host
+%s
+%s
+%s
+ %s`, eventBlock, codeBlock, "EXEC_CREATE\tsquirtle", codeBlock, eventBlock),
+					Host:           hostname,
+					Priority:       "normal",
+					SourceTypeName: "docker",
+					AggregationKey: "docker:pokemon/squirtle",
+					AlertType:      "info",
+					EventType:      "docker",
+					Tags: []string{
+						"image_name:pokemon/squirtle",
+						"container_name:squirtle",
+					},
+				},
+				{
+					Title: "pokemon/azurill 1 top on test-host",
+					Text: fmt.Sprintf(`%s 
+pokemon/azurill 1 top on test-host
+%s
+%s
+%s
+ %s`, eventBlock, codeBlock, "TOP\tazurill", codeBlock, eventBlock),
+					Host:           hostname,
+					Priority:       "normal",
+					SourceTypeName: "docker",
+					AggregationKey: "docker:pokemon/azurill",
+					AlertType:      "info",
+					EventType:      "docker",
+					Tags: []string{
+						"image_name:pokemon/azurill",
+						"container_name:azurill",
+					},
+				},
+				{
+					Title:          "Container 26b6a7785a966222fdbc2364ae69191f13ea3a487449f40a17cd7b356322a6bb: disable",
+					Text:           `Container 26b6a7785a966222fdbc2364ae69191f13ea3a487449f40a17cd7b356322a6bb (running image "pokemon/bagon"): disable`,
+					Host:           hostname,
+					Priority:       "normal",
+					AggregationKey: "docker:26b6a7785a966222fdbc2364ae69191f13ea3a487449f40a17cd7b356322a6bb",
+					AlertType:      "info",
+					SourceTypeName: "docker",
+					Tags: []string{
+						"image_name:pokemon/bagon",
+						"container_name:bagon",
+						"event_type:disable",
+					},
+				},
+				{
+					Title:          "Container 5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7: start",
+					Text:           `Container 5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7 (running image "pokemon/squirtle"): start`,
+					Host:           hostname,
+					Priority:       "normal",
+					AggregationKey: "docker:5797e0079f48037cb194683a571ffe270bdf93dde9b4f5ec26371d98e727dec7",
+					AlertType:      "info",
+					SourceTypeName: "docker",
+					Tags: []string{
+						"image_name:pokemon/squirtle",
+						"container_name:squirtle",
+						"event_type:start",
+					},
+				},
+				{
+					Title:          "Container 66b6a7785a962622fdbc2634a6e9191831e3aa48744f940a17cd7b36532b2b65: copy",
+					Text:           `Container 66b6a7785a962622fdbc2634a6e9191831e3aa48744f940a17cd7b36532b2b65 (running image "pokemon/bagon"): copy`,
+					Host:           hostname,
+					Priority:       "normal",
+					AggregationKey: "docker:66b6a7785a962622fdbc2634a6e9191831e3aa48744f940a17cd7b36532b2b65",
+					AlertType:      "info",
+					SourceTypeName: "docker",
+					Tags: []string{
+						"image_name:pokemon/bagon",
+						"container_name:bagon",
+						"event_type:copy",
 					},
 				},
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transformer := newUnbundledTransformer(hostname, []string{"oom", "kill"})
-
-			events, errors := transformer.Transform([]*docker.ContainerEvent{tt.event})
-
-			assert.Empty(t, errors)
-			assert.Equal(t, tt.expected, events)
+			var eventTransformer eventTransformer = noopEventTransformer{}
+			if tt.bundleUnspecifedEvents {
+				eventTransformer = newBundledTransformer(hostname, tt.filteredEventTypes)
+			}
+			transformer := newUnbundledTransformer(
+				hostname,
+				tt.collectedEventTypes,
+				eventTransformer,
+			)
+			evs, errs := transformer.Transform(incomingEvents)
+			require.Nil(t, errs)
+			slices.SortFunc(evs, func(a, b event.Event) int {
+				aSplitedTitle := strings.Split(a.Title, " ")
+				bSplitedTitle := strings.Split(b.Title, " ")
+				slices.Sort(aSplitedTitle)
+				slices.Sort(bSplitedTitle)
+				return cmp.Compare[string](
+					strings.Join(aSplitedTitle, " "),
+					strings.Join(bSplitedTitle, " "),
+				)
+			})
+			require.Len(t, evs, len(tt.expectedEvents))
+			require.Condition(t, func() (success bool) {
+				for i, expected := range tt.expectedEvents {
+					// Compare the semantics of the title and text to avoid character order issues.
+					actualSplitedTitle := strings.Split(evs[i].Title, " ")
+					expectedSplitedTitle := strings.Split(expected.Title, " ")
+					slices.Sort(actualSplitedTitle)
+					slices.Sort(expectedSplitedTitle)
+					if !assert.Equalf(
+						t,
+						expectedSplitedTitle,
+						actualSplitedTitle,
+						"EXPECTED: %s\nACTUAL: %s",
+						expected.Title,
+						evs[i].Title,
+					) {
+						return false
+					}
+					actualSplitedText := strings.Split(evs[i].Text, " ")
+					expectedSplitedText := strings.Split(expected.Text, " ")
+					slices.Sort(actualSplitedText)
+					slices.Sort(expectedSplitedText)
+					if !assert.Equalf(
+						t,
+						expectedSplitedText,
+						actualSplitedText,
+						"EXPECTED: %s\nACTUAL: %s",
+						expected.Text,
+						evs[i].Text,
+					) {
+						return false
+					}
+					// Compare the rest of the fields.
+					if !assert.Equal(t, expected.Host, evs[i].Host, "Host is not equal") {
+						return false
+					}
+					if !assert.Equal(t, expected.AggregationKey, evs[i].AggregationKey, "AggregationKey is not equal") {
+						return false
+					}
+					if !assert.Equal(t, expected.AlertType, evs[i].AlertType, "AlertType is not equal") {
+						return false
+					}
+					if !assert.Equal(t, expected.SourceTypeName, evs[i].SourceTypeName, "SourceTypeName is not equal") {
+						return false
+					}
+					if !assert.Equal(t, expected.Tags, evs[i].Tags, "Tags are not equal") {
+						return false
+					}
+				}
+				return true
+			})
 		})
 	}
 }

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -71,6 +71,7 @@ instances:
     docker.cpu.user: 1000
   collect_events: false
   unbundle_events: false
+  bundle_unspecified_events: false
   filtered_event_types:
   - top
   - exec_start

--- a/releasenotes/notes/docker-bundle-unspecified-events-26347e42e2201c30.yaml
+++ b/releasenotes/notes/docker-bundle-unspecified-events-26347e42e2201c30.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    Introduces an ``bundle_unspecifed_events`` config to the ``docker`` integration.
+    Introduces a ``bundle_unspecifed_events`` config to the ``docker`` integration.
     When ``bundle_unspecifed_events`` and ``unbundle_events`` are true,
     Docker events are unbundled according to ``collected_event_types`` and
-    the remaining events are bundled after the ``filtered_event_types`` + ``collected_event_types``.
+    the remaining events are bundled after excluding the ``filtered_event_types`` and ``collected_event_types``.

--- a/releasenotes/notes/docker-bundle-unspecified-events-26347e42e2201c30.yaml
+++ b/releasenotes/notes/docker-bundle-unspecified-events-26347e42e2201c30.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Introduces an ``bundle_unspecifed_events`` config to the ``docker`` integration.
+    When ``bundle_unspecifed_events`` and ``unbundle_events`` are true,
+    Docker events are unbundled according to ``collected_event_types`` and
+    the remaining events are bundled after the ``filtered_event_types`` + ``collected_event_types``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Send bundled and unbundled events both when `unbundle_events: true` and `bundle_unspecified_events: true`.

1. Unbundle events which matched the `collected_event_types` config.
2. Bundle events that are left after `filtered_event_types` + `collected_event_types`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Same as https://github.com/DataDog/datadog-agent/pull/25642.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```yaml
init_config:
instances:
  - unbundle_events: true
    bundle_unspecified_events: true
    collected_event_types:
    - "die"

```

```yaml
services:
  agent:
    container_name: datadog-agent
    image: datadog/agent-dev:keisku-docker-bundle-unspecified-events-py3
    volumes:
      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
      - /proc/:/host/proc/:ro
      - /var/run/docker.sock:/var/run/docker.sock:ro
      - ./docker.yaml:/etc/datadog-agent/conf.d/docker.yaml
    environment:
      - DD_ENV=pr26732
    env_file:
      - ~/sandbox.docker.env
  example-1:
    container_name: example-1
    image: busybox
    restart: always
    entrypoint: [ "sh", "-c", "sleep 60" ]
    depends_on:
      agent:
        condition: service_healthy
    healthcheck:
      test: [ "CMD", "curl", "-fs", "http://agent:8126/info" ]
      interval: 5s
      timeout: 5s
      retries: 3
  example-2:
    container_name: example-2
    image: busybox
    restart: always
    entrypoint: [ "sh", "-c", "sleep 60" ]
    depends_on:
      agent:
        condition: service_healthy
    healthcheck:
      test: [ "CMD", "curl", "-fs", "http://agent:8126/info" ]
      interval: 5s
      timeout: 5s
      retries: 3

```

<img width="1622" alt="2024-06-17_17-24-18" src="https://github.com/DataDog/datadog-agent/assets/41987730/5c1a38fd-739d-4063-b59e-d407305f6d2b">



