### PR TITLE
check for group in IsNodeMetadata

### DIFF
--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -22,7 +22,7 @@ func EntityFilterFuncAcceptAll(_ Entity) bool { return true }
 // IsNodeMetadata is a filter function that returns true if the metadata
 // belongs to a node.
 var IsNodeMetadata = func(metadata *KubernetesMetadata) bool {
-	return metadata.GVR.Resource == "nodes"
+	return metadata.GVR.Group == "" && metadata.GVR.Resource == "nodes"
 }
 
 // Filter allows a subscriber to filter events by entity kind, event source, and

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -10,8 +10,51 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func TestIsNodeMetadata(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		metadataEntity       KubernetesMetadata
+		shouldBeNodeMetadata bool
+	}{
+		{
+			name: "node metadata",
+			metadataEntity: KubernetesMetadata{
+				GVR: schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "nodes",
+				},
+			},
+			shouldBeNodeMetadata: true,
+		},
+
+		{
+			name: "node metadata, but not native group",
+			metadataEntity: KubernetesMetadata{
+				GVR: schema.GroupVersionResource{
+					Group:    "customgroup",
+					Version:  "v1",
+					Resource: "nodes",
+				},
+			},
+			shouldBeNodeMetadata: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.shouldBeNodeMetadata {
+				assert.True(tt, IsNodeMetadata(&test.metadataEntity))
+			} else {
+				assert.False(tt, IsNodeMetadata(&test.metadataEntity))
+			}
+		})
+	}
+
+}
 func TestFilterBuilder_Build(t *testing.T) {
 	dummyEntityFilterFunc := func(entity Entity) bool {
 		return len(entity.GetID().ID) == 5


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR checks for the resource group in `IsNodeMetadata` to avoid returning `true` for nodes that are not in the empty kubernetes group.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Some resources might have the name `nodes`, but they belong to another (custom) API Group (i.e. not the empty group in kubernetes). `IsNodeMetadata` should return `false` in these cases. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Currently there is an issue in the resource-group-version mapping for generic metadata collection, which, in some cases, leads to watching `metrics.k8s.io/v1beta1, Resource=nodes` instead of `/v1, Resource=nodes`. 

This will be fixed in a separate PR.

This fix done in this PR is useful to avoid using the metadata collected for `metrics.k8s.io/v1beta1, Resource=nodes` as if they were native node metadata, resulting in incorrect data. 


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No need for qa, we have automated testing.

