### PR TITLE
[EBPF] Fix test-json-review failing in local KMT jobs

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1059,6 +1059,7 @@ def test(
             target_folder.mkdir(parents=True, exist_ok=True)
             d.download(ctx, "/ci-visibility/junit/", target_folder)
 
+    info("[+] All domains finished, showing summary table of test results")
     show_last_test_results(ctx, stack)
 
 

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -88,7 +87,7 @@ func reviewTests(jsonFile string, flakyFile string) (*reviewOutput, error) {
 	}
 	defer jf.Close()
 
-	var ff *os.File
+	var ff io.ReadCloser
 	if flakyFile != "" {
 		ff, err = os.Open(flakyFile)
 		if err != nil {
@@ -103,7 +102,7 @@ func reviewTestsReaders(jf io.Reader, ff io.Reader) (*reviewOutput, error) {
 	var failedTests, flakyTests, rerunTests strings.Builder
 	var kf *flake.KnownFlakyTests
 	var err error
-	if ff != nil && !reflect.ValueOf(ff).IsNil() {
+	if ff != nil {
 		kf, err = flake.Parse(ff)
 		if err != nil {
 			return nil, fmt.Errorf("parse flakes.yaml: %s", err)

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -102,7 +103,7 @@ func reviewTestsReaders(jf io.Reader, ff io.Reader) (*reviewOutput, error) {
 	var failedTests, flakyTests, rerunTests strings.Builder
 	var kf *flake.KnownFlakyTests
 	var err error
-	if ff != nil {
+	if ff != nil && !reflect.ValueOf(ff).IsNil() {
 		kf, err = flake.Parse(ff)
 		if err != nil {
 			return nil, fmt.Errorf("parse flakes.yaml: %s", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix a `nil` check on `test-json-review` that was causing it to try to read the flakes file even when it wasn't provided.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
