### PR TITLE
[workloadmeta/collectors] Fix linter issues

### DIFF
--- a/comp/core/workloadmeta/collectors/collectors.go
+++ b/comp/core/workloadmeta/collectors/collectors.go
@@ -11,8 +11,8 @@ package collectors
 import (
 	"go.uber.org/fx"
 
-	cf_container "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/container"
-	cf_vm "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm"
+	cfcontainer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/container"
+	cfvm "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/containerd"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
@@ -31,8 +31,8 @@ import (
 // GetCatalog returns the set of FX options to populate the catalog
 func GetCatalog() fx.Option {
 	options := []fx.Option{
-		cf_container.GetFxOptions(),
-		cf_vm.GetFxOptions(),
+		cfcontainer.GetFxOptions(),
+		cfvm.GetFxOptions(),
 		containerd.GetFxOptions(),
 		docker.GetFxOptions(),
 		ecs.GetFxOptions(),

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package container provides a workloadmeta collector for CloudForundry container
+// Package container provides a workloadmeta collector for CloudFoundry container
 package container
 
 import (
@@ -12,13 +12,14 @@ import (
 	"os"
 	"strings"
 
+	"go.uber.org/fx"
+
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"go.uber.org/fx"
 )
 
 const (

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package vm provides a workloadmeta collector for CloudForundry VM
+// Package vm provides a workloadmeta collector for CloudFoundry VM
 package vm
 
 import (
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/fx"
+
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -19,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	ddjson "github.com/DataDog/datadog-agent/pkg/util/json"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"go.uber.org/fx"
 )
 
 const (

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -13,10 +13,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/content"
@@ -25,6 +21,10 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const imageTopicPrefix = "/images/"

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
@@ -10,10 +10,11 @@ package containerd
 import (
 	"testing"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 func TestKnownImages(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -23,7 +23,7 @@ import (
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
-	v3or4 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build docker
-// +build docker
 
 // ecs collector package
 package ecs

--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
@@ -77,7 +78,8 @@ func TestPullWithV1Parser(t *testing.T) {
 			c.collectResourceTags = test.collectResourceTags
 			c.taskCollectionParser = c.parseTasksFromV1Endpoint
 
-			c.Pull(context.TODO())
+			err := c.Pull(context.TODO())
+			require.NoError(t, err)
 
 			taskTags := c.resourceTags[entityID].tags
 			assert.Equal(t, taskTags, test.expectedTags)

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
@@ -112,6 +112,10 @@ func getDummyECS() (*httptest.Server, error) {
 		testutil.FileHandlerOption("/v4/1234-2/taskWithTags", "./testdata/nginx.json"),
 		testutil.FileHandlerOption("/v1/tasks", "./testdata/tasks.json"),
 	)
+	if err != nil {
+		return nil, err
+	}
+
 	ts := dummyECS.Start()
 	return ts, err
 }

--- a/comp/core/workloadmeta/collectors/internal/host/host.go
+++ b/comp/core/workloadmeta/collectors/internal/host/host.go
@@ -10,13 +10,12 @@ import (
 	"context"
 
 	"github.com/benbjohnson/clock"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/hosttags"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"go.uber.org/fx"
 )
 
 const id = "host"

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
@@ -11,13 +11,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPodParser_Parse(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/internal/third_party/golang/expansion"
+	"go.uber.org/fx"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/internal/third_party/golang/expansion"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -24,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-
-	"go.uber.org/fx"
 )
 
 const (

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -21,13 +21,12 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/version"
-
-	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 )
 
 type FakeDCAClient struct {

--- a/comp/core/workloadmeta/collectors/internal/podman/podman.go
+++ b/comp/core/workloadmeta/collectors/internal/podman/podman.go
@@ -15,14 +15,14 @@ import (
 	"sort"
 	"strings"
 
+	"go.uber.org/fx"
+
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/podman"
-
-	"go.uber.org/fx"
 )
 
 const (

--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -39,7 +39,7 @@ var errWorkloadmetaStreamNotStarted = errors.New("workloadmeta stream not starte
 
 // GrpcClient interface that represents a gRPC client for the remote workloadmeta.
 type GrpcClient interface {
-	// StreamEntites establishes the stream between the client and the remote gRPC server.
+	// StreamEntities establishes the stream between the client and the remote gRPC server.
 	StreamEntities(ctx context.Context, opts ...grpc.CallOption) (Stream, error)
 }
 

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"


### PR DESCRIPTION
### What does this PR do?

Fixes a variety of linter issues in the workloadmeta collectors directory that I found while working on the code.

All the fixes are minor. The list includes:
- rename some vars to follow Go's guidelines (avoid using "_").
- sort imports.
- fix some typos.
- delete redundant aliases in imports.
- delete redundant "//+build".
- improve error handling in some tests.


### Describe how to test/QA your changes

Skip.
