### PR TITLE
[ASCII-1931] Close auth_token file in test to avoid error when deleting it

### DIFF
--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -129,12 +129,15 @@ func TestStartServer(t *testing.T) {
 }
 
 func TestStartBothServers(t *testing.T) {
-	tmpDir := t.TempDir()
-	authToken, err := os.CreateTemp(tmpDir, "auth_token")
+	authToken, err := os.CreateTemp("", "auth_token")
 	require.NoError(t, err)
-	authTokenValue := strings.Repeat("a", 64)
+	defer os.Remove(authToken.Name())
 
+	authTokenValue := strings.Repeat("a", 64)
 	_, err = io.WriteString(authToken, authTokenValue)
+	require.NoError(t, err)
+
+	err = authToken.Close()
 	require.NoError(t, err)
 
 	deps := getComponentDependencies(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Close the `auth_token` file in a test to avoid errors when deleting it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Not having errors.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The test was added in https://github.com/DataDog/datadog-agent/pull/27129, it seems that it consistently passes on retries so the CI didn't complain, but it should succeed in one try.

Also updated the test to avoid using a tempdir since we only need a single file.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
