### PR TITLE
APM: use 64 bit trace id by default for prob sampler (OTEL-1870)

### DIFF
--- a/pkg/trace/sampler/probabilistic_test.go
+++ b/pkg/trace/sampler/probabilistic_test.go
@@ -31,6 +31,7 @@ func TestProbabilisticSampler(t *testing.T) {
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 41,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		sampled := sampler.Sample(&trace.Span{
@@ -45,6 +46,7 @@ func TestProbabilisticSampler(t *testing.T) {
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 40,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		sampled := sampler.Sample(&trace.Span{
@@ -59,6 +61,7 @@ func TestProbabilisticSampler(t *testing.T) {
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 41,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		sampled := sampler.Sample(&trace.Span{
@@ -73,6 +76,7 @@ func TestProbabilisticSampler(t *testing.T) {
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 40,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		sampled := sampler.Sample(&trace.Span{
@@ -81,11 +85,12 @@ func TestProbabilisticSampler(t *testing.T) {
 		})
 		assert.False(t, sampled)
 	})
-	t.Run("keep-dd-64", func(t *testing.T) {
+	t.Run("keep-dd-64-full", func(t *testing.T) {
 		conf := &config.AgentConfig{
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 40,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		span := &trace.Span{
@@ -96,16 +101,45 @@ func TestProbabilisticSampler(t *testing.T) {
 		assert.True(t, sampled)
 		assert.EqualValues(t, .4, span.Metrics["_dd.prob_sr"])
 	})
-	t.Run("drop-dd-64", func(t *testing.T) {
+	t.Run("drop-dd-64-full", func(t *testing.T) {
 		conf := &config.AgentConfig{
 			ProbabilisticSamplerEnabled:            true,
 			ProbabilisticSamplerHashSeed:           0,
 			ProbabilisticSamplerSamplingPercentage: 40,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 		}
 		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 		sampled := sampler.Sample(&trace.Span{
 			TraceID: 556,
 			Meta:    map[string]string{},
+		})
+		assert.False(t, sampled)
+	})
+	t.Run("keep-dd-128", func(t *testing.T) {
+		tid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		conf := &config.AgentConfig{
+			ProbabilisticSamplerEnabled:            true,
+			ProbabilisticSamplerHashSeed:           0,
+			ProbabilisticSamplerSamplingPercentage: 70,
+		}
+		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
+		sampled := sampler.Sample(&trace.Span{
+			TraceID: binary.BigEndian.Uint64(tid[8:]),
+			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
+		})
+		assert.True(t, sampled)
+	})
+	t.Run("drop-dd-128", func(t *testing.T) {
+		tid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		conf := &config.AgentConfig{
+			ProbabilisticSamplerEnabled:            true,
+			ProbabilisticSamplerHashSeed:           0,
+			ProbabilisticSamplerSamplingPercentage: 68,
+		}
+		sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
+		sampled := sampler.Sample(&trace.Span{
+			TraceID: 555,
+			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
 		})
 		assert.False(t, sampled)
 	})
@@ -140,6 +174,7 @@ func FuzzConsistentWithOtel(f *testing.F) {
 		ProbabilisticSamplerEnabled:            true,
 		ProbabilisticSamplerHashSeed:           hashSeed,
 		ProbabilisticSamplerSamplingPercentage: samplingPercent,
+		Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
 	}
 	sampler := NewProbabilisticSampler(conf, &statsd.NoOpClient{})
 

--- a/releasenotes/notes/probSampler64-95b49cccfa50a011.yaml
+++ b/releasenotes/notes/probSampler64-95b49cccfa50a011.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Probabilistic Sampler now only looks at the lower 64 bits of a trace ID by default to improve compatibility in distributed systems where some apps may truncate the trace ID. To maintain the previous behavior use the feature flag `probabilistic_sampler_full_trace_id`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Switch the probabilistic sampler to use the lower 64 bits by default. This improves compatibility in distributed systems that have legacy w3c support where 128 bit IDs might be truncated to 64 bits. Note that for customers who know they are only operating in 128 bit environments AND they need compatibility with the otel probabilistic sampler processor they can enable the feature flag `probabilistic_sampler_full_trace_id` for now, we may elect in the future to return to the default behavior or deprecate this flag when/if OTEL makes changes to handle this issue
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We want complete traces even in distributed systems where the trace ID may be truncated to 64 bits
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
This change is not compatible with the previous version of the probabilistic sampler or otel PSP by default. If you need compatibility with the old agent version and/or the otel probabilistic sampler processor use the feature flag `probabilistic_sampler_full_trace_id`
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Covered with unit tests
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
