### PR TITLE
[CWS] do not re-query macro store when fetching macro fields

### DIFF
--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -147,24 +147,12 @@ func (m *Macro) GenEvaluator(expression string, model Model) error {
 
 // GetEventTypes - Returns a list of all the Event Type that the `Expression` handles
 func (m *Macro) GetEventTypes() []EventType {
-	eventTypes := m.evaluator.EventTypes
-
-	for _, macro := range m.Opts.MacroStore.List() {
-		eventTypes = append(eventTypes, macro.evaluator.EventTypes...)
-	}
-
-	return eventTypes
+	return m.evaluator.EventTypes
 }
 
 // GetFields - Returns all the Field that the Macro handles included sub-Macro
 func (m *Macro) GetFields() []Field {
-	fields := m.evaluator.GetFields()
-
-	for _, macro := range m.Opts.MacroStore.List() {
-		fields = append(fields, macro.evaluator.GetFields()...)
-	}
-
-	return fields
+	return m.evaluator.GetFields()
 }
 
 // GetFields - Returns all the Field that the MacroEvaluator handles


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that we don't query the macro store when fetching macro fields and event types. It's important since it allocates, but also because it's useless since the parent callers already call those functions on every macro in the store already.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
