### PR TITLE
Include version in yaml import/export.

### DIFF
--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -33,8 +33,7 @@ type ProfileDefinition struct {
 
 	// Version is the profile version.
 	// It is currently used only with downloaded/RC profiles.
-	// It's not exposed as yaml field since not necessary.
-	Version uint64 `yaml:"-" json:"version"`
+	Version uint64 `yaml:"version,omitempty" json:"version"`
 }
 
 // DeviceProfileRcConfig represent the profile stored in remote config.


### PR DESCRIPTION
### What does this PR do?

This allows the 'version' field to be included in yaml dumps/loads of profiles.

### Motivation

This shouldn't change any behavior in the agent, except in the future when we have profiles with versions, but since this module is also used by the backend it also means that the backend profile exports will have the version field set, even if the agent won't use it right now.

### Describe how to test/QA your changes

Launch an agent with a profile that has no version and a profile that has a version, and verify that it doesn't report any parsing errors.
