### PR TITLE
[do not merge] bump test infra and enable flaky docker test

### DIFF
--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -2,6 +2,6 @@
 variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: "-dev"
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: b1653772e90a
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: b15cf74eede6

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -29,7 +29,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20240614094740-b1653772e90a
+	github.com/DataDog/test-infra-definitions v0.0.0-20240614163729-b15cf74eede6
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.138.1

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.26.0 h1:bZr0hu+hx8L91+yU5EGw8wK3F
 github.com/DataDog/datadog-api-client-go/v2 v2.26.0/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20240614094740-b1653772e90a h1:CkJ20HdgiQw4F6zXK2wyOhhcyJi4UiTqmEg/yLQb0Z8=
-github.com/DataDog/test-infra-definitions v0.0.0-20240614094740-b1653772e90a/go.mod h1:QSXCIW/94c0GQ2GeuCUIdBFWrzKSeLLu+ytw/caDIWo=
+github.com/DataDog/test-infra-definitions v0.0.0-20240614163729-b15cf74eede6 h1:gYG8fDP7nBmRhv9j4HAvKg9hNCgeUm5nmaCRiOG0Pgw=
+github.com/DataDog/test-infra-definitions v0.0.0-20240614163729-b15cf74eede6/go.mod h1:QSXCIW/94c0GQ2GeuCUIdBFWrzKSeLLu+ytw/caDIWo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -28,7 +27,7 @@ type dockerTestSuite struct {
 
 func TestDockerTestSuite(t *testing.T) {
 	// Tracked by ADXT-348
-	flake.Mark(t)
+	// flake.Mark(t)
 
 	t.Parallel()
 	agentOpts := []dockeragentparams.Option{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Bump test-infra to include changes from https://github.com/DataDog/test-infra-definitions/pull/888

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

process's docker test is highly flaky, failing on the infrastructure setup during the `UpdateEnv`. Checking the code we realised that we forgot to pass the dependencies to the docker agent operation, that explains why pulumi complains that the fakeintake resource is after the agent config copy file resource - each command is a resource for pulumi

```
post-step event returned an error: failed to save snapshot: .pulumi/stacks/e2eci/ci-543492643-4670-e2e-dockertestsuite-d098ed32879645a4.json: snapshot integrity failure; it was already written, but is invalid (backup available at .pulumi/stacks/e2eci/ci-543492643-4670-e2e-dockertestsuite-d098ed32879645a4.json.bak): resource urn:pulumi:ci-543492643-4670-e2e-dockertestsuite-d098ed32879645a4::e2eci::dd:Host$command:remote:CopyFile::remote-aws-dockervm-copy-$HOME/agent-compose-tmp/docker-compose-agent.yml's dependency urn:pulumi:ci-543492643-4670-e2e-dockertestsuite-d098ed32879645a4::e2eci::dd:Fakeintake$awsx:ecs:FargateTaskDefinition$aws:ecs/taskDefinition:TaskDefinition::aws-aws-fakeintake-dockervm-taskdef comes after it
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
