### PR TITLE
[Fleet Automation] Fix symbolic link on Windows

### DIFF
--- a/pkg/fleet/installer/repository/link.go
+++ b/pkg/fleet/installer/repository/link.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 func linkRead(linkPath string) (string, error) {
@@ -27,50 +26,9 @@ func linkExists(linkPath string) (bool, error) {
 }
 
 func linkSet(linkPath string, targetPath string) error {
-	if runtime.GOOS == "windows" {
-		return symlinkWithImpersonation(targetPath, linkPath, setReparsePoint)
-	} else {
-		return atomicSymlink(targetPath, linkPath)
-	}
+	return atomicSymlink(targetPath, linkPath)
 }
 
 func linkDelete(linkPath string) error {
 	return os.Remove(linkPath)
-}
-
-// atomicSymlink wraps os.Symlink, replacing an existing symlink with the same name
-// atomically (os.Symlink fails when newname already exists, at least on Linux).
-//
-// vendored from https://github.com/google/renameio/blob/v1.0.1/tempfile.go#L156-L187
-func atomicSymlink(oldname, newname string) error {
-	// Fast path: if newname does not exist yet, we can skip the whole dance
-	// below.
-	if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
-		return err
-	}
-
-	// We need to use ioutil.TempDir, as we cannot overwrite a ioutil.TempFile,
-	// and removing+symlinking creates a TOCTOU race.
-	d, err := os.MkdirTemp(filepath.Dir(newname), "."+filepath.Base(newname))
-	if err != nil {
-		return err
-	}
-	cleanup := true
-	defer func() {
-		if cleanup {
-			os.RemoveAll(d)
-		}
-	}()
-
-	symlink := filepath.Join(d, "tmp.symlink")
-	if err := os.Symlink(oldname, symlink); err != nil {
-		return err
-	}
-
-	if err := os.Rename(symlink, newname); err != nil {
-		return err
-	}
-
-	cleanup = false
-	return os.RemoveAll(d)
 }

--- a/pkg/fleet/installer/repository/link.go
+++ b/pkg/fleet/installer/repository/link.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 func linkRead(linkPath string) (string, error) {
@@ -26,7 +27,11 @@ func linkExists(linkPath string) (bool, error) {
 }
 
 func linkSet(linkPath string, targetPath string) error {
-	return atomicSymlink(targetPath, linkPath)
+	if runtime.GOOS == "windows" {
+		return symlinkWithImpersonation(targetPath, linkPath, setReparsePoint)
+	} else {
+		return atomicSymlink(targetPath, linkPath)
+	}
 }
 
 func linkDelete(linkPath string) error {

--- a/pkg/fleet/installer/repository/link_nix.go
+++ b/pkg/fleet/installer/repository/link_nix.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package repository
+
+// atomicSymlink wraps os.Symlink, replacing an existing symlink with the same name
+// atomically (os.Symlink fails when newname already exists, at least on Linux).
+//
+// vendored from https://github.com/google/renameio/blob/v1.0.1/tempfile.go#L156-L187
+func atomicSymlink(oldname, newname string) error {
+	// Fast path: if newname does not exist yet, we can skip the whole dance
+	// below.
+	if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
+		return err
+	}
+
+	// We need to use ioutil.TempDir, as we cannot overwrite a ioutil.TempFile,
+	// and removing+symlinking creates a TOCTOU race.
+	d, err := os.MkdirTemp(filepath.Dir(newname), "."+filepath.Base(newname))
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.RemoveAll(d)
+		}
+	}()
+
+	symlink := filepath.Join(d, "tmp.symlink")
+	if err := os.Symlink(oldname, symlink); err != nil {
+		return err
+	}
+
+	if err := os.Rename(symlink, newname); err != nil {
+		return err
+	}
+
+	cleanup = false
+	return os.RemoveAll(d)
+}

--- a/pkg/fleet/installer/repository/link_nix.go
+++ b/pkg/fleet/installer/repository/link_nix.go
@@ -7,6 +7,11 @@
 
 package repository
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // atomicSymlink wraps os.Symlink, replacing an existing symlink with the same name
 // atomically (os.Symlink fails when newname already exists, at least on Linux).
 //

--- a/pkg/fleet/installer/repository/link_test.go
+++ b/pkg/fleet/installer/repository/link_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-
 package repository
 
 import (
@@ -74,6 +72,25 @@ func TestLinkSet(t *testing.T) {
 	exists, err := linkExists(linkPath)
 	assert.NoError(t, err)
 	assert.True(t, exists)
+}
+
+func TestLinkSetWhenExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	stablePath := filepath.Join(tmpDir, "7.55.0-rc.2-1")
+	experimentPath := filepath.Join(tmpDir, "7.54.0-installer-0.0.8-rc.1.git.16.bcd53a6.pipeline.34898077-1")
+	linkPath := filepath.Join(tmpDir, "stable")
+
+	createTarget(t, stablePath)
+	err := linkSet(linkPath, stablePath)
+	assert.NoError(t, err)
+
+	exists, err := linkExists(linkPath)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	createTarget(t, experimentPath)
+	err = linkSet(linkPath, experimentPath)
+	assert.NoError(t, err)
 }
 
 func TestLinkDelete(t *testing.T) {

--- a/pkg/fleet/installer/repository/link_test.go
+++ b/pkg/fleet/installer/repository/link_test.go
@@ -21,6 +21,13 @@ func createLink(t *testing.T, linkPath string, targetPath string) {
 func createTarget(t *testing.T, targetPath string) {
 	err := os.Mkdir(targetPath, 0755)
 	assert.NoError(t, err)
+	// Also create a file in the directory, to cover cases where
+	// the underlying OS would work only on an empty directory...
+	f, err := os.CreateTemp(targetPath, "test*.txt")
+	assert.NoError(t, err)
+	defer f.Close()
+	_, err = f.Write([]byte("hello Fleet Automation"))
+	assert.NoError(t, err)
 }
 
 func TestLinkRead(t *testing.T) {

--- a/pkg/fleet/installer/repository/link_win.go
+++ b/pkg/fleet/installer/repository/link_win.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+//
+// Code in this file was blatantly taken from
+// https://go.dev/src/internal/syscall/windows/reparse_windows.go
+// https://go.dev/src/internal/syscall/windows/security_windows.go
+// https://go.dev/src/os/os_windows_test.go
+// and adapted.
+
+//go:build windows
+
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/sys/windows"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	//nolint:revive keep original name.
+	SYMLINK_FLAG_RELATIVE = 1
+)
+
+// REPARSE_DATA_BUFFER_HEADER is a common part of REPARSE_DATA_BUFFER structure.
+//
+//nolint:revive keep original name.
+type REPARSE_DATA_BUFFER_HEADER struct {
+	ReparseTag uint32
+	// The size, in bytes, of the reparse data that follows
+	// the common portion of the REPARSE_DATA_BUFFER element.
+	// This value is the length of the data starting at the
+	// SubstituteNameOffset field.
+	ReparseDataLength uint16
+	Reserved          uint16
+}
+
+type symbolicLinkReparseBuffer struct {
+	// The integer that contains the offset, in bytes,
+	// of the substitute name string in the PathBuffer array,
+	// computed as an offset from byte 0 of PathBuffer. Note that
+	// this offset must be divided by 2 to get the array index.
+	SubstituteNameOffset uint16
+	// The integer that contains the length, in bytes, of the
+	// substitute name string. If this string is null-terminated,
+	// SubstituteNameLength does not include the Unicode null character.
+	SubstituteNameLength uint16
+	// PrintNameOffset is similar to SubstituteNameOffset.
+	PrintNameOffset uint16
+	// PrintNameLength is similar to SubstituteNameLength.
+	PrintNameLength uint16
+	// Flags specifies whether the substitute name is a full path name or
+	// a path name relative to the directory containing the symbolic link.
+	Flags      uint32
+	PathBuffer [1]uint16
+}
+
+// reparseData is used to build reparse buffer data required for tests.
+type reparseData struct {
+	substituteName namePosition
+	printName      namePosition
+	pathBuf        []uint16
+}
+
+type namePosition struct {
+	offset uint16
+	length uint16
+}
+
+func (rd *reparseData) addUTF16s(s []uint16) (offset uint16) {
+	off := len(rd.pathBuf) * 2
+	rd.pathBuf = append(rd.pathBuf, s...)
+	return uint16(off)
+}
+
+func (rd *reparseData) addString(s string) (offset, length uint16) {
+	p, _ := syscall.UTF16FromString(s)
+	return rd.addUTF16s(p), uint16(len(p)-1) * 2 // do not include terminating NUL in the length (as per PrintNameLength and SubstituteNameLength documentation)
+}
+
+func (rd *reparseData) addSubstituteName(name string) {
+	rd.substituteName.offset, rd.substituteName.length = rd.addString(name)
+}
+
+func (rd *reparseData) addPrintName(name string) {
+	rd.printName.offset, rd.printName.length = rd.addString(name)
+}
+
+func (rd *reparseData) addStringNoNUL(s string) (offset, length uint16) {
+	p, _ := syscall.UTF16FromString(s)
+	p = p[:len(p)-1]
+	return rd.addUTF16s(p), uint16(len(p)) * 2
+}
+
+func (rd *reparseData) addSubstituteNameNoNUL(name string) {
+	rd.substituteName.offset, rd.substituteName.length = rd.addStringNoNUL(name)
+}
+
+func (rd *reparseData) addPrintNameNoNUL(name string) {
+	rd.printName.offset, rd.printName.length = rd.addStringNoNUL(name)
+}
+
+// pathBuffeLen returns length of rd pathBuf in bytes.
+func (rd *reparseData) pathBuffeLen() uint16 {
+	return uint16(len(rd.pathBuf)) * 2
+}
+
+// Windows REPARSE_DATA_BUFFER contains union member, and cannot be
+// translated into Go directly. _REPARSE_DATA_BUFFER type is to help
+// construct alternative versions of Windows REPARSE_DATA_BUFFER with
+// union part of symbolicLinkReparseBuffer or MountPointReparseBuffer type.
+type _REPARSE_DATA_BUFFER struct {
+	header REPARSE_DATA_BUFFER_HEADER
+	detail [syscall.MAXIMUM_REPARSE_DATA_BUFFER_SIZE]byte
+}
+
+func createDirLink(link string, rdb *_REPARSE_DATA_BUFFER) error {
+	err := os.Mkdir(link, 0777)
+	if err != nil && !errors.Is(err, syscall.ERROR_ALREADY_EXISTS) {
+		return err
+	}
+
+	linkp, err := syscall.UTF16FromString(link)
+	if err != nil {
+		return err
+	}
+
+	fd, err := syscall.CreateFile(&linkp[0], syscall.GENERIC_WRITE, 0, nil, syscall.OPEN_EXISTING,
+		syscall.FILE_FLAG_OPEN_REPARSE_POINT|syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(fd)
+
+	buflen := uint32(rdb.header.ReparseDataLength) + uint32(unsafe.Sizeof(rdb.header))
+	var bytesReturned uint32
+	return syscall.DeviceIoControl(fd, windows.FSCTL_SET_REPARSE_POINT,
+		(*byte)(unsafe.Pointer(&rdb.header)), buflen, nil, 0, &bytesReturned, nil)
+}
+
+func createSymbolicLink(link string, target *reparseData, isrelative bool) error {
+	var buf *symbolicLinkReparseBuffer
+	buflen := uint16(unsafe.Offsetof(buf.PathBuffer)) + target.pathBuffeLen() // see ReparseDataLength documentation
+	byteblob := make([]byte, buflen)
+	buf = (*symbolicLinkReparseBuffer)(unsafe.Pointer(&byteblob[0]))
+	buf.SubstituteNameOffset = target.substituteName.offset
+	buf.SubstituteNameLength = target.substituteName.length
+	buf.PrintNameOffset = target.printName.offset
+	buf.PrintNameLength = target.printName.length
+	if isrelative {
+		buf.Flags = SYMLINK_FLAG_RELATIVE
+	}
+	pbuflen := len(target.pathBuf)
+	copy((*[2048]uint16)(unsafe.Pointer(&buf.PathBuffer[0]))[:pbuflen:pbuflen], target.pathBuf)
+
+	var rdb _REPARSE_DATA_BUFFER
+	rdb.header.ReparseTag = syscall.IO_REPARSE_TAG_SYMLINK
+	rdb.header.ReparseDataLength = buflen
+	copy(rdb.detail[:], byteblob)
+
+	return createDirLink(link, &rdb)
+}
+
+func setReparsePoint(target, link string) error {
+	var t reparseData
+	t.addPrintName(target)
+	t.addSubstituteName(`\??\` + target)
+	return createSymbolicLink(link, &t, false)
+}
+
+func symlinkWithImpersonation(target, link string, fn func(target, link string) error) error {
+	err := windows.ImpersonateSelf(windows.SecurityImpersonation)
+	if err != nil {
+		return err
+	}
+	defer windows.RevertToSelf()
+
+	err = enableCurrentThreadPrivilege("SeCreateSymbolicLinkPrivilege")
+	if err != nil {
+		return fmt.Errorf(`could not enable "SeCreateSymbolicLinkPrivilege": %v`, err)
+	}
+
+	return fn(target, link)
+}
+
+func enableCurrentThreadPrivilege(privilegeName string) error {
+	ct := windows.CurrentThread()
+	var t windows.Token
+	err := windows.OpenThreadToken(ct, syscall.TOKEN_QUERY|windows.TOKEN_ADJUST_PRIVILEGES, false, &t)
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(syscall.Handle(t))
+
+	var tp windows.Tokenprivileges
+
+	privStr, err := syscall.UTF16PtrFromString(privilegeName)
+	if err != nil {
+		return err
+	}
+	err = windows.LookupPrivilegeValue(nil, privStr, &tp.Privileges[0].Luid)
+	if err != nil {
+		return err
+	}
+	tp.PrivilegeCount = 1
+	tp.Privileges[0].Attributes = windows.SE_PRIVILEGE_ENABLED
+	return windows.AdjustTokenPrivileges(t, false, &tp, 0, nil, nil)
+}

--- a/pkg/fleet/installer/repository/link_win.go
+++ b/pkg/fleet/installer/repository/link_win.go
@@ -211,3 +211,7 @@ func enableCurrentThreadPrivilege(privilegeName string) error {
 	tp.Privileges[0].Attributes = windows.SE_PRIVILEGE_ENABLED
 	return windows.AdjustTokenPrivileges(t, false, &tp, 0, nil, nil)
 }
+
+func atomicSymlink(oldname, newname string) error {
+	return symlinkWithImpersonation(oldname, newname, setReparsePoint)
+}

--- a/pkg/fleet/installer/repository/link_win.go
+++ b/pkg/fleet/installer/repository/link_win.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	//nolint:revive keep original name.
+	//nolint:revive // keep original name.
 	SYMLINK_FLAG_RELATIVE = 1
 )
 
 // REPARSE_DATA_BUFFER_HEADER is a common part of REPARSE_DATA_BUFFER structure.
 //
-//nolint:revive keep original name.
+//nolint:revive // keep original name.
 type REPARSE_DATA_BUFFER_HEADER struct {
 	ReparseTag uint32
 	// The size, in bytes, of the reparse data that follows
@@ -91,20 +91,6 @@ func (rd *reparseData) addPrintName(name string) {
 	rd.printName.offset, rd.printName.length = rd.addString(name)
 }
 
-func (rd *reparseData) addStringNoNUL(s string) (offset, length uint16) {
-	p, _ := syscall.UTF16FromString(s)
-	p = p[:len(p)-1]
-	return rd.addUTF16s(p), uint16(len(p)) * 2
-}
-
-func (rd *reparseData) addSubstituteNameNoNUL(name string) {
-	rd.substituteName.offset, rd.substituteName.length = rd.addStringNoNUL(name)
-}
-
-func (rd *reparseData) addPrintNameNoNUL(name string) {
-	rd.printName.offset, rd.printName.length = rd.addStringNoNUL(name)
-}
-
 // pathBuffeLen returns length of rd pathBuf in bytes.
 func (rd *reparseData) pathBuffeLen() uint16 {
 	return uint16(len(rd.pathBuf)) * 2
@@ -114,6 +100,8 @@ func (rd *reparseData) pathBuffeLen() uint16 {
 // translated into Go directly. _REPARSE_DATA_BUFFER type is to help
 // construct alternative versions of Windows REPARSE_DATA_BUFFER with
 // union part of symbolicLinkReparseBuffer or MountPointReparseBuffer type.
+//
+//nolint:revive // keep original name.
 type _REPARSE_DATA_BUFFER struct {
 	header REPARSE_DATA_BUFFER_HEADER
 	detail [syscall.MAXIMUM_REPARSE_DATA_BUFFER_SIZE]byte
@@ -181,7 +169,8 @@ func symlinkWithImpersonation(target, link string, fn func(target, link string) 
 	if err != nil {
 		return err
 	}
-	defer windows.RevertToSelf()
+
+	defer func() { _ = windows.RevertToSelf() }()
 
 	err = enableCurrentThreadPrivilege("SeCreateSymbolicLinkPrivilege")
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR enables the `link_test` unit tests to run on Windows.
At the same time, it fixes an issue with the the symbolic link creation algorithm used on Linux, which uses a rename operation when the symbolic link already exists.
They are doing this to avoid a TOCTOU race condition that is involved in deleting the link and re-creating it.
On Windows however, it's not possible to rename a directory (or symbolic link) to one that already exists.
Thankfully @clarkb7 suggested to use the [ZwFsControlFile](https://stackoverflow.com/a/11296651/25698343) function, which is what ended up working here.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We need to run unit tests on both platforms to catch bugs.
On Windows we can now change the target of a symbolic link as a single operation.

https://datadoghq.atlassian.net/browse/WINA-877
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
I am not sure that `DeviceIoControl` function offers the same guarantees as the POSIX compliant OSes.
Also the calling code needs to request the `SeCreateSymbolicLinkPrivilege`. This should probably be fine, but it's worth calling out because in [the MSDN](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links) there are some security considerations listed:
![image](https://github.com/DataDog/datadog-agent/assets/63521/3f1b986f-01ae-4f7d-8493-404e15c8a98d)


<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
The unit tests should cover the changes.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
