### PR TITLE
[CWS] use full go mod version in `pkg/security/secl`

### DIFF
--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/security/secl
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/security/seclwin
 
-go 1.22
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/pkg/security/secl => ../secl
 

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -222,10 +222,8 @@ DEFAULT_MODULES = {
     "pkg/process/util/api": GoModule("pkg/process/util/api", independent=True, used_by_otel=True),
     "pkg/proto": GoModule("pkg/proto", independent=True, used_by_otel=True),
     "pkg/remoteconfig/state": GoModule("pkg/remoteconfig/state", independent=True, used_by_otel=True),
-    "pkg/security/secl": GoModule("pkg/security/secl", independent=True, legacy_go_mod_version=True),
-    "pkg/security/seclwin": GoModule(
-        "pkg/security/seclwin", independent=True, condition=lambda: False, legacy_go_mod_version=True
-    ),
+    "pkg/security/secl": GoModule("pkg/security/secl", independent=True),
+    "pkg/security/seclwin": GoModule("pkg/security/seclwin", independent=True, condition=lambda: False),
     "pkg/serializer": GoModule("pkg/serializer", independent=True, used_by_otel=True),
     "pkg/status/health": GoModule("pkg/status/health", independent=True, used_by_otel=True),
     "pkg/tagger/types": GoModule("pkg/tagger/types", independent=True, used_by_otel=True),


### PR DESCRIPTION
### What does this PR do?

The downstream user of this package that was blocking us from using the new standard go mod statement has migrated to using a fully qualified version. This allows us to remove our hack on the secl and seclwin modules.

This PR:
- updates the go.mod file with full version
- updates the module definition so that future go upgrades work as expectde

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
