### PR TITLE
Fix DD_LOGS_CONFIG_LOGS_DD_URL env variable naming in config template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -913,7 +913,7 @@ api_key:
   # container_collect_all: false
 
   ## @param logs_dd_url - string - optional
-  ## @env DD_LOGS_CONFIG_DD_URL - string - optional
+  ## @env DD_LOGS_CONFIG_LOGS_DD_URL - string - optional
   ## Define the endpoint and port to hit when using a proxy for logs. The logs are forwarded in TCP
   ## therefore the proxy must be able to handle TCP connections.
   #


### PR DESCRIPTION
The name of the DD_LOGS_CONFIG_LOGS_DD_URL env variable is not correct in the config_template.yaml file (incorrect naming: DD_LOGS_CONFIG_DD_URL) Therefore the documentation  (https://docs.datadoghq.com/agent/logs/?tab=tailfiles) is not correct.

