### PR TITLE
[NDMII-2865] Add initial async rdnsquerier functionality.

### DIFF
--- a/comp/netflow/config/config.go
+++ b/comp/netflow/config/config.go
@@ -33,6 +33,8 @@ type NetflowConfig struct {
 
 	PrometheusListenerAddress string `mapstructure:"prometheus_listener_address"` // Example `localhost:9090`
 	PrometheusListenerEnabled bool   `mapstructure:"prometheus_listener_enabled"`
+
+	ReverseDNSEnrichmentEnabled bool `mapstructure:"reverse_dns_enrichment_enabled"`
 }
 
 // ListenerConfig contains configuration for a single flow listener

--- a/comp/netflow/config/config_test.go
+++ b/comp/netflow/config/config_test.go
@@ -58,6 +58,7 @@ network_devices:
         namespace: |
           my-ns2<abc
           zz
+    reverse_dns_enrichment_enabled: true
 `,
 			expectedConfig: NetflowConfig{
 				Enabled:                                true,
@@ -86,6 +87,7 @@ network_devices:
 						Namespace: "my-ns2-abczz",
 					},
 				},
+				ReverseDNSEnrichmentEnabled: true,
 			},
 		},
 		{
@@ -115,6 +117,7 @@ network_devices:
 						Namespace: "default",
 					},
 				},
+				ReverseDNSEnrichmentEnabled: false,
 			},
 		},
 		{
@@ -145,6 +148,7 @@ network_devices:
 						Namespace: "default",
 					},
 				},
+				ReverseDNSEnrichmentEnabled: false,
 			},
 		},
 		{
@@ -209,6 +213,7 @@ network_devices:
 						},
 					},
 				},
+				ReverseDNSEnrichmentEnabled: false,
 			},
 		},
 	}

--- a/comp/netflow/config/mock.go
+++ b/comp/netflow/config/mock.go
@@ -17,6 +17,7 @@ func newMock(conf *NetflowConfig, logger log.Component) (Component, error) {
 	if err := conf.SetDefaults("default", logger); err != nil {
 		return nil, err
 	}
+	conf.ReverseDNSEnrichmentEnabled = true
 	return &configService{conf}, nil
 }
 

--- a/comp/netflow/config/mock.go
+++ b/comp/netflow/config/mock.go
@@ -17,6 +17,8 @@ func newMock(conf *NetflowConfig, logger log.Component) (Component, error) {
 	if err := conf.SetDefaults("default", logger); err != nil {
 		return nil, err
 	}
+	// TODO Currently reverse DNS enrichment is disabled by default for the agent but we want it enabled by default for tests.
+	// Move this to conf.SetDefaults() if/when we enable it by default for the agent.
 	conf.ReverseDNSEnrichmentEnabled = true
 	return &configService{conf}, nil
 }

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -44,8 +44,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
 	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
-	"github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
-	rdnsqueriermock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+	rdnsquerierfxmock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 )
 
 func TestAggregator(t *testing.T) {
@@ -98,7 +98,8 @@ func TestAggregator(t *testing.T) {
     "ip": "10.10.10.20",
     "port": "80",
     "mac": "00:00:00:00:00:00",
-    "mask": "0.0.0.0/0"
+    "mask": "0.0.0.0/0",
+    "reverse_dns_hostname": "hostname-10.10.10.20"
   },
   "device": {
     "namespace": "my-ns"
@@ -131,7 +132,8 @@ func TestAggregator(t *testing.T) {
     "ip": "10.10.10.10",
     "port": "2000",
     "mac": "00:00:00:00:00:00",
-    "mask": "0.0.0.0/0"
+    "mask": "0.0.0.0/0",
+    "reverse_dns_hostname": "hostname-10.10.10.10"
   },
   "start": 1234568,
   "tcp_flags": [
@@ -167,7 +169,7 @@ func TestAggregator(t *testing.T) {
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(message.NewMessage(compactEvent.Bytes(), nil, "", 0), "network-devices-netflow").Return(nil).Times(1)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(message.NewMessage(compactMetadataEvent.Bytes(), nil, "", 0), "network-devices-metadata").Return(nil).Times(1)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 	aggregator.FlushFlowsToSendInterval = 1 * time.Second
@@ -270,7 +272,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(message.NewMessage(compactMetadataEvent.Bytes(), nil, "", 0), "network-devices-metadata").Return(nil).Times(1)
 
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 	aggregator.FlushFlowsToSendInterval = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
@@ -331,7 +333,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 func TestFlowAggregator_flush_submitCollectorMetrics_error(t *testing.T) {
 	// 1/ Arrange
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
@@ -403,7 +405,7 @@ func TestFlowAggregator_submitCollectorMetrics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
@@ -480,7 +482,7 @@ func TestFlowAggregator_submitCollectorMetrics_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
@@ -515,7 +517,7 @@ func TestFlowAggregator_sendExporterMetadata_multiplePayloads(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 
@@ -600,7 +602,7 @@ func TestFlowAggregator_sendExporterMetadata_noPayloads(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 
@@ -634,7 +636,7 @@ func TestFlowAggregator_sendExporterMetadata_invalidIPIgnored(t *testing.T) {
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 
 	now := time.Unix(1681295467, 0)
@@ -719,7 +721,7 @@ func TestFlowAggregator_sendExporterMetadata_multipleNamespaces(t *testing.T) {
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 
 	now := time.Unix(1681295467, 0)
@@ -822,7 +824,7 @@ func TestFlowAggregator_sendExporterMetadata_singleExporterIpWithMultipleFlowTyp
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
 
@@ -892,7 +894,7 @@ func TestFlowAggregator_sendExporterMetadata_singleExporterIpWithMultipleFlowTyp
 
 func TestFlowAggregator_getSequenceDelta(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	type round struct {
 		flowsToFlush          []*common.Flow
 		expectedSequenceDelta map[sequenceDeltaKey]sequenceDeltaValue

--- a/comp/netflow/flowaggregator/flowaccumulator.go
+++ b/comp/netflow/flowaggregator/flowaccumulator.go
@@ -162,7 +162,7 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 }
 
 func (f *flowAccumulator) addRDNSEnrichment(aggHash uint64, srcAddr []byte, dstAddr []byte) {
-	f.rdnsQuerier.GetHostname(
+	f.rdnsQuerier.GetHostnameAsync(
 		srcAddr,
 		func(hostname string) {
 			f.flowsMutex.Lock()
@@ -174,7 +174,7 @@ func (f *flowAccumulator) addRDNSEnrichment(aggHash uint64, srcAddr []byte, dstA
 			}
 		},
 	)
-	f.rdnsQuerier.GetHostname(
+	f.rdnsQuerier.GetHostnameAsync(
 		dstAddr,
 		func(hostname string) {
 			f.flowsMutex.Lock()

--- a/comp/netflow/flowaggregator/flowaccumulator_test.go
+++ b/comp/netflow/flowaggregator/flowaccumulator_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/DataDog/datadog-agent/comp/netflow/portrollup"
-	"github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
-	rdnsqueriermock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+	rdnsquerierfxmock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +36,7 @@ func setMockTimeNow(newTime time.Time) {
 
 func Test_flowAccumulator_add(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -118,7 +118,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 
 func Test_flowAccumulator_portRollUp(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -222,7 +222,7 @@ func Test_flowAccumulator_portRollUp(t *testing.T) {
 
 func Test_flowAccumulator_flush(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, logimpl.MockModule())
-	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsqueriermock.MockModule())
+	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 	timeNow = MockTimeNow
 	zeroTime := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 	flushInterval := 60 * time.Second

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder/forwarderimpl"
-	rdnsqueriermock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
+	rdnsquerierfxmock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 
 	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 
@@ -68,10 +68,10 @@ var testOptions = fx.Options(
 	demultiplexerimpl.MockModule(),
 	defaultforwarder.MockModule(),
 	core.MockBundle(),
-	rdnsqueriermock.MockModule(),
+	rdnsquerierfxmock.MockModule(),
 	fx.Invoke(func(lc fx.Lifecycle, c Component) {
 		// Set the internal flush frequency to a small number so tests don't take forever
-		c.(*Server).FlowAgg.FlushFlowsToSendInterval = 100 * time.Millisecond
+		c.(*Server).FlowAgg.FlushFlowsToSendInterval = 1 * time.Second
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {
 				// Remove the flow processor to avoid a spurious race detection error

--- a/comp/netflow/testutil/testutil.go
+++ b/comp/netflow/testutil/testutil.go
@@ -76,7 +76,8 @@ func ExpectNetflow5Payloads(t *testing.T, mockEpForwarder forwarder.MockComponen
         "ip": "10.154.20.12",
         "port": "22",
         "mac": "00:00:00:00:00:00",
-        "mask": "0.0.0.0/0"
+        "mask": "0.0.0.0/0",
+        "reverse_dns_hostname": "hostname-10.154.20.12"
     },
     "destination": {
         "ip": "0.0.0.92",
@@ -122,7 +123,8 @@ func ExpectNetflow5Payloads(t *testing.T, mockEpForwarder forwarder.MockComponen
         "ip": "10.154.20.12",
         "port": "22",
         "mac": "00:00:00:00:00:00",
-        "mask": "0.0.0.0/0"
+        "mask": "0.0.0.0/0",
+        "reverse_dns_hostname": "hostname-10.154.20.12"
     },
     "destination": {
         "ip": "0.0.0.93",

--- a/comp/rdnsquerier/def/component.go
+++ b/comp/rdnsquerier/def/component.go
@@ -10,5 +10,5 @@ package rdnsquerier
 
 // Component is the component type.
 type Component interface {
-	GetHostname([]byte) string
+	GetHostname([]byte, func(string))
 }

--- a/comp/rdnsquerier/def/component.go
+++ b/comp/rdnsquerier/def/component.go
@@ -10,5 +10,5 @@ package rdnsquerier
 
 // Component is the component type.
 type Component interface {
-	GetHostname([]byte, func(string))
+	GetHostnameAsync([]byte, func(string))
 }

--- a/comp/rdnsquerier/fx-none/fx.go
+++ b/comp/rdnsquerier/fx-none/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fxnone provides the fx module for the noop rdnsquerier component
+package fxnone
+
+import (
+	rdnsquerierimplnone "github.com/DataDog/datadog-agent/comp/rdnsquerier/impl-none"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			rdnsquerierimplnone.NewNone,
+		),
+	)
+}

--- a/comp/rdnsquerier/impl-none/none.go
+++ b/comp/rdnsquerier/impl-none/none.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package rdnsquerierimplnone provides the noop rdnsquerier component
+package rdnsquerierimplnone
+
+import (
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+)
+
+// Provides defines the output of the rdnsquerier component
+type Provides struct {
+	Comp rdnsquerier.Component
+}
+
+type rdnsQuerierImplNone struct{}
+
+// NewNone creates a new noop rdnsquerier component
+func NewNone() Provides {
+	return Provides{
+		Comp: &rdnsQuerierImplNone{},
+	}
+}
+
+// GetHostname does nothing for the noop rdnsquerier implementation
+func (q *rdnsQuerierImplNone) GetHostname(_ []byte, _ func(string)) {
+	// noop
+}

--- a/comp/rdnsquerier/impl-none/none.go
+++ b/comp/rdnsquerier/impl-none/none.go
@@ -24,7 +24,7 @@ func NewNone() Provides {
 	}
 }
 
-// GetHostname does nothing for the noop rdnsquerier implementation
-func (q *rdnsQuerierImplNone) GetHostname(_ []byte, _ func(string)) {
+// GetHostnameAsync does nothing for the noop rdnsquerier implementation
+func (q *rdnsQuerierImplNone) GetHostnameAsync(_ []byte, _ func(string)) {
 	// noop
 }

--- a/comp/rdnsquerier/mock/mock.go
+++ b/comp/rdnsquerier/mock/mock.go
@@ -9,6 +9,8 @@
 package mock
 
 import (
+	"net/netip"
+
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
 )
 
@@ -24,6 +26,13 @@ func NewMock() rdnsquerier.Component {
 	return &rdnsQuerierMock{}
 }
 
-func (m *rdnsQuerierMock) GetHostname(_ []byte) string {
-	return ""
+func (q *rdnsQuerierMock) GetHostname(ipAddr []byte, updateHostname func(string)) {
+	ipaddr, ok := netip.AddrFromSlice(ipAddr)
+	if !ok || !ipaddr.IsPrivate() {
+		return
+	}
+
+	go func() {
+		updateHostname("hostname-" + ipaddr.String())
+	}()
 }

--- a/comp/rdnsquerier/mock/mock.go
+++ b/comp/rdnsquerier/mock/mock.go
@@ -26,7 +26,9 @@ func NewMock() rdnsquerier.Component {
 	return &rdnsQuerierMock{}
 }
 
-func (q *rdnsQuerierMock) GetHostname(ipAddr []byte, updateHostname func(string)) {
+// GetHostnameAsync simulates resolving the hostname for the given IP address.  If the IP address is in the private address
+// space the updateHostname function will be called asynchronously with the simulated hostname.
+func (q *rdnsQuerierMock) GetHostnameAsync(ipAddr []byte, updateHostname func(string)) {
 	ipaddr, ok := netip.AddrFromSlice(ipAddr)
 	if !ok || !ipaddr.IsPrivate() {
 		return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds initial rdnsquerier functionality as a foundation for providing reverse DNS enrichment of private IP addresses to NDM NetFlow events, and a noop rdnsquerier implementation that is used by default.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
No specific QA is needed for these changes because the component is disabled by default.  QA has already been done to confirm that it is disabled by default and that the changes cause no difference in the agent or NDM NetFlow functionality.  These changes can be tested/QAed with subsequent related changes once full reverse DNS enrichment and related configuration is supported. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
