### PR TITLE
add CI visibility links to KMT run jobs

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -199,6 +199,7 @@
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2
+    EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
   before_script:
     - export DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $API_KEY_ORG2_SSM_NAME)
     - !reference [.kmt_new_profile]
@@ -207,6 +208,7 @@
     - echo "CI_JOB_ID=${CI_JOB_ID}" >> $DD_AGENT_TESTING_DIR/job_env.txt
     - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> $DD_AGENT_TESTING_DIR/job_env.txt
     - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/job_env.txt
+    - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
   script:
     - INSTANCE_IP=$(jq --exit-status --arg ARCH $ARCH -r '.[$ARCH].ip' $CI_PROJECT_DIR/stack.output)
     - !reference [.shared_filters_and_queries]
@@ -233,3 +235,6 @@
       - $DD_AGENT_TESTING_DIR/junit-$ARCH-$TAG-$TEST_SET.tar.gz
       - $DD_AGENT_TESTING_DIR/testjson-$ARCH-$TAG-$TEST_SET.tar.gz
       - $CI_PROJECT_DIR/logs
+    reports:
+      annotations:
+        - $EXTERNAL_LINKS_PATH

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -111,7 +111,7 @@ def get_link_to_pipeline_job_on_main(job_name: str):
 def get_link_to_test_runs(job_id: str):
     query_params = {
         "test_level": "test",
-        "@ci.job.url": f"https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/{job_id}",
+        "@ci.job.url": f"\"https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/{job_id}\"",
         "@test.service": "datadog-agent",
     }
     query_string = to_query_string(query_params)

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -8,11 +8,12 @@ from urllib.parse import quote
 
 from invoke import task
 
+from tasks.libs.ciproviders.gitlab_api import BASE_URL as GITLAB_BASE_URL
 from tasks.libs.common.color import Color, color_message
 
-CI_VISIBILITY_URL = "https://app.datadoghq.com/ci"
-PIPELINE_VISIBILITY_URL = f"{CI_VISIBILITY_URL}/pipeline-executions"
-TEST_VISIBILITY_URL = f"{CI_VISIBILITY_URL}/test-runs"
+CI_VISIBILITY_BASE_URL = "https://app.datadoghq.com/ci"
+CI_VISIBILITY_URL = f"{CI_VISIBILITY_BASE_URL}/pipeline-executions"
+TEST_VISIBILITY_URL = f"{CI_VISIBILITY_BASE_URL}/test-runs"
 
 
 @task
@@ -62,7 +63,7 @@ def create_gitlab_annotations_report(ci_job_id: str, ci_job_name: str):
             },
             {
                 "external_link": {
-                    "label": "CI Visibility: This job test runs",
+                    "label": "Test Visibility: This job test runs",
                     "url": get_link_to_test_runs(ci_job_id),
                 }
             },
@@ -74,7 +75,7 @@ def create_gitlab_annotations_report(ci_job_id: str, ci_job_name: str):
             },
             {
                 "external_link": {
-                    "label": "CI Visibility: This job test runs on main",
+                    "label": "Test Visibility: This job test runs on main",
                     "url": get_link_to_test_runs_on_main(ci_job_name),
                 }
             },
@@ -90,7 +91,7 @@ def get_link_to_pipeline_job_id(job_id: str):
     }
     query_string = to_query_string(query_params)
     quoted_query_string = quote(string=query_string, safe="")
-    return f"{PIPELINE_VISIBILITY_URL}?query={quoted_query_string}"
+    return f"{CI_VISIBILITY_URL}?query={quoted_query_string}"
 
 
 def get_link_to_pipeline_job_on_main(job_name: str):
@@ -105,13 +106,13 @@ def get_link_to_pipeline_job_on_main(job_name: str):
     }
     query_string = to_query_string(query_params)
     quoted_query_string = quote(string=query_string, safe="")
-    return f"{PIPELINE_VISIBILITY_URL}?query={quoted_query_string}"
+    return f"{CI_VISIBILITY_URL}?query={quoted_query_string}"
 
 
 def get_link_to_test_runs(job_id: str):
     query_params = {
         "test_level": "test",
-        "@ci.job.url": f"\"https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/{job_id}\"",
+        "@ci.job.url": f"\"{GITLAB_BASE_URL}/DataDog/datadog-agent/-/jobs/{job_id}\"",
         "@test.service": "datadog-agent",
     }
     query_string = to_query_string(query_params)

--- a/tasks/unit-tests/gitlab_helpers_tests.py
+++ b/tasks/unit-tests/gitlab_helpers_tests.py
@@ -1,10 +1,12 @@
 import unittest
+from urllib.parse import quote
 
 from tasks.gitlab_helpers import (
-    PIPELINE_VISIBILITY_URL,
+    CI_VISIBILITY_URL,
     TEST_VISIBILITY_URL,
     create_gitlab_annotations_report,
 )
+from tasks.libs.ciproviders.gitlab_api import BASE_URL as GITLAB_BASE_URL
 
 
 class TestCreateGitlabAnnotations(unittest.TestCase):
@@ -17,24 +19,24 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs",
-                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
+                        "label": "Test Visibility: This job test runs",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22{quote(GITLAB_BASE_URL)}%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs on main",
+                        "label": "Test Visibility: This job test runs on main",
                         "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },
@@ -54,24 +56,24 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs",
+                        "label": "Test Visibility: This job test runs",
                         "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs on main",
+                        "label": "Test Visibility: This job test runs on main",
                         "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },
@@ -91,24 +93,24 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs",
+                        "label": "Test Visibility: This job test runs",
                         "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
                     }
                 },
                 {
                     "external_link": {
-                        "label": "CI Visibility: This job test runs on main",
+                        "label": "Test Visibility: This job test runs on main",
                         "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },

--- a/tasks/unit-tests/gitlab_helpers_tests.py
+++ b/tasks/unit-tests/gitlab_helpers_tests.py
@@ -1,7 +1,8 @@
 import unittest
 
 from tasks.gitlab_helpers import (
-    CI_VISIBILITY_URL,
+    PIPELINE_VISIBILITY_URL,
+    TEST_VISIBILITY_URL,
     create_gitlab_annotations_report,
 )
 
@@ -16,13 +17,25 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs on main",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
                     }
                 },
             ]
@@ -41,13 +54,25 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs on main",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
                     }
                 },
             ]
@@ -66,13 +91,25 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job instance",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.id%3A123%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {
                     "external_link": {
                         "label": "CI Visibility: This job on main",
-                        "url": f"{CI_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                        "url": f"{PIPELINE_VISIBILITY_URL}?query=ci_level%3Ajob%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent",
+                    }
+                },
+                {
+                    "external_link": {
+                        "label": "CI Visibility: This job test runs on main",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
                     }
                 },
             ]

--- a/tasks/unit-tests/gitlab_helpers_tests.py
+++ b/tasks/unit-tests/gitlab_helpers_tests.py
@@ -25,7 +25,7 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "Test Visibility: This job test runs",
-                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22{quote(GITLAB_BASE_URL)}%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.url%3A%22{quote(GITLAB_BASE_URL, safe='')}%2FDataDog%2Fdatadog-agent%2F-%2Fjobs%2F123%22%20%40test.service%3Adatadog-agent",
                     }
                 },
                 {

--- a/tasks/unit-tests/gitlab_helpers_tests.py
+++ b/tasks/unit-tests/gitlab_helpers_tests.py
@@ -35,7 +35,7 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job test runs on main",
-                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test-job%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },
             ]
@@ -72,7 +72,7 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job test runs on main",
-                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },
             ]
@@ -109,7 +109,7 @@ class TestCreateGitlabAnnotations(unittest.TestCase):
                 {
                     "external_link": {
                         "label": "CI Visibility: This job test runs on main",
-                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain20%40test.service%3Adatadog-agent",
+                        "url": f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40ci.job.name%3A%22test%20job%20%5BOne%7CTwo%7CThree%5D%20--skip%20Four%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent",
                     }
                 },
             ]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- add CI visibility links to KMT run jobs
- add direct links to test runs

### Motivation

Easier pivot to CI Visibility product

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-524

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
