### PR TITLE
[USM] GoTLSAttachPID: do not error out on already registered binary

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -291,7 +291,13 @@ func GoTLSAttachPID(pid pid) error {
 		return errors.New("GoTLS is not enabled")
 	}
 
-	return goTLSSpec.Instance.(*goTLSProgram).AttachPID(pid)
+	err := goTLSSpec.Instance.(*goTLSProgram).AttachPID(pid)
+	if errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
+		// The process monitor has attached the process before us.
+		return nil
+	}
+
+	return err
 }
 
 // GoTLSDetachPID detaches Go TLS hooks on the binary of process with

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -102,6 +102,7 @@ func NewFileRegistry(programName string) *FileRegistry {
 	return r
 }
 
+//revive:disable:exported
 var (
 	errPidIsNotRegistered      = errors.New("pid is not registered")
 	errCallbackIsMissing       = errors.New("activationCB and deactivationCB must be both non-nil")
@@ -109,6 +110,8 @@ var (
 	errPathIsBlocked           = errors.New("path is blocked")
 	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
 )
+
+//revive:enable
 
 // Register inserts or updates a new file registration within to the `FileRegistry`;
 //

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -107,7 +107,7 @@ var (
 	errCallbackIsMissing       = errors.New("activationCB and deactivationCB must be both non-nil")
 	errAlreadyStopped          = errors.New("registry already stopped")
 	errPathIsBlocked           = errors.New("path is blocked")
-	errPathIsAlreadyRegistered = errors.New("path is already registered")
+	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
 )
 
 // Register inserts or updates a new file registration within to the `FileRegistry`;
@@ -149,7 +149,7 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 			r.byPID[pid][pathID] = struct{}{}
 		}
 		r.telemetry.fileAlreadyRegistered.Add(1)
-		return errPathIsAlreadyRegistered
+		return ErrPathIsAlreadyRegistered
 	}
 
 	if err := activationCB(path); err != nil {

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -102,16 +102,16 @@ func NewFileRegistry(programName string) *FileRegistry {
 	return r
 }
 
-//revive:disable:exported
 var (
-	errPidIsNotRegistered      = errors.New("pid is not registered")
-	errCallbackIsMissing       = errors.New("activationCB and deactivationCB must be both non-nil")
-	errAlreadyStopped          = errors.New("registry already stopped")
-	errPathIsBlocked           = errors.New("path is blocked")
+	errPidIsNotRegistered = errors.New("pid is not registered")
+	errCallbackIsMissing  = errors.New("activationCB and deactivationCB must be both non-nil")
+	errAlreadyStopped     = errors.New("registry already stopped")
+	errPathIsBlocked      = errors.New("path is blocked")
+
+	// ErrPathIsAlreadyRegistered is the error resulting if the
+	// path is already in the file registry.
 	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
 )
-
-//revive:enable
 
 // Register inserts or updates a new file registration within to the `FileRegistry`;
 //

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -57,7 +57,7 @@ func TestMultiplePIDsSharingSameFile(t *testing.T) {
 
 	// Trying to register the same file twice from different PIDs
 	require.NoError(t, r.Register(path, pid1, registerCallback, unregisterCallback))
-	require.Equal(t, errPathIsAlreadyRegistered, r.Register(path, pid2, registerCallback, unregisterCallback))
+	require.Equal(t, ErrPathIsAlreadyRegistered, r.Register(path, pid2, registerCallback, unregisterCallback))
 
 	// Assert that the callback should execute only *once*
 	assert.Equal(t, 1, registerRecorder.CallsForPathID(pathID))
@@ -100,7 +100,7 @@ func TestRepeatedRegistrationsFromSamePID(t *testing.T) {
 	pid := uint32(cmd.Process.Pid)
 
 	require.NoError(t, r.Register(path, pid, registerCallback, unregisterCallback))
-	require.Equal(t, errPathIsAlreadyRegistered, r.Register(path, pid, registerCallback, unregisterCallback))
+	require.Equal(t, ErrPathIsAlreadyRegistered, r.Register(path, pid, registerCallback, unregisterCallback))
 	require.NoError(t, r.Unregister(pid))
 
 	// Assert that despite multiple calls to `Register` from the same PID we


### PR DESCRIPTION
…as an error

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR changes the GoTLSAttachPID helper to not error out on already registered binaries. This error can cause tests depending on it to fail if the process monitor attaches the probes before the helper has time to do so. Since the caller of this function wants to ensure the binary is attached, this error should be ignored.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
