### PR TITLE
Fix (or at least attempt to fix) stop deadlock.

### DIFF
--- a/pkg/windowsdriver/procmon/procmon.go
+++ b/pkg/windowsdriver/procmon/procmon.go
@@ -120,11 +120,18 @@ func (wp *WinProcmon) OnError(err error) {
 
 	// if we get this error notification, then the driver can't continue.
 	// stop the notifications so that the driver can't get backed up
-	wp.Stop()
+	wp.sendStopIoctl()
 }
 
 //nolint:revive // TODO(WKIT) Fix revive linter
 func (wp *WinProcmon) Stop() {
+	wp.sendStopIoctl()
+	wp.reader.Stop()
+
+	_ = driver.StopDriverService(driverName, false)
+}
+
+func (wp *WinProcmon) sendStopIoctl() {
 	// since we're stopping, if for some reason this ioctl fails, there's nothing we can
 	// do, we're on our way out.  Closing the handle will ultimately cause the same cleanup
 	// to happen.
@@ -135,9 +142,7 @@ func (wp *WinProcmon) Stop() {
 		0,
 		nil,
 		nil)
-	wp.reader.Stop()
 
-	_ = driver.StopDriverService(driverName, false)
 }
 
 //nolint:revive // TODO(WKIT) Fix revive linter


### PR DESCRIPTION
### What does this PR do?

Fixes deadlock on stop.

Deadlock was discovered that in certain shutdown conditions, we could end up waiting on a waitgroup in the goroutine that was being waited on.

### Motivation

proper shutdown
### Additional Notes

### Describe how to test/QA your changes

Deadlock was discovered while writing tests to cover shutdown cases (#27010).

Tests applied by that PR serve as test for this change.