### PR TITLE
[ASCII-1909] Rename config's Loader interface to Setup, use where config gets set up

### DIFF
--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -29,8 +29,6 @@ type (
 	Writer = model.Writer
 	// ReaderWriter is alias to model.ReaderWriter
 	ReaderWriter = model.ReaderWriter
-	// Loader is alias to model.Loader
-	Loader = model.Loader
 	// Config is alias to model.Config
 	Config = model.Config
 )

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -105,8 +105,8 @@ type ReaderWriter interface {
 	Writer
 }
 
-// Loader is a subset of Config that allows loading the configuration
-type Loader interface {
+// Setup is a subset of Config that allows setting up the configuration
+type Setup interface {
 	// API implemented by viper.Viper
 
 	SetDefault(key string, value interface{})
@@ -117,6 +117,22 @@ type Loader interface {
 	SetEnvKeyReplacer(r *strings.Replacer)
 	SetEnvKeyTransformer(key string, fn func(string) interface{})
 
+	// SetKnown adds a key to the set of known valid config keys
+	SetKnown(key string)
+
+	// API not implemented by viper.Viper and that have proven useful for our config usage
+
+	// BindEnvAndSetDefault sets the default value for a config parameter and adds an env binding
+	// in one call, used for most config options.
+	//
+	// If env is provided, it will override the name of the environment variable used for this
+	// config key
+	BindEnvAndSetDefault(key string, val interface{}, env ...string)
+}
+
+// Compound is an interface for returning compound elements from the config, plus
+// some misc functions, that should likely be split into another interface
+type Compound interface {
 	UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error
 	Unmarshal(rawVal interface{}) error
 	UnmarshalExact(rawVal interface{}) error
@@ -132,18 +148,6 @@ type Loader interface {
 	SetConfigType(in string)
 
 	BindPFlag(key string, flag *pflag.Flag) error
-
-	// SetKnown adds a key to the set of known valid config keys
-	SetKnown(key string)
-
-	// API not implemented by viper.Viper and that have proven useful for our config usage
-
-	// BindEnvAndSetDefault sets the default value for a config parameter and adds an env binding
-	// in one call, used for most config options.
-	//
-	// If env is provided, it will override the name of the environment variable used for this
-	// config key
-	BindEnvAndSetDefault(key string, val interface{}, env ...string)
 }
 
 // Config represents an object that can load and store configuration parameters
@@ -154,5 +158,6 @@ type Loader interface {
 // - flags
 type Config interface {
 	ReaderWriter
-	Loader
+	Setup
+	Compound
 }

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -130,7 +130,7 @@ type Setup interface {
 	BindEnvAndSetDefault(key string, val interface{}, env ...string)
 }
 
-// Compound is an interface for returning compound elements from the config, plus
+// Compound is an interface for retrieving compound elements from the config, plus
 // some misc functions, that should likely be split into another interface
 type Compound interface {
 	UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -20,7 +20,7 @@ import (
 // Traces specifies the data type used for Vector override. See https://vector.dev/docs/reference/configuration/sources/datadog_agent/ for additional details.
 const Traces DataType = "traces"
 
-func setupAPM(config pkgconfigmodel.Config) {
+func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnv("apm_config.obfuscation.elasticsearch.enabled", "DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED")
 	config.BindEnv("apm_config.obfuscation.elasticsearch.keep_values", "DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES")
 	config.BindEnv("apm_config.obfuscation.elasticsearch.obfuscate_sql_values", "DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES")
@@ -97,7 +97,7 @@ func setupAPM(config pkgconfigmodel.Config) {
 	config.BindEnv("apm_config.target_traces_per_second", "DD_APM_TARGET_TPS")
 	config.BindEnv("apm_config.errors_per_second", "DD_APM_ERROR_TPS")
 	config.BindEnv("apm_config.enable_rare_sampler", "DD_APM_ENABLE_RARE_SAMPLER")
-	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER") //Deprecated
+	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER") // Deprecated
 	config.BindEnv("apm_config.max_remote_traces_per_second", "DD_APM_MAX_REMOTE_TPS")
 	config.BindEnv("apm_config.probabilistic_sampler.enabled", "DD_APM_PROBABILISTIC_SAMPLER_ENABLED")
 	config.BindEnv("apm_config.probabilistic_sampler.sampling_percentage", "DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -207,7 +207,7 @@ const (
 // serverlessConfigComponents are the config components that are used by all agents, and in particular serverless.
 // Components should only be added here if they are reachable by the serverless agent.
 // Otherwise directly add the configs to InitConfig.
-var serverlessConfigComponents = []func(pkgconfigmodel.Config){
+var serverlessConfigComponents = []func(pkgconfigmodel.Setup){
 	agent,
 	fips,
 	dogstatsd,
@@ -921,7 +921,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("djm_config.enabled", false)
 }
 
-func agent(config pkgconfigmodel.Config) {
+func agent(config pkgconfigmodel.Setup) {
 	config.BindEnv("api_key")
 
 	// Agent
@@ -1005,7 +1005,7 @@ func agent(config pkgconfigmodel.Config) {
 	config.SetKnown("proxy.no_proxy")
 }
 
-func fips(config pkgconfigmodel.Config) {
+func fips(config pkgconfigmodel.Setup) {
 	// Fips
 	config.BindEnvAndSetDefault("fips.enabled", false)
 	config.BindEnvAndSetDefault("fips.port_range_start", 9803)
@@ -1014,7 +1014,7 @@ func fips(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("fips.tls_verify", true)
 }
 
-func remoteconfig(config pkgconfigmodel.Config) {
+func remoteconfig(config pkgconfigmodel.Setup) {
 	// Remote config
 	config.BindEnvAndSetDefault("remote_configuration.enabled", true)
 	config.BindEnvAndSetDefault("remote_configuration.key", "")
@@ -1036,7 +1036,7 @@ func remoteconfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_log_config_scheduling", false)
 }
 
-func autoconfig(config pkgconfigmodel.Config) {
+func autoconfig(config pkgconfigmodel.Setup) {
 	// Autoconfig
 	// Defaut Timeout in second when talking to storage for configuration (etcd, zookeeper, ...)
 	config.BindEnvAndSetDefault("autoconf_template_url_timeout", 5)
@@ -1068,7 +1068,7 @@ func autoconfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("autoconfig_include_features", []string{})
 }
 
-func containerSyspath(config pkgconfigmodel.Config) {
+func containerSyspath(config pkgconfigmodel.Setup) {
 	if pkgconfigenv.IsContainerized() {
 		// In serverless-containerized environments (e.g Fargate)
 		// it's impossible to mount host volumes.
@@ -1110,7 +1110,7 @@ func containerSyspath(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("proc_root", "/proc")
 }
 
-func debugging(config pkgconfigmodel.Config) {
+func debugging(config pkgconfigmodel.Setup) {
 	// Debugging + C-land crash feature flags
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)
 	config.BindEnvAndSetDefault("c_core_dump", false)
@@ -1125,7 +1125,7 @@ func debugging(config pkgconfigmodel.Config) {
 	config.BindEnv("no_proxy_nonexact_match")
 }
 
-func telemetry(config pkgconfigmodel.Config) {
+func telemetry(config pkgconfigmodel.Setup) {
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.
 	// This create a lot of billable custom metrics.
@@ -1147,7 +1147,7 @@ func telemetry(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("agent_telemetry.enabled", false)
 }
 
-func serializer(config pkgconfigmodel.Config) {
+func serializer(config pkgconfigmodel.Setup) {
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", true)
@@ -1173,7 +1173,7 @@ func serializer(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("enable_payloads.json_to_v1_intake", true)
 }
 
-func aggregator(config pkgconfigmodel.Config) {
+func aggregator(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("aggregator_stop_timeout", 2)
 	config.BindEnvAndSetDefault("aggregator_buffer_size", 100)
 	config.BindEnvAndSetDefault("aggregator_use_tags_store", true)
@@ -1182,7 +1182,7 @@ func aggregator(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size", 4000)
 }
 
-func serverless(config pkgconfigmodel.Config) {
+func serverless(config pkgconfigmodel.Setup) {
 	// Serverless Agent
 	config.SetDefault("serverless.enabled", false)
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)
@@ -1194,7 +1194,7 @@ func serverless(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("serverless.service_mapping", nil, "DD_SERVICE_MAPPING")
 }
 
-func forwarder(config pkgconfigmodel.Config) {
+func forwarder(config pkgconfigmodel.Setup) {
 	// Forwarder
 	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
@@ -1225,7 +1225,7 @@ func forwarder(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("forwarder_requeue_buffer_size", 100)
 }
 
-func dogstatsd(config pkgconfigmodel.Config) {
+func dogstatsd(config pkgconfigmodel.Setup) {
 	// Dogstatsd
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125)    // Notice: 0 means UDP port closed
@@ -1320,7 +1320,7 @@ func dogstatsd(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")
 }
 
-func logsagent(config pkgconfigmodel.Config) {
+func logsagent(config pkgconfigmodel.Setup) {
 	// Logs Agent
 
 	// External Use: modify those parameters to configure the logs-agent.
@@ -1441,13 +1441,13 @@ func logsagent(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("logs_config.file_wildcard_selection_mode", "by_name")
 }
 
-func vector(config pkgconfigmodel.Config) {
+func vector(config pkgconfigmodel.Setup) {
 	// Vector integration
 	bindVectorOptions(config, Metrics)
 	bindVectorOptions(config, Logs)
 }
 
-func cloudfoundry(config pkgconfigmodel.Config) {
+func cloudfoundry(config pkgconfigmodel.Setup) {
 	// Cloud Foundry
 	config.BindEnvAndSetDefault("cloud_foundry", false)
 	config.BindEnvAndSetDefault("bosh_id", "")
@@ -1455,7 +1455,7 @@ func cloudfoundry(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("cloud_foundry_buildpack", false)
 }
 
-func containerd(config pkgconfigmodel.Config) {
+func containerd(config pkgconfigmodel.Setup) {
 	// Containerd
 	config.BindEnvAndSetDefault("containerd_namespace", []string{})
 	config.BindEnvAndSetDefault("containerd_namespaces", []string{}) // alias for containerd_namespace
@@ -1464,14 +1464,14 @@ func containerd(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 }
 
-func cri(config pkgconfigmodel.Config) {
+func cri(config pkgconfigmodel.Setup) {
 	// CRI
 	config.BindEnvAndSetDefault("cri_socket_path", "")              // empty is disabled
 	config.BindEnvAndSetDefault("cri_connection_timeout", int64(1)) // in seconds
 	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
 }
 
-func kubernetes(config pkgconfigmodel.Config) {
+func kubernetes(config pkgconfigmodel.Setup) {
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")
 	config.BindEnvAndSetDefault("kubernetes_kubelet_nodename", "")
@@ -1501,7 +1501,7 @@ func kubernetes(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})
 }
 
-func podman(config pkgconfigmodel.Config) {
+func podman(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("podman_db_path", "")
 }
 
@@ -2202,7 +2202,7 @@ func sanitizeExternalMetricsProviderChunkSize(config pkgconfigmodel.Config) {
 	}
 }
 
-func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Config, prefix string) {
+func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Setup, prefix string) {
 	config.BindEnv(prefix + "logs_dd_url") // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
 	config.BindEnv(prefix + "dd_url")
 	config.BindEnv(prefix + "additional_endpoints")
@@ -2370,7 +2370,7 @@ func getValidHostAliasesWithConfig(config pkgconfigmodel.Reader) []string {
 	return aliases
 }
 
-func bindVectorOptions(config pkgconfigmodel.Config, datatype DataType) {
+func bindVectorOptions(config pkgconfigmodel.Setup, datatype DataType) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
 

--- a/pkg/config/setup/multi_region_failover.go
+++ b/pkg/config/setup/multi_region_failover.go
@@ -11,7 +11,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-func setupMultiRegionFailover(config pkgconfigmodel.Config) {
+func setupMultiRegionFailover(config pkgconfigmodel.Setup) {
 	config.BindEnv("multi_region_failover.api_key")
 	config.BindEnv("multi_region_failover.site")
 	config.BindEnv("multi_region_failover.dd_url")

--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -28,7 +28,7 @@ const (
 )
 
 // OTLP related configuration.
-func OTLP(config pkgconfigmodel.Config) {
+func OTLP(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault(OTLPTracePort, 5003)
 	config.BindEnvAndSetDefault(OTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(OTLPTracesEnabled, true)
@@ -59,7 +59,7 @@ func OTLP(config pkgconfigmodel.Config) {
 // since we get the configuration through GetStringMap
 //
 // We are missing TLS settings: since some of them need more work to work right they are not included here.
-func setupOTLPEnvironmentVariables(config pkgconfigmodel.Config) {
+func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 	// gRPC settings
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.endpoint")
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.transport")


### PR DESCRIPTION

### What does this PR do?

Many individual functions in `pkg/config/setup` call methods (`BindEnv`, `SetKnown`, etc) to setup the initial state of the config. We have an interface (`Loader`, renamed to `Setup` here) that has just these methods, but it wasn't being used for these callsites. This change ensures these setup locations are using this more restricted API instead of having access to the entire `Config` interface.

### Motivation

Improve practices around how the config is used

### Additional Notes



### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

Functionality covered by existing unit tests.
