### PR TITLE
remote workloadmeta: do not double notify events when handling resync

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -239,9 +239,9 @@ func (c *GenericCollector) Run() {
 		if c.resyncNeeded {
 			c.StreamHandler.HandleResync(c.store, collectorEvents)
 			c.resyncNeeded = false
+		} else {
+			c.store.Notify(collectorEvents)
 		}
-
-		c.store.Notify(collectorEvents)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Implementors of `HandleResync` already call `store.Notify` with the given events after reseting the store. This means that currently we double notify the events when handling a resync. This PR fixes this by manually notify-ing events only in the non-resync case.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
