### PR TITLE
[Serverless] Post binary size change when serverless deps file changes.

### DIFF
--- a/.github/workflows/serverless-benchmarks.yml
+++ b/.github/workflows/serverless-benchmarks.yml
@@ -175,7 +175,7 @@ jobs:
 
             </details>
 
-            <details open>
+            <details>
             <summary>Benchmark stats</summary>
 
             ```

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -69,25 +69,41 @@ jobs:
         id: compare
         run: |
           OUTPUT=$(( ${{ steps.current.outputs.result }} - ${{ steps.previous.outputs.result }} ))
+          echo "binary size changed by $OUTPUT bytes"
           echo "diff=$OUTPUT" >> $GITHUB_OUTPUT
 
           OUTPUT=$(( $OUTPUT / 100000 ))
+          echo "cold start time changed by $OUTPUT ms"
           echo "coldstart=$OUTPUT" >> $GITHUB_OUTPUT
 
-      ### Steps below only run if size diff > SIZE_ALLOWANCE ###
+      - name: Should post comment
+        id: should
+        run: |
+          cd go/src/github.com/DataDog/datadog-agent
+          if test $(
+            git diff $GITHUB_BASE_REF..$GITHUB_SHA --name-only | grep dependencies_linux_amd64.txt
+          ); then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          elif [[ ${{ steps.compare.outputs.diff }} > env.SIZE_ALLOWANCE ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      ### Steps below run if size diff > SIZE_ALLOWANCE or file dependencies_linux_amd64.txt changed ###
 
       - name: Install graphviz
         uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
 
       - name: Install digraph
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
         run: |
           GOPATH=$(pwd)/go go install golang.org/x/tools/cmd/digraph@latest
 
       - name: List new dependencies
         id: deps
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
         run: |
           echo "deps<<EOF" >> $GITHUB_OUTPUT
           for dep in $(echo "${{ steps.current.outputs.deps }}"); do
@@ -98,7 +114,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create dependency graphs
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
         run: |
           export PATH=$(pwd)/go/bin:$PATH
           cd go/src/github.com/DataDog/datadog-lambda-extension
@@ -110,14 +126,14 @@ jobs:
 
       - name: Archive dependency graphs
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
         with:
           name: dependency-graphs
           path: go/src/github.com/DataDog/datadog-lambda-extension/graphs
 
       - name: Post comment
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        if: steps.should.outputs.should_run == 'true'
         with:
           hide_and_recreate: true
           hide_classify: "RESOLVED"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Makes serverless check results more easily consumable.
1. Collapse benchmark results by default
2. Post binary size change whenever deps file changes

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Whenever the `dependencies_linux_amd64.txt` file changes, our team must review the PR. One thing that will help us review these changes faster is to always know the change in binary size of the PR.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
