### PR TITLE
[USM] classification test: HTTPS: remove source of flakiness

### DIFF
--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -527,9 +527,6 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				cmd := ctx.extras["cmd"].(*exec.Cmd)
 				goTLSAttachPID(t, cmd.Process.Pid)
-				t.Cleanup(func() {
-					goTLSDetachPID(t, cmd.Process.Pid)
-				})
 
 				client := &nethttp.Client{
 					Transport: &nethttp.Transport{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR aims to fix the flakiness added by #27054.

The flakiness is caused by a race between the process monitor and our manual detaching of the server binary. When the tracer starts, the process monitor asynchronously goes through existing processes, in order of PID, to see if these can be hooked by our TLS hooks.

However, it can happen that, when the process monitor reaches the server process in that initial scan, the test itself already went through its course, and is doing its cleanup, leading to the following timeline of events:

- Test & process monitor starts existing processes scan.
- Server process manually attached
- Test runs & succeeds
- Cleanup starts
- Server process is manually detached.
- Server process is attached by process scan.
- Assertion of the "manual detaching" for the process to not be traced anymore fails.

The fix is simply to not use manual detaching. Since this protocol only has one test, the tracer will be started & stopped between each runs (for the different NAT modes), rendering the need for manual detach unneeded as it will be done during the process monitor cleanup. We still keep the manual attach, since we add failure due to the process monitor not attaching fast enough in the past.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is not solving all of the flakiness, but should reduce it. There is rarer but still present issue that is being investigated and affects more than this test.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
