### PR TITLE
[CI] Add missing `CI_JOB_ID` in windows container for Codecov settings

### DIFF
--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -24,6 +24,7 @@
       -e GITLAB_CI=true
       -e CI_JOB_URL="${CI_JOB_URL}"
       -e CI_JOB_NAME="${CI_JOB_NAME}"
+      -e CI_JOB_ID="${CI_JOB_ID}"
       -e CI_PIPELINE_ID="${CI_PIPELINE_ID}"
       -e CI_REPOSITORY_URL="${CI_REPOSITORY_URL}"
       -e CI_COMMIT_SHA="${CI_COMMIT_SHA}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the missing `CI_JOB_ID` env var in windows container.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix Codecov settings.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
