### PR TITLE
APM: add probabilistic sampling rate to span when kept

### DIFF
--- a/pkg/trace/sampler/probabilistic_test.go
+++ b/pkg/trace/sampler/probabilistic_test.go
@@ -88,11 +88,13 @@ func TestProbabilisticSampler(t *testing.T) {
 			ProbabilisticSamplerSamplingPercentage: 40,
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
-		sampled := sampler.Sample(&trace.Span{
+		span := &trace.Span{
 			TraceID: 555,
 			Meta:    map[string]string{},
-		})
+		}
+		sampled := sampler.Sample(span)
 		assert.True(t, sampled)
+		assert.EqualValues(t, .4, span.Metrics["_dd.prob_sr"])
 	})
 	t.Run("drop-dd-64", func(t *testing.T) {
 		conf := &config.AgentConfig{

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -47,7 +47,7 @@ func NewNoPrioritySampler(conf *config.AgentConfig, statsd statsd.ClientInterfac
 }
 
 // NewErrorsSampler returns an initialized Sampler dedicate to errors. It behaves
-// just like the the normal ScoreEngine except for its GetType method (useful
+// just like the normal ScoreEngine except for its GetType method (useful
 // for reporting).
 func NewErrorsSampler(conf *config.AgentConfig, statsd statsd.ClientInterface) *ErrorsSampler {
 	s := newSampler(conf.ExtraSampleRate, conf.ErrorTPS, []string{"sampler:error"}, statsd)


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds `_dd.prob_sr` to spans that have been kept by the probabilistic sampler with the sampling rate. (ie. `0.40` is 40% kept)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We use these sampling rates to help drive metrics to show the source and volume of spans
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Technically speaking this shouldn't be _strictly_ necessary since the probabilistic sampling rate _should_ be consistent across the whole trace to ensure a fully connected trace, but in actuality it's possible due to mis-configurations and having the data here on the span is much more consistent with the other sampling approaches.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
I updated the unit tests to check that this metric is properly set
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
