### PR TITLE
Reapply "[FA] Add upgrade e2e test (#27031)"

### DIFF
--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -57,6 +57,7 @@ var (
 		{t: testInstaller},
 		{t: testAgent},
 		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.Fedora37, e2eos.Suse15}},
+		{t: testUpgradeScenario},
 	}
 )
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -144,6 +144,14 @@ func (h *Host) WaitForUnitActive(units ...string) {
 	}
 }
 
+// WaitForUnitActivating waits for a systemd unit to be activating
+func (h *Host) WaitForUnitActivating(units ...string) {
+	for _, unit := range units {
+		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; unit=%s; while ! grep -q \"Active: activating\" <(sudo systemctl status $unit) && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", unit))
+		require.NoError(h.t, err, "unit %s did not become active", unit)
+	}
+}
+
 // BootstraperVersion returns the version of the bootstraper on the host.
 func (h *Host) BootstraperVersion() string {
 	return strings.TrimSpace(h.remote.MustExecute("sudo datadog-bootstrap version"))

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -152,6 +152,13 @@ func (h *Host) WaitForUnitActivating(units ...string) {
 	}
 }
 
+func (h *Host) WaitForFileExists(filePaths ...string) {
+	for _, path := range filePaths {
+		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path))
+		require.NoError(h.t, err, "file %s did not exist", path)
+	}
+}
+
 // BootstraperVersion returns the version of the bootstraper on the host.
 func (h *Host) BootstraperVersion() string {
 	return strings.TrimSpace(h.remote.MustExecute("sudo datadog-bootstrap version"))

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -152,6 +152,7 @@ func (h *Host) WaitForUnitActivating(units ...string) {
 	}
 }
 
+// WaitForFileExists waits for a file to exist on the host
 func (h *Host) WaitForFileExists(filePaths ...string) {
 	for _, path := range filePaths {
 		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path))

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/stretchr/testify/require"
+)
+
+type upgradeScenarioSuite struct {
+	packageBaseSuite
+}
+
+type packageEntry struct {
+	Package string `json:"package"`
+	Version string `json:"version"`
+	URL     string `json:"url"`
+}
+
+type catalog struct {
+	Packages []packageEntry `json:"packages"`
+}
+
+type packageStatus struct {
+	State             string `json:"state"`
+	StableVersion     string `json:"stable_version"`
+	ExperimentVersion string `json:"experiment_version"`
+}
+
+var testCatalog = catalog{
+	Packages: []packageEntry{
+		{
+			Package: "datadog-agent",
+			Version: latestAgentImageVersion,
+			URL:     fmt.Sprintf("oci://gcr.io/datadoghq/agent-package:%s", latestAgentImageVersion),
+		},
+	},
+}
+
+// datadog-agent
+//
+//	State: OK
+//	Installed versions:
+//	  ● stable: v7.52.0-rc.1.git.15.6c19b17.pipeline.28815219-1
+//	  ● experiment: none
+var installerStatusRegex = regexp.MustCompile(`([a-zA-Z-]+)\n[ \t]+State:.([a-zA-Z-]+)\n[ \t]+Installed versions:\n[ \t]+..stable:.([a-zA-Z0-9-\.]+)\n[ \t]+..experiment:.([a-zA-Z0-9-\.]+)`)
+
+const (
+	latestAgentVersion      = "7.54.1"
+	latestAgentImageVersion = "7.54.1-1"
+)
+
+func testUpgradeScenario(os e2eos.Descriptor, arch e2eos.Architecture) packageSuite {
+	return &upgradeScenarioSuite{
+		packageBaseSuite: newPackageSuite("upgrade_scenario", os, arch),
+	}
+}
+
+func (s *upgradeScenarioSuite) TestUpgradeSuccessful() {
+	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	defer s.Purge()
+	s.host.WaitForUnitActive(
+		"datadog-agent.service",
+		"datadog-agent-trace.service",
+		"datadog-agent-process.service",
+		"datadog-installer.service",
+	)
+
+	_, err := s.setCatalog(testCatalog)
+	require.NoError(s.T(), err)
+
+	timestamp := s.host.LastJournaldTimestamp()
+	_, err = s.startExperimentCommand(latestAgentImageVersion)
+	require.NoError(s.T(), err)
+	s.assertSuccessfulStartExperiment(timestamp, latestAgentImageVersion)
+
+	timestamp = s.host.LastJournaldTimestamp()
+	_, err = s.promoteExperimentCommand()
+	require.NoError(s.T(), err)
+	s.assertSuccessfulPromoteExperiment(timestamp, latestAgentImageVersion)
+}
+
+func (s *upgradeScenarioSuite) startExperimentCommand(version string) (string, error) {
+	cmd := fmt.Sprintf("sudo datadog-installer daemon start-experiment datadog-agent %s", version)
+	s.T().Logf("Running start command: %s", cmd)
+	return s.Env().RemoteHost.Execute(cmd)
+}
+
+func (s *upgradeScenarioSuite) promoteExperimentCommand() (string, error) {
+	cmd := "sudo datadog-installer daemon promote-experiment datadog-agent"
+	s.T().Logf("Running promote command: %s", cmd)
+	return s.Env().RemoteHost.Execute(cmd)
+}
+
+//lint:ignore U1000 Ignore unused function for now
+func (s *upgradeScenarioSuite) stopExperimentCommand() (string, error) {
+	cmd := "sudo datadog-installer daemon stop-experiment datadog-agent"
+	s.T().Logf("Running stop command: %s", cmd)
+	return s.Env().RemoteHost.Execute(cmd)
+}
+
+func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) (string, error) {
+	serializedCatalog, err := json.Marshal(newCatalog)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+	s.T().Logf("Running: daemon set-catalog '%s'", string(serializedCatalog))
+
+	return s.Env().RemoteHost.Execute(fmt.Sprintf(
+		"sudo datadog-installer daemon set-catalog '%s'", serializedCatalog),
+	)
+}
+
+func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.JournaldTimestamp, version string) {
+	s.host.WaitForUnitActivating(agentUnitXP)
+
+	// Assert experiment is running
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnit).
+			Stopped(traceUnit).
+			Stopped(processUnit),
+		).
+		Unordered(host.SystemdEvents().
+			Starting(agentUnitXP).
+			Started(traceUnitXP).
+			Started(processUnitXP),
+		),
+	)
+
+	installerStatus := s.getInstallerStatus()
+	require.Equal(s.T(), version, installerStatus["datadog-agent"].ExperimentVersion)
+}
+
+func (s *upgradeScenarioSuite) assertSuccessfulPromoteExperiment(timestamp host.JournaldTimestamp, version string) {
+	s.host.WaitForUnitActive(agentUnit)
+
+	// Assert experiment is promoted
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnitXP).
+			Stopped(processUnitXP).
+			Stopped(traceUnitXP),
+		).
+		Unordered(host.SystemdEvents().
+			Started(agentUnit).
+			Stopped(processUnit).
+			Stopped(traceUnit),
+		),
+	)
+
+	installerStatus := s.getInstallerStatus()
+	require.Equal(s.T(), version, installerStatus["datadog-agent"].StableVersion)
+	require.Equal(s.T(), "none", installerStatus["datadog-agent"].ExperimentVersion)
+}
+
+//lint:ignore U1000 Ignore unused function for now
+func (s *upgradeScenarioSuite) assertSuccessfulStopExperiment(timestamp host.JournaldTimestamp) {
+	// Assert experiment is stopped
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnitXP).
+			Stopped(processUnitXP).
+			Stopped(traceUnitXP),
+		).
+		Started(agentUnit).
+		Unordered(host.SystemdEvents().
+			Started(traceUnit).
+			Started(processUnit),
+		),
+	)
+
+	installerStatus := s.getInstallerStatus()
+	require.Equal(s.T(), "none", installerStatus["datadog-agent"].ExperimentVersion)
+}
+
+func (s *upgradeScenarioSuite) getInstallerStatus() map[string]packageStatus {
+	// 	Datadog Installer v7.55.0-devel+git.1079.69749ed
+	// datadog-agent
+	//   State: OK
+	//   Installed versions:
+	//     ● stable: v7.52.0-rc.1.git.15.6c19b17.pipeline.28815219-1
+	//     ● experiment: none
+	resp := s.Env().RemoteHost.MustExecute("sudo datadog-installer status")
+	status := make(map[string]packageStatus)
+
+	statusResponse := installerStatusRegex.FindAllStringSubmatch(resp, -1)
+	for _, st := range statusResponse {
+		if len(st) != 5 {
+			s.T().Fatal("unexpected status response")
+		}
+		status[st[1]] = packageStatus{
+			State:             st[2],
+			StableVersion:     strings.TrimPrefix(st[3], "v"),
+			ExperimentVersion: strings.TrimPrefix(st[4], "v"),
+		}
+	}
+
+	return status
+}

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -124,9 +124,6 @@ func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.Jo
 	s.host.WaitForUnitActivating(agentUnitXP)
 	s.host.WaitForFileExists("/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
-	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
-	s.T().Logf("Installer start logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-installer --no-pager"))
-
 	// Assert experiment is running
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
@@ -147,9 +144,6 @@ func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.Jo
 
 func (s *upgradeScenarioSuite) assertSuccessfulPromoteExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActive(agentUnit)
-
-	s.T().Logf("Agent exp logs promote: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
-	s.T().Logf("Installer promote logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-installer --no-pager"))
 
 	// Assert experiment is promoted
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -123,6 +123,8 @@ func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) (string, error) {
 func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActivating(agentUnitXP)
 
+	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("journalctl -u datadog-agent-exp --no-pager"))
+
 	// Assert experiment is running
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
@@ -143,6 +145,8 @@ func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.Jo
 
 func (s *upgradeScenarioSuite) assertSuccessfulPromoteExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActive(agentUnit)
+
+	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("journalctl -u datadog-agent-exp --no-pager"))
 
 	// Assert experiment is promoted
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -123,7 +123,7 @@ func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) (string, error) {
 func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActivating(agentUnitXP)
 
-	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("journalctl -u datadog-agent-exp --no-pager"))
+	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
 
 	// Assert experiment is running
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
@@ -146,7 +146,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.Jo
 func (s *upgradeScenarioSuite) assertSuccessfulPromoteExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActive(agentUnit)
 
-	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("journalctl -u datadog-agent-exp --no-pager"))
+	s.T().Logf("Agent exp logs promote: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
 
 	// Assert experiment is promoted
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -122,6 +122,7 @@ func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) (string, error) {
 
 func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActivating(agentUnitXP)
+	s.host.WaitForFileExists("/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
 	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
 	s.T().Logf("Installer start logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-installer --no-pager"))

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -124,6 +124,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.Jo
 	s.host.WaitForUnitActivating(agentUnitXP)
 
 	s.T().Logf("Agent exp logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
+	s.T().Logf("Installer start logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-installer --no-pager"))
 
 	// Assert experiment is running
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
@@ -147,6 +148,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulPromoteExperiment(timestamp host.
 	s.host.WaitForUnitActive(agentUnit)
 
 	s.T().Logf("Agent exp logs promote: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-agent-exp --no-pager"))
+	s.T().Logf("Installer promote logs: %s", s.Env().RemoteHost.MustExecute("sudo journalctl -u datadog-installer --no-pager"))
 
 	// Assert experiment is promoted
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add back the e2e test for agent upgrades after fixing the following flakiness:
* Start_experiment
  * After being `healthy`, the datadog-agent exp starts but does not have time to create its pid file
* Promote_experiment
  * We delete the experiment link, so the pid can't be created

There is ongoing work to make the promote safer, so we might not need this `WaitForPIDFile` in the future

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
