### PR TITLE
Disable broken e2e tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -157,8 +157,11 @@ new-e2e-containers:
     TEAM: container-integrations
   parallel:
     matrix:
-      - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
-      - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.22"
+      # Temporarily disable old version of Kubernetes
+      # On those versions, the SSI admission controller injects a lib
+      # that breaks alpine images.
+      # - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
+      # - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.22"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.27"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:20.04"


### PR DESCRIPTION
### What does this PR do?

Temporarily disable the `Kind` e2e tests on oldest versions of Kubernetes because of an issue still under investigation.

### Motivation

On those oldest versions of Kubernetes, the cluster-agent admission controller is injecting a continuous profiler library that is breaking the `alpine`-based containers.
It makes them fail with:
```
Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so)
Error relocating /datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so: __strdup: symbol not found
```

### Additional Notes

https://dd.slack.com/archives/CLWN64GAW/p1719500225503479

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
