### PR TITLE
[windows][system probe] Fix crash when probe is misconfigured on windows

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1054,6 +1054,12 @@ func (p *WindowsProbe) SendStats() error {
 	if err := p.statsdClient.Gauge(metrics.MetricWindowsApproverRejects, float64(p.stats.createFileApproverRejects), nil, 1); err != nil {
 		return err
 	}
+	if p.fimSession == nil {
+		return nil
+	}
+
+	// all stats below this line only valid if the full ETW session is enabled
+
 	if etwstats, err := p.fimSession.GetSessionStatistics(); err == nil {
 		if err := p.statsdClient.Gauge(metrics.MetricWindowsETWNumberOfBuffers, float64(etwstats.NumberOfBuffers), nil, 1); err != nil {
 			return err


### PR DESCRIPTION
Fixes crash discovered by accident in unrelated testing.

Inadvertendly enabled the process events with
`event_monitoring_config:
  network_process:
    enabled: true
  process:
    enabled: true
    enable: true`

while not enabling CWS.  This resulted in a crash when the stats method was called with fim not initialized.

Fixes the crash.

### Motivation


### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Install agent.
In system probe yaml, enable event stream as above, but do NOT enable CWS.
observe crash (without fix) and no crash (with fix)