### PR TITLE
usm: process monitor: tests: More robust TestProcessMonitorInNamespace

### DIFF
--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -233,13 +233,19 @@ func (s *processMonitorSuite) TestProcessMonitorInNamespace() {
 
 	time.Sleep(500 * time.Millisecond)
 	// Process in root NS
-	cmd := exec.Command("/bin/echo")
+	cmd := exec.Command("/bin/sleep", "1")
 	require.NoError(t, cmd.Run(), "could not run process in root namespace")
 	pid := uint32(cmd.ProcessState.Pid())
 
 	require.Eventually(t, func() bool {
 		_, capturedExec := execSet.Load(pid)
+		if !capturedExec {
+			t.Logf("pid %d not captured in exec", pid)
+		}
 		_, capturedExit := exitSet.Load(pid)
+		if !capturedExit {
+			t.Logf("pid %d not captured in exit", pid)
+		}
 		return capturedExec && capturedExit
 	}, time.Second, time.Millisecond*200, "did not capture process EXEC/EXIT from root namespace")
 
@@ -248,13 +254,19 @@ func (s *processMonitorSuite) TestProcessMonitorInNamespace() {
 	require.NoError(t, err, "could not create network namespace for process")
 	defer cmdNs.Close()
 
-	cmd = exec.Command("/bin/echo")
+	cmd = exec.Command("/bin/sleep", "1")
 	require.NoError(t, kernel.WithNS(cmdNs, cmd.Run), "could not run process in other network namespace")
 	pid = uint32(cmd.ProcessState.Pid())
 
 	require.Eventually(t, func() bool {
 		_, capturedExec := execSet.Load(pid)
+		if !capturedExec {
+			t.Logf("pid %d not captured in exec", pid)
+		}
 		_, capturedExit := exitSet.Load(pid)
+		if !capturedExit {
+			t.Logf("pid %d not captured in exit", pid)
+		}
 		return capturedExec && capturedExit
 	}, time.Second, 200*time.Millisecond, "did not capture process EXEC/EXIT from other namespace")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Improves TestProcessMonitorInNamespace by checking we captured events on the target PID, and not random exec/exit events.
Also, using a slower process (`sleep 1`) instead of `echo`, to reduce the chances we got exit event before exec event

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Test flakiness

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
