### PR TITLE
[gitlab] Fix deploy_containers-ot job rules

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -2,6 +2,11 @@
 # deploy containers stage
 # Contains jobs which deploy Agent 6 & 7 to staging repositories and to Dockerhub / GCR.
 
+# Notes: this defines a child pipline of the datadog-agent repository. Therefore:
+# - Only blocks defined in this file or the included files below can be used.
+#   In particular, blocks defined in the main .gitlab-ci.yml are unavailable.
+# - Dependencies / needs on jobs not defined in this file or the included files cannot be made.
+
 stages:
   - deploy_containers
 

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -86,7 +86,8 @@ deploy_containers-ot:
   extends: .docker_publish_job_definition
   stage: deploy_containers
   rules:
-    !reference [.manual]
+    - when: manual
+      allow_failure: true
   dependencies: []
   before_script:
     - source /root/.bashrc


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Explicitly write the manual rule for `deploy_containers-ot`, as the `.manual` block cannot be used in this context.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix failures in the `deploy_containers-a7` job.

The `deploy_containers-a7` job creates a child pipeline, only using `.gitlab/deploy_containers/deploy_containers_a7.yml` as its source. This only includes two files: `.gitlab/common/container_publish_job_templates.yml` and `.gitlab/deploy_containers/conditions.yml`.

Any block not defined in any of these three files cannot be used (and that's the case for `.manual`, used by `deploy_containers-ot`).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a
