### PR TITLE
[NPM] Use cookie to check for dups during iteration

### DIFF
--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -421,7 +421,7 @@ func (t *tracer) GetConnections(buffer *network.ConnectionBuffer, filter func(*n
 	// ebpf maps are being iterated over and deleted at the same time.
 	// The iteration can reset when that happens.
 	// See https://justin.azoff.dev/blog/bpf_map_get_next_key-pitfalls/
-	connsByTuple := make(map[netebpf.ConnTuple]struct{})
+	connsByTuple := make(map[netebpf.ConnTuple]uint32)
 
 	// Cached objects
 	conn := new(network.ConnectionStats)
@@ -430,7 +430,7 @@ func (t *tracer) GetConnections(buffer *network.ConnectionBuffer, filter func(*n
 	var tcp4, tcp6, udp4, udp6 float64
 	entries := t.conns.Iterate()
 	for entries.Next(key, stats) {
-		if _, exists := connsByTuple[*key]; exists {
+		if cookie, exists := connsByTuple[*key]; exists && cookie == stats.Cookie {
 			// already seen the connection in current batch processing,
 			// due to race between the iterator and bpf_map_delete
 			ConnTracerTelemetry.iterationDups.Inc()
@@ -438,7 +438,7 @@ func (t *tracer) GetConnections(buffer *network.ConnectionBuffer, filter func(*n
 		}
 
 		populateConnStats(conn, key, stats, t.ch)
-		connsByTuple[*key] = struct{}{}
+		connsByTuple[*key] = stats.Cookie
 
 		isTCP := conn.Type == network.TCP
 		switch conn.Family {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

We should be using the stats cookie to check for duplicates during connection iteration. There are instances where the same connection tuple can be re-used within the iteration; if the cookie is different then it is not really a duplicate of a connection we have seen before during the iteration.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
