### PR TITLE
Fix the `qa_agent_ot` GitLab job

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -283,19 +283,20 @@ qa_agent:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
-qa_agent_ot:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.on_container_or_e2e_changes]
-    - !reference [.manual]
-  needs:
-    - docker_build_ot_agent7
-    - docker_build_ot_agent7_arm64
-  variables:
-    IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot
+# TODO: OTEL fix it when doing e2e tests
+
+# qa_agent_ot:
+#   extends: .docker_publish_job_definition
+#   stage: dev_container_deploy
+#   rules:
+#     - !reference [.manual]
+#   needs:
+#     - docker_build_ot_agent7
+#     - docker_build_ot_agent7_arm64
+#   variables:
+#     IMG_REGISTRIES: agent-qa
+#     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
+#     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot
 
 dev_branch-ot:
   extends: .docker_publish_job_definition

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -287,8 +287,7 @@ qa_agent_ot:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    # incident-28463: this job is currently broken
-    # - !reference [.on_container_or_e2e_changes]
+    - !reference [.on_container_or_e2e_changes]
     - !reference [.manual]
   needs:
     - docker_build_ot_agent7

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -294,7 +294,7 @@ qa_agent_ot:
     - docker_build_ot_agent7_arm64
   variables:
     IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-arm64
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot
 
 dev_branch-ot:
@@ -361,4 +361,3 @@ qa_cws_instrumentation:
   rules:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
-


### PR DESCRIPTION
### What does this PR do?

Fix the `qa_agent_ot` GitLab job.

### Motivation

The tag of the docker image consumed by `qa_agent_ot` here: https://github.com/DataDog/datadog-agent/blob/04c5db04f035dbe33040df6e8a005dcfc03945e8/.gitlab/dev_container_deploy/docker_linux.yml#L298
needs to match the tag of the docker images produced by the dependencies declared here: https://github.com/DataDog/datadog-agent/blob/04c5db04f035dbe33040df6e8a005dcfc03945e8/.gitlab/dev_container_deploy/docker_linux.yml#L294-L295
and when we look at those jobs here: https://github.com/DataDog/datadog-agent/blob/04c5db04f035dbe33040df6e8a005dcfc03945e8/.gitlab/container_build/docker_linux.yml#L197
and there: https://github.com/DataDog/datadog-agent/blob/04c5db04f035dbe33040df6e8a005dcfc03945e8/.gitlab/container_build/docker_linux.yml#L211
we see that the `-beta` part of the suffix seems to be missing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
