### PR TITLE
kmt: Allow passing extra environment variables

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -973,6 +973,7 @@ def images_matching_ci(_: Context, domains: list[LibvirtDomain]):
         "verbose": "Enable full output of all commands executed",
         "test-logs": "Set 'gotestsum' verbosity to 'standard-verbose' to print all test logs. Default is 'testname'",
         "test-extra-arguments": "Extra arguments to pass to the test runner, see `go help testflag` for more details",
+        "test-extra-env": "Extra environment variables to pass to the test runner",
     }
 )
 def test(
@@ -989,6 +990,7 @@ def test(
     verbose=True,
     test_logs=False,
     test_extra_arguments=None,
+    test_extra_env=None,
 ):
     stack = check_and_get_stack(stack)
     assert stacks.stack_exists(
@@ -1044,6 +1046,7 @@ def test(
             f"-run-count {run_count}",
             f"-test-root /opt/{component}-tests",
             f"-extra-params {test_extra_arguments}" if test_extra_arguments is not None else "",
+            f"-extra-env {test_extra_env}" if test_extra_env is not None else "",
             "-test-tools /opt/testing-tools",
         ]
         for d in domains:

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -48,6 +48,7 @@ type testConfig struct {
 	testDirRoot       string
 	testingTools      string
 	extraParams       string
+	extraEnv          string
 }
 
 const ciVisibility = "/ci-visibility"
@@ -230,6 +231,9 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 			"DD_SYSTEM_PROBE_BPF_DIR="+filepath.Join(testConfig.testDirRoot, buildDir),
 			"DD_SERVICE_MONITORING_CONFIG_TLS_JAVA_DIR="+filepath.Join(testConfig.testDirRoot, "pkg/network/protocols/tls/java"),
 		)
+		if testConfig.extraEnv != "" {
+			baseEnv = append(baseEnv, strings.Split(testConfig.extraEnv, " ")...)
+		}
 		cmd.Env = append(cmd.Environ(), baseEnv...)
 
 		cmd.Dir = filepath.Dir(testsuite)
@@ -273,6 +277,7 @@ func buildTestConfiguration() (*testConfig, error) {
 	testRoot := flag.String("test-root", "/opt/system-probe-tests", "directory containing test packages")
 	testTools := flag.String("test-tools", "/opt/testing-tools", "directory containing test tools")
 	extraParams := flag.String("extra-params", "", "extra parameters to pass to the test runner")
+	extraEnv := flag.String("extra-env", "", "extra environment variables to pass to the test runner")
 
 	flag.Parse()
 
@@ -310,6 +315,7 @@ func buildTestConfiguration() (*testConfig, error) {
 		testDirRoot:       root,
 		testingTools:      tools,
 		extraParams:       *extraParams,
+		extraEnv:          *extraEnv,
 	}, nil
 }
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allow passing extra environment variables to the test runner.  The primary use of this is to enable BPF debug prints with, for example:

` inv -e kmt.test --test-extra-env BPF_DEBUG=true ...
`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
