### PR TITLE
[CWS-2572] use cws-centos7 image from test-infra-definitions instead of Paul's

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -585,9 +585,7 @@ def docker_functional_tests(
         kernel_release=kernel_release,
     )
 
-    image_tag = (
-        "ghcr.io/paulcacheux/cws-centos7@sha256:b16587f1cc7caebc1a18868b9fbd3823e79457065513e591352c4d929b14c426"
-    )
+    image_tag = "ghcr.io/datadog/apps-cws-centos7:main"
 
     container_name = 'security-agent-tests'
     capabilities = ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
@@ -166,13 +166,9 @@ if not ['redhat', 'suse', 'opensuseleap', 'rocky'].include?(node[:platform])
   end
 
   if ['docker', 'docker-fentry'].include?(node[:cws_platform])
-    # Please see https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile
-    # for the definition of this base image.
-    # If this successfully helps in reducing the amount of rate limits, this should be moved
-    # to DataDog/datadog-agent-buildimages.
     file "#{node['common']['work_dir']}/Dockerfile" do
       content <<-EOF
-      FROM ghcr.io/paulcacheux/cws-centos7@sha256:b16587f1cc7caebc1a18868b9fbd3823e79457065513e591352c4d929b14c426
+      FROM ghcr.io/datadog/apps-cws-centos7:main
 
       COPY clang-bpf /opt/datadog-agent/embedded/bin/
       COPY llc-bpf /opt/datadog-agent/embedded/bin/


### PR DESCRIPTION
### What does this PR do?

This `cws-centos7` image pulled from github container registry has proven its value. This PR switches to the one built in https://github.com/DataDog/test-infra-definitions/blob/main/components/datadog/apps/cws/images/cws-centos7/Dockerfile instead of my personal repo.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
