### PR TITLE
Fix panics due to Lock Contention Collector

### DIFF
--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -288,10 +288,6 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 	if l.initialized {
 		return nil
 	}
-	defer func() {
-		log.Infof("lock contention collector initialized")
-		l.initialized = true
-	}()
 
 	l.trackedLockMemRanges = make(map[LockRange]*mapStats)
 	maps := make(map[uint32]*targetMap)
@@ -470,6 +466,9 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 	// initialize buffers used in Collect
 	l.lockRanges = make([]LockRange, l.ranges)
 	l.contention = make([]ContentionData, l.ranges)
+
+	log.Infof("lock contention collector initialized")
+	l.initialized = true
 
 	return nil
 }

--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -426,7 +426,7 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 	}
 
 	if uint32(count) < ranges && !staticRanges {
-		return fmt.Errorf("discovered fewer ranges than expected: %d < %d", count, ranges)
+		log.Warnf("discovered fewer ranges than expected: %d < %d", count, ranges)
 	}
 
 	for i, id := range mapids {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes panics due to the lock contention collector. The collector was falsely setting the boolean `initialized` on an error path, causing panics in the `Collect` function.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
