### PR TITLE
add upgrade 5 and 6 tests

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -77,6 +77,7 @@
       - E2E_MSI_TEST: TestNPMUpgradeNPMToNPM
       - E2E_MSI_TEST: TestNPMInstallWithAddLocal
       - E2E_MSI_TEST: TestNPMUpgradeFromBeta
+      - E2E_MSI_TEST: TestUpgradeFromV6
 
 new-e2e_windows_powershell_module_test:
   extends: .new_e2e_template

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -59,6 +59,7 @@
       - E2E_MSI_TEST: TestRepair
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeRollback
+      - E2E_MSI_TEST: TestUpgradeChangeUser
       - E2E_MSI_TEST: TestAgentUser/user_only
       - E2E_MSI_TEST: TestAgentUser/dotslash_user
       - E2E_MSI_TEST: TestAgentUser/hostname_user
@@ -74,6 +75,7 @@
       - E2E_MSI_TEST: TestNPMUpgradeNPMToNPM
       - E2E_MSI_TEST: TestNPMInstallWithAddLocal
       - E2E_MSI_TEST: TestNPMUpgradeFromBeta
+      - E2E_MSI_TEST: TestUpgrade5to6to7
 
 new-e2e_windows_powershell_module_test:
   extends: .new_e2e_template

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -41,6 +41,7 @@
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeRollback
       - E2E_MSI_TEST: TestUpgradeChangeUser
+      - E2E_MSI_TEST: TestUpgradeFromV5
       - E2E_MSI_TEST: TestAgentUser/user_only
       - E2E_MSI_TEST: TestAgentUser/dotslash_user
       - E2E_MSI_TEST: TestAgentUser/hostname_user
@@ -60,6 +61,7 @@
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeRollback
       - E2E_MSI_TEST: TestUpgradeChangeUser
+      - E2E_MSI_TEST: TestUpgradeFromV5
       - E2E_MSI_TEST: TestAgentUser/user_only
       - E2E_MSI_TEST: TestAgentUser/dotslash_user
       - E2E_MSI_TEST: TestAgentUser/hostname_user
@@ -75,7 +77,6 @@
       - E2E_MSI_TEST: TestNPMUpgradeNPMToNPM
       - E2E_MSI_TEST: TestNPMInstallWithAddLocal
       - E2E_MSI_TEST: TestNPMUpgradeFromBeta
-      - E2E_MSI_TEST: TestUpgrade5to6to7
 
 new-e2e_windows_powershell_module_test:
   extends: .new_e2e_template

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -142,18 +142,3 @@
 
 # Kitchen: final test matrix (test types * scenarios)
 # ----------------------------------------------
-
-kitchen_windows_upgrade5_agent-a6:
-  extends:
-    - .kitchen_scenario_windows_a6
-    - .kitchen_test_upgrade5_agent
-
-kitchen_windows_upgrade5_agent-a7:
-  extends:
-    - .kitchen_scenario_windows_a7
-    - .kitchen_test_upgrade5_agent
-
-kitchen_windows_upgrade6_agent-a7:
-  extends:
-    - .kitchen_scenario_windows_a7
-    - .kitchen_test_upgrade6_agent

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -17,6 +17,7 @@ import (
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -108,6 +109,20 @@ func AssertUserRights(t *testing.T, host *components.RemoteHost, username string
 		return false
 	}
 	return assert.ElementsMatch(t, expectedRights, actualRights, "user %s should have user rights", username)
+}
+
+// RequireAgentVersionRunningWithNoErrors checks the agent is running the expected version with no errors
+func RequireAgentVersionRunningWithNoErrors(t *testing.T, client *common.TestClient, version string) {
+	// check version
+	if !t.Run("running expected agent version", func(t *testing.T) {
+		installedVersion, err := client.GetAgentVersion()
+		require.NoError(t, err, "should get agent version")
+		windowsAgent.TestAgentVersion(t, version, installedVersion)
+	}) {
+		t.FailNow()
+	}
+	// check no errors
+	RequireAgentRunningWithNoErrors(t, client)
 }
 
 // RequireAgentRunningWithNoErrors checks the agent is running with no errors

--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -138,7 +138,7 @@ func (s *baseAgentMSISuite) uninstallAgentAndRunUninstallTests(t *Tester) bool {
 	})
 }
 
-func (s *baseAgentMSISuite) installPreviousAgentVersion(vm *components.RemoteHost, agentPackage *windowsAgent.Package, options ...windowsAgent.InstallAgentOption) *Tester {
+func (s *baseAgentMSISuite) installAndTestPreviousAgentVersion(vm *components.RemoteHost, agentPackage *windowsAgent.Package, options ...windowsAgent.InstallAgentOption) *Tester {
 	// create the tester
 	t := s.newTester(vm,
 		WithAgentPackage(agentPackage),
@@ -161,7 +161,7 @@ func (s *baseAgentMSISuite) installLastStable(vm *components.RemoteHost, options
 	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
 	s.Require().NoError(err, "should get last stable agent package from env")
 
-	return s.installPreviousAgentVersion(vm, previousAgentPackage, options...)
+	return s.installAndTestPreviousAgentVersion(vm, previousAgentPackage, options...)
 }
 
 func (s *baseAgentMSISuite) readYamlConfig(host *components.RemoteHost, path string) (map[string]any, error) {

--- a/test/new-e2e/tests/windows/install-test/install_subservices_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_subservices_test.go
@@ -72,6 +72,7 @@ func (s *testSubServicesOptsSuite) SetupSuite() {
 		windowsAgent.WithAPMEnabled(strconv.FormatBool(tc.apmEnabled)),
 	}
 	_ = s.installAgentPackage(vm, s.AgentPackage, installOpts...)
+	RequireAgentVersionRunningWithNoErrors(s.T(), s.NewTestClientForHost(vm), s.AgentPackage.AgentVersion())
 
 	// read the config file and check the options
 	var err error

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -152,6 +152,7 @@ func (s *testRepairSuite) TestRepair() {
 
 	// install the agent
 	_ = s.installAgentPackage(vm, s.AgentPackage)
+	RequireAgentVersionRunningWithNoErrors(s.T(), s.NewTestClientForHost(vm), s.AgentPackage.AgentVersion())
 
 	err := windowsCommon.StopService(t.host, "DatadogAgent")
 	s.Require().NoError(err)
@@ -224,6 +225,7 @@ func (s *testInstallOptsSuite) TestInstallOpts() {
 	}
 
 	_ = s.installAgentPackage(vm, s.AgentPackage, installOpts...)
+	RequireAgentVersionRunningWithNoErrors(s.T(), s.NewTestClientForHost(vm), s.AgentPackage.AgentVersion())
 
 	// read the config file and check the options
 	confYaml, err := s.readAgentConfig(vm)

--- a/test/new-e2e/tests/windows/install-test/npm_test.go
+++ b/test/new-e2e/tests/windows/install-test/npm_test.go
@@ -97,6 +97,7 @@ func (s *testNPMInstallWithAddLocalSuite) TestNPMInstallWithAddLocal() {
 		s.AgentPackage,
 		windowsAgent.WithAddLocal("NPM"),
 	)
+	RequireAgentVersionRunningWithNoErrors(s.T(), s.NewTestClientForHost(s.Env().RemoteHost), s.AgentPackage.AgentVersion())
 
 	// run tests
 	s.Require().True(s.isNPMInstalled(), "NPM should be installed")
@@ -156,7 +157,7 @@ func (s *testNPMInstallSuite) installPreviousAgentVersion(vm *components.RemoteH
 		Version: s.previousVersion,
 		URL:     s.url,
 	}
-	return s.baseAgentMSISuite.installPreviousAgentVersion(vm, previousAgentPackage, options...)
+	return s.baseAgentMSISuite.installAndTestPreviousAgentVersion(vm, previousAgentPackage, options...)
 }
 
 func (s *testNPMInstallSuite) isNPMInstalled() bool {
@@ -223,17 +224,8 @@ func (s *testNPMInstallSuite) upgradeAgent(host *components.RemoteHost, agentPac
 	}
 
 	if !s.Run(fmt.Sprintf("test %s", agentPackage.AgentVersion()), func() {
-		// check version
 		client := s.NewTestClientForHost(host)
-		if !s.Run("running expected agent version", func() {
-			installedVersion, err := client.GetAgentVersion()
-			s.Require().NoError(err, "should get agent version")
-			windowsAgent.TestAgentVersion(s.T(), agentPackage.AgentVersion(), installedVersion)
-		}) {
-			s.T().FailNow()
-		}
-		// check no errors
-		RequireAgentRunningWithNoErrors(s.T(), client)
+		RequireAgentVersionRunningWithNoErrors(s.T(), client, agentPackage.AgentVersion())
 	}) {
 		s.T().FailNow()
 	}

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -41,8 +41,11 @@ func (s *testUpgradeSuite) TestUpgrade() {
 	// to ensure upgrade places new config files.
 	configRoot, err := windowsAgent.GetConfigRootFromRegistry(vm)
 	s.Require().NoError(err)
-	err = vm.RemoveAll(filepath.Join(configRoot, "runtime-security.d"))
-	s.Require().NoError(err)
+	path := filepath.Join(configRoot, "runtime-security.d")
+	if _, err = vm.Lstat(path); err == nil {
+		err = vm.RemoveAll(path)
+		s.Require().NoError(err)
+	}
 
 	// upgrade to the new version
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
@@ -230,6 +233,7 @@ func (s *testUpgradeFromV5Suite) TestUpgrade5() {
 
 	// TODO: The import command creates datadog.yaml so it has Owner:Administrator Group:None,
 	//       and the permissions tests expect Owner:SYSTEM Group:System
+	s.cleanupOnSuccessInDevMode()
 }
 
 func (s *testUpgradeFromV5Suite) installAgent5() {

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -21,7 +21,7 @@ import (
 func TestUpgrade(t *testing.T) {
 	s := &testUpgradeSuite{}
 	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
-	s.Require().NoError(err, "should get last stable agent package from env")
+	require.NoError(t, err, "should get last stable agent package from env")
 	s.previousAgentPackge = previousAgentPackage
 	run(t, s)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add E2E tests for upgrading from Agent5 and from Agent6

remove the replaced kitchen tests

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-507

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
