### PR TITLE
[workloadmeta/filter] Handle nil entity filter

### DIFF
--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -112,7 +112,8 @@ func (f *Filter) MatchEntity(entity *Entity) bool {
 	entityKind := (*entity).GetID().Kind
 
 	if entityFilterFunc, found := f.kinds[entityKind]; found {
-		return entityFilterFunc(*entity)
+		// A nil filter should match
+		return entityFilterFunc == nil || entityFilterFunc(*entity)
 	}
 
 	return false

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -298,6 +298,17 @@ func TestFilter_MatchEntity(t *testing.T) {
 			},
 			expectMatch: false,
 		},
+		{
+			name:   "a nil entity filter func should match",
+			filter: &Filter{kinds: map[Kind]GenericEntityFilterFunc{KindContainer: nil}},
+			entity: &Container{
+				EntityID: EntityID{
+					ID:   "cont-d",
+					Kind: KindContainer,
+				},
+			},
+			expectMatch: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

Handles nil entity filters in workloadmeta to avoid panics.
As discussed here: https://github.com/DataDog/datadog-agent/pull/26685#discussion_r1638110758


### Describe how to test/QA your changes

Skip.