### PR TITLE
[PROCS-3946] Add local process collector for language detection

### DIFF
--- a/comp/core/workloadmeta/collectors/collectors.go
+++ b/comp/core/workloadmeta/collectors/collectors.go
@@ -22,7 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/process"
+	remoteprocesscollector "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -41,9 +42,10 @@ func GetCatalog() fx.Option {
 		kubelet.GetFxOptions(),
 		kubemetadata.GetFxOptions(),
 		podman.GetFxOptions(),
+		process.GetFxOptions(),
 		remoteworkloadmeta.GetFxOptions(),
 		remoteWorkloadmetaParams(),
-		processcollector.GetFxOptions(),
+		remoteprocesscollector.GetFxOptions(),
 		host.GetFxOptions(),
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package process implements the local process collector for
+// Workloadmeta.
+package process
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"go.uber.org/fx"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
+	processwlm "github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	collectorID   = "local-process-collector"
+	componentName = "workloadmeta-process"
+)
+
+type collector struct {
+	id      string
+	store   workloadmeta.Component
+	catalog workloadmeta.AgentType
+
+	processDiffCh <-chan *processwlm.ProcessCacheDiff
+}
+
+// NewCollector returns a new docker collector provider and an error
+func NewCollector() (workloadmeta.CollectorProvider, error) {
+	return workloadmeta.CollectorProvider{
+		Collector: &collector{
+			id:      collectorID,
+			catalog: workloadmeta.NodeAgent,
+		},
+	}, nil
+}
+
+// GetFxOptions returns the FX framework options for the collector
+func GetFxOptions() fx.Option {
+	return fx.Provide(NewCollector)
+}
+
+func (c *collector) Start(ctx context.Context, store workloadmeta.Component) error {
+	if !config.Datadog().GetBool("language_detection.enabled") || flavor.GetFlavor() != flavor.DefaultAgent {
+		return errors.NewDisabled(componentName, "core agent language detection not enabled")
+	}
+
+	c.store = store
+	c.processDiffCh = processwlm.GetSharedWorkloadMetaExtractor(config.SystemProbe).ProcessCacheDiff()
+
+	go c.stream(ctx)
+
+	return nil
+}
+
+func collectorEventsFromProcessDiff(diff *processwlm.ProcessCacheDiff) []workloadmeta.CollectorEvent {
+	events := make([]workloadmeta.CollectorEvent, 0, len(diff.Creation)+len(diff.Deletion))
+
+	for _, creation := range diff.Creation {
+		events = append(events, workloadmeta.CollectorEvent{
+			Type: workloadmeta.EventTypeSet,
+			Entity: &workloadmeta.Process{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindProcess,
+					ID:   strconv.Itoa(int(creation.Pid)),
+				},
+				ContainerID:  creation.ContainerId,
+				NsPid:        creation.NsPid,
+				CreationTime: time.UnixMilli(creation.CreationTime),
+				Language:     creation.Language,
+			},
+			Source: workloadmeta.SourceLocalProcessCollector,
+		})
+	}
+
+	for _, deletion := range diff.Deletion {
+		events = append(events, workloadmeta.CollectorEvent{
+			Type: workloadmeta.EventTypeUnset,
+			Entity: &workloadmeta.Process{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindProcess,
+					ID:   strconv.Itoa(int(deletion.Pid)),
+				},
+			},
+			Source: workloadmeta.SourceLocalProcessCollector,
+		})
+	}
+
+	return events
+}
+
+func (c *collector) stream(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	health := health.RegisterLiveness(componentName)
+	for {
+		select {
+		case <-health.C:
+
+		case diff := <-c.processDiffCh:
+			log.Debugf("Received process diff with %d creations and %d deletions", len(diff.Creation), len(diff.Deletion))
+			events := collectorEventsFromProcessDiff(diff)
+			c.store.Notify(events)
+
+		case <-ctx.Done():
+			err := health.Deregister()
+			if err != nil {
+				log.Warnf("error de-registering health check: %s", err)
+			}
+			cancel()
+			return
+		}
+	}
+}
+
+func (c *collector) Pull(_ context.Context) error {
+	return nil
+}
+
+func (c *collector) GetID() string {
+	return c.id
+}
+
+func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
+	return c.catalog
+}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package process implements the local process collector for
-// Workloadmeta.
+// Package process implements the local process collector for Workloadmeta.
 package process
 
 import (
@@ -72,7 +71,7 @@ func collectorEventsFromProcessDiff(diff *processwlm.ProcessCacheDiff) []workloa
 	return events
 }
 
-// NewCollector returns a new docker collector provider and an error
+// NewCollector returns a new local process collector provider and an error
 func NewCollector() (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
@@ -92,8 +91,8 @@ func (c *collector) enabled() bool {
 		return false
 	}
 
-	processChecksInCoreAgent := (config.Datadog().GetBool("process_config.process_collection.enabled") &&
-		config.Datadog().GetBool("process_config.run_in_core_agent.enabled"))
+	processChecksInCoreAgent := config.Datadog().GetBool("process_config.process_collection.enabled") &&
+		config.Datadog().GetBool("process_config.run_in_core_agent.enabled")
 	langDetectionEnabled := config.Datadog().GetBool("language_detection.enabled")
 
 	return langDetectionEnabled && processChecksInCoreAgent

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -79,7 +79,6 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 func (c *collector) stream(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	health := health.RegisterLiveness(componentName)
 	for {
 		select {
@@ -95,6 +94,7 @@ func (c *collector) stream(ctx context.Context) {
 			if err != nil {
 				log.Warnf("error de-registering health check: %s", err)
 			}
+			cancel()
 			return
 		}
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -135,34 +135,46 @@ func TestProcessCollector(t *testing.T) {
 
 func TestProcessCollectorStart(t *testing.T) {
 	tests := []struct {
-		name                 string
-		agentFlavor          string
-		langDetectionEnabled bool
-		expectedEnabled      bool
+		name                      string
+		agentFlavor               string
+		langDetectionEnabled      bool
+		processesRunInCoreEnabled bool
+		expectedEnabled           bool
 	}{
 		{
-			name:                 "core agent + config enabled",
-			agentFlavor:          flavor.DefaultAgent,
-			langDetectionEnabled: true,
-			expectedEnabled:      true,
+			name:                      "core agent + configs enabled",
+			agentFlavor:               flavor.DefaultAgent,
+			langDetectionEnabled:      true,
+			processesRunInCoreEnabled: true,
+			expectedEnabled:           true,
 		},
 		{
-			name:                 "core agent + config disabled",
-			agentFlavor:          flavor.DefaultAgent,
-			langDetectionEnabled: false,
-			expectedEnabled:      false,
+			name:                      "core agent + checks disabled + lang detection",
+			agentFlavor:               flavor.DefaultAgent,
+			langDetectionEnabled:      true,
+			processesRunInCoreEnabled: false,
+			expectedEnabled:           false,
 		},
 		{
-			name:                 "process agent + config enabled",
-			agentFlavor:          flavor.ProcessAgent,
-			langDetectionEnabled: true,
-			expectedEnabled:      false,
+			name:                      "core agent + configs disabled",
+			agentFlavor:               flavor.DefaultAgent,
+			langDetectionEnabled:      false,
+			processesRunInCoreEnabled: false,
+			expectedEnabled:           false,
 		},
 		{
-			name:                 "process agent + config disabled",
-			agentFlavor:          flavor.ProcessAgent,
-			langDetectionEnabled: false,
-			expectedEnabled:      false,
+			name:                      "process agent + configs enabled",
+			agentFlavor:               flavor.ProcessAgent,
+			langDetectionEnabled:      true,
+			processesRunInCoreEnabled: true,
+			expectedEnabled:           false,
+		},
+		{
+			name:                      "process agent + configs disabled",
+			agentFlavor:               flavor.ProcessAgent,
+			langDetectionEnabled:      false,
+			processesRunInCoreEnabled: false,
+			expectedEnabled:           false,
 		},
 	}
 
@@ -173,7 +185,9 @@ func TestProcessCollectorStart(t *testing.T) {
 			flavor.SetFlavor(test.agentFlavor)
 
 			configOverrides := map[string]interface{}{
-				"language_detection.enabled": test.langDetectionEnabled,
+				"language_detection.enabled":                test.langDetectionEnabled,
+				"process_config.process_collection.enabled": test.processesRunInCoreEnabled,
+				"process_config.run_in_core_agent.enabled":  test.processesRunInCoreEnabled,
 			}
 
 			mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+// Package process implements the local process collector for
+// Workloadmeta.
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	processwlm "github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestProcessCollector(t *testing.T) {
+	originalFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(originalFlavor)
+	flavor.SetFlavor(flavor.DefaultAgent)
+
+	configOverrides := map[string]interface{}{
+		"language_detection.enabled": true,
+	}
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Replace(config.MockParams{Overrides: configOverrides}),
+		fx.Supply(workloadmeta.Params{
+			AgentType: workloadmeta.NodeAgent,
+		}),
+		workloadmetafxmock.MockModuleV2(),
+	))
+
+	time.Sleep(time.Second)
+
+	processDiffCh := make(chan *processwlm.ProcessCacheDiff)
+	processCollector := &collector{
+		id:            collectorID,
+		catalog:       workloadmeta.NodeAgent,
+		processDiffCh: processDiffCh,
+		store:         mockStore,
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	go processCollector.stream(ctx)
+
+	creationTime := time.Now().Unix()
+	processDiffCh <- &processwlm.ProcessCacheDiff{
+		Creation: []*processwlm.ProcessEntity{
+			{
+				Pid:          1,
+				ContainerId:  "cid",
+				NsPid:        1,
+				CreationTime: creationTime,
+				Language:     &languagemodels.Language{Name: languagemodels.Java},
+			},
+		},
+	}
+
+	expectedProc1 := &workloadmeta.Process{
+		EntityID: workloadmeta.EntityID{
+			ID:   "1",
+			Kind: workloadmeta.KindProcess,
+		},
+		NsPid:        1,
+		ContainerID:  "cid",
+		CreationTime: time.UnixMilli(creationTime),
+		Language:     &languagemodels.Language{Name: languagemodels.Java},
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		proc, err := mockStore.GetProcess(1)
+		assert.NoError(c, err)
+		assert.Equal(c, expectedProc1, proc)
+	}, time.Second, time.Millisecond*100)
+
+	processDiffCh <- &processwlm.ProcessCacheDiff{
+		Creation: []*processwlm.ProcessEntity{
+			{
+				Pid:          2,
+				ContainerId:  "cid",
+				NsPid:        2,
+				CreationTime: creationTime,
+				Language:     &languagemodels.Language{Name: languagemodels.Python},
+			},
+		},
+		Deletion: []*processwlm.ProcessEntity{
+			{
+				Pid:          1,
+				ContainerId:  "cid",
+				NsPid:        1,
+				CreationTime: creationTime,
+				Language:     &languagemodels.Language{Name: languagemodels.Java},
+			},
+		},
+	}
+
+	expectedProc2 := &workloadmeta.Process{
+		EntityID: workloadmeta.EntityID{
+			ID:   "2",
+			Kind: workloadmeta.KindProcess,
+		},
+		NsPid:        2,
+		ContainerID:  "cid",
+		CreationTime: time.UnixMilli(creationTime),
+		Language:     &languagemodels.Language{Name: languagemodels.Python},
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		proc, err := mockStore.GetProcess(2)
+		assert.NoError(c, err)
+		assert.Equal(c, expectedProc2, proc)
+
+		_, err = mockStore.GetProcess(1)
+		assert.Error(c, err)
+	}, time.Second, time.Millisecond*100)
+
+	cancel()
+}
+
+func TestProcessCollectorStart(t *testing.T) {
+	tests := []struct {
+		name                 string
+		agentFlavor          string
+		langDetectionEnabled bool
+		expectedEnabled      bool
+	}{
+		{
+			name:                 "core agent + config enabled",
+			agentFlavor:          flavor.DefaultAgent,
+			langDetectionEnabled: true,
+			expectedEnabled:      true,
+		},
+		{
+			name:                 "core agent + config disabled",
+			agentFlavor:          flavor.DefaultAgent,
+			langDetectionEnabled: false,
+			expectedEnabled:      false,
+		},
+		{
+			name:                 "process agent + config enabled",
+			agentFlavor:          flavor.ProcessAgent,
+			langDetectionEnabled: true,
+			expectedEnabled:      false,
+		},
+		{
+			name:                 "process agent + config disabled",
+			agentFlavor:          flavor.ProcessAgent,
+			langDetectionEnabled: false,
+			expectedEnabled:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalFlavor := flavor.GetFlavor()
+			defer flavor.SetFlavor(originalFlavor)
+			flavor.SetFlavor(test.agentFlavor)
+
+			configOverrides := map[string]interface{}{
+				"language_detection.enabled": test.langDetectionEnabled,
+			}
+
+			mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				core.MockBundle(),
+				fx.Replace(config.MockParams{Overrides: configOverrides}),
+				fx.Supply(workloadmeta.Params{
+					AgentType: workloadmeta.NodeAgent,
+				}),
+				workloadmetafxmock.MockModuleV2(),
+			))
+
+			processCollector := &collector{
+				id:      collectorID,
+				catalog: workloadmeta.NodeAgent,
+			}
+
+			ctx, cancel := context.WithCancel(context.TODO())
+
+			err := processCollector.Start(ctx, mockStore)
+			enabled := err == nil
+			assert.Equal(t, test.expectedEnabled, enabled)
+
+			cancel()
+		})
+	}
+}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -57,6 +57,7 @@ func TestProcessCollector(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 	go processCollector.stream(ctx)
 
 	creationTime := time.Now().Unix()
@@ -129,8 +130,6 @@ func TestProcessCollector(t *testing.T) {
 		_, err = mockStore.GetProcess(1)
 		assert.Error(c, err)
 	}, time.Second, time.Millisecond*100)
-
-	cancel()
 }
 
 func TestProcessCollectorStart(t *testing.T) {
@@ -205,12 +204,11 @@ func TestProcessCollectorStart(t *testing.T) {
 			}
 
 			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
 
 			err := processCollector.Start(ctx, mockStore)
 			enabled := err == nil
 			assert.Equal(t, test.expectedEnabled, enabled)
-
-			cancel()
 		})
 	}
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -88,6 +88,10 @@ const (
 
 	// SourceHost represents entities detected by the host such as host tags.
 	SourceHost Source = "host"
+
+	// SourceLocalProcessCollector reprents processes entities detected
+	// by the LocalProcessCollector.
+	SourceLocalProcessCollector Source = "local_process_collector"
 )
 
 // ContainerRuntime is the container runtime used by a container.

--- a/pkg/process/metadata/workloadmeta/extractor.go
+++ b/pkg/process/metadata/workloadmeta/extractor.go
@@ -71,7 +71,7 @@ var (
 		subsystem, "diffs_dropped", "The number of diffs dropped due to channel contention")
 )
 
-// GetSharedContainerProvider returns a shared WorkloadMetaExtractor
+// GetSharedWorkloadMetaExtractor returns a shared WorkloadMetaExtractor
 func GetSharedWorkloadMetaExtractor(sysprobeConfig config.Reader) *WorkloadMetaExtractor {
 	initWorkloadMetaExtractor.Do(func() {
 		sharedWorkloadMetaExtractor = NewWorkloadMetaExtractor(sysprobeConfig)

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -107,8 +107,8 @@ func TestExtractor(t *testing.T) {
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
 			ContainerId:  ctrId1,
 		},
-	}, diff.creation)
-	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
+	}, diff.Creation)
+	assert.ElementsMatch(t, []*ProcessEntity{}, diff.Deletion)
 
 	// Assert that if no process is created or terminated, the cache is not updated nor a diff generated
 	extractor.Extract(map[int32]*procutil.Process{
@@ -156,7 +156,7 @@ func TestExtractor(t *testing.T) {
 
 	diff = <-extractor.ProcessCacheDiff()
 	assert.Equal(t, int32(2), diff.cacheVersion)
-	assert.ElementsMatch(t, []*ProcessEntity{}, diff.creation)
+	assert.ElementsMatch(t, []*ProcessEntity{}, diff.Creation)
 	assert.ElementsMatch(t, []*ProcessEntity{
 		{
 			Pid:          Pid1,
@@ -165,7 +165,7 @@ func TestExtractor(t *testing.T) {
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
 			ContainerId:  ctrId1,
 		},
-	}, diff.deletion)
+	}, diff.Deletion)
 
 	// Process creation generates a cache update and diff event
 	extractor.Extract(map[int32]*procutil.Process{
@@ -202,8 +202,8 @@ func TestExtractor(t *testing.T) {
 			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
 			ContainerId:  ctrId1,
 		},
-	}, diff.creation)
-	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
+	}, diff.Creation)
+	assert.ElementsMatch(t, []*ProcessEntity{}, diff.Deletion)
 
 	// Process creation and deletion generate a cache update and diff event
 	extractor.Extract(map[int32]*procutil.Process{
@@ -240,7 +240,7 @@ func TestExtractor(t *testing.T) {
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
 			ContainerId:  ctrId2,
 		},
-	}, diff.creation)
+	}, diff.Creation)
 	assert.ElementsMatch(t, []*ProcessEntity{
 		{
 			Pid:          Pid2,
@@ -249,7 +249,7 @@ func TestExtractor(t *testing.T) {
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
 			ContainerId:  ctrId1,
 		},
-	}, diff.deletion)
+	}, diff.Deletion)
 }
 
 func BenchmarkHashProcess(b *testing.B) {
@@ -286,7 +286,7 @@ func TestLateContainerId(t *testing.T) {
 	})
 	assert.EqualValues(t, &ProcessCacheDiff{
 		cacheVersion: 1,
-		creation: []*ProcessEntity{
+		Creation: []*ProcessEntity{
 			{
 				Pid:          proc1.Pid,
 				ContainerId:  "",
@@ -295,7 +295,7 @@ func TestLateContainerId(t *testing.T) {
 				Language:     &languagemodels.Language{Name: languagemodels.Java},
 			},
 		},
-		deletion: []*ProcessEntity{},
+		Deletion: []*ProcessEntity{},
 	}, <-extractor.ProcessCacheDiff())
 
 	var (
@@ -311,7 +311,7 @@ func TestLateContainerId(t *testing.T) {
 	})
 	assert.EqualValues(t, &ProcessCacheDiff{
 		cacheVersion: 2,
-		creation: []*ProcessEntity{
+		Creation: []*ProcessEntity{
 			{
 				Pid:          proc1.Pid,
 				ContainerId:  ctrId1,
@@ -320,6 +320,6 @@ func TestLateContainerId(t *testing.T) {
 				Language:     &languagemodels.Language{Name: languagemodels.Java},
 			},
 		},
-		deletion: []*ProcessEntity{},
+		Deletion: []*ProcessEntity{},
 	}, <-extractor.ProcessCacheDiff())
 }

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -71,13 +71,13 @@ func NewGRPCServer(config config.Reader, extractor *WorkloadMetaExtractor) *GRPC
 }
 
 func (l *GRPCServer) consumeProcessDiff(diff *ProcessCacheDiff) ([]*pbgo.ProcessEventSet, []*pbgo.ProcessEventUnset) {
-	setEvents := make([]*pbgo.ProcessEventSet, len(diff.creation))
-	for i, proc := range diff.creation {
+	setEvents := make([]*pbgo.ProcessEventSet, len(diff.Creation))
+	for i, proc := range diff.Creation {
 		setEvents[i] = processEntityToEventSet(proc)
 	}
 
-	unsetEvents := make([]*pbgo.ProcessEventUnset, len(diff.deletion))
-	for i, proc := range diff.deletion {
+	unsetEvents := make([]*pbgo.ProcessEventUnset, len(diff.Deletion))
+	for i, proc := range diff.Deletion {
 		unsetEvents[i] = &pbgo.ProcessEventUnset{Pid: proc.Pid}
 	}
 

--- a/releasenotes/notes/process-language-detection-core-edd5b24aa71e99ba.yaml
+++ b/releasenotes/notes/process-language-detection-core-edd5b24aa71e99ba.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Language detection can run on the core Agent without needing a gRPC server.
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a local process collector for WorkloadMeta to be used for language detection when the process checks are running in the core agent. The main benefit is reduced complexity as the gRPC server is no longer needed. It's worth noting that this collector will only work with the Process check enabled for now. However, this is meant to be an intermediary step and should only affect internal clusters. Ideally, we don't want language detection to be always be reliant on live processes. On Linux, once the check migration is complete, Language detection should be able to run in the core agent with or without the process check. Windows will still be reliant on the remote process collector as it requires elevated permissions for process collection that the Core Agent does not have.

### Motivation

PROCS-3946

### Additional Notes

e2e language detection tests will be updated as a follow up. Another additional piece of work is allowing this to work without live processes enabled on the core agent.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run process checks on the core agent and enabled language detection
```yaml
# datadog.yaml
process_config:
  process_collection:
    enabled: true
  run_in_core_agent:
    enabled: true
language_detection:
  enabled: true
```
Start a python process and verify language is detected with `local_process_collector` as the source.
```bash
$ echo -e 'import time\ntime.sleep(60)' > prog.py
$ nohup python3 prog.py >myscript.log 2>&1 </dev/null &
[1] 13093
$ sudo /opt/datadog-agent/bin/agent/agent workload-list
=== Entity process sources(merged):[local_process_collector] id: 13093 ===
----------- Entity ID -----------
PID: 13093
Namespace PID: 13093
Container ID:
Creation time: 2024-06-18 13:34:48 -0700 PDT
Language: python
===
```
