### PR TITLE
[notify] Differentiate triggered pipelines from merge pipelines

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -35,6 +35,8 @@ notify:
       if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
         if [ "$DEPLOY_AGENT" = "true" ]; then
           invoke -e notify.send-message --notification-type "deploy"
+        elsif [ "$CI_PIPELINE_SOURCE" != "push" ]; then
+          invoke -e notify.send-message --notification-type "trigger"
         else
           invoke -e notify.send-message --notification-type "merge"
         fi

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -35,7 +35,7 @@ notify:
       if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
         if [ "$DEPLOY_AGENT" = "true" ]; then
           invoke -e notify.send-message --notification-type "deploy"
-        elsif [ "$CI_PIPELINE_SOURCE" != "push" ]; then
+        elif [ "$CI_PIPELINE_SOURCE" != "push" ]; then
           invoke -e notify.send-message --notification-type "trigger"
         else
           invoke -e notify.send-message --notification-type "merge"

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -196,7 +196,7 @@ def check_teams(_):
 
 
 @task
-def send_message(ctx, notification_type="merge", print_to_stdout=False):
+def send_message(ctx: Context, notification_type: str = "merge", print_to_stdout: bool = False):
     """
     Send notifications for the current pipeline. CI-only task.
     Use the --print-to-stdout option to test this locally, without sending
@@ -239,6 +239,8 @@ def send_message(ctx, notification_type="merge", print_to_stdout=False):
         header = f"{header_icon} :merged: datadog-agent merge"
     elif notification_type == "deploy":
         header = f"{header_icon} :rocket: datadog-agent deploy"
+    elif notification_type == "trigger":
+        header = f"{header_icon} :arrow_forward: datadog-agent triggered"
     base = base_message(header, state)
 
     # Send messages


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Makes the `notify` job able to detect new kinds of pipelines, to separate pipelines created by PR merges from pipelines created by other means (eg. conductor, manual triggers).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Clearer separation on pipeline source in Slack notifications.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Example test:
```
CI_PIPELINE_ID=37561452 inv -e notify.send-message --notification-type trigger --print-to-stdout
```

Should show a message starting with ":host-green: :arrow_forward: datadog-agent triggered pipeline".