### PR TITLE
installer: support apm_lang env

### DIFF
--- a/pkg/fleet/env/env.go
+++ b/pkg/fleet/env/env.go
@@ -28,6 +28,7 @@ const (
 	envApmLibraries          = "DD_APM_INSTRUMENTATION_LIBRARIES"
 	envAgentMajorVersion     = "DD_AGENT_MAJOR_VERSION"
 	envAgentMinorVersion     = "DD_AGENT_MINOR_VERSION"
+	envApmLanguages          = "DD_APM_INSTRUMENTATION_LANGUAGES"
 )
 
 var defaultEnv = Env{
@@ -164,7 +165,10 @@ func (e *Env) ToEnv() []string {
 }
 
 func parseApmLibrariesEnv() map[ApmLibLanguage]ApmLibVersion {
-	apmLibraries := os.Getenv(envApmLibraries)
+	apmLibraries, ok := os.LookupEnv(envApmLibraries)
+	if !ok {
+		return parseAPMLanguagesEnv()
+	}
 	apmLibrariesVersion := map[ApmLibLanguage]ApmLibVersion{}
 	if apmLibraries == "" {
 		return apmLibrariesVersion
@@ -176,6 +180,17 @@ func parseApmLibrariesEnv() map[ApmLibLanguage]ApmLibVersion {
 		apmLibrariesVersion[ApmLibLanguage(libraryName)] = ApmLibVersion(libraryVersion)
 	}
 	return apmLibrariesVersion
+}
+
+func parseAPMLanguagesEnv() map[ApmLibLanguage]ApmLibVersion {
+	apmLanguages := os.Getenv(envApmLanguages)
+	res := map[ApmLibLanguage]ApmLibVersion{}
+	for _, language := range strings.Split(apmLanguages, " ") {
+		if len(language) > 0 {
+			res[ApmLibLanguage(language)] = ""
+		}
+	}
+	return res
 }
 
 func overridesByNameFromEnv[T any](envPrefix string, convert func(string) T) map[string]T {

--- a/pkg/fleet/env/env_test.go
+++ b/pkg/fleet/env/env_test.go
@@ -111,6 +111,30 @@ func TestFromEnv(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "deprecated apm lang",
+			envVars: map[string]string{
+				envAPIKey:                    "123456",
+				envApmLanguages:              "java dotnet ruby",
+				envApmInstrumentationEnabled: "all",
+			},
+			expected: &Env{
+				APIKey: "123456",
+				Site:   "datadoghq.com",
+				ApmLibraries: map[ApmLibLanguage]ApmLibVersion{
+					"java":   "",
+					"dotnet": "",
+					"ruby":   "",
+				},
+				InstallScript: InstallScriptEnv{
+					APMInstrumentationEnabled: APMInstrumentationEnabledAll,
+				},
+				RegistryOverrideByImage:        map[string]string{},
+				RegistryAuthOverrideByImage:    map[string]string{},
+				DefaultPackagesInstallOverride: map[string]bool{},
+				DefaultPackagesVersionOverride: map[string]string{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Support parsing DD_APM_INSTRUMENTATION_LANGUAGES

On s3 install script DD_APM_INSTRUMENTATION_LIBRARIES is parsed first, and if it's there languages isn't
