### PR TITLE
[PROCS-4184] Skip realtime payloads in process and container aggregator in fake-intake

### DIFF
--- a/test/fakeintake/aggregator/containerAggregator.go
+++ b/test/fakeintake/aggregator/containerAggregator.go
@@ -44,6 +44,9 @@ func ParseContainerPayload(payload api.Payload) ([]*ContainerPayload, error) {
 	switch m := msg.Body.(type) {
 	case *agentmodel.CollectorContainer:
 		return []*ContainerPayload{{CollectorContainer: *m, collectedTime: payload.Timestamp}}, nil
+	case *agentmodel.CollectorContainerRealTime:
+		// skip real-time payloads
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected type %s", msg.Header.Type)
 	}

--- a/test/fakeintake/aggregator/containerAggregator.go
+++ b/test/fakeintake/aggregator/containerAggregator.go
@@ -45,7 +45,7 @@ func ParseContainerPayload(payload api.Payload) ([]*ContainerPayload, error) {
 	case *agentmodel.CollectorContainer:
 		return []*ContainerPayload{{CollectorContainer: *m, collectedTime: payload.Timestamp}}, nil
 	case *agentmodel.CollectorContainerRealTime:
-		// skip real-time payloads
+		// PROCS-4185 - skip real-time payloads
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected type %s", msg.Header.Type)

--- a/test/fakeintake/aggregator/processAggregator.go
+++ b/test/fakeintake/aggregator/processAggregator.go
@@ -45,7 +45,7 @@ func ParseProcessPayload(payload api.Payload) ([]*ProcessPayload, error) {
 	case *agentmodel.CollectorProc:
 		return []*ProcessPayload{{CollectorProc: *m, collectedTime: payload.Timestamp}}, nil
 	case *agentmodel.CollectorRealTime:
-		// skip real-time payloads
+		// PROCS-4185 - skip real-time payloads
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected type %s", msg.Header.Type)

--- a/test/fakeintake/aggregator/processAggregator.go
+++ b/test/fakeintake/aggregator/processAggregator.go
@@ -44,6 +44,9 @@ func ParseProcessPayload(payload api.Payload) ([]*ProcessPayload, error) {
 	switch m := msg.Body.(type) {
 	case *agentmodel.CollectorProc:
 		return []*ProcessPayload{{CollectorProc: *m, collectedTime: payload.Timestamp}}, nil
+	case *agentmodel.CollectorRealTime:
+		// skip real-time payloads
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected type %s", msg.Header.Type)
 	}


### PR DESCRIPTION
### What does this PR do?
This skips aggregating any realtime payloads to avoid flakiness in the k8s e2e tests as the environment is dual shipping to fake-intake and a live backend which enables RT mode.

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4184

### Additional Notes
Will have a follow-up PR to remove marking the [test](https://github.com/DataDog/datadog-agent/blob/97c9cc0693a16d9d9aa259ca49860998498b93ff/test/new-e2e/tests/process/k8s_test.go#L86) as flaky after a few days

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
