### PR TITLE
[EBPF] Fix generation of embedded BTF archive in KMT VMs

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -586,9 +586,6 @@ def kmt_secagent_prepare(
     ctx.run(f"ninja -d explain -v -f {nf_path}")
 
 
-btf_dir = "/opt/system-probe-tests/pkg/ebpf/bytecode/build/co-re/btf"
-
-
 @task
 def prepare(
     ctx: Context,
@@ -707,6 +704,7 @@ def prepare(
         d.copy(ctx, paths.arch_dir / "opt/*", "/opt/", exclude="*.ninja", verbose=verbose)
 
         # Copy BTF files
+        btf_dir = Path(f"/opt/{component}-tests") / get_ebpf_build_dir(arch_obj) / "co-re/btf"
         d.run_cmd(
             ctx,
             f"[ -f /sys/kernel/btf/vmlinux ] \


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes the path where the `minimized-btfs.tar.xz` file is located when using KMT.

### Motivation

Fix a bug introduced by https://github.com/DataDog/datadog-agent/pull/25592 where the path to the BTF file was not updated properly in the KMT python code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
