### PR TITLE
Remove unnecessary `WithDevMode` options in e2e tests

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -41,6 +41,7 @@
 //
 // Note: By default, the BaseSuite test suite will delete the environment when the test suite finishes (whether it's successful or not).
 // During development, it's highly recommended to use the [params.WithDevMode] option to prevent the environment from being deleted.
+// [params.WithDevMode] is automatically enabled when the `E2E_DEV_MODE` environment variable is set to `true`.
 //
 // # Organizing your tests
 //

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
@@ -8,8 +8,6 @@ package linuxfiletailing
 import (
 	_ "embed"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,12 +36,8 @@ const (
 
 // TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
 func TestE2EVMFakeintakeSuite(t *testing.T) {
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs(), agentparams.WithIntegration("custom_logs.d", logConfig)))),
-	}
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &LinuxFakeintakeSuite{}, options...)

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/multi_line_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/multi_line_test.go
@@ -8,8 +8,6 @@ package linuxfiletailing
 import (
 	_ "embed"
 	"fmt"
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -41,12 +39,8 @@ type MultiLineSuite struct {
 
 func TestMultiLineSuite(t *testing.T) {
 	s := &MultiLineSuite{}
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs()))),
-	}
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, s, options...)

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/utf_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/file-tailing/utf_test.go
@@ -8,8 +8,6 @@ package linuxfiletailing
 import (
 	_ "embed"
 	"fmt"
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -37,12 +35,8 @@ type UtfSuite struct {
 // TestUtfSuite runs the E2E test suite for tailing UTF encoded logs
 func TestUtfSuite(t *testing.T) {
 	s := &UtfSuite{}
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs(), agentparams.WithIntegration("custom_logs.d", logConfig)))),
-	}
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, s, options...)

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -8,8 +8,6 @@ package journaldlog
 import (
 	_ "embed"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -46,15 +44,11 @@ var randomLogger []byte
 
 // TestE2EVMFakeintakeSuite returns the stack definition required for the log agent test suite.
 func TestE2EVMFakeintakeSuite(t *testing.T) {
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(
 			awshost.WithAgentOptions(
 				agentparams.WithLogs(),
 				agentparams.WithIntegration("custom_logs.d", string(logBasicConfig))))),
-	}
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &LinuxJournaldFakeintakeSuite{}, options...)

--- a/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metric-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
@@ -8,8 +8,6 @@ package windowsfiletailing
 import (
 	_ "embed"
 	"fmt"
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -41,7 +39,6 @@ const (
 // TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
 func TestE2EVMFakeintakeSuite(t *testing.T) {
 	s := &WindowsFakeintakeSuite{}
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(
 			awshost.WithEC2InstanceOptions(ec2.WithOS(testos.WindowsDefault)),
@@ -50,9 +47,6 @@ func TestE2EVMFakeintakeSuite(t *testing.T) {
 				agentparams.WithIntegration("custom_logs.d", logConfig)))),
 	}
 
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
-	}
 	e2e.Run(t, s, options...)
 }
 

--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -10,8 +10,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,11 +37,6 @@ func TestLanguageDetectionSuite(t *testing.T) {
 
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentParams...))),
-	}
-
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &languageDetectionSuite{}, options...)

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -6,8 +6,6 @@
 package process
 
 import (
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -43,11 +41,6 @@ func TestDockerTestSuite(t *testing.T) {
 		e2e.WithProvisioner(awsdocker.Provisioner(
 			awsdocker.WithAgentOptions(agentOpts...),
 		)),
-	}
-
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &dockerTestSuite{}, options...)

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -6,8 +6,6 @@
 package process
 
 import (
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -32,11 +30,6 @@ func TestLinuxTestSuite(t *testing.T) {
 
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentParams...))),
-	}
-
-	devModeEnv, _ := os.LookupEnv("E2E_DEVMODE")
-	if devMode, err := strconv.ParseBool(devModeEnv); err == nil && devMode {
-		options = append(options, e2e.WithDevMode())
 	}
 
 	e2e.Run(t, &linuxTestSuite{}, options...)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Remove unnecessary `WithDevMode` options in e2e tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- The dev mode is automatically enabled when the `E2E_DEV_MODE` env variable is set. This is done [here](https://github.com/DataDog/datadog-agent/blob/c34f600da55e13b623267492b133544d33146a8d/test/new-e2e/pkg/e2e/suite.go#L536-L541)
- `E2E_DEVMODE` is wrong. see [this](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/pkg/runner/parameters/const.go#L51) and [this](https://github.com/DataDog/datadog-agent/blob/947baadb538eadc4a99a9c5f08e9237612aeccf7/test/new-e2e/pkg/runner/parameters/store_env.go#L30-L40)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
