### PR TITLE
(fleet) add a `SetCatalog` method to the local API

### DIFF
--- a/cmd/installer/subcommands/daemon/api.go
+++ b/cmd/installer/subcommands/daemon/api.go
@@ -30,11 +30,10 @@ type cliParams struct {
 }
 
 func apiCommands(global *command.GlobalParams) []*cobra.Command {
-	catalogCmd := &cobra.Command{
-		Use:     "catalog <catalog>",
-		Aliases: []string{"catalog"},
-		Short:   "Sets the catalog to use",
-		Args:    cobra.ExactArgs(1),
+	setCatalogCmd := &cobra.Command{
+		Use:   "set-catalog catalog",
+		Short: "Sets the catalog to use",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return experimentFxWrapper(catalog, &cliParams{
 				GlobalParams: *global,
@@ -92,7 +91,7 @@ func apiCommands(global *command.GlobalParams) []*cobra.Command {
 			})
 		},
 	}
-	return []*cobra.Command{catalogCmd, startExperimentCmd, stopExperimentCmd, promoteExperimentCmd, installCmd}
+	return []*cobra.Command{setCatalogCmd, startExperimentCmd, stopExperimentCmd, promoteExperimentCmd, installCmd}
 }
 
 func experimentFxWrapper(f interface{}, params *cliParams) error {

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -45,6 +45,7 @@ type Daemon interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 
+	SetCatalog(c catalog)
 	Install(ctx context.Context, url string, args []string) error
 	StartExperiment(ctx context.Context, url string) error
 	StopExperiment(ctx context.Context, pkg string) error
@@ -161,6 +162,13 @@ func (d *daemonImpl) GetPackage(pkg string, version string) (Package, error) {
 		return Package{}, fmt.Errorf("could not get package %s, %s for %s, %s", pkg, version, runtime.GOARCH, runtime.GOOS)
 	}
 	return catalogPackage, nil
+}
+
+// SetCatalog sets the catalog.
+func (d *daemonImpl) SetCatalog(c catalog) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	d.catalog = c
 }
 
 // Start starts remote config and the garbage collector.

--- a/pkg/fleet/daemon/local_api.go
+++ b/pkg/fleet/daemon/local_api.go
@@ -104,6 +104,7 @@ func (l *localAPIImpl) Stop(ctx context.Context) error {
 func (l *localAPIImpl) handler() http.Handler {
 	r := mux.NewRouter().Headers("Content-Type", "application/json").Subrouter()
 	r.HandleFunc("/status", l.status).Methods(http.MethodGet)
+	r.HandleFunc("/catalog", l.setCatalog).Methods(http.MethodPost)
 	r.HandleFunc("/{package}/experiment/start", l.startExperiment).Methods(http.MethodPost)
 	r.HandleFunc("/{package}/experiment/stop", l.stopExperiment).Methods(http.MethodPost)
 	r.HandleFunc("/{package}/experiment/promote", l.promoteExperiment).Methods(http.MethodPost)
@@ -134,6 +135,23 @@ func (l *localAPIImpl) status(w http.ResponseWriter, _ *http.Request) {
 		Packages:           packages,
 		ApmInjectionStatus: apmStatus,
 	}
+}
+
+func (l *localAPIImpl) setCatalog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var catalog catalog
+	var response APIResponse
+	defer func() {
+		_ = json.NewEncoder(w).Encode(response)
+	}()
+	err := json.NewDecoder(r.Body).Decode(&catalog)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		response.Error = &APIError{Message: err.Error()}
+		return
+	}
+	log.Infof("Received local request to set catalog")
+	l.daemon.SetCatalog(catalog)
 }
 
 // example: curl -X POST --unix-socket /opt/datadog-packages/installer.sock -H 'Content-Type: application/json' http://installer/datadog-agent/experiment/start -d '{"version":"1.21.5"}'
@@ -239,6 +257,7 @@ func (l *localAPIImpl) install(w http.ResponseWriter, r *http.Request) {
 type LocalAPIClient interface {
 	Status() (StatusResponse, error)
 
+	SetCatalog(catalog string) error
 	Install(pkg, version string) error
 	StartExperiment(pkg, version string) error
 	StopExperiment(pkg string) error
@@ -287,6 +306,30 @@ func (c *localAPIClientImpl) Status() (StatusResponse, error) {
 		return response, fmt.Errorf("error getting status: %s", response.Error.Message)
 	}
 	return response, nil
+}
+
+// SetCatalog sets the catalog for the daemon.
+func (c *localAPIClientImpl) SetCatalog(catalog string) error {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/catalog", c.addr), bytes.NewBuffer([]byte(catalog)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var response APIResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return err
+	}
+	if response.Error != nil {
+		return fmt.Errorf("error starting experiment: %s", response.Error.Message)
+	}
+	return nil
 }
 
 // StartExperiment starts an experiment for a package.

--- a/pkg/fleet/daemon/local_api_test.go
+++ b/pkg/fleet/daemon/local_api_test.go
@@ -70,6 +70,10 @@ func (m *testDaemon) GetAPMInjectionStatus() (APMInjectionStatus, error) {
 	return args.Get(0).(APMInjectionStatus), args.Error(1)
 }
 
+func (m *testDaemon) SetCatalog(catalog catalog) {
+	m.Called(catalog)
+}
+
 type testLocalAPI struct {
 	i *testDaemon
 	s *localAPIImpl


### PR DESCRIPTION
This PR adds a `SetCatalog` method to the local API of the installer. The goal is to allow us to write e2e tests that rely on the local API to simulate updates.