### PR TITLE
[workloadmeta/store_test] Delete duplicate assert

### DIFF
--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -695,7 +695,6 @@ func TestSubscribe(t *testing.T) {
 
 			<-doneCh
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION

### What does this PR do?

This PR is a small cleanup. It just deletes a duplicate assert in `comp/core/workloadmeta/impl/store_test.go`.


### Describe how to test/QA your changes

Skip.
