### PR TITLE
[workloadmeta/kubeapiserver] Use config component

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -10,17 +10,18 @@ package kubeapiserver
 
 import (
 	"context"
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"strings"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	languagedetectionUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
-
 	ddkube "github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
 
@@ -32,7 +33,7 @@ func (f *deploymentFilter) filteredOut(entity workloadmeta.Entity) bool {
 	return deployment == nil
 }
 
-func newDeploymentStore(ctx context.Context, wlm workloadmeta.Component, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+func newDeploymentStore(ctx context.Context, wlm workloadmeta.Component, _ config.Reader, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
 	deploymentListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, options)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -18,13 +18,13 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, metadataclient metadata.Interface, gvr schema.GroupVersionResource) (*cache.Reflector, *reflectorStore) {
+func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, config config.Reader, metadataclient metadata.Interface, gvr schema.GroupVersionResource) (*cache.Reflector, *reflectorStore) {
 	metadataListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return metadataclient.Resource(gvr).List(ctx, options)
@@ -34,7 +34,7 @@ func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, m
 		},
 	}
 
-	annotationsExclude := config.Datadog().GetStringSlice("cluster_agent.kube_metadata_collection.resource_annotations_exclude")
+	annotationsExclude := config.GetStringSlice("cluster_agent.kube_metadata_collection.resource_annotations_exclude")
 	parser, err := newMetadataParser(gvr, annotationsExclude)
 	if err != nil {
 		_ = log.Errorf("unable to parse all resource_annotations_exclude: %v, err:", err)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -65,7 +65,7 @@ func Test_AddDelete_Deployment(t *testing.T) {
 func Test_AddDelete_Pod(t *testing.T) {
 	workloadmetaComponent := mockedWorkloadmeta(t)
 
-	podStore := newPodReflectorStore(workloadmetaComponent)
+	podStore := newPodReflectorStore(workloadmetaComponent, workloadmetaComponent.GetConfig())
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,7 +142,7 @@ func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
 	}, timeout, interval)
 }
 
-func mockedWorkloadmeta(t *testing.T) workloadmeta.Component {
+func mockedWorkloadmeta(t *testing.T) workloadmetamock.Mock {
 	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		fx.Supply(workloadmeta.NewParams()),

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -54,7 +54,7 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 	))
 	ctx := context.TODO()
 
-	store, _ := newStore(ctx, wlm, client)
+	store, _ := newStore(ctx, wlm, wlm.GetConfig(), client)
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)
 
@@ -124,7 +124,7 @@ func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Objec
 	response, err := metadataclient.Resource(gvr).List(ctx, v1.ListOptions{})
 	assert.NoError(t, err)
 	fmt.Println("metadata client listing: ", response.String())
-	store, _ := newMetadataStore(ctx, wlm, metadataclient, gvr)
+	store, _ := newMetadataStore(ctx, wlm, wlm.GetConfig(), metadataclient, gvr)
 
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
@@ -11,7 +11,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func Test_filterMapStringKey(t *testing.T) {
@@ -27,7 +30,10 @@ func Test_filterMapStringKey(t *testing.T) {
 		"ad.datadoghq.com/tags":             `["bar","foo"]`,
 	}
 
-	defaultExclude := config.Datadog().GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
+	conf := fxutil.Test[config.Component](t, fx.Options(
+		config.MockModule(),
+	))
+	defaultExclude := conf.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	extraExclude := append(defaultExclude, "foo")
 
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?

It's a refactor to use the config component inside the kubeapiserver workloadmeta collector instead of using the old way of accessing the config.

### Describe how to test/QA your changes

Skip. It's a refactor and e2e tests and unit tests should cover the changes.
