### PR TITLE
fix(serverless/appsec): language runtime proxy not started if no API Key is available

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -138,7 +138,11 @@ func runAgent() {
 			log.Errorf("Can't start Lambda Runtime API Proxy for AppSec: %v", err)
 		}
 		if shutdownAppSec != nil {
-			defer shutdownAppSec(ctx)
+			defer func() {
+				if err := shutdownAppSec(ctx); err != nil {
+					log.Warnf("Failed to shut down AppSec proxy: %v", err)
+				}
+			}()
 		}
 
 		// we still need to register the extension but let's return after (no-op)


### PR DESCRIPTION
### What does this PR do?

This changes the no-op behavior to also start the AppSec language runtime API proxy to satisfy the function configuration; if AppSec would have started in normal conditions (with an API key).

### Motivation

When no Datadog API key is available (either because it is not configured, or because it cannot be accessed/decrypted), the Serverless agent runs in "no-op" mode. However in this case, the language runtime proxy is never started, even though the function's configuration may require it. This is the case when Serverless AppSec is enabled, and not having the language runtime API proxy available results in the language runtime client retrying connection to the proxy endlessly until the invocation times out.