### PR TITLE
Avoid division by zero when sending `datadog.trace_agent.receiver.out_chan_fill`

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -692,7 +692,11 @@ func (r *HTTPReceiver) loop() {
 			r.watchdog(now)
 		case now := <-t.C:
 			_ = r.statsd.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
-			_ = r.statsd.Gauge("datadog.trace_agent.receiver.out_chan_fill", float64(len(r.out))/float64(cap(r.out)), nil, 1)
+			if cap(r.out) == 0 {
+				_ = r.statsd.Gauge("datadog.trace_agent.receiver.out_chan_fill", 0, []string{"is_trace_buffer_set:false"}, 1)
+			} else if cap(r.out) > 0 {
+				_ = r.statsd.Gauge("datadog.trace_agent.receiver.out_chan_fill", float64(len(r.out))/float64(cap(r.out)), []string{"is_trace_buffer_set:true"}, 1)
+			}
 
 			// We update accStats with the new stats we collected
 			accStats.Acc(r.Stats)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Avoid division by zero when sending `datadog.trace_agent.receiver.out_chan_fill`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

To surpress noisy debug logs.

Unless [DD_APM_TRACE_BUFFER](https://github.com/DataDog/datadog-agent/blob/1248ec4f0bece8d46a33f20ff1447c7de7be6706/pkg/config/config_template.yaml#L1396-L1410) is set, this debug will be printed repeatedly.
Besides, [DD_APM_TRACE_BUFFER](https://github.com/DataDog/datadog-agent/blob/1248ec4f0bece8d46a33f20ff1447c7de7be6706/pkg/config/config_template.yaml#L1396-L1410) is 0 by default and it is not recommended to use.

```
2024-06-30 11:59:21 UTC | TRACE | INFO | (pkg/trace/agent/agent.go:106 in NewAgent) | Starting Agent with processor trace buffer of size 0
...
2024-06-30 22:27:17 UTC | CORE | DEBUG | (pkg/aggregator/time_sampler.go:105 in sample) | TimeSampler #0 Ignoring sample 'datadog.trace_agent.receiver.out_chan_fill' on host 'i-09df1e4674d40f561' and tags '[version:7.56.0-devel+git.532.8275bd4]': sample with value 'NaN'"
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- When `DD_APM_TRACE_BUFFER` is zero(default), `is_trace_buffer_set:false` is set to the metrics.
- When `DD_APM_TRACE_BUFFER` is greater than 0, `is_trace_buffer_set:true` is set to the metrics.

![2024-07-01_10-22-45](https://github.com/DataDog/datadog-agent/assets/41987730/8b16e088-4921-4205-bc22-da9bb8850652)

