### PR TITLE
[CWS] remove double join in `ProcRootFilePath`

### DIFF
--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -115,11 +114,15 @@ func ProcRootPath(pid uint32) string {
 
 // ProcRootFilePath returns the path to the input file after prepending the proc root path of the given pid
 func ProcRootFilePath(pid uint32, file string) string {
-	return filepath.Join(ProcRootPath(pid), file)
+	return procPidPath2(pid, "root", file)
 }
 
 func procPidPath(pid uint32, path string) string {
 	return kernel.HostProc(strconv.FormatUint(uint64(pid), 10), path)
+}
+
+func procPidPath2(pid uint32, path1 string, path2 string) string {
+	return kernel.HostProc(strconv.FormatUint(uint64(pid), 10), path1, path2)
 }
 
 // ModulesPath returns the path to the modules file in /proc


### PR DESCRIPTION
### What does this PR do?

This function was `filepath.Join`-ing the result of `HostProc` with something else. Calling `HostProc` directly with all path parts is better because it means only one join (with one big alloc) and one `filepath.Clean` call. Instead of 2.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
