### PR TITLE
[CWS-2492] Add test for `SIGTERM` handling of the security-agent

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -124,7 +124,7 @@ func (h *Host) executeAndReconnectOnError(command string) (string, error) {
 		stdout, err = execute(h.client, command)
 	}
 	if err != nil {
-		return "", fmt.Errorf("%v: %v", stdout, err)
+		return "", fmt.Errorf("%v: %w", stdout, err)
 	}
 	return stdout, err
 }

--- a/test/new-e2e/tests/cws/ec2_test.go
+++ b/test/new-e2e/tests/cws/ec2_test.go
@@ -272,6 +272,9 @@ func (a *agentSuite) Test04SecurityAgentSIGTERM() {
 	if exited {
 		a.T().Logf("security-agent exited after %s", end.Sub(start).String())
 	}
+
+	// make sure the security-agent is running after this test
+	a.Env().RemoteHost.MustExecute("sudo systemctl start datadog-agent-security.service")
 }
 
 // test that the detection of CWS is properly working


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a test to the host-based e2e testsuite of CWS to make sure the security-agent shuts down in a <30-seconds delay after receiving a SIGTERM signal.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
