### PR TITLE
[NPM] Make some errors sticky for sysctl

### DIFF
--- a/pkg/network/config/sysctl/sysctl_test.go
+++ b/pkg/network/config/sysctl/sysctl_test.go
@@ -8,11 +8,13 @@
 package sysctl
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +102,61 @@ func createTmpProcSys(t *testing.T) (procRoot string) {
 
 func createTmpSysctl(t *testing.T, procRoot, sysctl string, v string) {
 	require.NoError(t, os.WriteFile(filepath.Join(procRoot, "sys", sysctl), []byte(v), 0777))
+}
+
+func TestStickyError(t *testing.T) {
+	procRoot := createTmpProcSys(t)
+	t.Run("file does not exist", func(t *testing.T) {
+		calls := 0
+		s := newSCtl(procRoot, "foo", time.Minute, func(path string) ([]byte, error) {
+			calls++
+			return os.ReadFile(path)
+		})
+		_, updated, err := s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 1, calls)
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+
+		// try the get again, os.ReadFile should not be called
+		_, updated, err = s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 1, calls)
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		calls := 0
+		s := newSCtl(procRoot, "foo", time.Minute, func(path string) ([]byte, error) {
+			calls++
+			return nil, os.ErrPermission
+		})
+		_, updated, err := s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 1, calls)
+		assert.True(t, errors.Is(err, os.ErrPermission))
+
+		// try the get again, os.ReadFile should not be called
+		_, updated, err = s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 1, calls)
+		assert.True(t, errors.Is(err, os.ErrPermission))
+	})
+
+	t.Run("non sticky error", func(t *testing.T) {
+		calls := 0
+		s := newSCtl(procRoot, "foo", time.Minute, func(path string) ([]byte, error) {
+			calls++
+			return nil, os.ErrInvalid
+		})
+		_, updated, err := s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 1, calls)
+		assert.True(t, errors.Is(err, os.ErrInvalid))
+
+		// try the get again, os.ReadFile should not be called
+		_, updated, err = s.get(time.Now())
+		assert.False(t, updated)
+		assert.Equal(t, 2, calls)
+		assert.True(t, errors.Is(err, os.ErrInvalid))
+	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Makes some errors, like `EEXIST` and `EPERM` "sticky". For these errors, if we can't access the file in procfs, there is no use retrying. If we do retry, this ends retrying for every connection, which can have substantial cpu overhead on hosts with a large number of connections.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
