### PR TITLE
NDM: Upgrade pro-bing to fix a windows only bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -718,6 +718,12 @@ require (
 	k8s.io/kubectl v0.29.0
 )
 
+replace (
+	// NDM: Temporary fork until pro-bing merges the PR
+	github.com/prometheus-community/pro-bing => github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90
+)
+
+
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.8.0 // indirect
 	cloud.google.com/go/auth v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -718,11 +718,8 @@ require (
 	k8s.io/kubectl v0.29.0
 )
 
-replace (
-	// NDM: Temporary fork until pro-bing merges the PR
-	github.com/prometheus-community/pro-bing => github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90
-)
-
+// NDM: Temporary fork until pro-bing merges the PR
+replace github.com/prometheus-community/pro-bing => github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90
 
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -719,7 +719,7 @@ require (
 )
 
 // NDM: Temporary fork until pro-bing merges the PR
-replace github.com/prometheus-community/pro-bing => github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90
+replace github.com/prometheus-community/pro-bing => github.com/ken-schneider/pro-bing v0.0.0-20240702202240-4cb73c5b2d22
 
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2116,8 +2116,8 @@ github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwS
 github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90 h1:5BKXndS8e7bpJGGNtDXyYU3p8S/2jaB/T3Gc5BmRchk=
-github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90/go.mod h1:2S6OC9H+JSEDb2st9eFlPDH74LNsvoLssXwGSjJI2fc=
+github.com/ken-schneider/pro-bing v0.0.0-20240702202240-4cb73c5b2d22 h1:DgkktDAnqyoAPf8Xnzs73Bia3VuZiUrgwI8l9eaMoa4=
+github.com/ken-schneider/pro-bing v0.0.0-20240702202240-4cb73c5b2d22/go.mod h1:2S6OC9H+JSEDb2st9eFlPDH74LNsvoLssXwGSjJI2fc=
 github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
 github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -2116,6 +2116,8 @@ github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwS
 github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90 h1:5BKXndS8e7bpJGGNtDXyYU3p8S/2jaB/T3Gc5BmRchk=
+github.com/ken-schneider/pro-bing v0.0.0-20240702002736-76fe9e144a90/go.mod h1:2S6OC9H+JSEDb2st9eFlPDH74LNsvoLssXwGSjJI2fc=
 github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
 github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -2986,8 +2988,6 @@ github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/pro-bing v0.3.0 h1:SFT6gHqXwbItEDJhTkzPWVqU6CLEtqEfNAPp47RUON4=
-github.com/prometheus-community/pro-bing v0.3.0/go.mod h1:p9dLb9zdmv+eLxWfCT6jESWuDrS+YzpPkQBgysQF8a0=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/releasenotes/notes/NDM---Upgrade-pro-bing-9ba8f128c58f93be.yaml
+++ b/releasenotes/notes/NDM---Upgrade-pro-bing-9ba8f128c58f93be.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Upgrades the pro-bing library to fix a windows-only bug with too-long ICMP packets being received

--- a/releasenotes/notes/NDM---Upgrade-pro-bing-9ba8f128c58f93be.yaml
+++ b/releasenotes/notes/NDM---Upgrade-pro-bing-9ba8f128c58f93be.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Upgrades the pro-bing library to fix a windows-only bug with too-long ICMP packets being received
+    Upgrades the pro-bing library to fix a Windows-only bug with too-long ICMP packets being received


### PR DESCRIPTION
Internal context: https://datadoghq.atlassian.net/wiki/spaces/II/pages/3860988548/BUG+Windows+Ping+Buffer+Issue

A windows-only issue affects the pro-bing library, described in this issue: https://github.com/prometheus-community/pro-bing/issues/34

With this PR, we replace the pro-bing version to the one from a personal fork from @ken-schneider. Once the PR is merged upstream, we'll move back to the main branch. 