### PR TITLE
Fix empty string key in configuration map

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -408,18 +408,7 @@ func (ia *inventoryagent) marshalAndScrub(data interface{}) (string, error) {
 	return string(scrubbed), nil
 }
 
-func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
-	ia.m.Lock()
-	defer ia.m.Unlock()
-
-	ia.refreshMetadata()
-
-	// Create a static copy of agentMetadata for the payload
-	data := make(agentMetadata)
-	for k, v := range ia.data {
-		data[k] = v
-	}
-
+func (ia *inventoryagent) getConfigs(data agentMetadata) {
 	if ia.conf.GetBool("inventories_configuration_enabled") {
 		layers := ia.conf.AllSettingsBySource()
 		layersName := map[model.Source]string{
@@ -433,14 +422,31 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 		}
 
 		for source, conf := range layers {
-			if yaml, err := ia.marshalAndScrub(conf); err == nil {
-				data[layersName[source]] = yaml
+			if layer, ok := layersName[source]; ok {
+				if yaml, err := ia.marshalAndScrub(conf); err == nil {
+					data[layer] = yaml
+				}
 			}
 		}
 		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettings()); err == nil {
 			data["full_configuration"] = yaml
 		}
 	}
+}
+
+func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
+	ia.m.Lock()
+	defer ia.m.Unlock()
+
+	ia.refreshMetadata()
+
+	// Create a static copy of agentMetadata for the payload
+	data := make(agentMetadata)
+	for k, v := range ia.data {
+		data[k] = v
+	}
+
+	ia.getConfigs(data)
 
 	return &Payload{
 		Hostname:  ia.hostname,

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
+	"sort"
 	"testing"
 	"time"
 
@@ -687,4 +688,24 @@ func TestGetProvidedConfiguration(t *testing.T) {
 	assert.Contains(t, payload.Metadata, "remote_configuration")
 	assert.Contains(t, payload.Metadata, "cli_configuration")
 	assert.Contains(t, payload.Metadata, "source_local_configuration")
+}
+
+func TestGetProvidedConfigurationOnly(t *testing.T) {
+	ia := getTestInventoryPayload(t, map[string]any{
+		"inventories_configuration_enabled": true,
+	}, nil)
+
+	data := make(agentMetadata)
+	ia.getConfigs(data)
+
+	keys := []string{}
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	expected := []string{"provided_configuration", "full_configuration", "file_configuration", "environment_variable_configuration", "agent_runtime_configuration", "remote_configuration", "cli_configuration", "source_local_configuration"}
+	sort.Strings(expected)
+
+	assert.Equal(t, expected, keys)
 }


### PR DESCRIPTION
### What does this PR do?

Fix empty string key in configuration map.

Regression introduce in 7.55 would create an empty key entry in the `agent_metadata`.

### Describe how to test/QA your changes
EDIT: the backport PR was manually QA'ed already

Get the agent metadata payload `datadog-agent diagnose show-metadata inventory-agent` and check that the payload doesn't contains an empty string as a key.