### PR TITLE
[EBPF] - fixed LockContentionCollector init

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -339,7 +339,7 @@ func startSystemProbe(log log.Component, statsd compstatsd.Component, telemetry 
 				telemetry.RegisterCollector(pc)
 			}
 			if lcc := ddebpf.NewLockContentionCollector(); lcc != nil {
-				telemetry.RegisterCollector(ddebpf.NewLockContentionCollector())
+				telemetry.RegisterCollector(lcc)
 			}
 		}
 		go func() {

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -338,7 +338,9 @@ func startSystemProbe(log log.Component, statsd compstatsd.Component, telemetry 
 			if pc := ebpftelemetry.NewPerfUsageCollector(); pc != nil {
 				telemetry.RegisterCollector(pc)
 			}
-			telemetry.RegisterCollector(ddebpf.NewLockContentionCollector())
+			if lcc := ddebpf.NewLockContentionCollector(); lcc != nil {
+				telemetry.RegisterCollector(ddebpf.NewLockContentionCollector())
+			}
 		}
 		go func() {
 			common.ExpvarServer = &http.Server{

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 	"go4.org/intern"
 
@@ -78,13 +79,14 @@ var tracerTelemetry = struct {
 
 // Tracer implements the functionality of the network tracer
 type Tracer struct {
-	config      *config.Config
-	state       network.State
-	conntracker netlink.Conntracker
-	reverseDNS  dns.ReverseDNS
-	usmMonitor  *usm.Monitor
-	ebpfTracer  connection.Tracer
-	lastCheck   *atomic.Int64
+	config             *config.Config
+	state              network.State
+	conntracker        netlink.Conntracker
+	reverseDNS         dns.ReverseDNS
+	usmMonitor         *usm.Monitor
+	ebpfTracer         connection.Tracer
+	bpfErrorsCollector prometheus.Collector
+	lastCheck          *atomic.Int64
 
 	bufferLock sync.Mutex
 
@@ -402,6 +404,9 @@ func (t *Tracer) Stop() {
 		events.UnregisterHandler(t.processCache)
 		t.processCache.Stop()
 		telemetry.GetCompatComponent().UnregisterCollector(t.processCache)
+	}
+	if t.bpfErrorsCollector != nil {
+		telemetry.GetCompatComponent().UnregisterCollector(t.bpfErrorsCollector)
 	}
 }
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 	"go4.org/intern"
 
@@ -79,14 +78,13 @@ var tracerTelemetry = struct {
 
 // Tracer implements the functionality of the network tracer
 type Tracer struct {
-	config             *config.Config
-	state              network.State
-	conntracker        netlink.Conntracker
-	reverseDNS         dns.ReverseDNS
-	usmMonitor         *usm.Monitor
-	ebpfTracer         connection.Tracer
-	bpfErrorsCollector prometheus.Collector
-	lastCheck          *atomic.Int64
+	config      *config.Config
+	state       network.State
+	conntracker netlink.Conntracker
+	reverseDNS  dns.ReverseDNS
+	usmMonitor  *usm.Monitor
+	ebpfTracer  connection.Tracer
+	lastCheck   *atomic.Int64
 
 	bufferLock sync.Mutex
 
@@ -404,9 +402,6 @@ func (t *Tracer) Stop() {
 		events.UnregisterHandler(t.processCache)
 		t.processCache.Stop()
 		telemetry.GetCompatComponent().UnregisterCollector(t.processCache)
-	}
-	if t.bpfErrorsCollector != nil {
-		telemetry.GetCompatComponent().UnregisterCollector(t.bpfErrorsCollector)
 	}
 }
 


### PR DESCRIPTION

### What does this PR do?

checks for proper initialization of the LockContention Collector before registering it with the telemetry component
### Motivation

potential panic due to a nil deref

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
