### PR TITLE
[CONTINT-4153] Fix flaky ECS test

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -350,12 +350,11 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 
 func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook, store workloadmeta.Component) workloadmeta.ContainerImage {
 	imageSpec := container.Config.Image
-	image := workloadmeta.ContainerImage{
-		RawName: imageSpec,
-		Name:    imageSpec,
-	}
 
-	var err error
+	var (
+		image workloadmeta.ContainerImage
+		err   error
+	)
 
 	if strings.Contains(imageSpec, "@sha256") {
 		image, err = workloadmeta.NewContainerImage(container.Image, imageSpec)
@@ -364,7 +363,7 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 		}
 	}
 
-	if image.Name == "" && image.Tag == "" {
+	if (image.Name == "" && image.Tag == "") || err != nil {
 		resolvedImageSpec, err := resolve(ctx, container)
 		if err != nil {
 			log.Debugf("cannot resolve image name %q for container %q: %s", imageSpec, container.ID, err)

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -355,35 +355,29 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 		Name:    imageSpec,
 	}
 
-	var (
-		name      string
-		registry  string
-		shortName string
-		tag       string
-		err       error
-	)
+	var err error
 
 	if strings.Contains(imageSpec, "@sha256") {
-		name, registry, shortName, tag, err = containers.SplitImageName(imageSpec)
+		image, err = workloadmeta.NewContainerImage(container.Image, imageSpec)
 		if err != nil {
 			log.Debugf("cannot split image name %q for container %q: %s", imageSpec, container.ID, err)
 		}
 	}
 
-	if name == "" && tag == "" {
+	if image.Name == "" && image.Tag == "" {
 		resolvedImageSpec, err := resolve(ctx, container)
 		if err != nil {
 			log.Debugf("cannot resolve image name %q for container %q: %s", imageSpec, container.ID, err)
 			return image
 		}
 
-		name, registry, shortName, tag, err = containers.SplitImageName(resolvedImageSpec)
+		image, err = workloadmeta.NewContainerImage(container.Image, resolvedImageSpec)
 		if err != nil {
 			log.Debugf("cannot split image name %q for container %q: %s", resolvedImageSpec, container.ID, err)
 
 			// fallback and try to parse the original imageSpec anyway
 			if errors.Is(err, containers.ErrImageIsSha256) {
-				name, registry, shortName, tag, err = containers.SplitImageName(imageSpec)
+				image, err = workloadmeta.NewContainerImage(container.Image, imageSpec)
 				if err != nil {
 					log.Debugf("cannot split image name %q for container %q: %s", imageSpec, container.ID, err)
 					return image
@@ -394,11 +388,6 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 		}
 	}
 
-	image.Name = name
-	image.Registry = registry
-	image.ShortName = shortName
-	image.Tag = tag
-	image.ID = container.Image
 	image.RepoDigest = util.ExtractRepoDigestFromImage(image.ID, image.Registry, store) // "sha256:digest"
 	return image
 }


### PR DESCRIPTION
### What does this PR do?

This PR updates the ContainerImage workloadmeta creation for the docker runtime such that it should default to using the `latest` tag if no tag is found

### Motivation

For some reason, sometimes the ECS tests are failing because sometimes, a random host will be reporting the container image with no `image_tag` tag. We still do not know why this is happening, but in the investigation, we noticed that most of the other workloadmeta collectors use the `NewContainerImage` function when creating a ContainerImage object, but the docker collector does not. Functionally, this function is identical to what the docker function was already doing, but with the additional logic to set the tag to `latest` by default if no tag could be parsed, which should fix the failing tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

We have not yet been able to reproduce this locally, and the E2E test fails sporadically, so for the time being it could be such that we merge this in and verify that this test does not fail for a week after the change has been merged
