### PR TITLE
feat(origin detection): implement External Data Env

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -234,9 +234,7 @@ func injectionMode(pod *corev1.Pod, globalMode string) string {
 
 // injectExternalDataEnvVar injects the External Data environment variable.
 // The format is: it-<init>,cn-<container_name>,pu-<pod_uid>
-func injectExternalDataEnvVar(pod *corev1.Pod) bool {
-	injected := false
-
+func injectExternalDataEnvVar(pod *corev1.Pod) (injected bool) {
 	type containerInjection struct {
 		container *corev1.Container
 		init      bool

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -33,11 +33,19 @@ import (
 
 const (
 	// Env vars
-	agentHostEnvVarName    = "DD_AGENT_HOST"
-	ddEntityIDEnvVarName   = "DD_ENTITY_ID"
-	traceURLEnvVarName     = "DD_TRACE_AGENT_URL"
-	dogstatsdURLEnvVarName = "DD_DOGSTATSD_URL"
-	podUIDEnvVarName       = "DD_INTERNAL_POD_UID"
+	agentHostEnvVarName      = "DD_AGENT_HOST"
+	ddEntityIDEnvVarName     = "DD_ENTITY_ID"
+	ddExternalDataEnvVarName = "DD_EXTERNAL_ENV"
+	traceURLEnvVarName       = "DD_TRACE_AGENT_URL"
+	dogstatsdURLEnvVarName   = "DD_DOGSTATSD_URL"
+	podUIDEnvVarName         = "DD_INTERNAL_POD_UID"
+
+	// External Data Prefixes
+	// These prefixes are used to build the External Data Environment Variable.
+	// This variable is then used for Origin Detection.
+	externalDataInitPrefix          = "it-"
+	externalDataContainerNamePrefix = "cn-"
+	externalDataPodUIDPrefix        = "pu-"
 
 	// Config injection modes
 	hostIP  = "hostip"
@@ -163,19 +171,22 @@ func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
 	return common.Mutate(request.Raw, request.Namespace, w.Name(), w.inject, request.DynamicClient)
 }
 
-// inject injects DD_AGENT_HOST and DD_ENTITY_ID into a pod template if needed
+// inject injects the following environment variables into the pod template:
+// - DD_AGENT_HOST: the host IP of the node
+// - DD_ENTITY_ID: the entity ID of the pod
+// - DD_EXTERNAL_ENV: the External Data Environment Variable
 func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
-	var injectedConfig, injectedEntity bool
+	var injectedConfig, injectedEntity, injectedExternalEnv bool
 
 	if pod == nil {
 		return false, errors.New(metrics.InvalidInput)
-
 	}
 
 	if !autoinstrumentation.ShouldInject(pod, w.wmeta) {
 		return false, nil
 	}
 
+	// Inject DD_AGENT_HOST
 	switch injectionMode(pod, w.mode) {
 	case hostIP:
 		injectedConfig = common.InjectEnv(pod, agentHostIPEnvVar)
@@ -192,13 +203,17 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, 
 		return false, errors.New(metrics.InvalidInput)
 	}
 
+	// Inject DD_ENTITY_ID
 	if w.config.injectContName {
 		injectedEntity = injectFullIdentity(pod)
 	} else {
 		injectedEntity = common.InjectEnv(pod, defaultDdEntityIDEnvVar)
 	}
 
-	return injectedConfig || injectedEntity, nil
+	// Inject External Data Environment Variable
+	injectedExternalEnv = injectExternalDataEnvVar(pod)
+
+	return injectedConfig || injectedEntity || injectedExternalEnv, nil
 }
 
 // injectionMode returns the injection mode based on the global mode and pod labels
@@ -215,6 +230,53 @@ func injectionMode(pod *corev1.Pod, globalMode string) string {
 	}
 
 	return globalMode
+}
+
+// injectExternalDataEnvVar injects the External Data environment variable.
+// The format is: it-<init>,cn-<container_name>,pu-<pod_uid>
+func injectExternalDataEnvVar(pod *corev1.Pod) bool {
+	injected := false
+
+	type containerInjection struct {
+		container *corev1.Container
+		init      bool
+	}
+	var containerInjections []containerInjection
+
+	// Collect all containers and init containers
+	for i := range pod.Spec.Containers {
+		containerInjections = append(containerInjections, containerInjection{&pod.Spec.Containers[i], false})
+	}
+	for i := range pod.Spec.InitContainers {
+		containerInjections = append(containerInjections, containerInjection{&pod.Spec.InitContainers[i], true})
+	}
+
+	// Inject External Data Environment Variable for each container
+	for _, containerInjection := range containerInjections {
+		if containerInjection.container == nil {
+			_ = log.Errorf("Cannot inject identity into nil container")
+			continue
+		}
+
+		containerInjection.container.Env = append([]corev1.EnvVar{
+			{
+				Name: podUIDEnvVarName,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.uid",
+					},
+				},
+			},
+			{
+				Name:  ddExternalDataEnvVarName,
+				Value: fmt.Sprintf("%s%t,%s%s,%s$(%s)", externalDataInitPrefix, containerInjection.init, externalDataContainerNamePrefix, containerInjection.container.Name, externalDataPodUIDPrefix, podUIDEnvVarName),
+			},
+		}, containerInjection.container.Env...)
+
+		injected = true
+	}
+
+	return injected
 }
 
 func injectIdentityInContainer(container *corev1.Container, prefix, podStr string) bool {

--- a/pkg/clusteragent/admission/mutate/config/testdata/expected_jsonpatch.json
+++ b/pkg/clusteragent/admission/mutate/config/testdata/expected_jsonpatch.json
@@ -1,6 +1,6 @@
 [
     {
-        "value": "DD_ENTITY_ID",
+        "value": "DD_INTERNAL_POD_UID",
         "op": "replace",
         "path": "/spec/containers/0/env/0/name"
     },
@@ -18,22 +18,38 @@
         "path": "/spec/containers/0/env/0/valueFrom"
     },
     {
-        "value": "DD_AGENT_HOST",
+        "value": "DD_EXTERNAL_ENV",
         "op": "replace",
         "path": "/spec/containers/0/env/1/name"
     },
     {
-        "op": "remove",
+        "value": "it-false,cn-container,pu-$(DD_INTERNAL_POD_UID)",
+        "op": "replace",
         "path": "/spec/containers/0/env/1/value"
     },
     {
         "value": {
-            "fieldRef": {
-                "fieldPath": "status.hostIP"
+            "name": "DD_ENTITY_ID",
+            "valueFrom": {
+                "fieldRef": {
+                    "fieldPath": "metadata.uid"
+                }
             }
         },
         "op": "add",
-        "path": "/spec/containers/0/env/1/valueFrom"
+        "path": "/spec/containers/0/env/-"
+    },
+    {
+        "value": {
+            "name": "DD_AGENT_HOST",
+            "valueFrom": {
+                "fieldRef": {
+                    "fieldPath": "status.hostIP"
+                }
+            }
+        },
+        "op": "add",
+        "path": "/spec/containers/0/env/-"
     },
     {
         "value": {

--- a/pkg/clusteragent/admission/mutate/config/testdata/expected_jsonpatch_with_cont_name.json
+++ b/pkg/clusteragent/admission/mutate/config/testdata/expected_jsonpatch_with_cont_name.json
@@ -18,14 +18,34 @@
         "path": "/spec/containers/0/env/0/valueFrom"
     },
     {
-        "value": "DD_ENTITY_ID",
+        "value": "DD_EXTERNAL_ENV",
         "op": "replace",
         "path": "/spec/containers/0/env/1/name"
     },
     {
-        "value": "en-$(DD_INTERNAL_POD_UID)/container",
+        "value": "it-false,cn-container,pu-$(DD_INTERNAL_POD_UID)",
         "op": "replace",
         "path": "/spec/containers/0/env/1/value"
+    },
+    {
+        "value": {
+            "name": "DD_INTERNAL_POD_UID",
+            "valueFrom": {
+                "fieldRef": {
+                    "fieldPath": "metadata.uid"
+                }
+            }
+        },
+        "op": "add",
+        "path": "/spec/containers/0/env/-"
+    },
+    {
+        "value": {
+            "name": "DD_ENTITY_ID",
+            "value": "en-$(DD_INTERNAL_POD_UID)/container"
+        },
+        "op": "add",
+        "path": "/spec/containers/0/env/-"
     },
     {
         "value": {

--- a/releasenotes/notes/inject-external-data-7aa4bec746aac925.yaml
+++ b/releasenotes/notes/inject-external-data-7aa4bec746aac925.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Implement External Data environment variable injection in the Admission Controller.
+    Format for this new environment variable is `it-INIT_CONTAINER,cn-CONTAINER_NAME,pu-POD_UID`.
+    This new variable is needed for the New Origin Detection spec. It is used for Origin Detection
+    in case Local Data are unavailable, for example with Kata Containers and CGroups v2.


### PR DESCRIPTION
### What does this PR do?

Implement External Data environment variable injection in the Admission Controller. Format for this new environment variable would be `it-INIT_CONTAINER,cn-CONTAINER_NAME,pu-POD_UID` and would look like:

```
it-false,cn-nginx-webserver,pu-75a2b6d5-3949-4afb-ad0d-92ff0674e759
```

### Motivation

This new variable is needed for the New Origin Detection spec, especially as a solution to resolve Origin Detection in case Local Data are unavailable, for example with Kata Containers and CGroupv2.

### Describe how to test/QA your changes

* Deploy the Agent and dummy workload like those:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  annotations:
    environment: testing
    user: wassim
  labels:
    environment: testing
    user: wassim
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      annotations:
        environment: testing
        user: wassim
      labels:
        app: nginx
        admission.datadoghq.com/enabled: "true"
        environment: testing
        user: wassim
    spec:
      containers:
      - name: nginx
        image: nginx
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: init
spec:
  replicas: 1
  selector:
    matchLabels:
      app: init
  template:
    metadata:
      annotations:
        environment: testing
        user: wassim
      labels:
        app: init
        admission.datadoghq.com/enabled: "true"
        environment: testing
        user: wassim
    spec:
      initContainers:
      - name: init
        image: busybox
        command: ["sh", "-c", "while true; do sleep 3600; done"]
      containers:
      - name: nginx
        image: nginx
```
Note that you need the `admission.datadoghq.com/enabled` annotation.
* Verify the environment variables assigned to the workloads
```
➜  datadog-dev git:(main) ✗ k exec -it deployments/nginx -- env | grep DD_
DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket
DD_AGENT_HOST=192.168.49.2
DD_INTERNAL_POD_UID=9b00b901-ccf9-4a02-b35f-4b718c34b2c6
DD_EXTERNAL_ENV=it-false,cn-nginx,pu-9b00b901-ccf9-4a02-b35f-4b718c34b2c6
DD_INSTRUMENTATION_INSTALL_ID=d517565f-1a32-426a-87de-113335a9eeca
DD_INSTRUMENTATION_INSTALL_TIME=1720102315
DD_ENTITY_ID=9b00b901-ccf9-4a02-b35f-4b718c34b2c6
DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket
```
```
➜  datadog-dev git:(main) ✗ k exec -it deployments/init -c init -- env | grep DD_
DD_ENTITY_ID=b6eec695-76c2-4a7c-96b1-90d914c45665
DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket
DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket
DD_INTERNAL_POD_UID=b6eec695-76c2-4a7c-96b1-90d914c45665
DD_EXTERNAL_ENV=it-true,cn-init,pu-b6eec695-76c2-4a7c-96b1-90d914c45665
DD_INSTRUMENTATION_INSTALL_ID=14acf80d-2b7b-4aae-9764-431dc3c07ab5
DD_INSTRUMENTATION_INSTALL_TIME=1720195544
```
