### PR TITLE
feat(traces): implement local data header

### DIFF
--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -31,6 +31,12 @@ const cgroupV1BaseController = "memory"
 // It also needs to be small enough to catch the first traces of new containers.
 const readerCacheExpiration = 2 * time.Second
 
+const (
+	legacyContainerIDPrefix = "cid-"
+	containerIDPrefix       = "ci-"
+	inodePrefix             = "in-"
+)
+
 type ucredKey struct{}
 
 // connContext injects a Unix Domain Socket's User Credentials into the
@@ -129,70 +135,128 @@ type cgroupIDProvider struct {
 	cache  *Cache
 }
 
-// GetContainerID returns the container ID in the http.Header,
-// otherwise looks for a PID in the ctx which is used to search cgroups for a container ID.
+// GetContainerID returns the container ID.
+// The Container ID can come from either http headers or the context:
+// * Local Data header
+// * Datadog-Container-ID header
+// * Looks for a PID in the ctx which is used to search cgroups for a container ID.
 func (c *cgroupIDProvider) GetContainerID(ctx context.Context, h http.Header) string {
-	// Retrieve the container-id from Datadog-Container-ID header
-	if id := h.Get(header.ContainerID); id != "" {
-		return id
+	// Retrieve container ID from Local Data header
+	if LocalData := h.Get(header.LocalData); LocalData != "" {
+		return c.resolveContainerIDFromLocalData(LocalData)
 	}
+
+	// Retrieve container ID from Datadog-Container-ID header.
+	// Deprecated in favor of Local Data header. This is kept for backward compatibility with older libraries.
+	if containerIDFromHeader := h.Get(header.ContainerID); containerIDFromHeader != "" {
+		return containerIDFromHeader
+	}
+
 	// Retrieve the container-id from the pid in its context
-	cid := c.resolveContainerIDFromContext(ctx)
-	if cid != "" {
-		return cid
+	if containerID := c.resolveContainerIDFromContext(ctx); containerID != "" {
+		return containerID
 	}
-	// Retrieve from the entity id
-	if eid := h.Get(header.EntityID); eid != "" {
-		return c.resolveContainerIDFromEntityID(eid)
-	}
+
 	return ""
 }
 
-// resolveContainerIDFromEntityID returns the container ID for the given entity ID.
-// This is a fallback for when the container ID is not available in the http header.
-func (c *cgroupIDProvider) resolveContainerIDFromEntityID(eid string) string {
-	// The entityID can contain the container ID directly
-	if strings.HasPrefix(eid, "cid-") {
-		return eid[4:]
-	}
-	// The entityID can contain the cgroupv2 node inode
-	if !strings.HasPrefix(eid, "in-") {
-		return ""
-	}
-	inode, err := strconv.ParseUint(eid[3:], 10, 64)
-	if err != nil {
-		log.Debugf("Could not parse cgroupv2 inode: %s: %v", eid, err)
-		return ""
+// resolveContainerIDFromLocalData returns the container ID for the given Local Data.
+// The Local Data is a list that can contain one or two (split by a ',') of either:
+// * "cid-<container-id>" or "ci-<container-id>" for the container ID.
+// * "in-<cgroupv2-inode>" for the cgroupv2 inode.
+// Possible values:
+// * "cid-<container-id>"
+// * "ci-<container-id>,in-<cgroupv2-inode>"
+func (c *cgroupIDProvider) resolveContainerIDFromLocalData(LocalData string) string {
+	containerID := ""
+
+	if strings.Contains(LocalData, ",") {
+		// The Local Data can contain a list
+		containerID = c.resolveContainerIDFromLocalDataList(LocalData)
+	} else {
+		// The Local Data can contain a single value
+		if strings.HasPrefix(LocalData, legacyContainerIDPrefix) { // Container ID with old format: cid-<container-id>
+			containerID = LocalData[len(legacyContainerIDPrefix):]
+		} else if strings.HasPrefix(LocalData, containerIDPrefix) { // Container ID with new format: ci-<container-id>
+			containerID = LocalData[len(containerIDPrefix):]
+		} else if strings.HasPrefix(LocalData, inodePrefix) { // Cgroupv2 inode format: in-<cgroupv2-inode>
+			containerID = c.resolveContainerIDFromInode(LocalData[len(inodePrefix):])
+		}
 	}
 
-	cid, err := c.getCachedContainerID(eid, func() (string, error) { return c.getContainerIDByInode(inode) })
-	if err != nil {
-		log.Debugf("Could not get container ID from cgroupv2 inode: %s: %v", eid, err)
-		return ""
+	if containerID == "" {
+		log.Debugf("Could not parse container ID from Local Data: %s", LocalData)
 	}
-	return cid
+	return containerID
 }
 
-// getContainerIDByInode returns the container ID for the given cgroup inode.
-func (c *cgroupIDProvider) getContainerIDByInode(inode uint64) (string, error) {
-	cgroup := c.reader.GetCgroupByInode(inode)
-	if cgroup == nil {
-		err := c.reader.RefreshCgroups(readerCacheExpiration)
+// resolveContainerIDFromLocalDataList returns the container ID for the given Local Data list.
+func (c *cgroupIDProvider) resolveContainerIDFromLocalDataList(LocalData string) string {
+	containerID, err := c.getCachedContainerID(LocalData, func() (string, error) {
+		containerID := ""
+		ContainerIDFromInode := ""
+
+		items := strings.Split(LocalData, ",")
+		for _, item := range items {
+			log.Criticalf("Local Data item: %s", item)
+			if strings.HasPrefix(item, containerIDPrefix) {
+				containerID = item[len(containerIDPrefix):]
+			} else if strings.HasPrefix(item, inodePrefix) {
+				ContainerIDFromInode = c.resolveContainerIDFromInode(item[len(inodePrefix):])
+			}
+		}
+
+		if containerID != "" {
+			return containerID, nil
+		} else if ContainerIDFromInode != "" {
+			return ContainerIDFromInode, nil
+		}
+
+		return "", nil
+	})
+	if err != nil {
+		log.Debugf("Could not get container ID from Local Data: %s: %v", LocalData, err)
+		return ""
+	}
+
+	return containerID
+}
+
+// resolveContainerIDFromInode returns the container ID for the given cgroupv2 inode.
+func (c *cgroupIDProvider) resolveContainerIDFromInode(inodeString string) string {
+	containerID, err := c.getCachedContainerID(inodeString, func() (string, error) {
+		// Parse the cgroupv2 inode as a uint64.
+		inodeUint, err := strconv.ParseUint(inodeString, 10, 64)
 		if err != nil {
-			return "", fmt.Errorf("containerID not found from inode %d and unable to refresh cgroups, err: %w", inode, err)
+			return "", fmt.Errorf("could not parse cgroupv2 inode: %s: %v", inodeString, err)
 		}
 
-		cgroup = c.reader.GetCgroupByInode(inode)
+		// Get the container ID from the cgroupv2 inode.
+		cgroup := c.reader.GetCgroupByInode(inodeUint)
 		if cgroup == nil {
-			return "", fmt.Errorf("containerID not found from inode %d, err: %w", inode, err)
+			err := c.reader.RefreshCgroups(readerCacheExpiration)
+			if err != nil {
+				return "", fmt.Errorf("containerID not found from inode %d and unable to refresh cgroups, err: %w", inodeUint, err)
+			}
+
+			cgroup = c.reader.GetCgroupByInode(inodeUint)
+			if cgroup == nil {
+				return "", fmt.Errorf("containerID not found from inode %d, err: %w", inodeUint, err)
+			}
 		}
+
+		return cgroup.Identifier(), nil
+	})
+	if err != nil {
+		log.Debugf("Could not get container ID from cgroupv2 inode: %s: %v", inodeString, err)
+		return ""
 	}
 
-	return cgroup.Identifier(), nil
+	return containerID
 }
 
-// resolveContainerIDFromContext returns the container ID for the given entity ID.
-// This is a fallback for when the container ID is not available in the http header.
+// resolveContainerIDFromContext returns the container ID for the given context.
+// This is a fallback for when the container ID is not available in the http headers.
 func (c *cgroupIDProvider) resolveContainerIDFromContext(ctx context.Context) string {
 	ucred, ok := ctx.Value(ucredKey{}).(*syscall.Ucred)
 	if !ok || ucred == nil {

--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -196,6 +196,7 @@ func (c *cgroupIDProvider) resolveContainerIDFromLocalDataList(localData string)
 		containerID := ""
 		containerIDFromInode := ""
 
+		// The list should always contain two items. With a malformed list, we will overwrite variables.
 		items := strings.Split(localData, ",")
 		for _, item := range items {
 			if strings.HasPrefix(item, containerIDPrefix) {

--- a/pkg/trace/api/internal/header/headers.go
+++ b/pkg/trace/api/internal/header/headers.go
@@ -13,13 +13,17 @@ const (
 
 	// ContainerID specifies the name of the header which contains the ID of the
 	// container where the request originated.
+	// Deprecated in favor of Datadog-Entity-ID.
 	ContainerID = "Datadog-Container-ID"
 
-	// EntityID specifies the name of the header which contains entityID of the
-	// sender of the payload. This entityID can either be "cid-<container-id>", or
-	// "in-<cgroupv2-inode>" and is used to retrieve the container-id. It could be
-	// extended to support other entities such as the pid.
-	EntityID = "Datadog-Entity-ID"
+	// LocalData specifies the name of the header which contains the local data for Origin Detection.
+	// The Local Data is a list that can contain one or two (split by a ',') of either:
+	// * "cid-<container-id>" or "ci-<container-id>" for the container ID.
+	// * "in-<cgroupv2-inode>" for the cgroupv2 inode.
+	// Possible values:
+	// * "cid-<container-id>"
+	// * "ci-<container-id>,in-<cgroupv2-inode>"
+	LocalData = "Datadog-Entity-ID"
 
 	// Lang specifies the name of the header which contains the language from
 	// which the traces originate.


### PR DESCRIPTION
### What does this PR do?

Implements the new local data header format for Traces.

### Motivation

This is needed to implement the New Origin Detection Spec.

### Describe how to test/QA your changes

* Deploy the Agent on Kubernetes and this application
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-trace-python
  labels:
    app: dummy-trace-python
spec:
  selector:
    matchLabels:
      app: dummy-trace-python
  replicas: 1
  template:
    metadata:
      labels:
        app: dummy-trace-python
    spec:
      containers:
        - name: dummy-trace-python
          image: wdhifdatadog/dummy-trace-python
          env:
          - name: DD_AGENT_HOST
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
```
The [wdhifdatadog/dummy-trace-python](https://hub.docker.com/r/wdhifdatadog/dummy-trace-python) application implements a traced Python application with a modified version of ddtrace that uses the new local data header format.

* Verify that you are getting valid traces

![image](https://github.com/DataDog/datadog-agent/assets/5231539/016cf9d7-d87d-474e-a221-02b006e19699)
