### PR TITLE
Add a step to download e2e tests dependencies

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -101,7 +101,7 @@ go_e2e_deps:
   cache:
     - key:
         files:
-          - ./**/go.mod
+          - ./test/new-e2e/go.mod
         prefix: "go_e2e_deps"
       paths:
         - modcache_e2e.tar.xz

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -11,6 +11,10 @@
   - mkdir -p $GOPATH/pkg/mod && tar xJf modcache_tools.tar.xz -C $GOPATH/pkg/mod
   - rm -f modcache_tools.tar.xz
 
+.retrieve_linux_go_e2e_deps:
+  - mkdir -p $GOPATH/pkg/mod && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod
+  - rm -f modcache_e2e.tar.xz
+
 .cache_policy:
   rules:
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -75,4 +79,30 @@ go_tools_deps:
         prefix: "go_tools_deps"
       paths:
         - modcache_tools.tar.xz
+  retry: 1
+
+go_e2e_deps:
+  stage: deps_fetch
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["setup_agent_version"]
+  extends: .cache_policy
+  variables:
+    KUBERNETES_CPU_REQUEST: 16
+  script:
+    - if [ -f modcache_e2e.tar.xz  ]; then exit 0; fi
+    - source /root/.bashrc
+    - inv -e new-e2e-tests.deps
+    - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_e2e.tar.xz .
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - $CI_PROJECT_DIR/modcache_e2e.tar.xz
+  cache:
+    - key:
+        files:
+          - ./**/go.mod
+        prefix: "go_e2e_deps"
+      paths:
+        - modcache_e2e.tar.xz
   retry: 1

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,7 +85,6 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_e2e_deps"]
-  dependencies: ["go_e2e_deps"]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,7 +85,7 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials
@@ -127,26 +127,26 @@ k8s-e2e-otlp-main:
       annotations:
         - $EXTERNAL_LINKS_PATH
 
-.new_e2e_go_deps:
+.needs_new_e2e_template:
   - go_e2e_deps
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
     - qa_dca
     - qa_dogstatsd
@@ -247,7 +247,7 @@ new-e2e-npm-packages:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_x64
     - deploy_windows_testing-a7
@@ -273,7 +273,7 @@ new-e2e-npm-docker:
 new-e2e-aml:
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -291,7 +291,7 @@ new-e2e-cws:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_cws_instrumentation
@@ -313,7 +313,7 @@ new-e2e-cws:
 new-e2e-process:
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -341,7 +341,7 @@ new-e2e-apm:
     - !reference [.on_apm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
     - deploy_deb_testing-a7_x64
   variables:
@@ -360,7 +360,7 @@ new-e2e-installer:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_arm64
@@ -379,7 +379,7 @@ new-e2e-ndm-netflow:
     - !reference [.on_ndm_netflow_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/netflow
@@ -391,7 +391,7 @@ new-e2e-ndm-snmp:
     - !reference [.on_ndm_snmp_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/snmp

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -84,7 +84,8 @@ k8s-e2e-otlp-main:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials
@@ -126,21 +127,26 @@ k8s-e2e-otlp-main:
       annotations:
         - $EXTERNAL_LINKS_PATH
 
+.needs_new_e2e_template:
+  - go_e2e_deps
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
     - qa_dca
     - qa_dogstatsd
@@ -241,6 +247,7 @@ new-e2e-npm-packages:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_x64
     - deploy_windows_testing-a7
@@ -255,6 +262,7 @@ new-e2e-npm-docker:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - qa_dca
     - qa_agent
   variables:
@@ -265,6 +273,7 @@ new-e2e-npm-docker:
 new-e2e-aml:
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -282,6 +291,7 @@ new-e2e-cws:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_cws_instrumentation
@@ -303,6 +313,7 @@ new-e2e-cws:
 new-e2e-process:
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -330,6 +341,7 @@ new-e2e-apm:
     - !reference [.on_apm_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
     - deploy_deb_testing-a7_x64
   variables:
@@ -348,6 +360,7 @@ new-e2e-installer:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_arm64
@@ -366,6 +379,7 @@ new-e2e-ndm-netflow:
     - !reference [.on_ndm_netflow_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/netflow
@@ -377,6 +391,7 @@ new-e2e-ndm-snmp:
     - !reference [.on_ndm_snmp_or_e2e_changes]
     - !reference [.manual]
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/snmp

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,7 +85,7 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials
@@ -127,26 +127,26 @@ k8s-e2e-otlp-main:
       annotations:
         - $EXTERNAL_LINKS_PATH
 
-.needs_new_e2e_template:
+.new_e2e_go_deps:
   - go_e2e_deps
 
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - qa_agent
     - qa_dca
     - qa_dogstatsd
@@ -247,7 +247,7 @@ new-e2e-npm-packages:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_x64
     - deploy_windows_testing-a7
@@ -273,7 +273,7 @@ new-e2e-npm-docker:
 new-e2e-aml:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -291,7 +291,7 @@ new-e2e-cws:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_cws_instrumentation
@@ -313,7 +313,7 @@ new-e2e-cws:
 new-e2e-process:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -341,7 +341,7 @@ new-e2e-apm:
     - !reference [.on_apm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - qa_agent
     - deploy_deb_testing-a7_x64
   variables:
@@ -360,7 +360,7 @@ new-e2e-installer:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_arm64
@@ -379,7 +379,7 @@ new-e2e-ndm-netflow:
     - !reference [.on_ndm_netflow_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/netflow
@@ -391,7 +391,7 @@ new-e2e-ndm-snmp:
     - !reference [.on_ndm_snmp_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/snmp

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -84,8 +84,7 @@ k8s-e2e-otlp-main:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    - go_e2e_deps
+  needs: ["go_e2e_deps"]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,6 +85,7 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_e2e_deps"]
+  dependencies: ["go_e2e_deps"]
   before_script:
     - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -84,7 +84,10 @@ k8s-e2e-otlp-main:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
+  needs:
+    - go_e2e_deps
   before_script:
+    - !reference [ .retrieve_linux_go_e2e_deps ]
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $AGENT_QA_PROFILE_SSM_NAME >> ~/.aws/config

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,9 +85,9 @@ k8s-e2e-otlp-main:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
   before_script:
-    - !reference [ .retrieve_linux_go_e2e_deps ]
+    - !reference [.retrieve_linux_go_e2e_deps]
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - $CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $AGENT_QA_PROFILE_SSM_NAME >> ~/.aws/config
@@ -133,20 +133,20 @@ k8s-e2e-otlp-main:
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - qa_agent
     - qa_dca
     - qa_dogstatsd
@@ -247,7 +247,7 @@ new-e2e-npm-packages:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_x64
     - deploy_windows_testing-a7
@@ -262,7 +262,7 @@ new-e2e-npm-docker:
     - !reference [.on_npm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - qa_dca
     - qa_agent
   variables:
@@ -273,7 +273,7 @@ new-e2e-npm-docker:
 new-e2e-aml:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -291,7 +291,7 @@ new-e2e-cws:
     - !reference [.on_cws_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_cws_instrumentation
@@ -313,7 +313,7 @@ new-e2e-cws:
 new-e2e-process:
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
@@ -341,7 +341,7 @@ new-e2e-apm:
     - !reference [.on_apm_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - qa_agent
     - deploy_deb_testing-a7_x64
   variables:
@@ -360,7 +360,7 @@ new-e2e-installer:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_arm64
@@ -379,7 +379,7 @@ new-e2e-ndm-netflow:
     - !reference [.on_ndm_netflow_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/netflow
@@ -391,7 +391,7 @@ new-e2e-ndm-snmp:
     - !reference [.on_ndm_snmp_or_e2e_changes]
     - !reference [.manual]
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - qa_agent
   variables:
     TARGETS: ./tests/ndm/snmp

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -6,7 +6,7 @@ e2e_pre_test:
   stage: e2e_pre_test
   extends: .new_e2e_template
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - job: publish_fakeintake
       optional: true
   script:

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -6,7 +6,7 @@ e2e_pre_test:
   stage: e2e_pre_test
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - job: publish_fakeintake
       optional: true
   script:

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -6,9 +6,9 @@ e2e_pre_test:
   stage: e2e_pre_test
   extends: .new_e2e_template
   needs:
+    - !reference [ .needs_new_e2e_template ]
     - job: publish_fakeintake
       optional: true
-    - go_e2e_deps
   script:
     - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
   after_script:

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -8,6 +8,7 @@ e2e_pre_test:
   needs:
     - job: publish_fakeintake
       optional: true
+    - go_e2e_deps
   script:
     - inv -e new-e2e-tests.run --targets ./test-infra-definition --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
   after_script:

--- a/.gitlab/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/e2e_pre_test/e2e_pre_test.yml
@@ -6,7 +6,7 @@ e2e_pre_test:
   stage: e2e_pre_test
   extends: .new_e2e_template
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - job: publish_fakeintake
       optional: true
   script:

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_amazonlinux_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a6_arm64
 
 .new-e2e_amazonlinux_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_amazonlinux_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_amazonlinux_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a6_arm64
 
 .new-e2e_amazonlinux_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_amazonlinux_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_amazonlinux_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a6_arm64
 
 .new-e2e_amazonlinux_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_amazonlinux_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -8,7 +8,7 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a6_x64"]
+  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
 
 .new-e2e_amazonlinux_a6_arm64:
   variables:
@@ -16,7 +16,7 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a6_arm64"]
+  needs: ["deploy_rpm_testing-a6_arm64", "go_e2e_deps"]
 
 .new-e2e_amazonlinux_a7_x86_64:
   variables:
@@ -24,7 +24,7 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
 
 .new-e2e_amazonlinux_a7_arm64:
   variables:
@@ -32,7 +32,7 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_arm64"]
+  needs: ["deploy_rpm_testing-a7_arm64", "go_e2e_deps"]
 
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -8,7 +8,9 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a6_x64
 
 .new-e2e_amazonlinux_a6_arm64:
   variables:
@@ -16,7 +18,9 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a6_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a6_arm64
 
 .new-e2e_amazonlinux_a7_x86_64:
   variables:
@@ -24,7 +28,9 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a7_x64
 
 .new-e2e_amazonlinux_a7_arm64:
   variables:
@@ -32,7 +38,9 @@
     E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos_a7_x86_64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a6_x86_64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos6_a7_x86_64:
@@ -49,7 +49,7 @@
     E2E_BRANCH_OSVERS: "centos-610"
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_rpm_testing-a7_x64
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -8,7 +8,9 @@
     E2E_OSVERS: "centos-79,rhel-86"
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
-  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos_a7_x86_64:
   variables:
@@ -16,7 +18,9 @@
     E2E_OSVERS: "centos-79,rhel-86"
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
-  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a7_x86_64:
   variables:
@@ -24,7 +28,9 @@
     E2E_OSVERS: "rhel-86-fips"
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
-  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a6_x86_64:
   variables:
@@ -32,7 +38,9 @@
     E2E_OSVERS: "rhel-86-fips"
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
-  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos6_a7_x86_64:
   variables:
@@ -40,7 +48,9 @@
     E2E_OSVERS: "centos-610"
     E2E_BRANCH_OSVERS: "centos-610"
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
-  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_rpm_testing-a7_x64
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -8,7 +8,7 @@
     E2E_OSVERS: "centos-79,rhel-86"
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
-  needs: ["deploy_rpm_testing-a6_x64"]
+  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
 
 .new-e2e_centos_a7_x86_64:
   variables:
@@ -16,7 +16,7 @@
     E2E_OSVERS: "centos-79,rhel-86"
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
-  needs: ["deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
 
 .new-e2e_centos-fips_a7_x86_64:
   variables:
@@ -24,7 +24,7 @@
     E2E_OSVERS: "rhel-86-fips"
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
-  needs: ["deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
 
 .new-e2e_centos-fips_a6_x86_64:
   variables:
@@ -32,7 +32,7 @@
     E2E_OSVERS: "rhel-86-fips"
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
-  needs: ["deploy_rpm_testing-a6_x64"]
+  needs: ["deploy_rpm_testing-a6_x64", "go_e2e_deps"]
 
 .new-e2e_centos6_a7_x86_64:
   variables:
@@ -40,7 +40,7 @@
     E2E_OSVERS: "centos-610"
     E2E_BRANCH_OSVERS: "centos-610"
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
-  needs: ["deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_rpm_testing-a7_x64", "go_e2e_deps"]
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos_a7_x86_64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a6_x86_64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos6_a7_x86_64:
@@ -49,7 +49,7 @@
     E2E_BRANCH_OSVERS: "centos-610"
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_rpm_testing-a7_x64
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos_a7_x86_64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a7_x64
 
 .new-e2e_centos-fips_a6_x86_64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a6_x64
 
 .new-e2e_centos6_a7_x86_64:
@@ -49,7 +49,7 @@
     E2E_BRANCH_OSVERS: "centos-610"
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_rpm_testing-a7_x64
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -8,7 +8,7 @@
     E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
-  needs: ["deploy_deb_testing-a6_x64"]
+  needs: ["deploy_deb_testing-a6_x64", "go_e2e_deps"]
 
 .new-e2e_debian_a6_arm64:
   variables:
@@ -16,7 +16,7 @@
     E2E_OSVERS: "debian-10"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
-  needs: ["deploy_deb_testing-a6_arm64"]
+  needs: ["deploy_deb_testing-a6_arm64", "go_e2e_deps"]
 
 .new-e2e_debian_a7_x86_64:
   variables:
@@ -24,7 +24,7 @@
     E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
-  needs: ["deploy_deb_testing-a7_x64"]
+  needs: ["deploy_deb_testing-a7_x64", "go_e2e_deps"]
 
 .new-e2e_debian_a7_arm64:
   variables:
@@ -32,7 +32,7 @@
     E2E_OSVERS: "debian-10"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
-  needs: ["deploy_deb_testing-a7_arm64"]
+  needs: ["deploy_deb_testing-a7_arm64", "go_e2e_deps"]
 
 new-e2e-agent-platform-install-script-debian-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_debian_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_debian_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_debian_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-debian-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -8,7 +8,9 @@
     E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
-  needs: ["deploy_deb_testing-a6_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a6_x64
 
 .new-e2e_debian_a6_arm64:
   variables:
@@ -16,7 +18,9 @@
     E2E_OSVERS: "debian-10"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
-  needs: ["deploy_deb_testing-a6_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a6_arm64
 
 .new-e2e_debian_a7_x86_64:
   variables:
@@ -24,7 +28,9 @@
     E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
-  needs: ["deploy_deb_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a7_x64
 
 .new-e2e_debian_a7_arm64:
   variables:
@@ -32,7 +38,9 @@
     E2E_OSVERS: "debian-10"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
-  needs: ["deploy_deb_testing-a7_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-debian-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_debian_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_debian_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_debian_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-debian-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -9,7 +9,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_debian_a6_arm64:
@@ -19,7 +19,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_debian_a7_x86_64:
@@ -29,7 +29,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_debian_a7_arm64:
@@ -39,7 +39,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "debian-10"
     E2E_BRANCH_OSVERS: "debian-10"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-debian-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -15,7 +15,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_suse_rpm_testing_x64-a6
 
 .new-e2e_suse_a7_x86_64:
@@ -25,7 +25,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_suse_rpm_testing_x64-a7
 
 .new-e2e_suse_a7_arm64:
@@ -35,7 +35,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_suse_rpm_testing_arm64-a7
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -15,7 +15,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_suse_rpm_testing_x64-a6
 
 .new-e2e_suse_a7_x86_64:
@@ -25,7 +25,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_suse_rpm_testing_x64-a7
 
 .new-e2e_suse_a7_arm64:
@@ -35,7 +35,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_suse_rpm_testing_arm64-a7
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -14,7 +14,9 @@
     E2E_OSVERS: "sles-12,sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_x64-a6", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_suse_rpm_testing_x64-a6
 
 .new-e2e_suse_a7_x86_64:
   variables:
@@ -22,7 +24,9 @@
     E2E_OSVERS: "sles-12,sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_x64-a7", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_suse_rpm_testing_x64-a7
 
 .new-e2e_suse_a7_arm64:
   variables:
@@ -30,7 +34,9 @@
     E2E_OSVERS: "sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_arm64-a7", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_suse_rpm_testing_arm64-a7
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -15,7 +15,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_suse_rpm_testing_x64-a6
 
 .new-e2e_suse_a7_x86_64:
@@ -25,7 +25,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_suse_rpm_testing_x64-a7
 
 .new-e2e_suse_a7_arm64:
@@ -35,7 +35,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_suse_rpm_testing_arm64-a7
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -14,7 +14,7 @@
     E2E_OSVERS: "sles-12,sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_x64-a6"]
+  needs: ["deploy_suse_rpm_testing_x64-a6", "go_e2e_deps"]
 
 .new-e2e_suse_a7_x86_64:
   variables:
@@ -22,7 +22,7 @@
     E2E_OSVERS: "sles-12,sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_x64-a7"]
+  needs: ["deploy_suse_rpm_testing_x64-a7", "go_e2e_deps"]
 
 .new-e2e_suse_a7_arm64:
   variables:
@@ -30,7 +30,7 @@
     E2E_OSVERS: "sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_arm64-a7"]
+  needs: ["deploy_suse_rpm_testing_arm64-a7", "go_e2e_deps"]
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -22,7 +22,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_ubuntu_a6_arm64:
@@ -32,7 +32,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_ubuntu_a7_x86_64:
@@ -42,7 +42,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_ubuntu_a7_arm64:
@@ -52,7 +52,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -21,7 +21,7 @@
     E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
-  needs: ["deploy_deb_testing-a6_x64"]
+  needs: ["deploy_deb_testing-a6_x64", "go_e2e_deps"]
 
 .new-e2e_ubuntu_a6_arm64:
   variables:
@@ -29,7 +29,7 @@
     E2E_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
-  needs: ["deploy_deb_testing-a6_arm64"]
+  needs: ["deploy_deb_testing-a6_arm64", "go_e2e_deps"]
 
 .new-e2e_ubuntu_a7_x86_64:
   variables:
@@ -37,7 +37,7 @@
     E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
-  needs: ["deploy_deb_testing-a7_x64"]
+  needs: ["deploy_deb_testing-a7_x64", "go_e2e_deps"]
 
 .new-e2e_ubuntu_a7_arm64:
   variables:
@@ -45,7 +45,7 @@
     E2E_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
-  needs: ["deploy_deb_testing-a7_arm64"]
+  needs: ["deploy_deb_testing-a7_arm64", "go_e2e_deps"]
 
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -22,7 +22,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_ubuntu_a6_arm64:
@@ -32,7 +32,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_ubuntu_a7_x86_64:
@@ -42,7 +42,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_ubuntu_a7_arm64:
@@ -52,7 +52,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -22,7 +22,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a6_x64
 
 .new-e2e_ubuntu_a6_arm64:
@@ -32,7 +32,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a6_arm64
 
 .new-e2e_ubuntu_a7_x86_64:
@@ -42,7 +42,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
 
 .new-e2e_ubuntu_a7_arm64:
@@ -52,7 +52,7 @@
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -21,7 +21,9 @@
     E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
-  needs: ["deploy_deb_testing-a6_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a6_x64
 
 .new-e2e_ubuntu_a6_arm64:
   variables:
@@ -29,7 +31,9 @@
     E2E_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
-  needs: ["deploy_deb_testing-a6_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a6_arm64
 
 .new-e2e_ubuntu_a7_x86_64:
   variables:
@@ -37,7 +41,9 @@
     E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     E2E_BRANCH_OSVERS: "ubuntu-22-04"
-  needs: ["deploy_deb_testing-a7_x64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a7_x64
 
 .new-e2e_ubuntu_a7_arm64:
   variables:

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -51,7 +51,9 @@
     E2E_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
-  needs: ["deploy_deb_testing-a7_arm64", "go_e2e_deps"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_deb_testing-a7_arm64
 
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:
   stage: kitchen_testing

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -98,7 +98,7 @@ new-e2e_windows_powershell_module_test:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a6
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_windows_testing-a6
 
 ## full tests
@@ -119,7 +119,7 @@ new-e2e-windows-agent-msi-windows-server-a6-x86_64:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_windows_testing-a7
 
 ## full tests
@@ -141,7 +141,7 @@ new-e2e-windows-agent-domain-tests-a7-x86_64:
     - .new-e2e_windows_domain_test
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .new_e2e_go_deps ]
+    - !reference [ .needs_new_e2e_template ]
     - deploy_windows_testing-a7
   rules:
     - !reference [.on_deploy]

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -97,7 +97,9 @@ new-e2e_windows_powershell_module_test:
   extends:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a6
-  needs: ["deploy_windows_testing-a6"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_windows_testing-a6
 
 ## full tests
 new-e2e-windows-agent-msi-windows-server-a6-x86_64:
@@ -116,7 +118,9 @@ new-e2e-windows-agent-msi-windows-server-a6-x86_64:
   extends:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a7
-  needs: ["deploy_windows_testing-a7"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_windows_testing-a7
 
 ## full tests
 new-e2e-windows-agent-msi-windows-server-a7-x86_64:
@@ -136,7 +140,9 @@ new-e2e-windows-agent-domain-tests-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_windows_domain_test
     - .new-e2e_agent_a7
-  needs: ["deploy_windows_testing-a7"]
+  needs:
+    - !reference [ .needs_new_e2e_template ]
+    - deploy_windows_testing-a7
   rules:
     - !reference [.on_deploy]
     - !reference [.on_windows_installer_changes_or_manual]

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -98,7 +98,7 @@ new-e2e_windows_powershell_module_test:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a6
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_windows_testing-a6
 
 ## full tests
@@ -119,7 +119,7 @@ new-e2e-windows-agent-msi-windows-server-a6-x86_64:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_windows_testing-a7
 
 ## full tests
@@ -141,7 +141,7 @@ new-e2e-windows-agent-domain-tests-a7-x86_64:
     - .new-e2e_windows_domain_test
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [.needs_new_e2e_template]
     - deploy_windows_testing-a7
   rules:
     - !reference [.on_deploy]

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -98,7 +98,7 @@ new-e2e_windows_powershell_module_test:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a6
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_windows_testing-a6
 
 ## full tests
@@ -119,7 +119,7 @@ new-e2e-windows-agent-msi-windows-server-a6-x86_64:
     - .new-e2e_windows_msi
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_windows_testing-a7
 
 ## full tests
@@ -141,7 +141,7 @@ new-e2e-windows-agent-domain-tests-a7-x86_64:
     - .new-e2e_windows_domain_test
     - .new-e2e_agent_a7
   needs:
-    - !reference [ .needs_new_e2e_template ]
+    - !reference [ .new_e2e_go_deps ]
     - deploy_windows_testing-a7
   rules:
     - !reference [.on_deploy]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -251,8 +251,6 @@ go_mod_tidy_check:
   stage: source_test
   extends: .linux_x64
   needs: ["go_deps"]
-  variables:
-    KUBERNETES_CPU_REQUEST: 4
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]
@@ -262,6 +260,7 @@ go_mod_tidy_check:
   variables:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
+    KUBERNETES_CPU_REQUEST: 4
 
 new-e2e-unit-tests:
   extends: .linux_tests

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -10,6 +10,7 @@ import os.path
 import shutil
 import tempfile
 from pathlib import Path
+from time import sleep
 
 import yaml
 from invoke.context import Context
@@ -19,7 +20,7 @@ from invoke.tasks import task
 from tasks.flavor import AgentFlavor
 from tasks.gotest import process_test_result, test_flavor
 from tasks.libs.common.git import get_commit_sha
-from tasks.libs.common.utils import REPO_PATH, color_message, running_in_ci
+from tasks.libs.common.utils import REPO_PATH, color_message, running_in_ci, timed
 from tasks.modules import DEFAULT_MODULES
 
 
@@ -180,6 +181,27 @@ def clean(ctx, locks=True, stacks=False, output=False):
 
     if output:
         _clean_output()
+
+
+@task
+def deps(ctx, verbose=False):
+    """
+    Setup Go dependencies
+    """
+    max_retry = 3
+    print("downloading dependencies")
+    with timed("go mod download"):
+        verbosity = ' -x' if verbose else ''
+
+        with ctx.cd("test/new-e2e"):
+            for retry in range(max_retry):
+                result = ctx.run(f"go mod download{verbosity}")
+                if result.exited is None or result.exited > 0:
+                    wait = 10 ** (retry + 1)
+                    print(f"[{(retry + 1) / max_retry}] Failed downloading, retrying in {wait} seconds")
+                    sleep(wait)
+                    continue
+                break
 
 
 def _get_default_env():


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a step to download e2e tests dependencies. This is very similar to the other [two steps](https://github.com/DataDog/datadog-agent/blob/florentclarret/go-e2e-deps/.gitlab/deps_fetch/deps_fetch.yml) we already have. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Cache the dependencies so all the e2e test steps won't need to download them
- Avoid potential rate limiting issues on GH
- Reduce flakiness
- Very slightly speed up the process, a couple of seconds


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/ADXT-370

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
