### PR TITLE
Allow impl folder with suffix

### DIFF
--- a/tasks/components.py
+++ b/tasks/components.py
@@ -102,7 +102,8 @@ def check_component_contents_and_file_hiearchy(entry_point):
         return ""
 
     for folder in directory.iterdir():
-        if folder.match('*impl'):
+        # Allow implementation to be old style <component>impl or new style <component>/impl or <component>/impl-<suffix>
+        if folder.match('*impl') or folder.match('impl-*'):
             missing_implementation_folder = False
             # TODO: check that the implementation_definitions are present in any of the files of the impl folder
             break


### PR DESCRIPTION
### What does this PR do?

Allow components to pass the linter if they're using multiple implementations without a "primary" `impl` folder.

### Motivation

The docs explicitly allow components to use "non-primary" implementations, such as "impl-a" and "impl-b", but the linter doesn't take this use case into account: https://datadoghq.dev/datadog-agent/components/creating-components/#file-hierarchy

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
