### PR TITLE
[CWS] fix an issue with duplicated `service:` prefix in service field

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -468,7 +468,7 @@ func (c *RuntimeSecurityConfig) GetAnomalyDetectionMinimumStablePeriod(eventType
 func (c *RuntimeSecurityConfig) sanitize() error {
 	serviceName := utils.GetTagValue("service", configUtils.GetConfiguredTags(coreconfig.Datadog(), true))
 	if len(serviceName) > 0 {
-		c.HostServiceName = fmt.Sprintf("service:%s", serviceName)
+		c.HostServiceName = serviceName
 	}
 
 	if c.IMDSIPv4 == 0 {


### PR DESCRIPTION
### What does this PR do?

When collecting the service from the host tags configuration we would store it as `service:abcxyz` instead of simply `abcxyz`. Other service collection methods, like from env variables, or from the tagger, would give the service name directly without the prefix. This means that in some case we would report the service with the unnecessary prefix `service:` which is an error. This PR fixes this issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
