### PR TITLE
fix: allow MRF domain detection to work with dd_url

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -273,9 +273,12 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 
 	for domain, resolver := range options.DomainResolvers {
 		isMRF := false
-		if config.GetBool("multi_region_failover.enabled") && config.GetString("multi_region_failover.site") != "" {
-			log.Infof("MRF is enabled, checking site: %v ", config.GetString("multi_region_failover.site"))
-			siteURL := utils.BuildURLWithPrefix(utils.InfraURLPrefix, config.GetString("multi_region_failover.site"))
+		if config.GetBool("multi_region_failover.enabled") {
+			log.Infof("MRF is enabled, checking site: %v ", domain)
+			siteURL, err := utils.GetMRFInfraEndpoint(config)
+			if err != nil {
+				log.Error("Error building MRF infra endpoint: ", err)
+			}
 			if domain == siteURL {
 				log.Infof("MRF domain '%s', configured ", domain)
 				isMRF = true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adjusts the way that we detect whether a domain forwarder is for MRF to take into account both `site` and `dd_url` options.

### Motivation

This makes the detection consistent with the way the urls are built in the first place.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Validated by configuring `multi_region_failover.dd_url` instead of `multi_region_failover.site` and ensuring that `isMRF` was set correctly by observing the behavior of #26351, which relies on that flag.

APR-98
