### PR TITLE
[E2e] Wait for more time for Windows Fargate task to start

### DIFF
--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -186,7 +186,7 @@ func (suite *ecsSuite) Test00UpAndRunning() {
 					}
 				}
 			}
-		}, 10*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
+		}, 15*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Increase the time the `TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` e2e test waits for task to become ready.

### Motivation

#27281 introduced Windows ECS Fargate task.
The issue is that Windows tasks are way slower to start than Linux ones.
In https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/563274737, we the `TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` test failing with:
```
=== RUN   TestECSSuite/Test00UpAndRunning
    base_test.go:55: START  ecsSuite/Test00UpAndRunning 2024-07-05 11:28:02.952206982 +0000 UTC m=+360.814626049
=== RUN   TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready
    ecs_test.go:124: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/ecs_test.go:181
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.linux-amd64/src/runtime/asm_amd64.s:[169](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/563274737#L169)5
        	Error:      	Not equal: 
        	            	expected: "RUNNING"
        	            	actual  : "PENDING"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-RUNNING
        	            	+PENDING
        	Messages:   	Task arn:aws:ecs:us-east-1:669783387624:task/ci-563274737-4670-ecs-cluster-ecs/0659edd9a7a74ac9b5c8058ce70220d0 of service ci-563274737-4670-ecs-cluster-aspnetsample-fg is not running
    ecs_test.go:124: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/ecs_test.go:124
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready
        	Messages:   	Not all tasks became ready in time.
    base_test.go:59: FINISH ecsSuite/Test00UpAndRunning 2024-07-05 11:38:02.953141451 +0000 UTC m=+960.815560515
```

So, the test waited for the task to become ready for 10 minutes between `2024-07-05 11:28:02` and `2024-07-05 11:38:02`.
But if we look at [the metrics of the task](https://dddev.datadoghq.com/metric/explorer?fromUser=true&start=1720178880000&end=1720179600000&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMiZUggYojoAdJnyeE14GhjwwHBFTplonQg6TpHqNRAAtACsAGwAzABMAOwALCsLK1NrcysADFN9GlODwzpHRRQABPUaANZOGNoiyM+vGGAayMfInUcYDQIKZkZBzOYAThWAA4FgtoSs5ks1sg7vcAPSZabzZbrTbbXYHS4nM5Ai7HdH7OYzCFwKBQCEYFZMtYYTIQgBGM0y0P2M2h2QOSyW+yg+x4IB4AF0qK53HhMKFwnLVAqMDFSvFJTKQECsGgcqB5BgDQgRsooDgYANFRoIJlEmhGk45IplOknVBHc76ExlCI3B40JL+BB7JgsC6FDkQE6REppTw+Lr5E6EABhKTCGAoEQKtA8IA), we can see that it became live at `13:38:54`:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/72b23b97-becb-46b0-bafa-dfc969ff5188)


### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that `TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` isn’t flaky anymore.
