### PR TITLE
[PROCS-4186] Add payload source to Processes message headers

### DIFF
--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -408,6 +408,7 @@ func (s *CheckSubmitter) messagesToCheckResult(start time.Time, name string, mes
 		extraHeaders.Set(headers.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
 		extraHeaders.Set(headers.ContentTypeHeader, headers.ProtobufContentType)
 		extraHeaders.Set(headers.AgentStartTime, strconv.FormatInt(s.agentStartTime, 10))
+		extraHeaders.Set(headers.PayloadSource, flavor.GetFlavor())
 
 		switch name {
 		case checks.ProcessEventsCheckName:

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -174,6 +174,10 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 }
 
 func TestCollectorMessagesToCheckResult(t *testing.T) {
+	originalFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(originalFlavor)
+	flavor.SetFlavor(flavor.ProcessAgent)
+
 	deps := newSubmitterDeps(t)
 	submitter, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, testHostName)
 	assert.NoError(t, err)
@@ -203,6 +207,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
 				headers.RequestIDHeader:      requestID,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:        "process_agent",
 			},
 		},
 		{
@@ -219,6 +224,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ContainerCountHeader: "3",
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:        "process_agent",
 			},
 		},
 		{
@@ -235,6 +241,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ContainerCountHeader: "2",
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:        "process_agent",
 			},
 		},
 		{
@@ -251,6 +258,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ContainerCountHeader: "5",
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:        "process_agent",
 			},
 		},
 		{
@@ -263,6 +271,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ContainerCountHeader: "0",
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:        "process_agent",
 			},
 		},
 		{
@@ -277,6 +286,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.EVPOriginHeader:        "process-agent",
 				headers.EVPOriginVersionHeader: version.AgentVersion,
 				headers.AgentStartTime:         strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:          "process_agent",
 			},
 		},
 	}

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -33,4 +33,6 @@ const (
 	RequestIDHeader = "X-DD-Request-ID"
 	// AgentStartTime contains the timestamp that the agent was started
 	AgentStartTime = "X-DD-Agent-Start-Time"
+	// PayloadSource describes which agent process sent the payload (i.e. process or core agent)
+	PayloadSource = "X-DD-Payload-Source"
 )

--- a/releasenotes/notes/process-source-payload-header-43dcd5279833c833.yaml
+++ b/releasenotes/notes/process-source-payload-header-43dcd5279833c833.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds the source of the payload for Processes-owned messages.


### PR DESCRIPTION
### What does this PR do?

Adds an extra HTTP header, `PayloadSource`, to all Processes-owned messages. This will allow us to determine which agent a message came from and in turn help us create analytics around it.

### Motivation

We want to compare usage of the process checks in the core and process agents.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Unit tests were added for this behavior.