### PR TITLE
logs: optimization and fixes to `toValidUtf8`

### DIFF
--- a/pkg/logs/processor/encoder.go
+++ b/pkg/logs/processor/encoder.go
@@ -8,7 +8,6 @@ package processor
 
 import (
 	"strings"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -30,11 +29,10 @@ func toValidUtf8(msg []byte) string {
 
 	for len(msg) > 0 {
 		r, size := utf8.DecodeRune(msg)
-		if r == utf8.RuneError && size == 1 {
-			str.WriteRune(unicode.ReplacementChar)
-		} else {
-			str.WriteRune(r)
-		}
+		// in case of invalid utf-8, DecodeRune returns (utf8.RuneError, 1)
+		// and since RuneError is the same as unicode.ReplacementChar
+		// no need to handle the error explicitly
+		str.WriteRune(r)
 		msg = msg[size:]
 	}
 	return str.String()

--- a/pkg/logs/processor/encoder.go
+++ b/pkg/logs/processor/encoder.go
@@ -7,6 +7,7 @@
 package processor
 
 import (
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -23,14 +24,18 @@ func toValidUtf8(msg []byte) string {
 	if utf8.Valid(msg) {
 		return string(msg)
 	}
-	str := make([]rune, 0, len(msg))
-	for i := range msg {
-		r, size := utf8.DecodeRune(msg[i:])
+
+	var str strings.Builder
+	str.Grow(len(msg))
+
+	for len(msg) > 0 {
+		r, size := utf8.DecodeRune(msg)
 		if r == utf8.RuneError && size == 1 {
-			str = append(str, unicode.ReplacementChar)
+			str.WriteRune(unicode.ReplacementChar)
 		} else {
-			str = append(str, r)
+			str.WriteRune(r)
 		}
+		msg = msg[size:]
 	}
-	return string(str)
+	return str.String()
 }

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -223,8 +223,17 @@ func TestJsonEncoder(t *testing.T) {
 }
 
 func TestEncoderToValidUTF8(t *testing.T) {
+	// valid utf-8
+	assert.Equal(t, "", toValidUtf8(nil))
+	assert.Equal(t, "", toValidUtf8([]byte("")))
+	assert.Equal(t, "a", toValidUtf8([]byte("a")))
+	assert.Equal(t, "abc", toValidUtf8([]byte("abc")))
+	assert.Equal(t, "Hello, 世界", toValidUtf8([]byte("Hello, 世界")))
+
+	// invalid utf-8
 	assert.Equal(t, "a�z", toValidUtf8([]byte("a\xfez")))
 	assert.Equal(t, "a��z", toValidUtf8([]byte("a\xc0\xafz")))
 	assert.Equal(t, "a���z", toValidUtf8([]byte("a\xed\xa0\x80z")))
 	assert.Equal(t, "a����z", toValidUtf8([]byte("a\xf0\x8f\xbf\xbfz")))
+	assert.Equal(t, "世界����z 世界", toValidUtf8([]byte("世界\xf0\x8f\xbf\xbfz 世界")))
 }


### PR DESCRIPTION
### What does this PR do?

This PR:
- fixes an issue with utf8 validation, where a multi-byte rune would be decoded completely but the cursor would be moved to the next byte instead of after the rune
- uses a `strings.Builder` allowing to skip the `[]byte -> string` copy when returning the final string

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
