### PR TITLE
bump `github.com/DataDog/go-libddwaf/v2` to `v3`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -265,10 +265,6 @@ core,github.com/DataDog/ebpf-manager,MIT,Copyright (c) 2021 Authors of Datadog
 core,github.com/DataDog/ebpf-manager/internal,MIT,Copyright (c) 2021 Authors of Datadog
 core,github.com/DataDog/ebpf-manager/tracefs,MIT,Copyright (c) 2021 Authors of Datadog
 core,github.com/DataDog/extendeddaemonset/api/v1alpha1,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
-core,github.com/DataDog/go-libddwaf/v2,Apache-2.0,"Copyright 2016-present Datadog, Inc"
-core,github.com/DataDog/go-libddwaf/v2/internal/lib,Apache-2.0,"Copyright 2016-present Datadog, Inc"
-core,github.com/DataDog/go-libddwaf/v2/internal/log,Apache-2.0,"Copyright 2016-present Datadog, Inc"
-core,github.com/DataDog/go-libddwaf/v2/internal/noopfree,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/go-libddwaf/v3,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/go-libddwaf/v3/errors,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/go-libddwaf/v3/internal/bindings,Apache-2.0,"Copyright 2016-present Datadog, Inc"

--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -275,10 +275,6 @@ github.com/DataDog/datadog-api-client-go/v2
 github.com/DataDog/datadog-api-client-go/v2/api/datadog
 github.com/DataDog/datadog-api-client-go/v2/api/datadogV2
 github.com/DataDog/datadog-go/v5/statsd
-github.com/DataDog/go-libddwaf/v2
-github.com/DataDog/go-libddwaf/v2/internal/lib
-github.com/DataDog/go-libddwaf/v2/internal/log
-github.com/DataDog/go-libddwaf/v2/internal/noopfree
 github.com/DataDog/go-libddwaf/v3
 github.com/DataDog/go-libddwaf/v3/errors
 github.com/DataDog/go-libddwaf/v3/internal/bindings

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -275,10 +275,6 @@ github.com/DataDog/datadog-api-client-go/v2
 github.com/DataDog/datadog-api-client-go/v2/api/datadog
 github.com/DataDog/datadog-api-client-go/v2/api/datadogV2
 github.com/DataDog/datadog-go/v5/statsd
-github.com/DataDog/go-libddwaf/v2
-github.com/DataDog/go-libddwaf/v2/internal/lib
-github.com/DataDog/go-libddwaf/v2/internal/log
-github.com/DataDog/go-libddwaf/v2/internal/noopfree
 github.com/DataDog/go-libddwaf/v3
 github.com/DataDog/go-libddwaf/v3/errors
 github.com/DataDog/go-libddwaf/v3/internal/bindings

--- a/go.mod
+++ b/go.mod
@@ -673,7 +673,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.55.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/version v0.55.0-rc.3
-	github.com/DataDog/go-libddwaf/v2 v2.3.1
+	github.com/DataDog/go-libddwaf/v3 v3.2.1
 	github.com/DataDog/go-sqllexer v0.0.12
 	github.com/Datadog/dublin-traceroute v0.0.1
 	github.com/aquasecurity/trivy v0.49.2-0.20240227072422-e1ea02c7b80d
@@ -770,7 +770,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.55.0-rc.3 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.26.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe // indirect
-	github.com/DataDog/go-libddwaf/v3 v3.2.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.16.1 // indirect
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,6 @@ github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG56
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
-github.com/DataDog/go-libddwaf/v2 v2.3.1 h1:bujaT5+KnLDFQqVA5ilvVvW+evUSHow9FrTHRgUwN4A=
-github.com/DataDog/go-libddwaf/v2 v2.3.1/go.mod h1:gsCdoijYQfj8ce/T2bEDNPZFIYnmHluAgVDpuQOWMZE=
 github.com/DataDog/go-libddwaf/v3 v3.2.1 h1:lZPc6UxCOwioHc++nsldKR50FpIrRh1uGnGLuryqnE8=
 github.com/DataDog/go-libddwaf/v3 v3.2.1/go.mod h1:AP+7Atb8ftSsrha35wht7+K3R+xuzfVSQhabSO4w6CY=
 github.com/DataDog/go-sqllexer v0.0.12 h1:ncvAr5bbwtc7JMezzcU2379oKz1oHhRF1hkR6BSvhqM=

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"testing"
 
-	waf "github.com/DataDog/go-libddwaf/v2"
+	waf "github.com/DataDog/go-libddwaf/v3"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	waf "github.com/DataDog/go-libddwaf/v2"
+	waf "github.com/DataDog/go-libddwaf/v3"
 	json "github.com/json-iterator/go"
 )
 

--- a/pkg/serverless/appsec/rules_test.go
+++ b/pkg/serverless/appsec/rules_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/appsec-internal-go/appsec"
-	waf "github.com/DataDog/go-libddwaf/v2"
+	waf "github.com/DataDog/go-libddwaf/v3"
 
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/27150 bumped dd-trace-go to the latest version which is using go-libddwaf/v3. To not have to depend on v2 and v3 at the same time in the agent, this PR converts the serverless ASM usage to go-libddwaf/v3.

### Motivation

Simplify dependencies.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
