### PR TITLE
[ASCII-1908] Adding logging in Agent subcommands

### DIFF
--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
@@ -56,7 +57,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{configCheckCommand}
 }
 
-func run(config config.Component, cliParams *cliParams) error {
+func run(config config.Component, cliParams *cliParams, _ log.Component) error {
 	v := url.Values{}
 	if cliParams.verbose {
 		v.Set("verbose", "true")

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -35,10 +35,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	utillog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
-	"github.com/cihub/seelog"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -86,7 +84,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Validate Agent installation, configuration and environment",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			utillog.SetupLogger(seelog.Disabled, "off")
 			return fxutil.OneShot(cmdDiagnose,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
@@ -287,6 +284,7 @@ func cmdDiagnose(cliParams *cliParams,
 	wmeta optional.Option[workloadmeta.Component],
 	ac autodiscovery.Component,
 	secretResolver secrets.Component,
+	_ log.Component,
 ) error {
 	diagCfg := diagnosis.Config{
 		Verbose:  cliParams.verbose,

--- a/cmd/agent/subcommands/dogstatsd/command.go
+++ b/cmd/agent/subcommands/dogstatsd/command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	cconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
@@ -71,7 +72,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(core.BundleParams{
 					ConfigParams: cconfig.NewAgentParams(globalParams.ConfFilePath),
 					LogParams:    logimpl.ForOneShot(command.LoggerName, "off", true)}),
-
 				core.Bundle(),
 			)
 		},
@@ -108,7 +108,7 @@ func triggerDump(config cconfig.Component) (string, error) {
 	return path, nil
 }
 
-func dumpContexts(config cconfig.Component) error {
+func dumpContexts(config cconfig.Component, _ log.Component) error {
 	path, err := triggerDump(config)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ type metric struct {
 	tags  map[string]struct{}
 }
 
-func topContexts(config cconfig.Component, flags *topFlags) error {
+func topContexts(config cconfig.Component, flags *topFlags, _ log.Component) error {
 	var err error
 
 	path := flags.path

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -26,6 +26,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -111,7 +113,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		return fxutil.OneShot(callback,
 			fx.Supply(cliParams),
 			fx.Supply(core.BundleParams{
-				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigMissingOK(true))}),
+				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigMissingOK(true)),
+				LogParams:    logimpl.ForOneShot(command.LoggerName, "off", true),
+			}),
 			core.Bundle(),
 		)
 	}
@@ -365,7 +369,7 @@ func pip(cliParams *cliParams, args []string, stdout io.Writer, stderr io.Writer
 	return nil
 }
 
-func install(config config.Component, cliParams *cliParams) error {
+func install(config config.Component, cliParams *cliParams, _ log.Component) error {
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -862,7 +866,7 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 	return nil
 }
 
-func remove(config config.Component, cliParams *cliParams) error {
+func remove(config config.Component, cliParams *cliParams, _ log.Component) error {
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -886,7 +890,7 @@ func remove(config config.Component, cliParams *cliParams) error {
 	return pip(cliParams, pipArgs, os.Stdout, os.Stderr)
 }
 
-func list(config config.Component, cliParams *cliParams) error {
+func list(config config.Component, cliParams *cliParams, _ log.Component) error {
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -913,7 +917,7 @@ func list(config config.Component, cliParams *cliParams) error {
 	return nil
 }
 
-func show(config config.Component, cliParams *cliParams) error {
+func show(config config.Component, cliParams *cliParams, _ log.Component) error {
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/launchgui/command.go
+++ b/cmd/agent/subcommands/launchgui/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -36,8 +37,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(launchGui,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle(),
 			)
 		},
@@ -47,7 +47,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{launchCmd}
 }
 
-func launchGui(config config.Component, _ *cliParams) error {
+func launchGui(config config.Component, _ *cliParams, _ log.Component) error {
 	guiPort := config.GetString("GUI_port")
 	if guiPort == "-1" {
 		return fmt.Errorf("GUI not enabled: to enable, please set an appropriate port in your datadog.yaml file")

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -57,7 +58,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{secretInfoCommand}
 }
 
-func showSecretInfo(config config.Component) error {
+func showSecretInfo(config config.Component, _ log.Component) error {
 	res, err := callIPCEndpoint(config, "agent/secrets")
 	if err != nil {
 		return err
@@ -66,7 +67,7 @@ func showSecretInfo(config config.Component) error {
 	return nil
 }
 
-func secretRefresh(config config.Component) error {
+func secretRefresh(config config.Component, _ log.Component) error {
 	res, err := callIPCEndpoint(config, "agent/secret/refresh")
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -49,7 +50,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{stopCmd}
 }
 
-func stop(config config.Component, _ *cliParams) error {
+func stop(config config.Component, _ *cliParams, _ log.Component) error {
 	// Global Agent configuration
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR enforce the initialization in most of the Agent subcommands.
The logger would stay silent until `log_level` is set to a different value than `off`.
Most of these functions already provide `LogParams: logimpl.ForOneShot("CORE", "off", true)})`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
It's sometimes hard to debug "oneshot" commands without setting `log_level`  to `info` or below value.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
For every modified subcommand:
- check that its behaviour remains the same as before this PR
- check that it's printing logs when you run it with `DD_LOG_LEVEL=trace` env variable

