### PR TITLE
[CWS] move the bpf map names sync from a go:generate comment to the `cws-go-generate` task

### DIFF
--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -19,7 +19,6 @@ import (
 // TODO change probe.c path to runtime-compilation specific version
 //go:generate $GOPATH/bin/include_headers pkg/security/ebpf/c/prebuilt/probe.c pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/security/ebpf/c/include pkg/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/ebpf/bytecode/runtime/runtime-security.go runtime
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ../../ebpf/bytecode/build/runtime/runtime-security.c -output ../../security/secl/model/consts_map_names_linux.go -pkg-name model
 
 func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFentry, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	var cflags []string

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -674,7 +674,12 @@ def cws_go_generate(ctx):
     ctx.run("go generate ./pkg/security/...")
 
     # sync BPF map names constants
-    ctx.run("go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ./pkg/ebpf/bytecode/build/runtime/runtime-security.c -output ./pkg/security/secl/model/consts_map_names_linux.go -pkg-name model")
+    ctx.run(
+        "go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator "
+        "-runtime-path ./pkg/ebpf/bytecode/build/runtime/runtime-security.c "
+        "-output ./pkg/security/secl/model/consts_map_names_linux.go "
+        "-pkg-name model"
+    )
 
 
 @task

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -673,6 +673,9 @@ def cws_go_generate(ctx):
 
     ctx.run("go generate ./pkg/security/...")
 
+    # sync BPF map names constants
+    ctx.run("go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ./pkg/ebpf/bytecode/build/runtime/runtime-security.c -output ./pkg/security/secl/model/consts_map_names_linux.go -pkg-name model")
+
 
 @task
 def generate_syscall_table(ctx):


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The go:generate comment was never executed because the go generate command is never called with the correct build tags. This PR moves the bpf map name sync to the `security-agent.cws-go-generate` task for consistency.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
