### PR TITLE
[Fleet Automation] Fix build artifact not being copied to output directory

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -241,7 +241,7 @@ def send_build_metrics(ctx, overall_duration):
     if sys.platform == 'win32':
         aws_cmd = "aws.cmd"
         if src_dir is None:
-            src_dir = "C:/buildroot/datadog-agent"
+            src_dir = os.environ.get("REPO_ROOT", os.getcwd())
 
     job_name = os.environ.get('CI_JOB_NAME_SLUG')
     branch = os.environ.get('CI_COMMIT_REF_NAME')

--- a/tasks/winbuildscripts/buildinstaller.bat
+++ b/tasks/winbuildscripts/buildinstaller.bat
@@ -38,6 +38,12 @@ inv -e msi.build-installer || exit /b 2
 REM show output package directories (for debugging)
 dir \omnibus-ruby\pkg\
 
+dir %BUILD_ROOT%\datadog-agent\omnibus\pkg\
+
+REM copy resulting packages to expected location for collection by gitlab.
+if not exist c:\mnt\omnibus\pkg\ mkdir c:\mnt\omnibus\pkg\ || exit /b 5
+copy %BUILD_ROOT%\datadog-agent\omnibus\pkg\* c:\mnt\omnibus\pkg\ || exit /b 6
+
 REM show output binary directories (for debugging)
 dir C:\opt\datadog-installer\
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a copy-operation that was missing from https://github.com/DataDog/datadog-agent/pull/26155 to copy the Datadog Installer to the output folder that is being collected by the Gitlab runner.

It also fixes a hardcoded path that was found in `omnibus.py`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/WINA-858

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
