### PR TITLE
[CWS] fix fake event constructor when computing approvers

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -481,8 +481,10 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 	var ruleSet *rules.RuleSet
 	if args.windowsModel {
 		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
+		ruleSet.SetFakeEventCtor(newFakeWindowsEvent)
 	} else {
 		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+		ruleSet.SetFakeEventCtor(newFakeEvent)
 	}
 	evaluationSet, err := rules.NewEvaluationSet([]*rules.RuleSet{ruleSet})
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that approvers are computed on the expected fake events, and not the one with eBPF field handlers. This fixes a bug introduced in https://github.com/DataDog/datadog-agent/pull/26356. The callback set method is used to provide the fake windows model when validating windows policies on linux using the CLI.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
