### PR TITLE
AML-1804 Asynchronous dogstatsd flush

### DIFF
--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -944,6 +944,7 @@ log/internal
 log/slog
 log/slog/internal
 log/slog/internal/buffer
+maps
 math
 math/big
 math/bits

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -943,6 +943,7 @@ log/internal
 log/slog
 log/slog/internal
 log/slog/internal/buffer
+maps
 math
 math/big
 math/bits

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -7,6 +7,7 @@ package aggregator
 
 import (
 	"io"
+	"maps"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
@@ -33,6 +34,8 @@ type resolverEntry struct {
 	lastSeen int64
 	context  *Context
 }
+
+type resolverMap map[ckey.ContextKey]resolverEntry
 
 const (
 	// ContextSizeInBytes is the size of a context in bytes
@@ -66,7 +69,7 @@ var _ util.HasSizeInBytes = &Context{}
 // contextResolver allows tracking and expiring contexts
 type contextResolver struct {
 	id               string
-	contextsByKey    map[ckey.ContextKey]resolverEntry
+	contextsByKey    resolverMap
 	seendByMtype     []bool
 	countsByMtype    []uint64
 	bytesByMtype     []uint64
@@ -85,7 +88,7 @@ func (cr *contextResolver) generateContextKey(metricSampleContext metrics.Metric
 func newContextResolver(cache *tags.Store, id string) *contextResolver {
 	return &contextResolver{
 		id:               id,
-		contextsByKey:    make(map[ckey.ContextKey]resolverEntry),
+		contextsByKey:    resolverMap{},
 		seendByMtype:     make([]bool, metrics.NumMetricTypes),
 		countsByMtype:    make([]uint64, metrics.NumMetricTypes),
 		bytesByMtype:     make([]uint64, metrics.NumMetricTypes),
@@ -137,8 +140,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 }
 
 func (cr *contextResolver) get(key ckey.ContextKey) (*Context, bool) {
-	ctx, found := cr.contextsByKey[key]
-	return ctx.context, found
+	return cr.contextsByKey.get(key)
 }
 
 func (cr *contextResolver) length() int {
@@ -180,11 +182,10 @@ func (cr *contextResolver) release() {
 	}
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (cr *contextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
+func (rm resolverMap) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
 	// Within the contextResolver, each set of tags is represented by a unique pointer.
 	perOrigin := map[*tags.Entry]uint64{}
-	for _, cx := range cr.contextsByKey {
+	for _, cx := range rm {
 		perOrigin[cx.context.taggerTags]++
 	}
 
@@ -209,6 +210,11 @@ func (cr *contextResolver) sendOriginTelemetry(timestamp float64, series metrics
 			Points: []metrics.Point{{Ts: timestamp, Value: float64(count)}},
 		})
 	}
+}
+
+func (rm resolverMap) get(key ckey.ContextKey) (*Context, bool) {
+	ctx, found := rm[key]
+	return ctx.context, found
 }
 
 // timestampContextResolver allows tracking and expiring contexts based on time.
@@ -259,16 +265,16 @@ func (cr *timestampContextResolver) expireContexts(timestamp int64) {
 	}
 }
 
-func (cr *timestampContextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, tags []string) {
-	cr.resolver.sendOriginTelemetry(timestamp, series, hostname, tags)
-}
-
 func (cr *timestampContextResolver) dumpContexts(dest io.Writer) error {
 	return cr.resolver.dumpContexts(dest)
 }
 
 func (cr *timestampContextResolver) updateMetrics(countsByMTypeGauge telemetry.Gauge, bytesByMTypeGauge telemetry.Gauge) {
 	cr.resolver.updateMetrics(countsByMTypeGauge, bytesByMTypeGauge)
+}
+
+func (cr *timestampContextResolver) cloneContexts() resolverMap {
+	return maps.Clone(cr.resolver.contextsByKey)
 }
 
 // countBasedContextResolver allows tracking and expiring contexts based on the number

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -261,7 +261,7 @@ func TestOriginTelemetry(t *testing.T) {
 	r.trackContext(&mockSample{"bar", []string{"baz"}, []string{}}, 0)
 	sink := mockSink{}
 	ts := 1672835152.0
-	r.sendOriginTelemetry(ts, &sink, "test", []string{"test"})
+	r.contextsByKey.sendOriginTelemetry(ts, &sink, "test", []string{"test"})
 
 	assert.ElementsMatch(t, sink, []*metrics.Serie{{
 		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -164,6 +164,7 @@ func initAgentDemultiplexer(
 	log.Debug("the Demultiplexer will use", statsdPipelinesCount, "pipelines")
 
 	statsdWorkers := make([]*timeSamplerWorker, statsdPipelinesCount)
+	flushAsync := config.Datadog().GetBool("aggregator_use_async_flush")
 
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
@@ -173,7 +174,7 @@ func initAgentDemultiplexer(
 
 		// its worker (process loop + flush/serialization mechanism)
 
-		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval,
+		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval, flushAsync,
 			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore)
 	}
 

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -49,10 +49,11 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]string, forw
 	serializer := serializer.NewSerializer(forwarder, nil, compressionimpl.NewCompressor(config.Datadog()), config.Datadog(), h)
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize, utils.IsTelemetryEnabled(config.Datadog()))
 	tagsStore := tags.NewStore(config.Datadog().GetBool("aggregator_use_tags_store"), "timesampler")
+	flushAsync := config.Datadog().GetBool("aggregator_use_async_flush")
 
 	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, "")
 	flushAndSerializeInParallel := NewFlushAndSerializeInParallel(config.Datadog())
-	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
+	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, flushAsync, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
 
 	demux := &ServerlessDemultiplexer{
 		log:              log,

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -27,20 +27,26 @@ type SerieSignature struct {
 // TimeSamplerID is a type ID for sharded time samplers.
 type TimeSamplerID int
 
-// TimeSampler aggregates metrics by buckets of 'interval' seconds
-type TimeSampler struct {
-	interval           int64
-	contextResolver    *timestampContextResolver
-	metricsByTimestamp map[int64]metrics.ContextMetrics
-	lastCutOffTime     int64
-	sketchMap          sketchMap
+type metricsMap map[int64]metrics.ContextMetrics
 
+// Immutable part of the timeSampler that can be shared with async flush
+type timeSamplerConst struct {
 	// id is a number to differentiate multiple time samplers
 	// since we start running more than one with the demultiplexer introduction
 	id       TimeSamplerID
 	idString string
-
+	interval int64
 	hostname string
+}
+
+// TimeSampler aggregates metrics by buckets of 'interval' seconds
+type TimeSampler struct {
+	timeSamplerConst
+
+	contextResolver    *timestampContextResolver
+	metricsByTimestamp map[int64]metrics.ContextMetrics
+	lastCutOffTime     int64
+	sketchMap          sketchMap
 }
 
 // NewTimeSampler returns a newly initialized TimeSampler
@@ -56,13 +62,15 @@ func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, hostnam
 	counterExpireTime := contextExpireTime + config.Datadog().GetInt64("dogstatsd_expiry_seconds")
 
 	s := &TimeSampler{
-		interval:           interval,
+		timeSamplerConst: timeSamplerConst{
+			interval: interval,
+			id:       id,
+			idString: idString,
+			hostname: hostname,
+		},
 		contextResolver:    newTimestampContextResolver(cache, idString, contextExpireTime, counterExpireTime),
 		metricsByTimestamp: map[int64]metrics.ContextMetrics{},
 		sketchMap:          make(sketchMap),
-		id:                 id,
-		idString:           idString,
-		hostname:           hostname,
 	}
 
 	return s
@@ -103,8 +111,8 @@ func (s *TimeSampler) sample(metricSample *metrics.MetricSample, timestamp float
 	}
 }
 
-func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.SketchPoint) *metrics.SketchSeries {
-	ctx, ok := s.contextResolver.get(ck)
+func (s *timeSamplerConst) newSketchSeries(ck ckey.ContextKey, points []metrics.SketchPoint, resolver func(ckey.ContextKey) (*Context, bool)) *metrics.SketchSeries {
+	ctx, ok := resolver(ck)
 	if !ok {
 		return nil
 	}
@@ -123,6 +131,18 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 	return ss
 }
 
+// splitBefore removes and returns buckets that are closed at the time specified by cutoffTime.
+func (s *TimeSampler) splitBefore(cutoffTime int64) metricsMap {
+	closed := metricsMap{}
+	for bucketTimestamp, contextMetrics := range s.metricsByTimestamp {
+		if !s.isBucketStillOpen(bucketTimestamp, cutoffTime) {
+			closed[bucketTimestamp] = contextMetrics
+			delete(s.metricsByTimestamp, bucketTimestamp)
+		}
+	}
+	return closed
+}
+
 func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink) {
 	// Map to hold the expired contexts that will need to be deleted after the flush so that we stop sending zeros
 	contextMetricsFlusher := metrics.NewContextMetricsFlusher()
@@ -136,7 +156,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink) {
 
 			// Add a 0 sample to all the counters that are not expired.
 			// It is ok to add 0 samples to a counter that was already sampled for real in the bucket, since it won't change its value
-			s.countersSampleZeroValue(bucketTimestamp, contextMetrics)
+			s.countersSampleZeroValue(bucketTimestamp, contextMetrics, s.contextResolver.resolver.contextsByKey)
 			contextMetricsFlusher.Append(float64(bucketTimestamp), contextMetrics)
 
 			delete(s.metricsByTimestamp, bucketTimestamp)
@@ -147,7 +167,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink) {
 
 		contextMetrics := metrics.MakeContextMetrics()
 
-		s.countersSampleZeroValue(cutoffTime-s.interval, contextMetrics)
+		s.countersSampleZeroValue(cutoffTime-s.interval, contextMetrics, s.contextResolver.resolver.contextsByKey)
 		contextMetricsFlusher.Append(float64(cutoffTime-s.interval), contextMetrics)
 	}
 
@@ -155,14 +175,15 @@ func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink) {
 	serieBySignature := make(map[SerieSignature]*metrics.Serie)
 	s.flushContextMetrics(contextMetricsFlusher, func(rawSeries []*metrics.Serie) {
 		// Note: rawSeries is reused at each call
-		s.dedupSerieBySerieSignature(rawSeries, series, serieBySignature)
+		s.dedupSerieBySerieSignature(rawSeries, series, serieBySignature, s.contextResolver.get)
 	})
 }
 
-func (s *TimeSampler) dedupSerieBySerieSignature(
+func (s *timeSamplerConst) dedupSerieBySerieSignature(
 	rawSeries []*metrics.Serie,
 	serieSink metrics.SerieSink,
 	serieBySignature map[SerieSignature]*metrics.Serie,
+	resolver func(ckey.ContextKey) (*Context, bool),
 ) {
 	// clear the map. Reuse serieBySignature
 	for k := range serieBySignature {
@@ -177,7 +198,7 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 			existingSerie.Points = append(existingSerie.Points, serie.Points[0])
 		} else {
 			// Resolve context and populate new Serie
-			context, ok := s.contextResolver.get(serie.ContextKey)
+			context, ok := resolver(serie.ContextKey)
 			if !ok {
 				log.Errorf("TimeSampler #%d Ignoring all metrics on context key '%v': inconsistent context resolver state: the context is not tracked", s.id, serie.ContextKey)
 				continue
@@ -208,7 +229,7 @@ func (s *TimeSampler) flushSketches(cutoffTime int64, sketchesSink metrics.Sketc
 		pointsByCtx[ck] = append(pointsByCtx[ck], p)
 	})
 	for ck, points := range pointsByCtx {
-		ss := s.newSketchSeries(ck, points)
+		ss := s.newSketchSeries(ck, points, s.contextResolver.get)
 		if ss == nil {
 			log.Errorf("TimeSampler #%d Ignoring all metrics on context key '%v': inconsistent context resolver state: the context is not tracked", s.id, ck)
 			continue
@@ -228,7 +249,110 @@ func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketche
 	s.lastCutOffTime = cutoffTime
 
 	s.updateMetrics()
-	s.sendTelemetry(timestamp, series)
+	s.sendTelemetry(timestamp, s.contextResolver.resolver.contextsByKey, series)
+}
+
+func (s *TimeSampler) flushAsync(timestamp float64, series metrics.SerieSink, sketches metrics.SketchesSink, blockChan chan struct{}) {
+	// Compute a limit timestamp
+	cutoffTime := s.calculateBucketStart(timestamp)
+	// Move metrics and sketches buckets that will be flushed out of the active working set into local variables
+	metricsBuckets := s.splitBefore(cutoffTime)
+	sketchesBuckets := s.sketchMap.splitBefore(cutoffTime)
+	contexts := s.contextResolver.cloneContexts()
+
+	s.contextResolver.expireContexts(int64(timestamp))
+	s.updateMetrics()
+
+	go s.doFlushAsync(
+		timestamp,
+		cutoffTime,
+		s.lastCutOffTime,
+		contexts,
+		metricsBuckets,
+		sketchesBuckets,
+		series,
+		sketches,
+		blockChan,
+	)
+
+	s.lastCutOffTime = cutoffTime
+}
+
+// doFlushAsync performs asynchronous flush while time sampler
+// is processing new metrics.
+//
+// This function should not share non-readonly data with other
+// goroutines to avoid races.
+//
+// This isn't a method of TimeSampler to reduce chance of accidentally
+// accessing data that is concurrently modified.
+func (s *timeSamplerConst) doFlushAsync(
+	timestamp float64,
+	cutoffTime int64,
+	lastCutoffTime int64,
+	contexts resolverMap,
+	metricsBuckets metricsMap,
+	sketchesBuckets sketchMap,
+	seriesSink metrics.SerieSink,
+	sketchesSink metrics.SketchesSink,
+	blockChan chan struct{},
+) {
+	defer func() { blockChan <- struct{}{} }()
+
+	s.doFlushAsyncMetrics(cutoffTime, lastCutoffTime, contexts, metricsBuckets, seriesSink)
+	s.doFlushAsyncSketches(contexts, sketchesBuckets, sketchesSink)
+	s.sendTelemetry(timestamp, contexts, seriesSink)
+}
+
+func (s *timeSamplerConst) doFlushAsyncMetrics(
+	cutoffTime int64,
+	lastCutoffTime int64,
+	contexts resolverMap,
+	metricsBuckets metricsMap,
+	seriesSink metrics.SerieSink,
+) {
+	if len(metricsBuckets) == 0 && lastCutoffTime+s.interval <= cutoffTime {
+		// Even if there is no metric in this flush, recreate empty counters,
+		// but only if we've passed an interval since the last flush
+		metricsBuckets[cutoffTime-s.interval] = metrics.MakeContextMetrics()
+	}
+	contextMetricsFlusher := metrics.NewContextMetricsFlusher()
+	for bucketTimestamp, contextMetrics := range metricsBuckets {
+		// Add a 0 sample to all the counters that are not expired. It is ok to
+		// add 0 samples to a counter that was already sampled for real in the
+		// bucket, since it won't change its value.
+		s.countersSampleZeroValue(bucketTimestamp, contextMetrics, contexts)
+		contextMetricsFlusher.Append(float64(bucketTimestamp), contextMetrics)
+	}
+
+	// serieBySignature is reused for each call of dedupSerieBySerieSignature to avoid allocations.
+	serieBySignature := make(map[SerieSignature]*metrics.Serie)
+	errors := contextMetricsFlusher.FlushAndClear(func(rawSeries []*metrics.Serie) {
+		s.dedupSerieBySerieSignature(rawSeries, seriesSink, serieBySignature, contexts.get)
+	})
+	for ckey, err := range errors {
+		context, ok := contexts.get(ckey)
+		if !ok {
+			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
+			continue
+		}
+		log.Infof("No value returned for dogstatsd metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags(), err)
+	}
+}
+
+func (s *timeSamplerConst) doFlushAsyncSketches(
+	contexts resolverMap,
+	sketchesBuckets sketchMap,
+	sketchesSink metrics.SketchesSink,
+) {
+	for ck, points := range sketchesBuckets.toPoints() {
+		ss := s.newSketchSeries(ck, points, contexts.get)
+		if ss == nil {
+			log.Errorf("TimeSampler #%d Ignoring all sketches on context key '%v': inconsistent context resolver state: the context is not tracked", s.id, ck)
+			continue
+		}
+		sketchesSink.Append(ss)
+	}
 }
 
 // We do this here mostly because we want to avoid slow operations when we track/remove
@@ -263,9 +387,9 @@ func (s *TimeSampler) flushContextMetrics(contextMetricsFlusher *metrics.Context
 	}
 }
 
-func (s *TimeSampler) countersSampleZeroValue(timestamp int64, contextMetrics metrics.ContextMetrics) {
+func (s *timeSamplerConst) countersSampleZeroValue(timestamp int64, contextMetrics metrics.ContextMetrics, contexts resolverMap) {
 	expirySeconds := config.Datadog().GetInt64("dogstatsd_expiry_seconds")
-	for counterContext, entry := range s.contextResolver.resolver.contextsByKey {
+	for counterContext, entry := range contexts {
 		if entry.lastSeen+expirySeconds > timestamp && entry.context.mtype == metrics.CounterType {
 			sample := &metrics.MetricSample{
 				Name:       "",
@@ -284,7 +408,7 @@ func (s *TimeSampler) countersSampleZeroValue(timestamp int64, contextMetrics me
 	}
 }
 
-func (s *TimeSampler) sendTelemetry(timestamp float64, series metrics.SerieSink) {
+func (s *timeSamplerConst) sendTelemetry(timestamp float64, contexts resolverMap, series metrics.SerieSink) {
 	if !config.Datadog().GetBool("telemetry.enabled") {
 		return
 	}
@@ -297,7 +421,7 @@ func (s *TimeSampler) sendTelemetry(timestamp float64, series metrics.SerieSink)
 	}
 
 	if config.Datadog().GetBool("telemetry.dogstatsd_origin") {
-		s.contextResolver.sendOriginTelemetry(timestamp, series, s.hostname, tags)
+		contexts.sendOriginTelemetry(timestamp, series, s.hostname, tags)
 	}
 }
 

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -555,6 +555,8 @@ func flushSerie(sampler *TimeSampler, timestamp float64) (metrics.Series, metric
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches)
+	blockChan := make(chan struct{})
+	sampler.flushAsync(timestamp, &series, &sketches, blockChan)
+	<-blockChan
 	return series, sketches
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1180,6 +1180,7 @@ func aggregator(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("aggregator_stop_timeout", 2)
 	config.BindEnvAndSetDefault("aggregator_buffer_size", 100)
 	config.BindEnvAndSetDefault("aggregator_use_tags_store", true)
+	config.BindEnvAndSetDefault("aggregator_use_async_flush", true)
 	config.BindEnvAndSetDefault("basic_telemetry_add_container_tags", false) // configure adding the agent container tags to the basic agent telemetry metrics (e.g. `datadog.agent.running`)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_chan_size", 200)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size", 4000)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1180,7 +1180,7 @@ func aggregator(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("aggregator_stop_timeout", 2)
 	config.BindEnvAndSetDefault("aggregator_buffer_size", 100)
 	config.BindEnvAndSetDefault("aggregator_use_tags_store", true)
-	config.BindEnvAndSetDefault("aggregator_use_async_flush", true)
+	config.BindEnvAndSetDefault("aggregator_use_async_flush", false)
 	config.BindEnvAndSetDefault("basic_telemetry_add_container_tags", false) // configure adding the agent container tags to the basic agent telemetry metrics (e.g. `datadog.agent.running`)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_chan_size", 200)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size", 4000)


### PR DESCRIPTION
### What does this PR do?

Add an option (off by default) to perform the bulk of the dogstatsd flushing without blocking the rest of the pipeline.

### Motivation

Dogstatsd server has a queue that buffers incoming packets if they can not be processed immediately. Flushing large number of metrics can block the pipeline for a long time (around 1-2 seconds) leading to queue to buffer a lot of packets.

### Additional Notes

Processing new metrics needs to write to the context map when it encounters a new metric context. At the same time, flush process reads the same map to extract context information for metrics being flushed. To avoid lock overhead, asynchronous flush instead copies the context map, which is fast (~100ms) and needs less space than the buffer queue. Then we extract and remove buckets that need to be flushed from the working set. After this, metrics processing can resume, while the flush process works in background.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
