### PR TITLE
[windows] build script fixes

### DIFF
--- a/tasks/winbuildscripts/Generate-OCIPackage.ps1
+++ b/tasks/winbuildscripts/Generate-OCIPackage.ps1
@@ -1,4 +1,4 @@
-$omnibusOutput = "c:\buildroot\datadog-agent\omnibus\pkg\"
+$omnibusOutput = "$($Env:REPO_ROOT)\omnibus\pkg\"
 
 if (-not (Test-Path C:\tools\datadog-package.exe)) {
     Write-Host "Downloading datadog-package.exe"

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -12,9 +12,11 @@ if NOT DEFINED GO_VERSION_CHECK set GO_VERSION_CHECK=%~4
 set OMNIBUS_BUILD=omnibus.build
 set OMNIBUS_ARGS=--python-runtimes "%PY_RUNTIMES%"
 
+if "%OMNIBUS_TARGET%" == "" set OMNIBUS_TARGET=main
 if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--flavor iot
 if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_ARGS=--target-project dogstatsd
 if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --target-project agent-binaries
+
 if DEFINED GOMODCACHE set OMNIBUS_ARGS=%OMNIBUS_ARGS% --go-mod-cache %GOMODCACHE%
 if DEFINED USE_S3_CACHING set OMNIBUS_ARGS=%OMNIBUS_ARGS% %USE_S3_CACHING%
 


### PR DESCRIPTION
Fixes build script in two ways
- fixes hard coded location of ocipackage to correctly use existing variable to set build location

- fix environment check to build msi by default

https://datadoghq.atlassian.net/browse/WINA-858

