### PR TITLE
Fixed daily / weekly failure summary notifications

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -131,10 +131,10 @@ notify_failure_summary_daily:
         exit
       fi
     # Daily
-    - inv -e notify.failure-summary-send-notifications --is-daily-summary=true
+    - inv -e notify.failure-summary-send-notifications --daily-summary
     # Send weekly if necessary (note that this workflow is usually triggered early in the morning)
     - |
       if [ "$weekday" = "Friday" ]; then
         echo 'Sending weekly summary'
-        inv -e notify.failure-summary-send-notifications --is-daily-summary=false
+        inv -e notify.failure-summary-send-notifications --weekly-summary
       fi

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -120,12 +120,19 @@ def failure_summary_upload_pipeline_data(ctx):
 
 
 @task
-def failure_summary_send_notifications(ctx, is_daily_summary: bool, max_length=8):
+def failure_summary_send_notifications(
+    ctx, daily_summary: bool = False, weekly_summary: bool = False, max_length: int = 8
+):
     """
     Make summaries from data in s3 and send them to slack
     """
-    period = timedelta(days=1) if is_daily_summary else timedelta(weeks=1)
-    failure_summary.send_summary_messages(ctx, is_daily_summary, max_length, period)
+
+    assert (
+        daily_summary or weekly_summary and not (daily_summary and weekly_summary)
+    ), "Only one of daily or weekly summary can be set"
+
+    period = timedelta(days=1) if daily_summary else timedelta(weeks=1)
+    failure_summary.send_summary_messages(ctx, weekly_summary, max_length, period)
 
 
 @task


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes `notify.failure-summary-send-notifications`:

- Replaced `is_daily_summary` parameter (no auto boolean cast + was not explicit)
- Inversed allow_failure: Find job that not allow failure for daily summaries

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
