### PR TITLE
[CWS] small memory improvements in string evaluator code

### DIFF
--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -51,10 +51,7 @@ func (s *State) UpdateFields(field Field) {
 
 // UpdateFieldValues updates the field values
 func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
-	values, ok := s.fieldValues[field]
-	if !ok {
-		values = []FieldValue{}
-	}
+	values := s.fieldValues[field]
 	for _, v := range values {
 		// compare only comparable
 		switch v.Value.(type) {

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -28,8 +28,6 @@ type StringValues struct {
 	scalars        []string
 	stringMatchers []StringMatcher
 
-	// caches
-	scalarCache []string
 	fieldValues []FieldValue
 }
 
@@ -44,10 +42,6 @@ func (s *StringValues) AppendFieldValue(value FieldValue) {
 		return
 	}
 
-	if value.Type == ScalarValueType {
-		s.scalars = append(s.scalars, value.Value.(string))
-	}
-
 	s.fieldValues = append(s.fieldValues, value)
 }
 
@@ -58,7 +52,6 @@ func (s *StringValues) Compile(opts StringCmpOpts) error {
 		if opts == DefaultStringCmpOpts && value.Type == ScalarValueType {
 			str := value.Value.(string)
 			s.scalars = append(s.scalars, str)
-			s.scalarCache = append(s.scalarCache, str)
 		} else {
 			str, ok := value.Value.(string)
 			if !ok {
@@ -89,8 +82,8 @@ func (s *StringValues) GetStringMatchers() []StringMatcher {
 // SetFieldValues apply field values
 func (s *StringValues) SetFieldValues(values ...FieldValue) error {
 	// reset internal caches
-	s.stringMatchers = s.stringMatchers[:0]
-	s.scalarCache = nil
+	s.scalars = nil
+	s.stringMatchers = nil
 
 	for _, value := range values {
 		s.AppendFieldValue(value)
@@ -106,7 +99,7 @@ func (s *StringValues) AppendScalarValue(value string) {
 
 // Matches returns whether the value matches the string values
 func (s *StringValues) Matches(value string) bool {
-	if slices.Contains(s.scalarCache, value) {
+	if slices.Contains(s.scalars, value) {
 		return true
 	}
 	for _, pm := range s.stringMatchers {

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -20,7 +20,7 @@ func TestStringValues(t *testing.T) {
 			t.Error(err)
 		}
 
-		if !slices.Contains(values.scalarCache, "test123") {
+		if !slices.Contains(values.scalars, "test123") {
 			t.Error("expected cache key not found")
 		}
 
@@ -37,7 +37,7 @@ func TestStringValues(t *testing.T) {
 			t.Error(err)
 		}
 
-		if slices.Contains(values.scalarCache, "test123") {
+		if slices.Contains(values.scalars, "test123") {
 			t.Error("expected cache key found")
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR simplifies a bit the string evaluation code, removing the need to maintain both `scalars` and `scalarsCache` at the same time. It also fixes some small bugs when the values are reseted after some values were added before.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
