### PR TITLE
kmt: Exit kmt.test with error code if tests failed

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import tarfile
 import tempfile
 import xml.etree.ElementTree as ET
@@ -1752,6 +1753,7 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
     results: dict[str, dict[str, tuple[int, int, int]]] = defaultdict(dict)
     vm_list: list[str] = []
     total_by_vm: dict[str, tuple[int, int, int]] = defaultdict(lambda: (0, 0, 0))
+    sum_failures = 0
 
     for vm_folder in paths.test_results.iterdir():
         if not vm_folder.is_dir():
@@ -1770,6 +1772,7 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
 
                 tests = int(testsuite.get("tests") or "0")
                 failures = int(testsuite.get("failures") or "0")
+                sum_failures += failures
                 errors = int(testsuite.get("errors") or "0")
                 skipped = int(testsuite.get("skipped") or "0")
                 successes = tests - failures - errors - skipped
@@ -1794,6 +1797,9 @@ def show_last_test_results(ctx: Context, stack: str | None = None):
 
     print(tabulate(table, headers=["Package"] + vm_list))
     print("\nLegend: Successes/Failures/Skipped")
+
+    if sum_failures:
+        sys.exit(1)
 
 
 @task


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Make `kmt.test` exit with an error code if any of the tests failed. This is so that it can be used in shell commands like the below example which runs the test repetitively until failure:

`while inv -e kmt.test ... --retry=0 --=-test.failfast; do :; done`


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
