### PR TITLE
[FA] Wait for sock to be ready

### DIFF
--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -153,9 +153,13 @@ func (h *Host) WaitForUnitActivating(units ...string) {
 }
 
 // WaitForFileExists waits for a file to exist on the host
-func (h *Host) WaitForFileExists(filePaths ...string) {
+func (h *Host) WaitForFileExists(useSudo bool, filePaths ...string) {
+	sudo := ""
+	if useSudo {
+		sudo = "sudo"
+	}
 	for _, path := range filePaths {
-		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! sudo -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path))
+		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! %s -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path, sudo))
 		require.NoError(h.t, err, "file %s did not exist", path)
 	}
 }

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -155,7 +155,7 @@ func (h *Host) WaitForUnitActivating(units ...string) {
 // WaitForFileExists waits for a file to exist on the host
 func (h *Host) WaitForFileExists(filePaths ...string) {
 	for _, path := range filePaths {
-		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path))
+		_, err := h.remote.Execute(fmt.Sprintf("timeout=30; file=%s; while [ ! sudo -f $file ] && [ $timeout -gt 0 ]; do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]", path))
 		require.NoError(h.t, err, "file %s did not exist", path)
 	}
 }

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -75,6 +75,8 @@ func (s *upgradeScenarioSuite) TestUpgradeSuccessful() {
 		"datadog-installer.service",
 	)
 
+	s.host.WaitForFileExists("/var/run/datadog-installer/installer.sock")
+
 	_, err := s.setCatalog(testCatalog)
 	require.NoError(s.T(), err)
 

--- a/test/new-e2e/tests/installer/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/upgrade_scenario_test.go
@@ -75,7 +75,7 @@ func (s *upgradeScenarioSuite) TestUpgradeSuccessful() {
 		"datadog-installer.service",
 	)
 
-	s.host.WaitForFileExists("/var/run/datadog-installer/installer.sock")
+	s.host.WaitForFileExists(true, "/var/run/datadog-installer/installer.sock")
 
 	_, err := s.setCatalog(testCatalog)
 	require.NoError(s.T(), err)
@@ -124,7 +124,7 @@ func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) (string, error) {
 
 func (s *upgradeScenarioSuite) assertSuccessfulStartExperiment(timestamp host.JournaldTimestamp, version string) {
 	s.host.WaitForUnitActivating(agentUnitXP)
-	s.host.WaitForFileExists("/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
+	s.host.WaitForFileExists(false, "/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
 	// Assert experiment is running
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Wait for socket to be ready before running the catalog command

This is a flakiness only happening during testing, because we ask for a catalog change

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
