### PR TITLE
kube_metadata: Get metadata/labels once per namespace

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -207,6 +207,10 @@ func (c *collector) parsePods(
 		}
 	}
 
+	// To get metadata/labels once per namespace.
+	metadataByNS := make(map[string]*clusteragent.Metadata)
+	labelsByNS := make(map[string]map[string]string)
+
 	for _, pod := range pods {
 		if pod.Metadata.UID == "" {
 			continue
@@ -238,10 +242,14 @@ func (c *collector) parsePods(
 
 		if c.isDCAEnabled() && c.dcaClient.SupportsNamespaceMetadataCollection() {
 			// Cluster agent with version 7.55+
-			var nsMetadata *clusteragent.Metadata
-			nsMetadata, err = c.getNamespaceMetadata(pod.Metadata.Namespace)
-			if err != nil {
-				log.Errorf("Could not fetch namespace metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+			nsMetadata, ok := metadataByNS[pod.Metadata.Namespace]
+			if !ok {
+				nsMetadata, err = c.getNamespaceMetadata(pod.Metadata.Namespace)
+				if err == nil {
+					metadataByNS[pod.Metadata.Namespace] = nsMetadata
+				} else {
+					log.Errorf("Could not fetch namespace metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+				}
 			}
 
 			if nsMetadata != nil {
@@ -255,9 +263,15 @@ func (c *collector) parsePods(
 			}
 		} else {
 			// Cluster agent with version older than 7.55
-			nsLabels, err = c.getNamespaceLabels(pod.Metadata.Namespace)
-			if err != nil {
-				log.Errorf("Could not fetch namespace labels for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+			var ok bool
+			nsLabels, ok = labelsByNS[pod.Metadata.Namespace]
+			if !ok {
+				nsLabels, err = c.getNamespaceLabels(pod.Metadata.Namespace)
+				if err == nil {
+					labelsByNS[pod.Metadata.Namespace] = nsLabels
+				} else {
+					log.Errorf("Could not fetch namespace labels for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+				}
 			}
 
 			if c.collectNamespaceAnnotations {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use cache when `workloadmeta-kube_metadata` gets namespace metadata.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

CONS-6403

Improving the `kubemetadata.(*collector).parsePods()` performance.

Currently, when `workloadmeta-kube_metadata` parses 100 Pods, the implementation results in 100 communications with the DCA to retrieve namespace metadata. Since the namespace metadata is the same for multiple Pods, there is no need to communicate with the DCA for each Pod.

https://github.com/DataDog/datadog-agent/blob/1248ec4f0bece8d46a33f20ff1447c7de7be6706/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go#L210-L293

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- Cache expiration is same as `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` (= 60s by default).

https://github.com/DataDog/datadog-agent/blob/1cf1cce4b5711e0929b4eca8d3fd1c51cf3b8a4c/pkg/config/setup/config.go#L1499

- DCAClient doesn't use cache for the following functions.

https://github.com/DataDog/datadog-agent/blob/a9f51824ae913c875c8c39f187aa91b124b99de2/pkg/util/clusteragent/clusteragent.go#L405-L417

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
