### PR TITLE
Detect when running agent in AKS and set hostname accordingly

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // declare these as vars not const to ease testing
@@ -123,7 +122,7 @@ var instanceMetaFetcher = cachedfetch.Fetcher{
 	Name: "Azure Instance Metadata",
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		metadataJSON, err := getResponse(ctx,
-			metadataURL+"/metadata/instance/compute?api-version=2017-08-01")
+			metadataURL+"/metadata/instance/compute?api-version=2021-02-01")
 		if err != nil {
 			return "", fmt.Errorf("failed to get Azure instance metadata: %s", err)
 		}
@@ -131,20 +130,13 @@ var instanceMetaFetcher = cachedfetch.Fetcher{
 	},
 }
 
-func getTags(tags string) (map[string]string, error) {
-	tagsMap := map[string]string{}
-	if tags == "" {
-		return tagsMap, fmt.Errorf("No tags detected")
-	}
-	tagsSlice := strings.Split(tags, ";")
-	for _, tag := range tagsSlice {
-		tagSlice := strings.SplitN(tag, ":", 2)
-		if len(tagSlice) != 2 {
-			log.Debugf("AKS-OS: failed to parse tag %s", tag)
+func isKubernetesTag(tagsList []map[string]string) bool {
+	for _, tag := range tagsList {
+		if tag["name"] == "aks-managed-orchestrator" && strings.Contains(tag["value"], "Kubernetes") {
+			return true
 		}
-		tagsMap[tagSlice[0]] = tagSlice[1]
 	}
-	return tagsMap, nil
+	return false
 }
 
 func getHostnameWithConfig(ctx context.Context, config config.Config) (string, error) {
@@ -154,25 +146,30 @@ func getHostnameWithConfig(ctx context.Context, config config.Config) (string, e
 	if err != nil {
 		return "", err
 	}
+	type OsProfile struct {
+		computerName string
+	}
 
 	var metadata struct {
 		VMID              string
 		Name              string
 		ResourceGroupName string
 		SubscriptionID    string
-		Tags              string
+		TagsList          []map[string]string
+		OsProfile         struct {
+			ComputerName string
+		}
 	}
+
 	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
 		return "", fmt.Errorf("failed to parse Azure instance metadata: %s", err)
 	}
-	tagsList, err := getTags(metadata.Tags)
-	if err != nil {
-		log.Debugf("Failed to parse metadata tags: %s", err)
-	}
+	isKubernetes := isKubernetesTag(metadata.TagsList)
+
 	if style == "os" {
-		// If running in AKS, use name as fallback
-		if strings.Contains(tagsList["aks-managed-orchestrator"], "Kubernetes") {
-			style = "name"
+		if isKubernetes {
+			// If running in AKS, use the node name as the hostname
+			style = "os_computer_name"
 		} else {
 			return "", fmt.Errorf("azure_hostname_style is set to 'os'")
 		}
@@ -188,6 +185,8 @@ func getHostnameWithConfig(ctx context.Context, config config.Config) (string, e
 		name = fmt.Sprintf("%s.%s", metadata.Name, metadata.ResourceGroupName)
 	case "full":
 		name = fmt.Sprintf("%s.%s.%s", metadata.Name, metadata.ResourceGroupName, metadata.SubscriptionID)
+	case "os_computer_name":
+		name = strings.ToLower(metadata.OsProfile.ComputerName)
 	default:
 		return "", fmt.Errorf("invalid azure_hostname_style value: %s", style)
 	}

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -146,9 +146,6 @@ func getHostnameWithConfig(ctx context.Context, config config.Config) (string, e
 	if err != nil {
 		return "", err
 	}
-	type OsProfile struct {
-		computerName string
-	}
 
 	var metadata struct {
 		VMID              string

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -85,12 +85,15 @@ var vmIDFetcher = cachedfetch.Fetcher{
 func GetHostAliases(ctx context.Context) ([]string, error) {
 	aliases := []string{}
 	vm, err := vmIDFetcher.FetchStringSlice(ctx)
-	aliases = append(aliases, vm...)
-
-	metadata, metadataErr := getMetadata(ctx)
-	if err != nil {
-		return aliases, fmt.Errorf("%s; Azure HostAliases: unable to query metadata endpoint: %s", err, metadataErr)
+	if err == nil {
+		aliases = append(aliases, vm...)
 	}
+
+	metadata, err := getMetadata(ctx)
+	if err != nil {
+		return aliases, fmt.Errorf("Azure GetHostAliases: unable to query metadata endpoint: %s", err)
+	}
+
 	if isKubernetesTag(metadata.TagsList) {
 		aliases = append(aliases, metadata.OsProfile.ComputerName)
 	}

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -30,6 +30,8 @@ var (
 )
 
 const hostnameStyleSetting = "azure_hostname_style"
+const aksManagedOrchestratorTag = "aks-managed-orchestrator"
+const kubernetesTagValue = "Kubernetes"
 
 type metadata struct {
 	VMID              string
@@ -157,7 +159,7 @@ var instanceMetaFetcher = cachedfetch.Fetcher{
 
 func isKubernetesTag(tagsList []map[string]string) bool {
 	for _, tag := range tagsList {
-		if tag["name"] == "aks-managed-orchestrator" && strings.Contains(tag["value"], "Kubernetes") {
+		if tag["name"] == aksManagedOrchestratorTag && strings.Contains(tag["value"], kubernetesTagValue) {
 			return true
 		}
 	}

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -148,7 +148,8 @@ func TestGetHostnameKubernetesTag(t *testing.T) {
 			"resourceGroupName": "my-resource-group",
 			"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
 			"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
-			"tags": "aks-managed-orchestrator:Kubernetes"
+			"osProfile": {"computerName":"node-name-A"},
+			"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
 		}`)
 	}))
 	defer ts.Close()
@@ -158,7 +159,7 @@ func TestGetHostnameKubernetesTag(t *testing.T) {
 		style, value string
 		err          bool
 	}{
-		{"os", "vm-name", false},
+		{"os", "node-name-a", false}, // use osProfile.computerName when running in AKS
 		{"vmid", "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d", false},
 		{"name", "vm-name", false},
 		{"name_and_resource_group", "vm-name.my-resource-group", false},

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -22,20 +22,41 @@ import (
 
 func TestGetAlias(t *testing.T) {
 	ctx := context.Background()
-	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+	expectedNodeName := "node-name-A"
+	expectedVM := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+	responseIdx := 0
+	responses := []func(w http.ResponseWriter, r *http.Request){
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, fmt.Sprintf(`{
+				"name": "vm-name",
+				"resourceGroupName": "my-resource-group",
+				"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
+				"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
+				"osProfile": {"computerName":"%s"},
+				"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
+			}`, expectedNodeName))
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			io.WriteString(w, expectedVM)
+		},
+	}
 	var lastRequest *http.Request
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		io.WriteString(w, expected)
+	tsVm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		responses[responseIdx](w, r)
+		responseIdx++
 		lastRequest = r
 	}))
-	defer ts.Close()
-	metadataURL = ts.URL
+
+	defer tsVm.Close()
+	metadataURL = tsVm.URL
 
 	aliases, err := GetHostAliases(ctx)
 	assert.NoError(t, err)
-	require.Len(t, aliases, 1)
-	assert.Equal(t, expected, aliases[0])
+	require.Len(t, aliases, 2)
+	assert.Equal(t, expectedNodeName, aliases[0])
+	assert.Equal(t, expectedVM, aliases[1])
 	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
 	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-04-02&format=text")
 }

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -27,6 +27,10 @@ func TestGetAlias(t *testing.T) {
 	responseIdx := 0
 	responses := []func(w http.ResponseWriter, r *http.Request){
 		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			io.WriteString(w, expectedVM)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			io.WriteString(w, fmt.Sprintf(`{
 				"name": "vm-name",
@@ -36,10 +40,6 @@ func TestGetAlias(t *testing.T) {
 				"osProfile": {"computerName":"%s"},
 				"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
 			}`, expectedNodeName))
-		},
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "text/plain")
-			io.WriteString(w, expectedVM)
 		},
 	}
 	var lastRequest *http.Request
@@ -55,10 +55,10 @@ func TestGetAlias(t *testing.T) {
 	aliases, err := GetHostAliases(ctx)
 	assert.NoError(t, err)
 	require.Len(t, aliases, 2)
-	assert.Equal(t, expectedNodeName, aliases[0])
-	assert.Equal(t, expectedVM, aliases[1])
-	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
-	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-04-02&format=text")
+	assert.Equal(t, expectedVM, aliases[0])
+	assert.Equal(t, expectedNodeName, aliases[1])
+	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute")
+	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2021-02-01")
 }
 
 func TestGetClusterName(t *testing.T) {

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -43,14 +43,14 @@ func TestGetAlias(t *testing.T) {
 		},
 	}
 	var lastRequest *http.Request
-	tsVm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		responses[responseIdx](w, r)
 		responseIdx++
 		lastRequest = r
 	}))
 
-	defer tsVm.Close()
-	metadataURL = tsVm.URL
+	defer ts.Close()
+	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(ctx)
 	assert.NoError(t, err)

--- a/releasenotes/notes/use-cloud-provided-hostname-aks-929bfb01e0e336e5.yaml
+++ b/releasenotes/notes/use-cloud-provided-hostname-aks-929bfb01e0e336e5.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Use cloud-provided hostname as default when running the agent
+    in AKS.

--- a/releasenotes/notes/use-cloud-provided-hostname-aks-929bfb01e0e336e5.yaml
+++ b/releasenotes/notes/use-cloud-provided-hostname-aks-929bfb01e0e336e5.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Use cloud-provided hostname as default when running the agent
+    Use cloud-provided hostname as default when running the Agent
     in AKS.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Detect when running in AKS and set the hostname to the node name.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The current default value for `azure_hostname_style` is `os`, which prevents us from using the cloud-provided hostname. This change detects when we are running in AKS and sets the hostname to the kubernetes node name. It also adds this node name as a host alias.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Deploy the agent to an AKS cluster
2. Exec into an agent pod; verify that the output of `agent hostname` is the same as the node name
3. Check that only one entry in the host list appears for your agent https://dddev.datadoghq.com/infrastructure