### PR TITLE
Validate that all `go.mod` files are registered in `DEFAULT_MODULES`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,3 +123,9 @@ repos:
       entry: 'inv linter.update-go'
       language: system
       pass_filenames: false
+    - id: check-go-modules
+      name: check-go-modules
+      description: Validate all go modules are declared
+      entry: 'inv modules.validate'
+      language: system
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,9 +123,9 @@ repos:
       entry: 'inv linter.update-go'
       language: system
       pass_filenames: false
-    - id: check-go-modules
-      name: check-go-modules
-      description: Validate all go modules are declared
+    - id: check-go-modules-in-python
+      name: check-go-modules-in-python
+      description: Validate all go modules are declared in Invoke tasks
       entry: 'inv modules.validate'
       language: system
       pass_filenames: false

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -268,9 +268,6 @@ DEFAULT_MODULES = {
         targets=["./pkg/runner", "./pkg/utils/e2e/client"],
         lint_targets=[".", "./examples"],  # need to explicitly list "examples", otherwise it is skipped
     ),
-    "tools/retry_file_dump": GoModule(
-        "tools/retry_file_dump", independent=True, condition=lambda: False, should_tag=False
-    ),
     "tools/retry_file_dump": GoModule("tools/retry_file_dump", condition=lambda: False, should_tag=False),
 }
 

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -394,7 +394,7 @@ def validate(_: Context, fail_fast: bool = False):
         for dependency in module.dependencies:
             if dependency not in DEFAULT_MODULES:
                 if fail_fast:
-                    raise Exit(f"{color_message('ERROR', 'red')}: {module.path} depends on missing {dependency}")
+                    raise Exit(f"{color_message('ERROR', Color.RED)}: {module.path} depends on missing {dependency}")
                 missing_modules.append((module, dependency))
 
     # Find all go.mod files and make sure they are registered in DEFAULT_MODULES

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -392,7 +392,6 @@ def validate(_: Context):
 
     # Find all go.mod files and make sure they are registered in DEFAULT_MODULES
     for root, dirs, files in os.walk("."):
-        # Ignore the files that could be stored in the Python tests
         dirs[:] = [d for d in dirs if root + '/' + d not in IGNORED_MODULE_PATHS]
 
         if "go.mod" in files and root.removeprefix("./") not in DEFAULT_MODULES:

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -272,7 +272,7 @@ DEFAULT_MODULES = {
 }
 
 # Folder containing a `go.mod` file but that should not be added to the DEFAULT_MODULES
-IGNORED_MODULES = [
+IGNORED_MODULE_PATHS = [
     # Will be removed soon
     "./comp/otelcol/otlp/example/metric",
     # Test files
@@ -282,6 +282,8 @@ IGNORED_MODULES = [
     "./internal/tools/modparser/testdata/patchgoversion",
     # This `go.mod` is a hack
     "./pkg/process/procutil/resources",
+    # We have test files in the tasks folder
+    "./tasks",
     # Test files
     "./test/integration/serverless/recorder-extension",
     "./test/integration/serverless/src",
@@ -391,9 +393,9 @@ def validate(_: Context):
     # Find all go.mod files and make sure they are registered in DEFAULT_MODULES
     for root, dirs, files in os.walk("."):
         # Ignore the files that could be stored in the Python tests
-        dirs[:] = [d for d in dirs if root + '/' + d != "./tasks"]
+        dirs[:] = [d for d in dirs if root + '/' + d not in IGNORED_MODULE_PATHS]
 
-        if "go.mod" in files and root.removeprefix("./") not in DEFAULT_MODULES and root not in IGNORED_MODULES:
+        if "go.mod" in files and root.removeprefix("./") not in DEFAULT_MODULES:
             missing_modules.append(root)
 
     if missing_modules:

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -385,17 +385,11 @@ def for_each(ctx: Context, cmd: str, skip_untagged: bool = False):
 
 
 @task
-def validate(_: Context, fail_fast: bool = False):
+def validate(_: Context):
     """
     Test if every module was properly added in the DEFAULT_MODULES list.
     """
     missing_modules = []
-    for module in DEFAULT_MODULES.values():
-        for dependency in module.dependencies:
-            if dependency not in DEFAULT_MODULES:
-                if fail_fast:
-                    raise Exit(f"{color_message('ERROR', Color.RED)}: {module.path} depends on missing {dependency}")
-                missing_modules.append((module, dependency))
 
     # Find all go.mod files and make sure they are registered in DEFAULT_MODULES
     for root, dirs, files in os.walk("."):
@@ -403,14 +397,11 @@ def validate(_: Context, fail_fast: bool = False):
         dirs[:] = [d for d in dirs if root + '/' + d != "./tasks"]
 
         if "go.mod" in files and root.removeprefix("./") not in DEFAULT_MODULES and root not in IGNORED_MODULES:
-            missing_modules.append((root, None))
+            missing_modules.append(root)
 
     if missing_modules:
         message = f"{color_message('ERROR', Color.RED)}: some modules are missing from DEFAULT_MODULES\n"
-        for module, dependency in missing_modules:
-            if dependency:
-                message += f"  {module.path} depends on missing {dependency}\n"
-            else:
-                message += f"  {module} is missing from DEFAULT_MODULES\n"
+        for module in missing_modules:
+            message += f"  {module} is missing from DEFAULT_MODULES\n"
 
         raise Exit(message)

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -179,13 +179,6 @@ DEFAULT_MODULES = {
     "comp/otelcol/otlp/testutil": GoModule("comp/otelcol/otlp/testutil", independent=True, used_by_otel=True),
     "comp/otelcol/converter/def": GoModule("comp/otelcol/converter/def", independent=True, used_by_otel=True),
     "comp/otelcol/converter/impl": GoModule("comp/otelcol/converter/impl", independent=True, used_by_otel=True),
-    "comp/otelcol/otlp/example/metric": GoModule(
-        "comp/otelcol/otlp/example/metric",
-        independent=True,
-        used_by_otel=True,
-        condition=lambda: False,
-        should_tag=False,
-    ),
     "comp/serializer/compression": GoModule("comp/serializer/compression", independent=True, used_by_otel=True),
     "comp/trace/agent/def": GoModule("comp/trace/agent/def", independent=True, used_by_otel=True),
     "internal/tools": GoModule("internal/tools", condition=lambda: False, should_tag=False),
@@ -283,11 +276,16 @@ DEFAULT_MODULES = {
 
 # Folder containing a `go.mod` file but that should not be added to the DEFAULT_MODULES
 IGNORED_MODULES = [
+    # Will be removed soon
+    "./comp/otelcol/otlp/example/metric",
+    # Test files
     "./internal/tools/modparser/testdata/badformat",
     "./internal/tools/modparser/testdata/match",
     "./internal/tools/modparser/testdata/nomatch",
     "./internal/tools/modparser/testdata/patchgoversion",
+    # This `go.mod` is a hack
     "./pkg/process/procutil/resources",
+    # Test files
     "./test/integration/serverless/recorder-extension",
     "./test/integration/serverless/src",
 ]

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -386,7 +386,7 @@ def validate(_: Context):
     """
     Test if every module was properly added in the DEFAULT_MODULES list.
     """
-    missing_modules = []
+    missing_modules: list[str] = []
 
     # Find all go.mod files and make sure they are registered in DEFAULT_MODULES
     for root, dirs, files in os.walk("."):
@@ -400,5 +400,7 @@ def validate(_: Context):
         message = f"{color_message('ERROR', Color.RED)}: some modules are missing from DEFAULT_MODULES\n"
         for module in missing_modules:
             message += f"  {module} is missing from DEFAULT_MODULES\n"
+
+        message += "Please add them to the DEFAULT_MODULES list or exclude them from the validation."
 
         raise Exit(message)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Validate that all `go.mod` files are registered in `DEFAULT_MODULES`. We do not need the previous logic anymore since we check every single module in the repo.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We noticed some modules are not registered, so they are not validated by the `tidy` command in the CI. 

Because of that @wdhif had to fix it [afterward](https://github.com/DataDog/datadog-agent/pull/26771) 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- https://datadoghq.atlassian.net/browse/ADXT-358
- The Otel team will remove the otel module next week
- This new implementation is super fast which allows us to add it as a pre-commit hook without any issues

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
