### PR TITLE
[PROCS-4196] make the find containers test function more flexible

### DIFF
--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -227,9 +227,10 @@ func assertContainersCollected(t *testing.T, payloads []*aggregator.ProcessPaylo
 }
 
 // findContainer returns whether the container with the given name exists in the given list of
-// container and whether it has the expected data populated
+// containers and whether it has the expected data populated
 func findContainer(name string, containers []*agentmodel.Container) bool {
-	containerNameTag := fmt.Sprintf("container_name:%s", name)
+	// check if there is a tag for the container. The tag could be `container_name:*` or `short_image:*`
+	containerNameTag := fmt.Sprintf(":%s", name)
 	for _, container := range containers {
 		for _, tag := range container.Tags {
 			if strings.HasSuffix(tag, containerNameTag) {


### PR DESCRIPTION
### What does this PR do?
- Make the findContainer function for E2E tests more flexible. Instead of looking exactly for the `container_name:<containerName>` tag we now ignore the tag key and look for any tag that has the container name`*:<containerName>`

### Motivation
Fix flaky tests of the process-agent's manual checks in k8s and ECS where a specific tag might be delayed in workloadmeta. 
The tests which were failing were missing the tag `container_name:stress-ng`, but contained the tag `short_image:stress-ng`, which would be enough to verify the container was collected. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
