### PR TITLE
[CONTP-278] enable language detection in agent sidecar when needed

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 
 	admiv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -191,6 +192,10 @@ func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {
 						FieldPath:  "spec.nodeName",
 					},
 				},
+			},
+			{
+				Name:  "DD_LANGUAGE_DETECTION_ENABLED",
+				Value: strconv.FormatBool(config.Datadog().GetBool("language_detection.enabled") && config.Datadog().GetBool("language_detection.reporting.enabled")),
 			},
 		},
 		Image:           fmt.Sprintf("%s/%s:%s", containerRegistry, imageName, imageTag),

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -428,6 +428,12 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 				mockConfig := config.Mock(t)
 				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.cluster_agent.enabled", false)
 			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "DD_LANGUAGE_DETECTION_ENABLED",
+					Value: "false",
+				},
+			},
 			unexpectedEnvVars: []string{
 				"DD_CLUSTER_AGENT_ENABLED",
 				"DD_CLUSTER_AGENT_AUTH_TOKEN",
@@ -465,6 +471,47 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 					Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
 					Value: "true",
 				},
+				{
+					Name:  "DD_LANGUAGE_DETECTION_ENABLED",
+					Value: "false",
+				},
+			},
+		},
+		{
+			name: "cluster agent enabled with language derection enabled",
+			setConfig: func() {
+				mockConfig := config.Mock(t)
+				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.cluster_agent.enabled", true)
+				mockConfig.SetWithoutSource("language_detection.enabled", true)
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "DD_CLUSTER_AGENT_ENABLED",
+					Value: "true",
+				},
+				{
+					Name: "DD_CLUSTER_AGENT_AUTH_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "token",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "datadog-secret",
+							},
+						},
+					},
+				},
+				{
+					Name:  "DD_CLUSTER_AGENT_URL",
+					Value: fmt.Sprintf("https://datadog-cluster-agent.%s.svc.cluster.local:5005", apicommon.GetMyNamespace()),
+				},
+				{
+					Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "DD_LANGUAGE_DETECTION_ENABLED",
+					Value: "true",
+				},
 			},
 		},
 		{
@@ -474,6 +521,7 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.agent_sidecar.cluster_agent.enabled", true)
 				mockConfig.SetWithoutSource("cluster_agent.cmd_port", 12345)
 				mockConfig.SetWithoutSource("cluster_agent.kubernetes_service_name", "test-service-name")
+				mockConfig.SetWithoutSource("language_detection.enabled", "false")
 			},
 			expectedEnvVars: []corev1.EnvVar{
 				{
@@ -498,6 +546,10 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 				{
 					Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
 					Value: "true",
+				},
+				{
+					Name:  "DD_LANGUAGE_DETECTION_ENABLED",
+					Value: "false",
 				},
 			},
 		},

--- a/releasenotes-dca/notes/enable_pld_in_agent_sidecar-b8adcda46ec1fb45.yaml
+++ b/releasenotes-dca/notes/enable_pld_in_agent_sidecar-b8adcda46ec1fb45.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enabled language detection automatically in the injected agent sidecar on EKS Fargate when APM SSI is enabled.
+    This is only available for users using the admission controller to automatically inject the agent sidecar.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Enabled language detection in automatically injected agent sidecar from the admission controller when language detection is already enabled on the cluster agent. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Eliminate the need to explicitly set DD_LANGUAGE_DETECTION_ENABLED to true in the agent sidecar in order to enable language detection.

Without this PR, in order to enable language detection, users would need to define a profile for the sidecar webhook as such:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  apm:
    enabled: true
    instrumentation:
      enabled: true
      enabledNamespaces:
        - fargate
agents:
  enabled: false
clusterAgent:
  enabled: true
  replicas: 1
  admissionController:
    enabled: true
    agentSidecarInjection:
      enabled: true
      provider: fargate
      profiles:
        - env:
            - name: DD_LANGUAGE_DETECTION_ENABLED
              value: "true"
```

Thanks to this PR, users will no longer need to manually set `DD_LANGUAGE_DETECTION_ENABLED` env var to `true` explicitly, this will be handled automatically by the mutating webhook.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the cluster agent with agent sidecar injection and APM instrumentation enabled on an EKS fargate cluster and ensure that language detection is enabled on the agent sidecar. 

Below are the steps for the QA along with the results:

Create a fargate namespace, switch to it and create the datadog-secret:

```
kubectl create namespace fargate
kubens fargate
kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY
```
Deploy the following with helm on an EKS Cluster *in the fargate namespace* :

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  apm:
    enabled: true
    instrumentation:
      enabled: true
      enabledNamespaces:
        - fargate
agents:
  enabled: false
clusterAgent:
  enabled: true
  replicas: 1
  admissionController:
    enabled: true
    agentSidecarInjection:
      enabled: true
      provider: fargate
  env:
    - name: DD_EKS_FARGATE
      value: "true"
```

Copy the dca token from datadog-agent secret to datadog-secret secret
```
kubectl get secret datadog-agent-cluster-agent -o yaml
apiVersion: v1
data:
  token: Q0NKM2JVSms4VTlsM2s2MzhIaFBOQU5mNTZ2cjNtZTM=
....
```

```
kubectl edit secret datadog-secret

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
data:
  api-key: *****
  token: Q0NKM2JVSms4VTlsM2s2MzhIaFBOQU5mNTZ2cjNtZTM=
  app-key:  *****
```

Deploy a dummy python app in the same namespace:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-app
  namespace: fargate
spec:
  selector:
    matchLabels:
      app: main-app
  replicas: 2
  template:
    metadata:
      labels:
        app: main-app
        admission.datadoghq.com/enabled: "true"
        agent.datadoghq.com/sidecar: "fargate"
      name: my-app
    spec:
      serviceAccount: datadog-agent
      containers:
        - name: python-container
          image: python:3.9-slim
          command: ["/bin/sh"]
          args:
            [
              "-c",
              "python -c 'import time\nwhile True: time.sleep(4)' & python -c 'import time\nwhile True: time.sleep(4)' && wait",
            ]
```

Here are the running pods

```
kubectl get pods
NAME                                           READY   STATUS    RESTARTS   AGE
datadog-agent-cluster-agent-84db7bc49b-4tmhz   1/1     Running   0          14m
my-app-595c966dc5-lfwqs                        2/2     Running   0          9m32s
my-app-595c966dc5-sj5h2                        2/2     Running   0          9m32s
```

Ensure that language detection is automatically enabled in the agent sidecar:

```
kubectl exec my-app-595c966dc5-lfwqs -c datadog-agent-injected -- agent config


....
language_detection:
  enabled: true
  reporting:
    buffer_period: 10s
    enabled: true
    refresh_period: 20m
....
```

You can also verify that language detection is not enabled in the agent sidecar if APM SSI hadn't been enabled in helm when deploying the cluster agent.