### PR TITLE
always reload systemd on update config

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -137,6 +137,9 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 	if err := addSystemDEnvOverrides(ctx, traceAgentExp); err != nil {
 		return err
 	}
+	if err := systemdReload(ctx); err != nil {
+		return err
+	}
 
 	// /var/log/datadog is created by default with datadog-installer install
 	err = os.Mkdir("/var/log/datadog/dotnet", 0777)

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -131,6 +131,20 @@ func (s *packageApmInjectSuite) TestInstrumentDefault() {
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
+func (s *packageApmInjectSuite) TestSystemdReload() {
+	s.host.InstallDocker()
+	err := s.RunInstallScriptWithError()
+	defer s.Purge()
+	assert.NoError(s.T(), err)
+
+	err = s.RunInstallScriptWithError("DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-apm-inject"), envForceInstall("datadog-apm-library-python"))
+	assert.NoError(s.T(), err)
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
+	s.assertLDPreloadInstrumented(injectOCIPath)
+	s.assertSocketPath("/var/run/datadog-installer/apm.socket")
+	s.assertDockerdInstrumented(injectOCIPath)
+}
+
 // TestUpgrade_InjectorDeb_To_InjectorOCI tests the upgrade from the DEB injector to the OCI injector.
 // Library package is OCI.
 func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {


### PR DESCRIPTION
Enforce a reload on updating systemd configs, the reload happened previously as the agent is installed with the install script.
