### PR TITLE
[CWS] reduce allocation in stats reporting of activity tree

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -27,20 +27,50 @@ import (
 )
 
 // NodeDroppedReason is used to list the reasons to drop a node
-type NodeDroppedReason string
+type NodeDroppedReason byte
 
-var (
-	eventTypeReason       NodeDroppedReason = "event_type"
-	invalidRootNodeReason NodeDroppedReason = "invalid_root_node"
-	bindFamilyReason      NodeDroppedReason = "bind_family"
-	brokenEventReason     NodeDroppedReason = "broken_event"
-	allDropReasons                          = []NodeDroppedReason{
-		eventTypeReason,
-		invalidRootNodeReason,
-		bindFamilyReason,
-		brokenEventReason,
-	}
+const (
+	eventTypeReason NodeDroppedReason = iota
+	invalidRootNodeReason
+	bindFamilyReason
+	brokenEventReason
+
+	minNodeDroppedReason   = eventTypeReason
+	maxNodeDroppedReason   = brokenEventReason
+	nodeDroppedReasonCount = maxNodeDroppedReason - minNodeDroppedReason + 1
 )
+
+func (reason NodeDroppedReason) String() string {
+	switch reason {
+	case eventTypeReason:
+		return "event_type"
+	case invalidRootNodeReason:
+		return "invalid_root_node"
+	case bindFamilyReason:
+		return "bind_family"
+	case brokenEventReason:
+		return "broken_event"
+	default:
+		return "unknown"
+	}
+}
+
+// Tag returns the metric tag associated with this dropped reason, it's basically
+// fmt.Sprintf("reason:%s", reason)
+func (reason NodeDroppedReason) Tag() string {
+	switch reason {
+	case eventTypeReason:
+		return "reason:event_type"
+	case invalidRootNodeReason:
+		return "reason:invalid_root_node"
+	case bindFamilyReason:
+		return "reason:bind_family"
+	case brokenEventReason:
+		return "reason:broken_event"
+	default:
+		return "reason:unknown"
+	}
+}
 
 var (
 	// ErrBrokenLineage is returned when the given process don't have a full lineage

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -83,6 +83,23 @@ func (genType NodeGenerationType) String() string {
 	}
 }
 
+// Tag returns the metric tag associated with this generation type, it's basically
+// fmt.Sprintf("generation_type:%s", genType)
+func (genType NodeGenerationType) Tag() string {
+	switch genType {
+	case Runtime:
+		return "generation_type:runtime"
+	case Snapshot:
+		return "generation_type:snapshot"
+	case ProfileDrift:
+		return "generation_type:profile_drift"
+	case WorkloadWarmup:
+		return "generation_type:workload_warmup"
+	default:
+		return "generation_type:unknown"
+	}
+}
+
 // Owner is used to communicate with the owner of the activity tree
 type Owner interface {
 	MatchesSelector(entry *model.ProcessCacheEntry) bool

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -56,7 +56,7 @@ func NewActivityTreeNodeStats() *Stats {
 			droppedCount: make(map[NodeDroppedReason]*atomic.Uint64),
 		}
 
-		for _, reason := range allDropReasons {
+		for reason := minNodeDroppedReason; reason <= maxNodeDroppedReason; reason++ {
 			spet.droppedCount[reason] = atomic.NewUint64(0)
 		}
 		ats.counts[i] = spet

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -90,7 +90,7 @@ func (stats *Stats) SendStats(client statsd.ClientInterface, treeType string) er
 		}
 
 		for generationType, count := range count.addedCount {
-			tags := []string{evtTypeTag, fmt.Sprintf("generation_type:%s", generationType), treeTypeTag}
+			tags := []string{evtTypeTag, generationType.Tag(), treeTypeTag}
 			if value := count.Swap(0); value > 0 {
 				if err := client.Count(metrics.MetricActivityDumpEventAdded, int64(value), tags, 1.0); err != nil {
 					return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventAdded, err)


### PR DESCRIPTION
### What does this PR do?

About 5% of the total system probe allocations are done to create those metric tags, this is obviously a waste of CPU time and this PR makes sure we do not build the tags at usage time.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
