### PR TITLE
Fix race when enabling both api http servers

### DIFF
--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -7,6 +7,11 @@ package apiimpl
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	// component dependencies
@@ -34,11 +39,15 @@ import (
 
 	// package dependencies
 
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
 	// third-party dependencies
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 )
 
@@ -117,4 +126,61 @@ func TestStartServer(t *testing.T) {
 	defer srv.StopServer()
 
 	assert.NoError(t, err, "could not start api component servers: %v", err)
+}
+
+func TestStartBothServers(t *testing.T) {
+	tmpDir := t.TempDir()
+	authToken, err := os.CreateTemp(tmpDir, "auth_token")
+	require.NoError(t, err)
+	authTokenValue := strings.Repeat("a", 64)
+
+	_, err = io.WriteString(authToken, authTokenValue)
+	require.NoError(t, err)
+
+	deps := getComponentDependencies(t)
+
+	cfg := config.Mock(t)
+	cfg.Set("cmd_port", 0, model.SourceFile)
+	cfg.Set("agent_ipc.port", 56789, model.SourceFile)
+	cfg.Set("auth_token_file_path", authToken.Name(), model.SourceFile)
+
+	srv := getTestAPIServer(deps)
+	err = srv.StartServer()
+	require.NoError(t, err)
+	defer srv.StopServer()
+
+	testCases := []struct {
+		addr       string
+		serverName string
+	}{
+		{
+			addr:       cmdListener.Addr().String(),
+			serverName: "cmd",
+		},
+		{
+			addr:       ipcListener.Addr().String(),
+			serverName: "ipc",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.serverName, func(t *testing.T) {
+			url := fmt.Sprintf("https://%s/this_doesnt_exist", tc.addr)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authTokenValue))
+			resp, err := util.GetClient(false).Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// for debug purpose
+			content, err := io.ReadAll(resp.Body)
+			if assert.NoError(t, err) {
+				t.Log(string(content))
+			}
+
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		})
+	}
 }

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -88,16 +88,19 @@ func StartServers(
 		return fmt.Errorf("unable to initialize TLS: %v", err)
 	}
 
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{*tlsKeyPair},
-		NextProtos:   []string{"h2"},
-		MinVersion:   tls.VersionTLS12,
+	// tls.Config is written to when serving, so it has to be cloned for each server
+	tlsConfig := func() *tls.Config {
+		return &tls.Config{
+			Certificates: []tls.Certificate{*tlsKeyPair},
+			NextProtos:   []string{"h2"},
+			MinVersion:   tls.VersionTLS12,
+		}
 	}
 
 	// start the CMD server
 	if err := startCMDServer(
 		apiAddr,
-		tlsConfig,
+		tlsConfig(),
 		tlsCertPool,
 		configService,
 		configServiceMRF,
@@ -118,7 +121,7 @@ func StartServers(
 
 	// start the IPC server
 	if ipcServerEnabled {
-		if err := startIPCServer(ipcServerHostPort, tlsConfig); err != nil {
+		if err := startIPCServer(ipcServerHostPort, tlsConfig()); err != nil {
 			// if we fail to start the IPC server, we should stop the CMD server
 			StopServers()
 			return fmt.Errorf("unable to start IPC API server: %v", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Clone the `tls.Config` object used to start the two API servers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The `tls.Config` object given to an `http.Server` is unexpectedly written to when serving (some default values are added to a slice it contains), so it has to be cloned when used for two different servers to avoid a race.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Added a unit test starting both http servers and making a request to each. A very similar test caught this bug in another branch.
