### PR TITLE
[CONTP-277] add kubernetes_resources_annotations_as_tags and kubernetes_resources_labels_as_tags

### DIFF
--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -962,6 +962,7 @@ log/internal
 log/slog
 log/slog/internal
 log/slog/internal/buffer
+maps
 math
 math/big
 math/bits

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -961,6 +961,7 @@ log/internal
 log/slog
 log/slog/internal
 log/slog/internal/buffer
+maps
 math
 math/big
 math/bits

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -34,6 +35,7 @@ const (
 	processSource        = workloadmetaCollectorName + "-" + string(workloadmeta.KindProcess)
 	hostSource           = workloadmetaCollectorName + "-" + string(workloadmeta.KindHost)
 	kubeMetadataSource   = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesMetadata)
+	deploymentSource     = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesDeployment)
 
 	clusterTagNamePrefix = "kube_cluster_name"
 )
@@ -55,17 +57,13 @@ type WorkloadMetaCollector struct {
 	containerEnvAsTags    map[string]string
 	containerLabelsAsTags map[string]string
 
-	staticTags             map[string]string
-	labelsAsTags           map[string]string
-	annotationsAsTags      map[string]string
-	nsLabelsAsTags         map[string]string
-	nsAnnotationsAsTags    map[string]string
-	globLabels             map[string]glob.Glob
-	globAnnotations        map[string]glob.Glob
-	globNsLabels           map[string]glob.Glob
-	globNsAnnotations      map[string]glob.Glob
-	globContainerLabels    map[string]glob.Glob
-	globContainerEnvLabels map[string]glob.Glob
+	staticTags                    map[string]string
+	k8sResourcesAnnotationsAsTags map[string]map[string]string
+	k8sResourcesLabelsAsTags      map[string]map[string]string
+	globContainerLabels           map[string]glob.Glob
+	globContainerEnvLabels        map[string]glob.Glob
+	globK8sResourcesAnnotations   map[string]map[string]glob.Glob
+	globK8sResourcesLabels        map[string]map[string]glob.Glob
 
 	collectEC2ResourceTags            bool
 	collectPersistentVolumeClaimsTags bool
@@ -76,11 +74,19 @@ func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags 
 	c.containerEnvAsTags, c.globContainerEnvLabels = k8smetadata.InitMetadataAsTags(envAsTags)
 }
 
-func (c *WorkloadMetaCollector) initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags, nsAnnotationsAsTags map[string]string) {
-	c.labelsAsTags, c.globLabels = k8smetadata.InitMetadataAsTags(labelsAsTags)
-	c.annotationsAsTags, c.globAnnotations = k8smetadata.InitMetadataAsTags(annotationsAsTags)
-	c.nsLabelsAsTags, c.globNsLabels = k8smetadata.InitMetadataAsTags(nsLabelsAsTags)
-	c.nsAnnotationsAsTags, c.globNsAnnotations = k8smetadata.InitMetadataAsTags(nsAnnotationsAsTags)
+func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags, resourcesAnnotationsAsTags map[string]map[string]string) {
+	c.k8sResourcesAnnotationsAsTags = map[string]map[string]string{}
+	c.k8sResourcesLabelsAsTags = map[string]map[string]string{}
+	c.globK8sResourcesAnnotations = map[string]map[string]glob.Glob{}
+	c.globK8sResourcesLabels = map[string]map[string]glob.Glob{}
+
+	for resource, labelsAsTags := range resourcesLabelsAsTags {
+		c.k8sResourcesLabelsAsTags[resource], c.globK8sResourcesLabels[resource] = k8smetadata.InitMetadataAsTags(labelsAsTags)
+	}
+
+	for resource, annotationsAsTags := range resourcesAnnotationsAsTags {
+		c.k8sResourcesAnnotationsAsTags[resource], c.globK8sResourcesAnnotations[resource] = k8smetadata.InitMetadataAsTags(annotationsAsTags)
+	}
 }
 
 // Run runs the continuous event watching loop and sends new tags to the
@@ -178,11 +184,9 @@ func NewWorkloadMetaCollector(_ context.Context, store workloadmeta.Component, p
 	)
 	c.initContainerMetaAsTags(containerLabelsAsTags, containerEnvAsTags)
 
-	labelsAsTags := config.Datadog().GetStringMapString("kubernetes_pod_labels_as_tags")
-	annotationsAsTags := config.Datadog().GetStringMapString("kubernetes_pod_annotations_as_tags")
-	nsLabelsAsTags := config.Datadog().GetStringMapString("kubernetes_namespace_labels_as_tags")
-	nsAnnotationsAsTags := config.Datadog().GetStringMapString("kubernetes_namespace_annotations_as_tags")
-	c.initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags, nsAnnotationsAsTags)
+	// kubernetes resources metadata as tags
+	metadataAsTags := configutils.GetMetadataAsTags(config.Datadog())
+	c.initK8sResourcesMetaAsTags(metadataAsTags.GetResourcesLabelsAsTags(), metadataAsTags.GetResourcesAnnotationsAsTags())
 
 	return c
 }

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -21,6 +21,7 @@ import (
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -112,32 +113,38 @@ func TestHandleKubePod(t *testing.T) {
 	})
 
 	tests := []struct {
-		name                string
-		staticTags          map[string]string
-		labelsAsTags        map[string]string
-		annotationsAsTags   map[string]string
-		nsLabelsAsTags      map[string]string
-		nsAnnotationsAsTags map[string]string
-		pod                 workloadmeta.KubernetesPod
-		expected            []*types.TagInfo
+		name                          string
+		staticTags                    map[string]string
+		k8sResourcesAnnotationsAsTags map[string]map[string]string
+		k8sResourcesLabelsAsTags      map[string]map[string]string
+		pod                           workloadmeta.KubernetesPod
+		expected                      []*types.TagInfo
 	}{
 		{
 			name: "fully formed pod (no containers)",
-			annotationsAsTags: map[string]string{
-				"gitcommit": "+gitcommit",
-				"component": "component",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"pods": {
+					"ns_tier":   "ns_tier",
+					"ns_custom": "custom_generic_annotation",
+					"gitcommit": "+gitcommit",
+					"component": "component",
+				},
+				"namespaces": {
+					"ns_tier":            "ns_tier",
+					"namespace_security": "ns_security",
+				},
 			},
-			labelsAsTags: map[string]string{
-				"ownerteam": "team",
-				"tier":      "tier",
-			},
-			nsLabelsAsTags: map[string]string{
-				"ns_env":       "ns_env",
-				"ns-ownerteam": "ns-team",
-			},
-			nsAnnotationsAsTags: map[string]string{
-				"ns_tier":            "ns_tier",
-				"namespace_security": "ns_security",
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"pods": {
+					"ns_env":    "ns_env",
+					"ns_custom": "custom_generic_label",
+					"ownerteam": "team",
+					"tier":      "tier",
+				},
+				"namespaces": {
+					"ns_env":       "ns_env",
+					"ns_ownerteam": "ns_team",
+				},
 			},
 			pod: workloadmeta.KubernetesPod{
 				EntityID: podEntityID,
@@ -149,6 +156,7 @@ func TestHandleKubePod(t *testing.T) {
 						"GitCommit": "foobar",
 						"ignoreme":  "ignore",
 						"component": "agent",
+						"ns_custom": "gee",
 
 						// Custom tags from map
 						"ad.datadoghq.com/tags": `{"pod_template_version":"1.0.0"}`,
@@ -158,6 +166,7 @@ func TestHandleKubePod(t *testing.T) {
 						"OwnerTeam":         "container-integrations",
 						"tier":              "node",
 						"pod-template-hash": "490794276",
+						"ns_custom":         "zoo",
 
 						// Standard tags
 						"tags.datadoghq.com/env":     env,
@@ -177,7 +186,7 @@ func TestHandleKubePod(t *testing.T) {
 				// NS labels as tags
 				NamespaceLabels: map[string]string{
 					"ns_env":       "dev",
-					"ns-ownerteam": "containers",
+					"ns_ownerteam": "containers",
 					"foo":          "bar",
 				},
 
@@ -239,7 +248,7 @@ func TestHandleKubePod(t *testing.T) {
 						"kube_service:service2",
 						"kube_qos:guaranteed",
 						"kube_runtime_class:myclass",
-						"ns-team:containers",
+						"ns_team:containers",
 						"ns_env:dev",
 						"ns_tier:some_tier",
 						"ns_security:critical",
@@ -247,6 +256,8 @@ func TestHandleKubePod(t *testing.T) {
 						"pod_template_version:1.0.0",
 						"team:container-integrations",
 						"tier:node",
+						"custom_generic_label:zoo",
+						"custom_generic_annotation:gee",
 					}, standardTags...),
 					StandardTags: standardTags,
 				},
@@ -837,8 +848,7 @@ func TestHandleKubePod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			collector := NewWorkloadMetaCollector(context.Background(), store, nil)
 			collector.staticTags = tt.staticTags
-
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.nsAnnotationsAsTags)
+			collector.initK8sResourcesMetaAsTags(tt.k8sResourcesLabelsAsTags, tt.k8sResourcesAnnotationsAsTags)
 
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -969,8 +979,6 @@ func TestHandleKubePodWithoutPvcAsTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			collector := NewWorkloadMetaCollector(context.Background(), store, nil)
 			collector.staticTags = tt.staticTags
-
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.nsAnnotationsAsTags)
 
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -1118,8 +1126,6 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 			collector := NewWorkloadMetaCollector(context.Background(), store, nil)
 			collector.staticTags = tt.staticTags
 
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.annotationsAsTags)
-
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
 				Entity: &tt.pod,
@@ -1137,8 +1143,6 @@ func TestHandleKubeMetadata(t *testing.T) {
 		Kind: workloadmeta.KindKubernetesMetadata,
 		ID:   fmt.Sprintf("namespaces//%s", namespace),
 	}
-
-	taggerEntityID := fmt.Sprintf("kubernetes_metadata://%s", kubeMetadataEntityID.ID)
 
 	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		fx.Provide(func() log.Component { return logmock.New(t) }),
@@ -1159,41 +1163,169 @@ func TestHandleKubeMetadata(t *testing.T) {
 	})
 
 	tests := []struct {
-		name                string
-		labelsAsTags        map[string]string
-		annotationsAsTags   map[string]string
-		nsLabelsAsTags      map[string]string
-		nsAnnotationsAsTags map[string]string
-		kubeMetadata        workloadmeta.KubernetesMetadata
-		expected            []*types.TagInfo
+		name                          string
+		k8sResourcesAnnotationsAsTags map[string]map[string]string
+		k8sResourcesLabelsAsTags      map[string]map[string]string
+		kubeMetadata                  workloadmeta.KubernetesMetadata
+		expected                      []*types.TagInfo
 	}{
 		{
-			name: "namespace",
-			nsLabelsAsTags: map[string]string{
-				"ns_env":       "ns_env",
-				"ns-ownerteam": "ns-team",
+			name: "namespace with labels and annotations as tags",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"namespaces": {
+					"ns_tier":            "ns_tier",
+					"ns_custom":          "custom_generic_annotation",
+					"namespace_security": "ns_security",
+				},
 			},
-			nsAnnotationsAsTags: map[string]string{
-				"ns_tier":            "ns_tier",
-				"namespace_security": "ns_security",
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"namespaces": {
+					"ns_env":       "ns_env",
+					"ns_custom":    "custom_generic_label",
+					"ns_ownerteam": "ns_team",
+				},
 			},
 			kubeMetadata: workloadmeta.KubernetesMetadata{
 				EntityID: kubeMetadataEntityID,
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: namespace,
 					Labels: map[string]string{
-						"ns_env":       "dev",
-						"ns-ownerteam": "containers",
-						"foo":          "bar",
+						"a": "dev",
 					},
 					Annotations: map[string]string{
-						"ns_tier":            "some_tier",
-						"namespace_security": "critical",
+						"b": "some_tier",
 					},
 				},
 				GVR: &schema.GroupVersionResource{
 					Version:  "v1",
 					Resource: "namespaces",
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			collector := NewWorkloadMetaCollector(context.Background(), store, nil)
+
+			collector.initK8sResourcesMetaAsTags(test.k8sResourcesLabelsAsTags, test.k8sResourcesAnnotationsAsTags)
+
+			actual := collector.handleKubeMetadata(workloadmeta.Event{
+				Type:   workloadmeta.EventTypeSet,
+				Entity: &test.kubeMetadata,
+			})
+
+			assertTagInfoListEqual(tt, test.expected, actual)
+		})
+	}
+}
+
+func TestHandleKubeDeployment(t *testing.T) {
+	const deploymentName = "fooapp"
+
+	kubeMetadataID := string(util.GenerateKubeMetadataEntityID("apps", "deployments", "default", deploymentName))
+
+	kubeMetadataEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesMetadata,
+		ID:   kubeMetadataID,
+	}
+
+	taggerEntityID := fmt.Sprintf("kubernetes_metadata://%s", kubeMetadataEntityID.ID)
+
+	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		config.MockModule(),
+		fx.Supply(workloadmeta.NewParams()),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(),
+	))
+
+	store.Set(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   kubeMetadataID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      deploymentName,
+			Namespace: "default",
+		},
+	})
+
+	tests := []struct {
+		name                          string
+		k8sResourcesAnnotationsAsTags map[string]map[string]string
+		k8sResourcesLabelsAsTags      map[string]map[string]string
+		kubeMetadata                  workloadmeta.KubernetesMetadata
+		expected                      []*types.TagInfo
+	}{
+		{
+			name: "deployment with no matching labels/annotations for annotations/labels as tags. should return nil to avoid empty tagger entity",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"deployments.apps": {
+					"depl_tier":   "depl_tier",
+					"depl_custom": "custom_generic_annotation",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"deployments.apps": {
+					"depl_env":    "depl_env",
+					"depl_custom": "custom_generic_label",
+				},
+			},
+			kubeMetadata: workloadmeta.KubernetesMetadata{
+				EntityID: kubeMetadataEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: deploymentName,
+					Labels: map[string]string{
+						"a": "dev",
+					},
+					Annotations: map[string]string{
+						"b": "some_tier",
+					},
+				},
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Group:    "apps",
+					Resource: "deployments",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "deployment with generic annotations/labels as tags",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"deployments.apps": {
+					"depl_tier":   "depl_tier",
+					"depl_custom": "custom_generic_annotation",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"deployments.apps": {
+					"depl_env":    "depl_env",
+					"depl_custom": "custom_generic_label",
+				},
+			},
+			kubeMetadata: workloadmeta.KubernetesMetadata{
+				EntityID: kubeMetadataEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: deploymentName,
+					Labels: map[string]string{
+						"depl_env":       "dev",
+						"depl_ownerteam": "containers",
+						"foo":            "bar",
+						"depl_custom":    "zoo",
+					},
+					Annotations: map[string]string{
+						"depl_tier":     "some_tier",
+						"depl_security": "critical",
+						"depl_custom":   "gee",
+					},
+				},
+				GVR: &schema.GroupVersionResource{
+					Version:  "v1",
+					Group:    "apps",
+					Resource: "deployments",
 				},
 			},
 			expected: []*types.TagInfo{
@@ -1203,10 +1335,10 @@ func TestHandleKubeMetadata(t *testing.T) {
 					HighCardTags:         []string{},
 					OrchestratorCardTags: []string{},
 					LowCardTags: []string{
-						"ns_env:dev",
-						"ns-team:containers",
-						"ns_tier:some_tier",
-						"ns_security:critical",
+						"depl_env:dev",
+						"depl_tier:some_tier",
+						"custom_generic_label:zoo",
+						"custom_generic_annotation:gee",
 					},
 					StandardTags: []string{},
 				},
@@ -1214,18 +1346,18 @@ func TestHandleKubeMetadata(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
 			collector := NewWorkloadMetaCollector(context.Background(), store, nil)
 
-			collector.initPodMetaAsTags(tt.labelsAsTags, tt.annotationsAsTags, tt.nsLabelsAsTags, tt.nsAnnotationsAsTags)
+			collector.initK8sResourcesMetaAsTags(test.k8sResourcesLabelsAsTags, test.k8sResourcesAnnotationsAsTags)
 
 			actual := collector.handleKubeMetadata(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
-				Entity: &tt.kubeMetadata,
+				Entity: &test.kubeMetadata,
 			})
 
-			assertTagInfoListEqual(t, tt.expected, actual)
+			assertTagInfoListEqual(tt, test.expected, actual)
 		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -135,7 +135,27 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 			},
 		},
 		{
-			name: "only one resource (deployments), only one version, correct resource requested",
+			name: "only one resource (statefulsets), only one version, correct resource requested",
+			apiServerResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "statefulsets",
+							Kind:       "Statefulset",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+			expectedGVRs: []schema.GroupVersionResource{{Resource: "statefulsets", Group: "apps", Version: "v1"}},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "apps/statefulsets",
+			},
+		},
+		{
+			name: "deployments should be skipped from metadata collection",
 			apiServerResourceList: []*metav1.APIResourceList{
 				{
 					GroupVersion: "apps/v1",
@@ -148,30 +168,50 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 					},
 				},
 			},
-			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
+			expectedGVRs: []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments",
 			},
 		},
 		{
-			name: "only one resource (deployments), only one version, correct resource requested, but version is empty (with double slash)",
+			name: "pods should be skipped from metadata collection",
 			apiServerResourceList: []*metav1.APIResourceList{
 				{
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:       "deployments",
-							Kind:       "Deployment",
+							Name:       "pods",
+							Kind:       "Pod",
 							Namespaced: true,
 						},
 					},
 				},
 			},
-			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
+			expectedGVRs: []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "apps//deployments",
+				"cluster_agent.kube_metadata_collection.resources": "/pods",
+			},
+		},
+		{
+			name: "only one resource (statefulsets), only one version, correct resource requested, but version is empty (with double slash)",
+			apiServerResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "statefulsets",
+							Kind:       "Statefulset",
+							Namespaced: true,
+						},
+					},
+				},
+			},
+			expectedGVRs: []schema.GroupVersionResource{{Resource: "statefulsets", Group: "apps", Version: "v1"}},
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "apps//statefulsets",
 			},
 		},
 		{
@@ -248,7 +288,6 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 				},
 			},
 			expectedGVRs: []schema.GroupVersionResource{
-				{Resource: "deployments", Group: "apps", Version: "v1"},
 				{Resource: "statefulsets", Group: "apps", Version: "v1"},
 			},
 			cfg: map[string]interface{}{
@@ -300,7 +339,7 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 					},
 				},
 			},
-			expectedGVRs: []schema.GroupVersionResource{{Resource: "deployments", Group: "apps", Version: "v1"}},
+			expectedGVRs: []schema.GroupVersionResource{},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments",
@@ -333,6 +372,26 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
 						{
+							Name:       "daemonsets",
+							Kind:       "Daemonset",
+							Namespaced: true,
+						},
+					},
+				},
+				{
+					GroupVersion: "apps/v1beta1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "daemonsets",
+							Kind:       "Daemonset",
+							Namespaced: true,
+						},
+					},
+				},
+				{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{
 							Name:       "statefulsets",
 							Kind:       "StatefulSet",
 							Namespaced: true,
@@ -351,11 +410,11 @@ func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
 				},
 			},
 			expectedGVRs: []schema.GroupVersionResource{
-				{Resource: "deployments", Group: "apps", Version: "v1"},
+				{Resource: "daemonsets", Group: "apps", Version: "v1"},
 			},
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
-				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsetsy",
+				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/statefulsetsy",
 			},
 		},
 	}
@@ -401,10 +460,22 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets apps//deployments apps/v1/statefulsets apps/v1/daemonsets",
 			},
-			expectedResources: []string{"//nodes", "apps//deployments", "apps/v1/daemonsets"},
+			expectedResources: []string{"//nodes", "apps/v1/daemonsets"},
 		},
 		{
-			name: "deployments needed for language detection should be excluded from metadata collection",
+			name: "with generic resource tagging based on annotations and/or labels configured",
+			cfg: map[string]interface{}{
+				"language_detection.enabled":                       false,
+				"language_detection.reporting.enabled":             false,
+				"cluster_agent.kube_metadata_collection.enabled":   false,
+				"cluster_agent.kube_metadata_collection.resources": "",
+				"kubernetes_resources_labels_as_tags":              `{"deployments.apps": {"x-team": "team"}}`,
+				"kubernetes_resources_annotations_as_tags":         `{"namespaces": {"x-team": "team"}}`,
+			},
+			expectedResources: []string{"//nodes", "//namespaces"},
+		},
+		{
+			name: "deployments should be excluded from metadata collection",
 			cfg: map[string]interface{}{
 				"language_detection.enabled":                       true,
 				"language_detection.reporting.enabled":             true,
@@ -414,7 +485,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			expectedResources: []string{"apps//daemonsets", "//nodes"},
 		},
 		{
-			name: "pods needed for autoscaling should be excluded from metadata collection",
+			name: "pods should be excluded from metadata collection",
 			cfg: map[string]interface{}{
 				"autoscaling.workload.enabled":                     true,
 				"cluster_agent.kube_metadata_collection.enabled":   true,
@@ -428,7 +499,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets",
 			},
-			expectedResources: []string{"//nodes", "apps//deployments", "apps//statefulsets"},
+			expectedResources: []string{"//nodes", "apps//statefulsets"},
 		},
 		{
 			name: "namespaces needed for namespace labels as tags",
@@ -451,12 +522,8 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 		{
 			name: "namespaces needed for namespace labels and annotations as tags",
 			cfg: map[string]interface{}{
-				"kubernetes_namespace_labels_as_tags": map[string]string{
-					"label1": "tag1",
-				},
-				"kubernetes_namespace_annotations_as_tags": map[string]string{
-					"annotation1": "tag2",
-				},
+				"kubernetes_namespace_labels_as_tags":      `{"label1": "tag1"}`,
+				"kubernetes_namespace_annotations_as_tags": `{"annotation1": "tag2"}`,
 			},
 			expectedResources: []string{"//nodes", "//namespaces"},
 		},
@@ -465,11 +532,9 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			cfg: map[string]interface{}{
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "namespaces apps/deployments",
-				"kubernetes_namespace_labels_as_tags": map[string]string{
-					"label1": "tag1",
-				},
+				"kubernetes_namespace_labels_as_tags":              `{"label1": "tag1"}`,
 			},
-			expectedResources: []string{"//nodes", "//namespaces", "apps//deployments"}, // namespaces are not duplicated
+			expectedResources: []string{"//nodes", "//namespaces"}, // namespaces are not duplicated
 		},
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -119,8 +119,7 @@ func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Objec
 	ctx := context.TODO()
 
 	// Create a fake metadata client to mock API calls.
-
-	response, err := metadataclient.Resource(gvr).List(ctx, v1.ListOptions{})
+	_, err = metadataclient.Resource(gvr).List(ctx, v1.ListOptions{})
 	assert.NoError(t, err)
 	store, _ := newMetadataStore(ctx, wlm, wlm.GetConfig(), metadataclient, gvr)
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -9,7 +9,6 @@ package kubeapiserver
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -123,7 +122,6 @@ func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Objec
 
 	response, err := metadataclient.Resource(gvr).List(ctx, v1.ListOptions{})
 	assert.NoError(t, err)
-	fmt.Println("metadata client listing: ", response.String())
 	store, _ := newMetadataStore(ctx, wlm, wlm.GetConfig(), metadataclient, gvr)
 
 	stopStore := make(chan struct{})

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils.go
@@ -60,6 +60,28 @@ func filterToRegex(filter string) (*regexp.Regexp, error) {
 	return r, nil
 }
 
+// groupResourceToGVRString is a helper function that converts a group resource string to
+// a group-version-resource string
+// a group resource string is in the form `{resource}.{group}` or `{resource}` (example: deployments.apps, pods)
+// a group version resource string is in the form `{group}/{version}/{resource}` (example: apps/v1/deployments)
+// if the groupResource argument is not in the correct format, an empty string is returned
+func groupResourceToGVRString(groupResource string) string {
+	parts := strings.Split(groupResource, ".")
+
+	if len(parts) > 2 {
+		// incorrect format
+		log.Errorf("unexpected group resource format %q. correct format should be `{resource}.{group}` or `{resource}`", groupResource)
+	} else if len(parts) == 1 {
+		// format is `{resource}`
+		return parts[0]
+	} else {
+		// format is `{resource}/{group}`
+		return fmt.Sprintf("%s//%s", parts[1], parts[0])
+	}
+
+	return ""
+}
+
 // cleanDuplicateVersions detects if different versions are requested for the same resource within the same group
 // it logs an error for each occurrence, and a clean slice that doesn't contain any such duplication
 func cleanDuplicateVersions(resources []string) []string {

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -20,6 +20,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -114,8 +115,10 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Component) error
 	}
 
 	c.updateFreq = time.Duration(config.Datadog().GetInt("kubernetes_metadata_tag_update_freq")) * time.Second
-	c.collectNamespaceLabels = len(config.Datadog().GetStringMapString("kubernetes_namespace_labels_as_tags")) > 0
-	c.collectNamespaceAnnotations = len(config.Datadog().GetStringMapString("kubernetes_namespace_annotations_as_tags")) > 0
+
+	metadataAsTags := configutils.GetMetadataAsTags(config.Datadog())
+	c.collectNamespaceLabels = len(metadataAsTags.GetNamespaceLabelsAsTags()) > 0
+	c.collectNamespaceAnnotations = len(metadataAsTags.GetNamespaceAnnotationsAsTags()) > 0
 
 	return err
 }

--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -57,7 +57,7 @@ func getProvidersDefinitions(conf config.Reader) map[string]*providerDef {
 	}
 
 	if config.IsFeaturePresent(config.Kubernetes) {
-		providers["kubernetes"] = &providerDef{10, k8s.GetTags}
+		providers["kubernetes"] = &providerDef{10, k8s.NewKubeNodeTagsProvider(conf).GetTags}
 	}
 
 	if config.IsFeaturePresent(config.Docker) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -357,6 +357,24 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_namespace_annotations_as_tags", map[string]string{})
+	// kubernetes_resources_annotations_as_tags should be parseable as map[string]map[string]string
+	// it maps group resources to annotations as tags maps
+	// a group resource has the format `{resource}.{group}`, or simply `{resource}` if it belongs to the empty group
+	// examples of group resources:
+	// 	- `deployments.apps`
+	// 	- `statefulsets.apps`
+	// 	- `pods`
+	// 	- `nodes`
+	config.BindEnvAndSetDefault("kubernetes_resources_annotations_as_tags", map[string]map[string]string{})
+	// kubernetes_resources_labels_as_tags should be parseable as map[string]map[string]string
+	// it maps group resources to labels as tags maps
+	// a group resource has the format `{resource}.{group}`, or simply `{resource}` if it belongs to the empty group
+	// examples of group resources:
+	// 	- `deployments.apps`
+	// 	- `statefulsets.apps`
+	// 	- `pods`
+	// 	- `nodes`
+	config.BindEnvAndSetDefault("kubernetes_resources_labels_as_tags", map[string]map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_persistent_volume_claims_as_tags", true)
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 

--- a/pkg/config/utils/metadata_as_tags.go
+++ b/pkg/config/utils/metadata_as_tags.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package utils
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// MetadataAsTags contains the labels as tags and annotations as tags for each kubernetes resource based on the user configurations of the following options ordered in increasing order of priority:
+//
+// kubernetes_pod_labels_as_tags
+// kubernetes_pod_annotations_as_tags
+// kubernetes_node_labels_as_tags
+// kubernetes_node_annotations_as_tags
+// kubernetes_namespace_labels_as_tags
+// kubernetes_namespace_annotations_as_tags
+// kubernetes_resources_labels_as_tags
+// kubernetes_resources_anotations_as_tags
+//
+// In case of conflict, higher priority configuration value takes precedences
+// For example, if kubernetes_pod_labels_as_tags = {`l1`: `v1`, `l2`: `v2`} and kubernetes_resources_labels_as_tags = {`pods`: {`l1`: `x`}},
+// the resulting labels as tags for pods will be {`l1`: `x`, `l2`: `v2`}
+type MetadataAsTags struct {
+	labelsAsTags      map[string]map[string]string
+	annotationsAsTags map[string]map[string]string
+}
+
+// GetPodLabelsAsTags returns pod labels as tags
+func (m *MetadataAsTags) GetPodLabelsAsTags() map[string]string {
+	return m.labelsAsTags["pods"]
+}
+
+// GetPodAnnotationsAsTags returns pod annotations as tags
+func (m *MetadataAsTags) GetPodAnnotationsAsTags() map[string]string {
+	return m.annotationsAsTags["pods"]
+}
+
+// GetNodeLabelsAsTags returns node labels as tags
+func (m *MetadataAsTags) GetNodeLabelsAsTags() map[string]string {
+	return m.labelsAsTags["nodes"]
+}
+
+// GetNodeAnnotationsAsTags returns node annotations as tags
+func (m *MetadataAsTags) GetNodeAnnotationsAsTags() map[string]string {
+	return m.annotationsAsTags["nodes"]
+}
+
+// GetNamespaceLabelsAsTags returns namespace labels as tags
+func (m *MetadataAsTags) GetNamespaceLabelsAsTags() map[string]string {
+	return m.labelsAsTags["namespaces"]
+}
+
+// GetNamespaceAnnotationsAsTags returns namespace annotations as tags
+func (m *MetadataAsTags) GetNamespaceAnnotationsAsTags() map[string]string {
+	return m.annotationsAsTags["namespaces"]
+}
+
+// GetResourcesLabelsAsTags returns a map from group resource to labels as tags
+func (m *MetadataAsTags) GetResourcesLabelsAsTags() map[string]map[string]string {
+	return m.labelsAsTags
+}
+
+// GetResourcesAnnotationsAsTags returns a map from group resource to annotations as tags
+func (m *MetadataAsTags) GetResourcesAnnotationsAsTags() map[string]map[string]string {
+	return m.annotationsAsTags
+}
+
+func (m *MetadataAsTags) mergeGenericResourcesLabelsAsTags(cfg pkgconfigmodel.Reader) {
+	resourcesToLabelsAsTags := retrieveDoubleMappingFromConfig(cfg, "kubernetes_resources_labels_as_tags")
+
+	for resource, labelsAsTags := range resourcesToLabelsAsTags {
+		// "pods.", "nodes.", "namespaces." are valid configurations, but they should be replaced here by "pods", "nodes" and "namespaces" respectively to ensure that they override the existing configurations for pods, nodes and namespaces
+		cleanResource := strings.TrimSuffix(resource, ".")
+		_, found := m.labelsAsTags[cleanResource]
+		if !found {
+			m.labelsAsTags[cleanResource] = map[string]string{}
+		}
+		// When a key in `labelsAsTags` exist in `m.labelsAsTags[cleanResource]`, the value in `m.labelsAsTags[cleanResource]` will be overwritten by the value associated with the key in `labelsAsTags`
+		// source: https://pkg.go.dev/maps#Copy
+		maps.Copy(m.labelsAsTags[cleanResource], labelsAsTags)
+	}
+}
+
+func (m *MetadataAsTags) mergeGenericResourcesAnnotationsAsTags(cfg pkgconfigmodel.Reader) {
+	resourcesToAnnotationsAsTags := retrieveDoubleMappingFromConfig(cfg, "kubernetes_resources_annotations_as_tags")
+
+	for resource, annotationsAsTags := range resourcesToAnnotationsAsTags {
+		// "pods.", "nodes.", "namespaces." are valid configurations, but they should be replaced here by "pods", "nodes" and "namespaces" respectively to ensure that they override the existing configurations for pods, nodes and namesapces
+		cleanResource := strings.TrimSuffix(resource, ".")
+		_, found := m.annotationsAsTags[cleanResource]
+		if !found {
+			m.annotationsAsTags[cleanResource] = map[string]string{}
+		}
+		// When a key in `annotationsAsTags` exist in `m.annotationsAsTags[cleanResource]`, the value in `m.annotationsAsTags[cleanResource]` will be overwritten by the value associated with the key in `annotationsAsTags`
+		// source: https://pkg.go.dev/maps#Copy
+		maps.Copy(m.annotationsAsTags[cleanResource], annotationsAsTags)
+	}
+}
+
+// GetMetadataAsTags returns a merged configuration of all labels and annotations as tags set by the user
+func GetMetadataAsTags(c pkgconfigmodel.Reader) MetadataAsTags {
+
+	metadataAsTags := MetadataAsTags{
+		labelsAsTags:      map[string]map[string]string{},
+		annotationsAsTags: map[string]map[string]string{},
+	}
+
+	// node labels/annotations as tags
+	if nodeLabelsAsTags := c.GetStringMapString("kubernetes_node_labels_as_tags"); nodeLabelsAsTags != nil {
+		metadataAsTags.labelsAsTags["nodes"] = lowerCaseMapKeys(nodeLabelsAsTags)
+	}
+	if nodeAnnotationsAsTags := c.GetStringMapString("kubernetes_node_annotations_as_tags"); nodeAnnotationsAsTags != nil {
+		metadataAsTags.annotationsAsTags["nodes"] = lowerCaseMapKeys(nodeAnnotationsAsTags)
+	}
+
+	// namespace labels/annotations as tags
+	if namespaceLabelsAsTags := c.GetStringMapString("kubernetes_namespace_labels_as_tags"); namespaceLabelsAsTags != nil {
+		metadataAsTags.labelsAsTags["namespaces"] = lowerCaseMapKeys(namespaceLabelsAsTags)
+	}
+	if namespaceAnnotationsAsTags := c.GetStringMapString("kubernetes_namespace_annotations_as_tags"); namespaceAnnotationsAsTags != nil {
+		metadataAsTags.annotationsAsTags["namespaces"] = lowerCaseMapKeys(namespaceAnnotationsAsTags)
+	}
+
+	// pod labels/annotations as tags
+	if podLabelsAsTags := c.GetStringMapString("kubernetes_pod_labels_as_tags"); podLabelsAsTags != nil {
+		metadataAsTags.labelsAsTags["pods"] = lowerCaseMapKeys(podLabelsAsTags)
+	}
+	if podAnnotationsAsTags := c.GetStringMapString("kubernetes_pod_annotations_as_tags"); podAnnotationsAsTags != nil {
+		metadataAsTags.annotationsAsTags["pods"] = lowerCaseMapKeys(podAnnotationsAsTags)
+	}
+
+	// generic resources labels/annotations as tags
+	metadataAsTags.mergeGenericResourcesLabelsAsTags(c)
+	metadataAsTags.mergeGenericResourcesAnnotationsAsTags(c)
+
+	return metadataAsTags
+}
+
+func retrieveDoubleMappingFromConfig(cfg pkgconfigmodel.Reader, configKey string) map[string]map[string]string {
+	valueFromConfig := cfg.GetString(configKey)
+
+	var doubleMap map[string]map[string]string
+	err := json.Unmarshal([]byte(valueFromConfig), &doubleMap)
+
+	if err != nil {
+		log.Errorf("failed to parse %s with value %s into json: %v", configKey, valueFromConfig, err)
+		return map[string]map[string]string{}
+	}
+
+	for resource, tags := range doubleMap {
+		doubleMap[resource] = lowerCaseMapKeys(tags)
+	}
+
+	return doubleMap
+}
+
+// lowerCaseMapKeys lowercases all map keys
+func lowerCaseMapKeys(m map[string]string) map[string]string {
+	for label, value := range m {
+		delete(m, label)
+		m[strings.ToLower(label)] = value
+	}
+	return m
+}

--- a/pkg/config/utils/metadata_as_tags_test.go
+++ b/pkg/config/utils/metadata_as_tags_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package utils
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+func TestGetMetadataAsTagsNoError(t *testing.T) {
+
+	tests := []struct {
+		name                       string
+		podLabelsAsTags            map[string]string
+		podAnnotationsAsTags       map[string]string
+		nodeLabelsAsTags           map[string]string
+		nodeAnnotationsAsTags      map[string]string
+		namespaceLabelsAsTags      map[string]string
+		namespaceAnnotationsAsTags map[string]string
+		resourcesLabelsAsTags      string
+		resourcesAnnotationsAsTags string
+		expectedLabelsAsTags       map[string]map[string]string
+		expectedAnnotationsAsTags  map[string]map[string]string
+	}{
+		{
+			name:                       "no configs",
+			resourcesLabelsAsTags:      "{}",
+			resourcesAnnotationsAsTags: "{}",
+			expectedLabelsAsTags:       map[string]map[string]string{},
+			expectedAnnotationsAsTags:  map[string]map[string]string{},
+		},
+		{
+			name:                       "old configurations only",
+			podLabelsAsTags:            map[string]string{"l1": "v1", "l2": "v2"},
+			podAnnotationsAsTags:       map[string]string{"l3": "v3", "l4": "v4"},
+			nodeLabelsAsTags:           map[string]string{"L5": "v5", "L6": "v6"}, // keys should be lower-cased automatically
+			nodeAnnotationsAsTags:      map[string]string{"l7": "v7", "l8": "v8"},
+			namespaceLabelsAsTags:      map[string]string{"l9": "v9", "l10": "v10"},
+			namespaceAnnotationsAsTags: map[string]string{"l11": "v11", "l12": "v12"},
+			resourcesLabelsAsTags:      "{}",
+			resourcesAnnotationsAsTags: "{}",
+			expectedLabelsAsTags: map[string]map[string]string{
+				"nodes":      {"l5": "v5", "l6": "v6"},
+				"pods":       {"l1": "v1", "l2": "v2"},
+				"namespaces": {"l9": "v9", "l10": "v10"},
+			},
+			expectedAnnotationsAsTags: map[string]map[string]string{
+				"nodes":      {"l7": "v7", "l8": "v8"},
+				"pods":       {"l3": "v3", "l4": "v4"},
+				"namespaces": {"l11": "v11", "l12": "v12"},
+			},
+		},
+		{
+			name:                       "new configurations only",
+			resourcesLabelsAsTags:      `{"pods.": {"l1": "v1", "l2": "v2"}, "deployments.apps": {"l3": "v3", "l4": "v4"}, "namespaces": {"l5": "v5"}}`,
+			resourcesAnnotationsAsTags: `{"nodes.": {"l6": "v6", "l7": "v7"},"deployments.apps": {"l8": "v8", "l9": "v9"}, "namespaces": {"l10": "v10"}}`,
+			expectedLabelsAsTags: map[string]map[string]string{
+				"pods":             {"l1": "v1", "l2": "v2"},
+				"deployments.apps": {"l3": "v3", "l4": "v4"},
+				"namespaces":       {"l5": "v5"},
+			},
+			expectedAnnotationsAsTags: map[string]map[string]string{
+				"nodes":            {"l6": "v6", "l7": "v7"},
+				"deployments.apps": {"l8": "v8", "l9": "v9"},
+				"namespaces":       {"l10": "v10"},
+			},
+		},
+		{
+			name:                       "old and new configurations | new configuration should take precedence",
+			podLabelsAsTags:            map[string]string{"l1": "v1", "l2": "v2"},
+			podAnnotationsAsTags:       map[string]string{"l3": "v3", "l4": "v4"},
+			nodeLabelsAsTags:           map[string]string{"l5": "v5", "l6": "v6"},
+			nodeAnnotationsAsTags:      map[string]string{"l7": "v7", "l8": "v8"},
+			namespaceLabelsAsTags:      map[string]string{"l9": "v9", "l10": "v10"},
+			namespaceAnnotationsAsTags: map[string]string{"l11": "v11", "l12": "v12"},
+			resourcesLabelsAsTags:      `{"pods.": {"l1": "x1", "l99": "v99"}, "deployments.apps": {"l3": "v3", "l4": "v4"}}`,
+			resourcesAnnotationsAsTags: `{"nodes.": {"l6": "v6", "l7": "x7"}}`,
+			expectedLabelsAsTags: map[string]map[string]string{
+				"nodes":            {"l5": "v5", "l6": "v6"},
+				"pods":             {"l1": "x1", "l2": "v2", "l99": "v99"},
+				"deployments.apps": {"l3": "v3", "l4": "v4"},
+				"namespaces":       {"l9": "v9", "l10": "v10"},
+			},
+			expectedAnnotationsAsTags: map[string]map[string]string{
+				"nodes":      {"l6": "v6", "l7": "x7", "l8": "v8"},
+				"pods":       {"l3": "v3", "l4": "v4"},
+				"namespaces": {"l11": "v11", "l12": "v12"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(tt *testing.T) {
+			mockConfig := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+			pkgconfigsetup.InitConfig(mockConfig)
+
+			mockConfig.SetWithoutSource("kubernetes_pod_labels_as_tags", test.podLabelsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_pod_annotations_as_tags", test.podAnnotationsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_namespace_labels_as_tags", test.namespaceLabelsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_namespace_annotations_as_tags", test.namespaceAnnotationsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_node_labels_as_tags", test.nodeLabelsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_node_annotations_as_tags", test.nodeAnnotationsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_resources_labels_as_tags", test.resourcesLabelsAsTags)
+			mockConfig.SetWithoutSource("kubernetes_resources_annotations_as_tags", test.resourcesAnnotationsAsTags)
+
+			metadataAsTags := GetMetadataAsTags(mockConfig)
+
+			assert.NotNil(tt, metadataAsTags)
+
+			labelsAsTags := metadataAsTags.GetResourcesLabelsAsTags()
+			assert.Truef(tt, reflect.DeepEqual(labelsAsTags, test.expectedLabelsAsTags), "Expected %v, found %v", test.expectedLabelsAsTags, labelsAsTags)
+
+			annotationsAsTags := metadataAsTags.GetResourcesAnnotationsAsTags()
+			assert.Truef(tt, reflect.DeepEqual(annotationsAsTags, test.expectedAnnotationsAsTags), "Expected %v, found %v", test.expectedAnnotationsAsTags, annotationsAsTags)
+		})
+	}
+}

--- a/pkg/util/kubernetes/hostinfo/no_tags.go
+++ b/pkg/util/kubernetes/hostinfo/no_tags.go
@@ -7,11 +7,23 @@
 
 package hostinfo
 
-import "context"
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// KubeNodeTagsProvider allows computing node tags based on the user configurations for node labels and annotations as tags
+type KubeNodeTagsProvider struct{}
+
+// NewKubeNodeTagsProvider creates and returns a new kube node tags provider object
+func NewKubeNodeTagsProvider(_ config.Reader) KubeNodeTagsProvider {
+	return KubeNodeTagsProvider{}
+}
 
 // GetTags gets the tags from the kubernetes apiserver
 //
 //nolint:revive // TODO(CINT) Fix revive linter
-func GetTags(_ context.Context) ([]string, error) {
+func (k KubeNodeTagsProvider) GetTags(_ context.Context) ([]string, error) {
 	return nil, nil
 }

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -14,6 +14,7 @@ import (
 	k8smetadata "github.com/DataDog/datadog-agent/comp/core/tagger/k8s_metadata"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -80,7 +81,9 @@ func getDefaultLabelsToTags() map[string]string {
 
 func getLabelsToTags() map[string]string {
 	labelsToTags := getDefaultLabelsToTags()
-	for k, v := range config.Datadog().GetStringMapString("kubernetes_node_labels_as_tags") {
+
+	metadataAsTags := configutils.GetMetadataAsTags(config.Datadog())
+	for k, v := range metadataAsTags.GetNodeLabelsAsTags() {
 		// viper lower-cases map keys from yaml, but not from envvars
 		labelsToTags[strings.ToLower(k)] = v
 	}
@@ -90,7 +93,10 @@ func getLabelsToTags() map[string]string {
 
 func getAnnotationsToTags() map[string]string {
 	annotationsToTags := map[string]string{}
-	for k, v := range config.Datadog().GetStringMapString("kubernetes_node_annotations_as_tags") {
+
+	metadataAsTags := configutils.GetMetadataAsTags(config.Datadog())
+
+	for k, v := range metadataAsTags.GetNodeAnnotationsAsTags() {
 		// viper lower-cases map keys from yaml, but not from envvars
 		annotationsToTags[strings.ToLower(k)] = v
 	}

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestExtractTags(t *testing.T) {
@@ -111,50 +109,6 @@ func TestExtractTags(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			tags := extractTags(tc.nodeLabels, tc.labelsToTags)
 			assert.ElementsMatch(t, tc.expectedTags, tags)
-		})
-	}
-}
-
-func TestGetLabelsToTags(t *testing.T) {
-	tests := []struct {
-		name               string
-		configLabelsAsTags map[string]string
-		expectLabelsAsTags map[string]string
-	}{
-		{
-			name: "no labels in config",
-			expectLabelsAsTags: map[string]string{
-				"kubernetes.io/role": "kube_node_role",
-			},
-		},
-		{
-			name: "override node role label",
-			configLabelsAsTags: map[string]string{
-				"kubernetes.io/role": "role",
-			},
-			expectLabelsAsTags: map[string]string{
-				"kubernetes.io/role": "role",
-			},
-		},
-		{
-			name: "lower case all labels",
-			configLabelsAsTags: map[string]string{
-				"A": "a",
-			},
-			expectLabelsAsTags: map[string]string{
-				"kubernetes.io/role": "kube_node_role",
-				"a":                  "a",
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			config := configmock.New(t)
-			config.SetWithoutSource("kubernetes_node_labels_as_tags", test.configLabelsAsTags)
-
-			actuaLabelsAsTags := getLabelsToTags()
-			assert.Equal(t, test.expectLabelsAsTags, actuaLabelsAsTags)
 		})
 	}
 }

--- a/releasenotes-dca/notes/add_generic_k8s_resource_tagging-64b51a2ffaf3e2cc.yaml
+++ b/releasenotes-dca/notes/add_generic_k8s_resource_tagging-64b51a2ffaf3e2cc.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added capability to tag any Kubernetes resource based on labels and annotations.
+    This feature can be configured with `kubernetes_resources_annotations_as_tags` and `kubernetes_resources_labels_as_tags`.
+    These feature configurations are associate group resources with annotations-to-tags (or labels-to-tags) map
+    For example, `deployments.apps` can be associated with an annotations-to-tags map to configure annotations as tags for deployments.
+    Example:
+    {`deployments.apps`: {`annotationKey1`: `tag1`, `annotationKey2`: `tag2`}}

--- a/releasenotes/notes/add_generic_k8s_resource_tagging-e4806f65fc0a0be1.yaml
+++ b/releasenotes/notes/add_generic_k8s_resource_tagging-e4806f65fc0a0be1.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added capability to tag any Kubernetes resource based on labels and annotations.
+    This feature can be configured with `kubernetes_resources_annotations_as_tags` and `kubernetes_resources_labels_as_tags`.
+    These feature configurations are associate group resources with annotations-to-tags (or labels-to-tags) map
+    For example, `pods` can be associated with an annotations-to-tags map to configure annotations as tags for pods.
+    Example:
+    {`pods`: {`annotationKey1`: `tag1`, `annotationKey2`: `tag2`}}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds the capability to configure `kubernetes_resources_labels_as_tags` and `kubernetes_resources_annotations_as_tags`.

We already have the following possible configuration options:
- kubernetes_pod_labels_as_tags
- kubernetes_pod_annotations_as_tags
- kubernetes_node_labels_as_tags
- kubernetes_node_annotations_as_tags
- kubernetes_namespace_labels_as_tags
- kubernetes_namespace_annotations_as_tags

The 2 added configuration options should become the preferred way to configure kubernetes resource tagging based on labels and/or annotations. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Be able to generically choose how to tag kubernetes resources based on their annotations and/or labels.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

In order to preserve backward compatibility, we still support the old configuration options. 

In the event where the user configures both the old and new configurations, the agent will merge all configurations into one config while giving precedence to the new config option in case of conflict by key. (See QA section for examples).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

To simplify, we modified workloadmeta collector factories so that the metadata collector never collects pods or deployments. 

Pods and Deployments will always have their own dedicated collectors. 

This simplification helps ensure we have a single source of truth for pod and deployment data in workloadmeta, which translates to a single source of truth in the tagger for pods and deployments.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

To QA, let's create a kind cluster with few nodes.

create a file called `kind-config.yaml` with the following content:

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: worker
- role: worker
```

Run the following command:

`kind create cluster --config kind-config.yaml`

Let's check and note the nodes labels:

```
kubectl get node kind-worker -o yaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
    node.alpha.kubernetes.io/ttl: "0"
    volumes.kubernetes.io/controller-managed-attach-detach: "true"
  creationTimestamp: "2024-07-29T13:53:24Z"
  labels:
    beta.kubernetes.io/arch: arm64
    beta.kubernetes.io/os: linux
    kubernetes.io/arch: arm64
    kubernetes.io/hostname: kind-worker
    kubernetes.io/os: linux
```

#### Case 1: Ensure old configuration options still work as expected

Deploy the following with helm:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logLevel: DEBUG
  kubelet:
    tlsVerify: false

  logs:
    enabled: true
    containerCollectAll: true

  clusterTagger:
    # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.
    collectKubernetesTags: true

  podLabelsAsTags:
    stale-label: stale-label
  podAnnotationsAsTags:
    stale-annotation: stale-annotation

  namespaceLabelsAsTags:
    stale-label: stale-label

  namespaceAnnotationsAsTags:
    stale-annotation: stale-annotation #stale-annotation-should-be-overridden

  nodeLabelsAsTags:
    kubernetes.io/arch: arch-as-tag #should-not-be-used-should-be-overridden

clusterAgent:
  enabled: true
```

Create the following deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-nginx-app
  labels:
    x-team: cont-p
    x-email: cont-p-datadoghq.com
  annotations:
    x-team: cont-int
    x-email: cont-int-datadoghq.com
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-nginx-app
  template:
    metadata:
      labels:
        app: dummy-nginx-app
        x-ref: base
        stale-label: some-old-label-value
        admission.datadoghq.com/enabled: "false"
      annotations:
        x-ann: acid
        stale-annotation: some-old-annotation-value
    spec:
      containers:
        - name: dummy-nginx-app
          image: nginx
```

Let's also add some labels and annotations to the default namespace:

Run `kubectl edit namespace default`, then add the following label and annotation:
- `stale-annotation: some-old-annotation-value`
- `stale-label: some-old-label-value`

Verify that the tags are correct in the tagger for pods, namespaces and nodes, both on the cluster agent and on the node agent:

Verifying tags in DCA:
```
kubectl exec <cluster-agent-pod-name> -- agent tagger-list

=== Entity kubernetes_pod_uid://d9b4b8ea-7a1f-4dba-bb6a-dc36315123bd ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-5b4d8697f4 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-5b4d8697f4 pod_name:dummy-nginx-app-5b4d8697f4-4hs4k pod_phase:running stale-annotation:some-old-annotation-value stale-label:some-old-label-value]
===

=== Entity kubernetes_metadata:///nodes//kind-worker ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [arch-as-tag:arm64]
===

=== Entity kubernetes_metadata:///namespaces//default ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [stale-annotation:some-old-annotation-value stale-label:some-old-label-value]
===
```

Verifying tags in DA:
```
kubectl exec <agent-pod-name> -- agent tagger-list 

=== Entity kubernetes_pod_uid://9088f360-321d-4895-bb1e-25fe1c04df86 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_app_component:agent kube_app_instance:datadog-agent kube_app_managed_by:Helm kube_app_name:datadog-agent kube_daemon_set:datadog-agent kube_namespace:default kube_ownerref_kind:daemonset kube_ownerref_name:datadog-agent kube_qos:BestEffort kube_service:datadog-agent pod_name:datadog-agent-5fwkz pod_phase:running stale-annotation:some-old-annotation-value stale-label:some-old-label-value]
===
```


#### Case 2: Ensure new configuration options work along with old configuration options

This time let's install the helm chart with both the old configuration options and new ones.

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logLevel: DEBUG
  kubelet:
    tlsVerify: false

  logs:
    enabled: true
    containerCollectAll: true

  clusterTagger:
    # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.
    collectKubernetesTags: true

  podLabelsAsTags:
    stale-label: stale-label
  podAnnotationsAsTags:
    stale-annotation: stale-annotation

  namespaceLabelsAsTags:
    stale-label: stale-label

  namespaceAnnotationsAsTags:
    stale-annotation: stale-annotation-should-be-overridden

  nodeLabelsAsTags:
    kubernetes.io/arch: should-not-be-used-should-be-overridden

agents:
  containers:
    agent:
      env:
        - name: DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS
          value: |
            {"deployments.apps":{"x-team":"team-from-label"},"pods":{"x-ref":"reference"},"namespaces":{"kubernetes.io/metadata.name":"name-as-tag"},"nodes":{"kubernetes.io/os":"os-as-tag", "kubernetes.io/arch": "arch-as-tag"}}
        - name: DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS
          value: |
            {"deployments.apps":{"x-team":"team-from-annotation"},"pods":{"x-ann":"annotation-reference"}, "namespaces":{"stale-annotation": "annotation-as-tag"}}


clusterAgent:
  enabled: true
  replicas: 1
  env:
    - name: DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS
      value: |
        {"deployments.apps":{"x-team":"team-from-label"},"pods":{"x-ref":"reference"},"namespaces":{"kubernetes.io/metadata.name":"name-as-tag"},"nodes":{"kubernetes.io/os":"os-as-tag", "kubernetes.io/arch": "arch-as-tag"}}
    - name: DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS
      value: |
        {"deployments.apps":{"x-team":"team-from-annotation"},"pods":{"x-ann":"annotation-reference"}, "namespaces":{"stale-annotation": "annotation-as-tag"}}
```

Notice how we have some conflicting configurations. For example, `kubernetes.io/os` label is mapped to `os-as-tag` in the new configuration for nodes, but it is mapped to `should-not-be-used-should-be-overridden` in the old `nodeLabelsAsTags` configuration option. The new value should take precedence over the old one.

If not already done, create the following deployment :
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-nginx-app
  labels:
    x-team: cont-p
    x-email: cont-p-datadoghq.com
  annotations:
    x-team: cont-int
    x-email: cont-int-datadoghq.com
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-nginx-app
  template:
    metadata:
      labels:
        app: dummy-nginx-app
        x-ref: base
        stale-label: some-old-label-value
        admission.datadoghq.com/enabled: "false"
      annotations:
        x-ann: acid
        stale-annotation: some-old-annotation-value
    spec:
      containers:
        - name: dummy-nginx-app
          image: nginx
```

If not already done, let's also add some labels and annotations to the default namespace:

Run `kubectl edit namespace default`, then add the following label and annotation:
- `stale-annotation: some-old-annotation-value`
- `stale-label: some-old-label-value`

Verify that the tags are correct in the tagger for deployments, pods, namespaces and nodes, both on the cluster agent and on the node agent:

Verifying tags in DCA:
```
kubectl exec <cluster-agent-pod-name> -- agent tagger-list

=== Entity deployment://default/dummy-nginx-app ===
== Source workloadmeta-kubernetes_deployment =
=Tags: [team-from-annotation:cont-int team-from-label:cont-p]
===

=== Entity kubernetes_metadata:///namespaces//default ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [annotation-as-tag:some-old-annotation-value name-as-tag:default stale-label:some-old-label-value]
===

=== Entity kubernetes_metadata:///nodes//kind-worker ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [arch-as-tag:arm64 os-as-tag:linux]
===

=== Entity kubernetes_pod_uid://d9b4b8ea-7a1f-4dba-bb6a-dc36315123bd ===
== Source workloadmeta-kubernetes_pod =
=Tags: [annotation-reference:acid kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-5b4d8697f4 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-5b4d8697f4 pod_name:dummy-nginx-app-5b4d8697f4-4hs4k pod_phase:running reference:base stale-annotation:some-old-annotation-value stale-label:some-old-label-value]
===
```

Verifying tags in DA:
```
kubectl exec <agent-pod-name> -- agent tagger-list 

=== Entity kubernetes_pod_uid://d9b4b8ea-7a1f-4dba-bb6a-dc36315123bd ===
== Source workloadmeta-kubernetes_pod =
=Tags: [annotation-as-tag:some-old-annotation-value annotation-reference:acid kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-5b4d8697f4 kube_qos:BestEffort kube_replica_set:dummy-nginx-app-5b4d8697f4 name-as-tag:default pod_name:dummy-nginx-app-5b4d8697f4-4hs4k pod_phase:running reference:base stale-annotation:some-old-annotation-value stale-label:some-old-label-value]
===
```




