### PR TITLE
[CWS] fix user group test

### DIFF
--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -142,7 +142,11 @@ func TestUserGroup(t *testing.T) {
 				i := 0
 				dockerWrapper.RunTest(t, testCommand.name, func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
 					test.WaitSignals(t, func() error {
-						return cmdFunc(testCommand.cmd[0], testCommand.cmd[1:], nil).Run()
+						out, err := cmdFunc(testCommand.cmd[0], testCommand.cmd[1:], nil).CombinedOutput()
+						if err != nil {
+							t.Logf(string(out))
+						}
+						return err
 					}, func(event *model.Event, rule *rules.Rule) error {
 						assertTriggeredRule(t, rule, testCommand.rules[i])
 						i++

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -9,7 +9,6 @@
 package tests
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -140,21 +139,20 @@ func TestUserGroup(t *testing.T) {
 
 			for _, testCommand := range distroTest.testCommands {
 				i := 0
-				dockerWrapper.RunTest(t, testCommand.name, func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
-					test.WaitSignals(t, func() error {
-						out, err := cmdFunc(testCommand.cmd[0], testCommand.cmd[1:], nil).CombinedOutput()
-						if err != nil {
-							t.Logf(string(out))
-						}
-						return err
-					}, func(event *model.Event, rule *rules.Rule) error {
-						assertTriggeredRule(t, rule, testCommand.rules[i])
-						i++
-						if i < len(testCommand.rules) {
-							return errSkipEvent
-						}
-						return nil
-					})
+
+				test.WaitSignals(t, func() error {
+					out, err := dockerWrapper.Command(testCommand.cmd[0], testCommand.cmd[1:], nil).CombinedOutput()
+					if err != nil {
+						t.Logf(string(out))
+					}
+					return err
+				}, func(event *model.Event, rule *rules.Rule) error {
+					assertTriggeredRule(t, rule, testCommand.rules[i])
+					i++
+					if i < len(testCommand.rules) {
+						return errSkipEvent
+					}
+					return nil
 				})
 			}
 		})


### PR DESCRIPTION
### What does this PR do?

This PR removes the layer of subtest in `TestUserGroup`. This layer is not correct because each sub-test cannot be run on it's own but needs the previous subtests. This is an issue especially for the retry mechanism that can decide to only re-run one of the subtests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
