### PR TITLE
Fix typo in docker.conf around filtered_event_types

### DIFF
--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -34,7 +34,7 @@ instances:
 
     ## @param filtered_event_types - list of strings - optional - default: ['top', 'exec_start', 'exec_create', 'exec_die']
     ## List of excluded (filtered out) event types. Docker events of this type are not collected.
-    ## Only effective when unbundle_events is true, otherwise filtered_event_types is used.
+    ## Only effective when unbundle_events is false, otherwise collected_event_types is used.
     ## A list of available types can be found at:
     ## https://docs.docker.com/engine/reference/commandline/events/#object-types
     #


### PR DESCRIPTION
### What does this PR do?

This PR includes a minor fix to the comments for the filtered_event_types configuration option as it did not match the logic in the agent code.

### Motivation

### Additional Notes

This was originally contained in https://github.com/DataDog/datadog-agent/pull/26968 but was split out per https://github.com/DataDog/datadog-agent/pull/26968#issuecomment-2183471407

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
