### PR TITLE
[Oracle] - Depend on dba_tablespaces.status for tablespace statuses

### DIFF
--- a/pkg/collector/corechecks/oracle/tablespaces.go
+++ b/pkg/collector/corechecks/oracle/tablespaces.go
@@ -47,14 +47,14 @@ const (
 	maxSizeQuery12 = `SELECT
   c.name pdb_name,
   f.tablespace_name tablespace_name,
-  SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
+  COALESCE(SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END), 0) maxsize
 FROM cdb_data_files f, v$containers c
 WHERE c.con_id(+) = f.con_id
 GROUP BY c.name, f.tablespace_name`
 
 	maxSizeQuery11 = `SELECT
     f.tablespace_name tablespace_name,
-    SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
+    COALESCE(SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END), 0) maxsize
     FROM dba_data_files f
     GROUP BY f.tablespace_name`
 )

--- a/pkg/collector/corechecks/oracle/tablespaces.go
+++ b/pkg/collector/corechecks/oracle/tablespaces.go
@@ -27,7 +27,7 @@ const tablespaceQuery12 = `SELECT
 FROM
   cdb_tablespace_usage_metrics m, cdb_tablespaces t, v$containers c
 WHERE
-  m.con_id = t.con_id and m.tablespace_name(+) = t.tablespace_name and c.con_id(+) = t.con_id`
+  m.con_id(+) = t.con_id and m.tablespace_name(+) = t.tablespace_name and c.con_id(+) = t.con_id`
 
 const tablespaceQuery11 = `SELECT
   t.tablespace_name tablespace_name,

--- a/pkg/collector/corechecks/oracle/tablespaces.go
+++ b/pkg/collector/corechecks/oracle/tablespaces.go
@@ -20,7 +20,10 @@ const tablespaceQuery12 = `SELECT
   NVL(m.used_space * t.block_size, 0) used,
   NVL(m.tablespace_size * t.block_size, 0) size_,
   NVL(m.used_percent, 0) in_use,
-  NVL2(m.used_space, 0, 1) offline_
+  CASE t.status
+      WHEN 'OFFLINE' THEN 1
+    ELSE 0
+  END AS offline_
 FROM
   cdb_tablespace_usage_metrics m, cdb_tablespaces t, v$containers c
 WHERE
@@ -31,7 +34,10 @@ const tablespaceQuery11 = `SELECT
   NVL(m.used_space * t.block_size, 0) used,
   NVL(m.tablespace_size * t.block_size, 0) size_,
   NVL(m.used_percent, 0) in_use,
-  NVL2(m.used_space, 0, 1) offline_
+  CASE t.status
+      WHEN 'OFFLINE' THEN 1
+    ELSE 0
+  END AS offline_
 FROM
   dba_tablespace_usage_metrics m, dba_tablespaces t
 WHERE
@@ -47,10 +53,10 @@ WHERE c.con_id(+) = f.con_id
 GROUP BY c.name, f.tablespace_name`
 
 	maxSizeQuery11 = `SELECT
-	f.tablespace_name tablespace_name,
-	SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
-	FROM dba_data_files f
-	GROUP BY f.tablespace_name`
+    f.tablespace_name tablespace_name,
+    SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END) maxsize
+    FROM dba_data_files f
+    GROUP BY f.tablespace_name`
 )
 
 //nolint:revive // TODO(DBM) Fix revive linter

--- a/pkg/collector/corechecks/oracle/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle/tablespaces_test.go
@@ -37,4 +37,9 @@ func TestTablespaces(t *testing.T) {
 	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, c.dbHostname, tags)
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 0, c.dbHostname, tags)
+	_, err := c.db.Exec("ALTER TABLESPACE TBS_TEST OFFLINE")
+	err := c.Run()
+	require.NoError(t, err)
+	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 1, c.dbHostname, tags)
 }

--- a/pkg/collector/corechecks/oracle/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle/tablespaces_test.go
@@ -36,4 +36,5 @@ func TestTablespaces(t *testing.T) {
 	}
 	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, c.dbHostname, tags)
+	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 0, c.dbHostname, tags)
 }

--- a/pkg/collector/corechecks/oracle/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle/tablespaces_test.go
@@ -8,11 +8,13 @@
 package oracle
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
 	//"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 
+	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -37,9 +39,35 @@ func TestTablespaces(t *testing.T) {
 	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, c.dbHostname, tags)
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 0, c.dbHostname, tags)
-	_, err := c.db.Exec("ALTER TABLESPACE TBS_TEST OFFLINE")
+}
+
+func TestTablespacesOffline(t *testing.T) {
+	c, s := newDefaultCheck(t, "", "")
+	defer c.Teardown()
+
+	connection := getConnectData(t, useSysUser)
+	databaseUrl := go_ora.BuildUrl(connection.Server, connection.Port, connection.ServiceName, connection.Username, connection.Password, nil)
+	conn, err2 := sql.Open("oracle", databaseUrl)
+	require.NoError(t, err2)
+
+	defer func() {
+		_, err := conn.Exec("ALTER TABLESPACE TBS_TEST ONLINE")
+		require.NoError(t, err)
+		conn.Close()
+	}()
+
+	_, err3 := conn.Exec("ALTER TABLESPACE TBS_TEST OFFLINE")
+	require.NoError(t, err3)
+
 	err := c.Run()
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	var expectedPdb string
+	if c.connectedToPdb {
+		expectedPdb = c.cdbName
+	} else {
+		expectedPdb = "cdb$root"
+	}
+	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 1, c.dbHostname, tags)
 }

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -30,6 +30,7 @@ const (
 	useDefaultUser = iota
 	useLegacyUser
 	useDoesNotExistUser
+	useSysUser
 )
 
 const (
@@ -60,7 +61,13 @@ func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
 			passwordEnvVariable = "ORACLE_TEST_LEGACY_PASSWORD"
 			server = os.Getenv(serverEnvVariable)
 			serviceName = os.Getenv(serviceNameEnvVariable)
+		case useSysUser:
+			userEnvVariable = "ORACLE_TEST_SYS_USER"
+			passwordEnvVariable = "ORACLE_TEST_SYS_PASSWORD"
+			server = os.Getenv(serverEnvVariable)
+			serviceName = os.Getenv(serviceNameEnvVariable)
 		}
+
 		username = os.Getenv(userEnvVariable)
 		password = os.Getenv(passwordEnvVariable)
 		port, _ := strconv.Atoi(os.Getenv(portEnvVariable))
@@ -86,6 +93,8 @@ func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
 	switch userType {
 	case useLegacyUser:
 		return handleRealConnection(useLegacyUser)
+	case useSysUser:
+		return handleRealConnection(useSysUser)
 	case useDoesNotExistUser:
 		return config.ConnectionConfig{
 			Username:    doesNotExist,

--- a/releasenotes/notes/oracle-tablespace-status-7d80f4e243150e3e.yaml
+++ b/releasenotes/notes/oracle-tablespace-status-7d80f4e243150e3e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix oracle.tablespace.offline metric not emitting 1 when tablespace is offline.

--- a/releasenotes/notes/oracle-tablespace-status-7d80f4e243150e3e.yaml
+++ b/releasenotes/notes/oracle-tablespace-status-7d80f4e243150e3e.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix oracle.tablespace.offline metric not emitting 1 when tablespace is offline.
+    Fixes `oracle.tablespace.offline` metric not emitting 1 when tablespace is offline.


### PR DESCRIPTION
### What does this PR do?

Fixes the `oracle.tablespace.offline` metric which was not emitting `1` when a tablespace was offline.

### Motivation

2 customers reported the issue where `oracle.tablespace.offline` wasn't working correctly for offline tablespaces.
