### PR TITLE
usm: http2: tests: Cut 7m from TestGRPCScenarios

### DIFF
--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -113,6 +113,10 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
 
+	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
+	if s.isTLS {
+		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid)
+	}
 	// c is a stream endpoint
 	// a + b are unary endpoints
 	tests := []struct {
@@ -421,7 +425,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 				if tt.expectedError {
 					t.Skip("Skipping test due to known issue")
 				}
-				s.testGRPCScenarios(t, srv.Process.Pid, tt.runClients, tt.expectedEndpoints, clientCount)
+				s.testGRPCScenarios(t, usmMonitor, tt.runClients, tt.expectedEndpoints, clientCount)
 			})
 		}
 	}
@@ -436,6 +440,11 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 	srv, cancel := grpc.NewGRPCTLSServer(t, srvAddr, s.isTLS)
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
+
+	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
+	if s.isTLS {
+		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid)
+	}
 
 	// Random string generation is an heavy operation, and it's proportional for the length (15MB)
 	// Instead of generating the same long string (long name) for every test, we're generating it only once.
@@ -509,18 +518,14 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 		for _, clientCount := range []int{1} {
 			testNameSuffix := fmt.Sprintf("-different clients - %v", clientCount)
 			t.Run(tt.name+testNameSuffix, func(t *testing.T) {
-				s.testGRPCScenarios(t, srv.Process.Pid, tt.runClients, tt.expectedEndpoints, clientCount)
+				s.testGRPCScenarios(t, usmMonitor, tt.runClients, tt.expectedEndpoints, clientCount)
 			})
 		}
 	}
 }
 
-func (s *usmGRPCSuite) testGRPCScenarios(t *testing.T, srvPID int, runClientCallback func(*testing.T, int), expectedEndpoints map[http.Key]captureRange, clientCount int) {
-	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
-	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", srvPID)
-	}
-
+func (s *usmGRPCSuite) testGRPCScenarios(t *testing.T, usmMonitor *Monitor, runClientCallback func(*testing.T, int), expectedEndpoints map[http.Key]captureRange, clientCount int) {
+	t.Cleanup(http2.CleanHTTP2Maps)
 	runClientCallback(t, clientCount)
 
 	res := make(map[http.Key]int)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The PR reuses the same USM instance, and just clears the http2 maps in between the runs, to have a clean state in the next test.

Cuts 7m from the tests. From each test we remove about ~2-3s of initialization and teardown of usm monitor.
TestSimpleGRPCScenarios runs for (CO-RE, Runtime compilation, prebuilt), each with TLS and without TLS (besdies prebuilt).
Each time we have 10 scenarios, each scenario runs for 1, 2 and 5 clients, so totally 150 tests which gives us about 6-7m of improvement.
The improvement for TestLargeBodiesGRPCScenarios is negligible, as it runs for CO-RE, RC and prebuilt, only without TLS, so we cut another 10s.


### Motivation

Faster CI for system-probe teams 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
