### PR TITLE
reduce flakyness of process collector test

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -272,7 +272,6 @@ func TestCollection(t *testing.T) {
 				err := grpcServer.Serve(lis)
 				require.NoError(t, err)
 			}()
-			defer grpcServer.Stop()
 
 			_, portStr, err := net.SplitHostPort(lis.Addr().String())
 			require.NoError(t, err)
@@ -315,6 +314,7 @@ func TestCollection(t *testing.T) {
 			}
 
 			mockStore.Unsubscribe(ch)
+			grpcServer.Stop()
 			cancel()
 
 			// Verify final state

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -56,7 +56,7 @@ func (s *mockServer) StreamEntities(_ *pbgo.ProcessStreamEntitiesRequest, out pb
 	for _, response := range s.responses {
 		err := out.Send(response)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/26829 introduced a bit of flakyness in `processcollector.TestCollection`.
Since EOF now triggers a reconnection, the `mockServer.StreamEntities` can be called multiple times by the client. If this is the case and the client is closed soon after, the `Send` call can trigger an error ("transport is closing error") and panic.

This PR reduces the flakyness of `processcollector.TestCollection` by:
- ensuring we don't panic on error, because it doesn't really bring any value in this test, better let gRPC handle error itself
- ensuring the server is closed before the client, so that the server never hit "transport is closing error"

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
