### PR TITLE
[CSM] Support constants in secl arrays

### DIFF
--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -248,4 +248,5 @@ type Array struct {
 	StringMembers []StringMember `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
 	CIDRMembers   []CIDRMember   `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
 	Numbers       []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
+	Idents        []string       `parser:"| \"[\" @Ident { \",\" @Ident } \"]\""`
 }

--- a/pkg/security/secl/compiler/eval/evaluators.go
+++ b/pkg/security/secl/compiler/eval/evaluators.go
@@ -312,6 +312,11 @@ func (b *BoolArrayEvaluator) IsStatic() bool {
 	return b.EvalFnc == nil
 }
 
+// AppendValues to the array evaluator
+func (b *BoolArrayEvaluator) AppendValues(values ...bool) {
+	b.Values = append(b.Values, values...)
+}
+
 // CIDREvaluator returns a net.IP
 type CIDREvaluator struct {
 	EvalFnc     func(ctx *Context) net.IPNet

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -111,8 +111,9 @@ type testNetwork struct {
 }
 
 type testEvent struct {
-	id   string
-	kind string
+	id     string
+	kind   string
+	retval int
 
 	process testProcess
 	network testNetwork
@@ -478,6 +479,13 @@ func (m *testModel) GetEvaluator(field Field, _ RegisterID) (Evaluator, error) {
 			Field: field,
 		}, nil
 
+	case "retval":
+
+		return &IntEvaluator{
+			EvalFnc: func(ctx *Context) int { return ctx.Event.(*testEvent).retval },
+			Field:   field,
+		}, nil
+
 	case "mkdir.filename":
 
 		return &StringEvaluator{
@@ -544,6 +552,10 @@ func (e *testEvent) GetFieldValue(field Field) (interface{}, error) {
 	case "open.filename":
 
 		return e.open.filename, nil
+
+	case "retval":
+
+		return e.retval, nil
 
 	case "open.flags":
 
@@ -653,6 +665,10 @@ func (e *testEvent) GetFieldEventType(field Field) (string, error) {
 
 		return "open", nil
 
+	case "retval":
+
+		return "*", nil
+
 	case "open.flags":
 
 		return "open", nil
@@ -738,6 +754,11 @@ func (e *testEvent) SetFieldValue(field Field, value interface{}) error {
 	case "open.filename":
 
 		e.open.filename = value.(string)
+		return nil
+
+	case "retval":
+
+		e.retval = value.(int)
 		return nil
 
 	case "open.flags":
@@ -835,6 +856,10 @@ func (e *testEvent) GetFieldType(field Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "retval":
+
+		return reflect.Int, nil
+
 	case "open.flags":
 
 		return reflect.Int, nil
@@ -870,4 +895,14 @@ var testConstants = map[string]interface{}{
 	"O_EXCL":   &IntEvaluator{Value: syscall.O_EXCL},
 	"O_SYNC":   &IntEvaluator{Value: syscall.O_SYNC},
 	"O_TRUNC":  &IntEvaluator{Value: syscall.O_TRUNC},
+
+	// retval
+	"EPERM":        &IntEvaluator{Value: int(syscall.EPERM)},
+	"EACCES":       &IntEvaluator{Value: int(syscall.EACCES)},
+	"EPFNOSUPPORT": &IntEvaluator{Value: int(syscall.EPFNOSUPPORT)},
+	"EPIPE":        &IntEvaluator{Value: int(syscall.EPIPE)},
+
+	// string constants
+	"my_constant_1": &StringEvaluator{Value: "my_constant_1"},
+	"my_constant_2": &StringEvaluator{Value: "my_constant_2"},
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds support for constants in secl arrays. With this change, we now support `string`, `int` and `boolean` constants in arrays. Keep in mind that:
- The constants of an array should be of the same type as the field tested against the array (i.e. in the rule `X in [ EPERM, EACCES ]`, `X` has to be of type `int`)
- Arrays should contain constants of a unique type (i.e. `[ EPERM, true]` isn't valid)
- You can't mix constants with non-constants values (i.e. `[ EPERM, 42 ]` isn't valid)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This change was added so that we can now write rules like `open.retval in [ EPERM, EACCES ]`.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Unit tests were added but feel free to look for edge cases !