### PR TITLE
[USM] HTTPS classification test: replace Python server with a Golang server

### DIFF
--- a/pkg/network/protocols/tls/gotls/testutil/client_builder.go
+++ b/pkg/network/protocols/tls/gotls/testutil/client_builder.go
@@ -49,7 +49,7 @@ func NewGoTLSClient(t *testing.T, serverAddr string, numRequests int, enableHTTP
 func buildGoTLSClientBin(t *testing.T) string {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
-	serverBin, err := usmtestutil.BuildUnixTransparentProxyServer(curDir, "gotls_client")
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, "gotls_client")
 	require.NoError(t, err)
 	return serverBin
 }

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_server/.gitignore
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_server/.gitignore
@@ -1,0 +1,1 @@
+gotls_server

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_server/gotls_server.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_server/gotls_server.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"time"

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_server/gotls_server.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_server/gotls_server.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package main is a simple client for the gotls_server.
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+)
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+
+	file, err := os.CreateTemp("/tmp", "gotls_server-*.log")
+	if err != nil {
+		log.Fatalf("could not create log file: %s", err)
+	}
+	log.Default().SetOutput(file)
+
+	if len(args) < 1 {
+		log.Fatalf("usage: gotls_server <server_addr>")
+	}
+
+	addr := os.Args[1]
+
+	crtPath, keyPath, err := testutil.GetCertsPaths()
+	if err != nil {
+		log.Fatalf("Could not get certificates")
+	}
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		statusCode := testutil.StatusFromPath(req.URL.Path)
+		if statusCode == 0 {
+			log.Printf("wrong request format %s", req.URL.Path)
+		} else {
+			w.WriteHeader(int(statusCode))
+		}
+
+		defer req.Body.Close()
+		_, err := io.Copy(w, req.Body)
+		if err != nil {
+			log.Printf("could not write response body: %s", err)
+		}
+	}
+
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      http.HandlerFunc(handler),
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
+	}
+
+	// Disabling http2
+	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+	srv.SetKeepAlivesEnabled(true)
+
+	listenFn := func() error {
+		ln, err := net.Listen("tcp", srv.Addr)
+		if err == nil {
+			_ = srv.ServeTLS(ln, crtPath, keyPath)
+		}
+		return err
+	}
+
+	if err := listenFn(); err != nil {
+		log.Fatalf("server listen: %s", err)
+	}
+}

--- a/pkg/network/protocols/tls/gotls/testutil/server_builder.go
+++ b/pkg/network/protocols/tls/gotls/testutil/server_builder.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package testutil provides utilities for testing the TLS package.
+package testutil
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
+	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
+)
+
+// NewGoTLSServer starts a GoTLS HTTP server listening on `serverAddr`.
+// Returns the `exec.Cmd` handle for the server.
+func NewGoTLSServer(t *testing.T, serverAddr string) *exec.Cmd {
+	serverBin := buildGoTLSServerBin(t)
+	args := []string{serverBin, serverAddr}
+
+	timedCtx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	commandLine := strings.Join(args, " ")
+
+	c, _, err := nettestutil.StartCommandCtx(timedCtx, commandLine)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		defer cancel()
+		err := c.Process.Kill()
+		require.NoError(t, err)
+		err = c.Wait()
+		require.ErrorContains(t, err, "killed")
+	})
+
+	return c
+}
+
+func buildGoTLSServerBin(t *testing.T) string {
+	curDir, err := testutil.CurDir()
+	require.NoError(t, err)
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, "gotls_server")
+	require.NoError(t, err)
+	return serverBin
+}

--- a/pkg/network/protocols/tls/gotls/testutil/server_builder.go
+++ b/pkg/network/protocols/tls/gotls/testutil/server_builder.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 // Package testutil provides utilities for testing the TLS package.
 package testutil
 

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
@@ -27,7 +27,7 @@ const (
 func newExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS, useControl bool) (*exec.Cmd, context.CancelFunc) {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
-	serverBin, err := usmtestutil.BuildUnixTransparentProxyServer(curDir, serverSrcPath)
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, serverSrcPath)
 	require.NoError(t, err)
 
 	args := []string{serverBin, "-unix", unixPath, "-remote", remoteAddr}

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -487,7 +487,7 @@ func testTLSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, ser
 }
 
 func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, serverHost string) {
-	skipFunc := composeSkips(skipIfHTTPSNotSupported)
+	skipFunc := composeSkips(skipIfHTTPSNotSupported, skipIfGoTLSNotSupported)
 	skipFunc(t, testContext{
 		serverAddress: serverHost,
 		serverPort:    httpsPort,

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -252,7 +252,7 @@ func generateTemporaryFile(t *testing.T) string {
 func buildPrefetchFileBin(t *testing.T) string {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
-	serverBin, err := usmtestutil.BuildUnixTransparentProxyServer(filepath.Join(curDir, "testutil"), "prefetch_file")
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(filepath.Join(curDir, "testutil"), "prefetch_file")
 	require.NoError(t, err)
 	return serverBin
 }

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -63,7 +63,7 @@ func build(t *testing.T) string {
 
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
-	serverBin, err := usmtestutil.BuildUnixTransparentProxyServer(curDir, "fmapper")
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, "fmapper")
 	require.NoError(t, err)
 	return serverBin
 }

--- a/pkg/network/usm/testutil/generic_testutil_builder.go
+++ b/pkg/network/usm/testutil/generic_testutil_builder.go
@@ -13,9 +13,10 @@ import (
 	"path"
 )
 
-// BuildUnixTransparentProxyServer builds the unix transparent proxy server binary and returns the path to the binary.
-// If the binary is already built (meanly in the CI), it returns the path to the binary.
-func BuildUnixTransparentProxyServer(curDir, binaryDir string) (string, error) {
+// BuildGoBinaryWrapper builds a Go binary and returns the path to it.
+// If the binary is already built (meanly in the CI), it returns the
+// path to the binary.
+func BuildGoBinaryWrapper(curDir, binaryDir string) (string, error) {
 	serverSrcDir := path.Join(curDir, binaryDir)
 	cachedServerBinaryPath := path.Join(serverSrcDir, binaryDir)
 

--- a/pkg/network/usm/testutil/grpc/builder.go
+++ b/pkg/network/usm/testutil/grpc/builder.go
@@ -50,7 +50,7 @@ func buildGRPCServerBin(t *testing.T) string {
 
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
-	serverBin, err := usmtestutil.BuildUnixTransparentProxyServer(curDir, serverSrcPath)
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, serverSrcPath)
 	require.NoError(t, err)
 
 	return serverBin

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -892,6 +892,7 @@ def kmt_sysprobe_prepare(
 
             for gobin in [
                 "gotls_client",
+                "gotls_server",
                 "grpc_external_server",
                 "external_unix_proxy_server",
                 "fmapper",

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -927,7 +927,14 @@ def kitchen_prepare(ctx, kernel_release=None, ci=False, packages=""):
         if pkg.endswith("java"):
             shutil.copy(os.path.join(pkg, "agent-usm.jar"), os.path.join(target_path, "agent-usm.jar"))
 
-        for gobin in ["gotls_client", "grpc_external_server", "external_unix_proxy_server", "fmapper", "prefetch_file"]:
+        for gobin in [
+            "external_unix_proxy_server",
+            "fmapper",
+            "gotls_client",
+            "gotls_server",
+            "grpc_external_server",
+            "prefetch_file",
+        ]:
             src_file_path = os.path.join(pkg, f"{gobin}.go")
             if not is_windows and os.path.isdir(pkg) and os.path.isfile(src_file_path):
                 binary_path = os.path.join(target_path, gobin)


### PR DESCRIPTION

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR replaces the Python server used in our TLS+HTTP classification tests with a Golang server, as it seems to be less prone to flakiness.
It introduces an external Go server instead of re-using our existing HTTPServer. This is done in order to mimic the previous Python server setup.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix test flakiness.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
