### PR TITLE
usm: kafka: Cut 5m from kafka tests

### DIFF
--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -31,6 +31,7 @@ type protocol struct {
 	statkeeper         *StatKeeper
 	inFlightMapCleaner *ddebpf.MapCleaner[KafkaTransactionKey, KafkaTransaction]
 	eventsConsumer     *events.Consumer[EbpfTx]
+	mgr                *manager.Manager
 
 	kernelTelemetry            *kernelTelemetry
 	kernelTelemetryStopChannel chan struct{}
@@ -226,6 +227,7 @@ func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 
 // PreStart creates the kafka events consumer and starts it.
 func (p *protocol) PreStart(mgr *manager.Manager) error {
+	p.mgr = mgr
 	var err error
 	p.eventsConsumer, err = events.NewConsumer(
 		eventStreamName,

--- a/pkg/network/protocols/kafka/testutils.go
+++ b/pkg/network/protocols/kafka/testutils.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package kafka
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+var (
+	mapTypesToZero = map[ebpf.MapType]struct{}{
+		ebpf.PerCPUArray: {},
+		ebpf.Array:       {},
+		ebpf.PerCPUHash:  {},
+	}
+)
+
+// CleanKafkaMaps deletes all entries from the kafka maps. Test utility to allow reusing USM instance without caring
+// over previous data.
+func CleanKafkaMaps(t *testing.T) {
+	if Spec.Instance == nil {
+		t.Log("kafka protocol not initialized")
+		return
+	}
+
+	m := Spec.Instance.(*protocol).mgr
+	if m == nil {
+		t.Log("kafka manager not initialized")
+		return
+	}
+
+	// Getting all maps loaded into the manager
+	maps, err := m.GetMaps()
+	if err != nil {
+		t.Logf("failed to get maps: %v", err)
+		return
+	}
+	for mapName, mapInstance := range maps {
+		// We only want to clean kafka maps
+		if !strings.Contains(mapName, "kafka") {
+			continue
+		}
+		// Special case for batches, as the values is never "empty", but contain the CPU number.
+		if strings.HasSuffix(mapName, "kafka_batches") {
+			continue
+		}
+		_, shouldOnlyZero := mapTypesToZero[mapInstance.Type()]
+
+		key := make([]byte, mapInstance.KeySize())
+		value := make([]byte, mapInstance.ValueSize())
+		mapEntries := mapInstance.Iterate()
+		var keys [][]byte
+		for mapEntries.Next(&key, &value) {
+			keys = append(keys, key)
+		}
+
+		if shouldOnlyZero {
+			emptyValue := make([]byte, mapInstance.ValueSize())
+			for _, key := range keys {
+				if err := mapInstance.Put(&key, &emptyValue); err != nil {
+					t.Log("failed zeroing map entry; error: ", err)
+				}
+			}
+		} else {
+			for _, key := range keys {
+				if err := mapInstance.Delete(&key); err != nil {
+					t.Log("failed deleting map entry; error: ", err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	nethttp "net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,10 +75,6 @@ type kafkaParsingTestAttributes struct {
 	context testContext
 	// The test body
 	testBody func(t *testing.T, ctx *testContext, monitor *Monitor)
-	// Cleaning test resources if needed.
-	teardown func(t *testing.T, ctx testContext)
-	// Configuration for the monitor object
-	configuration func() *config.Config
 }
 
 type kafkaParsingValidation struct {
@@ -158,14 +153,11 @@ func (s *KafkaProtocolParsingSuite) TestKafkaProtocolParsing() {
 }
 
 func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls bool, version *kversion.Versions) {
-	targetHost := "127.0.0.1"
-	serverHost := "127.0.0.1"
-
-	kafkaTeardown := func(t *testing.T, ctx testContext) {
-		for _, client := range ctx.clients {
-			client.Client.Close()
-		}
-	}
+	const (
+		targetHost = "127.0.0.1"
+		serverHost = "127.0.0.1"
+		unixPath   = "/tmp/transparent.sock"
+	)
 
 	port := kafkaPort
 	if tls {
@@ -174,8 +166,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 
 	serverAddress := net.JoinHostPort(serverHost, port)
 	targetAddress := net.JoinHostPort(targetHost, port)
-
-	const unixPath = "/tmp/transparent.sock"
 
 	dialFn := func(ctx context.Context, network, address string) (net.Conn, error) {
 		var d net.Dialer
@@ -191,10 +181,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 		}
 
 		return count * 2
-	}
-
-	getConfig := func() *config.Config {
-		return getDefaultTestConfiguration(tls)
 	}
 
 	tmp, found := version.LookupMaxKeyVersion(kafka.FetchAPIKey)
@@ -252,8 +238,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					tlsEnabled:                      tls,
 				})
 			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
 		},
 		{
 			name: "TestProduceClientIdEmptyString",
@@ -292,8 +276,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					tlsEnabled:                      tls,
 				})
 			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
 		},
 		{
 			name: "TestManyProduceRequests",
@@ -334,138 +316,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					expectedAPIVersionFetch:         0,
 					tlsEnabled:                      tls,
 				})
-			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
-		},
-		{
-			name: "TestHTTPAndKafka",
-			context: testContext{
-				serverPort:    kafkaPort,
-				targetAddress: targetAddress,
-				serverAddress: serverAddress,
-				extras: map[string]interface{}{
-					"topic_name": s.getTopicName(),
-				},
-			},
-			testBody: func(t *testing.T, ctx *testContext, monitor *Monitor) {
-				topicName := ctx.extras["topic_name"].(string)
-				client, err := kafka.NewClient(kafka.Options{
-					ServerAddress: ctx.targetAddress,
-					DialFn:        dialFn,
-					CustomOptions: []kgo.Opt{
-						kgo.MaxVersions(version),
-						kgo.ClientID(""),
-					},
-				})
-				require.NoError(t, err)
-				ctx.clients = append(ctx.clients, client)
-				require.NoError(t, client.CreateTopic(topicName))
-
-				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
-				ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				require.NoError(t, client.Client.ProduceSync(ctxTimeout, record).FirstErr(), "record had a produce error while synchronously producing")
-				cancel()
-
-				serverAddr := "localhost:8081"
-				srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{})
-				t.Cleanup(srvDoneFn)
-				httpClient := nethttp.Client{}
-
-				req, err := nethttp.NewRequest(httpMethods[0], fmt.Sprintf("http://%s/%d/request", serverAddr, nethttp.StatusOK), nil)
-				require.NoError(t, err)
-
-				httpRequestCount := 10
-				for i := 0; i < httpRequestCount; i++ {
-					resp, err := httpClient.Do(req)
-					require.NoError(t, err)
-					// Have to read the response body to ensure the client will be able to properly close the connection.
-					io.Copy(io.Discard, resp.Body)
-					resp.Body.Close()
-				}
-				srvDoneFn()
-
-				httpOccurrences := 0
-				expectedKafkaRequestCount := fixCount(1)
-				kafkaStats := make(map[kafka.Key]*kafka.RequestStat)
-				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					allStats := monitor.GetProtocolStats()
-					require.NotNil(t, allStats)
-
-					httpStats, ok := allStats[protocols.HTTP]
-					if ok {
-						httpOccurrences += countRequestOccurrences(httpStats.(map[http.Key]*http.RequestStats), req)
-					}
-
-					kafkaProtocolStats, ok := allStats[protocols.Kafka]
-					// We might not have kafka stats, and it might be the expected case (to capture 0).
-					if ok {
-						currentStats := kafkaProtocolStats.(map[kafka.Key]*kafka.RequestStat)
-						for key, stats := range currentStats {
-							prevStats, ok := kafkaStats[key]
-							if ok && prevStats != nil {
-								prevStats.CombineWith(stats)
-							} else {
-								kafkaStats[key] = currentStats[key]
-							}
-						}
-					}
-					assert.Equal(collect, expectedKafkaRequestCount, len(kafkaStats), "Unexpected number of Kafka requests")
-					assert.Equal(collect, httpRequestCount, httpOccurrences, "Unexpected number of HTTP requests")
-					validateProduceFetchCount(collect, kafkaStats, topicName,
-						kafkaParsingValidation{
-							expectedNumberOfProduceRequests: fixCount(1),
-							expectedNumberOfFetchRequests:   0,
-							expectedAPIVersionProduce:       8,
-							expectedAPIVersionFetch:         0,
-							tlsEnabled:                      tls,
-						})
-				}, time.Second*3, time.Millisecond*100)
-			},
-			teardown: kafkaTeardown,
-			configuration: func() *config.Config {
-				cfg := getConfig()
-				cfg.EnableHTTPMonitoring = true
-				return cfg
-			},
-		},
-		{
-			name: "TestEnableHTTPOnly",
-			context: testContext{
-				serverPort:    kafkaPort,
-				targetAddress: targetAddress,
-				serverAddress: serverAddress,
-				extras: map[string]interface{}{
-					"topic_name": s.getTopicName(),
-				},
-			},
-			testBody: func(t *testing.T, ctx *testContext, monitor *Monitor) {
-				topicName := ctx.extras["topic_name"].(string)
-				client, err := kafka.NewClient(kafka.Options{
-					ServerAddress: ctx.targetAddress,
-					DialFn:        dialFn,
-					CustomOptions: []kgo.Opt{
-						kgo.MaxVersions(version),
-						kgo.ClientID(""),
-					},
-				})
-				require.NoError(t, err)
-				ctx.clients = append(ctx.clients, client)
-				require.NoError(t, client.CreateTopic(topicName))
-
-				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
-				ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				require.NoError(t, client.Client.ProduceSync(ctxTimeout, record).FirstErr(), "record had a produce error while synchronously producing")
-				cancel()
-
-				getAndValidateKafkaStats(t, monitor, 0, "", kafkaParsingValidation{tlsEnabled: tls})
-			},
-			teardown: kafkaTeardown,
-			configuration: func() *config.Config {
-				cfg := config.New()
-				cfg.EnableHTTPMonitoring = true
-				cfg.MaxTrackedConnections = 1000
-				return cfg
 			},
 		},
 		{
@@ -517,8 +367,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					tlsEnabled:                      tls,
 				})
 			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
 		},
 		{
 			name: "Multiple records with and without batching",
@@ -584,8 +432,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					tlsEnabled:                      tls,
 				})
 			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
 		},
 		{
 			name: "Kafka Kernel Telemetry",
@@ -663,8 +509,6 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 					})
 				}
 			},
-			teardown:      kafkaTeardown,
-			configuration: getConfig,
 		},
 	}
 
@@ -672,18 +516,20 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
+	cfg := getDefaultTestConfiguration(tls)
+	monitor := newKafkaMonitor(t, cfg)
+	if tls && cfg.EnableGoTLSSupport {
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.teardown != nil {
-				t.Cleanup(func() {
-					tt.teardown(t, tt.context)
-				})
-			}
-			cfg := tt.configuration()
-			monitor := newKafkaMonitor(t, cfg)
-			if tls && cfg.EnableGoTLSSupport {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid)
-			}
+			t.Cleanup(func() {
+				for _, client := range tt.context.clients {
+					client.Client.Close()
+				}
+				kafka.CleanKafkaMaps(t)
+			})
+
 			tt.testBody(t, &tt.context, monitor)
 		})
 	}

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -1255,8 +1255,8 @@ func testKafkaFetchRaw(t *testing.T, tls bool, apiVersion int) {
 	}
 }
 
-func TestKafkaFetchRaw(t *testing.T) {
-	skipTestIfKernelNotSupported(t)
+func (s *KafkaProtocolParsingSuite) TestKafkaFetchRaw() {
+	t := s.T()
 	versions := []int{4, 5, 7, 11, 12}
 
 	t.Run("without TLS", func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

* Runs KafkaFetchRawTests on all build modes
* Improves runtime of KafkaFetchRawTests, from 5m for a single build mode, to 2m for all buildmodes
* Improves runtime of KafkaProtocolParsing to 50s from 2m50s
* Removes redundant use-cases in KafkaProtocolParsing (Enabling http)
* Removed redundant fields in the test structure

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Faster CI and removing redundancy in the tests

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
