### PR TITLE
remote workloadmeta: ensure EOF actually triggers a re-sync

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -209,14 +209,7 @@ func (c *GenericCollector) Run() {
 			}, streamRecvTimeout)
 		}
 		if err != nil {
-			// at the end of stream, but its OK
-			if errors.Is(err, io.EOF) {
-				continue
-			}
-
 			c.streamCancel()
-
-			telemetry.RemoteClientErrors.Inc(c.CollectorID)
 
 			// when Recv() returns an error, the stream is aborted and the
 			// contents of our store are considered out of sync. The stream must
@@ -225,7 +218,10 @@ func (c *GenericCollector) Run() {
 			c.stream = nil
 			c.resyncNeeded = true
 
-			log.Warnf("error received from remote workloadmeta: %s", err)
+			if err != io.EOF {
+				telemetry.RemoteClientErrors.Inc(c.CollectorID)
+				log.Warnf("error received from remote workloadmeta: %s", err)
+			}
 
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the handling of EOF by the remote workloadmeta. Currently, when `Recv` returns an EOF error we continue with the same stream which can cause some real issue for the client since the server is no longer available. This is for example happening when the core agent (the remote wm server in our case) is getting OOM-killed, and it's triggering huge CPU usage (and allocation) for the security agent when using the remote mode.

Basically we fall into a loop of:
```
- call Recv -> this allocates a new buffer for the message
- instantly get EOF
- continue -> start again 
```

This PR fixes this issue by asking for a re-sync when EOF is reached.

This fix is not entirely new, it was already done like that before https://github.com/DataDog/datadog-agent/pull/17682/files#diff-a48cb39c4455a8d213283cd15194c52730ed1bce9e6413533ef597776d3234e3L175

Open question: should EOF errors be reported by telemetry and the log ?

### Motivation

I have been investigating very high CPU usage of the security agent for some time ([example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=host%3Ai-042abd4a944087117%20service%3Asecurity-agent&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&my_code=disabled&refresh_mode=paused&selected_tf=1718704802076.9543%2C1718706542801.5042&viz=flame_graph&from_ts=1718703414538&to_ts=1718707014538&live=false)). This issue is preventing us from using the remote WM more broadly.
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

2 components use the remote workloadmeta:
- non-core agents using it to sync their store with the one from the agent, especially the case of the security-agent. This needs to be QA-ed by ensuring the `datadog.security_agent.runtime.containers_running` metric is reporting correctly when the remote mode is enabled. The process agent can also make use of this in some configuration
- the core agent uses this to sync process data with the process agent (in this case the core agent is the client and the process agent is the server)
