### PR TITLE
Remove team/triage and triage milestone from external contributor pr workflow

### DIFF
--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -27,7 +27,7 @@ jobs:
         run: pip install -r requirements.txt -r tasks/requirements.txt
       - name: Set label on external contributor PRs
         run: |
-          gh issue edit "$NUMBER" --milestone "$MILESTONE"
+          gh issue edit "$NUMBER"
           inv -e github.handle-community-pr --repo="$GH_REPO" --pr-id="$NUMBER" --labels="$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,5 +36,4 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
           # labels is a comma-separated list of tags
-          LABELS: community,team/triage
-          MILESTONE: Triage
+          LABELS: community


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove the triage team label and triage milestone from the external contributor PR workflow.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Team labels and milestones are now automatically set by other workflows, so we don't need to add the triage ones.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
