### PR TITLE
[CONTP-283] Should require also API Group (in addition to resource name) for generic metadata collection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -65,7 +65,7 @@ func storeGenerators(cfg config.Reader) []storeGenerator {
 }
 
 func metadataCollectionGVRs(cfg config.Reader, discoveryClient discovery.DiscoveryInterface) ([]schema.GroupVersionResource, error) {
-	return getGVRsForGroupResources(discoveryClient, resourcesWithMetadataCollectionEnabled(cfg))
+	return getGVRsForRequestedResources(discoveryClient, resourcesWithMetadataCollectionEnabled(cfg))
 }
 
 func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -65,7 +65,7 @@ func storeGenerators(cfg config.Reader) []storeGenerator {
 }
 
 func metadataCollectionGVRs(cfg config.Reader, discoveryClient discovery.DiscoveryInterface) ([]schema.GroupVersionResource, error) {
-	return discoverGVRs(discoveryClient, resourcesWithMetadataCollectionEnabled(cfg))
+	return getGVRsForGroupResources(discoveryClient, resourcesWithMetadataCollectionEnabled(cfg))
 }
 
 func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"go.uber.org/fx"
@@ -106,12 +107,12 @@ func resourcesWithExplicitMetadataCollectionEnabled(cfg config.Reader) []string 
 	var resources []string
 	requestedResources := cfg.GetStringSlice("cluster_agent.kube_metadata_collection.resources")
 	for _, resource := range requestedResources {
-		if resource == "pods" && shouldHavePodStore(cfg) {
+		if strings.HasSuffix(resource, "pods") && shouldHavePodStore(cfg) {
 			log.Debugf("skipping pods from metadata collection because a separate pod store is initialised in workload metadata store.")
 			continue
 		}
 
-		if resource == "deployments" && shouldHaveDeploymentStore(cfg) {
+		if strings.HasSuffix(resource, "deployments") && shouldHaveDeploymentStore(cfg) {
 			log.Debugf("skipping deployments from metadata collection because a separate deployment store is initialised in workload metadata store.")
 			continue
 		}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -132,7 +132,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs:          []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments",
+				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
 			},
 		},
 		{
@@ -152,7 +152,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments",
+				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "daemonsets",
+				"cluster_agent.kube_metadata_collection.resources": "daemonsets.apps",
 			},
 		},
 		{
@@ -225,7 +225,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments statefulsets",
+				"cluster_agent.kube_metadata_collection.resources": "deployments.apps statefulsets.apps",
 			},
 		},
 		{
@@ -275,7 +275,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments",
+				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments statefulsetsy",
+				"cluster_agent.kube_metadata_collection.resources": "deployments.apps statefulsetsy.apps",
 			},
 		},
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -132,7 +132,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs:          []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments",
 			},
 		},
 		{
@@ -152,7 +152,36 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments",
+			},
+		},
+		{
+			name: "only one resource (deployments), only one version, correct resource requested, but version is empty (with double slash)",
+			apiServerResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "deployments",
+							Kind:       "Deployment",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "apps//deployments",
+			},
+		},
+		{
+			name:                  "only one resource with specific version",
+			apiServerResourceList: []*metav1.APIResourceList{},
+			expectedGVRs:          []schema.GroupVersionResource{{Resource: "foo", Group: "g", Version: "v"}},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "g/v/foo",
 			},
 		},
 		{
@@ -172,7 +201,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "daemonsets.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets",
 			},
 		},
 		{
@@ -225,7 +254,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments.apps statefulsets.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets",
 			},
 		},
 		{
@@ -275,7 +304,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments",
 			},
 		},
 		{
@@ -327,7 +356,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments.apps statefulsetsy.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments statefulsetsy.apps",
 			},
 		},
 	}
@@ -373,7 +402,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"language_detection.enabled":                       true,
 				"language_detection.reporting.enabled":             true,
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "daemonsets deployments",
+				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/deployments",
 			},
 			expectedResources: []string{"daemonsets", "nodes"},
 		},
@@ -382,7 +411,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			cfg: map[string]interface{}{
 				"autoscaling.workload.enabled":                     true,
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "daemonsets pods",
+				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets pods",
 			},
 			expectedResources: []string{"daemonsets", "nodes"},
 		},
@@ -390,7 +419,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			name: "resources explicitly requested",
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "deployments statefulsets",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets",
 			},
 			expectedResources: []string{"nodes", "deployments", "statefulsets"},
 		},
@@ -428,7 +457,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			name: "resources explicitly requested and also needed for namespace labels as tags",
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "namespaces deployments",
+				"cluster_agent.kube_metadata_collection.resources": "namespaces apps/deployments",
 				"kubernetes_namespace_labels_as_tags": map[string]string{
 					"label1": "tag1",
 				},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -356,7 +356,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "apps/deployments statefulsetsy.apps",
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsetsy",
 			},
 		},
 	}
@@ -404,7 +404,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/deployments",
 			},
-			expectedResources: []string{"daemonsets", "nodes"},
+			expectedResources: []string{"apps/daemonsets", "nodes"},
 		},
 		{
 			name: "pods needed for autoscaling should be excluded from metadata collection",
@@ -413,7 +413,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets pods",
 			},
-			expectedResources: []string{"daemonsets", "nodes"},
+			expectedResources: []string{"apps/daemonsets", "nodes"},
 		},
 		{
 			name: "resources explicitly requested",
@@ -421,7 +421,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets",
 			},
-			expectedResources: []string{"nodes", "deployments", "statefulsets"},
+			expectedResources: []string{"nodes", "apps/deployments", "apps/statefulsets"},
 		},
 		{
 			name: "namespaces needed for namespace labels as tags",
@@ -462,7 +462,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"label1": "tag1",
 				},
 			},
-			expectedResources: []string{"nodes", "namespaces", "deployments"}, // namespaces are not duplicated
+			expectedResources: []string{"nodes", "namespaces", "apps/deployments"}, // namespaces are not duplicated
 		},
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -107,7 +107,6 @@ func getGVRsForRequestedResources(discoveryClient discovery.DiscoveryInterface, 
 
 		if parsedVersion != "" {
 			// no need to discover preferred version if the version is already known
-
 			gvrs = append(gvrs, schema.GroupVersionResource{
 				Resource: parsedResource,
 				Group:    parsedGroup,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -472,15 +472,20 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.cleanup.period", "10m")
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.enabled", false)
 	// list of kubernetes resources for which we collect metadata
-	// each resource is specified in the format `{resourceName}.{apiGroup}`
-	// resources that belong to the empty group can be specified simply as `{resourceName}`
+	// each resource is specified in the format `{group}/{version}/{resource}` or `{group}/{resource}`
+	// resources that belong to the empty group can be specified simply as `{resource}` or as `/{resource}`
 	//
-	// examples:
-	// - deployments.apps
-	// - daemonsets.apps
+	// the version is optional and can be left empty, and in this case, the agent will automatically assign
+	// the version that is considered by the api server as the preferred version for the related group.
+	//
+	// examples with version:
+	// - apps/v1/deployments
+	// - /v1/nodes
+	//
+	// examples without version:
+	// - apps/deployments
+	// - /nodes
 	// - nodes
-	//
-	// the version of the api group is chosen by the discovery client based on the api server preferred group version.
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resources", []string{})
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resource_annotations_exclude", []string{})
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -471,6 +471,16 @@ func InitConfig(config pkgconfigmodel.Config) {
 	// language annotation cleanup period
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.cleanup.period", "10m")
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.enabled", false)
+	// list of kubernetes resources for which we collect metadata
+	// each resource is specified in the format `{resourceName}.{apiGroup}`
+	// resources that belong to the empty group can be specified simply as `{resourceName}`
+	//
+	// examples:
+	// - deployments.apps
+	// - daemonsets.apps
+	// - nodes
+	//
+	// the version of the api group is chosen by the discovery client based on the api server preferred group version.
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resources", []string{})
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resource_annotations_exclude", []string{})
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR includes the resource api group in the configuration parameter for generic metadata collection.

In other words, instead of having `DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES = [deployments statefulsets nodes]`, we will now have `DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES = [apps/deployments apps/statefulsets /nodes]`


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Avoid collisions in cases were we have the same resource name under different api groups.
An example of this is GKE:

On GKE, we have the `nodes` resource under two different API Groups:
- `metrics.k8s.io`
- `""` (empty api group, corresponding to the default empty group in kubernetes)

In this case, if the user asks to collect  metadata of `nodes`, it will not be possible to know if we need to collect metadata of
- `nodes.metrics.k8s.io`
- `nodes`

This results in a conflict. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- With this change, the user can also indicate the group version if they wish to by using the format `{group}/{version}/{resource}`. For example `apps/v1/deployments`. When using this format, the discovery client will not be used to fill the version, and the indicated version will be used as it is.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

❗ For better validation, do this QA on GKE because the issue was initially discovered on GKE due to having same resource name under different  api groups (see #motivation section for more information) ❗ 

Deploy the cluster agent with the following helm file:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false

clusterAgent:
  enabled: true
  replicas: 1
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "apps/deployments apps/daemonsets /nodes"
```

Ensure that metadata is collected successfully for deployments, daemonsets, and nodes. 

```
kubectl exec <cluster-agent-pod> -- agent workload-list -v

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: deployments/kube-system/kube-dns-autoscaler ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: deployments/kube-system/kube-dns-autoscaler

----------- Entity Meta -----------
Name: kube-dns-autoscaler
Namespace: kube-system
Annotations: deployment.kubernetes.io/revision:1 
Labels: addonmanager.kubernetes.io/mode:Reconcile k8s-app:kube-dns-autoscaler kubernetes.io/cluster-service:true 
----------- Resource -----------
apps/v1, Resource=deployments
===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: nodes//gke-adelhajhassan-default-pool-14a7bd1d-jnf2 ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: nodes//gke-adelhajhassan-default-pool-14a7bd1d-jnf2

----------- Entity Meta -----------
Name: gke-adelhajhassan-default-pool-14a7bd1d-jnf2
Namespace: 
Annotations: node.gke.io/last-applied-node-taints: volumes.kubernetes.io/controller-managed-attach-detach:true container.googleapis.com/instance_id:3216393220270216000 csi.volume.kubernetes.io/nodeid:{"pd.csi.storage.gke.io":"projects/datadog-sandbox/zones/us-central1-c/instances/gke-adelhajhassan-default-pool-14a7bd1d-jnf2"} node.alpha.kubernetes.io/ttl:0 node.gke.io/last-applied-node-labels:cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=2,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=e2,cloud.google.com/private-node=false 
Labels: beta.kubernetes.io/arch:amd64 cloud.google.com/gke-boot-disk:pd-balanced cloud.google.com/gke-cpu-scaling-level:2 kubernetes.io/arch:amd64 topology.gke.io/zone:us-central1-c cloud.google.com/gke-max-pods-per-node:110 cloud.google.com/gke-nodepool:default-pool cloud.google.com/gke-provisioning:standard failure-domain.beta.kubernetes.io/region:us-central1 topology.kubernetes.io/zone:us-central1-c cloud.google.com/gke-container-runtime:containerd cloud.google.com/gke-logging-variant:DEFAULT cloud.google.com/gke-os-distribution:cos failure-domain.beta.kubernetes.io/zone:us-central1-c kubernetes.io/os:linux topology.kubernetes.io/region:us-central1 node.kubernetes.io/instance-type:e2-medium beta.kubernetes.io/instance-type:e2-medium beta.kubernetes.io/os:linux cloud.google.com/gke-stack-type:IPV4 cloud.google.com/machine-family:e2 cloud.google.com/private-node:false kubernetes.io/hostname:gke-adelhajhassan-default-pool-14a7bd1d-jnf2 
----------- Resource -----------
/v1, Resource=nodes
===

=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: daemonsets/gmp-system/collector ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: daemonsets/gmp-system/collector

----------- Entity Meta -----------
Name: collector
Namespace: gmp-system
Annotations: components.gke.io/layer:addon 
Labels: addonmanager.kubernetes.io/mode:Reconcile 
----------- Resource -----------
apps/v1, Resource=daemonsets
===
```
