### PR TITLE
Add a k8s client wrapper for e2e tests

### DIFF
--- a/test/new-e2e/pkg/components/kubernetes_cluster.go
+++ b/test/new-e2e/pkg/components/kubernetes_cluster.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+
 	"github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	kubeClient "k8s.io/client-go/kubernetes"
@@ -21,7 +23,7 @@ const kubeClientTimeout = 60 * time.Second
 type KubernetesCluster struct {
 	kubernetes.ClusterOutput
 
-	client kubeClient.Interface
+	KubernetesClient *client.KubernetesClient
 }
 
 var _ e2e.Initializable = &KubernetesCluster{}
@@ -37,7 +39,7 @@ func (kc *KubernetesCluster) Init(e2e.Context) error {
 	config.Timeout = kubeClientTimeout
 
 	// Create client
-	kc.client, err = kubeClient.NewForConfig(config)
+	kc.KubernetesClient, err = client.NewKubernetesClient(config)
 	if err != nil {
 		return err
 	}
@@ -47,5 +49,5 @@ func (kc *KubernetesCluster) Init(e2e.Context) error {
 
 // Client returns the Kubernetes client
 func (kc *KubernetesCluster) Client() kubeClient.Interface {
-	return kc.client
+	return kc.KubernetesClient.K8sClient
 }

--- a/test/new-e2e/pkg/utils/e2e/client/k8s.go
+++ b/test/new-e2e/pkg/utils/e2e/client/k8s.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package client
 
 import (

--- a/test/new-e2e/pkg/utils/e2e/client/k8s.go
+++ b/test/new-e2e/pkg/utils/e2e/client/k8s.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeClient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// KubernetesClient is a wrapper around the k8s client library and provides convenience methods for interacting with a
+// k8s cluster
+type KubernetesClient struct {
+	K8sConfig *rest.Config
+	K8sClient kubeClient.Interface
+}
+
+// NewKubernetesClient creates a new KubernetesClient
+func NewKubernetesClient(config *rest.Config) (*KubernetesClient, error) {
+	// Create client
+	k8sClient, err := kubeClient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubernetesClient{
+		K8sConfig: config,
+		K8sClient: k8sClient,
+	}, nil
+}
+
+// PodExec execs into a given namespace/pod and returns the output for the given command
+func (k *KubernetesClient) PodExec(namespace, pod, container string, cmd []string) (stdout, stderr string, err error) {
+	req := k.K8sClient.CoreV1().RESTClient().Post().Resource("pods").Namespace(namespace).Name(pod).SubResource("exec")
+	option := &corev1.PodExecOptions{
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+		Container: container,
+		Command:   cmd,
+	}
+
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+
+	exec, err := remotecommand.NewSPDYExecutor(k.K8sConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", err
+	}
+
+	var stdoutSb, stderrSb strings.Builder
+	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+		Stdout: &stdoutSb,
+		Stderr: &stderrSb,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	return stdoutSb.String(), stderrSb.String(), nil
+}


### PR DESCRIPTION
### What does this PR do?
- Add a new k8s client for interacting with convenience methods for interacting with a k8s cluster in e2e tests.

The `PodExec` method was copied from the container k8s tests: https://github.com/DataDog/datadog-agent/blob/7bc50c660a55567c1e9320851c2bb28d19efc834/test/new-e2e/tests/containers/k8s_test.go#L1235

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
