### PR TITLE
Download a flare or logs when the Agent failed to start

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -224,7 +224,7 @@ func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, h
 			if host.osFamily != osComp.WindowsFamily {
 				_, err = host.Execute(fmt.Sprintf("sudo chmod 744 %s/%s", tmpFolder, entry.Name()))
 				if err != nil {
-					return fmt.Errorf("could update permission of flare file %s/%s : %v", tmpFolder, entry.Name(), err)
+					return fmt.Errorf("could not update permission of flare file %s/%s : %v", tmpFolder, entry.Name(), err)
 				}
 			}
 

--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -112,6 +112,15 @@ func (agent *agentCommandRunner) Flare(commandArgs ...agentclient.AgentArgsOptio
 	return agent.executeCommand("flare", commandArgs...)
 }
 
+// FlareWithError runs flare command and returns the output or an error. You should use the FakeIntake client to fetch the flare archive
+func (agent *agentCommandRunner) FlareWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
+	args, err := optional.MakeParams(commandArgs...)
+	require.NoError(agent.t, err)
+
+	arguments := append([]string{"flare"}, args.Args...)
+	return agent.executor.execute(arguments)
+}
+
 // Health runs health command and returns the runtime agent health
 func (agent *agentCommandRunner) Health() (string, error) {
 	arguments := []string{"health"}

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -318,6 +318,7 @@ func (h *Host) DialPort(port uint16) (net.Conn, error) {
 	return connection, err
 }
 
+// GetTmpFolder returns the temporary folder path for the host
 func (h *Host) GetTmpFolder() (string, error) {
 	switch osFamily := h.osFamily; osFamily {
 	case oscomp.WindowsFamily:
@@ -329,6 +330,7 @@ func (h *Host) GetTmpFolder() (string, error) {
 	}
 }
 
+// GetLogsFolder returns the logs folder path for the host
 func (h *Host) GetLogsFolder() (string, error) {
 	switch osFamily := h.osFamily; osFamily {
 	case oscomp.WindowsFamily:

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -322,7 +322,7 @@ func (h *Host) DialPort(port uint16) (net.Conn, error) {
 func (h *Host) GetTmpFolder() (string, error) {
 	switch osFamily := h.osFamily; osFamily {
 	case oscomp.WindowsFamily:
-		return h.Execute("echo $env:TEMP")
+		return h.Execute("echo %TEMP%")
 	case oscomp.LinuxFamily:
 		return "/tmp", nil
 	default:

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -51,6 +51,7 @@ type Host struct {
 	privateKeyPassphrase []byte
 	buildCommand         buildCommandFn
 	convertPathSeparator convertPathSeparatorFn
+	osFamily             oscomp.Family
 }
 
 // NewHost creates a new ssh client to connect to a remote host with
@@ -82,6 +83,7 @@ func NewHost(context e2e.Context, hostOutput remote.HostOutput) (*Host, error) {
 		privateKeyPassphrase: []byte(privateKeyPassword),
 		buildCommand:         buildCommandFactory(hostOutput.OSFamily),
 		convertPathSeparator: convertPathSeparatorFactory(hostOutput.OSFamily),
+		osFamily:             hostOutput.OSFamily,
 	}
 	err = host.Reconnect()
 	return host, err
@@ -314,6 +316,30 @@ func (h *Host) DialPort(port uint16) (net.Conn, error) {
 		connection, err = h.client.DialContext(context, protocol, address)
 	}
 	return connection, err
+}
+
+func (h *Host) GetTmpFolder() (string, error) {
+	switch osFamily := h.osFamily; osFamily {
+	case oscomp.WindowsFamily:
+		return h.Execute("echo $env:TEMP")
+	case oscomp.LinuxFamily:
+		return "/tmp", nil
+	default:
+		return "", errors.ErrUnsupported
+	}
+}
+
+func (h *Host) GetLogsFolder() (string, error) {
+	switch osFamily := h.osFamily; osFamily {
+	case oscomp.WindowsFamily:
+		return `C:\ProgramData\Datadog\logs`, nil
+	case oscomp.LinuxFamily:
+		return "/var/log/datadog/", nil
+	case oscomp.MacOSFamily:
+		return "/opt/datadog-agent/logs", nil
+	default:
+		return "", errors.ErrUnsupported
+	}
 }
 
 // appendWithSudo appends content to the file using sudo tee for Linux environment


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Download a flare or logs when the Agent failed to start

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When the Agent fails to start, we do not know exactly why and people need to run it in the DEV_MODE locally to get the logs. Here, in that case, we will:

1. Generate a flare
2. Download the flare 
3. Download the logs directly if there was an error while generating the flare (because the Agent is completely broken for instance)
4. Save the files in the `E2E_OUTPUT_DIR`, which will be uploaded as artefacts and attached to the job if we are in the CI

Hopefully this will save us some time debugging issues

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Job examples where I forced the upload of the flares AND logs:

- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/544761484 with https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/544761484/artifacts/browse/e2e-output/2024-06-17_08-11-33_215534705/

For now it's only on VMs, not for Docker hosts.

https://datadoghq.atlassian.net/browse/ADXT-336

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
