### PR TITLE
feat(release): Update the `create_rc` workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 14 * * 1,3,5' # Run on Monday, Wednesday, and Friday at 14:00 UTC
+    - cron: '0 8 * * 1,3,5' # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
 
 
 env:
@@ -49,10 +50,10 @@ jobs:
             - name: Check for changes since last RC
               id: check_for_changes
               run: |
-                echo CHANGES=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }} ${{env.WARNING}}) >> $GITHUB_ENV
+                echo "CHANGES=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }} ${{ env.WARNING }})" >> $GITHUB_ENV
                   
             - name: Create RC PR
-              if: ${{ steps.check_for_changes.outputs.COUNT != '0'}}
+              if: ${{ steps.check_for_changes.outputs.CHANGES == 'true'}}
               run: |
                 git config user.name "github-actions[bot]"
                 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -18,6 +18,7 @@ jobs:
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
               with:
                 fetch-depth: 0
+                sparse-checkout: 'tasks'
 
             - name: Install python
               uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -40,19 +41,12 @@ jobs:
               with:
                 ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
+                sparse-checkout: 'tasks'
 
             - name: Check for changes since last RC
               id: check_for_changes
               run: |
-                last_rc_commit=$(git log -1 --format=%H --grep="Update release.json and Go modules")
-                count=$(git rev-list --count HEAD ^"$last_rc_commit")
-                echo COUNT=$count >> $GITHUB_OUTPUT
-                  
-                if [ $count -eq '0' ]; then
-                    echo "No changes since last RC. Quitting workflow."
-                else
-                    echo "$count new commits found since last RC. Proceeding with the RC PR creation."
-                fi
+                echo COUNT=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }}) >> $GITHUB_ENV
                   
             - name: Create RC PR
               if: ${{ steps.check_for_changes.outputs.COUNT != '0'}}

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -17,7 +17,6 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
               with:
-                fetch-depth: 0
                 sparse-checkout: 'tasks'
 
             - name: Install python
@@ -36,17 +35,21 @@ jobs:
               run: |
                 echo "RELEASE_BRANCH=$(inv -e release.get-active-release-branch)" >> $GITHUB_ENV
             
+            - name: Set the warning option
+              if: github.event.schedule == '0 8 * * 1,3,5'
+              run: echo "WARNING='-w'" >> $GITHUB_ENV
+
             - name: Checkout release branch
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
               with:
                 ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
                 sparse-checkout: 'tasks'
-
+            
             - name: Check for changes since last RC
               id: check_for_changes
               run: |
-                echo COUNT=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }}) >> $GITHUB_ENV
+                echo CHANGES=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }} ${{env.WARNING}}) >> $GITHUB_ENV
                   
             - name: Create RC PR
               if: ${{ steps.check_for_changes.outputs.COUNT != '0'}}

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import os.path
+import os
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from invoke.exceptions import Exit
@@ -11,6 +12,23 @@ from tasks.libs.common.user_interactions import yes_no_question
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+
+@contextmanager
+def clone(ctx, repo, branch, destination="", options=""):
+    """
+    Context manager to clone a git repository and checkout a specific branch.
+    """
+    current_dir = os.getcwd()
+    if len(destination) == 0:
+        destination = repo
+    try:
+        ctx.run(f"git clone -b {branch} {options} https://github.com/DataDog/{repo} {destination}")
+        os.chdir(destination)
+        yield
+    finally:
+        os.chdir(current_dir)
+        ctx.run(f"rm -rf {destination}")
 
 
 def get_staged_files(ctx, commit="HEAD", include_deleted_files=False) -> Iterable[str]:

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -167,7 +167,7 @@ def email_to_slackid(ctx: Context, email: str) -> str:
     return slackid
 
 
-def warn_new_commits(release_manager, team, branch, next_rc):
+def warn_new_commits(release_managers, team, branch, next_rc):
     from slack_sdk import WebClient
 
     message = "Hello :wave:\n"
@@ -176,6 +176,6 @@ def warn_new_commits(release_manager, team, branch, next_rc):
         f"Could you please release and tag your repo to prepare the {next_rc} `datadog-agent` release candidate?\n"
     )
     message += "Thanks in advance!\n"
-    message += f"cc {release_manager}"
+    message += f"cc {' '.join(release_managers)}"
     client = WebClient(os.environ["SLACK_API_TOKEN"])
     client.chat_postMessage(channel=f"#{team}", text=message)

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -165,3 +165,17 @@ def email_to_slackid(ctx: Context, email: str) -> str:
     assert slackid != '', 'Email not found'
 
     return slackid
+
+
+def warn_new_commits(release_manager, team, branch, next_rc):
+    from slack_sdk import WebClient
+
+    message = "Hello :wave:\n"
+    message += f":announcement: We detected new commits on the {branch} release branch of `integrations-core`.\n"
+    message += (
+        f"Could you please release and tag your repo to prepare the {next_rc} `datadog-agent` release candidate?\n"
+    )
+    message += "Thanks in advance!\n"
+    message += f"cc {release_manager}"
+    client = WebClient(os.environ["SLACK_API_TOKEN"])
+    client.chat_postMessage(channel=f"#{team}", text=message)

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -3,6 +3,9 @@ from datetime import timedelta
 
 from tasks.libs.owners.parsing import list_owners
 
+CONFLUENCE_DOMAIN = "https://datadoghq.atlassian.net/wiki"
+SPACE_KEY = "agent"
+
 
 def _stringify_config(config_dict):
     """
@@ -31,25 +34,23 @@ def release_entry_for(agent_major_version):
 def create_release_page(version, freeze_date):
     username = os.environ['ATLASSIAN_USERNAME']
     password = os.environ['ATLASSIAN_PASSWORD']
-    space_key = "agent"
     parent_page_id = "2244936127"
     # Make the POST request to create the page
-    domain = "https://datadoghq.atlassian.net/wiki"
     from atlassian import Confluence
 
-    confluence = Confluence(url=domain, username=username, password=password)
+    confluence = Confluence(url=CONFLUENCE_DOMAIN, username=username, password=password)
     page_title = f"Agent {version}"
     teams = get_releasing_teams()
     page = confluence.create_page(
-        space=space_key,
+        space=SPACE_KEY,
         title=page_title,
         body=create_release_table(version, freeze_date, teams),
         parent_id=parent_page_id,
         editor="v2",
     )
-    release_page = {"id": page["id"], "url": f"{domain}{page['_links']['webui']}"}
+    release_page = {"id": page["id"], "url": f"{CONFLUENCE_DOMAIN}{page['_links']['webui']}"}
     confluence.create_page(
-        space=space_key,
+        space=SPACE_KEY,
         title=f"{page_title} Notes",
         body=create_release_notes(freeze_date, teams),
         parent_id=release_page["id"],
@@ -60,16 +61,14 @@ def create_release_page(version, freeze_date):
 def get_release_page_info(version):
     username = os.environ['ATLASSIAN_USERNAME']
     password = os.environ['ATLASSIAN_PASSWORD']
-    space_key = "agent"
-    domain = "https://datadoghq.atlassian.net/wiki"
     from atlassian import Confluence
 
-    c = Confluence(url=domain, username=username, password=password)
-    page = c.get_page_by_title(space_key, f"Agent {version}", expand="body.storage")
-    return f"{domain}{page['_links']['webui']}", parse_table(page['body']['storage']['value'])
+    c = Confluence(url=CONFLUENCE_DOMAIN, username=username, password=password)
+    page = c.get_page_by_title(SPACE_KEY, f"Agent {version}", expand="body.storage")
+    return f"{CONFLUENCE_DOMAIN}{page['_links']['webui']}", parse_table(page['body']['storage']['value'], missing=True)
 
 
-def parse_table(data):
+def parse_table(data, missing=True, teams=None):
     from bs4 import BeautifulSoup
 
     soup = BeautifulSoup(data, 'lxml')
@@ -81,8 +80,25 @@ def parse_table(data):
     start = rows.index(rm_start_row)
     for row in rows[start:]:
         cells = row.find_all('td')
-        if len(cells) > 1 and len(cells[-1].find_all('ri:user')) == 0:
+        users = cells[-1].find_all('ri:user')
+        if missing and len(cells) > 1 and len(users) == 0:
             yield cells[-2].text
+        if teams is not None and cells[0].text.casefold() in teams and len(users) > 0:
+            yield users[0]['ri:account-id']
+
+
+def release_manager(version, team):
+    username = os.environ['ATLASSIAN_USERNAME']
+    password = os.environ['ATLASSIAN_PASSWORD']
+
+    from atlassian import Confluence
+
+    c = Confluence(url=CONFLUENCE_DOMAIN, username=username, password=password)
+    page = c.get_page_by_title(SPACE_KEY, f"Agent {version}", expand="body.storage")
+    account_ids = parse_table(page['body']['storage']['value'], missing=False, teams=[team])
+    for id in account_ids:
+        user = c.get_user_by_account_id(id)
+        yield user['email']
 
 
 def get_releasing_teams():

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -35,7 +35,7 @@ INTERNAL_DEPS_REPOS = ["omnibus-software", "omnibus-ruby", "datadog-agent-macos-
 DEPENDENT_REPOS = INTERNAL_DEPS_REPOS + ["integrations-core"]
 ALL_REPOS = DEPENDENT_REPOS + [UNFREEZE_REPO_AGENT]
 UNFREEZE_REPOS = INTERNAL_DEPS_REPOS + [UNFREEZE_REPO_AGENT]
-DEFAULT_BRANCH = {
+DEFAULT_BRANCHES = {
     "omnibus-software": "master",
     "omnibus-ruby": "datadog-5.5.0",
     "datadog-agent-macos-build": "master",
@@ -336,7 +336,7 @@ def generate_repo_data(warning_mode, next_version, release_branch):
     for repo in repos:
         branch = release_branch
         if branch == "main":
-            branch = next_version.branch() if repo == "integrations-core" else DEFAULT_BRANCH.get(repo, "main")
+            branch = next_version.branch() if repo == "integrations-core" else DEFAULT_BRANCHES.get(repo, "main")
         data[repo] = {
             'branch': branch,
             'previous_tag': previous_tags.get(repo, ""),

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -23,6 +23,24 @@ from tasks.libs.types.version import Version
 # The order matters, eg. when fetching matching tags for an Agent 6 entry,
 # tags starting with 6 will be preferred to tags starting with 7.
 COMPATIBLE_MAJOR_VERSIONS = {6: ["6", "7"], 7: ["7"]}
+RELEASE_JSON_FIELDS_TO_UPDATE = [
+    "INTEGRATIONS_CORE_VERSION",
+    "OMNIBUS_SOFTWARE_VERSION",
+    "OMNIBUS_RUBY_VERSION",
+    "MACOS_BUILD_VERSION",
+]
+
+UNFREEZE_REPO_AGENT = "datadog-agent"
+INTERNAL_DEPS_REPOS = ["omnibus-software", "omnibus-ruby", "datadog-agent-macos-build"]
+DEPENDENT_REPOS = INTERNAL_DEPS_REPOS + ["integrations-core"]
+ALL_REPOS = DEPENDENT_REPOS + [UNFREEZE_REPO_AGENT]
+UNFREEZE_REPOS = INTERNAL_DEPS_REPOS + [UNFREEZE_REPO_AGENT]
+DEFAULT_BRANCH = {
+    "omnibus-software": "master",
+    "omnibus-ruby": "datadog-5.5.0",
+    "datadog-agent-macos-build": "master",
+    "datadog-agent": "main",
+}
 
 
 def _load_release_json():
@@ -297,3 +315,44 @@ def _get_release_json_value(key):
         release_json = release_json.get(element)
 
     return release_json
+
+
+def set_new_release_branch(branch):
+    rj = _load_release_json()
+
+    rj["base_branch"] = branch
+
+    for nightly in ["nightly", "nightly-a7"]:
+        for field in RELEASE_JSON_FIELDS_TO_UPDATE:
+            rj[nightly][field] = f"{branch}"
+
+    _save_release_json(rj)
+
+
+def generate_repo_data(warning_mode, next_version, release_branch):
+    repos = ["integrations-core"] if warning_mode else ALL_REPOS
+    previous_tags = find_previous_tags("release-a7", repos, RELEASE_JSON_FIELDS_TO_UPDATE)
+    data = {}
+    for repo in repos:
+        branch = release_branch
+        if branch == "main":
+            branch = next_version.branch() if repo == "integrations-core" else DEFAULT_BRANCH.get(repo, "main")
+        data[repo] = {
+            'branch': branch,
+            'previous_tag': previous_tags.get(repo, ""),
+        }
+    return data
+
+
+def find_previous_tags(build, repos, all_keys):
+    """
+    Finds the previous tags for the given repositories in the release.json file.
+    """
+    tags = {}
+    release_json = _load_release_json()
+    for key in all_keys:
+        r = key.casefold().removesuffix("_version").replace("_", "-")
+        repo = next((repo for repo in repos if r in repo), None)
+        if repo:
+            tags[repo] = release_json[build][key]
+    return tags

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -31,6 +31,9 @@ RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]\d+-rc\.\d+')
 # Regex matching minor release rc version tag like x.y.0-rc.1 (semver PATCH == 0), but not x.y.1-rc.1 (semver PATCH > 0)
 MINOR_RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]0-rc\.\d+')
 
+# Regex matching the git describe output
+DESCRIBE_PATTERN = re.compile(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$")
+
 
 def build_compatible_version_re(allowed_major_versions, minor_version):
     """
@@ -379,7 +382,7 @@ def query_version(ctx, major_version, git_sha_length=7, release=False):
     described_version = ctx.run(cmd, hide=True).stdout.strip()
 
     # for the example above, 6.0.0-beta.0-1-g4f19118, this will be 1
-    commit_number_match = re.match(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$", described_version)
+    commit_number_match = DESCRIBE_PATTERN.match(described_version)
     commit_number = 0
     if commit_number_match:
         commit_number = int(commit_number_match.group('commit_number'))

--- a/tasks/libs/requirements-github.txt
+++ b/tasks/libs/requirements-github.txt
@@ -9,3 +9,5 @@ PyJWT==2.4.0
 PyGithub==1.59.1
 toml~=0.10.2
 slack-sdk~=3.27.1
+beautifulsoup4~=4.12.3
+lxml~=5.2.2

--- a/tasks/libs/types/version.py
+++ b/tasks/libs/types/version.py
@@ -104,3 +104,6 @@ class Version:
             new_version.rc = 0
 
         return new_version
+
+    def tag_pattern(self):
+        return f"{self._safe_value('major')}.{self._safe_value('minor')}.{self._safe_value('patch')}*"

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -945,6 +945,6 @@ def check_for_changes(ctx, release_branch):
             describe = ctx.run(f'git describe --tags --match "{latest_tag}"', hide=True).stdout.strip()
             commit_match = describe_pattern.match(describe)
             if commit_match:
-                print(f"Merged {commit_match['commit_number']} commits since {latest_tag} on {repo}")
-                return int(commit_match['commit_number'])
-    return 0
+                print(f"Merged {commit_match['commit_number']} commits since {latest_tag} on {repo}", file=sys.stderr)
+                print(int(commit_match['commit_number']))
+    print(0)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -924,8 +924,8 @@ def check_for_changes(ctx, release_branch, warning_mode=False):
             changes = 'true'
             print(f"{repo_name} has new commits since {last_tag_name}", file=sys.stderr)
             if warning_mode:
-                rm = release_manager(repo_name, repo['branch'])
-                warn_new_commits(rm, "agent-integrations", repo['branch'], next_version)
+                emails = release_manager(repo_name, repo['branch'])
+                warn_new_commits(emails, "agent-integrations", repo['branch'], next_version)
             else:
                 if repo_name not in ["datadog-agent", "integrations-core"]:
                     with clone(ctx, repo_name, repo['branch'], options="--filter=blob:none --no-checkout"):

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import sys
 import unittest
 from collections import OrderedDict
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from invoke import MockContext, Result
 from invoke.exceptions import Exit
 
 from tasks import release
-from tasks.libs.releasing.documentation import nightly_entry_for, release_entry_for
+from tasks.libs.releasing.documentation import nightly_entry_for, parse_table, release_entry_for
 from tasks.libs.releasing.json import (
     COMPATIBLE_MAJOR_VERSIONS,
     _get_jmxfetch_release_json_info,
@@ -17,6 +18,8 @@ from tasks.libs.releasing.json import (
     _get_release_version_from_release_json,
     _get_windows_release_json_info,
     _update_release_json_entry,
+    find_previous_tags,
+    generate_repo_data,
 )
 from tasks.libs.releasing.version import _get_highest_repo_version, build_compatible_version_re
 from tasks.libs.types.version import Version
@@ -528,116 +531,646 @@ class TestCreateBuildLinksPatterns(unittest.TestCase):
         self.assertEqual(patterns[".50.0~rc.1"], ".51.1~rc.2")
 
 
+class TestParseTable(unittest.TestCase):
+    html = "<h2>Summary</h2><table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"09952c85-84b5-4e21-be40-a482c103026a\"><colgroup><col style=\"width: 174.0px;\" /><col style=\"width: 456.0px;\" /><col style=\"width: 129.0px;\" /></colgroup><tbody><tr><td><p>Status</p></td><td colspan=\"2\"><p style=\"text-align: center;\"><ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\" ac:macro-id=\"6ff30749-d85c-44cd-8ccb-5dfd367627e5\"><ac:parameter ac:name=\"title\">QA</ac:parameter><ac:parameter ac:name=\"colour\">Purple</ac:parameter></ac:structured-macro></p></td></tr><tr><td><p>Release date</p></td><td colspan=\"2\"><p style=\"text-align: center;\">TBD</p></td></tr><tr><td><p>Release notes</p></td><td colspan=\"2\"><p style=\"text-align: center;\"><a href=\"https://github.com/DataDog/datadog-agent/releases/tag/7.55.0\">https://github.com/DataDog/datadog-agent/releases/tag/7.55.0</a> </p></td></tr><tr><td><p>Code freeze date</p></td><td colspan=\"2\"><p><time datetime=\"2024-05-31\" /></p></td></tr><tr><td><p>Release coordinator</p></td><td colspan=\"2\"><p><ac:link><ri:user ri:account-id=\"712020:7411b245-7b49-44b7-a314-674e71629bf8\" ri:local-id=\"218452a5-3f6a-4ffc-b403-b078a35ccb3a\" /></ac:link> </p></td></tr><tr><td rowspan=\"25\"><p>Release managers</p></td><td><p>agent-metrics-logs</p></td><td><p><ac:link><ri:user ri:account-id=\"5f59348b0b2aef0068cafb55\" ri:local-id=\"dfb34b68-27c6-4b93-9ea5-177e97eb2ee8\" /></ac:link> </p></td></tr><tr><td><p>agent-shared-components</p></td><td><p> </p></td></tr><tr><td><p>agent-processing-and-routing</p></td><td><p><ac:link><ri:user ri:account-id=\"602449f4e7deee00693230d9\" ri:local-id=\"b0b470c4-7ee9-4d7c-8f59-67b8fa4156b3\" /></ac:link> </p></td></tr><tr><td><p>processes</p></td><td><p><ac:link><ri:user ri:account-id=\"70121:406e94f2-24c6-40d8-8efa-f66f1681a1e0\" ri:local-id=\"a31ca1ee-386b-4a8e-b713-067357771369\" /></ac:link> </p></td></tr><tr><td><p>network-device-monitoring</p></td><td><p><ac:link><ri:user ri:account-id=\"712020:d6ee80ab-d876-4815-b2db-cae8b553436a\" ri:local-id=\"9d04625e-6f8b-4b39-924a-72c9960a10f7\" /></ac:link> </p></td></tr><tr><td><p>container-app</p></td><td><p><ac:link><ri:user ri:account-id=\"61391782bba6c7006a3b8777\" ri:local-id=\"a48a807a-7293-4d41-827c-e0f633d593e7\" /></ac:link> </p></td></tr><tr><td><p>container-integrations</p></td><td><p> </p></td></tr><tr><td><p>container-platform</p></td><td><p><ac:link><ri:user ri:account-id=\"712020:fbcd60a3-242e-4921-8064-8b0a7678c22d\" ri:local-id=\"4f8a21eb-afa8-43c7-a0e0-a6582c2c2270\" /></ac:link> </p></td></tr><tr><td><p>agent-security (CWS)</p></td><td><p><ac:link><ri:user ri:account-id=\"6092f9f12c2f6c0068f15048\" ri:local-id=\"a143bf09-49a6-4401-b692-06ef94dad9a2\" /></ac:link> </p></td></tr><tr><td><p>agent-security (CSPM)</p></td><td><p><ac:link><ri:user ri:account-id=\"6092f9f12c2f6c0068f15048\" ri:local-id=\"fb0dde8c-1c3b-4a66-aa62-5059bbd378f1\" /></ac:link> </p></td></tr><tr><td><p>agent-build-and-releases</p></td><td><p><ac:link><ri:user ri:account-id=\"628550e00685de006fd1c8c4\" ri:local-id=\"9cd201ac-1c3f-4a3d-8876-d205bd508664\" /></ac:link> </p></td></tr><tr><td><p>agent-ci-experience</p></td><td rowspan=\"2\"><p><ac:link><ri:user ri:account-id=\"712020:c097ba60-b638-4fe4-bb46-7bf7c956269b\" ri:local-id=\"fbf70545-46d7-411a-a1c8-a44f2524d750\" /></ac:link> </p></td></tr><tr><td><p>agent-developer-tools</p></td></tr><tr><td><p>agent-integrations</p></td><td><p><ac:link><ri:user ri:account-id=\"5d4b47740fa6d40d14fc7af0\" ri:local-id=\"607c3409-229b-40da-a68e-00acb0d384ba\" /></ac:link> </p></td></tr><tr><td><p>network-performance-monitoring</p></td><td><p><ac:link><ri:user ri:account-id=\"6362ccf6fc0cc7a600b09220\" ri:local-id=\"89fdb46f-eee9-4ece-801a-345ed6199928\" /></ac:link> </p></td></tr><tr><td><p>platform-integrations</p></td><td><p><ac:link><ri:user ri:account-id=\"602449d341d0db00683c4a98\" ri:local-id=\"6d68a218-ab8d-447f-90e1-7a71b90f4943\" /></ac:link> </p></td></tr><tr><td><p>apm</p></td><td><p><ac:link><ri:user ri:account-id=\"5d91f278ede9300dd30ba76c\" ri:local-id=\"6cf76f75-7559-47d4-9e0c-6c6b0e952223\" /></ac:link> </p></td></tr><tr><td><p>database-monitoring</p></td><td><p><ac:link><ri:user ri:account-id=\"63599276b7b39379d71fc673\" ri:local-id=\"e68661a8-f511-44c4-bab9-0c2c43fc6783\" /></ac:link> </p></td></tr><tr><td><p>remote-config/fleet-automation</p></td><td><p><ac:link><ri:user ri:account-id=\"5d4b47192c0fea0d07ca153e\" ri:local-id=\"d50f5924-2271-4568-a0f1-859a2b6e0418\" /></ac:link> </p></td></tr><tr><td><p>windows-agent</p></td><td><p><ac:link><ri:user ri:account-id=\"5d4aeea52be2120ce3e5f41a\" ri:local-id=\"27f95d81-46c8-4b59-aa06-6ca08bdd97d4\" /></ac:link> </p></td></tr><tr><td><p>opentelemetry</p></td><td><p><ac:link><ri:user ri:account-id=\"5ea6b72b833be70b7eb0264a\" ri:local-id=\"fe14490e-b61c-4666-8c79-4ad1c829f933\" /></ac:link> </p></td></tr><tr><td><p>ebpf-platform</p></td><td><p><ac:link><ri:user ri:account-id=\"5ec5a8a527b66a0c224151f1\" ri:local-id=\"040a0973-2467-45e4-b98f-99376ce2e69c\" /></ac:link> </p></td></tr><tr><td><p>universal-service-monitoring</p></td><td><p><ac:link><ri:user ri:account-id=\"62aa4b57bf7afc006f3c68a7\" ri:local-id=\"3be6a137-f09b-420a-ab60-26f2ea2780ef\" /></ac:link> </p></td></tr><tr><td><p>windows-kernel-integrations</p></td><td><p><ac:link><ri:user ri:account-id=\"6260673c0f5cf500697f3452\" ri:local-id=\"7a3195b1-364f-48ff-928d-0c052f376482\" /></ac:link> </p></td></tr><tr><td><p>apm-onboarding</p></td><td><p><ac:link><ri:user ri:account-id=\"712020:4e17f58f-65ec-45f9-a2f1-5c5472966e25\" ri:local-id=\"d408f74e-a2e5-45fd-9cb7-78ab2015bac1\" /></ac:link> </p></td></tr></tbody></table><h2>Major changes</h2><table data-table-width=\"760\" data-layout=\"default\" ac:local-id=\"0967ea41-908b-4cdf-bc91-02112d3cbf1e\"><colgroup><col style=\"width: 760.0px;\" /></colgroup><tbody><tr><td><p>&nbsp;CVE for otel</p></td></tr><tr><td><p>&nbsp;</p></td></tr><tr><td><p>&nbsp;</p></td></tr><tr><td><p>&nbsp;</p></td></tr></tbody></table><p>&nbsp;</p>"
+
+    def test_find_missing_rm(self):
+        missing = list(parse_table(self.html, missing=True))
+        self.assertListEqual(['agent-shared-components', 'container-integrations'], missing)
+
+    def test_find_rm(self):
+        user = list(parse_table(self.html, missing=False, teams=['agent-integrations']))
+        self.assertListEqual(['5d4b47740fa6d40d14fc7af0'], user)
+
+
+class TestFindPreviousTags(unittest.TestCase):
+    keys = ["HARRY_POTTER_VERSION", "HERMIONE_GRANGER_VERSION", "WEASLEY_VERSION"]
+
+    @patch(
+        'tasks.libs.releasing.json._load_release_json',
+        new=MagicMock(
+            return_value={
+                'hogwarts': {
+                    'HARRY_POTTER_VERSION': '6.6.6',
+                    'HERMIONE_GRANGER_VERSION': '6.6.6',
+                    'WEASLEY_VERSION': '6.6.6',
+                }
+            }
+        ),
+    )
+    def test_one_repo(self):
+        repos = ["harry-potter"]
+        self.assertEqual({'harry-potter': '6.6.6'}, find_previous_tags("hogwarts", repos, self.keys))
+
+    @patch(
+        'tasks.libs.releasing.json._load_release_json',
+        new=MagicMock(
+            return_value={
+                'hogwarts': {
+                    'HARRY_POTTER_VERSION': '6.6.6',
+                    'HERMIONE_GRANGER_VERSION': '6.6.6',
+                    'WEASLEY_VERSION': '6.6.6',
+                }
+            }
+        ),
+    )
+    def test_several_repos(self):
+        repos = ["harry-potter", "hermione-granger", "ronald-weasley"]
+        self.assertEqual(
+            {'harry-potter': '6.6.6', 'hermione-granger': '6.6.6', 'ronald-weasley': '6.6.6'},
+            find_previous_tags("hogwarts", repos, self.keys),
+        )
+
+    @patch(
+        'tasks.libs.releasing.json._load_release_json',
+        new=MagicMock(
+            return_value={
+                'hogwarts': {
+                    'HARRY_POTTER_VERSION': '6.6.6',
+                    'HERMIONE_GRANGER_VERSION': '6.6.6',
+                    'WEASLEY_VERSION': '6.6.6',
+                }
+            }
+        ),
+    )
+    def test_no_repo(self):
+        repos = ["drago-malfoy"]
+        self.assertEqual({}, find_previous_tags("hogwarts", repos, self.keys))
+
+    @patch(
+        'tasks.libs.releasing.json._load_release_json',
+        new=MagicMock(
+            return_value={
+                'hogwarts': {
+                    'HARRY_POTTER_VERSION': '6.6.6',
+                    'HERMIONE_GRANGER_VERSION': '6.6.6',
+                    'WEASLEY_VERSION': '6.6.6',
+                }
+            }
+        ),
+    )
+    def test_match_and_no_match(self):
+        repos = ["drago-malfoy", "ronald-weasley"]
+        self.assertEqual({'ronald-weasley': '6.6.6'}, find_previous_tags("hogwarts", repos, self.keys))
+
+
+class TestGenerateRepoData(unittest.TestCase):
+    @patch(
+        'tasks.libs.releasing.json.find_previous_tags', new=MagicMock(return_value={'integrations-core': '9.1.1-rc.0'})
+    )
+    def test_integrations_core_only_main(self):
+        next_version = MagicMock()
+        next_version.branch.return_value = "9.1.x"
+        repo_data = generate_repo_data(True, next_version, "main")
+        self.assertEqual(len(repo_data), 1)
+        self.assertEqual("9.1.x", repo_data["integrations-core"]["branch"])
+        self.assertEqual("9.1.1-rc.0", repo_data["integrations-core"]["previous_tag"])
+
+    @patch(
+        'tasks.libs.releasing.json.find_previous_tags', new=MagicMock(return_value={'integrations-core': '9.1.1-rc.0'})
+    )
+    def test_integrations_core_only_release(self):
+        next_version = MagicMock()
+        next_version.branch.return_value = "9.1.x"
+        repo_data = generate_repo_data(True, next_version, "9.1.x")
+        self.assertEqual(len(repo_data), 1)
+        self.assertEqual("9.1.x", repo_data["integrations-core"]["branch"])
+        self.assertEqual("9.1.1-rc.0", repo_data["integrations-core"]["previous_tag"])
+
+    @patch(
+        'tasks.libs.releasing.json.find_previous_tags',
+        new=MagicMock(
+            return_value={
+                'integrations-core': '9.1.1-rc.0',
+                'omnibus-software': '1.2.3-rc.4',
+                'omnibus-ruby': "5.4.3-rc.2",
+                "datadog-agent-macos-build": "6.6.6-rc.6",
+            }
+        ),
+    )
+    def test_all_repos_default_branch(self):
+        next_version = MagicMock()
+        next_version.branch.return_value = "9.1.x"
+        repo_data = generate_repo_data(False, next_version, "main")
+        self.assertEqual(len(repo_data), 5)
+        self.assertEqual("9.1.x", repo_data["integrations-core"]["branch"])
+        self.assertEqual("9.1.1-rc.0", repo_data["integrations-core"]["previous_tag"])
+        self.assertEqual("master", repo_data["omnibus-software"]["branch"])
+        self.assertEqual("1.2.3-rc.4", repo_data["omnibus-software"]["previous_tag"])
+        self.assertEqual("datadog-5.5.0", repo_data["omnibus-ruby"]["branch"])
+        self.assertEqual("5.4.3-rc.2", repo_data["omnibus-ruby"]["previous_tag"])
+        self.assertEqual("master", repo_data["datadog-agent-macos-build"]["branch"])
+        self.assertEqual("6.6.6-rc.6", repo_data["datadog-agent-macos-build"]["previous_tag"])
+        self.assertEqual("main", repo_data["datadog-agent"]["branch"])
+        self.assertEqual("", repo_data["datadog-agent"]["previous_tag"])
+
+    @patch(
+        'tasks.libs.releasing.json.find_previous_tags',
+        new=MagicMock(
+            return_value={
+                'integrations-core': '9.1.1-rc.0',
+                'omnibus-software': '1.2.3-rc.4',
+                'omnibus-ruby': "5.4.3-rc.2",
+                "datadog-agent-macos-build": "6.6.6-rc.6",
+            }
+        ),
+    )
+    def test_all_repos_release(self):
+        next_version = MagicMock()
+        next_version.branch.return_value = "9.1.x"
+        repo_data = generate_repo_data(False, next_version, "9.1.x")
+        self.assertEqual(len(repo_data), 5)
+        self.assertEqual("9.1.x", repo_data["integrations-core"]["branch"])
+        self.assertEqual("9.1.x", repo_data["omnibus-software"]["branch"])
+        self.assertEqual("9.1.x", repo_data["omnibus-ruby"]["branch"])
+        self.assertEqual("9.1.x", repo_data["datadog-agent-macos-build"]["branch"])
+        self.assertEqual("9.1.x", repo_data["datadog-agent"]["branch"])
+
+
 class TestCheckForChanges(unittest.TestCase):
-    @patch('os.chdir', new=MagicMock())
-    @patch('tasks.release.GithubAPI')
-    def test_changes_on_first_repo(self, gh_mock):
-        gh = MagicMock()
-        gh.latest_release.return_value = "6.5.6"
-        gh_mock.return_value = gh
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'omnibus-software': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'omnibus-ruby': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent-macos-build': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent': {'branch': 'main', 'previous_tag': ''},
+            }
+        ),
+    )
+    def test_no_changes(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
         c = MockContext(
             run={
-                "git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software": Result(
-                    ""
+                'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t0        refs/heads/main"
                 ),
-                r"git tag -l --sort=version:refname --merged main | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -1": Result(
-                    "6.6.6-rc.6"
+                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                    "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
-                'git describe --tags --match "6.6.6-rc.6"': Result(stdout="6.6.6-rc.6-42-g1ace007"),
-                "rm -rf omnibus-software": Result(""),
+                'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t1        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                    "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t2        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                    "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t4        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                    "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
+                ),
             },
-            repeat=False,
         )
-        self.assertEqual(42, release.check_for_changes(c, "main"))
+        release.check_for_changes(c, "main")
+        print_mock.assert_called_with("false")
 
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'omnibus-software': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'omnibus-ruby': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent-macos-build': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent': {'branch': 'main', 'previous_tag': ''},
+            }
+        ),
+    )
     @patch('os.chdir', new=MagicMock())
-    @patch('tasks.release.GithubAPI')
-    def test_changes_on_main(self, gh_mock):
-        gh = MagicMock()
-        gh.latest_release.return_value = "6.5.6"
-        gh_mock.return_value = gh
+    def test_changes_new_commit_first_repo(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
         c = MockContext(
             run={
-                "git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software": Result(
+                'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t9        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                    "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
                     ""
                 ),
-                r"git tag -l --sort=version:refname --merged main | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -1": Result(
-                    "6.6.6"
+                'rm -rf omnibus-software': Result(""),
+                'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t1        refs/heads/main"
                 ),
-                'git describe --tags --match "6.6.6"': Result("6.6.6"),
-                "rm -rf omnibus-software": Result(""),
-                "git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby": Result(
+                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                    "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
                     ""
                 ),
-                "rm -rf omnibus-ruby": Result(""),
-                "git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build": Result(
+                'rm -rf omnibus-ruby': Result(""),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t2        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                    "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
                     ""
                 ),
-                "rm -rf datadog-agent-macos-build": Result(""),
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/integrations-core integrations-core": Result(
-                    ""
+                'rm -rf datadog-agent-macos-build': Result(""),
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                r"git tag -l --sort=version:refname --merged 6.6.x | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -1": Result(
-                    "6.6.6-rc.6"
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
-                'git describe --tags --match "6.6.6-rc.6"': Result("6.6.6-rc.6-1000000-g1ace007"),
-                "rm -rf integrations-core": Result(""),
-            }
+                'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t4        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                    "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
+                ),
+                'git tag 7.55.0-rc.2': Result(""),
+                'git push origin tag 7.55.0-rc.2': Result(""),
+            },
         )
-        self.assertEqual(1000000, release.check_for_changes(c, "main"))
+        release.check_for_changes(c, "main")
+        calls = [
+            call("omnibus-software has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("Creating new tag 7.55.0-rc.2 on omnibus-software", file=sys.stderr),
+            call("true"),
+        ]
+        print_mock.assert_has_calls(calls)
+        self.assertEqual(print_mock.call_count, 3)
 
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'omnibus-software': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'omnibus-ruby': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent-macos-build': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent': {'branch': 'main', 'previous_tag': ''},
+            }
+        ),
+    )
     @patch('os.chdir', new=MagicMock())
-    @patch('tasks.release.GithubAPI')
-    def test_changes_after_branching_out(self, gh_mock):
-        gh = MagicMock()
-        gh.latest_release.return_value = "6.5.6"
-        gh_mock.return_value = gh
+    def test_changes_new_commit_all_repo(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
         c = MockContext(
             run={
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software": Result(
+                'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t9        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                    "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
                     ""
                 ),
-                r"git tag -l --sort=version:refname --merged 6.6.x | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -1": Result(
-                    "6.6.6-rc.6"
+                'rm -rf omnibus-software': Result(""),
+                'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t8        refs/heads/main"
                 ),
-                'git describe --tags --match "6.6.6-rc.6"': Result("6.6.6-rc.6-1-g1ace007"),
-                "rm -rf omnibus-software": Result(""),
-            }
+                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                    "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
+                    ""
+                ),
+                'rm -rf omnibus-ruby': Result(""),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t7        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                    "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
+                    ""
+                ),
+                'rm -rf datadog-agent-macos-build': Result(""),
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t6        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t5        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                    "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
+                ),
+                'git tag 7.55.0-rc.2': Result(""),
+                'git push origin tag 7.55.0-rc.2': Result(""),
+            },
         )
-        self.assertEqual(1, release.check_for_changes(c, "6.6.x"))
+        release.check_for_changes(c, "main")
+        calls = [
+            call("omnibus-software has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("Creating new tag 7.55.0-rc.2 on omnibus-software", file=sys.stderr),
+            call("omnibus-ruby has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("Creating new tag 7.55.0-rc.2 on omnibus-ruby", file=sys.stderr),
+            call("datadog-agent-macos-build has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("Creating new tag 7.55.0-rc.2 on datadog-agent-macos-build", file=sys.stderr),
+            call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("datadog-agent has new commits since 7.55.0-devel", file=sys.stderr),
+            call("true"),
+        ]
+        print_mock.assert_has_calls(calls)
+        self.assertEqual(print_mock.call_count, 9)
 
-    @patch('os.chdir', new=MagicMock())
-    @patch('tasks.release.GithubAPI')
-    def test_no_changes(self, gh_mock):
-        gh = MagicMock()
-        gh.latest_release.return_value = "6.5.6"
-        gh_mock.return_value = gh
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'omnibus-software': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'omnibus-ruby': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent-macos-build': {'branch': 'main', 'previous_tag': '7.55.0-rc.1'},
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent': {'branch': 'main', 'previous_tag': ''},
+            }
+        ),
+    )
+    def test_changes_new_release_one_repo(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
         c = MockContext(
             run={
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software": Result(
-                    ""
+                'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t0        refs/heads/main"
                 ),
-                r"git tag -l --sort=version:refname --merged 6.6.x | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -1": Result(
-                    "6.6.6"
+                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                    "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
-                'git describe --tags --match "6.6.6"': Result("6.6.6"),
-                "rm -rf omnibus-software": Result(""),
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby": Result(
-                    ""
+                'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t1        refs/heads/main"
                 ),
-                "rm -rf omnibus-ruby": Result(""),
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build": Result(
-                    ""
+                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                    "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
-                "rm -rf datadog-agent-macos-build": Result(""),
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/integrations-core integrations-core": Result(
-                    ""
+                'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t2        refs/heads/main"
                 ),
-                "rm -rf integrations-core": Result(""),
-                "git clone -b 6.6.x --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent datadog-agent": Result(
-                    ""
+                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                    "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.2^{}"
                 ),
-                "rm -rf datadog-agent": Result(""),
-            }
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
+                    "4n0th3rc0mm1t4        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                    "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
+                ),
+            },
         )
-        self.assertEqual(0, release.check_for_changes(c, "6.6.x"))
+        release.check_for_changes(c, "main")
+        calls = [
+            call("true"),
+            call(
+                "datadog-agent-macos-build has a new tag 7.55.0-rc.2 since last release candidate (was 7.55.0-rc.1)",
+                file=sys.stderr,
+            ),
+        ]
+        print_mock.assert_has_calls(calls, any_order=True)
+        self.assertEqual(print_mock.call_count, 2)
+
+    # def test_changes_rc_branched_out_second_repo(self, print_mock):
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'omnibus-software': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'omnibus-ruby': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent-macos-build': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+                'datadog-agent': {'branch': '7.55.x', 'previous_tag': ''},
+            }
+        ),
+    )
+    @patch('os.chdir', new=MagicMock())
+    def test_changes_new_commit_second_repo_branch_out(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
+        c = MockContext(
+            run={
+                'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t0        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                    "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
+                    ""
+                ),
+                'rm -rf omnibus-software': Result(""),
+                'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t9        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                    "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
+                    ""
+                ),
+                'rm -rf omnibus-ruby': Result(""),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t2        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                    "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
+                    ""
+                ),
+                'rm -rf datadog-agent-macos-build': Result(""),
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+                'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t4        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                    "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
+                ),
+                'git tag 7.55.0-rc.2': Result(""),
+                'git push origin tag 7.55.0-rc.2': Result(""),
+            },
+        )
+        release.check_for_changes(c, "7.55.x")
+        calls = [
+            call("omnibus-ruby has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("Creating new tag 7.55.0-rc.2 on omnibus-ruby", file=sys.stderr),
+            call("true"),
+        ]
+        print_mock.assert_has_calls(calls)
+        self.assertEqual(print_mock.call_count, 3)
+
+    # def test_no_changes_warning(self, print_mock):
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+            }
+        ),
+    )
+    def test_no_changes_warning(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
+        c = MockContext(
+            run={
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+            },
+        )
+        release.check_for_changes(c, "main", True)
+        print_mock.assert_called_with("false")
+
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+            }
+        ),
+    )
+    @patch('tasks.release.release_manager', new=MagicMock(return_value="release_manager"))
+    @patch('tasks.release.warn_new_commits', new=MagicMock())
+    def test_changes_other_repo_warning(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
+        c = MockContext(
+            run={
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t3        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+            },
+        )
+        release.check_for_changes(c, "main", True)
+        print_mock.assert_called_with("false")
+
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+            }
+        ),
+    )
+    @patch('tasks.release.release_manager', new=MagicMock(return_value="release_manager"))
+    @patch('tasks.release.warn_new_commits', new=MagicMock())
+    def test_changes_integrations_core_warning(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
+        c = MockContext(
+            run={
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t9        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+            },
+        )
+        release.check_for_changes(c, "main", True)
+        calls = [
+            call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("true"),
+        ]
+        print_mock.assert_has_calls(calls)
+        self.assertEqual(print_mock.call_count, 2)
+
+    @patch('builtins.print')
+    @patch('tasks.release.next_rc_version')
+    @patch(
+        'tasks.release.generate_repo_data',
+        new=MagicMock(
+            return_value={
+                'integrations-core': {'branch': '7.55.x', 'previous_tag': '7.55.0-rc.1'},
+            }
+        ),
+    )
+    @patch('tasks.release.release_manager', new=MagicMock(return_value="release_manager"))
+    @patch('tasks.release.warn_new_commits', new=MagicMock())
+    def test_changes_integrations_core_warning_branch_out(self, version_mock, print_mock):
+        next = MagicMock()
+        next.tag_pattern.return_value = "7.55.0*"
+        next.__str__.return_value = "7.55.0-rc.2"
+        version_mock.return_value = next
+        c = MockContext(
+            run={
+                'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
+                    "4n0th3rc0mm1t9        refs/heads/main"
+                ),
+                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                    "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
+                ),
+            },
+        )
+        release.check_for_changes(c, "7.55.x", True)
+        calls = [
+            call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
+            call("true"),
+        ]
+        print_mock.assert_has_calls(calls)
+        self.assertEqual(print_mock.call_count, 2)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Improve the `create_rc` workflow:
- Add a new schedule before the RC PR creation for `integrations-core` repo only. This check is supposed to warn the `agent-integration` team in advance in case of change, to let them do releasing operations
- Check if any change (new commit or new release) occurred not only on `datadog-agent` but on dependencies: `omnibus-software`, `omnibus-ruby`, `datadog-agent-macos-build` and `integrations-core.
  - In case of new commits in the 3 first repositories, we can safely set ourselves the commit to prepare the RC PR creation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Automation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
As this workflow is doing some non idempotent changes on some repositories (adding tags), I did some tests using forks on my personal account
- Test on release branch "as is"
```
> inv -e release.check-for-changes -r 7.55.x
next_version 7.55.0-rc.10
omnibus-ruby has a new tag 7.55.0-rc.6 since last release candidate (was 7.55.0-rc.1)
datadog-agent-macos-build has a new tag 7.55.0-rc.5 since last release candidate (was 7.55.0-rc.1)
integrations-core has a new tag 7.55.0-rc.8 since last release candidate (was 7.55.0-rc.3)
datadog-agent has new commits since 7.55.0-rc.9
true
```
- Test with a new commit to trigger a tag
```
> inv -e release.check-for-changes -r 7.55.x
next_version 7.55.0-rc.10
omnibus-ruby has a new tag 7.55.0-rc.6 since last release candidate (was 7.55.0-rc.1)
datadog-agent-macos-build has new commits since 7.55.0-rc.5
git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/chouetz/datadog-agent-macos-build datadog-agent-macos-build
Cloning into 'datadog-agent-macos-build'...
Creating new tag 7.55.0-rc.10 on datadog-agent-macos-build
git tag 7.55.0-rc.10
git push origin tag 7.55.0-rc.10
To https://github.com/chouetz/datadog-agent-macos-build
 * [new tag]         7.55.0-rc.10 -> 7.55.0-rc.10
rm -rf datadog-agent-macos-build
integrations-core has a new tag 7.55.0-rc.8 since last release candidate (was 7.55.0-rc.3)
datadog-agent has new commits since 7.55.0-rc.9
true
```
- Test on warning mode
```
> inv -e release.check-for-changes -r 7.55.x -w
next_version 7.55.0-rc.10
integrations-core has a new tag 7.55.0-rc.8 since last release candidate (was 7.55.0-rc.3)
true
```
generate no slack message and
```
> inv -e release.check-for-changes -r 7.55.x -w
next_version 7.55.0-rc.10
integrations-core has new commits since 7.55.0-rc.8
true
```
generates a slack message

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
