### PR TITLE
fix(trigger_child_pipeline): Add a new `timeout` argument to fail fast in case of issue

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -23,7 +23,7 @@
       fi
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
-    - "inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main --timeout 1800
       --variable IMG_VARIABLES
       --variable IMG_REGISTRIES
       --variable IMG_SOURCES

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -10,7 +10,7 @@ test_install_script:
     - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
     - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - "inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref main
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref main --timeout 5400
       --variable TESTING_APT_URL
       --variable TESTING_YUM_URL
       --variable TEST_PIPELINE_ID"

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -31,7 +31,7 @@ docker_trigger_internal:
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600
       --variable IMAGE_VERSION
       --variable IMAGE_NAME
       --variable RELEASE_TAG
@@ -78,7 +78,7 @@ docker_trigger_cluster_agent_internal:
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600
       --variable IMAGE_VERSION
       --variable IMAGE_NAME
       --variable RELEASE_TAG
@@ -125,7 +125,7 @@ docker_trigger_cws_instrumentation_internal:
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
-    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600
       --variable IMAGE_VERSION
       --variable IMAGE_NAME
       --variable RELEASE_TAG

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -461,8 +461,8 @@ def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True)
 
     if follow:
         print("Waiting for child pipeline to finish...", flush=True)
-
-        wait_for_pipeline(repo, pipeline, pipeline_finish_timeout_sec=2700)
+        # Job timeout is 2h
+        wait_for_pipeline(repo, pipeline, pipeline_finish_timeout_sec=7200)
 
         # Check pipeline status
         refresh_pipeline(pipeline)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -401,7 +401,7 @@ def wait_for_pipeline_from_ref(repo: Project, ref):
 
 
 @task(iterable=['variable'])
-def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True):
+def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True, timeout=7200):
     """
     Trigger a child pipeline on a target repository and git ref.
     Used in CI jobs only (requires CI_JOB_TOKEN).
@@ -410,6 +410,8 @@ def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True)
     You can pass the argument multiple times for each new variable you wish to forward
 
     Use --follow to make this task wait for the pipeline to finish, and return 1 if it fails. (requires GITLAB_TOKEN).
+
+    Use --timeout to set up a timeout shorter than the default 2 hours, to anticipate failures if any.
 
     Examples:
     inv pipeline.trigger-child-pipeline --git-ref "main" --project-name "DataDog/agent-release-management" --variable "RELEASE_VERSION"
@@ -461,8 +463,7 @@ def trigger_child_pipeline(_, git_ref, project_name, variable=None, follow=True)
 
     if follow:
         print("Waiting for child pipeline to finish...", flush=True)
-        # Job timeout is 2h
-        wait_for_pipeline(repo, pipeline, pipeline_finish_timeout_sec=7200)
+        wait_for_pipeline(repo, pipeline, pipeline_finish_timeout_sec=timeout)
 
         # Check pipeline status
         refresh_pipeline(pipeline)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add a new `timeout` variable to be able to finish jobs earlier if jobs are stuck (fail fast)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Initially the pipeline timeout when using the CLI was 5h. As we have a maximum timeout of 2h per gitlab job definition the `trigger-child-pipeline` timeout should be 2h at maximum.
Looking at the maximum duration of the following pipeline
- [agent-release-management](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fagent-release-management%20%40ci.pipeline.name%3ADataDog%2Fagent-release-management%20%40ci.provider.instance%3Agitlab-ci%20%40git.branch%3Amain%20%40ci.pipeline.fingerprint%3AtBuFoSLT9_ks%20%40gitlab.upstream.project%3A%22DataDog%2Fagent-release-management%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&cipipeline_explorer_sort=%40duration%2Cdesc&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&fromUser=false&index=cipipeline&viz=stream&start=1717242365913&end=1719834365913&paused=false)
- [agent-linux-install-script](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fagent-linux-install-script%20%40ci.pipeline.name%3ADataDog%2Fagent-linux-install-script%20%40ci.provider.instance%3Agitlab-ci%20%40git.branch%3Amain%20%40gitlab.upstream.project%3A%22DataDog%2Fdatadog-agent%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&cipipeline_explorer_sort=%40duration%2Cdesc&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&fromUser=false&index=cipipeline&viz=stream&start=1717242539245&end=1719834539245&paused=false)
- [Images](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fimages%20%40ci.pipeline.name%3ADataDog%2Fimages%20%40ci.provider.instance%3Agitlab-ci%20%40git.branch%3Amaster%20%40gitlab.upstream.project%3A%22DataDog%2Fdatadog-agent%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&cipipeline_explorer_sort=%40duration%2Cdesc&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&fromUser=false&index=cipipeline&viz=stream&start=1717243019391&end=1719835019391&paused=false)
- [public-images](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fpublic-images%20%40ci.pipeline.name%3ADataDog%2Fpublic-images%20%40ci.provider.instance%3Agitlab-ci%20%40git.branch%3Amain%20%40gitlab.upstream.project%3A%22DataDog%2Fdatadog-agent%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&cipipeline_explorer_sort=%40duration%2Cdesc&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&fromUser=false&index=cipipeline&viz=stream&start=1717243126421&end=1719835126421&paused=false)
- [k8s-datadog-agent-ops](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fk8s-datadog-agent-ops%20%40ci.pipeline.name%3ADataDog%2Fk8s-datadog-agent-ops%20%40ci.provider.instance%3Agitlab-ci%20%40git.branch%3Amain%20%40gitlab.upstream.project%3A%22DataDog%2Fk8s-datadog-agent-ops%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&cipipeline_explorer_sort=%40duration%2Cdesc&cols=%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name%2C%40git.branch%2C%40ci_stages&fromUser=false&index=cipipeline&viz=stream&start=1717243679278&end=1719835679278&paused=false) 

We call the invoke task with more restricted timeouts when possible
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
