### PR TITLE
Decrease “The image … has no repo digest for repo …” log level

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -318,7 +318,7 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 		}
 
 		if len(repoDigests) == 0 {
-			log.Errorf("The image %s has no repo digest for repo %s", img.ID, repo)
+			log.Infof("The image %s has no repo digest for repo %s", img.ID, repo)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

Decrease the level of the `The image … has no repo digest for repo …` log.

### Motivation

We can see this log being emitted under harmless conditions.
It is quite spammy, even when the feature is working fine.

Ex. of such a log:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/38880d04-2d6b-40bd-b5a4-0cc833272fe8)
Yet, the exact same image could be found in the “Container Image” view:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/a0ff9afe-bd07-4e3e-ab86-758ca0bce5cb)
So, this should probably not deserve an `ERROR` log level.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
