### PR TITLE
parent test only flaky if subtest actually failed

### DIFF
--- a/pkg/util/testutil/flake/parse.go
+++ b/pkg/util/testutil/flake/parse.go
@@ -50,12 +50,6 @@ func (k *KnownFlakyTests) IsFlaky(pkg string, testName string) bool {
 		}
 	}
 
-	// check if any subtests are marked as flaky
-	for test := range k.packageTestList[pkg] {
-		if strings.HasPrefix(test, testName+"/") {
-			return true
-		}
-	}
 	return false
 }
 

--- a/pkg/util/testutil/flake/parse_test.go
+++ b/pkg/util/testutil/flake/parse_test.go
@@ -18,7 +18,8 @@ func TestIsFlaky(t *testing.T) {
 	kf.Add("", "TestEKSSuite/TestCPU")
 
 	assert.True(t, kf.IsFlaky("", "TestEKSSuite/TestCPU/TestCPUUtilization"))
-	assert.True(t, kf.IsFlaky("", "TestEKSSuite"))
+	// parents cannot be considered flaky without test results to ensure it may have failed because of a flaky subtest
+	assert.False(t, kf.IsFlaky("", "TestEKSSuite"))
 	assert.False(t, kf.IsFlaky("", "TestEKSSuite/TestMemory"))
 	assert.True(t, kf.IsFlaky("", "TestEKSSuite/TestCPU"))
 	assert.False(t, kf.IsFlaky("", "TestECSSuite/TestCPU"))

--- a/test/new-e2e/system-probe/test-json-review/main_test.go
+++ b/test/new-e2e/system-probe/test-json-review/main_test.go
@@ -35,6 +35,14 @@ const rerunTestData = `{"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","
 {"Time":"2024-06-14T22:28:02.039003529Z","Action":"pass","Package":"a/b/c","Test":"testname","Elapsed":26.25}
 `
 
+const onlyParentOfFlakeFailed = `{"Time":"2024-06-14T22:24:52.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent"}
+{"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent/testname"}
+{"Time":"2024-06-14T22:24:53.156263319Z","Action":"output","Package":"a/b/c","Test":"testparent/testname","Output":"=== RUN   testparent/testname\n"}
+{"Time":"2024-06-14T22:24:53.156271614Z","Action":"output","Package":"a/b/c","Test":"testparent/testname","Output":"    file_test.go:10: flakytest: this is a known flaky test\n"}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"pass","Package":"a/b/c","Test":"testparent/testname","Elapsed":26.25}
+{"Time":"2024-06-14T22:26:03.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent","Elapsed":28.25}
+`
+
 func TestFlakeInOutput(t *testing.T) {
 	out, err := reviewTestsReaders(bytes.NewBuffer([]byte(flakeTestData)), nil)
 	require.NoError(t, err)
@@ -57,4 +65,12 @@ func TestRerunInOutput(t *testing.T) {
 	assert.Empty(t, out.Failed)
 	assert.Empty(t, out.Flaky)
 	assert.Equal(t, fmt.Sprintf(rerunFormat, "a/b/c", "testname", "pass"), out.ReRuns)
+}
+
+func TestOnlyParentOfFlakeFailed(t *testing.T) {
+	out, err := reviewTestsReaders(bytes.NewBuffer([]byte(onlyParentOfFlakeFailed)), nil)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(failFormat, "a/b/c", "testparent"), out.Failed)
+	assert.Empty(t, out.Flaky)
+	assert.Empty(t, out.ReRuns)
 }


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This change restricts it so the subtest must actually fail before the parent can be considered flaky. 

### Motivation

The KMT TestWasher previously considered a parent test flaky if a subtest was marked as flaky, regardless if it actually failed. This will expose parent tests that fail for other reasons (assuming the subtest does not fail).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
