### PR TITLE
[USMON-1023] - Run Event monitoring tests for all build mods

### DIFF
--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -48,7 +48,6 @@ func launchProcessMonitor(t *testing.T, useEventStream bool) {
 
 type SharedLibrarySuite struct {
 	suite.Suite
-	useEventStream bool
 }
 
 func TestSharedLibrary(t *testing.T) {

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -57,11 +57,13 @@ func TestSharedLibrary(t *testing.T) {
 	}
 
 	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+		launchProcessMonitor(t, false)
 		suite.Run(t, new(SharedLibrarySuite))
 	})
 
 	t.Run("event stream", func(t *testing.T) {
-		suite.Run(t, &SharedLibrarySuite{useEventStream: true})
+		launchProcessMonitor(t, true)
+		suite.Run(t, new(SharedLibrarySuite))
 	})
 }
 
@@ -83,7 +85,6 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	require.NoError(t, err)
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
-	launchProcessMonitor(t, s.useEventStream)
 
 	// create files
 	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
@@ -141,7 +142,6 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDAndRootNamespace()
 	require.NoError(t, err)
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
-	launchProcessMonitor(t, s.useEventStream)
 
 	time.Sleep(10 * time.Millisecond)
 	// simulate a slow (1 second) : open, write, close of the file
@@ -190,7 +190,6 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	require.NoError(t, err)
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
-	launchProcessMonitor(t, s.useEventStream)
 
 	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
 	require.NoError(t, err)
@@ -237,7 +236,6 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	require.NoError(t, err)
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
-	launchProcessMonitor(t, s.useEventStream)
 
 	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
 	require.NoError(t, err)
@@ -310,7 +308,6 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
-	launchProcessMonitor(t, s.useEventStream)
 
 	require.Eventually(t, func() bool {
 		return registerRecorder.CallsForPathID(fooPathID1) == 1 &&

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -57,13 +57,14 @@ func TestSharedLibrary(t *testing.T) {
 	}
 
 	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
-		launchProcessMonitor(t, false)
-		suite.Run(t, new(SharedLibrarySuite))
-	})
-
-	t.Run("event stream", func(t *testing.T) {
-		launchProcessMonitor(t, true)
-		suite.Run(t, new(SharedLibrarySuite))
+		t.Run("netlink", func(t *testing.T) {
+			launchProcessMonitor(t, false)
+			suite.Run(t, new(SharedLibrarySuite))
+		})
+		t.Run("event stream", func(t *testing.T) {
+			launchProcessMonitor(t, true)
+			suite.Run(t, new(SharedLibrarySuite))
+		})
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

* Runs event monitoring tests for all build modes
* Setup event stream monitoring (if needed) and process monitor only once per a suite run.
In the leaf tests we register and de-register dedicated callbacks to verify the tests are
working. Thus, we don't have to create over and over again the event monitoring for every
leaf test. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The setup/teardown time for the event monitoring, which takes 10s.
Thus, running event monitoring tests are very expensive
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
