### PR TITLE
(fleet) fix experiment stuck on exit 0 following sigterm

### DIFF
--- a/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
@@ -13,8 +13,6 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent/environment
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/pkg/fleet/installer/service/embedded/datadog-installer-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-installer-exp.service
@@ -9,8 +9,6 @@ JobTimeoutSec=3000 #50 minutes
 Type=oneshot
 PIDFile=/var/run/datadog-installer/installer.pid
 ExecStart=/opt/datadog-packages/datadog-installer/experiment/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
-ExecStart=/opt/datadog-packages/datadog-installer/experiment/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
-ExecStart=/opt/datadog-packages/datadog-installer/experiment/bin/installer/installer run -p /var/run/datadog-installer/installer.pid
 ExecStart=/bin/false
 ExecStop=/bin/false
 

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -175,3 +175,9 @@ func (f FakeAgent) SetStopWithSigterm(agent string) FakeAgent {
 	f.setBinary("stop_with_sigterm.sh", agent)
 	return f
 }
+
+// SetStopWithSigtermExit0 sets the fake Agent to stop with SIGTERM and exit with code 0.
+func (f FakeAgent) SetStopWithSigtermExit0(agent string) FakeAgent {
+	f.setBinary("stop_with_sigterm_exit0.sh", agent)
+	return f
+}

--- a/test/new-e2e/tests/installer/host/fixtures/stop_with_sigterm_exit0.sh
+++ b/test/new-e2e/tests/installer/host/fixtures/stop_with_sigterm_exit0.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+handler() {
+    exit 0
+}
+trap 'handler' SIGINT SIGHUP SIGQUIT SIGTERM
+
+while true; do
+    sleep 1
+done

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -128,7 +128,10 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	s.host.SetupFakeAgentExp()
+	s.host.SetupFakeAgentExp().
+		SetStopWithSigtermExit0("core-agent").
+		SetStopWithSigtermExit0("process-agent").
+		SetStopWithSigtermExit0("trace-agent")
 
 	// assert timeout is already set
 	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "50min")


### PR DESCRIPTION
When an experiment times out a SIGTERM is sent to the experiment process. This was working fine in our e2e tests but was completely breaking in real life when we timed out for the agent.

The difference between our e2e and the agent was that the agent had a SIGTERM handler that would cleanup and return 0. Our fake agent did not have a handler and has such returned a non-0 exit code. 

With return 0:
- Experiment `ExecStart` line 1 starts
- 50min
- Timeout, SIGTERM sent to the process, process returns 0
- `ExecStart` line 2 starts
- The `-exp` unit is impossible to stop without manually killing processes

With return != 0:
- Experiment `ExecStart` line 1 starts
- 50min
- Timeout, SIGTERM sent to the process, process returns 133
- Unit marked as failed

To avoid any possibility of this scenario occurring this PR removes the 3 retries we had in `-exp` units. This means a single SIGTERM will be enough to stop the exp.