### PR TITLE
[ASCII-1940] Use Fx Lifecycle to cover starting and stoping of API servers

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -255,7 +255,7 @@ func run(log log.Component,
 	_ agenttelemetry.Component,
 ) error {
 	defer func() {
-		stopAgent(agentAPI)
+		stopAgent()
 	}()
 
 	// Setup a channel to catch OS signals
@@ -502,7 +502,7 @@ func startAgent(
 	_ serializer.MetricSerializer,
 	_ otelcollector.Component,
 	demultiplexer demultiplexer.Component,
-	agentAPI internalAPI.Component,
+	_ internalAPI.Component,
 	invChecks inventorychecks.Component,
 	_ status.Component,
 	collector collector.Component,
@@ -611,12 +611,12 @@ func startAgent(
 }
 
 // StopAgentWithDefaults is a temporary way for other packages to use stopAgent.
-func StopAgentWithDefaults(agentAPI internalAPI.Component) {
-	stopAgent(agentAPI)
+func StopAgentWithDefaults() {
+	stopAgent()
 }
 
 // stopAgent Tears down the agent process
-func stopAgent(agentAPI internalAPI.Component) {
+func stopAgent() {
 	// retrieve the agent health before stopping the components
 	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
 	health, err := health.GetReadyNonBlocking()

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -626,7 +626,6 @@ func stopAgent(agentAPI internalAPI.Component) {
 		pkglog.Warnf("Some components were unhealthy: %v", health.Unhealthy)
 	}
 
-	agentAPI.StopServer()
 	clcrunnerapi.StopCLCRunnerServer()
 	jmxfetch.StopJmxfetch()
 

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -561,11 +561,6 @@ func startAgent(
 		}
 	}
 
-	// start the cmd HTTP server
-	if err = agentAPI.StartServer(); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
-	}
-
 	// start clc runner server
 	// only start when the cluster agent is enabled and a cluster check runner host is enabled
 	if pkgconfig.Datadog().GetBool("cluster_agent.enabled") && pkgconfig.Datadog().GetBool("clc_runner_enabled") {

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -131,7 +131,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			_ optional.Option[gui.Component],
 			_ agenttelemetry.Component,
 		) error {
-			defer StopAgentWithDefaults(agentAPI)
+			defer StopAgentWithDefaults()
 
 			err := startAgent(
 				log,

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -7,7 +7,6 @@
 package apiimpl
 
 import (
-	"context"
 	"net"
 
 	"go.uber.org/fx"
@@ -100,18 +99,10 @@ func newAPIServer(deps dependencies) api.Component {
 
 	deps.Lc.Append(fx.Hook{
 		OnStart: server.startServers,
-		OnStop: func(_ context.Context) error {
-			return nil
-		},
+		OnStop:  server.stopServers,
 	})
 
 	return &server
-}
-
-// StopServer closes the connection and the server
-// stops listening to new commands.
-func (server *apiServer) StopServer() {
-	StopServers()
 }
 
 // ServerAddress returns the server address.

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -7,6 +7,7 @@
 package apiimpl
 
 import (
+	"context"
 	"net"
 
 	"go.uber.org/fx"
@@ -100,8 +101,11 @@ func newAPIServer(deps dependencies) api.Component {
 	}
 
 	deps.Lc.Append(fx.Hook{
-		OnStart: server.startServers,
-		OnStop:  server.stopServers,
+		OnStart: func(_ context.Context) error { return server.startServers() },
+		OnStop: func(_ context.Context) error {
+			server.stopServers()
+			return nil
+		},
 	})
 
 	return &server

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -50,6 +50,8 @@ type apiServer struct {
 	wmeta             workloadmeta.Component
 	collector         optional.Option[collector.Component]
 	senderManager     diagnosesendermanager.Component
+	cmdListener       net.Listener
+	ipcListener       net.Listener
 	telemetry         telemetry.Component
 	endpointProviders []api.EndpointProvider
 }
@@ -107,5 +109,5 @@ func newAPIServer(deps dependencies) api.Component {
 
 // ServerAddress returns the server address.
 func (server *apiServer) ServerAddress() *net.TCPAddr {
-	return ServerAddress()
+	return server.cmdListener.Addr().(*net.TCPAddr)
 }

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -112,6 +112,11 @@ func newAPIServer(deps dependencies) api.Component {
 }
 
 // ServerAddress returns the server address.
-func (server *apiServer) ServerAddress() *net.TCPAddr {
+func (server *apiServer) CMDServerAddress() *net.TCPAddr {
 	return server.cmdListener.Addr().(*net.TCPAddr)
+}
+
+// ServerAddress returns the server address.
+func (server *apiServer) IPCServerAddress() *net.TCPAddr {
+	return server.ipcListener.Addr().(*net.TCPAddr)
 }

--- a/comp/api/api/apiimpl/api_mock.go
+++ b/comp/api/api/apiimpl/api_mock.go
@@ -42,6 +42,11 @@ func (mock *mockAPIServer) StopServer() {
 }
 
 // ServerAddress returns the server address.
-func (mock *mockAPIServer) ServerAddress() *net.TCPAddr {
+func (mock *mockAPIServer) CMDServerAddress() *net.TCPAddr {
+	return nil
+}
+
+// ServerAddress returns the server address.
+func (mock *mockAPIServer) IPCServerAddress() *net.TCPAddr {
 	return nil
 }

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -45,6 +45,7 @@ import (
 
 	// third-party dependencies
 	dto "github.com/prometheus/client_model/go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -99,12 +100,7 @@ func TestStartServer(t *testing.T) {
 		"agent_ipc.port": 0,
 	}}
 
-	deps := getTestAPIServer(t, cfgOverride)
-
-	err := deps.API.StartServer()
-	defer deps.API.StopServer()
-
-	assert.NoError(t, err, "could not start api component servers: %v", err)
+	getTestAPIServer(t, cfgOverride)
 }
 
 func hasLabelValue(labels []*dto.LabelPair, name string, value string) bool {
@@ -135,9 +131,6 @@ func TestStartBothServersWithObservability(t *testing.T) {
 	}}
 
 	deps := getTestAPIServer(t, cfgOverride)
-	err = deps.API.StartServer()
-	require.NoError(t, err)
-	defer deps.API.StopServer()
 
 	registry := deps.Telemetry.GetRegistry()
 
@@ -146,11 +139,11 @@ func TestStartBothServersWithObservability(t *testing.T) {
 		serverName string
 	}{
 		{
-			addr:       cmdListener.Addr().String(),
+			addr:       deps.API.CMDServerAddress().String(),
 			serverName: cmdServerShortName,
 		},
 		{
-			addr:       ipcListener.Addr().String(),
+			addr:       deps.API.IPCServerAddress().String(),
 			serverName: ipcServerShortName,
 		},
 	}

--- a/comp/api/api/apiimpl/grpc.go
+++ b/comp/api/api/apiimpl/grpc.go
@@ -34,7 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-type server struct {
+type grpcServer struct {
 	pb.UnimplementedAgentServer
 }
 
@@ -50,7 +50,7 @@ type serverSecure struct {
 	pidMap             pidmap.Component
 }
 
-func (s *server) GetHostname(ctx context.Context, _ *pb.HostnameRequest) (*pb.HostnameReply, error) {
+func (s *grpcServer) GetHostname(ctx context.Context, _ *pb.HostnameRequest) (*pb.HostnameReply, error) {
 	h, err := hostname.Get(ctx)
 	if err != nil {
 		return &pb.HostnameReply{}, err
@@ -62,7 +62,7 @@ func (s *server) GetHostname(ctx context.Context, _ *pb.HostnameRequest) (*pb.Ho
 // override of the AuthFunc registered with the unary interceptor.
 //
 // see: https://godoc.org/github.com/grpc-ecosystem/go-grpc-middleware/auth#ServiceAuthFuncOverride
-func (s *server) AuthFuncOverride(ctx context.Context, _ string) (context.Context, error) {
+func (s *grpcServer) AuthFuncOverride(ctx context.Context, _ string) (context.Context, error) {
 	return ctx, nil
 }
 

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -6,7 +6,6 @@
 package apiimpl
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	stdLog "log"
@@ -45,7 +44,7 @@ func stopServer(listener net.Listener, name string) {
 }
 
 // StartServers creates certificates and starts API + IPC servers
-func (server *apiServer) startServers(ctx context.Context) error {
+func (server *apiServer) startServers() error {
 	apiAddr, err := getIPCAddressPort()
 	if err != nil {
 		return fmt.Errorf("unable to get IPC address and port: %v", err)
@@ -88,7 +87,7 @@ func (server *apiServer) startServers(ctx context.Context) error {
 	if ipcServerEnabled {
 		if err := server.startIPCServer(ipcServerHostPort, tlsConfig(), tmf); err != nil {
 			// if we fail to start the IPC server, we should stop the CMD server
-			server.stopServers(ctx)
+			server.stopServers()
 			return fmt.Errorf("unable to start IPC API server: %v", err)
 		}
 	}
@@ -97,7 +96,7 @@ func (server *apiServer) startServers(ctx context.Context) error {
 }
 
 // StopServers closes the connections and the servers
-func (server *apiServer) stopServers(_ context.Context) error {
+func (server *apiServer) stopServers() error {
 	stopServer(server.cmdListener, cmdServerName)
 	stopServer(server.ipcListener, ipcServerName)
 	return nil

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -96,8 +96,7 @@ func (server *apiServer) startServers() error {
 }
 
 // StopServers closes the connections and the servers
-func (server *apiServer) stopServers() error {
+func (server *apiServer) stopServers() {
 	stopServer(server.cmdListener, cmdServerName)
 	stopServer(server.ipcListener, ipcServerName)
-	return nil
 }

--- a/comp/api/api/apiimpl/server_ipc.go
+++ b/comp/api/api/apiimpl/server_ipc.go
@@ -7,7 +7,6 @@ package apiimpl
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"time"
 
@@ -19,10 +18,8 @@ import (
 const ipcServerName string = "IPC API Server"
 const ipcServerShortName string = "IPC"
 
-var ipcListener net.Listener
-
-func startIPCServer(ipcServerAddr string, tlsConfig *tls.Config, tmf observability.TelemetryMiddlewareFactory) (err error) {
-	ipcListener, err = getListener(ipcServerAddr)
+func (server *apiServer) startIPCServer(ipcServerAddr string, tlsConfig *tls.Config, tmf observability.TelemetryMiddlewareFactory) (err error) {
+	server.ipcListener, err = getListener(ipcServerAddr)
 	if err != nil {
 		return err
 	}
@@ -45,11 +42,7 @@ func startIPCServer(ipcServerAddr string, tlsConfig *tls.Config, tmf observabili
 		TLSConfig: tlsConfig,
 	}
 
-	startServer(ipcListener, ipcServer, ipcServerName)
+	startServer(server.ipcListener, ipcServer, ipcServerName)
 
 	return nil
-}
-
-func stopIPCServer() {
-	stopServer(ipcListener, ipcServerName)
 }

--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -22,7 +22,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	StopServer()
 	ServerAddress() *net.TCPAddr
 }
 

--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -22,7 +22,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	StartServer() error
 	StopServer()
 	ServerAddress() *net.TCPAddr
 }

--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -22,7 +22,8 @@ import (
 
 // Component is the component type.
 type Component interface {
-	ServerAddress() *net.TCPAddr
+	CMDServerAddress() *net.TCPAddr
+	IPCServerAddress() *net.TCPAddr
 }
 
 // EndpointProvider is an interface to register api endpoints

--- a/pkg/cli/standalone/jmx.go
+++ b/pkg/cli/standalone/jmx.go
@@ -59,10 +59,6 @@ func execJmxCommand(command string,
 	configs []integration.Config,
 	agentAPI internalAPI.Component,
 	logger jmxlogger.Component) error {
-	// start the cmd HTTP server
-	if err := agentAPI.StartServer(); err != nil {
-		return fmt.Errorf("Error while starting api server, exiting: %v", err)
-	}
 
 	runner := jmxfetch.NewJMXFetch(logger)
 

--- a/pkg/cli/standalone/jmx.go
+++ b/pkg/cli/standalone/jmx.go
@@ -64,7 +64,7 @@ func execJmxCommand(command string,
 
 	runner.Reporter = reporter
 	runner.Command = command
-	runner.IPCPort = agentAPI.ServerAddress().Port
+	runner.IPCPort = agentAPI.CMDServerAddress().Port
 	runner.Output = output
 	runner.LogLevel = logLevel
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR takes advantage of Fx Lifecycle hook to take care of API start and stop, and get rid of manual start and stop calls. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This PR takes place in the Fx adoption.

### Possible Drawbacks / Trade-offs

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
As it is written in [a comment above the API Component interface](https://github.com/DataDog/datadog-agent/pull/26099/files#diff-1fb0edb76ccb9025e023366aa0cb4b485ab8008cff0c153b463a4e30e4e419daR18-R21), some dependencies of the api Component are modified between the Fx initialization and the call to `api.StartServer()`
```
// TODO(components):
// * Lifecycle can't be used atm because:
//     - logsAgent and remoteconfig.Service are modified in `startAgent` in the run subcommand
//     - Same for workloadmeta and senderManager in `execJmxCommand` in the jmx subcommand
```
This PR changes the order of initialization, the API server is started before certain elements are modified :
- **remoteconfig.Service**: depending on some configuration, the rcclient.Component [is modified](https://github.com/DataDog/datadog-agent/blob/a0fd230906038e7b575b14d1d118937b2403a468/cmd/agent/subcommands/run/command.go#L533-L548), maybe we should move this logic in the `rcclient.Component` start lifecycle function because the API component is dependent of it so it will always be executed before.
- **workloadmeta**: [is modified here](https://github.com/DataDog/datadog-agent/blob/a0fd230906038e7b575b14d1d118937b2403a468/cmd/agent/subcommands/jmx/command.go#L323-L324)
I don't think it might break anything, I just think that the related API endpoints can be unreliable during this time interval. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
QA is covered by unit and e2e tests.
