### PR TITLE
[workloadmeta] Fix linter issues

### DIFF
--- a/comp/core/workloadmeta/def/collectors.go
+++ b/comp/core/workloadmeta/def/collectors.go
@@ -23,10 +23,10 @@ type Collector interface {
 	// store.
 	Pull(context.Context) error
 
-	// Returns the identifier for the respective component.
+	// GetID returns the identifier for the respective component.
 	GetID() string
 
-	// Get the expected catalog
+	// GetTargetCatalog gets the expected catalog.
 	GetTargetCatalog() AgentType
 }
 

--- a/comp/core/workloadmeta/def/merge_test.go
+++ b/comp/core/workloadmeta/def/merge_test.go
@@ -51,7 +51,7 @@ func container1(testTime time.Time) Container {
 	}
 }
 
-func container2(testTime time.Time) Container { //nolint:revive // TODO fix revive unused-parameter
+func container2() Container {
 	return Container{
 		EntityID: EntityID{
 			Kind: KindContainer,
@@ -143,7 +143,7 @@ func TestMerge(t *testing.T) {
 
 	// Test merging both ways
 	fromSource1 := container1(testTime)
-	fromSource2 := container2(testTime)
+	fromSource2 := container2()
 	err := merge(&fromSource1, &fromSource2)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedPorts, fromSource1.Ports)
@@ -153,7 +153,7 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, expectedContainer, fromSource1)
 
 	fromSource1 = container1(testTime)
-	fromSource2 = container2(testTime)
+	fromSource2 = container2()
 	err = merge(&fromSource2, &fromSource1)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedPorts, fromSource2.Ports)
@@ -164,14 +164,14 @@ func TestMerge(t *testing.T) {
 
 	// Test merging nil slice in src/dst
 	fromSource1 = container1(testTime)
-	fromSource2 = container2(testTime)
+	fromSource2 = container2()
 	fromSource2.Ports = nil
 	err = merge(&fromSource1, &fromSource2)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, container1(testTime).Ports, fromSource1.Ports)
 
 	fromSource1 = container1(testTime)
-	fromSource2 = container2(testTime)
+	fromSource2 = container2()
 	fromSource2.Ports = nil
 	err = merge(&fromSource2, &fromSource1)
 	assert.NoError(t, err)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1173,7 +1173,7 @@ func (p *Process) Merge(e Entity) error {
 }
 
 // String implements Entity#String.
-func (p Process) String(verbose bool) string { //nolint:revive // TODO fix revive unused-parameter
+func (p Process) String(_ bool) string {
 	var sb strings.Builder
 
 	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -9,13 +9,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log/logimpl"
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 )
 
 func TestDump(t *testing.T) {

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -147,7 +147,7 @@ func NewWorkloadMetaOptional(deps dependencies) OptionalProvider {
 	}
 }
 
-func (wm *workloadmeta) writeResponse(w http.ResponseWriter, r *http.Request) {
+func (w *workloadmeta) writeResponse(writer http.ResponseWriter, r *http.Request) {
 	verbose := false
 	params := r.URL.Query()
 	if v, ok := params["verbose"]; ok {
@@ -156,12 +156,12 @@ func (wm *workloadmeta) writeResponse(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	response := wm.Dump(verbose)
+	response := w.Dump(verbose)
 	jsonDump, err := json.Marshal(response)
 	if err != nil {
-		httputils.SetJSONError(w, wm.log.Errorf("Unable to marshal workload list response: %v", err), 500)
+		httputils.SetJSONError(writer, w.log.Errorf("Unable to marshal workload list response: %v", err), 500)
 		return
 	}
 
-	w.Write(jsonDump)
+	writer.Write(jsonDump)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a variety of linter issues in workloadmeta.

All of them are minor. Each one is on a separate commit.

There was a similar PR specific for the collectors: https://github.com/DataDog/datadog-agent/pull/27212

### Describe how to test/QA your changes

Skip.
