### PR TITLE
Fixing iptables-restore flakiness

### DIFF
--- a/pkg/network/testutil/iptables.go
+++ b/pkg/network/testutil/iptables.go
@@ -41,7 +41,10 @@ func IptablesSave(tb testing.TB) []byte {
 
 // IptablesRestore restores iptables state from a file
 func IptablesRestore(tb testing.TB, state []byte) {
-	cmd := exec.Command("iptables-restore", "--counters")
+	// Define the time to wait for the xtables lock.
+	// This is necessary because we noticed that iptables-restore fails with error code 4 when it can't acquire the lock.
+	lockWaitTimeSeconds := "5"
+	cmd := exec.Command("iptables-restore", "--counters", "--wait", lockWaitTimeSeconds)
 	cmd.Stdin = bytes.NewReader(state)
 	assert.NoError(tb, cmd.Run())
 }


### PR DESCRIPTION
### What does this PR do?
This PR addresses the cleanup flakiness in TestUSMSuite's TestProtocolClassification by introducing a retry mechanism.

### Motivation
We noticed errors in the cleanup process involving the iptables-restore command, specifically encountering error code 4, which typically indicates a locking issue.

### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes