### PR TITLE
[SBOM] Fix list of directories analyzed by Trivy

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -110,7 +110,7 @@ func getDefaultArtifactOption(root string, opts sbom.ScanOptions) artifact.Optio
 			"/etc/*",
 			"/lib/apk/*",
 			"/usr/lib/*",
-			"/usr/lib/sysimage/*",
+			"/usr/lib/sysimage/rpm/*",
 			"/var/lib/dpkg/**",
 			"/var/lib/rpm/*",
 		}


### PR DESCRIPTION
### What does this PR do?

This changes fixes the list of directories analyzed by Trivy.

The RPM database is located in the `/usr/lib/sysimage/rpm` directory.

### Motivation

Since Fedora 36 (2022-05-10), the RPM database was [moved](https://lwn.net/Articles/881107/)  from the `/var/lib/rpm` directory to the `/usr/lib/sysimage/rpm` directory.

This change also impacts the other RPM distributions like openSUSE, and, of course, the future RHEL 10.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The issue has been reported for this image: https://hub.docker.com/r/cafapi/opensuse-jdk17