### PR TITLE
[PROCS-4184] Remove Flake mark on the K8s E2E TestProcessCheck

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeClient "k8s.io/client-go/kubernetes"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -83,8 +82,6 @@ func TestK8sTestSuite(t *testing.T) {
 }
 
 func (s *K8sSuite) TestProcessCheck() {
-	// https://datadoghq.atlassian.net/browse/PROCS-4184
-	flake.Mark(s.T())
 	t := s.T()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {


### PR DESCRIPTION
### What does this PR do?
Removing the flake mark on this test as it's been stable for 2 days after merging of https://github.com/DataDog/datadog-agent/pull/27163

### Motivation
PROCS-4184

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
