### PR TITLE
test: Disable telemetry when API key is not provided in e2e install

### DIFF
--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -50,6 +50,9 @@ func Unix(t *testing.T, client *common.TestClient, options ...installparams.Opti
 		apikey = params.APIKey
 	} else {
 		apikey = "aaaaaaaaaa"
+
+		// If the API key is not provided, disable the telemetry to avoid 403 errors
+		commandLine += fmt.Sprint("DD_INSTRUMENTATION_TELEMETRY_ENABLED=false")
 	}
 
 	t.Run("Installing the agent", func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -52,7 +52,7 @@ func Unix(t *testing.T, client *common.TestClient, options ...installparams.Opti
 		apikey = "aaaaaaaaaa"
 
 		// If the API key is not provided, disable the telemetry to avoid 403 errors
-		commandLine += fmt.Sprint("DD_INSTRUMENTATION_TELEMETRY_ENABLED=false")
+		commandLine += "DD_INSTRUMENTATION_TELEMETRY_ENABLED=false"
 	}
 
 	t.Run("Installing the agent", func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -52,7 +52,7 @@ func Unix(t *testing.T, client *common.TestClient, options ...installparams.Opti
 		apikey = "aaaaaaaaaa"
 
 		// If the API key is not provided, disable the telemetry to avoid 403 errors
-		commandLine += "DD_INSTRUMENTATION_TELEMETRY_ENABLED=false"
+		commandLine += " DD_INSTRUMENTATION_TELEMETRY_ENABLED=false "
 	}
 
 	t.Run("Installing the agent", func(tt *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Disable telemetry reporting in E2E tests using the install script, when an API key isn't provided.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Telemetry reporting can emit a 403 error in the job logs, which causes confusion when debugging a failed job.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
