### PR TITLE
conductor: disable nighly schedule during the release freeze

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -13,7 +13,6 @@ extensions:
         - name: "staging"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
           branch: "main"
-          schedule: "0 3 * * 1-5"
         - name: "conductor-sandbox"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
           branch: "chouquette/conductor"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Disables our conductor based nightly build

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This build is currently bound to fail and overlaps with the conductor run issued by k8s-datadog-agent-ops & our gitlab scheduled pipeline.
Since it's likely that the switch won't be done before the freeze, let's disable the schedule for now

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
