### PR TITLE
match linux laptop umask

### DIFF
--- a/pkg/fleet/installer/service/file_test.go
+++ b/pkg/fleet/installer/service/file_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	originalContent    = "original content"
 	transformedContent = "transformed content"
-	defaultMode        = os.FileMode(0644)
+	defaultMode        = os.FileMode(0640)
 )
 
 var (
@@ -36,7 +36,7 @@ func TestFileTransformWithRollback(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	originalPath := tmpDir + "/original.txt"
-	mode := os.FileMode(0744)
+	mode := os.FileMode(0740)
 	require.Nil(t, os.WriteFile(originalPath, []byte(originalContent), mode))
 
 	mutator := newFileMutator(originalPath, transformFunc, nil, nil)
@@ -55,7 +55,7 @@ func TestNoChangesNeeded(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	originalPath := tmpDir + "/original.txt"
-	mode := os.FileMode(0744)
+	mode := os.FileMode(0740)
 	require.Nil(t, os.WriteFile(originalPath, []byte(originalContent), mode))
 
 	mutator := newFileMutator(originalPath, func(ctx context.Context, existing []byte) ([]byte, error) {
@@ -130,7 +130,7 @@ func assertFile(t *testing.T, path, expectedContent string, expectedMode os.File
 func TestCleanup(t *testing.T) {
 	tmpDir := t.TempDir()
 	originalPath := tmpDir + "/original.txt"
-	mode := fs.FileMode(0744)
+	mode := fs.FileMode(0740)
 	os.WriteFile(originalPath, []byte(originalContent), mode)
 	mutator := newFileMutator(originalPath, nil, nil, nil)
 	os.WriteFile(mutator.pathTmp, []byte(originalContent), mode)

--- a/pkg/fleet/installer/service/file_test.go
+++ b/pkg/fleet/installer/service/file_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,6 @@ import (
 const (
 	originalContent    = "original content"
 	transformedContent = "transformed content"
-	defaultMode        = os.FileMode(0640)
 )
 
 var (
@@ -78,10 +78,20 @@ func TestFileTransformWithRollback_No_original(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rollback)
 
-	assertFile(t, originalPath, transformedContent, defaultMode)
+	assertFile(t, originalPath, transformedContent, detectDefaultMode(t))
 
 	assert.Nil(t, rollback())
 	assertNoExists(t, originalPath)
+}
+
+func detectDefaultMode(t *testing.T) os.FileMode {
+	tmpDir := t.TempDir()
+	f, err := os.OpenFile(filepath.Join(tmpDir, "find_mode"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	defer f.Close()
+	fileInfo, err := f.Stat()
+	require.NoError(t, err)
+	return fileInfo.Mode()
 }
 
 func TestFileMutator_RollbackOnValidation(t *testing.T) {


### PR DESCRIPTION
On some linux laptops there's a umask 007, meaning that permissions to world are stripped by default on new files.
```
$> umask -S
u=rwx,g=rwx,o=
```

Updating test permissions to pass the tests

ex of failure
```
=== FAIL: pkg/fleet/installer/service TestFileTransformWithRollback_No_original (0.00s)
    file_test.go:127: 
        	Error Trace:	/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/pkg/fleet/installer/service/file_test.go:127
        	            				/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/pkg/fleet/installer/service/file_test.go:81
        	Error:      	Not equal: 
        	            	expected: 0x1a4
        	            	actual  : 0x1a0
```        	            