### PR TITLE
[Serverless] Maintain serverless PR comments independently.

### DIFF
--- a/.github/workflows/serverless-benchmarks.yml
+++ b/.github/workflows/serverless-benchmarks.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Post comment
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
+          header: serverless-benchmarks
           recreate: true
           message: |
             ## Serverless Benchmark Results

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -135,6 +135,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         if: steps.should.outputs.should_run == 'true'
         with:
+          header: serverless-binary-size
           hide_and_recreate: true
           hide_classify: "RESOLVED"
           message: |


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add `header` tag to each usage of the [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment#keep-more-than-one-comment) github action. From their docs:

> In some cases, different actions may require different comments. The header allows you to maintain comments independently.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We're noticing that the Serverless Binary Size comment keeps disappearing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
