### PR TITLE
Allow forcing usage of proc pid mapper

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1123,8 +1123,8 @@ func containerSyspath(config pkgconfigmodel.Setup) {
 	config.BindEnv("procfs_path")
 	config.BindEnv("container_proc_root")
 	config.BindEnv("container_cgroup_root")
+	config.BindEnv("container_pid_mapper")
 	config.BindEnvAndSetDefault("ignore_host_etc", false)
-
 	config.BindEnvAndSetDefault("proc_root", "/proc")
 }
 

--- a/pkg/util/cgroups/pid_mapper.go
+++ b/pkg/util/cgroups/pid_mapper.go
@@ -18,6 +18,10 @@ import (
 	"github.com/karrick/godirwalk"
 )
 
+const (
+	procPIDMapperID = "proc"
+)
+
 // IdentiferFromCgroupReferences returns cgroup identifier extracted from <proc>/<pid>/cgroup after applying the filter.
 func IdentiferFromCgroupReferences(procPath, pid, baseCgroupController string, filter ReaderFilter) (string, error) {
 	var identifier string
@@ -57,31 +61,38 @@ type pidMapper interface {
 }
 
 // cgroupRoot is cgroup base directory (like /host/sys/fs/cgroup/<baseController>)
-func getPidMapper(procPath, cgroupRoot, baseController string, filter ReaderFilter) pidMapper {
-	// Checking if we are in host pid. If that's the case `cgroup.procs` in any controller will contain PIDs
-	// In cgroupv2, the file contains 0 values, filtering for that
-	cgroupProcsTestFilePath := filepath.Join(cgroupRoot, cgroupProcsFile)
-	cgroupProcsUsable := false
-	err := parseFile(defaultFileReader, cgroupProcsTestFilePath, func(s string) error {
-		if s != "" && s != "0" {
-			cgroupProcsUsable = true
-		}
+func getPidMapper(procPath, cgroupRoot, baseController string, filter ReaderFilter, pidMapperID string) pidMapper {
+	// Empty pidMapperID means auto select. Only possible value is to force /proc usage.
+	if pidMapperID == "" {
+		// Checking if we are in host pid. If that's the case `cgroup.procs` in any controller will contain PIDs
+		// In cgroupv2, the file contains 0 values, filtering for that
+		cgroupProcsTestFilePath := filepath.Join(cgroupRoot, cgroupProcsFile)
+		cgroupProcsUsable := false
+		err := parseFile(defaultFileReader, cgroupProcsTestFilePath, func(s string) error {
+			if s != "" && s != "0" {
+				cgroupProcsUsable = true
+			}
 
-		return nil
-	})
+			return nil
+		})
 
-	if cgroupProcsUsable {
-		return &cgroupProcsPidMapper{
-			fr: defaultFileReader,
-			cgroupProcsFilePathBuilder: func(relativeCgroupPath string) string {
-				return filepath.Join(cgroupRoot, relativeCgroupPath, cgroupProcsFile)
-			},
+		if cgroupProcsUsable {
+			log.Debug("Using cgroup.procs for pid mapping")
+			return &cgroupProcsPidMapper{
+				fr: defaultFileReader,
+				cgroupProcsFilePathBuilder: func(relativeCgroupPath string) string {
+					return filepath.Join(cgroupRoot, relativeCgroupPath, cgroupProcsFile)
+				},
+			}
 		}
+		log.Debugf("cgroup.procs file at: %s is empty or unreadable, considering we're not running in host PID namespace, err: %v", cgroupProcsTestFilePath, err)
+	} else if pidMapperID != procPIDMapperID {
+		log.Warnf("Unknown PID mapper ID: %s, falling back to using proc PID mapper", pidMapperID)
 	}
-	log.Debugf("cgroup.procs file at: %s is empty or unreadable, considering we're not running in host PID namespace, err: %v", cgroupProcsTestFilePath, err)
 
 	// Checking if we're in host cgroup namespace, other the method below cannot be used either
 	// (we'll still return it in case the cgroup namespace detection failed but log a warning)
+	log.Debug("Using proc/pid for pid mapping")
 	pidMapper := &procPidMapper{
 		procPath:         procPath,
 		cgroupController: baseController,
@@ -111,8 +122,7 @@ type cgroupProcsPidMapper struct {
 	cgroupProcsFilePathBuilder func(string) string
 }
 
-//nolint:revive // TODO(CINT) Fix revive linter
-func (pm *cgroupProcsPidMapper) getPIDsForCgroup(identifier, relativeCgroupPath string, cacheValidity time.Duration) []int {
+func (pm *cgroupProcsPidMapper) getPIDsForCgroup(_, relativeCgroupPath string, _ time.Duration) []int {
 	var pids []int
 
 	if err := parseFile(pm.fr, pm.cgroupProcsFilePathBuilder(relativeCgroupPath), func(s string) error {

--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -28,6 +28,7 @@ const (
 // Calling RefreshCgroups() with your cache toleration is mandatory to retrieve accurate data
 // All Reader methods support concurrent calls
 type Reader struct {
+	pidMapperID            string
 	hostPrefix             string
 	procPath               string
 	cgroupVersion          int
@@ -111,6 +112,13 @@ func WithCgroupV1BaseController(controller string) ReaderOption {
 	}
 }
 
+// WithPIDMapper allows to force the selection of a specific PID mapper
+func WithPIDMapper(pidMapperID string) ReaderOption {
+	return func(r *Reader) {
+		r.pidMapperID = pidMapperID
+	}
+}
+
 // NewReader returns a new cgroup reader with given options
 func NewReader(opts ...ReaderOption) (*Reader, error) {
 	r := &Reader{}
@@ -141,14 +149,14 @@ func (r *Reader) init() error {
 	if isCgroup1(cgroupMounts) {
 		r.cgroupVersion = 1
 
-		r.impl, err = newReaderV1(r.procPath, cgroupMounts, r.cgroupV1BaseController, r.readerFilter)
+		r.impl, err = newReaderV1(r.procPath, cgroupMounts, r.cgroupV1BaseController, r.readerFilter, r.pidMapperID)
 		if err != nil {
 			return err
 		}
 	} else if isCgroup2(cgroupMounts) {
 		r.cgroupVersion = 2
 
-		r.impl, err = newReaderV2(r.procPath, cgroupMounts[cgroupV2Key], r.readerFilter)
+		r.impl, err = newReaderV2(r.procPath, cgroupMounts[cgroupV2Key], r.readerFilter, r.pidMapperID)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/cgroups/readerv1.go
+++ b/pkg/util/cgroups/readerv1.go
@@ -26,7 +26,7 @@ type readerV1 struct {
 	baseController string
 }
 
-func newReaderV1(procPath string, mountPoints map[string]string, baseController string, filter ReaderFilter) (*readerV1, error) {
+func newReaderV1(procPath string, mountPoints map[string]string, baseController string, filter ReaderFilter, pidMapperID string) (*readerV1, error) {
 	if baseController == "" {
 		baseController = defaultBaseController
 	}
@@ -36,7 +36,7 @@ func newReaderV1(procPath string, mountPoints map[string]string, baseController 
 			mountPoints:    mountPoints,
 			cgroupRoot:     path,
 			filter:         filter,
-			pidMapper:      getPidMapper(procPath, path, baseController, filter),
+			pidMapper:      getPidMapper(procPath, path, baseController, filter, pidMapperID),
 			baseController: baseController,
 		}, nil
 	}
@@ -66,7 +66,6 @@ func (r *readerV1) parseCgroups() (map[string]Cgroup, error) {
 			}
 
 			return err
-
 		},
 	})
 

--- a/pkg/util/cgroups/readerv1_test.go
+++ b/pkg/util/cgroups/readerv1_test.go
@@ -41,7 +41,7 @@ func TestReaderV1(t *testing.T) {
 		defaultBaseController: filepath.Join(fakeFsPath, defaultBaseController),
 	}
 
-	r, err := newReaderV1("", fakeMountPoints, defaultBaseController, ContainerFilter)
+	r, err := newReaderV1("", fakeMountPoints, defaultBaseController, ContainerFilter, "")
 	r.pidMapper = nil
 	assert.NoError(t, err)
 	assert.NotNil(t, r)

--- a/pkg/util/cgroups/readerv2.go
+++ b/pkg/util/cgroups/readerv2.go
@@ -27,7 +27,7 @@ type readerV2 struct {
 	pidMapper         pidMapper
 }
 
-func newReaderV2(procPath, cgroupRoot string, filter ReaderFilter) (*readerV2, error) {
+func newReaderV2(procPath, cgroupRoot string, filter ReaderFilter, pidMapperID string) (*readerV2, error) {
 	controllers, err := readCgroupControllers(cgroupRoot)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func newReaderV2(procPath, cgroupRoot string, filter ReaderFilter) (*readerV2, e
 		cgroupRoot:        cgroupRoot,
 		cgroupControllers: controllers,
 		filter:            filter,
-		pidMapper:         getPidMapper(procPath, cgroupRoot, "", filter),
+		pidMapper:         getPidMapper(procPath, cgroupRoot, "", filter, pidMapperID),
 	}, nil
 }
 

--- a/pkg/util/cgroups/readerv2_test.go
+++ b/pkg/util/cgroups/readerv2_test.go
@@ -41,7 +41,7 @@ func TestReaderV2(t *testing.T) {
 		"memory": {},
 	}
 
-	r, err := newReaderV2("", fakeFsPath, ContainerFilter)
+	r, err := newReaderV2("", fakeFsPath, ContainerFilter, "")
 	r.pidMapper = nil
 	assert.NoError(t, err)
 	assert.NotNil(t, r)

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -73,6 +73,7 @@ func newSystemCollector(cache *provider.Cache, wlm optional.Option[workloadmeta.
 		cgroups.WithProcPath(procPath),
 		cgroups.WithHostPrefix(hostPrefix),
 		cgroups.WithReaderFilter(cf.ContainerFilter),
+		cgroups.WithPIDMapper(config.Datadog().GetString("container_pid_mapper")),
 	)
 	if err != nil {
 		// Cgroup provider is pretty static. Except not having required mounts, it should always work.


### PR DESCRIPTION
### What does this PR do?

Allow forcing fallback to `proc` PID mapper

### Motivation

In some rare cases, using `cgroup.procs` does not work as container cgroup is not a leaf and contains other cgroups.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Testing can done by running the agent with `DD_CONTAINER_PID_MAPPER=proc` and verify presence of the log `Using proc/pid for pid mapping`.