### PR TITLE
(fleet) fix the OCI agent run_path

### DIFF
--- a/pkg/config/setup/config_nix.go
+++ b/pkg/config/setup/config_nix.go
@@ -15,9 +15,9 @@ var (
 	// It might be overridden at build time
 	InstallPath = "/opt/datadog-agent"
 
-	// defaultRunPath is the default path for the agent's runtime files
-	// It might be overridden at build time
-	defaultRunPath = "/opt/datadog-agent/run"
+	// defaultRunPath is the default run path
+	// It is set in osinit to take into account InstallPath overrides
+	defaultRunPath = ""
 )
 
 var (
@@ -48,4 +48,7 @@ const (
 // called by init in config.go, to ensure any os-specific config is done
 // in time
 func osinit() {
+	if defaultRunPath == "" {
+		defaultRunPath = filepath.Join(InstallPath, "run")
+	}
 }

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -183,8 +183,8 @@ func (h *Host) AssertPackageInstalledByInstaller(pkgs ...string) {
 }
 
 // AgentRuntimeConfig returns the runtime agent config on the host.
-func (h *Host) AgentRuntimeConfig() string {
-	return h.remote.MustExecute("sudo -u dd-agent datadog-agent config")
+func (h *Host) AgentRuntimeConfig() (string, error) {
+	return h.remote.Execute("sudo -u dd-agent datadog-agent config")
 }
 
 // AssertPackageVersion checks if a package is installed with the correct version

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -182,6 +182,11 @@ func (h *Host) AssertPackageInstalledByInstaller(pkgs ...string) {
 	}
 }
 
+// AgentRuntimeConfig returns the runtime agent config on the host.
+func (h *Host) AgentRuntimeConfig() string {
+	return h.remote.MustExecute("sudo -u dd-agent datadog-agent config")
+}
+
 // AssertPackageVersion checks if a package is installed with the correct version
 func (h *Host) AssertPackageVersion(pkg string, version string) {
 	state := h.State()

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -8,10 +8,13 @@ package installer
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -370,6 +373,20 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 			),
 		)
 	}
+}
+
+func (s *packageAgentSuite) TestRunPath() {
+	s.RunInstallScript(envForceInstall("datadog-agent"))
+	defer s.Purge()
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+
+	rawConfig := s.host.AgentRuntimeConfig()
+	var config map[string]interface{}
+	err := yaml.Unmarshal([]byte(rawConfig), &config)
+	assert.NoError(s.T(), err)
+	runPath, ok := config["run_path"].(string)
+	assert.True(s.T(), ok, "run_path not found in runtime config")
+	assert.True(s.T(), strings.HasPrefix(runPath, "/opt/datadog-packages/datadog-agent/"), "run_path is not in the expected location: %s", runPath)
 }
 
 func (s *packageAgentSuite) purgeAgentDebInstall() {

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
@@ -380,9 +381,14 @@ func (s *packageAgentSuite) TestRunPath() {
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
 
-	rawConfig := s.host.AgentRuntimeConfig()
+	var rawConfig string
+	var err error
+	assert.Eventually(s.T(), func() bool {
+		rawConfig, err = s.host.AgentRuntimeConfig()
+		return err == nil
+	}, 30*time.Second, 5*time.Second, "failed to get agent runtime config: %v", err)
 	var config map[string]interface{}
-	err := yaml.Unmarshal([]byte(rawConfig), &config)
+	err = yaml.Unmarshal([]byte(rawConfig), &config)
 	assert.NoError(s.T(), err)
 	runPath, ok := config["run_path"].(string)
 	assert.True(s.T(), ok, "run_path not found in runtime config")


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent/pull/26145 introduced a regression by hardcoding the agent `run_path` to `/opt/datadog-agent/run` instead of `<install_dir>/run`. 

This breaks features of the OCI agent that depend on this `run_path`. This PR fixes this regression.