### PR TITLE
[ADXT-372] [e2e] Check for e2e tests that can be run in parallel

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -199,16 +199,16 @@ new-e2e-agent-subcommands:
     TEAM: agent-shared-components
   parallel:
     matrix:
-      - EXTRA_PARAMS: --run Test(Linux|Windows)StatusSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)HealthSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)ConfigSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)HostnameSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)DiagnoseSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)ConfigCheckSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)FlareSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)SecretSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)CheckSuite
-      - EXTRA_PARAMS: --run Test(Linux|Windows)RunSuite
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)StatusSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)HealthSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)HostnameSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)DiagnoseSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigCheckSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)FlareSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)SecretSuite"
+      - EXTRA_PARAMS: --run "T"est(Linux|Windows)CheckSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)RunSuite"
 
 new-e2e-windows-service-test:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -203,7 +203,9 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)HealthSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)HostnameSuite"
-      - EXTRA_PARAMS: --run "Test(Linux|Windows)DiagnoseSuite"
+      # TODO: To regroup when the DiagnoseSuite support parallel #ASCII-1983
+      - EXTRA_PARAMS: --run "TestLinuxDiagnoseSuite"
+      - EXTRA_PARAMS: --run "TestWindowsDiagnoseSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigCheckSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)FlareSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)SecretSuite"

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -207,7 +207,7 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigCheckSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)FlareSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)SecretSuite"
-      - EXTRA_PARAMS: --run "T"est(Linux|Windows)CheckSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)CheckSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)RunSuite"
 
 new-e2e-windows-service-test:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -199,25 +199,16 @@ new-e2e-agent-subcommands:
     TEAM: agent-shared-components
   parallel:
     matrix:
-      - EXTRA_PARAMS: --run TestLinuxStatusSuite
-      - EXTRA_PARAMS: --run TestWindowsStatusSuite
-      - EXTRA_PARAMS: --run TestLinuxHealthSuite
-      - EXTRA_PARAMS: --run TestWindowsHealthSuite
-      - EXTRA_PARAMS: --run TestLinuxConfigSuite
-      - EXTRA_PARAMS: --run TestWindowsConfigSuite
-      - EXTRA_PARAMS: --run TestLinuxHostnameSuite
-      - EXTRA_PARAMS: --run TestWindowsHostnameSuite
-      - EXTRA_PARAMS: --run TestLinuxDiagnoseSuite
-      - EXTRA_PARAMS: --run TestWindowsDiagnoseSuite
-      - EXTRA_PARAMS: --run TestLinuxConfigCheckSuite
-      - EXTRA_PARAMS: --run TestWindowsConfigCheckSuite
-      - EXTRA_PARAMS: --run TestLinuxFlareSuite
-      - EXTRA_PARAMS: --run TestWindowsFlareSuite
-      - EXTRA_PARAMS: --run TestLinuxSecretSuite
-      - EXTRA_PARAMS: --run TestWindowsSecretSuite
-      - EXTRA_PARAMS: --run TestLinuxCheckSuite
-      - EXTRA_PARAMS: --run TestLinuxRunSuite
-      - EXTRA_PARAMS: --run TestWindowsRunSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)StatusSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)HealthSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)ConfigSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)HostnameSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)DiagnoseSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)ConfigCheckSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)FlareSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)SecretSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)CheckSuite
+      - EXTRA_PARAMS: --run Test(Linux|Windows)RunSuite
 
 new-e2e-windows-service-test:
   extends: .new_e2e_template

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_cca_off_test.go
@@ -27,6 +27,7 @@ type k8sCCAOffSuite struct {
 }
 
 func TestK8sCCAOff(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &k8sCCAOffSuite{}, e2e.WithProvisioner(kindfilelogger.Provisioner(kindfilelogger.WithAgentOptions(kubernetesagentparams.WithoutLogsContainerCollectAll()))))
 }
 

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_test.go
@@ -27,6 +27,7 @@ type k8sSuite struct {
 }
 
 func TestK8sSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &k8sSuite{}, e2e.WithProvisioner(kindfilelogger.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-metrics-logs/log-agent/utils"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 )
 
 // LinuxFakeintakeSuite defines a test suite for the log agent interacting with a virtual machine and fake intake.
@@ -39,7 +40,7 @@ func TestE2EVMFakeintakeSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs(), agentparams.WithIntegration("custom_logs.d", logConfig)))),
 	}
-
+	t.Parallel()
 	e2e.Run(t, &LinuxFakeintakeSuite{}, options...)
 }
 

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/multi_line_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/multi_line_test.go
@@ -42,7 +42,7 @@ func TestMultiLineSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs()))),
 	}
-
+	t.Parallel()
 	e2e.Run(t, s, options...)
 }
 

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/utf_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/utf_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+
 	fi "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/stretchr/testify/assert"
 )
 
 //go:embed config/utf-16-le.yaml
@@ -38,7 +39,7 @@ func TestUtfSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithLogs(), agentparams.WithIntegration("custom_logs.d", logConfig)))),
 	}
-
+	t.Parallel()
 	e2e.Run(t, s, options...)
 }
 

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_nix_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_nix_test.go
@@ -29,6 +29,7 @@ type configRefreshLinuxSuite struct {
 }
 
 func TestConfigRefreshLinuxSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &configRefreshLinuxSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
@@ -10,17 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	secrets "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/secretsutils"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type configRefreshWindowsSuite struct {
@@ -28,6 +29,7 @@ type configRefreshWindowsSuite struct {
 }
 
 func TestConfigRefreshWindowsSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &configRefreshWindowsSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-shared-components/secret/secret_nix_test.go
+++ b/test/new-e2e/tests/agent-shared-components/secret/secret_nix_test.go
@@ -25,6 +25,7 @@ type linuxRuntimeSecretSuite struct {
 }
 
 func TestLinuxRuntimeSecretSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxRuntimeSecretSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-shared-components/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/secret/secret_win_test.go
@@ -26,6 +26,7 @@ type windowsRuntimeSecretSuite struct {
 }
 
 func TestWindowsRuntimeSecretSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsRuntimeSecretSuite{}, e2e.WithProvisioner(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 	)))

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -10,11 +10,12 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/stretchr/testify/assert"
 )
 
 type linuxCheckSuite struct {
@@ -28,6 +29,7 @@ var customCheckYaml []byte
 var customCheckPython []byte
 
 func TestLinuxCheckSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(
 		agentparams.WithFile("/etc/datadog-agent/conf.d/hello.yaml", string(customCheckYaml), true),
 		agentparams.WithFile("/etc/datadog-agent/checks.d/hello.py", string(customCheckPython), true),

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -9,11 +9,12 @@ package check
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type windowsCheckSuite struct {
@@ -22,7 +23,7 @@ type windowsCheckSuite struct {
 
 func TestWindowsCheckSuite(t *testing.T) {
 	t.Skip("not working because of the following error: unable to import module 'hello': source code string cannot contain null bytes")
-
+	t.Parallel()
 	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),

--- a/test/new-e2e/tests/agent-subcommands/config/config_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/config/config_nix_test.go
@@ -21,5 +21,6 @@ type linuxConfigSuite struct {
 
 func TestLinuxConfigSuite(t *testing.T) {
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault))
+	t.Parallel()
 	e2e.Run(t, &linuxConfigSuite{baseConfigSuite: baseConfigSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }

--- a/test/new-e2e/tests/agent-subcommands/config/config_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/config/config_win_test.go
@@ -9,10 +9,11 @@ package config
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type windowsConfigSuite struct {
@@ -21,5 +22,6 @@ type windowsConfigSuite struct {
 
 func TestWindowsConfigSuite(t *testing.T) {
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))
+	t.Parallel()
 	e2e.Run(t, &windowsConfigSuite{baseConfigSuite: baseConfigSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
@@ -21,6 +21,7 @@ type linuxConfigCheckSuite struct {
 }
 
 func TestLinuxConfigCheckSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxConfigCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_win_test.go
@@ -24,6 +24,7 @@ type windowsConfigCheckSuite struct {
 }
 
 func TestWindowsConfigCheckSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsConfigCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_nix_test.go
@@ -23,6 +23,7 @@ type linuxDiagnoseSuite struct {
 }
 
 func TestLinuxDiagnoseSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxDiagnoseSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_win_test.go
@@ -22,6 +22,7 @@ type windowsDiagnoseSuite struct {
 }
 
 func TestWindowsDiagnoseSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsDiagnoseSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
@@ -11,10 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 )
 
 //go:embed fixtures/datadog-agent.yaml
@@ -31,6 +32,7 @@ type linuxFlareSuite struct {
 }
 
 func TestLinuxFlareSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxFlareSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_win_test.go
@@ -24,6 +24,7 @@ type windowsFlareSuite struct {
 }
 
 func TestWindowsFlareSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsFlareSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -8,11 +8,12 @@ package health
 import (
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/stretchr/testify/assert"
 )
 
 type linuxHealthSuite struct {
@@ -20,6 +21,7 @@ type linuxHealthSuite struct {
 }
 
 func TestLinuxHealthSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -8,13 +8,14 @@ package health
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type windowsHealthSuite struct {
@@ -22,6 +23,7 @@ type windowsHealthSuite struct {
 }
 
 func TestWindowsHealthSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
@@ -22,6 +22,7 @@ type linuxHostnameSuite struct {
 }
 
 func TestLinuxHostnameSuite(t *testing.T) {
+	t.Parallel()
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault))
 	e2e.Run(t, &linuxHostnameSuite{baseHostnameSuite: baseHostnameSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }

--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
@@ -23,6 +23,7 @@ type windowsHostnameSuite struct {
 }
 
 func TestWindowsHostnameSuite(t *testing.T) {
+	t.Parallel()
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))
 	e2e.Run(t, &windowsHostnameSuite{baseHostnameSuite: baseHostnameSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(osOption)))
 }

--- a/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_nix_test.go
@@ -19,6 +19,7 @@ type linuxRunSuite struct {
 }
 
 func TestLinuxRunSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxRunSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/run/run_win_test.go
@@ -11,11 +11,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 )
 
 type windowsRunSuite struct {
@@ -23,6 +24,7 @@ type windowsRunSuite struct {
 }
 
 func TestWindowsRunSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsRunSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_nix_test.go
@@ -25,6 +25,7 @@ type linuxSecretSuite struct {
 }
 
 func TestLinuxSecretSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxSecretSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
@@ -27,6 +27,7 @@ type windowsSecretSuite struct {
 }
 
 func TestWindowsSecretSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsSecretSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 )
 
 type linuxStatusSuite struct {
@@ -20,6 +21,7 @@ type linuxStatusSuite struct {
 }
 
 func TestLinuxStatusSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 )
 
 type windowsStatusSuite struct {
@@ -21,6 +22,7 @@ type windowsStatusSuite struct {
 }
 
 func TestWindowsStatusSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &windowsStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 

--- a/test/new-e2e/tests/remote-config/rc_ssl_config_test.go
+++ b/test/new-e2e/tests/remote-config/rc_ssl_config_test.go
@@ -12,10 +12,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 )
 
 type sslConfigSuite struct {
@@ -26,6 +27,7 @@ type sslConfigSuite struct {
 var sslMismatchConfig string
 
 func TestSslConfigSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &sslConfigSuite{},
 		e2e.WithProvisioner(
 			awshost.ProvisionerNoFakeIntake(

--- a/test/new-e2e/tests/remote-config/tracer_test.go
+++ b/test/new-e2e/tests/remote-config/tracer_test.go
@@ -12,10 +12,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 )
 
 type tracerSuite struct {
@@ -31,6 +32,7 @@ var tracerPayloadJSON string
 // TestRcTracerSuite tests the remote-config service by attempting to retrieve RC payloads as if a tracer were calling it
 // Requires a valid Datadog API key
 func TestRcTracerSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &tracerSuite{},
 		e2e.WithProvisioner(
 			awshost.ProvisionerNoFakeIntake(

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -14,15 +14,16 @@ import (
 	"testing"
 	"time"
 
+	componentsos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	componentsos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/require"
 )
 
 type vmSuite struct {
@@ -40,7 +41,6 @@ func TestVMSuite(t *testing.T) {
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}
-
 	e2e.Run(t, &vmSuite{}, suiteParams...)
 }
 

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -14,16 +14,15 @@ import (
 	"testing"
 	"time"
 
-	componentsos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/require"
-
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	componentsos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/require"
 )
 
 type vmSuite struct {
@@ -41,6 +40,7 @@ func TestVMSuite(t *testing.T) {
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}
+
 	e2e.Run(t, &vmSuite{}, suiteParams...)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds t.Parallel when we can to speed up e2e tests.
It also regroup some agent-subcommand tests, it reduce the number of runner required by running in parallel on the same runner both Linux and Windows tests

We can not the following changes in test execution time:
- AML tests: 30 minutes -> 17 minutes
- Sub command tests: Before the change we had two different job lasting 6 and 13 minutes, we now have only one that lasts 15 minutes (we save resources for no significant increase in the duration)
- Remote config: 10 minutes -> 7 minutes

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Make e2e tests faster

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
