### PR TITLE
USM: protocols testutils: add helpers to generate PCAP and keylog for a test

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -61,6 +61,7 @@
   - scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
   - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
   - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
+  - ssh metal_instance "scp -r ${MICRO_VM_IP}:/tmp/test_pcaps /home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
   - !reference [.tag_kmt_ci_job]
 
 .upload_junit_kmt:
@@ -235,6 +236,7 @@
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'CI=true /root/fetch_dependencies.sh ${ARCH} && /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}"
     - ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml'"
+    - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}"
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -242,6 +244,7 @@
       - $DD_AGENT_TESTING_DIR/junit-$ARCH-$TAG-$TEST_SET.tar.gz
       - $DD_AGENT_TESTING_DIR/testjson-$ARCH-$TAG-$TEST_SET.tar.gz
       - $CI_PROJECT_DIR/logs
+      - $CI_PROJECT_DIR/pcaps
     reports:
       annotations:
         - $EXTERNAL_LINKS_PATH

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -62,6 +62,7 @@
   - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
   - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
   - ssh metal_instance "scp -r ${MICRO_VM_IP}:/tmp/test_pcaps /home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
+  - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}"
   - !reference [.tag_kmt_ci_job]
 
 .upload_junit_kmt:
@@ -236,7 +237,6 @@
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'CI=true /root/fetch_dependencies.sh ${ARCH} && /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}"
     - ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml'"
-    - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}"
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -62,7 +62,7 @@
   - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
   - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
   - ssh metal_instance "scp -r ${MICRO_VM_IP}:/tmp/test_pcaps /home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
-  - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}"
+  - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
   - !reference [.tag_kmt_ci_job]
 
 .upload_junit_kmt:

--- a/pkg/network/protocols/testutil/example_test.go
+++ b/pkg/network/protocols/testutil/example_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package testutil_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
+)
+
+func ExampleWithPCAP_plaintext() {
+	t := &testing.T{}
+
+	// Run tcpdump alongside the test and only save the resulting
+	// PCAP if the test failed. We don't need the keylog writer
+	// here so we discard it.
+	_ = testutil.WithPCAP(t, "80", testutil.GetShortTestName("HTTP", "simple request"), false)
+
+	client := &http.Client{}
+	client.Get("http://httpbin.org/status/200")
+}
+
+func ExampleWithPCAP_tls() {
+	t := &testing.T{}
+
+	// Run tcpdump alongside the test and always save the resulting PCAP.
+	klw := testutil.WithPCAP(t, "443", testutil.GetShortTestName("HTTP", "simple request - TLS"), true)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				KeyLogWriter:       klw,
+			},
+		},
+	}
+	client.Get("https://httpbin.org/status/200")
+}

--- a/pkg/network/protocols/testutil/example_test.go
+++ b/pkg/network/protocols/testutil/example_test.go
@@ -24,7 +24,14 @@ func ExampleWithPCAP_plaintext() {
 	_ = testutil.WithPCAP(t, "80", testutil.GetShortTestName("HTTP", "simple request"), false)
 
 	client := &http.Client{}
-	client.Get("http://httpbin.org/status/200")
+	resp, err := client.Get("http://httpbin.org/status/200")
+	if err != nil {
+		t.Errorf("error while making request")
+	}
+
+	if err = resp.Body.Close(); err != nil {
+		t.Errorf("error while closing request body")
+	}
 }
 
 func ExampleWithPCAP_tls() {
@@ -41,5 +48,12 @@ func ExampleWithPCAP_tls() {
 			},
 		},
 	}
-	client.Get("https://httpbin.org/status/200")
+	resp, err := client.Get("https://httpbin.org/status/200")
+	if err != nil {
+		t.Errorf("error while making request")
+	}
+
+	if err = resp.Body.Close(); err != nil {
+		t.Errorf("error while closing request body")
+	}
 }

--- a/pkg/network/protocols/testutil/pcaputils.go
+++ b/pkg/network/protocols/testutil/pcaputils.go
@@ -58,7 +58,7 @@ func WithPCAP(t *testing.T, port string, suffix string, alwaysSave bool) io.Writ
 	require.NoError(t, tcpdumpCmd.Start())
 
 	t.Cleanup(func() {
-		tcpdumpCmd.Process.Signal(os.Interrupt)
+		require.NoError(t, tcpdumpCmd.Process.Signal(os.Interrupt), "could not send signal to tcpdump")
 		out, err := io.ReadAll(stderr)
 		require.NoError(t, err, "could not read stderr")
 		require.NoError(t, tcpdumpCmd.Wait(), "error during tcpdump: "+string(out))
@@ -68,8 +68,8 @@ func WithPCAP(t *testing.T, port string, suffix string, alwaysSave bool) io.Writ
 			return
 		}
 
-		os.Rename(pcapTempPath, tmpDest+pcapFile)
-		os.Rename(klwTempPath, tmpDest+klwFile)
+		require.NoError(t, os.Rename(pcapTempPath, tmpDest+pcapFile))
+		require.NoError(t, os.Rename(klwTempPath, tmpDest+klwFile))
 	})
 
 	return klw

--- a/pkg/network/protocols/testutil/pcaputils.go
+++ b/pkg/network/protocols/testutil/pcaputils.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const tmpDest string = "/tmp/test_pcaps/"
+
+// GetShortTestName generates a suffix in the form
+// "<protocol>-<subtest name>" to be passed to WithPCAP.
+func GetShortTestName(proto, subtest string) string {
+	subtest = strings.ReplaceAll(subtest, " ", "_")
+	return fmt.Sprintf("%s-%s", proto, subtest)
+}
+
+// WithPCAP runs tcpdump for the duration of the test.
+//
+// It returns an `io.Writer` to be used as a KeyLogWriter in
+// tls.Config to be able, to decrypt the TLS traffic in the resulting
+// PCAP. The resulting PCAPs and keylog files will be saved in
+// `/tmp/test_pcaps`
+//
+// Unless alwaysSave is true, WithPCAP will only save the resulting
+// PCAP if the test fails.
+func WithPCAP(t *testing.T, port string, suffix string, alwaysSave bool) io.Writer {
+	t.Helper()
+
+	// Ensure destination directory exists
+	if _, err := os.Stat(tmpDest); os.IsNotExist(err) {
+		require.NoError(t, os.Mkdir(tmpDest, 0755))
+	} else {
+		require.NoError(t, err)
+	}
+
+	pcapFile := fmt.Sprintf("test-%s.pcap", suffix)
+	pcapTempPath := fmt.Sprintf("%s/%s", t.TempDir(), pcapFile)
+
+	klwFile := fmt.Sprintf("test-%s.keylog", suffix)
+	klwTempPath := fmt.Sprintf("%s/%s", t.TempDir(), klwFile)
+	klw, err := os.Create(klwTempPath)
+	require.NoError(t, err, "could not create keylog writer")
+
+	tcpdumpCmd := exec.Command("tcpdump", "-i", "any", "-w", pcapTempPath, "port", port)
+	stderr, err := tcpdumpCmd.StderrPipe()
+	require.NoError(t, err, "could not get tcpdump stderr pipe")
+	require.NoError(t, tcpdumpCmd.Start())
+
+	t.Cleanup(func() {
+		tcpdumpCmd.Process.Signal(os.Interrupt)
+		out, err := io.ReadAll(stderr)
+		require.NoError(t, err, "could not read stderr")
+		require.NoError(t, tcpdumpCmd.Wait(), "error during tcpdump: "+string(out))
+		klw.Close()
+
+		if !alwaysSave && !t.Failed() {
+			return
+		}
+
+		os.Rename(pcapTempPath, tmpDest+pcapFile)
+		os.Rename(klwTempPath, tmpDest+klwFile)
+	})
+
+	return klw
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a test helper that can be used in tests to generate a PCAP and keylog file for a test.
The resulting PCAPs gets stored in `/tmp/test_pcaps`. Unless configured otherwise, the PCAP will only be saved on test failures, to not create unnecessary PCAPs.

Additionally, this PR makes the KMT tests publish those PCAPs as jobs artifacts to allows us to better debug CI failures.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Help us investigate tests failures.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
