### PR TITLE
[workloadmeta/kubeapiserver] Add missing types to Delete() in reflectorStore

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -144,13 +144,13 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	var uid types.UID
 	var entity workloadmeta.Entity
 	switch v := obj.(type) {
+	// All the supported objects need to be in this switch statement to be able
+	// to be deleted.
 	case *corev1.Pod:
-		uid = v.UID
-	case *corev1.Node:
 		uid = v.UID
 	case *appsv1.Deployment:
 		uid = v.UID
-	case *corev1.Namespace:
+	case *metav1.PartialObjectMetadata:
 		uid = v.UID
 	default:
 		return fmt.Errorf("failed to identify Kind of object: %#v", obj)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+var timeout = 10 * time.Second
+var interval = 50 * time.Millisecond
+
+func Test_AddDelete_Deployment(t *testing.T) {
+	workloadmetaComponent := mockedWorkloadmeta(t)
+
+	deploymentStore := newDeploymentReflectorStore(workloadmetaComponent)
+
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "test-value",
+			},
+		},
+	}
+
+	err := deploymentStore.Add(&deployment)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesDeployment("test-namespace/test-deployment")
+		return err == nil
+	}, timeout, interval)
+
+	err = deploymentStore.Delete(&deployment)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesDeployment("test-namespace/test-deployment")
+		return err != nil
+	}, timeout, interval)
+}
+
+func Test_AddDelete_Pod(t *testing.T) {
+	workloadmetaComponent := mockedWorkloadmeta(t)
+
+	podStore := newPodReflectorStore(workloadmetaComponent)
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "test-value",
+			},
+		},
+	}
+
+	err := podStore.Add(&pod)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesPod(string(pod.UID))
+		return err == nil
+	}, timeout, interval)
+
+	err = podStore.Delete(&pod)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesDeployment(string(pod.UID))
+		return err != nil
+	}, timeout, interval)
+}
+
+func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
+	workloadmetaComponent := mockedWorkloadmeta(t)
+
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+	parser, err := newMetadataParser(gvr, nil)
+	require.NoError(t, err)
+
+	metadataStore := &reflectorStore{
+		wlmetaStore: workloadmetaComponent,
+		seen:        make(map[string]workloadmeta.EntityID),
+		parser:      parser,
+	}
+
+	partialObjMetadata := metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-object",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "test-value",
+			},
+		},
+	}
+
+	kubeMetadataEntityID := util.GenerateKubeMetadataEntityID("namespaces", "", "test-object")
+
+	err = metadataStore.Add(&partialObjMetadata)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesMetadata(kubeMetadataEntityID)
+		return err == nil
+	}, timeout, interval)
+
+	err = metadataStore.Delete(&partialObjMetadata)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesMetadata(kubeMetadataEntityID)
+		return err != nil
+	}, timeout, interval)
+}
+
+func mockedWorkloadmeta(t *testing.T) workloadmeta.Component {
+	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(workloadmeta.NewParams()),
+		workloadmetafxmock.MockModuleV2(),
+	))
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the `kubeapiserver` workloadmeta collector.

It doesn't delete kube metadata objects and shows an error like this one:
```
workloadmeta-kubeapiserver: unable to delete watch event object
```

I also added some test cases that cover this.


### Describe how to test/QA your changes

Enable kubernetes metadata collection. Any object will do, for example, namespaces. You can use this config when deploying with the Helm chart:
```
datadog:
  kubelet:
    tlsVerify: false
clusterAgent:
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: true
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: namespaces
```

Then create a namespace. For example: `kubectl create namespace example` and check that it shows in the cluster-agent `datadog-cluster-agent workload-list`. Then, delete the namespace and check that the error pasted above doesn't appear in the logs and the namespace no longer appears in `datadog-cluster-agent workload-list`.