### PR TITLE
Improve lock contention metric tags

### DIFF
--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -179,7 +179,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_max",
 				Help:      "gauge tracking maximum time a tracked lock was contended for",
 			},
-			[]string{"name", "lock_type"},
+			[]string{"ebpf_name", "lock_type", "module"},
 		),
 		avgContention: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -187,7 +187,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_avg",
 				Help:      "gauge tracking average time a tracked lock was contended for",
 			},
-			[]string{"name", "lock_type"},
+			[]string{"ebpf_name", "lock_type", "module"},
 		),
 		totalContention: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -195,7 +195,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_total",
 				Help:      "counter tracking total time a tracked lock was contended for",
 			},
-			[]string{"name", "lock_type"},
+			[]string{"ebpf_name", "lock_type", "module"},
 		),
 	}
 
@@ -257,15 +257,20 @@ func (l *LockContentionCollector) Collect(metrics chan<- prometheus.Metric) {
 			continue
 		}
 
+		module, err := GetModuleFromMapID(mp.id)
+		if err != nil {
+			module = "n/a"
+		}
+
 		if (data.Total_time > 0) && (mp.totalTime != data.Total_time) {
 			avgTime := data.Total_time / uint64(data.Count)
 
 			lockType := lockTypes[lr.Type]
-			l.maxContention.WithLabelValues(mp.name, lockType).Set(float64(data.Max_time))
-			l.avgContention.WithLabelValues(mp.name, lockType).Set(float64(avgTime))
+			l.maxContention.WithLabelValues(mp.name, lockType, module).Set(float64(data.Max_time))
+			l.avgContention.WithLabelValues(mp.name, lockType, module).Set(float64(avgTime))
 
 			// TODO: should we consider overflows. u64 overflow seems very unlikely?
-			l.totalContention.WithLabelValues(mp.name, lockType).Add(float64(data.Total_time - mp.totalTime))
+			l.totalContention.WithLabelValues(mp.name, lockType, module).Add(float64(data.Total_time - mp.totalTime))
 			mp.totalTime = data.Total_time
 		}
 	}

--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -179,7 +179,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_max",
 				Help:      "gauge tracking maximum time a tracked lock was contended for",
 			},
-			[]string{"ebpf_name", "lock_type", "module"},
+			[]string{"resource_name", "lock_type", "module"},
 		),
 		avgContention: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -187,7 +187,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_avg",
 				Help:      "gauge tracking average time a tracked lock was contended for",
 			},
-			[]string{"ebpf_name", "lock_type", "module"},
+			[]string{"resource_name", "lock_type", "module"},
 		),
 		totalContention: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -195,7 +195,7 @@ func NewLockContentionCollector() *LockContentionCollector {
 				Name:      "_total",
 				Help:      "counter tracking total time a tracked lock was contended for",
 			},
-			[]string{"ebpf_name", "lock_type", "module"},
+			[]string{"resource_name", "lock_type", "module"},
 		),
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR changes the tag `name` to `resource_name` to avoid collisions.
It also adds a new tag `module` to allow easier filtering of locks of interest by teams.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
