### PR TITLE
[e2e] recreate stack on "resource did not exist infra error"

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -31,5 +31,10 @@ func getKnownErrors() []knownError {
 			errorMessage: "failed attempts: dial tcp :22: connect: connection refused",
 			retryType:    reCreate,
 		},
+		{
+			// https://datadoghq.atlassian.net/browse/ADXT-295
+			errorMessage: "Resource provider reported that the resource did not exist while updating",
+			retryType:    reCreate,
+		},
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Recreate a stack on pulumi reporting that a resource does not exist at update

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In the past we had e2e setup failing with the error 

```
Resource provider reported that the resource did not exist while updating
```

[Example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/528269160)

This can mean that the resource was destroyed elsewhere, we can destroy and recreate the stack to retry the setup

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
