### PR TITLE
[CI] Fix the `get_distro` function for CentOS

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -118,7 +118,7 @@ def get_distro():
         with open('/etc/os-release', encoding="utf-8") as f:
             for line in f:
                 if line.startswith('ID='):
-                    system = line.strip()[3:]
+                    system = line.strip()[3:].replace('"', '')
                     break
     return f"{system}_{arch}".lower()
 

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -118,7 +118,7 @@ def get_distro():
         with open('/etc/os-release', encoding="utf-8") as f:
             for line in f:
                 if line.startswith('ID='):
-                    system = line.strip()[3:].replace('"', '')
+                    system = line.strip().removeprefix('ID=').replace('"', '')
                     break
     return f"{system}_{arch}".lower()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes the `get_distro` util function on CentOS.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In Python `get_distro()` returned `'"centos"_x86_64'` on CentOS and 'ubuntu_x86_64' on Ubuntu. It works with all Linux OS except CentOS because of the added `"` that break everything.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
