### PR TITLE
Remove unused config method

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -76,10 +76,6 @@ type Reader interface {
 	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
 	GetEnvVars() []string
 
-	// IsSectionSet checks if a given section is set by checking if any of
-	// its subkeys is set.
-	IsSectionSet(section string) bool
-
 	// Warnings returns pointer to a list of warnings (completes config.Component interface)
 	Warnings() *Warnings
 

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -60,7 +60,6 @@ type Reader interface {
 	AllKeysLowercased() []string
 
 	IsSet(key string) bool
-	IsSetForSource(key string, source Source) bool
 
 	// UnmarshalKey Unmarshal a configuration key into a struct
 	UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -255,13 +255,6 @@ func (c *safeConfig) IsSet(key string) bool {
 	return c.Viper.IsSet(key)
 }
 
-// IsSet wraps Viper for concurrent access
-func (c *safeConfig) IsSetForSource(key string, source Source) bool {
-	c.RLock()
-	defer c.RUnlock()
-	return c.configSources[source].IsSet(key)
-}
-
 // IsSectionSet checks if a section is set by checking if either it
 // or any of its subkeys is set.
 func (c *safeConfig) IsSectionSet(section string) bool {

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -255,30 +255,6 @@ func (c *safeConfig) IsSet(key string) bool {
 	return c.Viper.IsSet(key)
 }
 
-// IsSectionSet checks if a section is set by checking if either it
-// or any of its subkeys is set.
-func (c *safeConfig) IsSectionSet(section string) bool {
-	// The section is considered set if any of the keys
-	// inside it is set.
-	// This is needed when keys within the section
-	// are set through env variables.
-
-	// Add trailing . to make sure we don't take into account unrelated
-	// settings, eg. IsSectionSet("section") shouldn't return true
-	// if "section_key" is set.
-	sectionPrefix := section + "."
-
-	for _, key := range c.AllKeysLowercased() {
-		if strings.HasPrefix(key, sectionPrefix) && c.IsSet(key) {
-			return true
-		}
-	}
-
-	// If none of the keys are set, the section is still considered as set
-	// if it has been explicitly set in the config.
-	return c.IsSet(section)
-}
-
 func (c *safeConfig) AllKeysLowercased() []string {
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -162,37 +162,6 @@ float_list:
 	assert.Equal(t, []float64{1.1, 2.2, 3.3}, list)
 }
 
-func TestIsSectionSet(t *testing.T) {
-	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
-
-	config.BindEnv("test.key")
-	config.BindEnv("othertest.key")
-	config.SetKnown("yetanothertest_key")
-	config.SetConfigType("yaml")
-
-	yamlExample := []byte(`
-test:
-  key:
-`)
-
-	config.ReadConfig(bytes.NewBuffer(yamlExample))
-
-	res := config.IsSectionSet("test")
-	assert.Equal(t, true, res)
-
-	res = config.IsSectionSet("othertest")
-	assert.Equal(t, false, res)
-
-	t.Setenv("DD_OTHERTEST_KEY", "value")
-
-	res = config.IsSectionSet("othertest")
-	assert.Equal(t, true, res)
-
-	config.SetWithoutSource("yetanothertest_key", "value")
-	res = config.IsSectionSet("yetanothertest")
-	assert.Equal(t, false, res)
-}
-
 func TestSet(t *testing.T) {
 	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 	config.Set("foo", "bar", SourceFile)

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -219,13 +219,6 @@ func TestGetSource(t *testing.T) {
 	assert.Equal(t, SourceEnvVar, config.GetSource("foo"))
 }
 
-func TestIsSet(t *testing.T) {
-	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
-	assert.False(t, config.IsSetForSource("foo", SourceFile))
-	config.Set("foo", "bar", SourceFile)
-	assert.True(t, config.IsSetForSource("foo", SourceFile))
-}
-
 func TestIsKnown(t *testing.T) {
 	testCases := []struct {
 		setDefault bool
@@ -275,13 +268,6 @@ func TestIsKnown(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUnsetForSource(t *testing.T) {
-	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
-	config.Set("foo", "bar", SourceFile)
-	config.UnsetForSource("foo", SourceFile)
-	assert.False(t, config.IsSetForSource("foo", SourceFile))
 }
 
 func TestAllFileSettingsWithoutDefault(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Remove unused method from the config interface. This is preliminary work to replace viper by something better. A smaller API for the config will make things easier to migrate.