### PR TITLE
Fix testwasher to not mark parent as flaky when marked test does not …

### DIFF
--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -37,7 +37,9 @@ class TestWasher:
 
         for package, tests in failing_tests.items():
             non_flaky_failing_tests_in_package = set()
-            known_flaky_tests_parents = self.get_tests_family(all_known_flakes[package])
+            known_flaky_tests_parents = self.get_tests_family_if_failing_tests(
+                all_known_flakes[package], failing_tests[package]
+            )
             for failing_test in tests:
                 if not self.is_known_flaky_test(failing_test, all_known_flakes[package], known_flaky_tests_parents):
                     non_flaky_failing_tests_in_package.add(failing_test)
@@ -130,7 +132,7 @@ class TestWasher:
         If a test is a parent of a test that is known to be flaky, the test should be considered flaky
         For example:
         - if TestEKSSuite/TestCPU is known to be flaky, TestEKSSuite/TestCPU/TestCPUUtilization should be considered flaky
-        - if TestEKSSuite/TestCPU is known to be flaky, TestEKSSuite should be considered flaky
+        - if TestEKSSuite/TestCPU is known to be flaky, TestEKSSuite should be considered flaky unless TestEKSSuite/TestCPU is not failing
         - if TestEKSSuite/TestCPU is known to be flaky, TestEKSSuite/TestMemory should not be considered flaky
         """
 
@@ -140,6 +142,19 @@ class TestWasher:
             return True
 
         return failing_test in known_flaky_tests_parents
+
+    def get_tests_family_if_failing_tests(self, test_name_list, failing_tests: set):
+        """
+        Get the parent tests of a list of tests only if the marked test is failing
+        For example with the test ["TestEKSSuite/TestCPU/TestCPUUtilization", "TestKindSuite/TestCPU"]
+        this method should return the set{"TestEKSSuite/TestCPU/TestCPUUtilization", "TestEKSSuite/TestCPU", "TestEKSSuite", "TestKindSuite/TestCPU", "TestKindSuite"}
+        if TestKindSuite/TestCPU and TestEKSSuite/TestCPU/TestCPUUtilization are failing
+        Another example, with the test ["TestEKSSuite/TestCPU/TestCPUUtilization", "TestKindSuite/TestCPU"]
+        if only TestKindSuite/TestCPU is failing, the method should return the set{"TestKindSuite/TestCPU", "TestKindSuite"}
+        """
+        test_name_set = set(test_name_list)
+        marked_tests_failing = failing_tests.intersection(test_name_set)
+        return self.get_tests_family(list(marked_tests_failing))
 
     def get_tests_family(self, test_name_list):
         """

--- a/tasks/unit-tests/testdata/flakes_3.yaml
+++ b/tasks/unit-tests/testdata/flakes_3.yaml
@@ -1,0 +1,2 @@
+test/new-e2e/tests/containers:
+  - TestEKSSuite/Ifail

--- a/tasks/unit-tests/testdata/test_output_failure_only_parent.json
+++ b/tasks/unit-tests/testdata/test_output_failure_only_parent.json
@@ -1,0 +1,4 @@
+{"Time":"2024-04-25T19:35:40.871444+02:00","Action":"run","Package":"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers","Test":"TestEKSSuite"}
+{"Time":"2024-04-25T19:35:40.871448+02:00","Action":"output","Package":"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers","Test":"TestEKSSuite","Output":"=== RUN   TestGetPayloadContainerizedWithDocker0\n"}
+{"Time":"2024-04-25T19:35:40.873652+02:00","Action":"fail","Package":"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers","Test":"TestEKSSuite","Elapsed":0}
+{"Time":"2024-04-25T19:35:40.874579+02:00","Action":"fail","Package":"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers","Elapsed":0.494}

--- a/tasks/unit-tests/testwasher_tests.py
+++ b/tasks/unit-tests/testwasher_tests.py
@@ -55,6 +55,22 @@ class TestUtils(unittest.TestCase):
             {"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers": {"TestEKSSuite/TestMemory"}},
         )
 
+    def test_should_not_be_considered_flaky(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_only_parent.json",
+            flakes_file_path="tasks/unit-tests/testdata/flakes_3.yaml",
+        )
+        module_path = "tasks/unit-tests/testdata"
+        failing_tests, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        non_flaky_failing_tests = test_washer.get_non_flaky_failing_tests(
+            failing_tests=failing_tests, flaky_marked_tests=marked_flaky_tests
+        )
+        print("TOTOTO", non_flaky_failing_tests)
+        self.assertEqual(
+            non_flaky_failing_tests,
+            {"github.com/DataDog/datadog-agent/test/new-e2e/tests/containers": {"TestEKSSuite"}},
+        )
+
 
 class TestMergeKnownFlakes(unittest.TestCase):
     def test_with_shared_keys(self):


### PR DESCRIPTION
…fail

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Testwasher can mark test as flaky even when they are not. In the current implementation if you mark `TestA/TestB` as flaky, any failure on `TestA` will be ignored. We want that to happen only if `TestA/TestB` actually failed otherwise we're hiding an earlier failure.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
