### PR TITLE
feat(dogstatsd): implement local data header

### DIFF
--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -36,11 +36,19 @@ var (
 	colonSeparator = []byte(":")
 	commaSeparator = []byte(",")
 
-	// containerIDFieldPrefix is the prefix for a common field holding the sender's container ID
-	containerIDFieldPrefix = []byte("c:")
+	// LocalDataPrefix is the prefix for a common field which contains the local data for Origin Detection.
+	// The Local Data is a list that can contain one or two (split by a ',') of either:
+	// * "cid-<container-id>" or "ci-<container-id>" for the container ID.
+	// * "in-<cgroupv2-inode>" for the cgroupv2 inode.
+	// Possible values:
+	// * "cid-<container-id>"
+	// * "ci-<container-id>,in-<cgroupv2-inode>"
+	LocalDataPrefix = []byte("c:")
 
-	// containerInodeFieldPrefix is the prefix for a notation holding the sender's container Inode in the containerIDField
-	containerIDFieldInodePrefix = []byte("in-")
+	// containerIDPrefix is the prefix for a notation holding the sender's container Inode in the containerIDField
+	containerIDPrefix = []byte("ci-")
+	// inodePrefix is the prefix for a notation holding the sender's container Inode in the containerIDField
+	inodePrefix = []byte("in-")
 )
 
 // parser parses dogstatsd messages
@@ -194,8 +202,8 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			}
 			timestamp = time.Unix(ts, 0)
 		// container ID
-		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, containerIDFieldPrefix):
-			containerID = p.extractContainerID(optionalField)
+		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+			containerID = p.resolveContainerIDFromLocalData(optionalField)
 		}
 	}
 
@@ -249,28 +257,66 @@ func (p *parser) parseFloat64List(rawFloats []byte) ([]float64, error) {
 	return values, nil
 }
 
-// extractContainerID parses the value of the container ID field.
-// If the field is prefixed by `in-`, it corresponds to the cgroup controller's inode of the source
-// and is used for ContainerID resolution.
-func (p *parser) extractContainerID(rawContainerIDField []byte) []byte {
-	containerIDField := rawContainerIDField[len(containerIDFieldPrefix):]
+// resolveContainerIDFromLocalData returns the container ID for the given Local Data.
+// The Local Data is a list that can contain one or two (split by a ',') of either:
+// * "ci-<container-id>" for the container ID.
+// * "in-<cgroupv2-inode>" for the cgroupv2 inode.
+// Possible values:
+// * "<container-id>"
+// * "ci-<container-id>"
+// * "ci-<container-id>,in-<cgroupv2-inode>"
+func (p *parser) resolveContainerIDFromLocalData(RawLocalData []byte) []byte {
+	// Remove prefix from Local Data
+	LocalData := RawLocalData[len(LocalDataPrefix):]
 
-	if bytes.HasPrefix(containerIDField[:len(containerIDFieldInodePrefix)], containerIDFieldInodePrefix) {
-		inodeField, err := strconv.ParseUint(string(containerIDField[len(containerIDFieldPrefix)+1:]), 10, 64)
-		if err != nil {
-			log.Debugf("Failed to parse inode from %s, got %v", containerIDField, err)
-			return nil
-		}
+	var containerID []byte
+	var containerIDFromInode []byte
 
-		containerID, err := p.provider.GetMetaCollector().GetContainerIDForInode(inodeField, cacheValidity)
-		if err != nil {
-			log.Debugf("Failed to get container ID, got %v", err)
-			return nil
+	if bytes.Contains(LocalData, []byte(",")) {
+		// The Local Data can contain a list
+		items := bytes.Split(LocalData, []byte{','})
+		for _, item := range items {
+			if bytes.HasPrefix(item, containerIDPrefix) {
+				containerID = item[len(containerIDPrefix):]
+			} else if bytes.HasPrefix(item, inodePrefix) {
+				containerIDFromInode = p.resolveContainerIDFromInode(item[len(inodePrefix):])
+			}
 		}
-		return []byte(containerID)
+		if containerID == nil {
+			containerID = containerIDFromInode
+		}
+	} else {
+		// The Local Data can contain a single value
+		if bytes.HasPrefix(LocalData, containerIDPrefix) { // Container ID with new format: ci-<container-id>
+			containerID = LocalData[len(containerIDPrefix):]
+		} else if bytes.HasPrefix(LocalData, inodePrefix) { // Cgroupv2 inode format: in-<cgroupv2-inode>
+			containerID = p.resolveContainerIDFromInode(LocalData[len(inodePrefix):])
+		} else { // Container ID with old format: <container-id>
+			containerID = LocalData
+		}
 	}
 
-	return containerIDField
+	if containerID == nil {
+		log.Debugf("Could not parse container ID from Local Data: %s", LocalData)
+	}
+
+	return containerID
+}
+
+// resolveContainerIDFromInode returns the container ID for the given cgroupv2 inode.
+func (p *parser) resolveContainerIDFromInode(inode []byte) []byte {
+	inodeField, err := strconv.ParseUint(string(inode), 10, 64)
+	if err != nil {
+		log.Debugf("Failed to parse inode from %s, got %v", inode, err)
+		return nil
+	}
+
+	containerID, err := p.provider.GetMetaCollector().GetContainerIDForInode(inodeField, cacheValidity)
+	if err != nil {
+		log.Debugf("Failed to get container ID, got %v", err)
+		return nil
+	}
+	return []byte(containerID)
 }
 
 // the std API does not have methods to do []byte => float parsing

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -163,8 +163,8 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 		newEvent.alertType, err = parseEventAlertType(optionalField[len(eventAlertTypePrefix):])
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
-	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, containerIDFieldPrefix):
-		newEvent.containerID = p.extractContainerID(optionalField)
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+		newEvent.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	}
 	if err != nil {
 		return event, err

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -97,8 +97,8 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 		newServiceCheck.tags = p.parseTags(optionalField[len(serviceCheckTagsPrefix):])
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
-	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, containerIDFieldPrefix):
-		newServiceCheck.containerID = p.extractContainerID(optionalField)
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+		newServiceCheck.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	}
 	if err != nil {
 		return serviceCheck, err


### PR DESCRIPTION
### What does this PR do?

Implements the new local data header format for DogStatsD.

### Motivation

This is needed to implement the New Origin Detection Spec.

### Describe how to test/QA your changes

* Deploy the Agent on Kubernetes and this application
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
    spec:
      containers:
      - name: datadogpy
        image: wdhifdatadog/datadogpy
        imagePullPolicy: Always
        env:
        - name: DD_DOGSTATSD_URL
          value: /var/run/datadog/dsd.socket
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_ENTITY_ID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
        volumeMounts:
        - mountPath: /var/run/datadog
          name: dogstatsd-socket
      volumes:
      - name: dogstatsd-socket
        hostPath:
          path: /var/run/datadog/
```
Note that you will need to deploy the Agent with the `DD_ORIGIN_DETECTION_UNIFIED` setting activated to have a working Origin Detection.

The [wdhifdatadog/datadogpy](https://hub.docker.com/r/wdhifdatadog/datadogpy) application implements a traced Python application with a modified version of datadogpy that uses the new local data header format.

The code that generate those metrics is as follows:
```
➜  datadogpy git:(main) ✗ cat udp.py
#!/usr/bin/env python3

from datadog import initialize, statsd
import time
import os

options = {
    'statsd_host': os.environ.get("DD_AGENT_HOST"),
    'statsd_port': 8125
}

initialize(**options)

while(1):
  statsd.increment('dummy_dsd_udp_python.increment', tags=["environment:wdhif"])
  statsd.decrement('dummy_dsd_udp_python.decrement', tags=["environment:wdhif", "dd.internal.card:low"])
  time.sleep(2)
➜  datadogpy git:(main) ✗ cat uds.py
#!/usr/bin/env python3

from datadog import initialize, statsd
import time
import os

options = {
    'statsd_socket_path': os.environ.get("DD_DOGSTATSD_URL"),
}

initialize(**options)

while(1):
  statsd.increment('dummy_dsd_uds_python.increment', tags=["environment:wdhif"])
  statsd.decrement('dummy_dsd_uds_python.decrement', tags=["environment:wdhif"])
  time.sleep(2)
```

* Verify that you are getting valid traces

![image](https://github.com/DataDog/datadog-agent/assets/5231539/9b0d3493-cc3c-4ab2-b0d8-da4dad68f8ea)