### PR TITLE
Add `Scheduled` as retry status

### DIFF
--- a/pkg/util/retry/error.go
+++ b/pkg/util/retry/error.go
@@ -63,3 +63,12 @@ func IsErrWillRetry(err error) bool {
 	}
 	return (e.RetryStatus == FailWillRetry)
 }
+
+// IsScheduled checks whether an `error` is a Retrier scheduled retry
+func IsScheduled(err error) bool {
+	ok, e := IsRetryError(err)
+	if !ok {
+		return false
+	}
+	return (e.RetryStatus == Scheduled)
+}

--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -108,6 +108,7 @@ func (r *Retrier) TriggerRetry() *Error {
 func (r *Retrier) doTry() *Error {
 	r.RLock()
 	if !r.nextTry.IsZero() && r.cfg.now().Before(r.nextTry) {
+		r.status = Scheduled
 		r.RUnlock()
 		return r.errorf("try delay not elapsed yet")
 	}

--- a/pkg/util/retry/retrier_test.go
+++ b/pkg/util/retry/retrier_test.go
@@ -209,6 +209,7 @@ func TestRetryDelayNotElapsed(t *testing.T) {
 	err = mocked.TriggerRetry()
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "try delay not elapsed yet")
+	assert.True(t, IsScheduled(err))
 }
 
 func TestRetryDelayRecover(t *testing.T) {

--- a/pkg/util/retry/types.go
+++ b/pkg/util/retry/types.go
@@ -22,6 +22,8 @@ const (
 	FailWillRetry
 	// PermaFail informs the user the object will not be available.
 	PermaFail
+	// Scheduled informs the user the object is waiting for next retry.
+	Scheduled
 )
 
 // Strategy sets how the Retrier should handle failure


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add new `Scheduled` status in `pkg/util/retry`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

After adding this status, I will use it as below to suppress same debug logs.

```diff
git diff | cat
diff --git a/pkg/util/containers/cri/util.go b/pkg/util/containers/cri/util.go
index 5c4fb37697..ab49b6f1e0 100644
--- a/pkg/util/containers/cri/util.go
+++ b/pkg/util/containers/cri/util.go
@@ -126,7 +126,11 @@ func GetUtil() (*CRIUtil, error) {
 	})

 	if err := globalCRIUtil.initRetry.TriggerRetry(); err != nil {
-		log.Debugf("CRI init error: %s", err)
+		if retry.IsScheduled(err) {
+			log.Trace("CLI init scheduled")
+		} else {
+			log.Debugf("CRI init error: %s", err)
+		}
 		return nil, err
 	}
 	return globalCRIUtil, nil
```

In my environment, there are more than 400 debug logs like below in last 15 minutes.

```
CRI init error: temporary failure in criutil, will retry later: try delay not elapsed yet
```

![2024-07-02_22-14-48](https://github.com/DataDog/datadog-agent/assets/41987730/8cb00fa4-bf1d-444d-9dd4-f8233682ddc3)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The status and functions added in this PR are intended to be used in subsequent PRs, so there will be no change in the Agent’s behavior.
