### PR TITLE
[ADXT-340] [Flakes Finder] Implement Flakes Finder

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -392,10 +392,9 @@ generate-flakes-finder-pipeline:
     paths:
       - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
 
-new-e2e-trigger-flakes-finder:
-
+trigger-flakes-finder:
   stage: .pre
-  needs: [new-e2e-flakes-finder]
+  needs: [generate-flakes-finder-pipeline]
   # rules: !reference [.on_deploy_nightly_repo_branch]
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
@@ -403,4 +402,4 @@ new-e2e-trigger-flakes-finder:
   trigger:
     include:
       - artifact: flake-finder-gitlab-ci.yml
-        job: new-e2e-flakes-finder
+        job: generate-flakes-finder-pipeline

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -368,6 +368,7 @@ new-e2e-ndm-snmp:
     TEAM: network-device-monitoring
 
 new-e2e-flakes-finder:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
   script:
     - inv -e testwasher.generate-flake-finder-pipeline
@@ -376,6 +377,7 @@ new-e2e-flakes-finder:
       - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
 
 new-e2e-trigger-flakes-finder:
+
   stage: .pre
   needs: [new-e2e-flakes-finder]
   variables:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -371,20 +371,20 @@ generate-flakes-finder-pipeline:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
   # rules: !reference [.on_deploy_nightly_repo_branch]
-  needs:
-    - deploy_deb_testing-a7_arm64
-    - deploy_deb_testing-a7_x64
-    - deploy_rpm_testing-a7_arm64
-    - deploy_rpm_testing-a7_x64
-    - deploy_suse_rpm_testing_arm64-a7
-    - deploy_suse_rpm_testing_x64-a7
-    - deploy_windows_testing-a7
-    - qa_installer_oci
-    - qa_agent_oci
-    - qa_cws_instrumentation
-    - qa_dca
-    - qa_dogstatsd
-    - qa_agent
+  # needs:
+  #   - deploy_deb_testing-a7_arm64
+  #   - deploy_deb_testing-a7_x64
+  #   - deploy_rpm_testing-a7_arm64
+  #   - deploy_rpm_testing-a7_x64
+  #   - deploy_suse_rpm_testing_arm64-a7
+  #   - deploy_suse_rpm_testing_x64-a7
+  #   - deploy_windows_testing-a7
+  #   - qa_installer_oci
+  #   - qa_agent_oci
+  #   - qa_cws_instrumentation
+  #   - qa_dca
+  #   - qa_dogstatsd
+  #   - qa_agent
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -370,6 +370,7 @@ new-e2e-ndm-snmp:
 new-e2e-flakes-finder:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
+  tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline
   artifacts:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -97,7 +97,7 @@ k8s-e2e-otlp-main:
     # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
   variables:
-    FLAKES_FINDER: "true"
+    SHOULD_RUN_IN_FLAKES_FINDER: "true"
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
     KUBERNETES_CPU_REQUEST: 6

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -97,6 +97,7 @@ k8s-e2e-otlp-main:
     # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
   variables:
+    FLAKES_FINDER: true
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
     KUBERNETES_CPU_REQUEST: 6
@@ -365,3 +366,22 @@ new-e2e-ndm-snmp:
   variables:
     TARGETS: ./tests/ndm/snmp
     TEAM: network-device-monitoring
+
+new-e2e-flakes-finder:
+  stage: .pre
+  script:
+    - inv -e testwasher.generate-flake-finder-pipeline
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
+
+new-e2e-trigger-flakes-finder:
+  stage: .pre
+  needs: [new-e2e-flakes-finder]
+  variables:
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    PARENT_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
+  trigger:
+    include:
+      - artifact: flake-finder-gitlab-ci.yml
+        job: new-e2e-flakes-finder

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -369,22 +369,22 @@ new-e2e-ndm-snmp:
 
 generate-flakes-finder-pipeline:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  stage: .pre
-  # rules: !reference [.on_deploy_nightly_repo_branch]
-  # needs:
-  #   - deploy_deb_testing-a7_arm64
-  #   - deploy_deb_testing-a7_x64
-  #   - deploy_rpm_testing-a7_arm64
-  #   - deploy_rpm_testing-a7_x64
-  #   - deploy_suse_rpm_testing_arm64-a7
-  #   - deploy_suse_rpm_testing_x64-a7
-  #   - deploy_windows_testing-a7
-  #   - qa_installer_oci
-  #   - qa_agent_oci
-  #   - qa_cws_instrumentation
-  #   - qa_dca
-  #   - qa_dogstatsd
-  #   - qa_agent
+  stage: e2e
+  rules: !reference [.on_deploy_nightly_repo_branch]
+  needs:
+    - deploy_deb_testing-a7_arm64
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_arm64
+    - deploy_rpm_testing-a7_x64
+    - deploy_suse_rpm_testing_arm64-a7
+    - deploy_suse_rpm_testing_x64-a7
+    - deploy_windows_testing-a7
+    - qa_installer_oci
+    - qa_agent_oci
+    - qa_cws_instrumentation
+    - qa_dca
+    - qa_dogstatsd
+    - qa_agent
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline
@@ -393,9 +393,9 @@ generate-flakes-finder-pipeline:
       - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
 
 trigger-flakes-finder:
-  stage: .pre
+  stage: e2e
   needs: [generate-flakes-finder-pipeline]
-  # rules: !reference [.on_deploy_nightly_repo_branch]
+  rules: !reference [.on_deploy_nightly_repo_branch]
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     PARENT_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
@@ -403,3 +403,4 @@ trigger-flakes-finder:
     include:
       - artifact: flake-finder-gitlab-ci.yml
         job: generate-flakes-finder-pipeline
+  allow_failure: true

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -367,9 +367,24 @@ new-e2e-ndm-snmp:
     TARGETS: ./tests/ndm/snmp
     TEAM: network-device-monitoring
 
-new-e2e-flakes-finder:
+generate-flakes-finder-pipeline:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
+  # rules: !reference [.on_deploy_nightly_repo_branch]
+  needs:
+    - deploy_deb_testing-a7_arm64
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_arm64
+    - deploy_rpm_testing-a7_x64
+    - deploy_suse_rpm_testing_arm64-a7
+    - deploy_suse_rpm_testing_x64-a7
+    - deploy_windows_testing-a7
+    - qa_installer_oci
+    - qa_agent_oci
+    - qa_cws_instrumentation
+    - qa_dca
+    - qa_dogstatsd
+    - qa_agent
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline
@@ -381,6 +396,7 @@ new-e2e-trigger-flakes-finder:
 
   stage: .pre
   needs: [new-e2e-flakes-finder]
+  # rules: !reference [.on_deploy_nightly_repo_branch]
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     PARENT_COMMIT_SHA: $CI_COMMIT_SHORT_SHA

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -97,7 +97,7 @@ k8s-e2e-otlp-main:
     # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
   variables:
-    FLAKES_FINDER: true
+    FLAKES_FINDER: "true"
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
     KUBERNETES_CPU_REQUEST: 6

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -47,6 +47,7 @@ from tasks import (
     setup,
     system_probe,
     systray,
+    testwasher,
     trace_agent,
     vscode,
 )
@@ -174,6 +175,7 @@ ns.add_collection(release)
 ns.add_collection(rtloader)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
+ns.add_collection(testwasher)
 ns.add_collection(security_agent)
 ns.add_collection(cws_instrumentation)
 ns.add_collection(vscode)

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -145,14 +145,14 @@ def convert_to_config_node(json_data):
         return json_data
 
 
-def convert_to_dict(config_node):
+def convert_to_std_collections(config_node):
     """
-    Convert ConfigNode to dict
+    Convert ConfigNode to standard collections (list, dict)
     """
     if isinstance(config_node, ConfigNodeDict):
-        return {k: convert_to_dict(v) for k, v in config_node.items()}
+        return {k: convert_to_std_collections(v) for k, v in config_node.items()}
     elif isinstance(config_node, ConfigNodeList):
-        return [convert_to_dict(v) for v in config_node]
+        return [convert_to_std_collections(v) for v in config_node]
     else:
         return config_node
 
@@ -192,7 +192,7 @@ def apply_yaml_extends(config: dict, node):
             for key, value in parent.items():
                 if key not in node:
                     node[key] = value
-                if key in node and isinstance(node[key], dict) and isinstance(value, dict):
+                elif key in node and isinstance(node[key], dict) and isinstance(value, dict):
                     node[key].update(value)
 
         del node['extends']
@@ -248,7 +248,7 @@ def apply_yaml_reference(config: dict, node):
             node[key] = apply_ref(value)
     elif isinstance(node, list):
         results = []
-        for _, value in enumerate(node):
+        for value in node:
             postprocessed_value = apply_ref(value)
             # If list referenced within list, flatten lists
             if isinstance(value, YamlReferenceTagList) and isinstance(postprocessed_value, list):
@@ -317,7 +317,7 @@ def generate_gitlab_full_configuration(
         full_configuration = convert_to_config_node(full_configuration)
         apply_yaml_postprocessing(full_configuration, full_configuration)
 
-    full_configuration = convert_to_dict(full_configuration)
+    full_configuration = convert_to_std_collections(full_configuration)
     return yaml.safe_dump(full_configuration) if return_dump else full_configuration
 
 

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import copy
 import json
 from collections import defaultdict
 
 import yaml
+from invoke import task
 
+from tasks.libs.ciproviders.gitlab_api import (
+    generate_gitlab_full_configuration,
+)
 from tasks.test_core import ModuleTestResult
 
 
@@ -148,3 +153,55 @@ class TestWasher:
                 test_name = test_name.rsplit('/', 1)[0]
                 test_family.add(test_name)
         return test_family
+
+
+@task()
+def generate_flake_finder_pipeline(_, n=3):
+    """
+    Verify that the jobs defined within job_files contain a change path rule.
+    """
+
+    # Read gitlab config
+    config = generate_gitlab_full_configuration(".gitlab-ci.yml", {}, return_dump=False, apply_postprocessing=True)
+
+    for job in config:
+        print(job)
+    # Lets keep only variables and jobs with flake finder variable
+    kept_job = {}
+    for job, job_details in config.items():
+        if job == 'new-e2e-process':
+            kept_job[job] = job_details
+        # if (job == 'variables' or 'variables' in job_details and 'FLAKES_FINDER' in job_details['variables'] and job_details['variables']['FLAKES_FINDER']):
+        #     kept_job[job] = job_details
+
+    # Remove needs, rules and retry from the jobs
+    for job in kept_job:
+        if 'needs' in kept_job[job]:
+            del kept_job[job]["needs"]
+        if 'rules' in kept_job[job]:
+            del kept_job[job]["rules"]
+        if 'retry' in kept_job[job]:
+            del kept_job[job]["retry"]
+
+    new_jobs = {}
+    new_jobs['variables'] = copy.deepcopy(config['variables'])
+    new_jobs['variables']['PARENT_PIPELINE_ID'] = 'undefined'
+    new_jobs['variables']['PARENT_COMMIT_SHA'] = 'undefined'
+    new_jobs['stages'] = [f'flake-finder-{i}' for i in range(n)]
+
+    # Create n jobs with the same configuration
+    for job in kept_job:
+        for i in range(n):
+            new_job = copy.deepcopy(kept_job[job])
+            new_job["stage"] = f"flake-finder-{i}"
+            if 'variables' in new_job:
+                if 'E2E_PIPELINE_ID' in new_job['variables']:
+                    new_job['variables']['E2E_PIPELINE_ID'] = "$PARENT_PIPELINE_ID"
+                if 'E2E_COMMIT_SHA' in new_job['variables']:
+                    new_job['variables']['E2E_COMMIT_SHA'] = "$PARENT_COMMIT_SHA"
+            new_jobs[f"{job}-{i}"] = new_job
+
+    with open("flake-finder-gitlab-ci.yml", "w") as f:
+        f.write(yaml.safe_dump(new_jobs))
+
+    print("New Gitlab-ci.yml:", yaml.safe_dump(new_jobs))

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -170,8 +170,7 @@ def generate_flake_finder_pipeline(_, n=3):
     kept_job = {}
     for job, job_details in config.items():
         if (
-            job == 'variables'
-            or 'variables' in job_details
+            'variables' in job_details
             and 'FLAKES_FINDER' in job_details['variables']
             and job_details['variables']['FLAKES_FINDER'] == "true"
         ):

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -169,10 +169,16 @@ def generate_flake_finder_pipeline(_, n=3):
     # Lets keep only variables and jobs with flake finder variable
     kept_job = {}
     for job, job_details in config.items():
-        if job == 'new-e2e-process':
+        if (
+            job == 'variables'
+            or 'variables' in job_details
+            and 'FLAKES_FINDER' in job_details['variables']
+            and job_details['variables']['FLAKES_FINDER'] == "true"
+        ):
+            # Let's exlude job that are retried for now untill we find a solution to tackle them
+            if 'retry' in job_details:
+                continue
             kept_job[job] = job_details
-        # if (job == 'variables' or 'variables' in job_details and 'FLAKES_FINDER' in job_details['variables'] and job_details['variables']['FLAKES_FINDER'] == "true"):
-        #     kept_job[job] = job_details
 
     # Remove needs, rules and retry from the jobs
     for job in kept_job:

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -158,7 +158,7 @@ class TestWasher:
 @task()
 def generate_flake_finder_pipeline(_, n=3):
     """
-    Verify that the jobs defined within job_files contain a change path rule.
+    Generate a child pipeline where jobs marked with SHOULD_RUN_IN_FLAKES_FINDER are run n times
     """
 
     # Read gitlab config
@@ -171,10 +171,10 @@ def generate_flake_finder_pipeline(_, n=3):
     for job, job_details in config.items():
         if (
             'variables' in job_details
-            and 'FLAKES_FINDER' in job_details['variables']
-            and job_details['variables']['FLAKES_FINDER'] == "true"
+            and 'SHOULD_RUN_IN_FLAKES_FINDER' in job_details['variables']
+            and job_details['variables']['SHOULD_RUN_IN_FLAKES_FINDER'] == "true"
         ):
-            # Let's exlude job that are retried for now untill we find a solution to tackle them
+            # Let's exclude job that are retried for now until we find a solution to tackle them
             if 'retry' in job_details:
                 continue
             kept_job[job] = job_details

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -171,7 +171,7 @@ def generate_flake_finder_pipeline(_, n=3):
     for job, job_details in config.items():
         if job == 'new-e2e-process':
             kept_job[job] = job_details
-        # if (job == 'variables' or 'variables' in job_details and 'FLAKES_FINDER' in job_details['variables'] and job_details['variables']['FLAKES_FINDER']):
+        # if (job == 'variables' or 'variables' in job_details and 'FLAKES_FINDER' in job_details['variables'] and job_details['variables']['FLAKES_FINDER'] == "true"):
         #     kept_job[job] = job_details
 
     # Remove needs, rules and retry from the jobs

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -204,6 +204,7 @@ def generate_flake_finder_pipeline(_, n=3):
                     new_job['variables']['E2E_PIPELINE_ID'] = "$PARENT_PIPELINE_ID"
                 if 'E2E_COMMIT_SHA' in new_job['variables']:
                     new_job['variables']['E2E_COMMIT_SHA'] = "$PARENT_COMMIT_SHA"
+            new_job["rules"] = [{"when": "always"}]
             new_jobs[f"{job}-{i}"] = new_job
 
     with open("flake-finder-gitlab-ci.yml", "w") as f:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

It implements flakes finder described [here](https://docs.google.com/document/d/1ab6Skqxnm5TP_Fp0NoKGAqbYIguvKQFHQnPjtCfhuRg/edit#heading=h.f15lamw0kmcp)
The goal is to run the e2e tests several times on nightly pipelines. To detect when they are flaky. It will allow CI Visibility to be aware of flaky tests and help us to mark them flaky

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation


Handle flaky tests

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

As a followup we might stop relying on CI Visibility to know which of our test are flaky and instead improve flakes finder to also mark the tests it detected as flaky

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
