### PR TITLE
Installer change user on upgrade E2E test

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -38,6 +38,7 @@
       - E2E_MSI_TEST: TestRepair
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeRollback
+      - E2E_MSI_TEST: TestUpgradeChangeUser
       - E2E_MSI_TEST: TestAgentUser/user_only
       - E2E_MSI_TEST: TestAgentUser/dotslash_user
       - E2E_MSI_TEST: TestAgentUser/hostname_user

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -9,7 +9,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"slices"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 
@@ -396,9 +395,9 @@ func NewInheritSecurityInfo(owner Identity, group Identity, access []AccessRule)
 	}
 }
 
-// ContainsRuleForIdentity returns true if the list contains a rule for the given identity
-func ContainsRuleForIdentity[T AuthorizationRuleWithRights](acl []T, identity Identity) bool {
-	return slices.ContainsFunc(acl, func(rule T) bool {
+// FilterRulesForIdentity returns the rules that match the given identity
+func FilterRulesForIdentity[T AuthorizationRuleWithRights](acl []T, identity Identity) []T {
+	return Filter(acl, func(rule T) bool {
 		return rule.GetAuthorizationRule().Identity.Equal(identity)
 	})
 }

--- a/test/new-e2e/tests/windows/common/assert.go
+++ b/test/new-e2e/tests/windows/common/assert.go
@@ -169,3 +169,14 @@ func AssertNotContainsEqualable[T equalable[T]](t *testing.T, list []T, elem T, 
 		return a.Equal(b)
 	}, msgAndArgs...)
 }
+
+// Filter is a generic function that filters a list based on a provided filter function
+func Filter[T any](list []T, filter func(T) bool) []T {
+	var filtered []T
+	for _, elem := range list {
+		if filter(elem) {
+			filtered = append(filtered, elem)
+		}
+	}
+	return filtered
+}

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -117,6 +117,14 @@ func WithPreviousVersion() TesterOption {
 	}
 }
 
+// WithExpectedAgentUserName sets the expected user name the agent should run as
+// the domain remains the default for the host.
+func WithExpectedAgentUserName(user string) TesterOption {
+	return func(t *Tester) {
+		t.expectedUserName = user
+	}
+}
+
 // WithExpectedAgentUser sets the expected user the agent should run as
 func WithExpectedAgentUser(domain string, user string) TesterOption {
 	return func(t *Tester) {

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	servicetest "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test"
 
 	"testing"
 )
@@ -96,4 +97,86 @@ func (s *testUpgradeRollbackSuite) TestUpgradeRollback() {
 	}
 
 	s.uninstallAgentAndRunUninstallTests(previousTester)
+}
+
+func TestUpgradeChangeUser(t *testing.T) {
+	s := &testUpgradeChangeUserSuite{}
+	run(t, s)
+}
+
+type testUpgradeChangeUserSuite struct {
+	baseAgentMSISuite
+}
+
+func (s *testUpgradeChangeUserSuite) TestUpgradeChangeUser() {
+	host := s.Env().RemoteHost
+
+	oldUserName := windowsAgent.DefaultAgentUserName
+	newUserName := "newagentuser"
+	s.Require().NotEqual(oldUserName, newUserName, "new user name should be different from the default")
+
+	// install previous version with defaults
+	_ = s.installLastStable(host)
+
+	// upgrade to the new version
+	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
+		_, err := s.InstallAgent(host,
+			windowsAgent.WithPackage(s.AgentPackage),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithAgentUser(newUserName),
+		)
+		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
+	}) {
+		s.T().FailNow()
+	}
+
+	// run tests, checking for new user
+	t := s.newTester(host,
+		WithExpectedAgentUserName(newUserName),
+	)
+	if !t.TestInstallExpectations(s.T()) {
+		s.T().FailNow()
+	}
+
+	// old user shouldn't be deleted, so Identity should still exist
+	oldUserIdentity, err := windowsCommon.GetIdentityForUser(host, oldUserName)
+	s.Require().NoError(err)
+
+	s.Run("removes file and registry permissions for old user", func() {
+		installPath, err := windowsAgent.GetInstallPathFromRegistry(host)
+		s.Require().NoError(err)
+		configRoot, err := windowsAgent.GetConfigRootFromRegistry(host)
+		s.Require().NoError(err)
+		paths := []string{
+			configRoot,
+			filepath.Join(installPath, "embedded3"),
+			windowsAgent.RegistryKeyPath,
+		}
+
+		// oldUserIdentity should not have permissions on the paths
+		for _, path := range paths {
+			out, err := windowsCommon.GetSecurityInfoForPath(host, path)
+			s.Require().NoError(err)
+			s.Assert().Empty(windowsCommon.FilterRulesForIdentity(out.Access, oldUserIdentity),
+				"%s should not have permissions on %s", oldUserIdentity, path)
+		}
+	})
+	s.Run("removes service permissions for old user", func() {
+		// services should not have permissions for the old user
+		serviceConfigs, err := windowsCommon.GetServiceConfigMap(host, servicetest.ExpectedInstalledServices())
+		s.Require().NoError(err)
+		for _, serviceName := range servicetest.ExpectedInstalledServices() {
+			conf := serviceConfigs[serviceName]
+			if windowsCommon.IsKernelModeServiceType(conf.ServiceType) {
+				// we don't modify kernel mode services
+				continue
+			}
+			out, err := windowsCommon.GetServiceSecurityInfo(host, serviceName)
+			s.Require().NoError(err)
+			s.Assert().Empty(windowsCommon.FilterRulesForIdentity(out.Access, oldUserIdentity),
+				"%s should not have permissions on %s", oldUserIdentity, serviceName)
+		}
+	})
+
+	s.uninstallAgentAndRunUninstallTests(t)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add test to ensure ddagentuser can be changed when upgrading Agent version. Verifies that permissions were updated to remove previous agent user.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
