### PR TITLE
[test] Delete unecessary calls to collectors.GetCatalog()

### DIFF
--- a/comp/core/autodiscovery/providers/container_test.go
+++ b/comp/core/autodiscovery/providers/container_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -27,7 +26,6 @@ func TestProcessEvents(t *testing.T) {
 	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		config.MockModule(),
 		logimpl.MockModule(),
-		collectors.GetCatalog(),
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmetafxmock.MockModuleV2(),
 	))
@@ -417,7 +415,6 @@ func TestGenerateConfig(t *testing.T) {
 				config.MockModule(),
 				logimpl.MockModule(),
 				fx.Replace(config.MockParams{Overrides: overrides}),
-				collectors.GetCatalog(),
 				fx.Supply(workloadmeta.NewParams()),
 				workloadmetafxmock.MockModuleV2(),
 			))

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -98,7 +97,6 @@ func (suite *ProviderTestSuite) SetupTest() {
 
 	store := fxutil.Test[workloadmetamock.Mock](suite.T(), fx.Options(
 		core.MockBundle(),
-		collectors.GetCatalog(),
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmetafxmock.MockModuleV2(),
 	))

--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -129,7 +128,6 @@ func (suite *ProviderTestSuite) SetupTest() {
 
 	store := fxutil.Test[workloadmetamock.Mock](suite.T(), fx.Options(
 		core.MockBundle(),
-		collectors.GetCatalog(),
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmetafxmock.MockModuleV2(),
 	))

--- a/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -264,7 +263,6 @@ func TestProvider_Provide(t *testing.T) {
 			store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 				core.MockBundle(),
 				fx.Supply(context.Background()),
-				collectors.GetCatalog(),
 				fx.Supply(workloadmeta.NewParams()),
 				workloadmetafxmock.MockModuleV2(),
 			))

--- a/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -165,7 +164,6 @@ func TestProvider_Provide(t *testing.T) {
 
 			store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 				core.MockBundle(),
-				collectors.GetCatalog(),
 				fx.Supply(workloadmeta.NewParams()),
 				workloadmetafxmock.MockModuleV2(),
 			))
@@ -233,7 +231,6 @@ func TestProvider_DisableProvider(t *testing.T) {
 
 	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
-		collectors.GetCatalog(),
 		fx.Supply(workloadmeta.NewParams()),
 		workloadmetafxmock.MockModuleV2(),
 	))


### PR DESCRIPTION
### What does this PR do?

Deletes unnecessary calls to `collectors.GetCatalog()` in some tests.

These tests create their own workloadmeta events, so they don't need to start the collectors. Starting the collectors might even be confusing if they can run in the test environment and generate other workloadmeta events that the test does not expect.

### Describe how to test/QA your changes

Skip.
