### PR TITLE
[EBPF] Fix deletion of KMT stacks without vmconfig.json file

### DIFF
--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -330,7 +330,7 @@ def destroy_stack_force(ctx: Context, stack: str):
     stack_dir = os.path.join(get_kmt_os().stacks_dir, stack)
     vm_config = os.path.join(stack_dir, VMCONFIG)
 
-    if local_vms_in_config(vm_config):
+    if os.path.exists(vm_config) and local_vms_in_config(vm_config):
         if libvirt is None:
             raise NoLibvirt()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes a bug where stacks without a `vmconfig.json` file (e.g., those that were created but without a config generated) could not be deleted.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
