### PR TITLE
Remove AWS environment from component and use provisioner params instead

### DIFF
--- a/test/new-e2e/pkg/environments/aws/ecs/ecs.go
+++ b/test/new-e2e/pkg/environments/aws/ecs/ecs.go
@@ -207,8 +207,6 @@ func Run(ctx *pulumi.Context, env *environments.ECS, params *ProvisionerParams) 
 	// Export cluster’s properties
 	ctx.Export("ecs-cluster-name", ecsCluster.Name)
 	ctx.Export("ecs-cluster-arn", ecsCluster.Arn)
-	env.ClusterName = ecsCluster.Name
-	env.ClusterArn = ecsCluster.Arn
 
 	// Handle capacity providers
 	capacityProviders := pulumi.StringArray{}

--- a/test/new-e2e/pkg/environments/aws/ecs/ecs.go
+++ b/test/new-e2e/pkg/environments/aws/ecs/ecs.go
@@ -46,6 +46,7 @@ type ProvisionerParams struct {
 	ecsWindowsNodeGroup               bool
 	infraShouldDeployFakeintakeWithLB bool
 	workloadAppFuncs                  []WorkloadAppFunc
+	awsEnv                            *aws.Environment
 }
 
 func newProvisionerParams() *ProvisionerParams {
@@ -166,6 +167,14 @@ func WithoutAgent() ProvisionerOption {
 	}
 }
 
+// WithAwsEnv asks the provisioner to use the given environment, it is created otherwise
+func WithAwsEnv(env *aws.Environment) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.awsEnv = env
+		return nil
+	}
+}
+
 // WorkloadAppFunc is a function that deploys a workload app to an ECS cluster
 type WorkloadAppFunc func(e aws.Environment, clusterArn pulumi.StringInput) (*ecsComp.Workload, error)
 
@@ -181,8 +190,8 @@ func WithWorkloadApp(appFunc WorkloadAppFunc) ProvisionerOption {
 func Run(ctx *pulumi.Context, env *environments.ECS, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error
-	if env.AwsEnvironment != nil {
-		awsEnv = *env.AwsEnvironment
+	if params.awsEnv != nil {
+		awsEnv = *params.awsEnv
 	} else {
 		awsEnv, err = aws.NewEnvironment(ctx)
 		if err != nil {

--- a/test/new-e2e/pkg/environments/aws/kubernetes/eks.go
+++ b/test/new-e2e/pkg/environments/aws/kubernetes/eks.go
@@ -46,13 +46,13 @@ func eksDiagnoseFunc(ctx context.Context, stackName string) (string, error) {
 }
 
 // EKSProvisioner creates a new provisioner
-func EKSProvisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.AwsKubernetes] {
+func EKSProvisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Kubernetes] {
 	// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 	// and it's easy to forget about it, leading to hard to debug issues.
 	params := newProvisionerParams()
 	_ = optional.ApplyOptions(params, opts)
 
-	provisioner := e2e.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.AwsKubernetes) error {
+	provisioner := e2e.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.Kubernetes) error {
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
 		params := newProvisionerParams()
@@ -67,11 +67,11 @@ func EKSProvisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments
 }
 
 // EKSRunFunc deploys a EKS environment given a pulumi.Context
-func EKSRunFunc(ctx *pulumi.Context, env *environments.AwsKubernetes, params *ProvisionerParams) error {
+func EKSRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
 	var err error
-	if env.AwsEnvironment != nil {
-		awsEnv = *env.AwsEnvironment
+	if params.awsEnv != nil {
+		awsEnv = *params.awsEnv
 	} else {
 		awsEnv, err = aws.NewEnvironment(ctx)
 		if err != nil {

--- a/test/new-e2e/pkg/environments/aws/kubernetes/params.go
+++ b/test/new-e2e/pkg/environments/aws/kubernetes/params.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 	kubeComp "github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
 
@@ -34,6 +35,7 @@ type ProvisionerParams struct {
 	eksLinuxARMNodeGroup     bool
 	eksBottlerocketNodeGroup bool
 	eksWindowsNodeGroup      bool
+	awsEnv                   *aws.Environment
 	deployDogstatsd          bool
 }
 
@@ -170,6 +172,14 @@ type WorkloadAppFunc func(e config.Env, kubeProvider *kubernetes.Provider) (*kub
 func WithWorkloadApp(appFunc WorkloadAppFunc) ProvisionerOption {
 	return func(params *ProvisionerParams) error {
 		params.workloadAppFuncs = append(params.workloadAppFuncs, appFunc)
+		return nil
+	}
+}
+
+// WithAwsEnv asks the provisioner to use the given environment, it is created otherwise
+func WithAwsEnv(env *aws.Environment) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.awsEnv = env
 		return nil
 	}
 }

--- a/test/new-e2e/pkg/environments/ecs.go
+++ b/test/new-e2e/pkg/environments/ecs.go
@@ -6,7 +6,6 @@
 package environments
 
 import (
-	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/zorkian/go-datadog-api"
 
@@ -18,9 +17,8 @@ import (
 
 // ECS is an environment that contains a ECS deployed in a cluster, FakeIntake and Agent configured to talk to each other.
 type ECS struct {
-	AwsEnvironment *aws.Environment
-	ClusterName    pulumi.StringInput
-	ClusterArn     pulumi.StringInput
+	ClusterName pulumi.StringInput
+	ClusterArn  pulumi.StringInput
 
 	// Components
 	FakeIntake    *components.FakeIntake

--- a/test/new-e2e/pkg/environments/ecs.go
+++ b/test/new-e2e/pkg/environments/ecs.go
@@ -6,7 +6,6 @@
 package environments
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/zorkian/go-datadog-api"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
@@ -17,9 +16,6 @@ import (
 
 // ECS is an environment that contains a ECS deployed in a cluster, FakeIntake and Agent configured to talk to each other.
 type ECS struct {
-	ClusterName pulumi.StringInput
-	ClusterArn  pulumi.StringInput
-
 	// Components
 	FakeIntake    *components.FakeIntake
 	DatadogClient *datadog.Client

--- a/test/new-e2e/pkg/environments/kubernetes.go
+++ b/test/new-e2e/pkg/environments/kubernetes.go
@@ -6,23 +6,11 @@
 package environments
 
 import (
-	"github.com/DataDog/test-infra-definitions/resources/aws"
-
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 )
 
 // Kubernetes is an environment that contains a Kubernetes cluster, the Agent and a FakeIntake.
 type Kubernetes struct {
-	// Components
-	KubernetesCluster *components.KubernetesCluster
-	FakeIntake        *components.FakeIntake
-	Agent             *components.KubernetesAgent
-}
-
-// AwsKubernetes is an environment that contains a AWS Kubernetes cluster (EKS), the Agent and a FakeIntake.
-type AwsKubernetes struct {
-	AwsEnvironment *aws.Environment
-
 	// Components
 	KubernetesCluster *components.KubernetesCluster
 	FakeIntake        *components.FakeIntake

--- a/test/new-e2e/tests/npm/ecs_1host_test.go
+++ b/test/new-e2e/tests/npm/ecs_1host_test.go
@@ -19,6 +19,8 @@ import (
 	npmtools "github.com/DataDog/test-infra-definitions/components/datadog/apps/npm-tools"
 	"github.com/DataDog/test-infra-definitions/components/datadog/ecsagentparams"
 	"github.com/DataDog/test-infra-definitions/components/docker"
+	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
+
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 )
@@ -67,15 +69,12 @@ func ecsHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[ecsHttpbinEnv] {
 			envecs.WithAwsEnv(&awsEnv),
 			envecs.WithECSLinuxECSOptimizedNodeGroup(),
 			envecs.WithAgentOptions(ecsagentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")),
+			envecs.WithWorkloadApp(func(e aws.Environment, clusterArn pulumi.StringInput) (*ecsComp.Workload, error) {
+				testURL := "http://" + env.HTTPBinHost.Address + "/"
+				return npmtools.EcsAppDefinition(e, clusterArn, testURL)
+			}),
 		)
 		envecs.Run(ctx, &env.ECS, params)
-
-		// Workload
-		testURL := "http://" + env.HTTPBinHost.Address + "/"
-		if _, err := npmtools.EcsAppDefinition(awsEnv, env.ClusterArn, testURL); err != nil {
-			return err
-		}
-
 		return nil
 	}
 }

--- a/test/new-e2e/tests/npm/ecs_1host_test.go
+++ b/test/new-e2e/tests/npm/ecs_1host_test.go
@@ -40,7 +40,6 @@ func ecsHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[ecsHttpbinEnv] {
 		if err != nil {
 			return err
 		}
-		env.ECS.AwsEnvironment = &awsEnv
 
 		vmName := "httpbinvm"
 		nginxHost, err := ec2.NewVM(awsEnv, vmName)
@@ -65,6 +64,7 @@ func ecsHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[ecsHttpbinEnv] {
 		}
 
 		params := envecs.GetProvisionerParams(
+			envecs.WithAwsEnv(&awsEnv),
 			envecs.WithECSLinuxECSOptimizedNodeGroup(),
 			envecs.WithAgentOptions(ecsagentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")),
 		)

--- a/test/new-e2e/tests/npm/eks_1host_test.go
+++ b/test/new-e2e/tests/npm/eks_1host_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 type eksHttpbinEnv struct {
-	environments.AwsKubernetes
+	environments.Kubernetes
 
 	// Extra Components
 	HTTPBinHost *components.RemoteHost
@@ -43,8 +43,6 @@ func eksHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[eksHttpbinEnv] {
 		if err != nil {
 			return err
 		}
-		env.AwsKubernetes.AwsEnvironment = &awsEnv
-
 		vmName := "httpbinvm"
 		httpbinHost, err := ec2.NewVM(awsEnv, vmName)
 		if err != nil {
@@ -74,11 +72,12 @@ func eksHttpbinEnvProvisioner() e2e.PulumiEnvRunFunc[eksHttpbinEnv] {
 		}
 
 		params := envkube.GetProvisionerParams(
+			envkube.WithAwsEnv(&awsEnv),
 			envkube.WithEKSLinuxNodeGroup(),
 			envkube.WithAgentOptions(kubernetesagentparams.WithHelmValues(systemProbeConfigNPMHelmValues)),
 			envkube.WithWorkloadApp(npmToolsWorkload),
 		)
-		envkube.EKSRunFunc(ctx, &env.AwsKubernetes, params)
+		envkube.EKSRunFunc(ctx, &env.Kubernetes, params)
 
 		return nil
 	}

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -35,9 +35,9 @@ func ecsCPUStressProvisioner() e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
 		if err != nil {
 			return err
 		}
-		env.ECS.AwsEnvironment = &awsEnv
 
 		params := ecs.GetProvisionerParams(
+			ecs.WithAwsEnv(&awsEnv),
 			ecs.WithECSLinuxECSOptimizedNodeGroup(),
 			ecs.WithAgentOptions(
 				ecsagentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true"),

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/ecs"
 )
@@ -42,13 +44,12 @@ func ecsCPUStressProvisioner() e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
 			ecs.WithAgentOptions(
 				ecsagentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true"),
 			),
+			ecs.WithWorkloadApp(func(e aws.Environment, clusterArn pulumi.StringInput) (*ecsComp.Workload, error) {
+				return cpustress.EcsAppDefinition(e, clusterArn)
+			}),
 		)
 
 		if err := ecs.Run(ctx, &env.ECS, params); err != nil {
-			return err
-		}
-
-		if _, err := cpustress.EcsAppDefinition(awsEnv, env.ClusterArn); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Remove AWS environment from Kubernetes and ECS environment so they remain "cloud agnostic" and rather use a provider parameter to provide an existing environment

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
