### PR TITLE
fix(dogstatsd): fix variables names

### DIFF
--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -36,14 +36,14 @@ var (
 	colonSeparator = []byte(":")
 	commaSeparator = []byte(",")
 
-	// LocalDataPrefix is the prefix for a common field which contains the local data for Origin Detection.
+	// localDataPrefix is the prefix for a common field which contains the local data for Origin Detection.
 	// The Local Data is a list that can contain one or two (split by a ',') of either:
 	// * "cid-<container-id>" or "ci-<container-id>" for the container ID.
 	// * "in-<cgroupv2-inode>" for the cgroupv2 inode.
 	// Possible values:
 	// * "cid-<container-id>"
 	// * "ci-<container-id>,in-<cgroupv2-inode>"
-	LocalDataPrefix = []byte("c:")
+	localDataPrefix = []byte("c:")
 
 	// containerIDPrefix is the prefix for a notation holding the sender's container Inode in the containerIDField
 	containerIDPrefix = []byte("ci-")
@@ -202,7 +202,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			}
 			timestamp = time.Unix(ts, 0)
 		// container ID
-		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 			containerID = p.resolveContainerIDFromLocalData(optionalField)
 		}
 	}
@@ -265,16 +265,16 @@ func (p *parser) parseFloat64List(rawFloats []byte) ([]float64, error) {
 // * "<container-id>"
 // * "ci-<container-id>"
 // * "ci-<container-id>,in-<cgroupv2-inode>"
-func (p *parser) resolveContainerIDFromLocalData(RawLocalData []byte) []byte {
+func (p *parser) resolveContainerIDFromLocalData(rawLocalData []byte) []byte {
 	// Remove prefix from Local Data
-	LocalData := RawLocalData[len(LocalDataPrefix):]
+	localData := rawLocalData[len(localDataPrefix):]
 
 	var containerID []byte
 	var containerIDFromInode []byte
 
-	if bytes.Contains(LocalData, []byte(",")) {
+	if bytes.Contains(localData, []byte(",")) {
 		// The Local Data can contain a list
-		items := bytes.Split(LocalData, []byte{','})
+		items := bytes.Split(localData, []byte{','})
 		for _, item := range items {
 			if bytes.HasPrefix(item, containerIDPrefix) {
 				containerID = item[len(containerIDPrefix):]
@@ -287,17 +287,17 @@ func (p *parser) resolveContainerIDFromLocalData(RawLocalData []byte) []byte {
 		}
 	} else {
 		// The Local Data can contain a single value
-		if bytes.HasPrefix(LocalData, containerIDPrefix) { // Container ID with new format: ci-<container-id>
-			containerID = LocalData[len(containerIDPrefix):]
-		} else if bytes.HasPrefix(LocalData, inodePrefix) { // Cgroupv2 inode format: in-<cgroupv2-inode>
-			containerID = p.resolveContainerIDFromInode(LocalData[len(inodePrefix):])
+		if bytes.HasPrefix(localData, containerIDPrefix) { // Container ID with new format: ci-<container-id>
+			containerID = localData[len(containerIDPrefix):]
+		} else if bytes.HasPrefix(localData, inodePrefix) { // Cgroupv2 inode format: in-<cgroupv2-inode>
+			containerID = p.resolveContainerIDFromInode(localData[len(inodePrefix):])
 		} else { // Container ID with old format: <container-id>
-			containerID = LocalData
+			containerID = localData
 		}
 	}
 
 	if containerID == nil {
-		log.Debugf("Could not parse container ID from Local Data: %s", LocalData)
+		log.Debugf("Could not parse container ID from Local Data: %s", localData)
 	}
 
 	return containerID

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -163,7 +163,7 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 		newEvent.alertType, err = parseEventAlertType(optionalField[len(eventAlertTypePrefix):])
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
-	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newEvent.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	}
 	if err != nil {

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -97,7 +97,7 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 		newServiceCheck.tags = p.parseTags(optionalField[len(serviceCheckTagsPrefix):])
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
-	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, LocalDataPrefix):
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newServiceCheck.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	}
 	if err != nil {

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -114,7 +114,7 @@ func TestUnsafeParseInt(t *testing.T) {
 
 func TestResolveContainerIDFromLocalData(t *testing.T) {
 	const (
-		LocalDataPrefix   = "c:"
+		localDataPrefix   = "c:"
 		containerIDPrefix = "ci-"
 		inodePrefix       = "in-"
 		containerID       = "abcdef"
@@ -142,67 +142,67 @@ func TestResolveContainerIDFromLocalData(t *testing.T) {
 	}{
 		{
 			name:     "Empty LocalData",
-			input:    []byte(LocalDataPrefix),
+			input:    []byte(localDataPrefix),
 			expected: []byte{},
 		},
 		{
 			name:     "LocalData with new container ID",
-			input:    []byte(LocalDataPrefix + containerIDPrefix + containerID),
+			input:    []byte(localDataPrefix + containerIDPrefix + containerID),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData with old container ID format",
-			input:    []byte(LocalDataPrefix + containerID),
+			input:    []byte(localDataPrefix + containerID),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData with inode",
-			input:    []byte(LocalDataPrefix + inodePrefix + containerInode),
+			input:    []byte(localDataPrefix + inodePrefix + containerInode),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData with invalid inode",
-			input:    []byte(LocalDataPrefix + inodePrefix + "invalid"),
+			input:    []byte(localDataPrefix + inodePrefix + "invalid"),
 			expected: []byte(nil),
 		},
 		{
 			name:     "LocalData as a list",
-			input:    []byte(LocalDataPrefix + containerIDPrefix + containerID + "," + inodePrefix + containerInode),
+			input:    []byte(localDataPrefix + containerIDPrefix + containerID + "," + inodePrefix + containerInode),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only inode",
-			input:    []byte(LocalDataPrefix + inodePrefix + containerInode),
+			input:    []byte(localDataPrefix + inodePrefix + containerInode),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only container ID",
-			input:    []byte(LocalDataPrefix + containerIDPrefix + containerID),
+			input:    []byte(localDataPrefix + containerIDPrefix + containerID),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only inode with trailing comma",
-			input:    []byte(LocalDataPrefix + inodePrefix + containerInode + ","),
+			input:    []byte(localDataPrefix + inodePrefix + containerInode + ","),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only container ID with trailing comma",
-			input:    []byte(LocalDataPrefix + containerIDPrefix + containerID + ","),
+			input:    []byte(localDataPrefix + containerIDPrefix + containerID + ","),
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only inode surrounded by commas",
-			input:    []byte(LocalDataPrefix + "," + inodePrefix + containerInode + ","), // This is an invalid format, but we should still be able to extract the container ID
+			input:    []byte(localDataPrefix + "," + inodePrefix + containerInode + ","), // This is an invalid format, but we should still be able to extract the container ID
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as a list with only inode surrounded by commas",
-			input:    []byte(LocalDataPrefix + "," + containerIDPrefix + containerID + ","), // This is an invalid format, but we should still be able to extract the container ID
+			input:    []byte(localDataPrefix + "," + containerIDPrefix + containerID + ","), // This is an invalid format, but we should still be able to extract the container ID
 			expected: []byte(containerID),
 		},
 		{
 			name:     "LocalData as an invalid list",
-			input:    []byte(LocalDataPrefix + ","),
+			input:    []byte(localDataPrefix + ","),
 			expected: []byte(nil),
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Fix variables names.

### Motivation

Respect Go conventions and best practices.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

* Deploy the Agent on Kubernetes and this application
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
    spec:
      containers:
      - name: datadogpy
        image: wdhifdatadog/datadogpy
        imagePullPolicy: Always
        env:
        - name: DD_DOGSTATSD_URL
          value: /var/run/datadog/dsd.socket
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_ENTITY_ID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
        volumeMounts:
        - mountPath: /var/run/datadog
          name: dogstatsd-socket
      volumes:
      - name: dogstatsd-socket
        hostPath:
          path: /var/run/datadog/
```
Note that you will need to deploy the Agent with the `DD_ORIGIN_DETECTION_UNIFIED` setting activated to have a working Origin Detection.

The [wdhifdatadog/datadogpy](https://hub.docker.com/r/wdhifdatadog/datadogpy) application implements a traced Python application with a modified version of datadogpy that uses the new local data header format.

The code that generate those metrics is as follows:
```
➜  datadogpy git:(main) ✗ cat udp.py
#!/usr/bin/env python3

from datadog import initialize, statsd
import time
import os

options = {
    'statsd_host': os.environ.get("DD_AGENT_HOST"),
    'statsd_port': 8125
}

initialize(**options)

while(1):
  statsd.increment('dummy_dsd_udp_python.increment', tags=["environment:wdhif"])
  statsd.decrement('dummy_dsd_udp_python.decrement', tags=["environment:wdhif", "dd.internal.card:low"])
  time.sleep(2)
➜  datadogpy git:(main) ✗ cat uds.py
#!/usr/bin/env python3

from datadog import initialize, statsd
import time
import os

options = {
    'statsd_socket_path': os.environ.get("DD_DOGSTATSD_URL"),
}

initialize(**options)

while(1):
  statsd.increment('dummy_dsd_uds_python.increment', tags=["environment:wdhif"])
  statsd.decrement('dummy_dsd_uds_python.decrement', tags=["environment:wdhif"])
  time.sleep(2)
```

* Verify that you are getting valid traces

![image](https://github.com/DataDog/datadog-agent/assets/5231539/9b0d3493-cc3c-4ab2-b0d8-da4dad68f8ea)

You can also rely on the following Notebook: https://dddev.datadoghq.com/notebook/7881831/dogstatsd-origin-detection?view=view-mode