### PR TITLE
Remove codeowners of mockery.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@
 
 # Config files for various CI systems / tasks
 /.*                                     @DataDog/agent-devx-infra
+# changing the config of mockery will regenerate the mocks, so owners will have to review anyway
+/.mockery.yaml                          # do not notify anyone
 /.go-version                            @DataDog/agent-shared-components @DataDog/agent-delivery
 
 /CHANGELOG.rst                          @DataDog/agent-delivery


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Explicitly set no codeowners for `.mockery.yaml`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
No team really makes sense as a codeowners since this is a config to autogenerate mocks for various components in the datadog-agent repo.
Changing this file will result in updates to the autogenerated mocks, meaning the PR will have to be reviewed by the CODEOWNERS of the mocks anyway.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
