### PR TITLE
[CONTP-225] ensure we have only 1 collector for pods or deployments

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -367,6 +367,25 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			expectedResources: []string{"nodes"},
 		},
 		{
+			name: "deployments needed for language detection should be excluded from metadata collection",
+			cfg: map[string]interface{}{
+				"language_detection.enabled":                       true,
+				"language_detection.reporting.enabled":             true,
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "daemonsets deployments",
+			},
+			expectedResources: []string{"daemonsets", "nodes"},
+		},
+		{
+			name: "pods needed for autoscaling should be excluded from metadata collection",
+			cfg: map[string]interface{}{
+				"autoscaling.workload.enabled":                     true,
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "daemonsets pods",
+			},
+			expectedResources: []string{"daemonsets", "nodes"},
+		},
+		{
 			name: "resources explicitly requested",
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR helps avoiding having a situation where 2 collectors are registered to collect pods data or 2 collectors are registered to collect deployments data in workload metadata store.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Thanks to the generic metadata collection feature that was added recently, it is possible to configure the agent to collect metadata (name, namespace, gvr, labels, annotations) of the resource types that are specified in the agent config. 

Pods and deployments are special cases because:
- For pods, we collect a lot more data than labels and annotations
- For deployments, we have some external components (specifically language detection) which populate other fields in the deployment entities in workload metadata store.

For this reason, we want to avoid having both generic metadata collectors and concrete collectors collecting data for deployments and/or pods at the same time because this will result in duplicating a part of the data in workloadmetadata store.

When deployments and pods are included in the list of generic metadata collection, the expectation is the following:

- If language detection is enabled, a pod reflector store is created, no generic metadata collector is registered for pods. We should end up having pod entities in the store.
- If language detection is disabled, 

| Condition                                                    | Generic Metadata Collector | Separate Collector | Collected Entity |
|--------------------------------------------------------------|----------------------------|--------------------|------------------|
| Language Detection Enabled                                   | ❌                         | ✅             | Deployments      |
| Language Detection Disabled                                  | ✅                     | ❌                 | KubeMetadata     |
| Workload Autoscaling or Kubernetes Tag Collection  Enabled   | ❌                          | ✅              | Pods             |
| Workload Autoscaling and Kubernetes Tag Collection  Disabled | ✅                      | ❌                  | KubeMetadata     |

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

We should ensure that the behaviour is identical to what is expected in the table above: 

- When language detection is enabled, we should only get Deployment Entities, and no KubeMetadata Entities for deployments. 

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  kubeStateMetricsCore:
    enabled: true

  logLevel: DEBUG

  apm:
    enabled: true
    instrumentation:
      enabled: true

clusterAgent:
  enabled: true
  image:
    repository: metadata-data-dedup
    tag: latest
    ImagePullPolicy: Never
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "deployments daemonsets"
```

We can then inspect the content of workloadmeta *in the cluster agent*, and we can find deployment enities:
```
=== Entity kubernetes_deployment sources(merged):[kubeapiserver] id: default/datadog-agent-cluster-agent ===
----------- Entity ID -----------
Kind: kubernetes_deployment ID: default/datadog-agent-cluster-agent

----------- Unified Service Tagging -----------
Env : 
Service : 
Version : 
----------- Injectable Languages -----------
----------- Detected Languages -----------
===

=== Entity kubernetes_deployment sources(merged):[kubeapiserver] id: default/dummy-nginx-app ===
----------- Entity ID -----------
Kind: kubernetes_deployment ID: default/dummy-nginx-app

----------- Unified Service Tagging -----------
Env : 
Service : 
Version : 
----------- Injectable Languages -----------
----------- Detected Languages -----------
===
``` 

But we can't find `kubernetes_metadata` for deployments.

- When language detection is disabled and deployment is included in the generic metadata collection

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  kubeStateMetricsCore:
    enabled: true

  logLevel: DEBUG

clusterAgent:
  enabled: true
  image:
    repository: metadata-data-dedup
    tag: latest
    ImagePullPolicy: Never
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "deployments daemonsets"
```

In this case, we should find `kubernetes_metadata` entities for deployments, and we should not find any kubernetes_deployment entities:

```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/default/datadog-agent-cluster-agent ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/default/datadog-agent-cluster-agent

----------- Entity Meta -----------
Name: datadog-agent-cluster-agent
Namespace: default
Annotations: deployment.kubernetes.io/revision:1 meta.helm.sh/release-name:datadog-agent meta.helm.sh/release-namespace:default 
Labels: helm.sh/chart:datadog-3.59.5 app.kubernetes.io/component:cluster-agent app.kubernetes.io/instance:datadog-agent app.kubernetes.io/managed-by:Helm app.kubernetes.io/name:datadog-agent app.kubernetes.io/version:7 
----------- Resource -----------
apps/v1, Resource=deployments
===
```

- Next, we verify that when kubernetes tag collection is enabled, we should only get `kubernetes_pod` entities, and not get `kubernetes_metadata` entities for pods:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  kubeStateMetricsCore:
    enabled: true

  logLevel: DEBUG

  clusterTagger:
    collectKubernetesTags: true

clusterAgent:
  enabled: true
  image:
    repository: metadata-data-dedup
    tag: latest
    ImagePullPolicy: Never
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "deployments daemonsets"
```

When inspecting the content of workloadmeta of the cluster agent, we get kubernetes pod entities, and we don't get kubernetes metadata entities for pods:

```
=== Entity kubernetes_pod sources(merged):[kubeapiserver] id: 311853b9-105f-4f44-a8cd-1262571ed961 ===
----------- Entity ID -----------
Kind: kubernetes_pod ID: 311853b9-105f-4f44-a8cd-1262571ed961

----------- Entity Meta -----------
Name: local-path-provisioner-6bc4bddd6b-8dkpb
Namespace: local-path-storage
Annotations: 
Labels: app:local-path-provisioner pod-template-hash:6bc4bddd6b 
----------- Owners -----------
Kind: ReplicaSet Name: local-path-provisioner-6bc4bddd6b
ID: 5b8c72cf-71b7-4930-9031-c687e9e5ef5d
----------- Pod Info -----------
Ready: true
Phase: Running
IP: 10.244.0.4
Priority Class: 
QOS Class: BestEffort
PVCs: 
Kube Services: 
Namespace Labels: 
Namespace Annotations: 
===
```

- Finally, when pods are included in generic metadata collection, but tag collection is disabled, we should get kubernetes_metadata entities for pods and not get kubernetes_pod entities in workloadmeta of the cluster agent.

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  kubeStateMetricsCore:
    enabled: true

  logLevel: DEBUG

  clusterTagger:
    collectKubernetesTags: false

clusterAgent:
  enabled: true
  image:
    repository: metadata-data-dedup
    tag: latest
    ImagePullPolicy: Never
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "deployments daemonsets"
```

Example:
```
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: pods/kube-system/coredns-5d78c9869d-2cx5z ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: pods/kube-system/coredns-5d78c9869d-2cx5z

----------- Entity Meta -----------
Name: coredns-5d78c9869d-2cx5z
Namespace: kube-system
Annotations: 
Labels: k8s-app:kube-dns pod-template-hash:5d78c9869d 
----------- Resource -----------
/v1, Resource=pods
===
```


