### PR TITLE
[ASCII-1924] Improve error printing and help messages in the Agent GUI

### DIFF
--- a/comp/core/gui/guiimpl/gui.go
+++ b/comp/core/gui/guiimpl/gui.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"embed"
 	"encoding/json"
+	"html/template"
 	"io"
 	"mime"
 	"net"
@@ -18,7 +19,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"text/template"
 	"time"
 
 	"go.uber.org/fx"
@@ -203,8 +203,8 @@ func renderIndexPage(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	e = t.Execute(w, map[string]any{
-		"restartEnabled":    restartEnabled(),
-		"logginInstruction": logginInstructions(),
+		"restartEnabled":   restartEnabled(),
+		"loginInstruction": logginInstructions(),
 	})
 	if e != nil {
 		http.Error(w, e.Error(), http.StatusInternalServerError)

--- a/comp/core/gui/guiimpl/gui.go
+++ b/comp/core/gui/guiimpl/gui.go
@@ -111,8 +111,8 @@ func newGui(deps dependencies) provides {
 		intentTokens: make(map[string]bool),
 	}
 
-	// Instantiate the gorilla/mux router
-	router := mux.NewRouter()
+	// Instantiate the gorilla/mux publicRouter
+	publicRouter := mux.NewRouter()
 
 	// Fetch the authentication token (persists across sessions)
 	authToken, e := security.FetchAuthToken(deps.Config)
@@ -124,14 +124,14 @@ func newGui(deps dependencies) provides {
 	sessionExpiration := deps.Config.GetDuration("GUI_session_expiration")
 	g.auth = newAuthenticator(authToken, sessionExpiration)
 
-	router.HandleFunc("/auth", g.getAccessToken).Methods("GET")
-	// Serve the (secured) index page on the default endpoint
-	securedRouter := router.PathPrefix("/").Subrouter()
-	securedRouter.HandleFunc("/", generateIndex).Methods("GET")
+	// register the public routes
+	publicRouter.HandleFunc("/", renderIndexPage).Methods("GET")
+	publicRouter.HandleFunc("/auth", g.getAccessToken).Methods("GET")
+	// Mount our filesystem at the view/{path} route
+	publicRouter.PathPrefix("/view/").Handler(http.StripPrefix("/view/", http.HandlerFunc(serveAssets)))
 
-	// Mount our (secured) filesystem at the view/{path} route
-	securedRouter.PathPrefix("/view/").Handler(http.StripPrefix("/view/", http.HandlerFunc(serveAssets)))
-
+	// Create a subrouter to handle routes that needs authentication
+	securedRouter := publicRouter.PathPrefix("/").Subrouter()
 	// Set up handlers for the API
 	agentRouter := securedRouter.PathPrefix("/agent").Subrouter().StrictSlash(true)
 	agentHandler(agentRouter, deps.Flare, deps.Status, deps.Config, g.startTimestamp)
@@ -141,7 +141,7 @@ func newGui(deps dependencies) provides {
 	// Check token on every securedRouter endpoints
 	securedRouter.Use(g.authMiddleware)
 
-	g.router = router
+	g.router = publicRouter
 
 	deps.Lc.Append(fx.Hook{
 		OnStart: g.start,
@@ -190,7 +190,7 @@ func (g *gui) getIntentToken(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte(token))
 }
 
-func generateIndex(w http.ResponseWriter, _ *http.Request) {
+func renderIndexPage(w http.ResponseWriter, _ *http.Request) {
 	data, err := viewsFS.ReadFile("views/templates/index.tmpl")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -202,7 +202,10 @@ func generateIndex(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	e = t.Execute(w, map[string]bool{"restartEnabled": restartEnabled()})
+	e = t.Execute(w, map[string]any{
+		"restartEnabled":    restartEnabled(),
+		"logginInstruction": logginInstructions(),
+	})
 	if e != nil {
 		http.Error(w, e.Error(), http.StatusInternalServerError)
 		return

--- a/comp/core/gui/guiimpl/gui.go
+++ b/comp/core/gui/guiimpl/gui.go
@@ -202,9 +202,18 @@ func renderIndexPage(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	e = t.Execute(w, map[string]any{
-		"restartEnabled":   restartEnabled(),
-		"loginInstruction": logginInstructions(),
+	t, e = t.Parse(instructionTemplate)
+	if e != nil {
+		http.Error(w, e.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	e = t.Execute(w, struct {
+		RestartEnabled bool
+		DocURL         template.URL
+	}{
+		RestartEnabled: restartEnabled(),
+		DocURL:         docURL,
 	})
 	if e != nil {
 		http.Error(w, e.Error(), http.StatusInternalServerError)

--- a/comp/core/gui/guiimpl/platform_darwin.go
+++ b/comp/core/gui/guiimpl/platform_darwin.go
@@ -20,16 +20,15 @@ func restart() error {
 }
 
 func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Instructions</h3>
-<p>Please ensure you access the Datadog Agent Manager as follows:</p>
+	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
 <ul>
-	<li>- Through the systray app, by clicking on <strong>Open Web Ui</strong></li>
-	<li>- By running the following bash command: "<code>datadog-agent launch-gui</code>"</li>
+	<li>- through the Agent's menu bar extras icon by selecting "Open Web UI"</li>
+	<li>- by running the following terminal command: "<code>datadog-agent launch-gui</code>"</li>
 </ul>
 
 <p>For more information, please visit: <u><a href="%s">%s</a></u></p>
 
-<h4>Be Aware of Token Expiration</h4>
-The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
 		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_darwin.go
+++ b/comp/core/gui/guiimpl/platform_darwin.go
@@ -9,10 +9,27 @@ import (
 	"fmt"
 )
 
+const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/osx"
+
 func restartEnabled() bool {
 	return false
 }
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
+}
+
+func logginInstructions() string {
+	return fmt.Sprintf(`<h3>Instructions</h3>
+<p>Please ensure you access the Datadog Agent Manager as follows:</p>
+<ul>
+	<li>- Through the systray app, by clicking on <strong>Open Web Ui</strong></li>
+	<li>- By running the following bash command: "<code>datadog-agent launch-gui</code>"</li>
+</ul>
+
+<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
+
+<h4>Be Aware of Token Expiration</h4>
+The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+		DocURL, DocURL)
 }

--- a/comp/core/gui/guiimpl/platform_darwin.go
+++ b/comp/core/gui/guiimpl/platform_darwin.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 )
 
-const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/osx"
+const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/osx"
 
 func restartEnabled() bool {
 	return false
@@ -31,5 +31,5 @@ func logginInstructions() string {
 
 <h4>Be Aware of Token Expiration</h4>
 The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
-		DocURL, DocURL)
+		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_darwin.go
+++ b/comp/core/gui/guiimpl/platform_darwin.go
@@ -7,9 +7,22 @@ package guiimpl
 
 import (
 	"fmt"
+	"html/template"
 )
 
-const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/osx"
+const docURL template.URL = template.URL("https://docs.datadoghq.com/agent/basic_agent_usage/osx")
+const instructionTemplate = `{{define "loginInstruction" }}
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
+<ul>
+	<li>- through the Agent's menu bar extras icon by selecting "Open Web UI"</li>
+	<li>- by running the following terminal command: "<code>datadog-agent launch-gui</code>"</li>
+</ul>
+
+<p>For more information, please visit: <u><a href="{{ .DocURL }}">{{ .DocURL }}</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+{{end}}`
 
 func restartEnabled() bool {
 	return false
@@ -17,18 +30,4 @@ func restartEnabled() bool {
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
-}
-
-func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
-<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
-<ul>
-	<li>- through the Agent's menu bar extras icon by selecting "Open Web UI"</li>
-	<li>- by running the following terminal command: "<code>datadog-agent launch-gui</code>"</li>
-</ul>
-
-<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
-
-<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
-		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_darwin_test.go
+++ b/comp/core/gui/guiimpl/platform_darwin_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package guiimpl
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedBody = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Datadog Agent</title>
+    <link rel="stylesheet" href="view/css/font-awesome.min.css">
+    <link rel="stylesheet" href="view/css/codemirror.css">
+    <link rel="stylesheet" href="view/css/stylesheet.css">
+    <script src="view/js/polyfills.js"> </script>
+    <script src="view/js/jquery-3.5.1.min.js"> </script>
+    <script src="view/js/codemirror.js"> </script>
+    <script src="view/js/yaml.js"> </script>
+    <script src="view/js/javascript.js"> </script>
+    <script src="view/js/purify.min.js"> </script>
+</head>
+
+<body>
+  <div id="sidebar">
+    <img id="logo" src="view/images/datadog_icon_white.svg">
+
+    <ul class="navbar">
+      <li class="nav_item multi active">
+        <i class="fa fa-info fa-fw"> </i>&nbsp;
+        Status
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="status_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadStatus('general')" class="side_menu_item">General</a>
+          <a href="javascript:void(0)" onclick="loadStatus('collector')" class="side_menu_item">Collector</a>
+        </div>
+      </li>
+      <li id="log_button" class="nav_item">
+        <i class="fa fa-book fa-fw"> </i>&nbsp;
+        Log
+      </li>
+      <li id="settings_button" class="nav_item">
+        <i class="fa fa-cog fa-fw"> </i>&nbsp;
+        Settings
+      </li>
+      <li class="nav_item multi">
+        <i class="fa fa-check fa-fw"> </i>&nbsp;
+        Checks
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="checks_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadManageChecks()" class="side_menu_item">Manage Checks</a>
+          <a href="javascript:void(0)" onclick="seeRunningChecks()" class="side_menu_item">Checks Summary</a>
+        </div>
+      </li>
+      <li id="flare_button" class="nav_item">
+        <i class="fa fa-flag fa-fw"> </i>&nbsp;
+        Flare
+      </li>
+    </ul>
+  </div>
+  <div class="top_bar">
+    <div id="title">Datadog Agent Manager</div>
+    <div id="agent_info">
+      <div id="restart_status">Restart Agent to apply changes.</div>
+      <div id="agent_status" class="disconnected">Not connected<br>to Agent</div>
+      <div id="version">Version: </div>
+      <div id="hostname">Hostname: </div>
+    </div>
+  </div>
+  <div id="main">
+    <div id="error" class="page">
+      <div id="error_content"></div>
+      <div id="logged_out">
+        
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
+<ul>
+	<li>- through the Agent's menu bar extras icon by selecting "Open Web UI"</li>
+	<li>- by running the following terminal command: "<code>datadog-agent launch-gui</code>"</li>
+</ul>
+
+<p>For more information, please visit: <u><a href="https://docs.datadoghq.com/agent/basic_agent_usage/osx">https://docs.datadoghq.com/agent/basic_agent_usage/osx</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+
+      </div>
+    </div>
+    <div id="tests" class="page"></div>
+    <div id="general_status" class="page"></div>
+    <div id="collector_status" class="page"></div>
+    <div id="settings" class="page"></div>
+    <div id="logs" class="page"></div>
+    <div id="manage_checks" class="page">
+      <div id="checks_description"></div>
+      <div class="interface">
+        <div class="left">
+            <span class="dropdown">
+              <select id="checks_dropdown">
+                <option value="enabled">Edit Enabled Checks</option>
+                <option value="add">Add a Check</option>
+              </select>
+            </span>
+          <div class="list"></div>
+        </div>
+        <div class="right"></div>
+      </div>
+    </div>
+    <div id="running_checks" class="page"></div>
+    <div id="flare" class="page">
+        <div id="flare_description"></div>
+        <form class="flare_input center">
+          <input type="number" id="ticket_num" placeholder="Ticket number, if you have one"/>
+          <input type="email" id="email" placeholder="Email address"/>
+          <input type="button" id="submit_flare" value="Submit"/>
+        </form>
+    </div>
+
+  </div>
+</body>
+`
+
+func TestRenderIndexPage(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(renderIndexPage)
+
+	handler.ServeHTTP(rr, req)
+
+	res := rr.Result()
+	defer res.Body.Close()
+	bodyBytes, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, string(bodyBytes))
+}

--- a/comp/core/gui/guiimpl/platform_nix.go
+++ b/comp/core/gui/guiimpl/platform_nix.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 )
 
-const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux"
+const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux#datadog-agent-manager-gui"
 
 func restartEnabled() bool {
 	return false
@@ -22,11 +22,10 @@ func restart() error {
 }
 
 func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Instructions</h3>
-<p>Please ensure you access the Datadog Agent Manager by running the following bash command: "<code>datadog-agent launch-gui</code>"</p>
+	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager by running the following terminal command: "<code>datadog-agent launch-gui</code>"</p>
 <p>For more information, please visit: <u><a href="%s">%s</a></u></p>
 
-<h4>Be Aware of Token Expiration</h4>
-The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
 		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_nix.go
+++ b/comp/core/gui/guiimpl/platform_nix.go
@@ -11,10 +11,22 @@ import (
 	"fmt"
 )
 
+const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux"
+
 func restartEnabled() bool {
 	return false
 }
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
+}
+
+func logginInstructions() string {
+	return fmt.Sprintf(`<h3>Instructions</h3>
+<p>Please ensure you access the Datadog Agent Manager by running the following bash command: "<code>datadog-agent launch-gui</code>"</p>
+<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
+
+<h4>Be Aware of Token Expiration</h4>
+The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+		DocURL, DocURL)
 }

--- a/comp/core/gui/guiimpl/platform_nix.go
+++ b/comp/core/gui/guiimpl/platform_nix.go
@@ -9,9 +9,17 @@ package guiimpl
 
 import (
 	"fmt"
+	"html/template"
 )
 
-const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux#datadog-agent-manager-gui"
+const docURL template.URL = template.URL("https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux#datadog-agent-manager-gui")
+const instructionTemplate = `{{define "loginInstruction" }}
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager by running the following terminal command: "<code>datadog-agent launch-gui</code>"</p>
+<p>For more information, please visit: <u><a href="{{ .DocURL }}">{{ .DocURL }}</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+{{end}}`
 
 func restartEnabled() bool {
 	return false
@@ -19,13 +27,4 @@ func restartEnabled() bool {
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
-}
-
-func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
-<p>Please ensure you access the Datadog Agent Manager by running the following terminal command: "<code>datadog-agent launch-gui</code>"</p>
-<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
-
-<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
-		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_nix.go
+++ b/comp/core/gui/guiimpl/platform_nix.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 )
 
-const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux"
+const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux"
 
 func restartEnabled() bool {
 	return false
@@ -28,5 +28,5 @@ func logginInstructions() string {
 
 <h4>Be Aware of Token Expiration</h4>
 The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
-		DocURL, DocURL)
+		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_nix_test.go
+++ b/comp/core/gui/guiimpl/platform_nix_test.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build freebsd || netbsd || openbsd || solaris || dragonfly || linux
+
+package guiimpl
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedBody = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Datadog Agent</title>
+    <link rel="stylesheet" href="view/css/font-awesome.min.css">
+    <link rel="stylesheet" href="view/css/codemirror.css">
+    <link rel="stylesheet" href="view/css/stylesheet.css">
+    <script src="view/js/polyfills.js"> </script>
+    <script src="view/js/jquery-3.5.1.min.js"> </script>
+    <script src="view/js/codemirror.js"> </script>
+    <script src="view/js/yaml.js"> </script>
+    <script src="view/js/javascript.js"> </script>
+    <script src="view/js/purify.min.js"> </script>
+</head>
+
+<body>
+  <div id="sidebar">
+    <img id="logo" src="view/images/datadog_icon_white.svg">
+
+    <ul class="navbar">
+      <li class="nav_item multi active">
+        <i class="fa fa-info fa-fw"> </i>&nbsp;
+        Status
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="status_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadStatus('general')" class="side_menu_item">General</a>
+          <a href="javascript:void(0)" onclick="loadStatus('collector')" class="side_menu_item">Collector</a>
+        </div>
+      </li>
+      <li id="log_button" class="nav_item">
+        <i class="fa fa-book fa-fw"> </i>&nbsp;
+        Log
+      </li>
+      <li id="settings_button" class="nav_item">
+        <i class="fa fa-cog fa-fw"> </i>&nbsp;
+        Settings
+      </li>
+      <li class="nav_item multi">
+        <i class="fa fa-check fa-fw"> </i>&nbsp;
+        Checks
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="checks_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadManageChecks()" class="side_menu_item">Manage Checks</a>
+          <a href="javascript:void(0)" onclick="seeRunningChecks()" class="side_menu_item">Checks Summary</a>
+        </div>
+      </li>
+      <li id="flare_button" class="nav_item">
+        <i class="fa fa-flag fa-fw"> </i>&nbsp;
+        Flare
+      </li>
+    </ul>
+  </div>
+  <div class="top_bar">
+    <div id="title">Datadog Agent Manager</div>
+    <div id="agent_info">
+      <div id="restart_status">Restart Agent to apply changes.</div>
+      <div id="agent_status" class="disconnected">Not connected<br>to Agent</div>
+      <div id="version">Version: </div>
+      <div id="hostname">Hostname: </div>
+    </div>
+  </div>
+  <div id="main">
+    <div id="error" class="page">
+      <div id="error_content"></div>
+      <div id="logged_out">
+        
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager by running the following terminal command: "<code>datadog-agent launch-gui</code>"</p>
+<p>For more information, please visit: <u><a href="https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux#datadog-agent-manager-gui">https://docs.datadoghq.com/agent/basic_agent_usage/?tab=Linux#datadog-agent-manager-gui</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+
+      </div>
+    </div>
+    <div id="tests" class="page"></div>
+    <div id="general_status" class="page"></div>
+    <div id="collector_status" class="page"></div>
+    <div id="settings" class="page"></div>
+    <div id="logs" class="page"></div>
+    <div id="manage_checks" class="page">
+      <div id="checks_description"></div>
+      <div class="interface">
+        <div class="left">
+            <span class="dropdown">
+              <select id="checks_dropdown">
+                <option value="enabled">Edit Enabled Checks</option>
+                <option value="add">Add a Check</option>
+              </select>
+            </span>
+          <div class="list"></div>
+        </div>
+        <div class="right"></div>
+      </div>
+    </div>
+    <div id="running_checks" class="page"></div>
+    <div id="flare" class="page">
+        <div id="flare_description"></div>
+        <form class="flare_input center">
+          <input type="number" id="ticket_num" placeholder="Ticket number, if you have one"/>
+          <input type="email" id="email" placeholder="Email address"/>
+          <input type="button" id="submit_flare" value="Submit"/>
+        </form>
+    </div>
+
+  </div>
+</body>
+`
+
+func TestRenderIndexPage(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(renderIndexPage)
+
+	handler.ServeHTTP(rr, req)
+
+	res := rr.Result()
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, string(bodyBytes))
+}

--- a/comp/core/gui/guiimpl/platform_windows.go
+++ b/comp/core/gui/guiimpl/platform_windows.go
@@ -7,6 +7,7 @@ package guiimpl
 
 import (
 	"fmt"
+	"html/template"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +15,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
-const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/windows"
+const docURL template.URL = template.URL("https://docs.datadoghq.com/agent/basic_agent_usage/windows")
+const instructionTemplate = `{{define "loginInstruction" }}
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
+<ul>
+    <li>- Right click on the Datadog Agent system tray icon -&gt; Configure, or</li>
+    <li>- Run <code>launch-gui</code> command from an <strong>elevated (run as Admin)</strong> command line
+		<ul>
+            <li>- PowerShell: <code>&amp; "&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+            <li>- cmd: <code>"&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+        </ul>
+    </li>
+</ul>
+<p>For more information, please visit: <u><a href="{{ .DocURL }}">{{ .DocURL }}</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+{{end}}`
 
 func restartEnabled() bool {
 	return true
@@ -33,22 +50,4 @@ func restart() error {
 	}
 
 	return nil
-}
-
-func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
-<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
-<ul>
-    <li>- Right click on the Datadog Agent system tray icon -&gt; Configure, or</li>
-    <li>- Run <code>launch-gui</code> command from an <strong>elevated (run as Admin)</strong> command line
-		<ul>
-            <li>- PowerShell: <code>&amp; "&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
-            <li>- cmd: <code>"&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
-        </ul>
-    </li>
-</ul>
-<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
-
-<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
-		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_windows.go
+++ b/comp/core/gui/guiimpl/platform_windows.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
+const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/windows"
+
 func restartEnabled() bool {
 	return true
 }
@@ -31,4 +33,23 @@ func restart() error {
 	}
 
 	return nil
+}
+
+func logginInstructions() string {
+	return fmt.Sprintf(`<h3>Instructions</h3>
+Please ensure you access the Datadog Agent Manager as follows:
+<ul>
+    <li>- Right click on the Datadog Agent system tray icon -&gt; Configure, or</li>
+    <li>- Run <code>launch-gui</code> command from an <strong>elevated (run as Admin)</strong> command line
+		<ul>
+            <li>- PowerShell: <code>&amp; "&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+            <li>- cmd: <code>"&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+        </ul>
+    </li>
+</ul>
+<p>For more information, please visit: <u><a href="%s">%s</a></u></p>
+
+<h4>Be Aware of Token Expiration</h4>
+The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+		DocURL, DocURL)
 }

--- a/comp/core/gui/guiimpl/platform_windows.go
+++ b/comp/core/gui/guiimpl/platform_windows.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
-const DocURL = "https://docs.datadoghq.com/agent/basic_agent_usage/windows"
+const docURL = "https://docs.datadoghq.com/agent/basic_agent_usage/windows"
 
 func restartEnabled() bool {
 	return true
@@ -51,5 +51,5 @@ Please ensure you access the Datadog Agent Manager as follows:
 
 <h4>Be Aware of Token Expiration</h4>
 The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
-		DocURL, DocURL)
+		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_windows.go
+++ b/comp/core/gui/guiimpl/platform_windows.go
@@ -36,8 +36,8 @@ func restart() error {
 }
 
 func logginInstructions() string {
-	return fmt.Sprintf(`<h3>Instructions</h3>
-Please ensure you access the Datadog Agent Manager as follows:
+	return fmt.Sprintf(`<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
 <ul>
     <li>- Right click on the Datadog Agent system tray icon -&gt; Configure, or</li>
     <li>- Run <code>launch-gui</code> command from an <strong>elevated (run as Admin)</strong> command line
@@ -49,7 +49,6 @@ Please ensure you access the Datadog Agent Manager as follows:
 </ul>
 <p>For more information, please visit: <u><a href="%s">%s</a></u></p>
 
-<h4>Be Aware of Token Expiration</h4>
-The Datadog Agent parameter <code>GUI_session_expiration</code> (set in <code>datadog.yaml</code>) allows you to define a time expiration for the Datadog Agent Manager sessions.`,
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>`,
 		docURL, docURL)
 }

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package guiimpl
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedBody = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Datadog Agent</title>
+    <link rel="stylesheet" href="view/css/font-awesome.min.css">
+    <link rel="stylesheet" href="view/css/codemirror.css">
+    <link rel="stylesheet" href="view/css/stylesheet.css">
+    <script src="view/js/polyfills.js"> </script>
+    <script src="view/js/jquery-3.5.1.min.js"> </script>
+    <script src="view/js/codemirror.js"> </script>
+    <script src="view/js/yaml.js"> </script>
+    <script src="view/js/javascript.js"> </script>
+    <script src="view/js/purify.min.js"> </script>
+</head>
+
+<body>
+  <div id="sidebar">
+    <img id="logo" src="view/images/datadog_icon_white.svg">
+
+    <ul class="navbar">
+      <li class="nav_item multi active">
+        <i class="fa fa-info fa-fw"> </i>&nbsp;
+        Status
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="status_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadStatus('general')" class="side_menu_item">General</a>
+          <a href="javascript:void(0)" onclick="loadStatus('collector')" class="side_menu_item">Collector</a>
+        </div>
+      </li>
+      <li id="log_button" class="nav_item">
+        <i class="fa fa-book fa-fw"> </i>&nbsp;
+        Log
+      </li>
+      <li id="settings_button" class="nav_item">
+        <i class="fa fa-cog fa-fw"> </i>&nbsp;
+        Settings
+      </li>
+      <li class="nav_item multi">
+        <i class="fa fa-check fa-fw"> </i>&nbsp;
+        Checks
+        <i class="fa fa-chevron-down fa-rotate-270"> </i>
+        <div id="checks_side_menu" class="side_menu">
+          <a href="javascript:void(0)" onclick="loadManageChecks()" class="side_menu_item">Manage Checks</a>
+          <a href="javascript:void(0)" onclick="seeRunningChecks()" class="side_menu_item">Checks Summary</a>
+        </div>
+      </li>
+      <li id="flare_button" class="nav_item">
+        <i class="fa fa-flag fa-fw"> </i>&nbsp;
+        Flare
+      </li>
+    </ul>
+  </div>
+  <div class="top_bar">
+    <div id="title">Datadog Agent Manager</div>
+    <div id="agent_info">
+      <div id="restart_status">Restart Agent to apply changes.</div>
+      <div id="agent_status" class="disconnected">Not connected<br>to Agent</div>
+      <div id="version">Version: </div>
+      <div id="hostname">Hostname: </div>
+    </div>
+  </div>
+  <div id="main">
+    <div id="error" class="page">
+      <div id="error_content"></div>
+      <div id="logged_out">
+        
+<h3>Refreshing the Session</h3>
+<p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
+<ul>
+    <li>- Right click on the Datadog Agent system tray icon -&gt; Configure, or</li>
+    <li>- Run <code>launch-gui</code> command from an <strong>elevated (run as Admin)</strong> command line
+		<ul>
+            <li>- PowerShell: <code>&amp; "&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+            <li>- cmd: <code>"&lt;PATH_TO_AGENT.EXE&gt;" launch-gui</code></li>
+        </ul>
+    </li>
+</ul>
+<p>For more information, please visit: <u><a href="https://docs.datadoghq.com/agent/basic_agent_usage/windows">https://docs.datadoghq.com/agent/basic_agent_usage/windows</a></u></p>
+
+<p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
+
+      </div>
+    </div>
+    <div id="tests" class="page"></div>
+    <div id="general_status" class="page"></div>
+    <div id="collector_status" class="page"></div>
+    <div id="settings" class="page"></div>
+    <div id="logs" class="page"></div>
+    <div id="manage_checks" class="page">
+      <div id="checks_description"></div>
+      <div class="interface">
+        <div class="left">
+            <span class="dropdown">
+              <select id="checks_dropdown">
+                <option value="enabled">Edit Enabled Checks</option>
+                <option value="add">Add a Check</option>
+              </select>
+            </span>
+          <div class="list"></div>
+        </div>
+        <div class="right"></div>
+      </div>
+    </div>
+    <div id="running_checks" class="page"></div>
+    <div id="flare" class="page">
+        <div id="flare_description"></div>
+        <form class="flare_input center">
+          <input type="number" id="ticket_num" placeholder="Ticket number, if you have one"/>
+          <input type="email" id="email" placeholder="Email address"/>
+          <input type="button" id="submit_flare" value="Submit"/>
+        </form>
+    </div>
+
+  </div>
+</body>
+`
+
+func TestRenderIndexPage(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(renderIndexPage)
+
+	handler.ServeHTTP(rr, req)
+
+	res := rr.Result()
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, string(bodyBytes))
+}

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -101,7 +101,6 @@ const expectedBody = `<!DOCTYPE html>
 
 <p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
 
-
       </div>
     </div>
     <div id="tests" class="page"></div>
@@ -135,7 +134,8 @@ const expectedBody = `<!DOCTYPE html>
     </div>
 
   </div>
-</body>`
+</body>
+`
 
 func TestRenderIndexPage(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -65,6 +65,10 @@ const expectedBody = `<!DOCTYPE html>
         <i class="fa fa-flag fa-fw"> </i>&nbsp;
         Flare
       </li>
+      <li id="restart_button" class="nav_item no-active">
+        <i class="fa fa-power-off fa-fw"> </i>&nbsp;
+        Restart Agent
+      </li>
     </ul>
   </div>
   <div class="top_bar">

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -101,6 +101,7 @@ const expectedBody = `<!DOCTYPE html>
 
 <p>Note: If you would like to adjust the GUI session timeout, you can modify the <code>GUI_session_expiration</code> parameter in <code>datadog.yaml</code>
 
+
       </div>
     </div>
     <div id="tests" class="page"></div>
@@ -134,8 +135,7 @@ const expectedBody = `<!DOCTYPE html>
     </div>
 
   </div>
-</body>
-`
+</body>`
 
 func TestRenderIndexPage(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -69,6 +69,7 @@ const expectedBody = `<!DOCTYPE html>
         <i class="fa fa-power-off fa-fw"> </i>&nbsp;
         Restart Agent
       </li>
+      
     </ul>
   </div>
   <div class="top_bar">

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,5 +157,10 @@ func TestRenderIndexPage(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
-	assert.Equal(t, expectedBody, string(bodyBytes))
+
+	// We replace windows line break by linux so the tests pass on every OS
+	expectedResult := strings.Replace(expectedBody, "\r\n", "\n", -1)
+	output := strings.Replace(string(bodyBytes), "\r\n", "\n", -1)
+
+	assert.Equal(t, expectedResult, output)
 }

--- a/comp/core/gui/guiimpl/views/private/css/stylesheet.css
+++ b/comp/core/gui/guiimpl/views/private/css/stylesheet.css
@@ -156,20 +156,28 @@ a {
   font-size: 25px;
 }
 .top_bar #agent_status {
-  background: linear-gradient(to bottom, #89c403 5%, #77a809 100%);
-  background-color: #89c403;
-  background-color: red;
-  border: 1px solid #74b807;
-  text-shadow: 0px 1px 0px #528009;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  left: -150px;
   border-radius: 26px;
   color: #ffffff;
   padding: 6px 24px;
   text-decoration: none;
   text-align: center;
+}
+.connected {
+  background: linear-gradient(to bottom, #89c403 5%, #77a809 100%);
+  background-color: #89c403;
+  border: 1px solid #74b807;
+  text-shadow: 0px 1px 0px #528009;
+  left: -150px;
+}
+.disconnected {
+  background: linear-gradient(to bottom, #c62d1f 5%, #f24437 100%);
+  background-color: #c62d1f;
+  border: 1px solid #d02718;
+  text-shadow: 0px 1px 0px #810e05;
+  left: -180px;
 }
 .top_bar #restart_status {
   color: #ff0000;
@@ -204,11 +212,13 @@ a {
   display: none;
 }
 
-#main .error_page {
-  width: auto;
-  height: auto;
+#main #error.page {
+  width: calc(100% - 80px);
+  height: calc(100% - 80px);
+  padding: 20px;
+  overflow-y: scroll;
   background-color: #f9ecec;
-  padding: 5vh;
+  z-index: 6;
 }
  
 #main #settings_input, #main #check_input, #main #new_config_input {

--- a/comp/core/gui/guiimpl/views/private/css/stylesheet.css
+++ b/comp/core/gui/guiimpl/views/private/css/stylesheet.css
@@ -195,6 +195,7 @@ a {
   position: absolute;
   top: 20px;
   left: 20px;
+  right: 20px;
   border: 1px solid #e4e4e4;
   background-color: white;
   box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
@@ -206,16 +207,7 @@ a {
 #main .error_page {
   width: auto;
   height: auto;
-
-  /* top: 20px; */
-  /* left: 20px;
-  border: 1px solid #e4e4e4; */
   background-color: #f9ecec;
-  /* box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
-  -moz-box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
-  -webkit-box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22); */
-  /* text-align: center; */
-  /* margin: 5vh; */
   padding: 5vh;
 }
  

--- a/comp/core/gui/guiimpl/views/private/css/stylesheet.css
+++ b/comp/core/gui/guiimpl/views/private/css/stylesheet.css
@@ -202,6 +202,23 @@ a {
   -webkit-box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
   display: none;
 }
+
+#main .error_page {
+  width: auto;
+  height: auto;
+
+  /* top: 20px; */
+  /* left: 20px;
+  border: 1px solid #e4e4e4; */
+  background-color: #f9ecec;
+  /* box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
+  -moz-box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22);
+  -webkit-box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.22); */
+  /* text-align: center; */
+  /* margin: 5vh; */
+  padding: 5vh;
+}
+ 
 #main #settings_input, #main #check_input, #main #new_config_input {
   width: calc(100% - 2px);
   height: calc(100% - 2px);

--- a/comp/core/gui/guiimpl/views/private/js/javascript.js
+++ b/comp/core/gui/guiimpl/views/private/js/javascript.js
@@ -24,7 +24,7 @@ function sendMessage(endpoint, data, method, callback, callbackErr){
       $("#logged_out").hide();
 
       // Set Agent state to "connected"
-      $("#agent_status").html("Connected <br> to Agent");
+      $("#agent_status").html("Connected<br>to Agent");
       $("#agent_status").removeClass("disconnected")
       $("#agent_status").addClass("connected")
 
@@ -42,7 +42,7 @@ function sendMessage(endpoint, data, method, callback, callbackErr){
       }
 
       // Set Agent state to "disconnected"
-      $("#agent_status").html("Not connected<br> to Agent");
+      $("#agent_status").html("Not connected<br>to Agent");
       $("#agent_status").removeClass("connected")
       $("#agent_status").addClass("disconnected")
 
@@ -703,7 +703,7 @@ function restartAgent() {
   $(".active").removeClass("active");
   $("#main").append('<i class="fa fa-spinner fa-pulse fa-3x fa-fw center loading_spinner"></i>');
 
-  $("#agent_status").html("Not connected<br> to Agent");
+  $("#agent_status").html("Not connected<br>to Agent");
   $("#agent_status").removeClass("connected")
   $("#agent_status").addClass("disconnected")
 

--- a/comp/core/gui/guiimpl/views/private/js/javascript.js
+++ b/comp/core/gui/guiimpl/views/private/js/javascript.js
@@ -63,7 +63,7 @@ function setError(status, message) {
     message = "Unable to contact the Datadog Agent. Please ensure it is running."
   }
   else if (status == 401) {
-    message = `Not logged in. Please ensure that your GUI session has not expired. (initial message: ${message.trim()})`
+    message = `Not logged in. Please ensure that your GUI session has not expired. (Agent replied with: ${message.trim()})`
   }
 
   $("#error_content").html(`<h3>Error</h3> ${DOMPurify.sanitize(message)}`)

--- a/comp/core/gui/guiimpl/views/templates/index.tmpl
+++ b/comp/core/gui/guiimpl/views/templates/index.tmpl
@@ -96,5 +96,13 @@
           <input type="button" id="submit_flare" value="Submit"/>
         </form>
     </div>
+    <div id="error" class="page">
+      <div class="error_page">
+        <div id="error_content"></div>
+        <div id="loggedout">
+          {{ .logginInstruction }}
+        </div>
+      </div>
+    </div>
   </div>
 </body>

--- a/comp/core/gui/guiimpl/views/templates/index.tmpl
+++ b/comp/core/gui/guiimpl/views/templates/index.tmpl
@@ -61,12 +61,18 @@
     <div id="title">Datadog Agent Manager</div>
     <div id="agent_info">
       <div id="restart_status">Restart Agent to apply changes.</div>
-      <div id="agent_status">Connected <br>to Agent</div>
+      <div id="agent_status" class="disconnected">Connected <br>to Agent</div>
       <div id="version">Version: </div>
       <div id="hostname">Hostname: </div>
     </div>
   </div>
   <div id="main">
+    <div id="error" class="page">
+      <div id="error_content"></div>
+      <div id="logged_out">
+        {{ .loginInstruction }}
+      </div>
+    </div>
     <div id="tests" class="page"></div>
     <div id="general_status" class="page"></div>
     <div id="collector_status" class="page"></div>
@@ -96,13 +102,6 @@
           <input type="button" id="submit_flare" value="Submit"/>
         </form>
     </div>
-    <div id="error" class="page">
-      <div class="error_page">
-        <div id="error_content"></div>
-        <div id="loggedout">
-          {{ .logginInstruction }}
-        </div>
-      </div>
-    </div>
+
   </div>
 </body>

--- a/comp/core/gui/guiimpl/views/templates/index.tmpl
+++ b/comp/core/gui/guiimpl/views/templates/index.tmpl
@@ -49,7 +49,7 @@
         <i class="fa fa-flag fa-fw"> </i>&nbsp;
         Flare
       </li>
-      {{- if .restartEnabled }}
+      {{- if .RestartEnabled }}
       <li id="restart_button" class="nav_item no-active">
         <i class="fa fa-power-off fa-fw"> </i>&nbsp;
         Restart Agent
@@ -61,7 +61,7 @@
     <div id="title">Datadog Agent Manager</div>
     <div id="agent_info">
       <div id="restart_status">Restart Agent to apply changes.</div>
-      <div id="agent_status" class="disconnected">Connected <br>to Agent</div>
+      <div id="agent_status" class="disconnected">Not connected<br>to Agent</div>
       <div id="version">Version: </div>
       <div id="hostname">Hostname: </div>
     </div>
@@ -70,7 +70,7 @@
     <div id="error" class="page">
       <div id="error_content"></div>
       <div id="logged_out">
-        {{ .loginInstruction }}
+        {{template "loginInstruction" . }}
       </div>
     </div>
     <div id="tests" class="page"></div>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR enhances the error messages displayed to the customer for scenarios such as invalid token, session expired, or Agent unreachable.

Here is an example of the page displayed to the user when logged out:
![Screenshot 2024-07-02 at 11 19 36](https://github.com/DataDog/datadog-agent/assets/65339037/9faac99e-37c5-457b-a82a-a5ec3c680bf4)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This PR aims to provide better information in case of errors when using the GUI.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- (run the Agent)
- run the command `datadog-agent launch-gui`
- check that everything is working as before
- add a session expiration with the following parameter in `datadog.yaml` : `GUI_session_expiration: 20s`
- restart the Agent
- run the command `datadog-agent launch-gui`
- check that after ~20s you get the error displayed