### PR TITLE
[CWS] skip `TestContainerCreatedAt` on opensuse 15.3 in CI

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -265,6 +265,11 @@ func (k *Version) IsOpenSUSELeapKernel() bool {
 	return k.OsRelease["ID"] == "opensuse-leap"
 }
 
+// IsOpenSUSELeap15_3Kernel returns whether the kernel is an opensuse 15.3 kernel
+func (k *Version) IsOpenSUSELeap15_3Kernel() bool {
+	return k.IsOpenSUSELeapKernel() && strings.HasPrefix(k.OsRelease["VERSION_ID"], "15.3")
+}
+
 // IsOracleUEKKernel returns whether the kernel is an oracle uek kernel
 func (k *Version) IsOracleUEKKernel() bool {
 	return k.OsRelease["ID"] == "ol" && k.Code >= Kernel5_4

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,11 @@ import (
 
 func TestContainerCreatedAt(t *testing.T) {
 	SkipIfNotAvailable(t)
+
+	checkKernelCompatibility(t, "OpenSUSE 15.3 kernel", func(kv *kernel.Version) bool {
+		// because of some strange btrfs subvolume error
+		return kv.IsOpenSUSELeap15_3Kernel()
+	})
 
 	ruleDefs := []*rules.RuleDefinition{
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This test (`TestContainerCreatedAt`) is failing on opensuse 15.3 because of some strange btrfs issue with the sub-volume id:

```
# opensuse 15.3
346 323 0 53 /@/tmp/TestContainerCreatedAt3156859767/001 /tmp/TestContainerCreatedAt3156859767/001 rw,relatime  btrfs /dev/vda3 rw,space_cache,subvolid=264,subvol=/@/tmp/TestContainerCreatedAt3156859767/001

# opensuse 15.5
394 370 0 53 /@/tmp/TestContainerCreatedAt624163600/001 /tmp/TestContainerCreatedAt624163600/001 rw,relatime  btrfs /dev/vda3 rw,space_cache,subvolid=264,subvol=/@/tmp
```
the fact that we are not able to get the actual sub volume prevents us from trimming it from the mount root and to correctly handle further path with the btrfs handling from https://github.com/DataDog/datadog-agent/pull/25538. Since the issue is fixed in more recent version of opensuse we are just skipping the test for now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
