### PR TITLE
usm: kafka: Fix build with EXTRA_DEBUG

### DIFF
--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -806,7 +806,7 @@ static __always_inline enum parse_result kafka_continue_parse_response_record_ba
         switch (response->state) {
         case KAFKA_FETCH_RESPONSE_RECORD_BATCH_START:
                 extra_debug("KAFKA_FETCH_RESPONSE_RECORD_BATCH_START: response->error_code %u, transaction.error_code %u, transaction.records_count: %d \n", response->partition_error_code,
-                response->transaction.partition_error_code,
+                response->partition_error_code,
                 response->transaction.records_count);
             if (response->transaction.records_count > 0 && response->partition_error_code != response->transaction.error_code) {
                 goto exit;
@@ -1093,7 +1093,7 @@ static __always_inline enum parse_result kafka_continue_parse_response(void *ctx
         if (ret == RET_LOOP_END) {
                 extra_debug("enqueue from new condition, records_count %d, error_code %d",
                     response->transaction.records_count,
-                    response->transaction.partition_error_code);
+                    response->partition_error_code);
                 kafka_batch_enqueue_wrapper(kafka, tup, &response->transaction);
                 response->transaction.records_count = 0;
                 response->transaction.error_code = 0;


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix a compilation error in USM kafka support if the `EXTRA_DEBUG` macro is defined.  Note that this macro is only used during development and has to be enabled manually by editing the source code.

```
 pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h:1097:43: error: no
 member named 'partition_error_code' in 'struct kafka_transaction_t'
                     response->transaction.partition_error_code);
                     ~~~~~~~~~~~~~~~~~~~~~ ^
```


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
