### PR TITLE
[e2e] update centos-79 arm64 AMI

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -16,7 +16,7 @@
                 "rocky-92": "ami-08f362c39d03a4eb5"
             },
             "arm64": {
-                "centos-79": "ami-0144a5a84f5699847",
+                "centos-79": "ami-0cb7a00afccf30559",
                 "rhel-86": "ami-0238411fb452f8275"
             }
         },

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -55,7 +55,7 @@
             "rhel-86-fips": "ami-0d0fb96b595c56e03"
         },
         "arm64": {
-            "centos-79": "ami-0144a5a84f5699847",
+            "centos-79": "ami-0cb7a00afccf30559",
             "rhel-86": "ami-0238411fb452f8275"
         }
     },


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Update AMIs for CentOS 79 arm64

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

On July 1st, 2024 CentOS entered EOL and dropped their legacy mirrorlist. This broke few e2e and kitchen tests. The new AMI is a clone of the old one with mirrorlist updated

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

I created a VM from `test-infra-definitions` with 

```
inv create-vm --os-family=centos --no-install-agent --architecture=arm64    
```

ssh into it, and ran

```
sudo yum update
```

ensuring it was working fine