### PR TITLE
[workloadmeta/store] Fix filters that match entities

### DIFF
--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -689,9 +689,15 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 
 		for _, sub := range w.subscribers {
 			filter := sub.filter
-			if !filter.MatchEntity(&ev.Entity) || !filter.MatchSource(ev.Source) || !filter.MatchEventType(ev.Type) {
+
+			// Notice that we cannot call filter.MatchEntity() here because
+			// the entity included in the event might be incomplete if it's
+			// an unset event. Some collectors only send the entity ID in
+			// unset events, for example. The call to filter.MatchEntity()
+			// is done below using the cached entity.
+			if !filter.MatchSource(ev.Source) || !filter.MatchEventType(ev.Type) {
 				// event should be filtered out because it
-				// doesn't match the filter
+				// doesn't match the filter.
 				continue
 			}
 
@@ -705,6 +711,10 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 			}
 
 			entity := cachedEntity.get(filter.Source())
+			if !filter.MatchEntity(&entity) {
+				continue
+			}
+
 			if isEventTypeSet {
 				filteredEvents[sub] = append(filteredEvents[sub], wmdef.Event{
 					Type:   wmdef.EventTypeSet,


### PR DESCRIPTION

### What does this PR do?

Fixes a bug in the workloadmeta store. It was not working correctly for filters that match entities, like `workloadmeta.IsNodeMetadata` used by the metadata controller.

I've set the no-changelog label because this doesn't affect any released versions.

### Describe how to test/QA your changes

Skip. It's a bit difficult to test this case manually, but I added a unit test that should cover it.
