### PR TITLE
[CWS] skip on-demand tests on fentry

### DIFF
--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -21,8 +21,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func skipOnFentry(t *testing.T) {
+	if os.Getenv("DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY") == "true" {
+		t.Skip("fentry is not supported for on-demand yet")
+	}
+}
+
 func TestOnDemandOpen(t *testing.T) {
 	SkipIfNotAvailable(t)
+	skipOnFentry(t)
 
 	onDemands := []rules.OnDemandHookPoint{
 		{
@@ -84,6 +91,7 @@ func TestOnDemandOpen(t *testing.T) {
 
 func TestOnDemandChdir(t *testing.T) {
 	SkipIfNotAvailable(t)
+	skipOnFentry(t)
 
 	onDemands := []rules.OnDemandHookPoint{
 		{
@@ -133,6 +141,7 @@ func TestOnDemandChdir(t *testing.T) {
 
 func TestOnDemandMprotect(t *testing.T) {
 	SkipIfNotAvailable(t)
+	skipOnFentry(t)
 
 	onDemands := []rules.OnDemandHookPoint{
 		{


### PR DESCRIPTION
### What does this PR do?

This PR skips on-demand tests when in fentry mode since those probes don't correctly support the fentry mode yet. This will be fixed in a follow up PR.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
