### PR TITLE
usm: http2: tests: Cut 9m from TestRawTraffic

### DIFF
--- a/pkg/network/protocols/http2/testutils.go
+++ b/pkg/network/protocols/http2/testutils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-// CleanHTTP2Maps deletes all entries from the http2 maps. Test utility to allow reusing USM instance without carring
+// CleanHTTP2Maps deletes all entries from the http2 maps. Test utility to allow reusing USM instance without caring
 // over previous data.
 func CleanHTTP2Maps() {
 	if Spec.Instance == nil {

--- a/pkg/network/protocols/http2/testutils.go
+++ b/pkg/network/protocols/http2/testutils.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package http2
+
+import (
+	"strings"
+
+	"github.com/cilium/ebpf"
+)
+
+// CleanHTTP2Maps deletes all entries from the http2 maps. Test utility to allow reusing USM instance without carring
+// over previous data.
+func CleanHTTP2Maps() {
+	if Spec.Instance == nil {
+		return
+	}
+
+	m := Spec.Instance.(*Protocol).mgr
+	if m == nil {
+		return
+	}
+
+	for _, mapElement := range Spec.Maps {
+		if strings.HasSuffix(mapElement.Name, "http2_batches") || strings.HasSuffix(mapElement.Name, "http2_telemetry") {
+			continue
+		}
+		mapInstance, _, err := m.GetMap(mapElement.Name)
+		if err != nil {
+			continue
+		}
+		// We shouldn't clean percpu maps and percpu arrays.
+		if mapInstance.Type() == ebpf.PerCPUArray || mapInstance.Type() == ebpf.Array || mapInstance.Type() == ebpf.PerCPUHash {
+			continue
+		}
+		key := make([]byte, mapInstance.KeySize())
+		value := make([]byte, mapInstance.ValueSize())
+		mapEntries := mapInstance.Iterate()
+		var keysToDelete [][]byte
+		for mapEntries.Next(&key, &value) {
+			keysToDelete = append(keysToDelete, key)
+		}
+		for _, key := range keysToDelete {
+			_ = mapInstance.Delete(&key)
+		}
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The PR reuses the same USM instance, and just clears the http2 maps in between the runs, to have a clean state in the next test.

Now each instance of TestRawTraffic (CO-RE, RC, prebuilt) x (TLS, without TLS) takes 20s each (prebuilt TLS is not supported), instead of 100-168s before


### Motivation

Faster CI for system-probe teams 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
