### PR TITLE
[oracle] Fix empty lock payloads

### DIFF
--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/benbjohnson/clock"
 )
 
 type vInstance struct {
@@ -150,6 +151,7 @@ func (c *Check) init() error {
 
 	c.fqtEmitted = getFqtEmittedCache()
 	c.planEmitted = getPlanEmittedCache(c)
+	c.clock = clock.New()
 	c.initialized = true
 
 	return nil

--- a/pkg/collector/corechecks/oracle/locks.go
+++ b/pkg/collector/corechecks/oracle/locks.go
@@ -132,6 +132,11 @@ func (c *Check) locks() error {
 		}
 		oracleRows = append(oracleRows, p)
 	}
+
+	if len(oracleRows) == 0 {
+		return nil
+	}
+
 	hname, _ := hostname.Get(context.TODO())
 	m := metricsPayload{
 		Host:                  c.dbHostname,

--- a/pkg/collector/corechecks/oracle/locks.go
+++ b/pkg/collector/corechecks/oracle/locks.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -138,10 +137,11 @@ func (c *Check) locks() error {
 	}
 
 	hname, _ := hostname.Get(context.TODO())
+	ts := float64(c.clock.Now().UnixMilli())
 	m := metricsPayload{
 		Host:                  c.dbHostname,
 		Kind:                  "lock_metrics",
-		Timestamp:             float64(time.Now().UnixMilli()),
+		Timestamp:             ts,
 		MinCollectionInterval: float64(c.config.MinCollectionInterval),
 		Tags:                  c.tags,
 		AgentVersion:          c.agentVersion,

--- a/pkg/collector/corechecks/oracle/locks_test.go
+++ b/pkg/collector/corechecks/oracle/locks_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocks(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	c, sender := newDbDoesNotExistCheck(t, "", "")
+	c.dbVersion = "19.2"
+	c.db = sqlx.NewDb(db, "sqlmock")
+	c.Run()
+
+	sender.SetupAcceptAll()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	hname, _ := hostname.Get(context.TODO())
+	m := metricsPayload{
+		Host:                  c.dbHostname,
+		Kind:                  "lock_metrics",
+		Timestamp:             float64(time.Now().UnixMilli()),
+		MinCollectionInterval: float64(c.config.MinCollectionInterval),
+		Tags:                  c.tags,
+		AgentVersion:          c.agentVersion,
+		AgentHostname:         hname,
+		OracleVersion:         c.dbVersion,
+	}
+
+	dbMock.ExpectQuery("SELECT.*transaction.*").WillReturnError(sql.ErrNoRows)
+	err = c.locks()
+	assert.NoError(t, err, "failed to execute locks query")
+	emptyPayload := lockMetricsPayload{
+		OracleRows: []oracleLockRow{},
+	}
+	emptyPayload.metricsPayload = m
+	payloadBytes, err := json.Marshal(emptyPayload)
+	require.NoError(t, err, "failed to marshal lock metrics payload")
+	sender.AssertNotCalled(t, "EventPlatformEvent", payloadBytes, "dbm-metrics")
+
+	rows := sqlmock.NewRows([]string{"SECONDS", "PROGRAM"}).
+		AddRow(17, "test-program")
+	dbMock.ExpectQuery("SELECT.*transaction.*").WillReturnRows(rows)
+	err = c.locks()
+	assert.NoError(t, err, "failed to execute locks query")
+	payload := lockMetricsPayload{
+		OracleRows: []oracleLockRow{
+			{
+				SecondsInTransaction: 17,
+				Program:              "test-program",
+			},
+		},
+	}
+	payload.metricsPayload = m
+	payloadBytes, err = json.Marshal(payload)
+	require.NoError(t, err, "failed to marshal lock metrics payload")
+	sender.AssertEventPlatformEvent(t, payloadBytes, "dbm-metrics")
+}

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/benbjohnson/clock"
 
 	//nolint:revive // TODO(DBM) Fix revive linter
 	_ "github.com/godror/godror"
@@ -113,6 +114,7 @@ type Check struct {
 	databaseRole                            string
 	openMode                                string
 	legacyIntegrationCompatibilityMode      bool
+	clock                                   clock.Clock
 }
 
 type vDatabase struct {

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -158,10 +158,3 @@ func assertConnectionCount(t *testing.T, c *Check, max int) {
 	require.NoError(t, err, "failed to execute the session count query")
 	require.LessOrEqual(t, n, max, "too many sessions:")
 }
-
-// TODO: move this to a shared package managed by the Agent logs and metrics team
-func assertEventPlatformEventMissing(t *testing.T, m *mocksender.MockSender, expectedRawEvent []byte, expectedEventType string) {
-	if m.Mock.AssertCalled(t, "EventPlatformEvent", expectedRawEvent, expectedEventType) {
-		assert.Fail(t, "event shouldn't have been sent")
-	}
-}

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -158,3 +158,10 @@ func assertConnectionCount(t *testing.T, c *Check, max int) {
 	require.NoError(t, err, "failed to execute the session count query")
 	require.LessOrEqual(t, n, max, "too many sessions:")
 }
+
+// TODO: move this to a shared package managed by the Agent logs and metrics team
+func assertEventPlatformEventMissing(t *testing.T, m *mocksender.MockSender, expectedRawEvent []byte, expectedEventType string) {
+	if m.Mock.AssertCalled(t, "EventPlatformEvent", expectedRawEvent, expectedEventType) {
+		assert.Fail(t, "event shouldn't have been sent")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes empty lock payloads.

### Motivation

`dbm-metrics-processor` was sending empty series to metrics intake. Meanwhile, a workaround was implemented on `dbm-metrics-processor` but the agent shouldn't be sending empty payloads.

### Additional Notes

No changelog, since the bug wasn't customer facing.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
