### PR TITLE
[CWS] Fix invalid syscall context for `NULL` arguments

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -14,6 +14,7 @@
 #define SYSCALL_CTX_ARG(type, pos) (type << (pos * 2))
 #define SYSCALL_CTX_ARG_STR(pos) SYSCALL_CTX_ARG(SYSCALL_CTX_STR_TYPE, pos)
 #define SYSCALL_CTX_ARG_INT(pos) SYSCALL_CTX_ARG(SYSCALL_CTX_INT_TYPE, pos)
+#define SYSCALL_CTX_ARG_MASK(pos) (SYSCALL_CTX_ARG_STR(pos) | SYSCALL_CTX_ARG_INT(pos))
 
 #define IS_SYSCALL_CTX_ARG(types, type, pos) (types & (type << (pos * 2)))
 #define IS_SYSCALL_CTX_ARG_STR(types, pos) IS_SYSCALL_CTX_ARG(types, SYSCALL_CTX_STR_TYPE, pos)
@@ -36,9 +37,10 @@ void __attribute__((always_inline)) collect_syscall_ctx(struct syscall_cache_t *
     u32 *id_ptr = (u32 *)&data[0];
     id_ptr[0] = *id;
 
-    data[4] = types;
+    u8 effective_types = 0;
 
     if (arg1) {
+        effective_types |= (types & SYSCALL_CTX_ARG_MASK(0));
         if (IS_SYSCALL_CTX_ARG_STR(types, 0)) {
             bpf_probe_read_str(&data[5], MAX_SYSCALL_ARG_MAX_SIZE, arg1);
         } else {
@@ -48,6 +50,7 @@ void __attribute__((always_inline)) collect_syscall_ctx(struct syscall_cache_t *
     }
 
     if (arg2) {
+        effective_types |= (types & SYSCALL_CTX_ARG_MASK(1));
         if (IS_SYSCALL_CTX_ARG_STR(types, 1)) {
             bpf_probe_read_str(&data[5 + MAX_SYSCALL_ARG_MAX_SIZE], MAX_SYSCALL_ARG_MAX_SIZE, arg2);
         } else {
@@ -57,6 +60,7 @@ void __attribute__((always_inline)) collect_syscall_ctx(struct syscall_cache_t *
     }
 
     if (arg3) {
+        effective_types |= (types & SYSCALL_CTX_ARG_MASK(2));
         if (IS_SYSCALL_CTX_ARG_STR(types, 2)) {
             bpf_probe_read_str(&data[5 + MAX_SYSCALL_ARG_MAX_SIZE * 2], MAX_SYSCALL_ARG_MAX_SIZE, arg3);
         } else {
@@ -64,6 +68,8 @@ void __attribute__((always_inline)) collect_syscall_ctx(struct syscall_cache_t *
             addr[0] = *(s64 *)arg3;
         }
     }
+
+    data[4] = effective_types;
 
     syscall->ctx_id = *id;
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes a bug in the syscall context resolution where NULL arguments would wrongly be resolved to the argument of a previous syscall.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
