### PR TITLE
[ASCII-1899] Scrub layers separately in `GetFullConfigBySource` to avoid hitting size limit

### DIFF
--- a/comp/core/settings/settingsimpl/settingsimpl.go
+++ b/comp/core/settings/settingsimpl/settingsimpl.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	json "github.com/json-iterator/go"
+	"github.com/mohae/deepcopy"
 	"go.uber.org/fx"
 	"gopkg.in/yaml.v2"
 
@@ -147,6 +148,13 @@ func (s *settingsRegistry) GetFullConfigBySource() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 
 		settings := s.config.AllSettingsBySource()
+		// scrub each config layer separately to avoid hitting scrubber size limits
+		for source, setting := range settings {
+			// deepcopy the config layer to avoid accidentally updating the original config object
+			setting = deepcopy.Copy(setting)
+			scrubber.ScrubDataObj(&setting)
+			settings[source] = setting
+		}
 
 		jsonData, err := json.Marshal(settings)
 		if err != nil {
@@ -156,15 +164,7 @@ func (s *settingsRegistry) GetFullConfigBySource() http.HandlerFunc {
 			return
 		}
 
-		scrubbed, err := scrubber.ScrubJSON(jsonData)
-		if err != nil {
-			s.log.Errorf("Unable to scrub sensitive data from config by layer: %s", err)
-			body, _ := json.Marshal(map[string]string{"error": err.Error()})
-			http.Error(w, string(body), http.StatusInternalServerError)
-			return
-		}
-
-		_, _ = w.Write(scrubbed)
+		_, _ = w.Write(jsonData)
 	}
 }
 

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -328,6 +328,11 @@ func ScrubLine(url string) string {
 	return DefaultScrubber.ScrubLine(url)
 }
 
+// ScrubDataObj scrubs credentials from the data interface by recursively walking over all the nodes
+func ScrubDataObj(data *interface{}) {
+	DefaultScrubber.ScrubDataObj(data)
+}
+
 // HideKeyExceptLastFiveChars replaces all characters in the key with "*", except
 // for the last 5 characters. If the key is an unrecognized length, replace
 // all of it with the default string of "*"s instead.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change `GetFullConfigBySource` to scrub each config layer independently rather than all at once.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The scrubber has an implicit max size of 65kB (default size of `bufio.NewScanner`), we don't want to hit the limit.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It's not really clear how big the config can be so for now just go with this fix, but we'll probably need to increase the scrubber limit at some point.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Added a unit test which ensures that the endpoint will not error as long as layers are smaller than ~60kB.

QA'ed manually:
- reproduced the previous error by setting a config with size 40kb in different layers (with latest release candidate)
- with this fix the error disappears