### PR TITLE
Add environment variables to ruby cache key

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -49,7 +49,9 @@
         # This is coarser than needed, but there's no more convenient way
         # to get a hold of OMNIBUS_RUBY_VERSION and OMNIBUS_SOFTWARE version
         - release.json
-      prefix: omnibus-deps-$CI_JOB_NAME
+      # We still need to add the environment omnibus-related variables so that triggered pipelines
+      # don't get undesired cache hits
+      prefix: omnibus-deps-$CI_JOB_NAME-$OMNIBUS_RUBY_VERSION-$OMNIBUS_SOFTWARE
     paths:
       - omnibus/vendor/bundle
 


### PR DESCRIPTION
### What does this PR do?

Adds environment variables to the cache key used for Ruby dependencies used by Omnibus.

### Motivation

Avoiding "wrong" cache hits when release.json values are overridden by environment variables (typically on triggered pipelines).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
