### PR TITLE
feat(deps): Add a retry in case of failed go mod download

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -15,6 +15,7 @@ import traceback
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
+from time import sleep
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -108,13 +109,20 @@ def deps(ctx, verbose=False):
     """
     Setup Go dependencies
     """
-
+    max_retry = 3
     print("downloading dependencies")
     with timed("go mod download"):
         verbosity = ' -x' if verbose else ''
         for mod in DEFAULT_MODULES.values():
             with ctx.cd(mod.full_path()):
-                ctx.run(f"go mod download{verbosity}")
+                for retry in range(max_retry):
+                    result = ctx.run(f"go mod download{verbosity}")
+                    if result.exited is None or result.exited > 0:
+                        wait = 10 ** (retry + 1)
+                        print(f"[{(retry + 1) / max_retry}] Failed downloading {mod.path}, retrying in {wait} seconds")
+                        sleep(wait)
+                        continue
+                    break
 
 
 @task


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add a retry in case of failed go mod download
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Improve CI resilience as gomod download can fail from times to times (eg [here](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/9698834905/job/26766331548))
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
