### PR TITLE
[CONTP-268] Autodiscovery SchdulerController: update scheduledConfig after scheduler call

### DIFF
--- a/comp/core/autodiscovery/scheduler/controller.go
+++ b/comp/core/autodiscovery/scheduler/controller.go
@@ -172,13 +172,17 @@ func (ms *Controller) processNextWorkItem() bool {
 		if desiredState == Scheduled {
 			//to be scheduled
 			scheduler.Schedule(([]integration.Config{*desiredConfigState.config})) // TODO: check status of action
-			ms.scheduledConfigs[configDigest] = desiredConfigState.config
 		} else {
 			//to be unscheduled
 			scheduler.Unschedule(([]integration.Config{*desiredConfigState.config})) // TODO: check status of action
-			delete(ms.scheduledConfigs, configDigest)
-			ms.configStateStore.Cleanup(configDigest)
 		}
+	}
+	if desiredState == Scheduled {
+		// add the config to scheduled
+		ms.scheduledConfigs[configDigest] = desiredConfigState.config
+	} else {
+		delete(ms.scheduledConfigs, configDigest)
+		ms.configStateStore.Cleanup(configDigest)
 	}
 	ms.m.Unlock()
 	ms.queue.Done(item)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
[CONTP-268](https://datadoghq.atlassian.net/browse/CONTP-268) 
update scheduledConfig after scheduler calls are finished. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
A flaky unit test revealed the problem. The scheduled configuration was not refreshed when no active scheduler was present. This situation only arises in the unit test where no scheduler is initially added. However, during a standard agent start, a scheduler is loaded at the beginning.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
The fix should only affect [this unit test](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/scheduler/controller_test.go#L58). So to reproduce the error, we can add a time.Sleep(2 time.second) [here](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/scheduler/controller_test.go#L66). Without the fix, this test will fail because the configs are not added to ms.scheduledConfigs during the processing. 


[CONTP-268]: https://datadoghq.atlassian.net/browse/CONTP-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ