### PR TITLE
ebpf check: implement helper based map counting technique

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
@@ -1,0 +1,201 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package ebpfcheck is the system-probe side of the eBPF check
+package ebpfcheck
+
+import (
+	"sync"
+
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+type mapProgHelperCache struct {
+	cacheLock sync.Mutex
+	cache     map[ebpf.MapID]helperProgData
+
+	entryBtf    *btf.Func
+	callbackBtf *btf.Func
+}
+
+func newMapProgHelperCache() *mapProgHelperCache {
+	entryBtf := &btf.Func{
+		Name: "entry",
+		Type: &btf.FuncProto{
+			Return: &btf.Int{
+				Name:     "int",
+				Size:     4,
+				Encoding: btf.Signed,
+			},
+		},
+	}
+
+	u64Btf := &btf.Int{
+		Name:     "long",
+		Size:     8,
+		Encoding: btf.Unsigned,
+	}
+
+	callbackBtf := &btf.Func{
+		Name: "callback",
+		Type: &btf.FuncProto{
+			Return: u64Btf,
+			Params: []btf.FuncParam{
+				{
+					Name: "map",
+					Type: u64Btf,
+				},
+				{
+					Name: "key",
+					Type: u64Btf,
+				},
+				{
+					Name: "value",
+					Type: u64Btf,
+				},
+				{
+					Name: "ctx",
+					Type: u64Btf,
+				},
+			},
+		},
+	}
+
+	return &mapProgHelperCache{
+		cache: make(map[ebpf.MapID]helperProgData),
+
+		entryBtf:    entryBtf,
+		callbackBtf: callbackBtf,
+	}
+}
+
+func (c *mapProgHelperCache) newCachedProgramForMap(mp *ebpf.Map, mapid ebpf.MapID) (*ebpf.Program, error) {
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
+
+	if data, ok := c.cache[mapid]; ok {
+		return data.prog, nil
+	}
+
+	data, err := c.newHelperProgramForFd(mp.FD())
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache[mapid] = data
+	return data.prog, nil
+}
+
+type helperProgData struct {
+	id   ebpf.ProgramID
+	prog *ebpf.Program
+}
+
+func (c *mapProgHelperCache) newHelperProgramForFd(fd int) (helperProgData, error) {
+	/*
+		equivalent to the following C code, based on the fact that `for_each_map_elem`
+		returns the amount of entries visited, so visiting all the entries ensures we
+		get the amount of entries in the map.
+
+		int callback(struct bpf_map* map, const void* key, void* value, void * ctx) {
+			return 0;
+		}
+
+		int entry() {
+			return bpf_for_each_map_elem(fd, callback, NULL, 0);
+		}
+	*/
+
+	spec := &ebpf.ProgramSpec{
+		Type: ebpf.SocketFilter,
+		Instructions: asm.Instructions{
+			// entry
+			btf.WithFuncMetadata(
+				asm.LoadMapPtr(asm.R1, fd), // map fd
+				c.entryBtf,
+			),
+			asm.Instruction{
+				OpCode:   asm.LoadImmOp(asm.DWord),
+				Src:      asm.PseudoFunc,
+				Dst:      asm.R2,
+				Constant: -1,
+			}.WithReference("callback"),
+			asm.LoadImm(asm.R3, 0, asm.DWord), // callback ctx
+			asm.LoadImm(asm.R4, 0, asm.DWord), // flags
+			asm.FnForEachMapElem.Call(),
+
+			asm.Instruction{
+				OpCode: asm.Exit.Op(asm.ImmSource),
+			},
+
+			// callback
+			btf.WithFuncMetadata(
+				asm.LoadImm(asm.R0, 0, asm.DWord).WithSymbol("callback"),
+				c.callbackBtf,
+			),
+			asm.Instruction{
+				OpCode: asm.Exit.Op(asm.ImmSource),
+			},
+		},
+		License: "GPL",
+	}
+
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return helperProgData{}, err
+	}
+
+	var progid ebpf.ProgramID
+	info, err := prog.Info()
+	if err == nil {
+		if id, ok := info.ID(); ok {
+			ddebpf.AddIgnoredProgramID(id)
+			progid = id
+		}
+	}
+
+	return helperProgData{
+		id:   progid,
+		prog: prog,
+	}, nil
+}
+
+func (c *mapProgHelperCache) Close() {
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
+
+	for _, data := range c.cache {
+		if err := data.prog.Close(); err != nil {
+			log.Warnf("failed to close helper program: %v", err)
+		}
+		ddebpf.RemoveIgnoredProgramID(data.id)
+	}
+	clear(c.cache)
+}
+
+func (c *mapProgHelperCache) closeUnusedPrograms() {
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
+
+	for id, data := range c.cache {
+		_, err := ddebpf.GetMapNameFromMapID(uint32(id))
+		if err != nil {
+			// the mapping is no longer existent so we can safely remove the program
+			if err := data.prog.Close(); err != nil {
+				log.Warnf("failed to close helper program: %v", err)
+			}
+			ddebpf.RemoveIgnoredProgramID(data.id)
+			delete(c.cache, id)
+		}
+	}
+}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
@@ -175,6 +175,10 @@ func (c *mapProgHelperCache) newHelperProgramForFd(fd int) (helperProgData, erro
 }
 
 func (c *mapProgHelperCache) Close() {
+	if c == nil {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 
@@ -188,6 +192,10 @@ func (c *mapProgHelperCache) Close() {
 }
 
 func (c *mapProgHelperCache) clearLiveMapIDs() {
+	if c == nil {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 
@@ -195,6 +203,10 @@ func (c *mapProgHelperCache) clearLiveMapIDs() {
 }
 
 func (c *mapProgHelperCache) addLiveMapID(id ebpf.MapID) {
+	if c == nil {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 
@@ -202,6 +214,10 @@ func (c *mapProgHelperCache) addLiveMapID(id ebpf.MapID) {
 }
 
 func (c *mapProgHelperCache) closeUnusedPrograms() {
+	if c == nil {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -239,6 +239,11 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 	uniquePrograms := make(map[programKey]struct{})
 	progid := ebpf.ProgramID(0)
 	for progid, err = ebpf.ProgramGetNextID(progid); err == nil; progid, err = ebpf.ProgramGetNextID(progid) {
+		// skip programs generated on the flight for hash map entry counting with helper
+		if ddebpf.IsProgramIDIgnored(progid) {
+			continue
+		}
+
 		fd, err := ProgGetFdByID(&ProgGetFdByIDAttr{ID: uint32(progid)})
 		if err != nil {
 			log.Debugf("error getting program fd prog_id=%d: %s", progid, err)
@@ -1013,6 +1018,15 @@ func hashMapNumberOfEntriesWithHelper(mp *ebpf.Map) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	info, err := prog.Info()
+	if err != nil {
+		log.Warnf("failed to fetch info for helper program: %v", err)
+	} else if id, ok := info.ID(); ok {
+		ddebpf.AddIgnoredProgramID(id)
+		defer ddebpf.RemoveIgnoredProgramID(id)
+	}
+
 	defer prog.Close()
 
 	res, _, err := prog.Test(make([]byte, 32))

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -98,7 +98,9 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	probe.mapBuffers.iterationRestartDetectionEntries = ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.entries_for_iteration_restart_detection")
 	probe.entryCountMaxRestarts = ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.max_restarts")
 
-	probe.mphCache = newMapProgHelperCache()
+	if isForEachElemHelperAvailable() {
+		probe.mphCache = newMapProgHelperCache()
+	}
 
 	log.Debugf("successfully loaded ebpf check probe")
 	return probe, nil
@@ -916,7 +918,7 @@ func hashMapNumberOfEntries(mp *ebpf.Map, mapid ebpf.MapID, mphCache *mapProgHel
 
 	var numElements int64
 	var err error
-	if mphCache != nil && isForEachElemHelperAvailable() && mp.Type() != ebpf.HashOfMaps && mapid != 0 {
+	if mphCache != nil && mp.Type() != ebpf.HashOfMaps && mapid != 0 {
 		numElements, err = hashMapNumberOfEntriesWithHelper(mp, mapid, mphCache)
 	} else if ddmaps.BatchAPISupported() && mp.Type() != ebpf.HashOfMaps { // HashOfMaps doesn't work with batch API
 		numElements, err = hashMapNumberOfEntriesWithBatch(mp, buffers, maxRestarts)

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -918,7 +918,7 @@ func hashMapNumberOfEntries(mp *ebpf.Map, mapid ebpf.MapID, mphCache *mapProgHel
 
 	var numElements int64
 	var err error
-	if mphCache != nil && mp.Type() != ebpf.HashOfMaps && mapid != 0 {
+	if mphCache != nil && mp.Type() != ebpf.HashOfMaps {
 		numElements, err = hashMapNumberOfEntriesWithHelper(mp, mapid, mphCache)
 	} else if ddmaps.BatchAPISupported() && mp.Type() != ebpf.HashOfMaps { // HashOfMaps doesn't work with batch API
 		numElements, err = hashMapNumberOfEntriesWithBatch(mp, buffers, maxRestarts)

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -317,8 +317,13 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 	ebpfmaps := make(map[string]*model.EBPFMapStats)
 	defer clear(ebpfmaps)
 
+	// instruct the cache to start a new iteration
+	k.mphCache.clearLiveMapIDs()
+
 	mapid := ebpf.MapID(0)
 	for mapid, err = ebpf.MapGetNextID(mapid); err == nil; mapid, err = ebpf.MapGetNextID(mapid) {
+		k.mphCache.addLiveMapID(mapid)
+
 		mp, err := ebpf.NewMapFromID(mapid)
 		if err != nil {
 			log.Debugf("unable to get map map_id=%d: %s", mapid, err)

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -943,7 +943,8 @@ func hashMapNumberOfEntriesWithHelper(mp *ebpf.Map, mapid ebpf.MapID, mphCache *
 		return 0, err
 	}
 
-	res, _, err := prog.Test(make([]byte, 32))
+	var buf [32]byte
+	res, _, err := prog.Test(buf[:])
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -918,7 +918,7 @@ func hashMapNumberOfEntries(mp *ebpf.Map, mapid ebpf.MapID, mphCache *mapProgHel
 
 	var numElements int64
 	var err error
-	if mphCache != nil && mp.Type() != ebpf.HashOfMaps {
+	if mphCache != nil && isForEachElemHelperAvailable() && mp.Type() != ebpf.HashOfMaps {
 		numElements, err = hashMapNumberOfEntriesWithHelper(mp, mapid, mphCache)
 	} else if ddmaps.BatchAPISupported() && mp.Type() != ebpf.HashOfMaps { // HashOfMaps doesn't work with batch API
 		numElements, err = hashMapNumberOfEntriesWithBatch(mp, buffers, maxRestarts)

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -218,6 +218,14 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 				}
 			}
 
+			if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps {
+				t.Run("Helper", func(t *testing.T) {
+					num, err := hashMapNumberOfEntriesWithHelper(m)
+					require.NoError(t, err)
+					require.Equal(t, int64(filledEntries), num)
+				})
+			}
+
 			if maps.BatchAPISupported() && mapType != ebpf.HashOfMaps {
 				t.Run("BatchAPI", func(t *testing.T) {
 					num, err := hashMapNumberOfEntriesWithBatch(m, &buffers, 1)
@@ -306,13 +314,6 @@ func TestHashMapNumberOfEntriesNoExtraAllocations(t *testing.T) {
 					require.LessOrEqual(t, allocs, 8.0) // Multiple batches mean we need to use a map to keep track of the keys, that causes allocations for the values
 				})
 			}
-
-			t.Run("MainFunction", func(t *testing.T) {
-				allocs := testing.AllocsPerRun(10, func() {
-					hashMapNumberOfEntries(m, &buffers, 1)
-				})
-				require.LessOrEqual(t, allocs, 0.0)
-			})
 		})
 	}
 }
@@ -479,6 +480,15 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 		buffers.values = addMargin(buffers.values)
 		buffers.cursor = addMargin(buffers.cursor)
 		validateMargin(t)
+
+		if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps {
+			t.Run("Helper", func(t *testing.T) {
+				num, err := hashMapNumberOfEntriesWithHelper(m)
+				require.NoError(t, err)
+				require.Equal(t, int64(filledEntries), num)
+				validateMargin(t)
+			})
+		}
 
 		if maps.BatchAPISupported() && mapType != ebpf.HashOfMaps {
 			t.Run("BatchAPI", func(t *testing.T) {

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -182,6 +182,9 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
 		maxEntries := uint32(50)
 
+		mphCache := newMapProgHelperCache()
+		t.Cleanup(mphCache.Close)
+
 		testWithEntryCount := func(t *testing.T, mapType ebpf.MapType, filledEntries uint32) {
 			var innerMapSpec *ebpf.MapSpec
 			buffers := entryCountBuffers{
@@ -207,6 +210,10 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = m.Close() })
 
+			mapInfo, err := m.Info()
+			require.NoError(t, err)
+			mapid, mapidOk := mapInfo.ID()
+
 			for i := uint32(0); i < filledEntries; i++ {
 				if mapType == ebpf.HashOfMaps {
 					innerMap, err := ebpf.NewMap(innerMapSpec)
@@ -218,9 +225,9 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 				}
 			}
 
-			if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps {
+			if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps && mapidOk {
 				t.Run("Helper", func(t *testing.T) {
-					num, err := hashMapNumberOfEntriesWithHelper(m)
+					num, err := hashMapNumberOfEntriesWithHelper(m, mapid, mphCache)
 					require.NoError(t, err)
 					require.Equal(t, int64(filledEntries), num)
 				})
@@ -241,7 +248,7 @@ func TestHashMapNumberOfEntries(t *testing.T) {
 			})
 
 			// Test the complete function just in case
-			require.Equal(t, int64(filledEntries), hashMapNumberOfEntries(m, &buffers, 1))
+			require.Equal(t, int64(filledEntries), hashMapNumberOfEntries(m, mapid, mphCache, &buffers, 1))
 		}
 
 		mapTypes := []ebpf.MapType{ebpf.Hash, ebpf.LRUHash, ebpf.HashOfMaps}
@@ -322,6 +329,10 @@ func TestHashMapNumberOfEntriesMapTypeSupport(t *testing.T) {
 	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
 	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
 		maxEntries := uint32(1000)
+
+		mphCache := newMapProgHelperCache()
+		t.Cleanup(mphCache.Close)
+
 		testMapType := func(t *testing.T, mapType ebpf.MapType, expectedReturn int64) {
 			buffers := entryCountBuffers{
 				keysBufferSizeLimit:   0, // No limit
@@ -346,8 +357,12 @@ func TestHashMapNumberOfEntriesMapTypeSupport(t *testing.T) {
 			})
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = m.Close() })
+			mapInfo, err := m.Info()
+			require.NoError(t, err)
+			mapid, _ := mapInfo.ID()
+
 			buffers.tryEnsureSizeForFullBatch(m)
-			require.Equal(t, expectedReturn, hashMapNumberOfEntries(m, &buffers, 1))
+			require.Equal(t, expectedReturn, hashMapNumberOfEntries(m, mapid, mphCache, &buffers, 1))
 		}
 
 		// Test supported types first
@@ -403,6 +418,9 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
 	require.NoError(t, rlimit.RemoveMemlock())
 
+	mphCache := newMapProgHelperCache()
+	t.Cleanup(mphCache.Close)
+
 	testInner := func(t *testing.T, mapType ebpf.MapType, filledEntries uint32, maxEntries uint32, keySize uint32, valueSize uint32, keysLimit uint32, valuesLimit uint32) {
 		var innerMapSpec *ebpf.MapSpec
 		buffers := entryCountBuffers{
@@ -419,6 +437,10 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = m.Close() })
+
+		mapInfo, err := m.Info()
+		require.NoError(t, err)
+		mapid, _ := mapInfo.ID()
 
 		keys := make([]byte, keySize)
 		values := make([]byte, valueSize)
@@ -483,7 +505,7 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 
 		if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps {
 			t.Run("Helper", func(t *testing.T) {
-				num, err := hashMapNumberOfEntriesWithHelper(m)
+				num, err := hashMapNumberOfEntriesWithHelper(m, mapid, mphCache)
 				require.NoError(t, err)
 				require.Equal(t, int64(filledEntries), num)
 				validateMargin(t)
@@ -507,7 +529,7 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 		})
 
 		// Test the complete function just in case
-		require.Equal(t, int64(filledEntries), hashMapNumberOfEntries(m, &buffers, 3))
+		require.Equal(t, int64(filledEntries), hashMapNumberOfEntries(m, mapid, mphCache, &buffers, 3))
 		validateMargin(t)
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -440,7 +440,7 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 
 		mapInfo, err := m.Info()
 		require.NoError(t, err)
-		mapid, _ := mapInfo.ID()
+		mapid, mapidok := mapInfo.ID()
 
 		keys := make([]byte, keySize)
 		values := make([]byte, valueSize)
@@ -503,7 +503,7 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 		buffers.cursor = addMargin(buffers.cursor)
 		validateMargin(t)
 
-		if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps {
+		if isForEachElemHelperAvailable() && mapType != ebpf.HashOfMaps && mapidok {
 			t.Run("Helper", func(t *testing.T) {
 				num, err := hashMapNumberOfEntriesWithHelper(m, mapid, mphCache)
 				require.NoError(t, err)

--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -23,6 +23,8 @@ var mapModuleMapping = make(map[uint32]string)
 var progNameMapping = make(map[uint32]string)
 var progModuleMapping = make(map[uint32]string)
 
+var progIgnoredIds = make(map[ebpf.ProgramID]struct{})
+
 // errNoMapping is returned when a give map or program id is
 // not tracked as part of system-probe/security-agent
 var errNoMapping = errors.New("no mapping found for given id")
@@ -177,4 +179,29 @@ func iterateProgs(progs map[string]*ebpf.Program, mapFn func(progid uint32, name
 			}
 		}
 	}
+}
+
+// AddIgnoredProgramID adds a program ID to the list of ignored programs
+func AddIgnoredProgramID(id ebpf.ProgramID) {
+	mappingLock.Lock()
+	defer mappingLock.Unlock()
+
+	progIgnoredIds[id] = struct{}{}
+}
+
+// RemoveIgnoredProgramID removes a program ID from the list of ignored programs
+func RemoveIgnoredProgramID(id ebpf.ProgramID) {
+	mappingLock.Lock()
+	defer mappingLock.Unlock()
+
+	progIgnoredIds[id] = struct{}{}
+}
+
+// IsProgramIDIgnored returns true if this program ID should be ignored
+func IsProgramIDIgnored(id ebpf.ProgramID) bool {
+	mappingLock.RLock()
+	defer mappingLock.RUnlock()
+
+	_, ok := progIgnoredIds[id]
+	return ok
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds a third way for the ebpf check to count the number of entries in a given map. The main idea of this new solution is based on the `bpf_for_each_map_elem` helper, and the fact that it returns the number of traversed elements. This allows us to simply call this helper on the given map to get the number of elements in the map.

This helper was introduced in the kernel 5.13 (this PR includes correct feature detection, and falls back to buffer based iteration if not available).

This solution has multiple advantages compared to iteration:
- no iteration restart mechanism needed 
- no userspace buffer management
- constant cost in allocation (we only need to allocate the program and related BTF) regardless of the map

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
