### PR TITLE
[workloadmeta/mock] Use config component

### DIFF
--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -10,9 +10,9 @@ package workloadmeta
 // team: container-platform
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	wmmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 const (
@@ -49,7 +49,7 @@ func (w *workloadMetaMock) Set(e wmdef.Entity) {
 }
 
 // GetConfig returns a Config Reader for the internal injected config
-func (w *workloadMetaMock) GetConfig() pkgconfig.Reader {
+func (w *workloadMetaMock) GetConfig() config.Reader {
 	return w.config
 }
 

--- a/comp/core/workloadmeta/mock/mock.go
+++ b/comp/core/workloadmeta/mock/mock.go
@@ -9,8 +9,8 @@
 package mock
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // Mock implements mock-specific methods.


### PR DESCRIPTION
### What does this PR do?

It's a small cleanup in the workloadmeta mock.
It replaces usages of `pkg/config` with the Config component.

### Describe how to test/QA your changes

Skip. This only affects tests.
