### PR TITLE
[ASCII-1975] Fix e2e flakyness (test/new-e2e/tests/agent-shared-components/config-refresh/TestConfigRefreshWindowsSuite)

### DIFF
--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
@@ -10,17 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	secrets "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/secretsutils"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type configRefreshWindowsSuite struct {
@@ -99,5 +100,5 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
-	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
+	}, 3*configRefreshIntervalSec*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR aims to fix the flakiness of e2e test `test/new-e2e/tests/agent-shared-components/config-refresh/TestConfigRefreshWindowsSuite`.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
QA is done through manual checks.