### PR TITLE
fix(installer): Few fixes for injector installation

### DIFF
--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -33,6 +33,14 @@ var PackagesList = []Package{
 	{Name: "datadog-agent", released: false, releasedWithRemoteUpdates: true},
 }
 
+var packageDependencies = map[string][]string{
+	"datadog-apm-library-java":   {"datadog-apm-inject"},
+	"datadog-apm-library-ruby":   {"datadog-apm-inject"},
+	"datadog-apm-library-js":     {"datadog-apm-inject"},
+	"datadog-apm-library-dotnet": {"datadog-apm-inject"},
+	"datadog-apm-library-python": {"datadog-apm-inject"},
+}
+
 // DefaultPackages resolves the default packages URLs to install based on the environment.
 func DefaultPackages(env *env.Env) []string {
 	return defaultPackages(env, PackagesList)

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -135,6 +135,18 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 		span.SetTag(ext.ResourceName, pkg.Name)
 		span.SetTag("package_version", pkg.Version)
 	}
+
+	for _, dependency := range packageDependencies[pkg.Name] {
+		installed, err := i.IsInstalled(ctx, dependency)
+		if err != nil {
+			return fmt.Errorf("could not check if required package %s is installed: %w", dependency, err)
+		}
+		if !installed {
+			// TODO: we should resolve the dependency version & install it instead
+			return fmt.Errorf("required package %s is not installed", dependency)
+		}
+	}
+
 	dbPkg, err := i.db.GetPackage(pkg.Name)
 	if err != nil && !errors.Is(err, db.ErrPackageNotFound) {
 		return fmt.Errorf("could not get package: %w", err)

--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -138,7 +138,7 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 		return err
 	}
 
-	// /var/log/datadog is created by default with datadog-installer install
+	// Create mandatory dirs
 	err = os.Mkdir("/var/log/datadog/dotnet", 0777)
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("error creating /var/log/datadog/dotnet: %w", err)
@@ -147,6 +147,10 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 	err = os.Chmod("/var/log/datadog/dotnet", 0777)
 	if err != nil {
 		return fmt.Errorf("error changing permissions on /var/log/datadog/dotnet: %w", err)
+	}
+	err = os.Mkdir("/etc/datadog-agent/inject", 0755)
+	if err != nil && !os.IsExist(err) {
+		return fmt.Errorf("error creating /etc/datadog-agent/inject: %w", err)
 	}
 
 	err = a.addInstrumentScripts(ctx)

--- a/pkg/fleet/installer/service/docker.go
+++ b/pkg/fleet/installer/service/docker.go
@@ -140,6 +140,12 @@ func (a *apmInjectorInstaller) deleteDockerConfigContent(_ context.Context, prev
 func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "verify_docker_runtime")
 	defer func() { span.Finish(tracer.WithError(err)) }()
+
+	if !isDockerActive(ctx) {
+		log.Warn("docker is inactive, skipping docker runtime verification")
+		return nil
+	}
+
 	for i := 0; i < 3; i++ {
 		if i > 0 {
 			time.Sleep(time.Second)
@@ -166,6 +172,10 @@ func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err err
 func reloadDockerConfig(ctx context.Context) (err error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "reload_docker")
 	defer func() { span.Finish(tracer.WithError(err)) }()
+	if !isDockerActive(ctx) {
+		log.Warn("docker is inactive, skipping docker reload")
+		return nil
+	}
 	return exec.CommandContext(ctx, "systemctl", "reload", "docker").Run()
 }
 
@@ -187,4 +197,20 @@ func isDockerInstalled(ctx context.Context) bool {
 		return false
 	}
 	return true
+}
+
+// isDockerActive checks if docker is active on the system
+func isDockerActive(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "docker")
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	err := cmd.Run()
+	if err != nil {
+		log.Warn("installer: failed to check if docker is active, assuming it isn't: ", err)
+		return false
+	}
+	if strings.TrimSpace(outb.String()) == "active" {
+		return true
+	}
+	return false
 }

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -50,6 +50,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	state.AssertFileExists("/etc/ld.so.preload", 0644, "root", "root")
 	state.AssertFileExists("/usr/bin/dd-host-install", 0755, "root", "root")
 	state.AssertFileExists("/usr/bin/dd-container-install", 0755, "root", "root")
+	state.AssertDirExists("/etc/datadog-agent/inject", 0755, "root", "root")
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath("/var/run/datadog-installer/apm.socket")
 	s.assertDockerdInstrumented(injectOCIPath)
@@ -406,7 +407,7 @@ func (s *packageApmInjectSuite) TestInstallDependencies() {
 	s.RunInstallScript()
 	defer s.Purge()
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-inject")
-	s.Env().RemoteHost.MustExecute("sudo datadog-installer install oci://datadoghq.com/datadog-apm-library-python:2.8.2-dev")
+	s.Env().RemoteHost.MustExecute("sudo datadog-installer install oci://gcr.io/datadoghq/apm-library-python-package:2.8.2-dev-1")
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
 }
 

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -402,6 +402,14 @@ func (s *packageApmInjectSuite) TestInstrumentDockerInactive() {
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
+func (s *packageApmInjectSuite) TestInstallDependencies() {
+	s.RunInstallScript()
+	defer s.Purge()
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-inject")
+	s.Env().RemoteHost.MustExecute("sudo datadog-installer install oci://datadoghq.com/datadog-apm-library-python:2.8.2-dev")
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
+}
+
 func (s *packageApmInjectSuite) assertTraceReceived(traceID uint64) {
 	found := assert.Eventually(s.T(), func() bool {
 		tracePayloads, err := s.Env().FakeIntake.Client().GetTraces()

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -412,7 +412,8 @@ func (s *packageApmInjectSuite) TestInstallDependencies() {
 	s.RunInstallScript()
 	defer s.Purge()
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-inject")
-	s.Env().RemoteHost.MustExecute("sudo datadog-installer install oci://gcr.io/datadoghq/apm-library-python-package:2.8.2-dev-1")
+	_, err := s.Env().RemoteHost.Execute("sudo datadog-installer install oci://gcr.io/datadoghq/apm-library-python-package:2.8.2-dev-1")
+	assert.Error(s.T(), err)
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
 }
 


### PR DESCRIPTION
### What does this PR do?
- Don't run Docker commands if docker is inactive
- Create `/etc/datadog-agent/inject` at injector installation
- Don't install tracer OCIs if the injector OCI isn't installed

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
