### PR TITLE
[CONTP-287] refuse duplicate group-resource with different versions

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -68,7 +68,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	var dataBytes []byte
 	nodeName := vars["nodeName"]
 
-	entityID := util.GenerateKubeMetadataEntityID("nodes", "", nodeName)
+	entityID := util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName)
 	nodeMetadata, err := wmeta.GetKubernetesMetadata(entityID)
 	if err != nil {
 		log.Errorf("Could not retrieve the node %s of %s: %v", what, nodeName, err.Error()) //nolint:errcheck
@@ -118,7 +118,7 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	vars := mux.Vars(r)
 	var metadataBytes []byte
 	nsName := vars["ns"]
-	namespaceMetadata, err := wmeta.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("namespaces", "", nsName))
+	namespaceMetadata, err := wmeta.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("", "namespaces", "", nsName))
 	if err != nil {
 		log.Debugf("Could not retrieve the %s of namespace %s: %v", what, nsName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -10,8 +10,6 @@ package kubeapiserver
 
 import (
 	"context"
-	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -76,8 +74,8 @@ func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {
 	)
 
 	// Remove duplicates
-	sort.Strings(resources)
-	return slices.Compact(resources)
+	resources = cleanDuplicateVersions(resources)
+	return resources
 }
 
 // resourcesWithRequiredMetadataCollection returns the list of resources that we

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -73,9 +73,8 @@ func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {
 		resourcesWithExplicitMetadataCollectionEnabled(cfg)...,
 	)
 
-	// Remove duplicates
-	resources = cleanDuplicateVersions(resources)
-	return resources
+	// Remove duplicates and return
+	return cleanDuplicateVersions(resources)
 }
 
 // resourcesWithRequiredMetadataCollection returns the list of resources that we

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -394,7 +394,15 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "",
 			},
-			expectedResources: []string{"nodes"},
+			expectedResources: []string{"//nodes"},
+		},
+		{
+			name: "duplicate versions for the same group/resource should not be allowed",
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets apps//deployments apps/v1/statefulsets apps/v1/daemonsets",
+			},
+			expectedResources: []string{"//nodes", "apps//deployments", "apps/v1/daemonsets"},
 		},
 		{
 			name: "deployments needed for language detection should be excluded from metadata collection",
@@ -404,7 +412,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/deployments",
 			},
-			expectedResources: []string{"apps/daemonsets", "nodes"},
+			expectedResources: []string{"apps//daemonsets", "//nodes"},
 		},
 		{
 			name: "pods needed for autoscaling should be excluded from metadata collection",
@@ -413,7 +421,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets pods",
 			},
-			expectedResources: []string{"apps/daemonsets", "nodes"},
+			expectedResources: []string{"apps//daemonsets", "//nodes"},
 		},
 		{
 			name: "resources explicitly requested",
@@ -421,7 +429,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets",
 			},
-			expectedResources: []string{"nodes", "apps/deployments", "apps/statefulsets"},
+			expectedResources: []string{"//nodes", "apps//deployments", "apps//statefulsets"},
 		},
 		{
 			name: "namespaces needed for namespace labels as tags",
@@ -430,7 +438,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"label1": "tag1",
 				},
 			},
-			expectedResources: []string{"nodes", "namespaces"},
+			expectedResources: []string{"//nodes", "//namespaces"},
 		},
 		{
 			name: "namespaces needed for namespace annotations as tags",
@@ -439,7 +447,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"annotation1": "tag1",
 				},
 			},
-			expectedResources: []string{"nodes", "namespaces"},
+			expectedResources: []string{"//nodes", "//namespaces"},
 		},
 		{
 			name: "namespaces needed for namespace labels and annotations as tags",
@@ -451,7 +459,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"annotation1": "tag2",
 				},
 			},
-			expectedResources: []string{"nodes", "namespaces"},
+			expectedResources: []string{"//nodes", "//namespaces"},
 		},
 		{
 			name: "resources explicitly requested and also needed for namespace labels as tags",
@@ -462,7 +470,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"label1": "tag1",
 				},
 			},
-			expectedResources: []string{"nodes", "namespaces", "apps/deployments"}, // namespaces are not duplicated
+			expectedResources: []string{"//nodes", "//namespaces", "apps//deployments"}, // namespaces are not duplicated
 		},
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -73,7 +73,7 @@ func newMetadataParser(gvr schema.GroupVersionResource, annotationsExclude []str
 
 func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 	partialObjectMetadata := obj.(*metav1.PartialObjectMetadata)
-	id := util.GenerateKubeMetadataEntityID(p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
+	id := util.GenerateKubeMetadataEntityID(p.gvr.Group, p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
 
 	return &workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -49,7 +49,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   "deployments/default/test-app",
+					ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "default", "test-app")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-app",
@@ -83,7 +83,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
+					ID:   string(util.GenerateKubeMetadataEntityID("", "namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",
@@ -117,7 +117,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
+					ID:   string(util.GenerateKubeMetadataEntityID("", "namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",
@@ -153,7 +153,7 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 			expected: &workloadmeta.KubernetesMetadata{
 				EntityID: workloadmeta.EntityID{
 					Kind: workloadmeta.KindKubernetesMetadata,
-					ID:   string(util.GenerateKubeMetadataEntityID("namespaces", "", "test-namespace")),
+					ID:   string(util.GenerateKubeMetadataEntityID("", "namespaces", "", "test-namespace")),
 				},
 				EntityMeta: workloadmeta.EntityMeta{
 					Name:        "test-namespace",
@@ -217,7 +217,7 @@ func Test_MetadataFakeClient(t *testing.T) {
 				Type: workloadmeta.EventTypeSet,
 				Entity: &workloadmeta.KubernetesMetadata{
 					EntityID: workloadmeta.EntityID{
-						ID:   "deployments/default/test-app",
+						ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "default", "test-app")),
 						Kind: workloadmeta.KindKubernetesMetadata,
 					},
 					EntityMeta: workloadmeta.EntityMeta{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -127,7 +127,7 @@ func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
 		},
 	}
 
-	kubeMetadataEntityID := util.GenerateKubeMetadataEntityID("namespaces", "", "test-object")
+	kubeMetadataEntityID := util.GenerateKubeMetadataEntityID("", "namespaces", "", "test-object")
 
 	err = metadataStore.Add(&partialObjMetadata)
 	require.NoError(t, err)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -159,7 +159,7 @@ func TestReplace(t *testing.T) {
 	testNodeMetadata := workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   "nodes//test-node",
+			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "test-node")),
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: "test-node",

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
@@ -13,25 +13,25 @@ import (
 )
 
 // GenerateKubeMetadataEntityID generates and returns a unique entity id for KubernetesMetadata entity
-// for namespaced objects, the id will have the format {resourceType}/{namespace}/{name} (e.g. deployments/default/app )
-// for cluster scoped objects, the id will have the format {resourceType}//{name} (e.g. nodes//master-node)
-func GenerateKubeMetadataEntityID(resource, namespace, name string) workloadmeta.KubeMetadataEntityID {
-	return workloadmeta.KubeMetadataEntityID(fmt.Sprintf("%s/%s/%s", resource, namespace, name))
+// for namespaced objects, the id will have the format {group}/{resourceType}/{namespace}/{name} (e.g. app/deployments/default/app )
+// for cluster scoped objects, the id will have the format {group}/{resourceType}//{name} (e.g. /nodes//master-node)
+func GenerateKubeMetadataEntityID(group, resource, namespace, name string) workloadmeta.KubeMetadataEntityID {
+	return workloadmeta.KubeMetadataEntityID(fmt.Sprintf("%s/%s/%s/%s", group, resource, namespace, name))
 }
 
 // ParseKubeMetadataEntityID parses a metadata entity ID and returns the resource type, namespace and resource name.
 // The parsed id should be in the following format: <resourceType>/<namespace>/<name>
 // The namespace field is left empty for cluster-scoped objects.
 // Examples:
-// - deployments/default/app
-// - namespaces//default
+// - app/deployments/default/app
+// - /namespaces//default
 // If the parsed id is malformatted, this function will return empty strings and a non nil error
-func ParseKubeMetadataEntityID(id workloadmeta.KubeMetadataEntityID) (resource, namespace, name string, err error) {
+func ParseKubeMetadataEntityID(id workloadmeta.KubeMetadataEntityID) (group, resource, namespace, name string, err error) {
 	parts := strings.Split(string(id), "/")
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		err := fmt.Errorf("malformatted metadata entity id: %s", id)
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 
-	return parts[0], parts[1], parts[2], nil
+	return parts[0], parts[1], parts[2], parts[3], nil
 }

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -131,7 +131,7 @@ func TestSubscribe(t *testing.T) {
 	testNodeMetadata := wmdef.KubernetesMetadata{
 		EntityID: wmdef.EntityID{
 			Kind: wmdef.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("nodes", "", "test-node")),
+			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "test-node")),
 		},
 		EntityMeta: wmdef.EntityMeta{
 			Name: "test-node",
@@ -1456,7 +1456,7 @@ func TestListKubernetesMetadata(t *testing.T) {
 	nodeMetadata := wmdef.KubernetesMetadata{
 		EntityID: wmdef.EntityID{
 			Kind: wmdef.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("nodes", "", "node1")),
+			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "node1")),
 		},
 		EntityMeta: wmdef.EntityMeta{
 			Name:        "node1",

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -362,7 +362,7 @@ func (ci *CWSInstrumentation) injectForCommand(request *admission.MutateRequest)
 func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kubernetes.Interface) (string, error) {
 	var arch string
 	// try with the wmeta
-	entityID := util.GenerateKubeMetadataEntityID("nodes", "", nodeName)
+	entityID := util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName)
 
 	out, err := ci.wmeta.GetKubernetesMetadata(entityID)
 	if err == nil && out != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR refuses to collect generic metadata for resources of the same group that are requested with different versions. 

For example, if the user requests the metadata collection for the following, we should refuse to collect metadata for deployments because this configuration might lead to conflicting versions of the same group resource (in this case apps/deployments):
- `apps//deployments`
- `apps/v1/deployments`
- `apps/statefulsets`
- `nodes` 


### Motivation

Thanks to [this](https://github.com/DataDog/datadog-agent/pull/27225) PR, it is possible to request generic metadata collection for specific resources by setting the env var `DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES` to a list of requested resources. Each resource is specified either by (group, version, resource), or by (group, resource). In the latter case, the discovery client automatically detects the preferred version and uses it. 

As a result to this capability, it might happen that the user requests collecting generic metadata for different versions of the same resource group, which is something we should not accept as it makes handling tagging and workloadmeta collection very complex. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- I also modified the ID of the Entity KubeMetadata to include the group of the resource. This is done in order to handle the case where we have same resource under different groups. 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
It will not be possible to collect metadata of different versions of the same resource within the same group at the same time, which is ok because this is an extreme edge case with no clear usage.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the following on a kubernetes cluster using helm:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false

clusterAgent:
  enabled: true
  replicas: 1
  env:
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_KUBE_METADATA_COLLECTION_RESOURCES
      value: "apps/deployments apps/daemonsets /nodes apps/v1/deployments apps/v1/statefulsets apps//statefulsets /v1/nodes"
```

Only `apps/daemonsets` should be considered for generic metadata collection, all others should be refused because multiple versions are requested. 

To verify this, first check the logs of the cluster agent, it should contain error messages about which resources were refused and why:

```
2024-07-05 10:14:50 UTC | CLUSTER | ERROR | (comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go:87 in cleanDuplicateVersions) | can't collect metadata for different versions of the same group and resource: versions requested for nodes.: ["" "v1"]
2024-07-05 10:14:50 UTC | CLUSTER | ERROR | (comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go:87 in cleanDuplicateVersions) | can't collect metadata for different versions of the same group and resource: versions requested for deployments.apps: ["" "v1"]
2024-07-05 10:14:50 UTC | CLUSTER | ERROR | (comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go:87 in cleanDuplicateVersions) | can't collect metadata for different versions of the same group and resource: versions requested for statefulsets.apps: ["" "v1"]
```

Check that we have kubemetadata entities in workloadmeta of the cluster agent only for daemonsets:
```
kubectl exec <cluster-agent> -c cluster-agent -- agent workload-list -v

....
=== Entity kubernetes_metadata sources(merged):[kubeapiserver] id: apps/daemonsets/kube-system/maintenance-handler ===
----------- Entity ID -----------
Kind: kubernetes_metadata ID: apps/daemonsets/kube-system/maintenance-handler

----------- Entity Meta -----------
Name: maintenance-handler
Namespace: kube-system
Annotations: 
Labels: k8s-app:maintenance-handler name:maintenance-handler addonmanager.kubernetes.io/mode:Reconcile 
----------- Resource -----------
apps/v1, Resource=daemonsets
===
....
```
