### PR TITLE
`inv *.set-buildtags` sets all the build tags

### DIFF
--- a/tasks/emacs.py
+++ b/tasks/emacs.py
@@ -6,14 +6,24 @@ Helpers for getting Emacs set up nicely
 
 from invoke import task
 
-from tasks.build_tags import build_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
+from tasks.build_tags import (
+    build_tags,
+    filter_incompatible_tags,
+    get_build_tags,
+    get_default_build_tags,
+)
 from tasks.flavor import AgentFlavor
 
 
-@task
+@task(
+    help={
+        "targets": f"Comma separated list of targets to include. Possible values: all, {', '.join(build_tags[AgentFlavor.base].keys())}. Default: all",
+        "flavor": f"Agent flavor to use. Possible values: {', '.join(AgentFlavor.__members__.keys())}. Default: {AgentFlavor.base.name}",
+    }
+)
 def set_buildtags(
     _,
-    target="agent",
+    targets="all",
     build_include=None,
     build_exclude=None,
     flavor=AgentFlavor.base.name,
@@ -23,21 +33,27 @@ def set_buildtags(
     """
     flavor = AgentFlavor[flavor]
 
-    if target not in build_tags[flavor]:
-        print("Must choose a valid target.  Valid targets are: \n")
-        print(f'{", ".join(build_tags[flavor].keys())} \n')
-        return
+    if targets == "all":
+        targets = build_tags[flavor].keys()
+    else:
+        targets = targets.split(",")
+        if not set(targets).issubset(build_tags[flavor]):
+            print("Must choose valid targets. Valid targets are:")
+            print(f'{", ".join(build_tags[flavor].keys())}')
+            return
 
-    build_include = (
-        get_default_build_tags(build=target, flavor=flavor)
-        if build_include is None
-        else filter_incompatible_tags(build_include.split(","))
-    )
+    if build_include is None:
+        build_include = []
+        for target in targets:
+            build_include.extend(get_default_build_tags(build=target, flavor=flavor))
+    else:
+        build_include = filter_incompatible_tags(build_include.split(","))
+
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
 
     with open(".dir-locals.el", "w") as f:
-        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags", "{",".join(use_tags)}"])\n')
+        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags", "{",".join(sorted(use_tags))}"])\n')
         f.write(
             '             (eval . (lsp-register-custom-settings \'(("gopls.allowImplicitNetworkAccess" t t)))))))\n'
         )

--- a/tasks/emacs.py
+++ b/tasks/emacs.py
@@ -53,7 +53,4 @@ def set_buildtags(
     use_tags = get_build_tags(build_include, build_exclude)
 
     with open(".dir-locals.el", "w") as f:
-        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags", "{",".join(sorted(use_tags))}"])\n')
-        f.write(
-            '             (eval . (lsp-register-custom-settings \'(("gopls.allowImplicitNetworkAccess" t t)))))))\n'
-        )
+        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags" "{",".join(sorted(use_tags))}"]))))\n')

--- a/tasks/vim.py
+++ b/tasks/vim.py
@@ -15,10 +15,15 @@ from tasks.build_tags import (
 from tasks.flavor import AgentFlavor
 
 
-@task
+@task(
+    help={
+        "targets": f"Comma separated list of targets to include. Possible values: all, {', '.join(build_tags[AgentFlavor.base].keys())}. Default: all",
+        "flavor": f"Agent flavor to use. Possible values: {', '.join(AgentFlavor.__members__.keys())}. Default: {AgentFlavor.base.name}",
+    }
+)
 def set_buildtags(
     _,
-    target="agent",
+    targets="all",
     build_include=None,
     build_exclude=None,
     flavor=AgentFlavor.base.name,
@@ -28,18 +33,24 @@ def set_buildtags(
     """
     flavor = AgentFlavor[flavor]
 
-    if target not in build_tags[flavor]:
-        print("Must choose a valid target.  Valid targets are: \n")
-        print(f'{", ".join(build_tags[flavor].keys())} \n')
-        return
+    if targets == "all":
+        targets = build_tags[flavor].keys()
+    else:
+        targets = targets.split(",")
+        if not set(targets).issubset(build_tags[flavor]):
+            print("Must choose valid targets. Valid targets are:")
+            print(f'{", ".join(build_tags[flavor].keys())}')
+            return
 
-    build_include = (
-        get_default_build_tags(build=target, flavor=flavor)
-        if build_include is None
-        else filter_incompatible_tags(build_include.split(","))
-    )
+    if build_include is None:
+        build_include = []
+        for target in targets:
+            build_include.extend(get_default_build_tags(build=target, flavor=flavor))
+    else:
+        build_include = filter_incompatible_tags(build_include.split(","))
+
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
 
     with open(".vimrc", "w") as f:
-        f.write(f"let g:ale_go_gopls_init_options = {{'buildFlags': ['-tags', '{','.join(use_tags)}']}}\n")
+        f.write(f"let g:ale_go_gopls_init_options = {{'buildFlags': ['-tags', '{','.join(sorted(use_tags))}']}}\n")

--- a/tasks/vscode.py
+++ b/tasks/vscode.py
@@ -15,7 +15,12 @@ from pathlib import Path
 from invoke import Context, task
 from invoke.exceptions import Exit
 
-from tasks.build_tags import build_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
+from tasks.build_tags import (
+    build_tags,
+    filter_incompatible_tags,
+    get_build_tags,
+    get_default_build_tags,
+)
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.json import JSONWithCommentsDecoder
@@ -25,10 +30,15 @@ VSCODE_FILE = "settings.json"
 VSCODE_EXTENSIONS_FILE = "extensions.json"
 
 
-@task
+@task(
+    help={
+        "targets": f"Comma separated list of targets to include. Possible values: all, {', '.join(build_tags[AgentFlavor.base].keys())}. Default: all",
+        "flavor": f"Agent flavor to use. Possible values: {', '.join(AgentFlavor.__members__.keys())}. Default: {AgentFlavor.base.name}",
+    }
+)
 def set_buildtags(
     _,
-    target="agent",
+    targets="all",
     build_include=None,
     build_exclude=None,
     flavor=AgentFlavor.base.name,
@@ -38,16 +48,22 @@ def set_buildtags(
     """
     flavor = AgentFlavor[flavor]
 
-    if target not in build_tags[flavor]:
-        print("Must choose a valid target.  Valid targets are: \n")
-        print(f'{", ".join(build_tags[flavor].keys())} \n')
-        return
+    if targets == "all":
+        targets = build_tags[flavor].keys()
+    else:
+        targets = targets.split(",")
+        if not set(targets).issubset(build_tags[flavor]):
+            print("Must choose valid targets. Valid targets are:")
+            print(f'{", ".join(build_tags[flavor].keys())}')
+            return
 
-    build_include = (
-        get_default_build_tags(build=target, flavor=flavor)
-        if build_include is None
-        else filter_incompatible_tags(build_include.split(","))
-    )
+    if build_include is None:
+        build_include = []
+        for target in targets:
+            build_include.extend(get_default_build_tags(build=target, flavor=flavor))
+    else:
+        build_include = filter_incompatible_tags(build_include.split(","))
+
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
 
@@ -60,7 +76,7 @@ def set_buildtags(
         with open(fullpath) as sf:
             settings = json.load(sf, object_pairs_hook=OrderedDict)
 
-    settings["go.buildTags"] = ",".join(use_tags)
+    settings["go.buildTags"] = ",".join(sorted(use_tags))
 
     with open(fullpath, "w") as sf:
         json.dump(settings, sf, indent=4, sort_keys=False, separators=(',', ': '))


### PR DESCRIPTION
### What does this PR do?

Enhance the `vscode.set-buildtags`, `emacs.set-buildtags` and `vim.set-buildtags` invoke tasks to make them support several targets (`agent`, `cluster-agent`, `security-agent`, `system-probe`, etc.) at the same time.
Defaults to `all` instead of `agent`.

### Motivation

Because all `datadog-agent` files have build tags, `gopls` needs to be explicitly configured in order to benefit from LSP integrations inside our IDEs.
That’s what the `vscode.set-buildtags`, `emacs.set-buildtags` and `vim.set-buildtags` invoke targets are meant for.
They used to have a `--target` option that allows to specify for which target we want the build tags.

This wasn’t very convenient as it means that we were supposed to reconfigure our IDE (to update the build tags passed to `gopls`) each time we switch between implementing the `agent` part of a feature and its `cluster-agent` part. Or each time we switch between implementing the `security-agent` part of a feature and its `system-probe` part.

Now, `--targets` allows to specify several targets and `gopls` will be configured with the union of the build tags of all the targets.
It defaults to `all` so that, by default, LSP features should work on all the files except the empty stub.

### Additional Notes

### Possible Drawbacks / Trade-offs

`gopls` might consume even more memory.
But it’s anyway still possible to explicitly pass `--targets=…` to restrict the build tags as before.

### Describe how to test/QA your changes

LSP features should be available 