### PR TITLE
[AI-3991] Add mappings for community python integrations

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -62,6 +62,74 @@ const (
 	MetricSourceSnmp
 
 	// Python Checks
+    MetricSourceZenohRouter
+    MetricSourceZabbix
+    MetricSourceWayfinder
+    MetricSourceVespa
+    MetricSourceUpsc
+    MetricSourceUpboundUxp
+    MetricSourceUnifiConsole
+    MetricSourceUnbound
+    MetricSourceTraefik
+    MetricSourceTidb
+    MetricSourceSyncthing
+    MetricSourceStorm
+    MetricSourceStardog
+    MetricSourceSpeedtest
+    MetricSourceSortdb
+    MetricSourceSonarr
+    MetricSourceSnmpwalk
+    MetricSourceSendmail
+    MetricSourceScalr
+    MetricSourceRiakRepl
+    MetricSourceRedpanda
+    MetricSourceRedisenterprise
+    MetricSourceRedisSentinel
+    MetricSourceRebootRequired
+    MetricSourceRadarr
+    MetricSourcePurefb
+    MetricSourcePurefa
+    MetricSourcePuma
+    MetricSourcePortworx
+    MetricSourcePing
+    MetricSourcePihole
+    MetricSourcePhpOpcache
+    MetricSourcePhpApcu
+    MetricSourceOpenPolicyAgent
+    MetricSourceOctoprint
+    MetricSourceNvml
+    MetricSourceNs1
+    MetricSourceNnSdwan
+    MetricSourceNextcloud
+    MetricSourceNeutrona
+    MetricSourceNeo4j
+    MetricSourceMergify
+    MetricSourceLogstash
+    MetricSourceLighthouse
+    MetricSourceKernelcare
+    MetricSourceJfrogPlatformSelfHosted
+    MetricSourceHikaricp
+    MetricSourceGrpcCheck
+    MetricSourceGoPprofScraper
+    MetricSourceGnatsdStreaming
+    MetricSourceGnatsd
+    MetricSourceGitea
+    MetricSourceGatekeeper
+    MetricSourceFluentbit
+    MetricSourceFilemage
+    MetricSourceFilebeat
+    MetricSourceFiddler
+    MetricSourceExim
+    MetricSourceEventstore
+    MetricSourceEmqx
+    MetricSourceCyral
+    MetricSourceCybersixgillActionableAlerts
+    MetricSourceCloudsmith
+    MetricSourceCloudnatix
+    MetricSourceCfssl
+    MetricSourceBind9
+    MetricSourceAwsPricing
+    MetricSourceAqua
 	MetricSourceKubernetesClusterAutoscaler
 	MetricSourceTraefikMesh
 	MetricSourceWeaviate
@@ -634,6 +702,142 @@ func (ms MetricSource) String() string {
 		return "traefik_mesh"
 	case MetricSourceKubernetesClusterAutoscaler:
 		return "kubernetes_cluster_autoscaler"
+    case MetricSourceAqua:
+		return "aqua"
+    case MetricSourceAwsPricing:
+		return "aws_pricing"
+    case MetricSourceBind9:
+		return "bind9"
+    case MetricSourceCfssl:
+		return "cfssl"
+    case MetricSourceCloudnatix:
+		return "cloudnatix"
+    case MetricSourceCloudsmith:
+		return "cloudsmith"
+    case MetricSourceCybersixgillActionableAlerts:
+		return "cybersixgill_actionable_alerts"
+    case MetricSourceCyral:
+		return "cyral"
+    case MetricSourceEmqx:
+		return "emqx"
+    case MetricSourceEventstore:
+		return "eventstore"
+    case MetricSourceExim:
+		return "exim"
+    case MetricSourceFiddler:
+		return "fiddler"
+    case MetricSourceFilebeat:
+		return "filebeat"
+    case MetricSourceFilemage:
+		return "filemage"
+    case MetricSourceFluentbit:
+		return "fluentbit"
+    case MetricSourceGatekeeper:
+		return "gatekeeper"
+    case MetricSourceGitea:
+		return "gitea"
+    case MetricSourceGnatsd:
+		return "gnatsd"
+    case MetricSourceGnatsdStreaming:
+		return "gnatsd_streaming"
+    case MetricSourceGoPprofScraper:
+		return "go_pprof_scraper"
+    case MetricSourceGrpcCheck:
+		return "grpc_check"
+    case MetricSourceHikaricp:
+		return "hikaricp"
+    case MetricSourceJfrogPlatformSelfHosted:
+		return "jfrog_platform_self_hosted"
+    case MetricSourceKernelcare:
+		return "kernelcare"
+    case MetricSourceLighthouse:
+		return "lighthouse"
+    case MetricSourceLogstash:
+		return "logstash"
+    case MetricSourceMergify:
+		return "mergify"
+    case MetricSourceNeo4j:
+		return "neo4j"
+    case MetricSourceNeutrona:
+		return "neutrona"
+    case MetricSourceNextcloud:
+		return "nextcloud"
+    case MetricSourceNnSdwan:
+		return "nn_sdwan"
+    case MetricSourceNs1:
+		return "ns1"
+    case MetricSourceNvml:
+		return "nvml"
+    case MetricSourceOctoprint:
+		return "octoprint"
+    case MetricSourceOpenPolicyAgent:
+		return "open_policy_agent"
+    case MetricSourcePhpApcu:
+		return "php_apcu"
+    case MetricSourcePhpOpcache:
+		return "php_opcache"
+    case MetricSourcePihole:
+		return "pihole"
+    case MetricSourcePing:
+		return "ping"
+    case MetricSourcePortworx:
+		return "portworx"
+    case MetricSourcePuma:
+		return "puma"
+    case MetricSourcePurefa:
+		return "purefa"
+    case MetricSourcePurefb:
+		return "purefb"
+    case MetricSourceRadarr:
+		return "radarr"
+    case MetricSourceRebootRequired:
+		return "reboot_required"
+    case MetricSourceRedisSentinel:
+		return "redis_sentinel"
+    case MetricSourceRedisenterprise:
+		return "redisenterprise"
+    case MetricSourceRedpanda:
+		return "redpanda"
+    case MetricSourceRiakRepl:
+		return "riak_repl"
+    case MetricSourceScalr:
+		return "scalr"
+    case MetricSourceSendmail:
+		return "sendmail"
+    case MetricSourceSnmpwalk:
+		return "snmpwalk"
+    case MetricSourceSonarr:
+		return "sonarr"
+    case MetricSourceSortdb:
+		return "sortdb"
+    case MetricSourceSpeedtest:
+		return "speedtest"
+    case MetricSourceStardog:
+		return "stardog"
+    case MetricSourceStorm:
+		return "storm"
+    case MetricSourceSyncthing:
+		return "syncthing"
+    case MetricSourceTidb:
+		return "tidb"
+    case MetricSourceTraefik:
+		return "traefik"
+    case MetricSourceUnbound:
+		return "unbound"
+    case MetricSourceUnifiConsole:
+		return "unifi_console"
+    case MetricSourceUpboundUxp:
+		return "upbound_uxp"
+    case MetricSourceUpsc:
+		return "upsc"
+    case MetricSourceVespa:
+		return "vespa"
+    case MetricSourceWayfinder:
+		return "wayfinder"
+    case MetricSourceZabbix:
+		return "zabbix"
+    case MetricSourceZenohRouter:
+		return "zenoh_router"
 	default:
 		return "<unknown>"
 	}
@@ -1016,6 +1220,142 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceTraefikMesh
 	case "kubernetes_cluster_autoscaler":
 		return MetricSourceKubernetesClusterAutoscaler
+    case "aqua":
+		return MetricSourceAqua
+    case "aws_pricing":
+		return MetricSourceAwsPricing
+    case "bind9":
+		return MetricSourceBind9
+    case "cfssl":
+		return MetricSourceCfssl
+    case "cloudnatix":
+		return MetricSourceCloudnatix
+    case "cloudsmith":
+		return MetricSourceCloudsmith
+    case "cybersixgill_actionable_alerts":
+		return MetricSourceCybersixgillActionableAlerts
+    case "cyral":
+		return MetricSourceCyral
+    case "emqx":
+		return MetricSourceEmqx
+    case "eventstore":
+		return MetricSourceEventstore
+    case "exim":
+		return MetricSourceExim
+    case "fiddler":
+		return MetricSourceFiddler
+    case "filebeat":
+		return MetricSourceFilebeat
+    case "filemage":
+		return MetricSourceFilemage
+    case "fluentbit":
+		return MetricSourceFluentbit
+    case "gatekeeper":
+		return MetricSourceGatekeeper
+    case "gitea":
+		return MetricSourceGitea
+    case "gnatsd":
+		return MetricSourceGnatsd
+    case "gnatsd_streaming":
+		return MetricSourceGnatsdStreaming
+    case "go_pprof_scraper":
+		return MetricSourceGoPprofScraper
+    case "grpc_check":
+		return MetricSourceGrpcCheck
+    case "hikaricp":
+		return MetricSourceHikaricp
+    case "jfrog_platform_self_hosted":
+		return MetricSourceJfrogPlatformSelfHosted
+    case "kernelcare":
+		return MetricSourceKernelcare
+    case "lighthouse":
+		return MetricSourceLighthouse
+    case "logstash":
+		return MetricSourceLogstash
+    case "mergify":
+		return MetricSourceMergify
+    case "neo4j":
+		return MetricSourceNeo4j
+    case "neutrona":
+		return MetricSourceNeutrona
+    case "nextcloud":
+		return MetricSourceNextcloud
+    case "nn_sdwan":
+		return MetricSourceNnSdwan
+    case "ns1":
+		return MetricSourceNs1
+    case "nvml":
+		return MetricSourceNvml
+    case "octoprint":
+		return MetricSourceOctoprint
+    case "open_policy_agent":
+		return MetricSourceOpenPolicyAgent
+    case "php_apcu":
+		return MetricSourcePhpApcu
+    case "php_opcache":
+		return MetricSourcePhpOpcache
+    case "pihole":
+		return MetricSourcePihole
+    case "ping":
+		return MetricSourcePing
+    case "portworx":
+		return MetricSourcePortworx
+    case "puma":
+		return MetricSourcePuma
+    case "purefa":
+		return MetricSourcePurefa
+    case "purefb":
+		return MetricSourcePurefb
+    case "radarr":
+		return MetricSourceRadarr
+    case "reboot_required":
+		return MetricSourceRebootRequired
+    case "redis_sentinel":
+		return MetricSourceRedisSentinel
+    case "redisenterprise":
+		return MetricSourceRedisenterprise
+    case "redpanda":
+		return MetricSourceRedpanda
+    case "riak_repl":
+		return MetricSourceRiakRepl
+    case "scalr":
+		return MetricSourceScalr
+    case "sendmail":
+		return MetricSourceSendmail
+    case "snmpwalk":
+		return MetricSourceSnmpwalk
+    case "sonarr":
+		return MetricSourceSonarr
+    case "sortdb":
+		return MetricSourceSortdb
+    case "speedtest":
+		return MetricSourceSpeedtest
+    case "stardog":
+		return MetricSourceStardog
+    case "storm":
+		return MetricSourceStorm
+    case "syncthing":
+		return MetricSourceSyncthing
+    case "tidb":
+		return MetricSourceTidb
+    case "traefik":
+		return MetricSourceTraefik
+    case "unbound":
+		return MetricSourceUnbound
+    case "unifi_console":
+		return MetricSourceUnifiConsole
+    case "upbound_uxp":
+		return MetricSourceUpboundUxp
+    case "upsc":
+		return MetricSourceUpsc
+    case "vespa":
+		return MetricSourceVespa
+    case "wayfinder":
+		return MetricSourceWayfinder
+    case "zabbix":
+		return MetricSourceZabbix
+    case "zenoh_router":
+		return MetricSourceZenohRouter
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -62,74 +62,74 @@ const (
 	MetricSourceSnmp
 
 	// Python Checks
-    MetricSourceZenohRouter
-    MetricSourceZabbix
-    MetricSourceWayfinder
-    MetricSourceVespa
-    MetricSourceUpsc
-    MetricSourceUpboundUxp
-    MetricSourceUnifiConsole
-    MetricSourceUnbound
-    MetricSourceTraefik
-    MetricSourceTidb
-    MetricSourceSyncthing
-    MetricSourceStorm
-    MetricSourceStardog
-    MetricSourceSpeedtest
-    MetricSourceSortdb
-    MetricSourceSonarr
-    MetricSourceSnmpwalk
-    MetricSourceSendmail
-    MetricSourceScalr
-    MetricSourceRiakRepl
-    MetricSourceRedpanda
-    MetricSourceRedisenterprise
-    MetricSourceRedisSentinel
-    MetricSourceRebootRequired
-    MetricSourceRadarr
-    MetricSourcePurefb
-    MetricSourcePurefa
-    MetricSourcePuma
-    MetricSourcePortworx
-    MetricSourcePing
-    MetricSourcePihole
-    MetricSourcePhpOpcache
-    MetricSourcePhpApcu
-    MetricSourceOpenPolicyAgent
-    MetricSourceOctoprint
-    MetricSourceNvml
-    MetricSourceNs1
-    MetricSourceNnSdwan
-    MetricSourceNextcloud
-    MetricSourceNeutrona
-    MetricSourceNeo4j
-    MetricSourceMergify
-    MetricSourceLogstash
-    MetricSourceLighthouse
-    MetricSourceKernelcare
-    MetricSourceJfrogPlatformSelfHosted
-    MetricSourceHikaricp
-    MetricSourceGrpcCheck
-    MetricSourceGoPprofScraper
-    MetricSourceGnatsdStreaming
-    MetricSourceGnatsd
-    MetricSourceGitea
-    MetricSourceGatekeeper
-    MetricSourceFluentbit
-    MetricSourceFilemage
-    MetricSourceFilebeat
-    MetricSourceFiddler
-    MetricSourceExim
-    MetricSourceEventstore
-    MetricSourceEmqx
-    MetricSourceCyral
-    MetricSourceCybersixgillActionableAlerts
-    MetricSourceCloudsmith
-    MetricSourceCloudnatix
-    MetricSourceCfssl
-    MetricSourceBind9
-    MetricSourceAwsPricing
-    MetricSourceAqua
+	MetricSourceZenohRouter
+	MetricSourceZabbix
+	MetricSourceWayfinder
+	MetricSourceVespa
+	MetricSourceUpsc
+	MetricSourceUpboundUxp
+	MetricSourceUnifiConsole
+	MetricSourceUnbound
+	MetricSourceTraefik
+	MetricSourceTidb
+	MetricSourceSyncthing
+	MetricSourceStorm
+	MetricSourceStardog
+	MetricSourceSpeedtest
+	MetricSourceSortdb
+	MetricSourceSonarr
+	MetricSourceSnmpwalk
+	MetricSourceSendmail
+	MetricSourceScalr
+	MetricSourceRiakRepl
+	MetricSourceRedpanda
+	MetricSourceRedisenterprise
+	MetricSourceRedisSentinel
+	MetricSourceRebootRequired
+	MetricSourceRadarr
+	MetricSourcePurefb
+	MetricSourcePurefa
+	MetricSourcePuma
+	MetricSourcePortworx
+	MetricSourcePing
+	MetricSourcePihole
+	MetricSourcePhpOpcache
+	MetricSourcePhpApcu
+	MetricSourceOpenPolicyAgent
+	MetricSourceOctoprint
+	MetricSourceNvml
+	MetricSourceNs1
+	MetricSourceNnSdwan
+	MetricSourceNextcloud
+	MetricSourceNeutrona
+	MetricSourceNeo4j
+	MetricSourceMergify
+	MetricSourceLogstash
+	MetricSourceLighthouse
+	MetricSourceKernelcare
+	MetricSourceJfrogPlatformSelfHosted
+	MetricSourceHikaricp
+	MetricSourceGrpcCheck
+	MetricSourceGoPprofScraper
+	MetricSourceGnatsdStreaming
+	MetricSourceGnatsd
+	MetricSourceGitea
+	MetricSourceGatekeeper
+	MetricSourceFluentbit
+	MetricSourceFilemage
+	MetricSourceFilebeat
+	MetricSourceFiddler
+	MetricSourceExim
+	MetricSourceEventstore
+	MetricSourceEmqx
+	MetricSourceCyral
+	MetricSourceCybersixgillActionableAlerts
+	MetricSourceCloudsmith
+	MetricSourceCloudnatix
+	MetricSourceCfssl
+	MetricSourceBind9
+	MetricSourceAwsPricing
+	MetricSourceAqua
 	MetricSourceKubernetesClusterAutoscaler
 	MetricSourceTraefikMesh
 	MetricSourceWeaviate
@@ -702,141 +702,141 @@ func (ms MetricSource) String() string {
 		return "traefik_mesh"
 	case MetricSourceKubernetesClusterAutoscaler:
 		return "kubernetes_cluster_autoscaler"
-    case MetricSourceAqua:
+	case MetricSourceAqua:
 		return "aqua"
-    case MetricSourceAwsPricing:
+	case MetricSourceAwsPricing:
 		return "aws_pricing"
-    case MetricSourceBind9:
+	case MetricSourceBind9:
 		return "bind9"
-    case MetricSourceCfssl:
+	case MetricSourceCfssl:
 		return "cfssl"
-    case MetricSourceCloudnatix:
+	case MetricSourceCloudnatix:
 		return "cloudnatix"
-    case MetricSourceCloudsmith:
+	case MetricSourceCloudsmith:
 		return "cloudsmith"
-    case MetricSourceCybersixgillActionableAlerts:
+	case MetricSourceCybersixgillActionableAlerts:
 		return "cybersixgill_actionable_alerts"
-    case MetricSourceCyral:
+	case MetricSourceCyral:
 		return "cyral"
-    case MetricSourceEmqx:
+	case MetricSourceEmqx:
 		return "emqx"
-    case MetricSourceEventstore:
+	case MetricSourceEventstore:
 		return "eventstore"
-    case MetricSourceExim:
+	case MetricSourceExim:
 		return "exim"
-    case MetricSourceFiddler:
+	case MetricSourceFiddler:
 		return "fiddler"
-    case MetricSourceFilebeat:
+	case MetricSourceFilebeat:
 		return "filebeat"
-    case MetricSourceFilemage:
+	case MetricSourceFilemage:
 		return "filemage"
-    case MetricSourceFluentbit:
+	case MetricSourceFluentbit:
 		return "fluentbit"
-    case MetricSourceGatekeeper:
+	case MetricSourceGatekeeper:
 		return "gatekeeper"
-    case MetricSourceGitea:
+	case MetricSourceGitea:
 		return "gitea"
-    case MetricSourceGnatsd:
+	case MetricSourceGnatsd:
 		return "gnatsd"
-    case MetricSourceGnatsdStreaming:
+	case MetricSourceGnatsdStreaming:
 		return "gnatsd_streaming"
-    case MetricSourceGoPprofScraper:
+	case MetricSourceGoPprofScraper:
 		return "go_pprof_scraper"
-    case MetricSourceGrpcCheck:
+	case MetricSourceGrpcCheck:
 		return "grpc_check"
-    case MetricSourceHikaricp:
+	case MetricSourceHikaricp:
 		return "hikaricp"
-    case MetricSourceJfrogPlatformSelfHosted:
+	case MetricSourceJfrogPlatformSelfHosted:
 		return "jfrog_platform_self_hosted"
-    case MetricSourceKernelcare:
+	case MetricSourceKernelcare:
 		return "kernelcare"
-    case MetricSourceLighthouse:
+	case MetricSourceLighthouse:
 		return "lighthouse"
-    case MetricSourceLogstash:
+	case MetricSourceLogstash:
 		return "logstash"
-    case MetricSourceMergify:
+	case MetricSourceMergify:
 		return "mergify"
-    case MetricSourceNeo4j:
+	case MetricSourceNeo4j:
 		return "neo4j"
-    case MetricSourceNeutrona:
+	case MetricSourceNeutrona:
 		return "neutrona"
-    case MetricSourceNextcloud:
+	case MetricSourceNextcloud:
 		return "nextcloud"
-    case MetricSourceNnSdwan:
+	case MetricSourceNnSdwan:
 		return "nn_sdwan"
-    case MetricSourceNs1:
+	case MetricSourceNs1:
 		return "ns1"
-    case MetricSourceNvml:
+	case MetricSourceNvml:
 		return "nvml"
-    case MetricSourceOctoprint:
+	case MetricSourceOctoprint:
 		return "octoprint"
-    case MetricSourceOpenPolicyAgent:
+	case MetricSourceOpenPolicyAgent:
 		return "open_policy_agent"
-    case MetricSourcePhpApcu:
+	case MetricSourcePhpApcu:
 		return "php_apcu"
-    case MetricSourcePhpOpcache:
+	case MetricSourcePhpOpcache:
 		return "php_opcache"
-    case MetricSourcePihole:
+	case MetricSourcePihole:
 		return "pihole"
-    case MetricSourcePing:
+	case MetricSourcePing:
 		return "ping"
-    case MetricSourcePortworx:
+	case MetricSourcePortworx:
 		return "portworx"
-    case MetricSourcePuma:
+	case MetricSourcePuma:
 		return "puma"
-    case MetricSourcePurefa:
+	case MetricSourcePurefa:
 		return "purefa"
-    case MetricSourcePurefb:
+	case MetricSourcePurefb:
 		return "purefb"
-    case MetricSourceRadarr:
+	case MetricSourceRadarr:
 		return "radarr"
-    case MetricSourceRebootRequired:
+	case MetricSourceRebootRequired:
 		return "reboot_required"
-    case MetricSourceRedisSentinel:
+	case MetricSourceRedisSentinel:
 		return "redis_sentinel"
-    case MetricSourceRedisenterprise:
+	case MetricSourceRedisenterprise:
 		return "redisenterprise"
-    case MetricSourceRedpanda:
+	case MetricSourceRedpanda:
 		return "redpanda"
-    case MetricSourceRiakRepl:
+	case MetricSourceRiakRepl:
 		return "riak_repl"
-    case MetricSourceScalr:
+	case MetricSourceScalr:
 		return "scalr"
-    case MetricSourceSendmail:
+	case MetricSourceSendmail:
 		return "sendmail"
-    case MetricSourceSnmpwalk:
+	case MetricSourceSnmpwalk:
 		return "snmpwalk"
-    case MetricSourceSonarr:
+	case MetricSourceSonarr:
 		return "sonarr"
-    case MetricSourceSortdb:
+	case MetricSourceSortdb:
 		return "sortdb"
-    case MetricSourceSpeedtest:
+	case MetricSourceSpeedtest:
 		return "speedtest"
-    case MetricSourceStardog:
+	case MetricSourceStardog:
 		return "stardog"
-    case MetricSourceStorm:
+	case MetricSourceStorm:
 		return "storm"
-    case MetricSourceSyncthing:
+	case MetricSourceSyncthing:
 		return "syncthing"
-    case MetricSourceTidb:
+	case MetricSourceTidb:
 		return "tidb"
-    case MetricSourceTraefik:
+	case MetricSourceTraefik:
 		return "traefik"
-    case MetricSourceUnbound:
+	case MetricSourceUnbound:
 		return "unbound"
-    case MetricSourceUnifiConsole:
+	case MetricSourceUnifiConsole:
 		return "unifi_console"
-    case MetricSourceUpboundUxp:
+	case MetricSourceUpboundUxp:
 		return "upbound_uxp"
-    case MetricSourceUpsc:
+	case MetricSourceUpsc:
 		return "upsc"
-    case MetricSourceVespa:
+	case MetricSourceVespa:
 		return "vespa"
-    case MetricSourceWayfinder:
+	case MetricSourceWayfinder:
 		return "wayfinder"
-    case MetricSourceZabbix:
+	case MetricSourceZabbix:
 		return "zabbix"
-    case MetricSourceZenohRouter:
+	case MetricSourceZenohRouter:
 		return "zenoh_router"
 	default:
 		return "<unknown>"
@@ -1220,141 +1220,141 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceTraefikMesh
 	case "kubernetes_cluster_autoscaler":
 		return MetricSourceKubernetesClusterAutoscaler
-    case "aqua":
+	case "aqua":
 		return MetricSourceAqua
-    case "aws_pricing":
+	case "aws_pricing":
 		return MetricSourceAwsPricing
-    case "bind9":
+	case "bind9":
 		return MetricSourceBind9
-    case "cfssl":
+	case "cfssl":
 		return MetricSourceCfssl
-    case "cloudnatix":
+	case "cloudnatix":
 		return MetricSourceCloudnatix
-    case "cloudsmith":
+	case "cloudsmith":
 		return MetricSourceCloudsmith
-    case "cybersixgill_actionable_alerts":
+	case "cybersixgill_actionable_alerts":
 		return MetricSourceCybersixgillActionableAlerts
-    case "cyral":
+	case "cyral":
 		return MetricSourceCyral
-    case "emqx":
+	case "emqx":
 		return MetricSourceEmqx
-    case "eventstore":
+	case "eventstore":
 		return MetricSourceEventstore
-    case "exim":
+	case "exim":
 		return MetricSourceExim
-    case "fiddler":
+	case "fiddler":
 		return MetricSourceFiddler
-    case "filebeat":
+	case "filebeat":
 		return MetricSourceFilebeat
-    case "filemage":
+	case "filemage":
 		return MetricSourceFilemage
-    case "fluentbit":
+	case "fluentbit":
 		return MetricSourceFluentbit
-    case "gatekeeper":
+	case "gatekeeper":
 		return MetricSourceGatekeeper
-    case "gitea":
+	case "gitea":
 		return MetricSourceGitea
-    case "gnatsd":
+	case "gnatsd":
 		return MetricSourceGnatsd
-    case "gnatsd_streaming":
+	case "gnatsd_streaming":
 		return MetricSourceGnatsdStreaming
-    case "go_pprof_scraper":
+	case "go_pprof_scraper":
 		return MetricSourceGoPprofScraper
-    case "grpc_check":
+	case "grpc_check":
 		return MetricSourceGrpcCheck
-    case "hikaricp":
+	case "hikaricp":
 		return MetricSourceHikaricp
-    case "jfrog_platform_self_hosted":
+	case "jfrog_platform_self_hosted":
 		return MetricSourceJfrogPlatformSelfHosted
-    case "kernelcare":
+	case "kernelcare":
 		return MetricSourceKernelcare
-    case "lighthouse":
+	case "lighthouse":
 		return MetricSourceLighthouse
-    case "logstash":
+	case "logstash":
 		return MetricSourceLogstash
-    case "mergify":
+	case "mergify":
 		return MetricSourceMergify
-    case "neo4j":
+	case "neo4j":
 		return MetricSourceNeo4j
-    case "neutrona":
+	case "neutrona":
 		return MetricSourceNeutrona
-    case "nextcloud":
+	case "nextcloud":
 		return MetricSourceNextcloud
-    case "nn_sdwan":
+	case "nn_sdwan":
 		return MetricSourceNnSdwan
-    case "ns1":
+	case "ns1":
 		return MetricSourceNs1
-    case "nvml":
+	case "nvml":
 		return MetricSourceNvml
-    case "octoprint":
+	case "octoprint":
 		return MetricSourceOctoprint
-    case "open_policy_agent":
+	case "open_policy_agent":
 		return MetricSourceOpenPolicyAgent
-    case "php_apcu":
+	case "php_apcu":
 		return MetricSourcePhpApcu
-    case "php_opcache":
+	case "php_opcache":
 		return MetricSourcePhpOpcache
-    case "pihole":
+	case "pihole":
 		return MetricSourcePihole
-    case "ping":
+	case "ping":
 		return MetricSourcePing
-    case "portworx":
+	case "portworx":
 		return MetricSourcePortworx
-    case "puma":
+	case "puma":
 		return MetricSourcePuma
-    case "purefa":
+	case "purefa":
 		return MetricSourcePurefa
-    case "purefb":
+	case "purefb":
 		return MetricSourcePurefb
-    case "radarr":
+	case "radarr":
 		return MetricSourceRadarr
-    case "reboot_required":
+	case "reboot_required":
 		return MetricSourceRebootRequired
-    case "redis_sentinel":
+	case "redis_sentinel":
 		return MetricSourceRedisSentinel
-    case "redisenterprise":
+	case "redisenterprise":
 		return MetricSourceRedisenterprise
-    case "redpanda":
+	case "redpanda":
 		return MetricSourceRedpanda
-    case "riak_repl":
+	case "riak_repl":
 		return MetricSourceRiakRepl
-    case "scalr":
+	case "scalr":
 		return MetricSourceScalr
-    case "sendmail":
+	case "sendmail":
 		return MetricSourceSendmail
-    case "snmpwalk":
+	case "snmpwalk":
 		return MetricSourceSnmpwalk
-    case "sonarr":
+	case "sonarr":
 		return MetricSourceSonarr
-    case "sortdb":
+	case "sortdb":
 		return MetricSourceSortdb
-    case "speedtest":
+	case "speedtest":
 		return MetricSourceSpeedtest
-    case "stardog":
+	case "stardog":
 		return MetricSourceStardog
-    case "storm":
+	case "storm":
 		return MetricSourceStorm
-    case "syncthing":
+	case "syncthing":
 		return MetricSourceSyncthing
-    case "tidb":
+	case "tidb":
 		return MetricSourceTidb
-    case "traefik":
+	case "traefik":
 		return MetricSourceTraefik
-    case "unbound":
+	case "unbound":
 		return MetricSourceUnbound
-    case "unifi_console":
+	case "unifi_console":
 		return MetricSourceUnifiConsole
-    case "upbound_uxp":
+	case "upbound_uxp":
 		return MetricSourceUpboundUxp
-    case "upsc":
+	case "upsc":
 		return MetricSourceUpsc
-    case "vespa":
+	case "vespa":
 		return MetricSourceVespa
-    case "wayfinder":
+	case "wayfinder":
 		return MetricSourceWayfinder
-    case "zabbix":
+	case "zabbix":
 		return MetricSourceZabbix
-    case "zenoh_router":
+	case "zenoh_router":
 		return MetricSourceZenohRouter
 	default:
 		return MetricSourceUnknown

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -62,74 +62,74 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceNetwork,
 		metrics.MetricSourceSnmp,
 		// Python Checks
-    	metrics.MetricSourceZenohRouter,
-    	metrics.MetricSourceZabbix,
-    	metrics.MetricSourceWayfinder,
-    	metrics.MetricSourceVespa,
-    	metrics.MetricSourceUpsc,
-    	metrics.MetricSourceUpboundUxp,
-    	metrics.MetricSourceUnifiConsole,
-    	metrics.MetricSourceUnbound,
-    	metrics.MetricSourceTraefik,
-    	metrics.MetricSourceTidb,
-    	metrics.MetricSourceSyncthing,
-    	metrics.MetricSourceStorm,
-    	metrics.MetricSourceStardog,
-    	metrics.MetricSourceSpeedtest,
-    	metrics.MetricSourceSortdb,
-    	metrics.MetricSourceSonarr,
-    	metrics.MetricSourceSnmpwalk,
-    	metrics.MetricSourceSendmail,
-    	metrics.MetricSourceScalr,
-    	metrics.MetricSourceRiakRepl,
-    	metrics.MetricSourceRedpanda,
-    	metrics.MetricSourceRedisenterprise,
-    	metrics.MetricSourceRedisSentinel,
-    	metrics.MetricSourceRebootRequired,
-    	metrics.MetricSourceRadarr,
-    	metrics.MetricSourcePurefb,
-    	metrics.MetricSourcePurefa,
-    	metrics.MetricSourcePuma,
-    	metrics.MetricSourcePortworx,
-    	metrics.MetricSourcePing,
-    	metrics.MetricSourcePihole,
-    	metrics.MetricSourcePhpOpcache,
-    	metrics.MetricSourcePhpApcu,
-    	metrics.MetricSourceOpenPolicyAgent,
-    	metrics.MetricSourceOctoprint,
-    	metrics.MetricSourceNvml,
-    	metrics.MetricSourceNs1,
-    	metrics.MetricSourceNnSdwan,
-    	metrics.MetricSourceNextcloud,
-    	metrics.MetricSourceNeutrona,
-    	metrics.MetricSourceNeo4j,
-    	metrics.MetricSourceMergify,
-    	metrics.MetricSourceLogstash,
-    	metrics.MetricSourceLighthouse,
-    	metrics.MetricSourceKernelcare,
-    	metrics.MetricSourceJfrogPlatformSelfHosted,
-    	metrics.MetricSourceHikaricp,
-    	metrics.MetricSourceGrpcCheck,
-    	metrics.MetricSourceGoPprofScraper,
-    	metrics.MetricSourceGnatsdStreaming,
-    	metrics.MetricSourceGnatsd,
-    	metrics.MetricSourceGitea,
-    	metrics.MetricSourceGatekeeper,
-    	metrics.MetricSourceFluentbit,
-    	metrics.MetricSourceFilemage,
-    	metrics.MetricSourceFilebeat,
-    	metrics.MetricSourceFiddler,
-    	metrics.MetricSourceExim,
-    	metrics.MetricSourceEventstore,
-    	metrics.MetricSourceEmqx,
-    	metrics.MetricSourceCyral,
-    	metrics.MetricSourceCybersixgillActionableAlerts,
-    	metrics.MetricSourceCloudsmith,
-    	metrics.MetricSourceCloudnatix,
-    	metrics.MetricSourceCfssl,
-    	metrics.MetricSourceBind9,
-    	metrics.MetricSourceAwsPricing,
-    	metrics.MetricSourceAqua,
+		metrics.MetricSourceZenohRouter,
+		metrics.MetricSourceZabbix,
+		metrics.MetricSourceWayfinder,
+		metrics.MetricSourceVespa,
+		metrics.MetricSourceUpsc,
+		metrics.MetricSourceUpboundUxp,
+		metrics.MetricSourceUnifiConsole,
+		metrics.MetricSourceUnbound,
+		metrics.MetricSourceTraefik,
+		metrics.MetricSourceTidb,
+		metrics.MetricSourceSyncthing,
+		metrics.MetricSourceStorm,
+		metrics.MetricSourceStardog,
+		metrics.MetricSourceSpeedtest,
+		metrics.MetricSourceSortdb,
+		metrics.MetricSourceSonarr,
+		metrics.MetricSourceSnmpwalk,
+		metrics.MetricSourceSendmail,
+		metrics.MetricSourceScalr,
+		metrics.MetricSourceRiakRepl,
+		metrics.MetricSourceRedpanda,
+		metrics.MetricSourceRedisenterprise,
+		metrics.MetricSourceRedisSentinel,
+		metrics.MetricSourceRebootRequired,
+		metrics.MetricSourceRadarr,
+		metrics.MetricSourcePurefb,
+		metrics.MetricSourcePurefa,
+		metrics.MetricSourcePuma,
+		metrics.MetricSourcePortworx,
+		metrics.MetricSourcePing,
+		metrics.MetricSourcePihole,
+		metrics.MetricSourcePhpOpcache,
+		metrics.MetricSourcePhpApcu,
+		metrics.MetricSourceOpenPolicyAgent,
+		metrics.MetricSourceOctoprint,
+		metrics.MetricSourceNvml,
+		metrics.MetricSourceNs1,
+		metrics.MetricSourceNnSdwan,
+		metrics.MetricSourceNextcloud,
+		metrics.MetricSourceNeutrona,
+		metrics.MetricSourceNeo4j,
+		metrics.MetricSourceMergify,
+		metrics.MetricSourceLogstash,
+		metrics.MetricSourceLighthouse,
+		metrics.MetricSourceKernelcare,
+		metrics.MetricSourceJfrogPlatformSelfHosted,
+		metrics.MetricSourceHikaricp,
+		metrics.MetricSourceGrpcCheck,
+		metrics.MetricSourceGoPprofScraper,
+		metrics.MetricSourceGnatsdStreaming,
+		metrics.MetricSourceGnatsd,
+		metrics.MetricSourceGitea,
+		metrics.MetricSourceGatekeeper,
+		metrics.MetricSourceFluentbit,
+		metrics.MetricSourceFilemage,
+		metrics.MetricSourceFilebeat,
+		metrics.MetricSourceFiddler,
+		metrics.MetricSourceExim,
+		metrics.MetricSourceEventstore,
+		metrics.MetricSourceEmqx,
+		metrics.MetricSourceCyral,
+		metrics.MetricSourceCybersixgillActionableAlerts,
+		metrics.MetricSourceCloudsmith,
+		metrics.MetricSourceCloudnatix,
+		metrics.MetricSourceCfssl,
+		metrics.MetricSourceBind9,
+		metrics.MetricSourceAwsPricing,
+		metrics.MetricSourceAqua,
 		metrics.MetricSourceKubernetesClusterAutoscaler,
 		metrics.MetricSourceTraefikMesh,
 		metrics.MetricSourceWeaviate,
@@ -708,141 +708,141 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 330
 	case metrics.MetricSourceKubernetesClusterAutoscaler:
 		return 331
-    case metrics.MetricSourceAqua:
+	case metrics.MetricSourceAqua:
 		return 332
-    case metrics.MetricSourceAwsPricing:
+	case metrics.MetricSourceAwsPricing:
 		return 333
-    case metrics.MetricSourceBind9:
+	case metrics.MetricSourceBind9:
 		return 334
-    case metrics.MetricSourceCfssl:
+	case metrics.MetricSourceCfssl:
 		return 335
-    case metrics.MetricSourceCloudnatix:
+	case metrics.MetricSourceCloudnatix:
 		return 336
-    case metrics.MetricSourceCloudsmith:
+	case metrics.MetricSourceCloudsmith:
 		return 337
-    case metrics.MetricSourceCybersixgillActionableAlerts:
+	case metrics.MetricSourceCybersixgillActionableAlerts:
 		return 338
-    case metrics.MetricSourceCyral:
+	case metrics.MetricSourceCyral:
 		return 339
-    case metrics.MetricSourceEmqx:
+	case metrics.MetricSourceEmqx:
 		return 340
-    case metrics.MetricSourceEventstore:
+	case metrics.MetricSourceEventstore:
 		return 341
-    case metrics.MetricSourceExim:
+	case metrics.MetricSourceExim:
 		return 342
-    case metrics.MetricSourceFiddler:
+	case metrics.MetricSourceFiddler:
 		return 343
-    case metrics.MetricSourceFilebeat:
+	case metrics.MetricSourceFilebeat:
 		return 344
-    case metrics.MetricSourceFilemage:
+	case metrics.MetricSourceFilemage:
 		return 345
-    case metrics.MetricSourceFluentbit:
+	case metrics.MetricSourceFluentbit:
 		return 346
-    case metrics.MetricSourceGatekeeper:
+	case metrics.MetricSourceGatekeeper:
 		return 347
-    case metrics.MetricSourceGitea:
+	case metrics.MetricSourceGitea:
 		return 348
-    case metrics.MetricSourceGnatsd:
+	case metrics.MetricSourceGnatsd:
 		return 349
-    case metrics.MetricSourceGnatsdStreaming:
+	case metrics.MetricSourceGnatsdStreaming:
 		return 350
-    case metrics.MetricSourceGoPprofScraper:
+	case metrics.MetricSourceGoPprofScraper:
 		return 351
-    case metrics.MetricSourceGrpcCheck:
+	case metrics.MetricSourceGrpcCheck:
 		return 352
-    case metrics.MetricSourceHikaricp:
+	case metrics.MetricSourceHikaricp:
 		return 353
-    case metrics.MetricSourceJfrogPlatformSelfHosted:
+	case metrics.MetricSourceJfrogPlatformSelfHosted:
 		return 354
-    case metrics.MetricSourceKernelcare:
+	case metrics.MetricSourceKernelcare:
 		return 355
-    case metrics.MetricSourceLighthouse:
+	case metrics.MetricSourceLighthouse:
 		return 356
-    case metrics.MetricSourceLogstash:
+	case metrics.MetricSourceLogstash:
 		return 357
-    case metrics.MetricSourceMergify:
+	case metrics.MetricSourceMergify:
 		return 358
-    case metrics.MetricSourceNeo4j:
+	case metrics.MetricSourceNeo4j:
 		return 359
-    case metrics.MetricSourceNeutrona:
+	case metrics.MetricSourceNeutrona:
 		return 360
-    case metrics.MetricSourceNextcloud:
+	case metrics.MetricSourceNextcloud:
 		return 361
-    case metrics.MetricSourceNnSdwan:
+	case metrics.MetricSourceNnSdwan:
 		return 362
-    case metrics.MetricSourceNs1:
+	case metrics.MetricSourceNs1:
 		return 363
-    case metrics.MetricSourceNvml:
+	case metrics.MetricSourceNvml:
 		return 364
-    case metrics.MetricSourceOctoprint:
+	case metrics.MetricSourceOctoprint:
 		return 365
-    case metrics.MetricSourceOpenPolicyAgent:
+	case metrics.MetricSourceOpenPolicyAgent:
 		return 366
-    case metrics.MetricSourcePhpApcu:
+	case metrics.MetricSourcePhpApcu:
 		return 367
-    case metrics.MetricSourcePhpOpcache:
+	case metrics.MetricSourcePhpOpcache:
 		return 368
-    case metrics.MetricSourcePihole:
+	case metrics.MetricSourcePihole:
 		return 369
-    case metrics.MetricSourcePing:
+	case metrics.MetricSourcePing:
 		return 370
-    case metrics.MetricSourcePortworx:
+	case metrics.MetricSourcePortworx:
 		return 371
-    case metrics.MetricSourcePuma:
+	case metrics.MetricSourcePuma:
 		return 372
-    case metrics.MetricSourcePurefa:
+	case metrics.MetricSourcePurefa:
 		return 373
-    case metrics.MetricSourcePurefb:
+	case metrics.MetricSourcePurefb:
 		return 374
-    case metrics.MetricSourceRadarr:
+	case metrics.MetricSourceRadarr:
 		return 375
-    case metrics.MetricSourceRebootRequired:
+	case metrics.MetricSourceRebootRequired:
 		return 376
-    case metrics.MetricSourceRedisSentinel:
+	case metrics.MetricSourceRedisSentinel:
 		return 377
-    case metrics.MetricSourceRedisenterprise:
+	case metrics.MetricSourceRedisenterprise:
 		return 378
-    case metrics.MetricSourceRedpanda:
+	case metrics.MetricSourceRedpanda:
 		return 379
-    case metrics.MetricSourceRiakRepl:
+	case metrics.MetricSourceRiakRepl:
 		return 380
-    case metrics.MetricSourceScalr:
+	case metrics.MetricSourceScalr:
 		return 381
-    case metrics.MetricSourceSendmail:
+	case metrics.MetricSourceSendmail:
 		return 382
-    case metrics.MetricSourceSnmpwalk:
+	case metrics.MetricSourceSnmpwalk:
 		return 383
-    case metrics.MetricSourceSonarr:
+	case metrics.MetricSourceSonarr:
 		return 384
-    case metrics.MetricSourceSortdb:
+	case metrics.MetricSourceSortdb:
 		return 385
-    case metrics.MetricSourceSpeedtest:
+	case metrics.MetricSourceSpeedtest:
 		return 386
-    case metrics.MetricSourceStardog:
+	case metrics.MetricSourceStardog:
 		return 387
-    case metrics.MetricSourceStorm:
+	case metrics.MetricSourceStorm:
 		return 388
-    case metrics.MetricSourceSyncthing:
+	case metrics.MetricSourceSyncthing:
 		return 389
-    case metrics.MetricSourceTidb:
+	case metrics.MetricSourceTidb:
 		return 390
-    case metrics.MetricSourceTraefik:
+	case metrics.MetricSourceTraefik:
 		return 391
-    case metrics.MetricSourceUnbound:
+	case metrics.MetricSourceUnbound:
 		return 392
-    case metrics.MetricSourceUnifiConsole:
+	case metrics.MetricSourceUnifiConsole:
 		return 393
-    case metrics.MetricSourceUpboundUxp:
+	case metrics.MetricSourceUpboundUxp:
 		return 394
-    case metrics.MetricSourceUpsc:
+	case metrics.MetricSourceUpsc:
 		return 395
-    case metrics.MetricSourceVespa:
+	case metrics.MetricSourceVespa:
 		return 396
-    case metrics.MetricSourceWayfinder:
+	case metrics.MetricSourceWayfinder:
 		return 397
-    case metrics.MetricSourceZabbix:
+	case metrics.MetricSourceZabbix:
 		return 398
-    case metrics.MetricSourceZenohRouter:
+	case metrics.MetricSourceZenohRouter:
 		return 399
 	default:
 		return 0

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -62,6 +62,74 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceNetwork,
 		metrics.MetricSourceSnmp,
 		// Python Checks
+    	metrics.MetricSourceZenohRouter,
+    	metrics.MetricSourceZabbix,
+    	metrics.MetricSourceWayfinder,
+    	metrics.MetricSourceVespa,
+    	metrics.MetricSourceUpsc,
+    	metrics.MetricSourceUpboundUxp,
+    	metrics.MetricSourceUnifiConsole,
+    	metrics.MetricSourceUnbound,
+    	metrics.MetricSourceTraefik,
+    	metrics.MetricSourceTidb,
+    	metrics.MetricSourceSyncthing,
+    	metrics.MetricSourceStorm,
+    	metrics.MetricSourceStardog,
+    	metrics.MetricSourceSpeedtest,
+    	metrics.MetricSourceSortdb,
+    	metrics.MetricSourceSonarr,
+    	metrics.MetricSourceSnmpwalk,
+    	metrics.MetricSourceSendmail,
+    	metrics.MetricSourceScalr,
+    	metrics.MetricSourceRiakRepl,
+    	metrics.MetricSourceRedpanda,
+    	metrics.MetricSourceRedisenterprise,
+    	metrics.MetricSourceRedisSentinel,
+    	metrics.MetricSourceRebootRequired,
+    	metrics.MetricSourceRadarr,
+    	metrics.MetricSourcePurefb,
+    	metrics.MetricSourcePurefa,
+    	metrics.MetricSourcePuma,
+    	metrics.MetricSourcePortworx,
+    	metrics.MetricSourcePing,
+    	metrics.MetricSourcePihole,
+    	metrics.MetricSourcePhpOpcache,
+    	metrics.MetricSourcePhpApcu,
+    	metrics.MetricSourceOpenPolicyAgent,
+    	metrics.MetricSourceOctoprint,
+    	metrics.MetricSourceNvml,
+    	metrics.MetricSourceNs1,
+    	metrics.MetricSourceNnSdwan,
+    	metrics.MetricSourceNextcloud,
+    	metrics.MetricSourceNeutrona,
+    	metrics.MetricSourceNeo4j,
+    	metrics.MetricSourceMergify,
+    	metrics.MetricSourceLogstash,
+    	metrics.MetricSourceLighthouse,
+    	metrics.MetricSourceKernelcare,
+    	metrics.MetricSourceJfrogPlatformSelfHosted,
+    	metrics.MetricSourceHikaricp,
+    	metrics.MetricSourceGrpcCheck,
+    	metrics.MetricSourceGoPprofScraper,
+    	metrics.MetricSourceGnatsdStreaming,
+    	metrics.MetricSourceGnatsd,
+    	metrics.MetricSourceGitea,
+    	metrics.MetricSourceGatekeeper,
+    	metrics.MetricSourceFluentbit,
+    	metrics.MetricSourceFilemage,
+    	metrics.MetricSourceFilebeat,
+    	metrics.MetricSourceFiddler,
+    	metrics.MetricSourceExim,
+    	metrics.MetricSourceEventstore,
+    	metrics.MetricSourceEmqx,
+    	metrics.MetricSourceCyral,
+    	metrics.MetricSourceCybersixgillActionableAlerts,
+    	metrics.MetricSourceCloudsmith,
+    	metrics.MetricSourceCloudnatix,
+    	metrics.MetricSourceCfssl,
+    	metrics.MetricSourceBind9,
+    	metrics.MetricSourceAwsPricing,
+    	metrics.MetricSourceAqua,
 		metrics.MetricSourceKubernetesClusterAutoscaler,
 		metrics.MetricSourceTraefikMesh,
 		metrics.MetricSourceWeaviate,
@@ -640,6 +708,142 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 330
 	case metrics.MetricSourceKubernetesClusterAutoscaler:
 		return 331
+    case metrics.MetricSourceAqua:
+		return 332
+    case metrics.MetricSourceAwsPricing:
+		return 333
+    case metrics.MetricSourceBind9:
+		return 334
+    case metrics.MetricSourceCfssl:
+		return 335
+    case metrics.MetricSourceCloudnatix:
+		return 336
+    case metrics.MetricSourceCloudsmith:
+		return 337
+    case metrics.MetricSourceCybersixgillActionableAlerts:
+		return 338
+    case metrics.MetricSourceCyral:
+		return 339
+    case metrics.MetricSourceEmqx:
+		return 340
+    case metrics.MetricSourceEventstore:
+		return 341
+    case metrics.MetricSourceExim:
+		return 342
+    case metrics.MetricSourceFiddler:
+		return 343
+    case metrics.MetricSourceFilebeat:
+		return 344
+    case metrics.MetricSourceFilemage:
+		return 345
+    case metrics.MetricSourceFluentbit:
+		return 346
+    case metrics.MetricSourceGatekeeper:
+		return 347
+    case metrics.MetricSourceGitea:
+		return 348
+    case metrics.MetricSourceGnatsd:
+		return 349
+    case metrics.MetricSourceGnatsdStreaming:
+		return 350
+    case metrics.MetricSourceGoPprofScraper:
+		return 351
+    case metrics.MetricSourceGrpcCheck:
+		return 352
+    case metrics.MetricSourceHikaricp:
+		return 353
+    case metrics.MetricSourceJfrogPlatformSelfHosted:
+		return 354
+    case metrics.MetricSourceKernelcare:
+		return 355
+    case metrics.MetricSourceLighthouse:
+		return 356
+    case metrics.MetricSourceLogstash:
+		return 357
+    case metrics.MetricSourceMergify:
+		return 358
+    case metrics.MetricSourceNeo4j:
+		return 359
+    case metrics.MetricSourceNeutrona:
+		return 360
+    case metrics.MetricSourceNextcloud:
+		return 361
+    case metrics.MetricSourceNnSdwan:
+		return 362
+    case metrics.MetricSourceNs1:
+		return 363
+    case metrics.MetricSourceNvml:
+		return 364
+    case metrics.MetricSourceOctoprint:
+		return 365
+    case metrics.MetricSourceOpenPolicyAgent:
+		return 366
+    case metrics.MetricSourcePhpApcu:
+		return 367
+    case metrics.MetricSourcePhpOpcache:
+		return 368
+    case metrics.MetricSourcePihole:
+		return 369
+    case metrics.MetricSourcePing:
+		return 370
+    case metrics.MetricSourcePortworx:
+		return 371
+    case metrics.MetricSourcePuma:
+		return 372
+    case metrics.MetricSourcePurefa:
+		return 373
+    case metrics.MetricSourcePurefb:
+		return 374
+    case metrics.MetricSourceRadarr:
+		return 375
+    case metrics.MetricSourceRebootRequired:
+		return 376
+    case metrics.MetricSourceRedisSentinel:
+		return 377
+    case metrics.MetricSourceRedisenterprise:
+		return 378
+    case metrics.MetricSourceRedpanda:
+		return 379
+    case metrics.MetricSourceRiakRepl:
+		return 380
+    case metrics.MetricSourceScalr:
+		return 381
+    case metrics.MetricSourceSendmail:
+		return 382
+    case metrics.MetricSourceSnmpwalk:
+		return 383
+    case metrics.MetricSourceSonarr:
+		return 384
+    case metrics.MetricSourceSortdb:
+		return 385
+    case metrics.MetricSourceSpeedtest:
+		return 386
+    case metrics.MetricSourceStardog:
+		return 387
+    case metrics.MetricSourceStorm:
+		return 388
+    case metrics.MetricSourceSyncthing:
+		return 389
+    case metrics.MetricSourceTidb:
+		return 390
+    case metrics.MetricSourceTraefik:
+		return 391
+    case metrics.MetricSourceUnbound:
+		return 392
+    case metrics.MetricSourceUnifiConsole:
+		return 393
+    case metrics.MetricSourceUpboundUxp:
+		return 394
+    case metrics.MetricSourceUpsc:
+		return 395
+    case metrics.MetricSourceVespa:
+		return 396
+    case metrics.MetricSourceWayfinder:
+		return 397
+    case metrics.MetricSourceZabbix:
+		return 398
+    case metrics.MetricSourceZenohRouter:
+		return 399
 	default:
 		return 0
 	}

--- a/releasenotes/notes/python_metrics_origins_community-c64eea75352e9d98.yaml
+++ b/releasenotes/notes/python_metrics_origins_community-c64eea75352e9d98.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Add metric origins for community Python integrations.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This is a follow-up to [this PR](https://github.com/DataDog/datadog-agent/pull/25051), making the same addition for community python checks.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
`OriginSubProduct` and `OriginProductDetail` can be viewed using [scott's proxy-dumper](https://github.com/DataDog/datadog-agent-benchmarks/tree/main/docker/proxy-dumper).
Run the proxy-dumper and change dd_url to http://localhost:8081/.
Run the agent.
See that the correct `OriginSubProduct` and `OriginProductDetail` values being populated for the checks
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
