### PR TITLE
conductor: add a sandbox target

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -14,6 +14,9 @@ extensions:
         - name: "staging"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
           branch: "main"
+        - name: "conductor-sandbox"
+          ci_pipeline: "//fake_placeholder:fake_placeholder"
+          branch: "chouquette/conductor"
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a conductor target that can be used to iterate outside of main

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fully integrating with conductor will likely involve many small changes to our CI configuration. Using a dedicated branch will allow to iterate without polluting main in the process 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Conductor only reads its config from the default branch, so still needs to be merged to main, along with any conductor related changes. However this will allow us to iterate on the pipeline config

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
