### PR TITLE
[ASCII-1946] Fix deadlock in config wrapper

### DIFF
--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -659,7 +659,7 @@ func (c *safeConfig) AllSettingsBySource() map[Source]interface{} {
 	for _, source := range sources {
 		res[source] = c.configSources[source].AllSettingsWithoutDefault()
 	}
-	res[SourceProvided] = c.AllSettingsWithoutDefault()
+	res[SourceProvided] = c.Viper.AllSettingsWithoutDefault()
 	return res
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix a deadlock in the config wrapper caused by a recursive read-lock.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Do not deadlock.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The deadlock happens if a routine tries to write-lock between the two read-locks, that's unlikely, but it can definitely happen, especially since `AllSettingsBySource` does some work between the two locks.

Introduced by https://github.com/DataDog/datadog-agent/pull/26129.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

