### PR TITLE
feat(dogstatsd): implement external data origin detection

### DIFF
--- a/comp/core/tagger/taggerimpl/tagger_test.go
+++ b/comp/core/tagger/taggerimpl/tagger_test.go
@@ -23,46 +23,69 @@ import (
 
 // TODO Improve test coverage with dogstatsd/enrich tests once Origin Detection is refactored.
 
-func Test_taggerCardinality(t *testing.T) {
-	tests := []struct {
-		name        string
-		cardinality string
-		want        types.TagCardinality
+type fakeCIDProvider struct {
+	entries     map[string]string
+	initEntries map[string]string
+}
+
+func (f *fakeCIDProvider) ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, _ time.Duration) (string, error) {
+	id := podUID + "/" + contName
+	if initCont {
+		return f.initEntries[id], nil
+	}
+	return f.entries[id], nil
+}
+
+func TestEnrichTags(t *testing.T) {
+	// Create fake tagger
+	fakeTagger := fxutil.Test[tagger.Mock](t, MockModule())
+	defer fakeTagger.ResetTagger()
+
+	// Fill fake tagger with entities
+	fakeTagger.SetTags(kubelet.KubePodTaggerEntityPrefix+"pod", "host", []string{"pod-low"}, []string{"pod-orch"}, []string{"pod-high"}, []string{"pod-std"})
+	fakeTagger.SetTags(containers.BuildTaggerEntityName("container"), kubelet.KubePodTaggerEntityPrefix+"pod", []string{"container-low"}, []string{"container-orch"}, []string{"container-high"}, []string{"container-std"})
+
+	for _, tt := range []struct {
+		name         string
+		originInfo   taggertypes.OriginInfo
+		cidProvider  *fakeCIDProvider
+		expectedTags []string
 	}{
 		{
-			name:        "high",
-			cardinality: "high",
-			want:        types.HighCardinality,
+			name:         "no origin",
+			originInfo:   taggertypes.OriginInfo{},
+			expectedTags: []string{},
+			cidProvider:  &fakeCIDProvider{},
 		},
 		{
-			name:        "orchestrator",
-			cardinality: "orchestrator",
-			want:        types.OrchestratorCardinality,
+			name:         "with local data (containerID) and low cardinality",
+			originInfo:   taggertypes.OriginInfo{FromMsg: "container", Cardinality: "low"},
+			expectedTags: []string{"container-low"},
+			cidProvider:  &fakeCIDProvider{},
 		},
 		{
-			name:        "orch",
-			cardinality: "orch",
-			want:        types.OrchestratorCardinality,
+			name:         "with local data (containerID) and high cardinality",
+			originInfo:   taggertypes.OriginInfo{FromMsg: "container", Cardinality: "high"},
+			expectedTags: []string{"container-low", "container-orch", "container-high"},
+			cidProvider:  &fakeCIDProvider{},
 		},
 		{
-			name:        "low",
-			cardinality: "low",
-			want:        types.LowCardinality,
+			name:         "with local data (podUID) and low cardinality",
+			originInfo:   taggertypes.OriginInfo{FromTag: "pod", Cardinality: "low"},
+			expectedTags: []string{"pod-low"},
+			cidProvider:  &fakeCIDProvider{},
 		},
 		{
-			name:        "empty",
-			cardinality: "",
-			want:        tagger.DogstatsdCardinality(),
+			name:         "with local data (podUID) and high cardinality",
+			originInfo:   taggertypes.OriginInfo{FromTag: "pod", Cardinality: "high"},
+			expectedTags: []string{"pod-low", "pod-orch", "pod-high"},
+			cidProvider:  &fakeCIDProvider{},
 		},
-		{
-			name:        "unknown",
-			cardinality: "foo",
-			want:        tagger.DogstatsdCardinality(),
-		},
-	}
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality, tagger.DogstatsdCardinality()))
+			tb := tagset.NewHashingTagsAccumulator()
+			fakeTagger.EnrichTags(tb, tt.originInfo)
+			assert.Equal(t, tt.expectedTags, tb.Get())
 		})
 	}
 }
@@ -89,17 +112,72 @@ func TestEnrichTagsOptOut(t *testing.T) {
 	assert.Equal(t, []string{}, tb.Get())
 }
 
-type fakeCIDProvider struct {
-	entries     map[string]string
-	initEntries map[string]string
-}
-
-func (f *fakeCIDProvider) ContainerIDForPodUIDAndContName(podUID, contName string, initCont bool, _ time.Duration) (string, error) {
-	id := podUID + "/" + contName
-	if initCont {
-		return f.initEntries[id], nil
+func TestGenerateContainerIDFromExternalData(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		externalData externalData
+		expected     string
+		cidProvider  *fakeCIDProvider
+	}{
+		{
+			name:         "empty",
+			externalData: externalData{},
+			expected:     "",
+			cidProvider:  &fakeCIDProvider{},
+		},
+		{
+			name: "found container",
+			externalData: externalData{
+				init:          false,
+				containerName: "containerName",
+				podUID:        "podUID",
+			},
+			expected: "containerID",
+			cidProvider: &fakeCIDProvider{
+				entries: map[string]string{
+					"podUID/containerName": "containerID",
+				},
+				initEntries: map[string]string{},
+			},
+		},
+		{
+			name: "found init container",
+			externalData: externalData{
+				init:          true,
+				containerName: "initContainerName",
+				podUID:        "podUID",
+			},
+			expected: "initContainerID",
+			cidProvider: &fakeCIDProvider{
+				entries: map[string]string{},
+				initEntries: map[string]string{
+					"podUID/initContainerName": "initContainerID",
+				},
+			},
+		},
+		{
+			name: "container not found",
+			externalData: externalData{
+				init:          true,
+				containerName: "containerName",
+				podUID:        "podUID",
+			},
+			expected: "",
+			cidProvider: &fakeCIDProvider{
+				entries: map[string]string{},
+				initEntries: map[string]string{
+					"podUID/initContainerName": "initContainerID",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeTagger := TaggerClient{}
+			containerID, err := fakeTagger.generateContainerIDFromExternalData(tt.externalData, tt.cidProvider)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, containerID)
+		})
 	}
-	return f.entries[id], nil
 }
 
 func TestParseEntityID(t *testing.T) {
@@ -150,6 +228,50 @@ func TestParseEntityID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeCl := TaggerClient{}
 			assert.Equal(t, tt.expected, fakeCl.parseEntityID(tt.entityID, tt.cidProvider))
+		})
+	}
+}
+
+func TestTaggerCardinality(t *testing.T) {
+	tests := []struct {
+		name        string
+		cardinality string
+		want        types.TagCardinality
+	}{
+		{
+			name:        "high",
+			cardinality: "high",
+			want:        types.HighCardinality,
+		},
+		{
+			name:        "orchestrator",
+			cardinality: "orchestrator",
+			want:        types.OrchestratorCardinality,
+		},
+		{
+			name:        "orch",
+			cardinality: "orch",
+			want:        types.OrchestratorCardinality,
+		},
+		{
+			name:        "low",
+			cardinality: "low",
+			want:        types.LowCardinality,
+		},
+		{
+			name:        "empty",
+			cardinality: "",
+			want:        tagger.DogstatsdCardinality(),
+		},
+		{
+			name:        "unknown",
+			cardinality: "foo",
+			want:        tagger.DogstatsdCardinality(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality, tagger.DogstatsdCardinality()))
 		})
 	}
 }

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, "", conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1112,6 +1112,7 @@ func TestEnrichTags(t *testing.T) {
 		tags          []string
 		originFromUDS string
 		originFromMsg []byte
+		externalData  string
 		conf          enrichConfig
 	}
 	tests := []struct {
@@ -1126,6 +1127,7 @@ func TestEnrichTags(t *testing.T) {
 			name: "empty tags, host=foo",
 			args: args{
 				originFromUDS: "",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1141,6 +1143,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1156,6 +1159,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          nil,
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1171,6 +1175,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1186,6 +1191,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "none")},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1201,6 +1207,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42")},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1216,6 +1223,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.HighCardinalityString},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1231,6 +1239,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.OrchestratorCardinalityString},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1246,6 +1255,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.LowCardinalityString},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1261,6 +1271,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.UnknownCardinalityString},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1276,6 +1287,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix},
 				originFromUDS: "originID",
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1292,6 +1304,7 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
@@ -1307,6 +1320,7 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
+				externalData:  "",
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
@@ -1316,12 +1330,48 @@ func TestEnrichTags(t *testing.T) {
 			wantedOrigin:       taggertypes.OriginInfo{FromUDS: "originID", FromMsg: "container-id"},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
+		{
+			name: "only external data",
+			args: args{
+				tags:          []string{"env:prod"},
+				originFromUDS: "",
+				externalData:  "it-false,cn-container_name,pu-pod_uid",
+				conf: enrichConfig{
+					defaultHostname: "foo",
+				},
+			},
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       taggertypes.OriginInfo{ExternalData: "it-false,cn-container_name,pu-pod_uid"},
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+		},
+		{
+			name: "external data with entity_id=pod-uid and originFromMsg=container-id",
+			args: args{
+				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
+				originFromUDS: "originID",
+				originFromMsg: []byte("container-id"),
+				externalData:  "it-false,cn-container_name,pu-pod_uid",
+				conf: enrichConfig{
+					defaultHostname: "foo",
+				},
+			},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				FromUDS:      "originID",
+				FromTag:      "pod-uid",
+				FromMsg:      "container-id",
+				ExternalData: "it-false,cn-container_name,pu-pod_uid",
+			},
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+		},
 	}
 	for _, tt := range tests {
 		tt.wantedOrigin.ProductOrigin = taggertypes.ProductOriginDogStatsD
 
 		t.Run(tt.name, func(t *testing.T) {
-			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.conf)
+			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.externalData, tt.args.conf)
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedHost, host)
 			assert.Equal(t, tt.wantedOrigin, origin)
@@ -1369,7 +1419,7 @@ func TestEnrichTagsWithJMXCheckName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", []byte{}, enrichConfig{})
+			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", []byte{}, "", enrichConfig{})
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedMetricSource, metricSource)
 			assert.NotContains(t, tags, tt.jmxCheckName)

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -40,6 +40,8 @@ type dogstatsdEvent struct {
 	tags           []string
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
+	// externalData is used for Origin Detection
+	externalData string
 }
 
 type eventHeader struct {
@@ -165,6 +167,8 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newEvent.containerID = p.resolveContainerIDFromLocalData(optionalField)
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
+		newEvent.externalData = string(optionalField[len(externalDataPrefix):])
 	}
 	if err != nil {
 		return event, err

--- a/comp/dogstatsd/server/parse_metrics.go
+++ b/comp/dogstatsd/server/parse_metrics.go
@@ -48,6 +48,8 @@ type dogstatsdMetricSample struct {
 	tags       []string
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
+	// externalData is used for Origin Detection
+	externalData string
 	// timestamp read in the message if any
 	ts time.Time
 }

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -31,6 +31,8 @@ type dogstatsdServiceCheck struct {
 	tags      []string
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
+	// externalData is used for Origin Detection
+	externalData string
 }
 
 var (
@@ -99,6 +101,8 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newServiceCheck.containerID = p.resolveContainerIDFromLocalData(optionalField)
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
+		newServiceCheck.externalData = string(optionalField[len(externalDataPrefix):])
 	}
 	if err != nil {
 		return serviceCheck, err

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -24,6 +24,7 @@ type OriginInfo struct {
 	FromUDS       string        // FromUDS is the origin resolved using Unix Domain Socket.
 	FromTag       string        // FromTag is the origin resolved from tags.
 	FromMsg       string        // FromMsg is the origin resolved from the message.
+	ExternalData  string        // ExternalData is the external data list.
 	Cardinality   string        // Cardinality is the cardinality of the resolved origin.
 	ProductOrigin ProductOrigin // ProductOrigin is the product that sent the origin information.
 }


### PR DESCRIPTION
### What does this PR do?

Implement External Data resolution for DogStatsD Origin Detection.

### Motivation

Follows the New Origin Detection Spec.

### Additional Notes

TODO Add profiling information

### Describe how to test/QA your changes

* Deploy the following workload:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
        admission.datadoghq.com/enabled: "true"
    spec:
      containers:
      - name: datadogpy
        image: wdhifdatadog/datadogpy
        imagePullPolicy: Always
        env:
        - name: USER
          value: "wdhif"
        - name: DD_DOGSTATSD_URL
          value: /var/run/datadog/dsd.socket
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_ENTITY_ID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
        volumeMounts:
        - mountPath: /var/run/datadog
          name: dogstatsd-socket
      volumes:
      - name: dogstatsd-socket
        hostPath:
          path: /var/run/datadog/
```

This modified workload is a modified version of [datadogpy](https://github.com/DataDog/datadogpy) that only send the External Data.

```
diff --git a/datadog/dogstatsd/base.py b/datadog/dogstatsd/base.py
index c284a74..734faee 100644
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -995,14 +995,14 @@ class DogStatsd(object):
         self, metric, metric_type, value, tags, sample_rate=1, timestamp=0
     ):
         # Create/format the metric packet
-        return "%s%s:%s|%s%s%s%s%s%s" % (
+        return "%s%s:%s|%s%s%s%s%s" % (
             (self.namespace + ".") if self.namespace else "",
             metric,
             value,
             metric_type,
             ("|@" + text(sample_rate)) if sample_rate != 1 else "",
             ("|#" + ",".join(normalize_tags(tags))) if tags else "",
-            ("|c:" + self._container_id if self._container_id else ""),
+            #("|c:" + self._container_id if self._container_id else ""),
             ("|e:" + os.environ.get(EXTERNAL_DATA_ENV_VAR, "")),
             ("|T" + text(timestamp)) if timestamp > 0 else "",
         )
```

* Validate that you are still getting the metrics correctly tagged with the Container ID
![image](https://github.com/user-attachments/assets/5feb1e6c-2484-4021-89d7-58395df04ac7)
![image](https://github.com/user-attachments/assets/ebda264c-43c0-48e2-9500-e35fda76bacf)
![image](https://github.com/user-attachments/assets/b21aded0-18d4-4691-b4d8-4fd823e39a85)

