### PR TITLE
[CWS] Add coredump action to `ruleset_loaded` event

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -185,10 +185,11 @@ type PolicyState struct {
 // RuleAction is used to report policy was loaded
 // easyjson:json
 type RuleAction struct {
-	Filter *string         `json:"filter,omitempty"`
-	Set    *RuleSetAction  `json:"set,omitempty"`
-	Kill   *RuleKillAction `json:"kill,omitempty"`
-	Hash   *HashAction     `json:"hash,omitempty"`
+	Filter   *string         `json:"filter,omitempty"`
+	Set      *RuleSetAction  `json:"set,omitempty"`
+	Kill     *RuleKillAction `json:"kill,omitempty"`
+	Hash     *HashAction     `json:"hash,omitempty"`
+	CoreDump *CoreDumpAction `json:"coredump,omitempty"`
 }
 
 // HashAction is used to report 'hash' action
@@ -212,6 +213,15 @@ type RuleSetAction struct {
 type RuleKillAction struct {
 	Signal string `json:"signal,omitempty"`
 	Scope  string `json:"scope,omitempty"`
+}
+
+// CoreDumpAction is used to report the 'coredump' action
+// easyjson:json
+type CoreDumpAction struct {
+	Process       bool `json:"process,omitempty"`
+	Mount         bool `json:"mount,omitempty"`
+	Dentry        bool `json:"dentry,omitempty"`
+	NoCompression bool `json:"no_compression,omitempty"`
 }
 
 // RulesetLoadedEvent is used to report that a new ruleset was loaded
@@ -277,6 +287,13 @@ func RuleStateFromDefinition(def *rules.RuleDefinition, status string, message s
 		case action.Hash != nil:
 			ruleAction.Hash = &HashAction{
 				Enabled: true,
+			}
+		case action.CoreDump != nil:
+			ruleAction.CoreDump = &CoreDumpAction{
+				Process:       action.CoreDump.Process,
+				Mount:         action.CoreDump.Mount,
+				Dentry:        action.CoreDump.Dentry,
+				NoCompression: action.CoreDump.NoCompression,
 			}
 		}
 		ruleState.Actions = append(ruleState.Actions, ruleAction)

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -186,7 +186,7 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 				in.Delim('[')
 				if out.Actions == nil {
 					if !in.IsDelim(']') {
-						out.Actions = make([]RuleAction, 0, 2)
+						out.Actions = make([]RuleAction, 0, 1)
 					} else {
 						out.Actions = []RuleAction{}
 					}
@@ -522,6 +522,16 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor4(
 				}
 				(*out.Hash).UnmarshalEasyJSON(in)
 			}
+		case "coredump":
+			if in.IsNull() {
+				in.Skip()
+				out.CoreDump = nil
+			} else {
+				if out.CoreDump == nil {
+					out.CoreDump = new(CoreDumpAction)
+				}
+				(*out.CoreDump).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -571,6 +581,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor4(
 			out.RawString(prefix)
 		}
 		(*in.Hash).MarshalEasyJSON(out)
+	}
+	if in.CoreDump != nil {
+		const prefix string = ",\"coredump\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.CoreDump).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -833,4 +853,93 @@ func (v HashAction) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *HashAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(l, v)
+}
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(in *jlexer.Lexer, out *CoreDumpAction) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "process":
+			out.Process = bool(in.Bool())
+		case "mount":
+			out.Mount = bool(in.Bool())
+		case "dentry":
+			out.Dentry = bool(in.Bool())
+		case "no_compression":
+			out.NoCompression = bool(in.Bool())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(out *jwriter.Writer, in CoreDumpAction) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.Process {
+		const prefix string = ",\"process\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Bool(bool(in.Process))
+	}
+	if in.Mount {
+		const prefix string = ",\"mount\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Mount))
+	}
+	if in.Dentry {
+		const prefix string = ",\"dentry\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Dentry))
+	}
+	if in.NoCompression {
+		const prefix string = ",\"no_compression\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.NoCompression))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CoreDumpAction) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CoreDumpAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(l, v)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds coredump action (#25797) information to the `ruleset_loaded` event.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
