### PR TITLE
[ASCII-1947] Fix tests running next to an agent on MacOS runner

### DIFF
--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -223,6 +223,8 @@ func (c *commandTestSuite) TestReadProfileDataErrors() {
 	mockConfig.SetWithoutSource("expvar_port", 0)
 	mockConfig.SetWithoutSource("apm_config.enabled", true)
 	mockConfig.SetWithoutSource("apm_config.debug.port", 0)
+	mockConfig.SetWithoutSource("process_config.enabled", true)
+	mockConfig.SetWithoutSource("process_config.expvar_port", 0)
 
 	data, err := readProfileData(10)
 	require.Error(t, err)

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -218,8 +218,8 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 func (c *commandTestSuite) TestReadProfileDataErrors() {
 	t := c.T()
 	mockConfig := config.Mock(t)
-	// setting Core Agent Expvar port to 0 to force failing on fetch (letting the default value can leads to
-	// successful request in case of test running next to Agent)
+	// setting Core Agent Expvar port to 0 to ensure failing on fetch (using the default value can lead to
+	// successful request when running next to an Agent)
 	mockConfig.SetWithoutSource("expvar_port", 0)
 	mockConfig.SetWithoutSource("apm_config.enabled", true)
 	mockConfig.SetWithoutSource("apm_config.debug.port", 0)

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -218,6 +218,9 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 func (c *commandTestSuite) TestReadProfileDataErrors() {
 	t := c.T()
 	mockConfig := config.Mock(t)
+	// setting Core Agent Expvar port to 0 to force failing on fetch (letting the default value can leads to
+	// successful request in case of test running next to Agent)
+	mockConfig.SetWithoutSource("expvar_port", 0)
 	mockConfig.SetWithoutSource("apm_config.enabled", true)
 	mockConfig.SetWithoutSource("apm_config.debug.port", 0)
 

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -18,22 +18,19 @@ import (
 
 	// component dependencies
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
-	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/observability"
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
-	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/pidmapimpl"
 	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -43,8 +40,6 @@ import (
 	// package dependencies
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
@@ -58,30 +53,15 @@ import (
 type testdeps struct {
 	fx.In
 
-	// additional StartServer arguments
-	//
-	// TODO: remove these in the next PR once StartServer component arguments
-	//       are part of the api component dependency struct
-	DogstatsdServer       dogstatsdServer.Component
-	Capture               replay.Component
-	SecretResolver        secrets.Component
-	RcService             optional.Option[rcservice.Component]
-	RcServiceMRF          optional.Option[rcservicemrf.Component]
-	AuthToken             authtoken.Component
-	WorkloadMeta          workloadmeta.Component
-	Tagger                tagger.Mock
-	Autodiscovery         autodiscovery.Mock
-	Logs                  optional.Option[logsAgent.Component]
-	Collector             optional.Option[collector.Component]
-	DiagnoseSenderManager diagnosesendermanager.Component
-	Telemetry             telemetry.Component
-	EndpointProviders     []api.EndpointProvider `group:"agent_endpoint"`
+	API       api.Component
+	Telemetry telemetry.Mock
 }
 
-func getComponentDependencies(t *testing.T) testdeps {
-	// TODO: this fxutil.Test[T] can take a component and return the component
+func getTestAPIServer(t *testing.T, params config.MockParams) testdeps {
 	return fxutil.Test[testdeps](
 		t,
+		Module(),
+		fx.Replace(params),
 		hostnameimpl.MockModule(),
 		dogstatsdServer.MockModule(),
 		replaymock.MockModule(),
@@ -92,10 +72,17 @@ func getComponentDependencies(t *testing.T) testdeps {
 		fetchonlyimpl.MockModule(),
 		fx.Supply(context.Background()),
 		taggerimpl.MockModule(),
+		fx.Provide(func(mock tagger.Mock) tagger.Component {
+			return mock
+		}),
 		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
 		autodiscoveryimpl.MockModule(),
+		fx.Provide(func(mock autodiscovery.Mock) autodiscovery.Component {
+			return mock
+		}),
 		fx.Supply(optional.NewNoneOption[logsAgent.Component]()),
 		fx.Supply(optional.NewNoneOption[collector.Component]()),
+		pidmapimpl.Module(),
 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
 		fx.Provide(func() api.AgentEndpointProvider {
 			return api.AgentEndpointProvider{
@@ -105,30 +92,17 @@ func getComponentDependencies(t *testing.T) testdeps {
 	)
 }
 
-func getTestAPIServer(deps testdeps) api.Component {
-	apideps := dependencies{
-		DogstatsdServer:   deps.DogstatsdServer,
-		Capture:           deps.Capture,
-		SecretResolver:    deps.SecretResolver,
-		RcService:         deps.RcService,
-		RcServiceMRF:      deps.RcServiceMRF,
-		AuthToken:         deps.AuthToken,
-		Tagger:            deps.Tagger,
-		LogsAgentComp:     deps.Logs,
-		WorkloadMeta:      deps.WorkloadMeta,
-		Collector:         deps.Collector,
-		Telemetry:         deps.Telemetry,
-		EndpointProviders: deps.EndpointProviders,
-	}
-	return newAPIServer(apideps)
-}
-
 func TestStartServer(t *testing.T) {
-	deps := getComponentDependencies(t)
+	cfgOverride := config.MockParams{Overrides: map[string]interface{}{
+		"cmd_port": 0,
+		// doesn't test agent_ipc because it would try to register an already registered expvar in TestStartBothServersWithObservability
+		"agent_ipc.port": 0,
+	}}
 
-	srv := getTestAPIServer(deps)
-	err := srv.StartServer()
-	defer srv.StopServer()
+	deps := getTestAPIServer(t, cfgOverride)
+
+	err := deps.API.StartServer()
+	defer deps.API.StopServer()
 
 	assert.NoError(t, err, "could not start api component servers: %v", err)
 }
@@ -154,20 +128,18 @@ func TestStartBothServersWithObservability(t *testing.T) {
 	err = authToken.Close()
 	require.NoError(t, err)
 
-	deps := getComponentDependencies(t)
+	cfgOverride := config.MockParams{Overrides: map[string]interface{}{
+		"cmd_port":             0,
+		"agent_ipc.port":       56789,
+		"auth_token_file_path": authToken.Name(),
+	}}
 
-	cfg := config.Mock(t)
-	cfg.Set("cmd_port", 0, model.SourceFile)
-	cfg.Set("agent_ipc.port", 56789, model.SourceFile)
-	cfg.Set("auth_token_file_path", authToken.Name(), model.SourceFile)
-
-	srv := getTestAPIServer(deps)
-	err = srv.StartServer()
+	deps := getTestAPIServer(t, cfgOverride)
+	err = deps.API.StartServer()
 	require.NoError(t, err)
-	defer srv.StopServer()
+	defer deps.API.StopServer()
 
-	telemetryMock := deps.Telemetry.(telemetry.Mock)
-	registry := telemetryMock.GetRegistry()
+	registry := deps.Telemetry.GetRegistry()
 
 	testCases := []struct {
 		addr       string

--- a/pkg/util/grpc/agent_client_test.go
+++ b/pkg/util/grpc/agent_client_test.go
@@ -26,7 +26,7 @@ func TestGetDDAgentClientTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	_, err := GetDDAgentClient(ctx, "127.0.0.1", "5001")
+	_, err := GetDDAgentClient(ctx, "127.0.0.1", "0")
 	assert.Equal(t, context.DeadlineExceeded, err)
 }
 

--- a/pkg/util/grpc/agent_client_test.go
+++ b/pkg/util/grpc/agent_client_test.go
@@ -26,6 +26,7 @@ func TestGetDDAgentClientTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
+	// Port 0 is use to avoid to bind to a running Agent
 	_, err := GetDDAgentClient(ctx, "127.0.0.1", "0")
 	assert.Equal(t, context.DeadlineExceeded, err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR aims to fix ASC owned tests that were failing when executed next to a running Agent (due to already bound port, or in the opposite, unexpectedly get successful response from the Agent).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
To be able to run tests on gitlab MacOS runner which run the Agent in parallel.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Manual tests done.
