### PR TITLE
[SBOM] Add some Trivy analyzers to be deactivated by default

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -169,7 +169,12 @@ func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
 	if analyzersDisabled(TypeImageConfigSecret) {
 		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeImageConfigSecret)
 	}
-
+	disabledAnalyzers = append(disabledAnalyzers,
+		analyzer.TypeExecutable,
+		analyzer.TypeRedHatContentManifestType,
+		analyzer.TypeRedHatDockerfileType,
+		analyzer.TypeSBOM,
+		analyzer.TypeUbuntuESM)
 	return disabledAnalyzers
 }
 


### PR DESCRIPTION
### What does this PR do?

Deactivate by default some trivy analyzers that can cost IOs and that are not used in resulting SBOM.

### Motivation

Reduce unnecessary work and IO.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
