### PR TITLE
[CWS] fix defunct sleep process after `TestTCFilters`

### DIFF
--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -181,8 +181,11 @@ func TestTCFilters(t *testing.T) {
 
 	var newNetNSSleep *exec.Cmd
 	defer func() {
-		if newNetNSSleep != nil && newNetNSSleep.Process != nil {
-			_ = newNetNSSleep.Process.Kill()
+		if newNetNSSleep != nil {
+			if newNetNSSleep.Process != nil {
+				_ = newNetNSSleep.Process.Kill()
+			}
+			_ = newNetNSSleep.Wait()
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

`newNetNSSleep` was correctly killed to skip the sleep duration but not `Wait` which created a defunct process. This can cause issues in some OS that are a bit more strict with defunct processes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
