### PR TITLE
feat(auto_instrumentation): Set default major versions for language images 

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -154,6 +154,22 @@ var (
 	initOnce                  sync.Once
 )
 
+func (l language) defaultLibInfo(registry, ctrName string) libInfo {
+	return libInfo{
+		lang:    l,
+		ctrName: ctrName,
+		image:   libImageName(registry, l, l.defaultLibVersion()),
+	}
+}
+
+func (l language) defaultLibVersion() string {
+	langVersion, ok := languageVersions[l]
+	if !ok {
+		return "latest"
+	}
+	return langVersion
+}
+
 // Webhook is the auto instrumentation webhook
 type Webhook struct {
 	name              string
@@ -465,21 +481,10 @@ func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) []libInfo {
 func (w *Webhook) getAllLatestLibraries() []libInfo {
 	var libsToInject []libInfo
 	for _, lang := range supportedLanguages {
-		libsToInject = append(libsToInject, libInfo{
-			lang:  language(lang),
-			image: libImageName(w.containerRegistry, lang, defaultLibVersion(lang)),
-		})
+		libsToInject = append(libsToInject, lang.defaultLibInfo(w.containerRegistry, ""))
 	}
 
 	return libsToInject
-}
-
-func defaultLibVersion(l language) string {
-	langVersion, ok := languageVersions[l]
-	if !ok {
-		return "latest"
-	}
-	return langVersion
 }
 
 type libInfo struct {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -856,15 +856,6 @@ func expBasicConfig() []corev1.EnvVar {
 	}
 }
 
-func appends(evs ...[]corev1.EnvVar) []corev1.EnvVar {
-	var out []corev1.EnvVar
-	for _, ev := range evs {
-		out = append(out, ev...)
-	}
-
-	return out
-}
-
 func injectAllEnvs() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
@@ -1035,14 +1026,8 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 					Value: "/datadog-lib/logs",
 				},
 			},
-			expectedInjectedLibraries: map[string]string{
-				"java":   "latest",
-				"python": "latest",
-				"ruby":   "latest",
-				"dotnet": "latest",
-				"js":     "latest",
-			},
-			wantErr: false,
+			expectedInjectedLibraries: defaultLibraries,
+			wantErr:                   false,
 		},
 		{
 			name: "inject all",
@@ -1517,7 +1502,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 					Value: "false",
 				},
 			}, "replicaset", "test-deployment-123"),
-			expectedEnvs: appends(injectAllEnvs(), []corev1.EnvVar{
+			expectedEnvs: append(injectAllEnvs(), []corev1.EnvVar{
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
@@ -51,11 +51,7 @@ func getLibListFromDeploymentAnnotations(store workloadmeta.Component, deploymen
 	for container, languages := range deployment.InjectableLanguages {
 		for lang := range languages {
 			l := language(lang)
-			libList = append(libList, libInfo{
-				ctrName: container.Name,
-				lang: l,
-				image: libImageName(registry, l, defaultLibVersion(l)),
-			})
+			libList = append(libList, l.defaultLibInfo(registry, container.Name))
 		}
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
@@ -50,8 +50,12 @@ func getLibListFromDeploymentAnnotations(store workloadmeta.Component, deploymen
 	var libList []libInfo
 	for container, languages := range deployment.InjectableLanguages {
 		for lang := range languages {
-			imageToInject := libImageName(registry, language(lang), "latest")
-			libList = append(libList, libInfo{ctrName: container.Name, lang: language(lang), image: imageToInject})
+			l := language(lang)
+			libList = append(libList, libInfo{
+				ctrName: container.Name,
+				lang: l,
+				image: libImageName(registry, l, defaultLibVersion(l)),
+			})
 		}
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
@@ -136,9 +136,9 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			namespace:      "default",
 			registry:       "registry",
 			expectedLibList: []libInfo{
-				{ctrName: "container-1", lang: "java", image: libImageName("registry", "java", "latest")},
-				{ctrName: "container-1", lang: "js", image: libImageName("registry", "js", "latest")},
-				{ctrName: "container-2", lang: "python", image: libImageName("registry", "python", "latest")},
+				java.defaultLibInfo("registry", "container-1"),
+				js.defaultLibInfo("registry", "container-1"),
+				python.defaultLibInfo("registry", "container-2"),
 			},
 		},
 		{
@@ -147,9 +147,9 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			namespace:      "custom",
 			registry:       "registry",
 			expectedLibList: []libInfo{
-				{ctrName: "container-1", lang: "ruby", image: libImageName("registry", "ruby", "latest")},
-				{ctrName: "container-1", lang: "python", image: libImageName("registry", "python", "latest")},
-				{ctrName: "container-2", lang: "java", image: libImageName("registry", "java", "latest")},
+				ruby.defaultLibInfo("registry", "container-1"),
+				python.defaultLibInfo("registry", "container-1"),
+				java.defaultLibInfo("registry", "container-2"),
 			},
 		},
 	}
@@ -157,7 +157,6 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			libList := getLibListFromDeploymentAnnotations(mockStore, tt.deploymentName, tt.namespace, tt.registry)
-
 			if !assertEqualLibInjection(libList, tt.expectedLibList) {
 				t.Fatalf("Expected %s, got %s", tt.expectedLibList, libList)
 			}

--- a/releasenotes-dca/notes/auto_instrumentation_default_versions-9dfcae8b2133e2d5.yaml
+++ b/releasenotes-dca/notes/auto_instrumentation_default_versions-9dfcae8b2133e2d5.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Library package versions for auto-instrumentation are now set to the major latest
+    version of the library-package instead of `latest`.
+
+    * java:v1
+    * dotnet:v2
+    * python:v2
+    * ruby:v2
+    * js:v5

--- a/releasenotes-dca/notes/auto_instrumentation_default_versions-9dfcae8b2133e2d5.yaml
+++ b/releasenotes-dca/notes/auto_instrumentation_default_versions-9dfcae8b2133e2d5.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Library package versions for auto-instrumentation are now set to the major latest
+    Library package versions for auto-instrumentation are now set to the latest major
     version of the library-package instead of `latest`.
 
     * java:v1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->

### What does this PR do?

1. sets default major versions for containers injected via the auto instrumentation webhook, moving them from "major" to what is specified by the libraries teams. 
2. Adds a php language, but does not set it as a "supported" language.



### Motivation

https://datadoghq.atlassian.net/browse/APMON-1127

We are currently pulling the `latest` image for each language which can cross major versions as libraries are updated. We want to make sure that the rollout across major versions is more controlled.

### Additional Notes

We cannot ship this until all of the languages libraries have been deployed with that major version tag. 

### Describe how to test/QA your changes

Updated and added tests to validate the changes.