### PR TITLE
Use E2E_PIPELINE_ID to determine the package to install

### DIFF
--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -83,7 +83,7 @@ func TestInstallScript(t *testing.T) {
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),
-				e2e.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *flavor, *majorVersion)),
+				e2e.WithStackName(fmt.Sprintf("install-script-test-%v-%s-%s-%v", osVers, *architecture, *flavor, *majorVersion)),
 			)
 		})
 	}

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -86,8 +86,7 @@ func TestPackageSigningComponent(t *testing.T) {
 			e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(
 				awshost.WithEC2InstanceOptions(ec2.WithAMI(ami, osDesc, osDesc.Architecture)),
 			)),
-			//e2e.WithAgentParams(agentparams.WithPipeline(os.Getenv("CI_PIPELINE_ID"), "x86_64")), e2e.WithVMParams(ec2params.WithOS(testedOS))),
-			e2e.WithStackName(fmt.Sprintf("pkgSigning-%s-%s", platform, os.Getenv("CI_PIPELINE_ID"))),
+			e2e.WithStackName(fmt.Sprintf("pkgSigning-%s-%s", platform)),
 		)
 	})
 }

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -16,7 +16,6 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -85,7 +85,7 @@ func TestPackageSigningComponent(t *testing.T) {
 			e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(
 				awshost.WithEC2InstanceOptions(ec2.WithAMI(ami, osDesc, osDesc.Architecture)),
 			)),
-			e2e.WithStackName(fmt.Sprintf("pkgSigning-%s-%s", platform)),
+			e2e.WithStackName(fmt.Sprintf("pkgSigning-%s", platform)),
 		)
 	})
 }

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"regexp"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -86,7 +86,6 @@ func TestPackageSigningComponent(t *testing.T) {
 			&packageSigningTestSuite{osName: platform},
 			e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(
 				awshost.WithEC2InstanceOptions(ec2.WithAMI(ami, osDesc, osDesc.Architecture)),
-				awshost.WithAgentOptions(agentparams.WithPipeline(os.Getenv("CI_PIPELINE_ID"))),
 			)),
 			//e2e.WithAgentParams(agentparams.WithPipeline(os.Getenv("CI_PIPELINE_ID"), "x86_64")), e2e.WithVMParams(ec2params.WithOS(testedOS))),
 			e2e.WithStackName(fmt.Sprintf("pkgSigning-%s-%s", platform, os.Getenv("CI_PIPELINE_ID"))),

--- a/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
+++ b/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
@@ -112,7 +112,7 @@ func (is *rpmTestSuite) TestRpm() {
 		arch = *architecture
 	}
 	yumrepo := fmt.Sprintf("http://yumtesting.datad0g.com/testing/pipeline-%s-a%s/%s/%s/",
-		os.Getenv("CI_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
+		os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
 	fileManager := VMclient.FileManager
 
 	protocol := "https"

--- a/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
+++ b/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
@@ -88,7 +88,7 @@ func TestRpmScript(t *testing.T) {
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),
-				e2e.WithStackName(fmt.Sprintf("rpm-test-%v-%v-%s-%v", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *majorVersion)),
+				e2e.WithStackName(fmt.Sprintf("rpm-test-%v-%s-%v", osVers, *architecture, *majorVersion)),
 			)
 		})
 	}

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -179,7 +179,7 @@ func (is *stepByStepSuite) StepByStepDebianTest(VMclient *common.TestClient) {
 	aptTrustedDKeyring := "/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 	aptUsrShareKeyring := "/usr/share/keyrings/datadog-archive-keyring.gpg"
 	aptrepo := "[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] http://apttesting.datad0g.com/"
-	aptrepoDist := fmt.Sprintf("pipeline-%s-a%s-%s", os.Getenv("CI_PIPELINE_ID"), *majorVersion, *architecture)
+	aptrepoDist := fmt.Sprintf("pipeline-%s-a%s-%s", os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *architecture)
 	fileManager := VMclient.FileManager
 	var err error
 
@@ -215,7 +215,7 @@ func (is *stepByStepSuite) StepByStepRhelTest(VMclient *common.TestClient) {
 		arch = *architecture
 	}
 	yumrepo := fmt.Sprintf("http://yumtesting.datad0g.com/testing/pipeline-%s-a%s/%s/%s/",
-		os.Getenv("CI_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
+		os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
 	fileManager := VMclient.FileManager
 	var err error
 
@@ -257,7 +257,7 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 	}
 
 	suseRepo := fmt.Sprintf("http://yumtesting.datad0g.com/suse/testing/pipeline-%s-a%s/%s/%s/",
-		os.Getenv("CI_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
+		os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
 	fileManager := VMclient.FileManager
 	var err error
 

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -109,7 +109,7 @@ func TestStepByStepScript(t *testing.T) {
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),
-				e2e.WithStackName(fmt.Sprintf("step-by-step-test-%v-%v-%s-%s", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture, *majorVersion)),
+				e2e.WithStackName(fmt.Sprintf("step-by-step-test-%v-%s-%s", osVers, *architecture, *majorVersion)),
 			)
 		})
 	}

--- a/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
+++ b/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
@@ -78,7 +78,7 @@ func TestUpgradeScript(t *testing.T) {
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),
-				e2e.WithStackName(fmt.Sprintf("upgrade-from-%s-to-%s-test-%s-%v-%v-%s", *srcAgentVersion, *destAgentVersion, *flavorName, os.Getenv("CI_PIPELINE_ID"), osVers, *architecture)),
+				e2e.WithStackName(fmt.Sprintf("upgrade-from-%s-to-%s-test-%s-%v-%s", *srcAgentVersion, *destAgentVersion, *flavorName, osVers, *architecture)),
 			)
 		})
 	}

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -7,7 +7,6 @@ package apm
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -28,7 +28,7 @@ type DockerFakeintakeSuite struct {
 func dockerSuiteOpts(tr transport, opts ...awsdocker.ProvisionerOption) []e2e.SuiteOption {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awsdocker.Provisioner(opts...)),
-		e2e.WithStackName(fmt.Sprintf("apm-docker-suite-%s-%v", tr, os.Getenv("CI_PIPELINE_ID"))),
+		e2e.WithStackName(fmt.Sprintf("apm-docker-suite-%s", tr)),
 	}
 	return options
 }

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -67,7 +67,7 @@ func vmSuiteOpts(tr transport, opts ...awshost.ProvisionerOption) []e2e.SuiteOpt
 	opts = vmProvisionerOpts(opts...)
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(opts...)),
-		e2e.WithStackName(fmt.Sprintf("apm-vm-suite-%s-%v", tr, os.Getenv("CI_PIPELINE_ID"))),
+		e2e.WithStackName(fmt.Sprintf("apm-vm-suite-%s", tr)),
 	}
 	return options
 }

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -61,8 +61,8 @@ var (
 )
 
 var packagesConfig = []testPackageConfig{
-	{name: "datadog-installer", defaultVersion: fmt.Sprintf("pipeline-%v", os.Getenv("CI_PIPELINE_ID")), registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", auth: "ecr"},
-	{name: "datadog-agent", defaultVersion: fmt.Sprintf("pipeline-%v", os.Getenv("CI_PIPELINE_ID")), registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", auth: "ecr"},
+	{name: "datadog-installer", defaultVersion: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", auth: "ecr"},
+	{name: "datadog-agent", defaultVersion: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", auth: "ecr"},
 	{name: "datadog-apm-inject", defaultVersion: "latest"},
 	{name: "datadog-apm-library-java", defaultVersion: "latest"},
 	{name: "datadog-apm-library-ruby", defaultVersion: "latest"},
@@ -81,6 +81,12 @@ func shouldSkip(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool {
 }
 
 func TestPackages(t *testing.T) {
+
+	if _, ok := os.LookupEnv("E2E_PIPELINE_ID"); !ok {
+		t.Log("E2E_PIPELINE_ID env var is not set, this test requires this variable to be set to work")
+		t.FailNow()
+	}
+
 	var flavors []e2eos.Descriptor
 	for _, flavor := range amd64Flavors {
 		flavor.Architecture = e2eos.AMD64Arch
@@ -228,9 +234,9 @@ func installScriptPackageManagerEnv(env map[string]string, arch e2eos.Architectu
 	env["DD_INSTALLER"] = "true"
 	env["TESTING_KEYS_URL"] = "keys.datadoghq.com"
 	env["TESTING_APT_URL"] = "apttesting.datad0g.com"
-	env["TESTING_APT_REPO_VERSION"] = fmt.Sprintf("pipeline-%s-a7-%s 7", os.Getenv("CI_PIPELINE_ID"), arch)
+	env["TESTING_APT_REPO_VERSION"] = fmt.Sprintf("pipeline-%s-a7-%s 7", os.Getenv("E2E_PIPELINE_ID"), arch)
 	env["TESTING_YUM_URL"] = "yumtesting.datad0g.com"
-	env["TESTING_YUM_VERSION_PATH"] = fmt.Sprintf("testing/pipeline-%s-a7/7", os.Getenv("CI_PIPELINE_ID"))
+	env["TESTING_YUM_VERSION_PATH"] = fmt.Sprintf("testing/pipeline-%s-a7/7", os.Getenv("E2E_PIPELINE_ID"))
 
 }
 

--- a/test/new-e2e/tests/windows/common/agent/package.go
+++ b/test/new-e2e/tests/windows/common/agent/package.go
@@ -247,7 +247,7 @@ func LookupChannelURLFromEnv() (string, bool) {
 //
 // WINDOWS_AGENT_MSI_URL: manually provided URL (all other parameters are informational only)
 //
-// CI_PIPELINE_ID: use the URL from a specific CI pipeline, major version and arch are used, channel is blank
+// E2E_PIPELINE_ID: use the URL from a specific CI pipeline, major version and arch are used, channel is blank
 //
 // WINDOWS_AGENT_VERSION: The complete version, e.g. 7.49.0-1, 7.49.0-rc.3-1, or a major version, e.g. 7, arch and channel are used
 //

--- a/test/new-e2e/tests/windows/common/agent/package.go
+++ b/test/new-e2e/tests/windows/common/agent/package.go
@@ -267,7 +267,7 @@ func GetPackageFromEnv() (*Package, error) {
 	channel, channelFound := LookupChannelFromEnv()
 	version, _ := LookupVersionFromEnv()
 	arch, _ := LookupArchFromEnv()
-	pipelineID, pipelineIDFound := os.LookupEnv("CI_PIPELINE_ID")
+	pipelineID, pipelineIDFound := os.LookupEnv("E2E_PIPELINE_ID")
 
 	majorVersion := strings.Split(version, ".")[0]
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Stop relying on `CI_PIPELINE_ID` and rather use `E2E_PIPELINE_ID` that is configured to be equal to `CI_PIPELINE_ID` in classic pipelines. But it offers us more flexibility. 
For example this is useful if tests are running in  a child pipeline and we want to use the artifact from parent pipeline

Also add a failure on installer tests when `E2E_PIPELINE_ID` does not exist. The test is doomed to fail 

It also removes `CI_PIPELINE_ID` reference in `WithStackName` the framework itself is already responsible for creating unique stack name from the `CI_JOB_ID` variable
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
