### PR TITLE
AMLII-1830 Fix Flaky UDP tests

### DIFF
--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -224,31 +224,13 @@ func TestUDPReceive(t *testing.T) {
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
 	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
-
-	readyChan := make(chan struct{}) // Create a channel to signal readiness
-	timeout := time.After(10 * time.Second)
-
-	go func() {
-		s.Listen()       // Start listening in a goroutine
-		close(readyChan) // Signal readiness by closing the channel
-	}()
-
-	select {
-	case <-readyChan:
-		// Server is ready, proceed with assertions
-		assert.Nil(t, err)
-		assert.NotNil(t, s, "Failed to create UDP listener")
-		// Dial udp port
-		conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
-		assert.Nil(t, err)
-		assert.NotNilf(t, conn, "Failed to connect to dogstatsd udp port 127.0.0.1:%d", port)
-		defer conn.Close()
-		// Send contents
-		_, err = conn.Write(contents)
-		assert.Nil(t, err)
-	case <-timeout:
-		require.FailNow(t, "Timeout: Server did not start listening within the expected time")
-	}
+	assert.Nil(t, err)
+	require.NotNil(t, s)
+	conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
+	assert.Nil(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+	conn.Write(contents)
 
 	defer s.Stop()
 

--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -224,7 +224,7 @@ func TestUDPReceive(t *testing.T) {
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
 	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	require.NotNil(t, s)
 	s.Listen()
 	defer s.Stop()

--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -224,14 +224,17 @@ func TestUDPReceive(t *testing.T) {
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
 	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
-	require.NotNil(t, s)
-	assert.Nil(t, err)
-
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Nil(t, err)
+		assert.NotNil(t, s, "Failed to create UDP listener")
+	}, 2*time.Minute, 2*time.Second)
 	s.Listen()
 	defer s.Stop()
 	conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
-	require.NotNil(t, conn)
-	assert.Nil(t, err)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Nil(t, err)
+		assert.NotNilf(t, conn, "Failed to connect to dogstatsd udp port 127.0.0.1:%d", port)
+	}, 2*time.Minute, 2*time.Second)
 	defer conn.Close()
 	conn.Write(contents)
 

--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -226,13 +226,13 @@ func TestUDPReceive(t *testing.T) {
 	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
 	assert.Nil(t, err)
 	require.NotNil(t, s)
+	s.Listen()
+	defer s.Stop()
 	conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	assert.Nil(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()
 	conn.Write(contents)
-
-	defer s.Stop()
 
 	select {
 	case pkts := <-packetChannel:

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -503,8 +503,8 @@ func TestUDPForward(t *testing.T) {
 	requireStart(t, deps.Server)
 
 	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
-	assert.NoError(t, err)
-	require.NotNilf(t, conn, "Failed to connect to UDP local address %s", err)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
 	defer conn.Close()
 
 	// Check if message is forwarded
@@ -512,7 +512,7 @@ func TestUDPForward(t *testing.T) {
 
 	conn.Write(message)
 
-	pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+	pc.SetReadDeadline(time.Now().Add(4 * time.Second))
 
 	buffer := make([]byte, len(message))
 	_, _, err = pc.ReadFrom(buffer)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -503,10 +503,8 @@ func TestUDPForward(t *testing.T) {
 	requireStart(t, deps.Server)
 
 	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.NoError(t, err)
-		assert.NotNilf(t, conn, "Failed to connect to UDP local address %s", err)
-	}, 2*time.Minute, 2*time.Second)
+	assert.NoError(t, err)
+	require.NotNilf(t, conn, "Failed to connect to UDP local address %s", err)
 	defer conn.Close()
 
 	// Check if message is forwarded

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -503,7 +503,10 @@ func TestUDPForward(t *testing.T) {
 	requireStart(t, deps.Server)
 
 	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
-	require.NoError(t, err, "cannot connect to DSD socket")
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(t, err)
+		assert.NotNilf(t, conn, "Failed to connect to UDP local address %s", err)
+	}, 2*time.Minute, 2*time.Second)
 	defer conn.Close()
 
 	// Check if message is forwarded


### PR DESCRIPTION
### What does this PR do?
This PR add retries for some flaky tests in case a server or listener is not ready yet before testing.

### Motivation
We got some reports on flaky tests here:
[TestUDPReceive](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fcomp%2Fdogstatsd%2Flisteners.TestUDPReceive%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AgAAAY_pDASOFxciWQAAAAAAAAAYAAAAAEFZX3BEQVNPQUFERGtZeDQzMGFrV0tIMQAAACQAAAAAMDE4ZmU5MTMtMzA1Zi00MDkzLWIxYzEtMTIxMTkyZTI5YTBl&fromUser=false&index=citest&testId=AgAAAY_pDASOFxciWQAAAAAAAAAYAAAAAEFZX3BEQVNPQUFERGtZeDQzMGFrV0tIMQAAACQAAAAAMDE4ZmU5MTMtMzA1Zi00MDkzLWIxYzEtMTIxMTkyZTI5YTBl&trace=AgAAAY_pDASOFxciWQAAAAAAAAAYAAAAAEFZX3BEQVNPQUFERGtZeDQzMGFrV0tIMQAAACQAAAAAMDE4ZmU5MTMtMzA1Zi00MDkzLWIxYzEtMTIxMTkyZTI5YTBl&start=1717011459544&end=1719603459544&paused=false)

[TestUDPForward](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.name%3ATestUDPForward&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AgAAAZAyF926Pdo5XQAAAAAAAAAYAAAAAEFaQXlGOTI2QUFDOHlmRHBqdThYRHI2OQAAACQAAAAAMDE5MDMyMjMtNjk5ZC00M2JkLWE1YWQtYjE2ZjVmZDliNTk1&fromUser=false&index=citest&testId=AgAAAZAyF926Pdo5XQAAAAAAAAAYAAAAAEFaQXlGOTI2QUFDOHlmRHBqdThYRHI2OQAAACQAAAAAMDE5MDMyMjMtNjk5ZC00M2JkLWE1YWQtYjE2ZjVmZDliNTk1&trace=AgAAAZAyF926Pdo5XQAAAAAAAAAYAAAAAEFaQXlGOTI2QUFDOHlmRHBqdThYRHI2OQAAACQAAAAAMDE5MDMyMjMtNjk5ZC00M2JkLWE1YWQtYjE2ZjVmZDliNTk1&start=1717011605442&end=1719603605442&paused=false)