### PR TITLE
[CONTP-268] fix collector typo in ad controll test

### DIFF
--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -68,7 +68,7 @@ func TestController(t *testing.T) {
 	// all configs are scheduled once and only once
 	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
 		s1.mutex.Lock()
-		assert.ElementsMatch(t, []event{{true, "one"}, {true, "two"}}, s1.events)
+		assert.ElementsMatch(c, []event{{true, "one"}, {true, "two"}}, s1.events)
 		s1.mutex.Unlock()
 	}, 2*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
 	assert.Neverf(t, func() bool {
@@ -112,7 +112,7 @@ func TestController(t *testing.T) {
 
 	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
 		s2.mutex.Lock()
-		assert.ElementsMatch(t, []event{{false, "two"}}, s2.events)
+		assert.ElementsMatch(c, []event{{false, "two"}}, s2.events)
 		s2.mutex.Unlock()
 	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
 	s2.reset()

--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -70,7 +70,7 @@ func TestController(t *testing.T) {
 		s1.mutex.Lock()
 		assert.ElementsMatch(c, []event{{true, "one"}, {true, "two"}}, s1.events)
 		s1.mutex.Unlock()
-	}, 2*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
+	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
 	assert.Neverf(t, func() bool {
 		s1.mutex.Lock()
 		defer s1.mutex.Unlock()
@@ -87,7 +87,7 @@ func TestController(t *testing.T) {
 		s1.mutex.Lock()
 		assert.ElementsMatch(c, []event{{false, "one"}, {true, "three"}}, s1.events)
 		s1.mutex.Unlock()
-	}, 2*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
+	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
 	s1.reset()
 
 	// subscribe a new scheduler and see that it does not get c1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
[CONTP-268](https://datadoghq.atlassian.net/browse/CONTP-268)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Assert function inside EventuallyWithTf should use provided CollectT c instead of main thread t *testing.T. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Fixing broken CI unit test

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[CONTP-268]: https://datadoghq.atlassian.net/browse/CONTP-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ