### PR TITLE
Use `sizeHint` in scrubber when bigger than the default token max size

### DIFF
--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -136,6 +136,10 @@ func (c *Scrubber) scrubReader(file io.Reader, sizeHint int) ([]byte, error) {
 	}
 
 	scanner := bufio.NewScanner(file)
+	if sizeHint+1 > bufio.MaxScanTokenSize {
+		buffer := make([]byte, 0, sizeHint+1)
+		scanner.Buffer(buffer, sizeHint+1)
+	}
 
 	// First, we go through the file line by line, applying any
 	// single-line replacer that matches the line.

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -6,6 +6,7 @@
 package scrubber
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -94,4 +95,12 @@ func TestScrubLine(t *testing.T) {
 	})
 	res := scrubber.ScrubLine("https://foo:bar@example.com")
 	require.Equal(t, "https://foo:********@example.com", res)
+}
+
+func TestScrubBig(t *testing.T) {
+	scrubber := New()
+	content := bytes.Repeat([]byte("a"), 1000000)
+
+	_, err := scrubber.ScrubBytes(content)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Use the `sizeHint` argument in `scrubReader`, if it is bigger than `bufio.MaxScanTokenSize`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The scrubber uses `bufio.NewScanner` to read from an `io.Reader`. The scanner by default uses `bufio.MaxScanTokenSize` (65k) as max buffer size to read the input.
If the input is bigger than this limit, scrubbing will fail.

The scrubber takes a `sizeHint` as parameter, if this is bigger than `bufio.MaxScanTokenSize` then we can just increase the limit to that instead.
It will only avoid errors and won't have any noticeable memory impact unless we try to scrub a single line 100MB string.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit tested