### PR TITLE
Add an option on fakeintake to forward payload to dddev

### DIFF
--- a/test/fakeintake/cmd/server/main.go
+++ b/test/fakeintake/cmd/server/main.go
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	portPtr := flag.Int("port", 80, "fakeintake listening port, default to 80. Using -port=0 will use a random available port")
-	dddevForward := flag.Bool("dddev-forward", false, "Datadog Developer Forward API Key")
+	dddevForward := flag.Bool("dddev-forward", false, "Forward POST payloads to dddev, using the env variable DD_API_KEY as API key")
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)

--- a/test/fakeintake/cmd/server/main.go
+++ b/test/fakeintake/cmd/server/main.go
@@ -19,18 +19,22 @@ import (
 
 func main() {
 	portPtr := flag.Int("port", 80, "fakeintake listening port, default to 80. Using -port=0 will use a random available port")
+	dddevForward := flag.Bool("dddev-forward", false, "Datadog Developer Forward API Key")
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
-
-	log.Println("⌛️ Starting fake intake")
 	ready := make(chan bool, 1)
-	fi := fakeintake.NewServer(
+	fiOptions := []fakeintake.Option{
 		fakeintake.WithPort(*portPtr),
 		fakeintake.WithReadyChannel(ready),
 		fakeintake.WithStoreDriver(os.Getenv("STORAGE_DRIVER")),
-	)
+	}
+	if *dddevForward {
+		fiOptions = append(fiOptions, fakeintake.WithDDDevForward())
+	}
+	log.Println("⌛️ Starting fake intake")
+	fi := fakeintake.NewServer(fiOptions...)
 	fi.Start()
 	timeout := time.NewTimer(5 * time.Second)
 

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -60,12 +63,13 @@ type Option func(*Server)
 
 // Server is a struct implementing a fakeintake server
 type Server struct {
-	uuid      uuid.UUID
-	server    http.Server
-	ready     chan bool
-	clock     clock.Clock
-	retention time.Duration
-	shutdown  chan struct{}
+	uuid         uuid.UUID
+	server       http.Server
+	ready        chan bool
+	clock        clock.Clock
+	retention    time.Duration
+	shutdown     chan struct{}
+	dddevForward bool
 
 	urlMutex sync.RWMutex
 	url      string
@@ -206,6 +210,17 @@ func WithRetention(retention time.Duration) Option {
 	}
 }
 
+// WithDDDevForward enable forwarding payload to dddev
+func WithDDDevForward() Option {
+	return func(fi *Server) {
+		if _, ok := os.LookupEnv("DD_API_KEY"); !ok {
+			log.Println("DD_API_KEY is not set, cannot forward to DDDev")
+			return
+		}
+		fi.dddevForward = true
+	}
+}
+
 // Start Starts a fake intake server in a separate go-routine
 // Notifies when ready to the ready channel
 func (fi *Server) Start() {
@@ -311,6 +326,7 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 		if err == nil {
 			return
 		}
+
 	case http.MethodGet:
 		fallthrough
 	case http.MethodHead:
@@ -326,6 +342,36 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 	writeHTTPResponse(w, response)
 }
 
+func (fi *Server) forwardRequestToDDDev(req *http.Request, payload []byte) error {
+	url := "https://app.datadoghq.com" + req.URL.Path
+
+	proxyReq, err := http.NewRequest(req.Method, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	proxyReq.Header = make(http.Header)
+	for h, val := range req.Header {
+		if strings.ToLower(h) == "dd-api-key" {
+			continue
+		}
+		proxyReq.Header[h] = val
+	}
+
+	proxyReq.Header["DD-API-KEY"] = []string{os.Getenv("DD_API_KEY")}
+
+	client := &http.Client{}
+	res, err := client.Do(proxyReq)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status code %d", res.StatusCode)
+	}
+
+	return nil
+}
 func (fi *Server) handleDatadogPostRequest(w http.ResponseWriter, req *http.Request) error {
 	if req.Body == nil {
 		response := buildErrorResponse(errors.New("invalid request, nil body"))
@@ -339,7 +385,12 @@ func (fi *Server) handleDatadogPostRequest(w http.ResponseWriter, req *http.Requ
 		writeHTTPResponse(w, response)
 		return nil
 	}
-
+	if fi.dddevForward {
+		err := fi.forwardRequestToDDDev(req, payload)
+		if err != nil {
+			log.Printf("Error forwarding request to DDDev: %v", err)
+		}
+	}
 	encoding := req.Header.Get("Content-Encoding")
 	if req.URL.Path == "/support/flare" || encoding == "" {
 		encoding = req.Header.Get("Content-Type")

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -229,6 +229,8 @@ func WithDDDevForward() Option {
 }
 
 // WihDDDevAPIKey sets the API key to use when forwarding to DDDev, useful for testing
+//
+//nolint:unused // this function is used in the tests
 func withDDDevAPIKey(apiKey string) Option {
 	return func(fi *Server) {
 		fi.apiKey = apiKey
@@ -236,6 +238,8 @@ func withDDDevAPIKey(apiKey string) Option {
 }
 
 // withForwardEndpoint sets the endpoint to forward the payload to, useful for testing
+//
+//nolint:unused // this function is used in the tests
 func withForwardEndpoint(endpoint string) Option {
 	return func(fi *Server) {
 		fi.forwardEndpoint = endpoint

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -15,15 +15,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
 
 func TestServer(t *testing.T) {
@@ -603,6 +605,27 @@ func testServer(t *testing.T, opts ...Option) {
 		defer response.Body.Close()
 		assert.NotEmpty(t, response.Header.Get("Fakeintake-ID"), "Fakeintake-ID header is empty")
 		assert.Equal(t, http.StatusOK, response.StatusCode, "unexpected code")
+	})
+	t.Run("should forward payload to dddev", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Logf("Received request in test %+v", r)
+			responseBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err, "Error reading request body")
+			assert.Equal(t, "totoro|5|tag:valid,owner:toto", string(responseBody))
+			assert.Equal(t, r.Header.Get("DD-API-KEY"), "thisisatestapikey")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+
+		defer testServer.Close()
+		testOpts := append(opts, withForwardEndpoint(testServer.URL), withDDDevAPIKey("thisisatestapikey"), WithDDDevForward())
+		fi, _ := InitialiseForTests(t, testOpts...)
+		defer fi.Stop()
+		res, err := http.Post(fi.URL()+"/totoro", "text/plain", strings.NewReader("totoro|5|tag:valid,owner:toto"))
+		require.NoError(t, err, "Error on POST request")
+		defer res.Body.Close()
+		t.Logf("Response: %v", res)
+		assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected code")
+
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

It adds an option on fakeintake server to forward all the received payloads to dddev. We only modify the fake intake in this PR. The option will be available once the [PR on test-infra](https://github.com/DataDog/test-infra-definitions/pull/936) is merged as well.

All the payload sent to the fakeintake with `POST` requests are forwarded to dddev. The data are tagged with the following tags:
<img width="519" alt="image" src="https://github.com/DataDog/datadog-agent/assets/132568982/19672a47-478f-453a-bce1-d97f0fc93c25">

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
