### PR TITLE
PROF-10073: Read and propagate helm config for profiling

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2118,6 +2118,44 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 				wConfig("admission_controller.auto_instrumentation.asm_sca.enabled", false),
 			},
 		},
+		{
+			name: "Single Step Instrumentation: enable profiling",
+			pod: common.FakePodWithParent(
+				"ns",
+				map[string]string{},
+				map[string]string{},
+				[]corev1.EnvVar{},
+				"replicaset", "test-app-123",
+			),
+			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...),
+				corev1.EnvVar{
+					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
+					Value: "k8s_single_step",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE",
+					Value: "test-app",
+				},
+				corev1.EnvVar{
+					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
+					Value: installTime,
+				},
+				corev1.EnvVar{
+					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
+					Value: uuid,
+				},
+				corev1.EnvVar{
+					Name:  "DD_PROFILING_ENABLED",
+					Value: "auto",
+				},
+			),
+			expectedInjectedLibraries: map[string]string{"java": "latest", "python": "latest", "js": "latest", "ruby": "latest", "dotnet": "latest"},
+			wantErr:                   false,
+			setupConfig: funcs{
+				enableAPMInstrumentation,
+				wConfig("admission_controller.auto_instrumentation.profiling.enabled", "auto"),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -707,9 +707,10 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", false)                                   // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
-	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")         // config for ASM which is implemented in the client libraries
-	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")          // config for IAST which is implemented in the client libraries
-	config.BindEnv("admission_controller.auto_instrumentation.asm_sca.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED") // config for SCA
+	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")          // config for ASM which is implemented in the client libraries
+	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")           // config for IAST which is implemented in the client libraries
+	config.BindEnv("admission_controller.auto_instrumentation.asm_sca.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED")  // config for SCA
+	config.BindEnv("admission_controller.auto_instrumentation.profiling.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED") // config for profiling
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.pod_endpoint", "/inject-pod-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.command_endpoint", "/inject-command-cws")

--- a/releasenotes-dca/notes/admission-controller-profiling-fd7678fa28f7b90e.yaml
+++ b/releasenotes-dca/notes/admission-controller-profiling-fd7678fa28f7b90e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Cluster Agent now supports activating Continuous Profiling
+    via Admission Controller.

--- a/releasenotes-dca/notes/admission-controller-profiling-fd7678fa28f7b90e.yaml
+++ b/releasenotes-dca/notes/admission-controller-profiling-fd7678fa28f7b90e.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Cluster Agent now supports activating Continuous Profiling
-    via Admission Controller.
+    The Cluster Agent now supports activating Continuous Profiling
+    using Admission Controller.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allows Continuous Profiler to be enabled (or disabled) by Helm Charts config on the controller pod. The cluster-agent, running on the controller pod, will read an environment variable and use this to mutate the configuration of other pods to set the environment variables that will activate profiling within the tracer/profiler client libraries.

This PR follows the same approach as #23618 did for activation of ASM products.

### Motivation

to make it easier for k8s clients to activate Continous Profiling. Simplified installation is a common request.

### Additional Notes

The PR is designed to establish the fundamentals that will make these other PRs work:
* https://github.com/DataDog/helm-charts/pull/1443
* https://github.com/DataDog/datadog-operator/pull/1271
It is necessary to first have the functionality here in the agent before we can make the Helm and Operator changes available. 

Continuous Profiler will have the env var `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED` set by changes in those Datadog Operator and Helm Charts PRs. It will result in `DD_PROFILING_ENABLED` being propagated to all pods (or those conforming to the filters).

### Possible Drawbacks / Trade-offs

* More complexity in our config handling, to make it easier for customers.

### Describe how to test/QA your changes

* Unit tests have been added and ensured to pass with `invoke test --targets=./pkg/clusteragent`
