### PR TITLE
remove last internal usage of `xerrors`

### DIFF
--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -10,6 +10,8 @@ package trivy
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -27,7 +29,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
@@ -59,7 +60,7 @@ func (n familiarNamed) String() string {
 func imageWriter(client *containerd.Client, img containerd.Image) imageSave {
 	return func(ctx context.Context, ref []string) (io.ReadCloser, error) {
 		if len(ref) < 1 {
-			return nil, xerrors.New("no image reference")
+			return nil, errors.New("no image reference")
 		}
 		imgOpts := archive.WithImage(client.ImageService(), ref[0])
 		manifestOpts := archive.WithManifest(img.Target())
@@ -79,7 +80,7 @@ func convertContainerdImage(ctx context.Context, client *containerd.Client, imgM
 
 	f, err := os.CreateTemp("", "fanal-containerd-*")
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to create a temporary file: %w", err)
+		return nil, cleanup, fmt.Errorf("failed to create a temporary file: %w", err)
 	}
 
 	cleanup = func() {
@@ -89,7 +90,7 @@ func convertContainerdImage(ctx context.Context, client *containerd.Client, imgM
 
 	insp, history, ref, err := inspect(ctx, imgMeta, img)
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("inspect error: %w", err) // Note: the original code doesn't return "cleanup".
+		return nil, cleanup, fmt.Errorf("inspect error: %w", err) // Note: the original code doesn't return "cleanup".
 	}
 
 	return &image{

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -9,12 +9,12 @@ package trivy
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 
 	"github.com/docker/docker/client"
-	"golang.org/x/xerrors"
 )
 
 // DockerCollector defines the docker collector name
@@ -33,18 +33,18 @@ func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMe
 		imageID = imgMeta.ID // <image_id> pattern like `5ac716b05a9c`
 		inspect, _, err = client.ImageInspectWithRaw(ctx, imageID)
 		if err != nil {
-			return nil, cleanup, xerrors.Errorf("unable to inspect the image (%s): %w", imageID, err)
+			return nil, cleanup, fmt.Errorf("unable to inspect the image (%s): %w", imageID, err)
 		}
 	}
 
 	history, err := client.ImageHistory(ctx, imageID)
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("unable to get history (%s): %w", imageID, err)
+		return nil, cleanup, fmt.Errorf("unable to get history (%s): %w", imageID, err)
 	}
 
 	f, err := os.CreateTemp("", "fanal-docker-*")
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to create a temporary file")
+		return nil, cleanup, fmt.Errorf("failed to create a temporary file")
 	}
 
 	cleanup = func() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the last users of `xerrors` replacing them with stdlib `errors` or `fmt.Errorf` when applicable.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
