### PR TITLE
Use custom port for process expvar tests

### DIFF
--- a/comp/process/expvars/expvarsimpl/expvars_test.go
+++ b/comp/process/expvars/expvarsimpl/expvars_test.go
@@ -28,6 +28,9 @@ func TestExpvarServer(t *testing.T) {
 
 	_ = fxutil.Test[expvars.Component](t, fx.Options(
 		fx.Supply(core.BundleParams{}),
+		fx.Replace(config.MockParams{Overrides: map[string]interface{}{
+			"process_config.expvar_port": 43423,
+		}}),
 
 		Module(),
 		hostinfoimpl.MockModule(),
@@ -35,7 +38,7 @@ func TestExpvarServer(t *testing.T) {
 	))
 
 	assert.Eventually(t, func() bool {
-		res, err := http.Get("http://localhost:6062/debug/vars")
+		res, err := http.Get("http://localhost:43423/debug/vars")
 		if err != nil {
 			return false
 		}
@@ -53,7 +56,8 @@ func TestTelemetry(t *testing.T) {
 	_ = fxutil.Test[expvars.Component](t, fx.Options(
 		fx.Supply(core.BundleParams{}),
 		fx.Replace(config.MockParams{Overrides: map[string]interface{}{
-			"telemetry.enabled": true,
+			"telemetry.enabled":          true,
+			"process_config.expvar_port": 43423,
 		}}),
 
 		Module(),
@@ -62,7 +66,7 @@ func TestTelemetry(t *testing.T) {
 	))
 
 	assert.Eventually(t, func() bool {
-		res, err := http.Get("http://localhost:6062/telemetry")
+		res, err := http.Get("http://localhost:43423/telemetry")
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Update the tests in the `/comp/process/expvars` component to use a non-default port, so that it doesn't conflict with the agent installed on the CI runner.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is required to upgrade to the faster Gitlab macOS runners for CI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Unit tests pass locally:

```
datadog@2a682a41e360:/workspaces/datadog-agent$ deva test --targets=./comp/process/expvars/expvarsimpl
--- Setting rtloader paths to lib:/workspaces/datadog-agent/dev/lib | header:/workspaces/datadog-agent/dev/include | common headers:
--- Flavor base: unit tests
-----  Module '/workspaces/datadog-agent'
✓  comp/process/expvars/expvarsimpl (cached)

DONE 2 tests in 0.458s
All tests passed
Tests final status (including re-runs): ALL TESTS PASSED
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

N/A, only test code was changed

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
