### PR TITLE
[PROCS-4153] Create basic e2e k8s/kind test environment setup for the process-agent

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -268,6 +268,7 @@ qa_dca:
   stage: dev_container_deploy
   rules:
     - !reference [.on_container_or_e2e_changes]
+    - !reference [.on_process_or_e2e_changes]
     - !reference [.manual]
   needs:
     - docker_build_cluster_agent_amd64

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -226,7 +226,7 @@ new-e2e-language-detection:
 
 new-e2e-npm-packages:
   extends: .new_e2e_template
-  rules: 
+  rules:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
@@ -256,7 +256,7 @@ new-e2e-aml:
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
-  rules: 
+  rules:
     - !reference [.on_aml_or_e2e_changes]
     - !reference [.manual]
   variables:
@@ -265,7 +265,7 @@ new-e2e-aml:
 
 new-e2e-cws:
   extends: .new_e2e_template
-  rules: 
+  rules:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
   needs:
@@ -291,7 +291,8 @@ new-e2e-process:
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
-  rules: 
+    - qa_dca
+  rules:
     - !reference [.on_process_or_e2e_changes]
     - !reference [.manual]
   variables:

--- a/test/new-e2e/tests/process/compose/stress-compose.yaml
+++ b/test/new-e2e/tests/process/compose/stress-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  stress:
+    image: polinux/stress
+    container_name: stress
+    command:
+      - "stress"
+      - "-d"
+      - "1"

--- a/test/new-e2e/tests/process/compose/stress-compose.yaml
+++ b/test/new-e2e/tests/process/compose/stress-compose.yaml
@@ -1,8 +1,0 @@
-services:
-  stress:
-    image: polinux/stress
-    container_name: stress
-    command:
-      - "stress"
-      - "-d"
-      - "1"

--- a/test/new-e2e/tests/process/config/helm-template.tmpl
+++ b/test/new-e2e/tests/process/config/helm-template.tmpl
@@ -1,0 +1,7 @@
+datadog:
+  processAgent:
+    enabled: {{.ProcessAgentEnabled}}
+    processCollection: {{.ProcessCollection}}
+    processDiscovery: {{.ProcessDiscoveryCollection}}
+  networkMonitoring:
+    enabled: false

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package process
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
+	kubeComp "github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/kubernetes"
+)
+
+type K8sSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func TestK8sTestSuite(t *testing.T) {
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(awskubernetes.KindProvisioner(
+			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return cpustress.K8sAppDefinition(e, kubeProvider, "workload-stress")
+			}),
+		)),
+	}
+
+	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
+	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
+		options = append(options, e2e.WithDevMode())
+	}
+
+	e2e.Run(t, &K8sSuite{}, options...)
+}
+
+func (s *K8sSuite) TestWorkloadsInstalled() {
+	res, _ := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), v1.ListOptions{})
+	containsClusterAgent := false
+	for _, pod := range res.Items {
+		s.T().Logf("pod name: %s", pod.Name)
+		if strings.Contains(pod.Name, "cluster-agent") {
+			containsClusterAgent = true
+			break
+		}
+	}
+
+	res, _ = s.Env().KubernetesCluster.Client().CoreV1().Pods("workload-stress").List(context.TODO(), v1.ListOptions{})
+	for _, pod := range res.Items {
+		s.T().Logf("pod name: %s", pod.Name)
+	}
+
+	assert.True(s.T(), containsClusterAgent, "Cluster Agent not found")
+	assert.Equal(s.T(), s.Env().Agent.InstallNameLinux, "dda-linux")
+}

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -9,8 +9,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"os"
-	"strconv"
 	"testing"
 	"text/template"
 
@@ -70,11 +68,6 @@ func TestK8sTestSuite(t *testing.T) {
 			}),
 			awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
 		)),
-	}
-
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &K8sSuite{}, options...)


### PR DESCRIPTION
### What does this PR do?
- Creates a new test skeleton with k8s/kind env setup for a process-agent e2e tests.
- Creates an initial helm template to control the dd-agent's configuration

### Motivation
PROCS-4153

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

