### PR TITLE
(fleet) support DD_AGENT_MAJOR_VERSION and DD_AGENT_MINOR_VERSION when installing the agent OCI

### DIFF
--- a/pkg/fleet/env/env.go
+++ b/pkg/fleet/env/env.go
@@ -25,6 +25,8 @@ const (
 	envDefaultPackageVersion = "DD_INSTALLER_DEFAULT_PKG_VERSION"
 	envDefaultPackageInstall = "DD_INSTALLER_DEFAULT_PKG_INSTALL"
 	envApmLibraries          = "DD_APM_INSTRUMENTATION_LIBRARIES"
+	envAgentMajorVersion     = "DD_AGENT_MAJOR_VERSION"
+	envAgentMinorVersion     = "DD_AGENT_MINOR_VERSION"
 )
 
 var defaultEnv = Env{
@@ -76,6 +78,9 @@ type Env struct {
 
 	ApmLibraries map[ApmLibLanguage]ApmLibVersion
 
+	AgentMajorVersion string
+	AgentMinorVersion string
+
 	InstallScript InstallScriptEnv
 }
 
@@ -95,6 +100,9 @@ func FromEnv() *Env {
 		DefaultPackagesVersionOverride: overridesByNameFromEnv(envDefaultPackageVersion, func(s string) string { return s }),
 
 		ApmLibraries: parseApmLibrariesEnv(),
+
+		AgentMajorVersion: os.Getenv(envAgentMajorVersion),
+		AgentMinorVersion: os.Getenv(envAgentMinorVersion),
 
 		InstallScript: installScriptEnvFromEnv(),
 	}

--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -16,6 +16,7 @@ import (
 // Package represents a package known to the installer
 type Package struct {
 	Name                      string
+	version                   func(Package, *env.Env) string
 	released                  bool
 	releasedBySite            []string
 	releasedWithRemoteUpdates bool
@@ -25,12 +26,12 @@ type Package struct {
 // PackagesList lists all known packages. Not all of them are installable
 var PackagesList = []Package{
 	{Name: "datadog-apm-inject", released: true, condition: apmInjectEnabled},
-	{Name: "datadog-apm-library-java", released: true, condition: apmLanguageEnabled},
-	{Name: "datadog-apm-library-ruby", released: true, condition: apmLanguageEnabled},
-	{Name: "datadog-apm-library-js", released: true, condition: apmLanguageEnabled},
-	{Name: "datadog-apm-library-dotnet", released: true, condition: apmLanguageEnabled},
-	{Name: "datadog-apm-library-python", released: true, condition: apmLanguageEnabled},
-	{Name: "datadog-agent", released: false, releasedWithRemoteUpdates: true},
+	{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+	{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+	{Name: "datadog-apm-library-js", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+	{Name: "datadog-apm-library-dotnet", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+	{Name: "datadog-apm-library-python", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+	{Name: "datadog-agent", version: agentVersion, released: false, releasedWithRemoteUpdates: true},
 }
 
 var packageDependencies = map[string][]string{
@@ -62,13 +63,9 @@ func defaultPackages(env *env.Env, defaultPackages []Package) []string {
 		}
 
 		version := "latest"
-
-		// Respect pinned version of APM packages if we don't define any overwrite
-		if apmLibVersion, ok := env.ApmLibraries[packageToLanguage(p.Name)]; ok {
-			version = apmLibVersion.AsVersionTag()
-			// TODO(paullgdc): Emit a warning here if APM packages are not pinned to at least a major
+		if p.version != nil {
+			version = p.version(p, env)
 		}
-
 		if v, ok := env.DefaultPackagesVersionOverride[p.Name]; ok {
 			version = v
 		}
@@ -104,10 +101,28 @@ func apmLanguageEnabled(p Package, e *env.Env) bool {
 	return false
 }
 
+func apmLanguageVersion(p Package, e *env.Env) string {
+	if apmLibVersion, ok := e.ApmLibraries[packageToLanguage(p.Name)]; ok {
+		return apmLibVersion.AsVersionTag()
+		// TODO(paullgdc): Emit a warning here if APM packages are not pinned to at least a major
+	}
+	return "latest"
+}
+
 func packageToLanguage(packageName string) env.ApmLibLanguage {
 	lang, found := strings.CutPrefix(packageName, "datadog-apm-library-")
 	if !found {
 		return ""
 	}
 	return env.ApmLibLanguage(lang)
+}
+
+func agentVersion(_ Package, e *env.Env) string {
+	if e.AgentMajorVersion != "" && e.AgentMinorVersion != "" {
+		return e.AgentMajorVersion + "." + e.AgentMinorVersion + "-1"
+	}
+	if e.AgentMinorVersion != "" {
+		return "7." + e.AgentMinorVersion + "-1"
+	}
+	return "latest"
 }

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -39,6 +39,31 @@ func TestDefaultPackagesAPMInjectEnabled(t *testing.T) {
 	}, packages)
 }
 
+func TestDefaultPackagesAgentVersion(t *testing.T) {
+	env := &env.Env{
+		AgentMajorVersion: "7",
+		AgentMinorVersion: "42.0",
+		DefaultPackagesInstallOverride: map[string]bool{
+			"datadog-agent": true,
+		},
+	}
+	packages := DefaultPackages(env)
+
+	assert.Equal(t, []string{"oci://gcr.io/datadoghq/agent-package:7.42.0-1"}, packages)
+}
+
+func TestDefaultPackagesAgentMinorVersion(t *testing.T) {
+	env := &env.Env{
+		AgentMinorVersion: "42.0",
+		DefaultPackagesInstallOverride: map[string]bool{
+			"datadog-agent": true,
+		},
+	}
+	packages := DefaultPackages(env)
+
+	assert.Equal(t, []string{"oci://gcr.io/datadoghq/agent-package:7.42.0-1"}, packages)
+}
+
 func TestDefaultPackages(t *testing.T) {
 	type pkg struct {
 		n string
@@ -121,9 +146,9 @@ func TestDefaultPackages(t *testing.T) {
 		{
 			name: "Package is a language with a pinned version",
 			packages: []Package{
-				{Name: "datadog-apm-library-java", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-ruby", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-js", released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-js", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{
@@ -139,9 +164,9 @@ func TestDefaultPackages(t *testing.T) {
 		{
 			name: "Package is a language with a pinned version",
 			packages: []Package{
-				{Name: "datadog-apm-library-java", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-ruby", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-js", released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-js", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{
@@ -160,9 +185,9 @@ func TestDefaultPackages(t *testing.T) {
 		{
 			name: "Override ignore package pin",
 			packages: []Package{
-				{Name: "datadog-apm-library-java", released: false, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-ruby", released: false, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-js", released: false, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: false, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: false, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-js", version: apmLanguageVersion, released: false, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{


### PR DESCRIPTION
This PR adds support for customers to decide which version of the agent should be installed by default.
