### PR TITLE
[workloadmeta/mock] Delete functions not implemented in mock V2

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container_test.go
@@ -7,8 +7,10 @@ package container
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -22,7 +24,7 @@ func TestStartError(t *testing.T) {
 	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		fx.Supply(workloadmeta.NewParams()),
-		workloadmetafxmock.MockModule(),
+		workloadmetafxmock.MockModuleV2(),
 	))
 	c := collector{
 		store: workloadmetaStore,
@@ -36,7 +38,7 @@ func TestPull(t *testing.T) {
 	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		fx.Supply(workloadmeta.NewParams()),
-		workloadmetafxmock.MockModule(),
+		workloadmetafxmock.MockModuleV2(),
 	))
 	fakeNodeName := "fake-hostname"
 
@@ -46,16 +48,13 @@ func TestPull(t *testing.T) {
 	}
 
 	err := c.Pull(context.TODO())
-	assert.NoError(t, err)
-	evs := workloadmetaStore.GetNotifiedEvents()
-	assert.NotEmpty(t, evs)
+	require.NoError(t, err)
 
-	event0 := evs[0]
-
-	assert.Equal(t, event0.Type, workloadmeta.EventTypeSet)
-	assert.Equal(t, event0.Source, workloadmeta.SourceClusterOrchestrator)
-
-	containerEntity, ok := event0.Entity.(*workloadmeta.Container)
-	assert.True(t, ok)
-	assert.Equal(t, containerEntity.ID, fakeNodeName)
+	assert.Eventually(t, func() bool {
+		container, err := workloadmetaStore.GetContainer(fakeNodeName)
+		if err != nil {
+			return false
+		}
+		return container.Runtime == workloadmeta.ContainerRuntimeGarden
+	}, 10*time.Second, 50*time.Millisecond)
 }

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -32,10 +32,9 @@ type workloadMetaMock struct {
 	log    log.Component
 	config config.Component
 
-	mu             sync.RWMutex
-	store          map[wmdef.Kind]map[string]wmdef.Entity
-	notifiedEvents []wmdef.CollectorEvent
-	eventsChan     chan wmdef.CollectorEvent
+	mu         sync.RWMutex
+	store      map[wmdef.Kind]map[string]wmdef.Entity
+	eventsChan chan wmdef.CollectorEvent
 }
 
 // NewWorkloadMetaMock returns a new workloadMetaMock.
@@ -312,8 +311,6 @@ func (w *workloadMetaMock) Notify(events []wmdef.CollectorEvent) {
 			w.eventsChan <- event
 		}
 	}
-
-	w.notifiedEvents = append(w.notifiedEvents, events...)
 }
 
 // Push pushes events from an external source into workloadmeta store
@@ -330,26 +327,6 @@ func (w *workloadMetaMock) Push(source wmdef.Source, events ...wmdef.Event) erro
 
 	w.Notify(collectorEvents)
 	return nil
-}
-
-// GetNotifiedEvents returns all registered notification events.
-func (w *workloadMetaMock) GetNotifiedEvents() []wmdef.CollectorEvent {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	var events []wmdef.CollectorEvent
-	events = append(events, w.notifiedEvents...)
-
-	return events
-}
-
-// SubscribeToEvents returns a channel that receives events
-func (w *workloadMetaMock) SubscribeToEvents() chan wmdef.CollectorEvent {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	w.eventsChan = make(chan wmdef.CollectorEvent, 100)
-	return w.eventsChan
 }
 
 // Dump is not implemented in the testing store.
@@ -421,16 +398,6 @@ func NewWorkloadMetaMockV2(deps dependencies) wmmock.Mock {
 // Notify overrides store to allow for synchronous event processing
 func (w *workloadMetaMockV2) Notify(events []wmdef.CollectorEvent) {
 	w.handleEvents(events)
-}
-
-// GetNotifiedEvents is not implemented for V2 mocks.
-func (w *workloadMetaMockV2) GetNotifiedEvents() []wmdef.CollectorEvent {
-	panic("not implemented")
-}
-
-// SubscribeToEvents is not implemented for V2 mocks.
-func (w *workloadMetaMockV2) SubscribeToEvents() chan wmdef.CollectorEvent {
-	panic("not implemented")
 }
 
 // SetEntity generates a Set event

--- a/comp/core/workloadmeta/mock/mock.go
+++ b/comp/core/workloadmeta/mock/mock.go
@@ -18,6 +18,7 @@ type Mock interface {
 	wmdef.Component
 
 	// The following are for testing purposes and should maybe be revisited
+
 	// Set allows setting an entity in the workloadmeta store
 	Set(entity wmdef.Entity)
 
@@ -26,10 +27,4 @@ type Mock interface {
 
 	// GetConfig returns a Config Reader for the internal injected config
 	GetConfig() config.Reader
-
-	// GetConfig returns a Config Reader for the internal injected config
-	GetNotifiedEvents() []wmdef.CollectorEvent
-
-	// SubscribeToEvents returns a channel that receives events
-	SubscribeToEvents() chan wmdef.CollectorEvent
 }


### PR DESCRIPTION
### What does this PR do?

This PR is a first step to be able to clean the code around workloadmeta mocks.

The code is a bit confusing right now because we have 2 mocks (`workloadMetaMock` and `workloadMetaMockV2`). The first re-implements a lot of the functionality whereas the second it's just a thin wrapper with a few functions that are useful for testing. I think we should just use V2 everywhere because the implementation is closer to the real one.

There are only 2 functions defined in the workloadmeta mock interface that are implemented in `workloadMetaMock` but not in `workloadMetaMockV2`. Those 2 functions are only used in the tests of a couple of collectors: host and cloudfoundry. This PR migrates the tests of those 2 collectors to use the V2 of the mock by using functions that already exist in workloadmeta instead of relying in functions that only exist in mocks.

After this change it will be easier to migrate all the usages of the V1 of the mock to V2, but I prefer to do that on a separate PR because there are many users of each mock.


### Describe how to test/QA your changes

Skip.
