### PR TITLE
[AMLII-1850] Enabling AML e2e tests on qa_agent job

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -248,8 +248,9 @@ qa_agent:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    - !reference [.on_container_or_e2e_changes]
+    - !reference [.on_aml_or_e2e_changes]
     - !reference [.on_apm_or_e2e_changes]
+    - !reference [.on_container_or_e2e_changes]
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.on_process_or_e2e_changes]
     - !reference [.manual]


### PR DESCRIPTION
### What does this PR do?

Makes sure that AML's e2e tests can run on CI when the relevant code changes.

### Motivation

Currently to run the AML e2e tests `qa_agent` job needs to be run manually.
