### PR TITLE
[ASCII-1980] remove the go vet invoke task and pre commit as we are running govet as part of our linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,14 +53,6 @@ repos:
       language: system
       pass_filenames: false
       stages: [pre-commit, pre-push]
-    - id: govet
-      name: govet
-      description: go vet
-      entry: 'inv linter.go-vet'
-      language: system
-      require_serial: true
-      files: \.go$
-      pass_filenames: false
     - id: copyright
       name: copyright
       description: copyright headers

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -5,7 +5,6 @@ import re
 import sys
 from collections import defaultdict
 from glob import glob
-from os.path import dirname, exists, join, relpath
 
 from invoke import Exit, task
 
@@ -464,87 +463,3 @@ def test_change_path(ctx, job_files=None):
         )
     else:
         print(color_message("success: All tests contain a change paths rule", "green"))
-
-
-# modules -> packages that should not be vetted, each with a reason
-EXCLUDED_PACKAGES = {
-    '.': {
-        './pkg/ebpf/compiler': "requires C libraries not available everywhere",
-        './cmd/py-launcher': "requires building rtloader",
-        './pkg/collector/python': "requires building rtloader",
-    },
-}
-
-GO_TAGS = ["test"]
-
-
-@task
-def go_vet(ctx):
-    def go_module_for_package(package_path):
-        """
-        Finds the go module containing the given package, and the package's path
-        relative to that module.  This only works for `./`-relative package paths,
-        in the current repository.  The returned module does not contain a trailing
-        `/` character.  If the package path does not exist, the return value is
-        `.`.
-        """
-        assert package_path.startswith('./')
-        module_path = package_path
-        while module_path != '.' and not exists(join(module_path, 'go.mod')):
-            module_path = dirname(module_path)
-        relative_package = relpath(package_path, start=module_path)
-        if relative_package != '.' and not relative_package[0].startswith('./'):
-            relative_package = f"./{relative_package}"
-        return module_path, relative_package
-
-    def is_go_file(path):
-        """Checks if file is a go file from the Agent code."""
-        return (path.startswith("pkg") or path.startswith("cmd")) and path.endswith(".go")
-
-    # Exclude non go files
-    go_files = (path for path in get_staged_files(ctx) if is_go_file(path))
-
-    # Get the package for each file
-    packages = {f'./{dirname(f)}' for f in go_files}
-
-    if not packages:
-        return
-
-    # separate those by module
-    by_mod = {}
-    for package_path in packages:
-        module, package = go_module_for_package(package_path)
-        reason = EXCLUDED_PACKAGES.get(module, {}).get(package, None)
-        if reason:
-            print(f"Skipping {package} in {module}: {reason}")
-            continue
-        by_mod.setdefault(module, set()).add(package)
-
-    # now, for each module, we use 'go list' to list all of the *valid* packages
-    # (those with at least one .go file included by the current build tags), and
-    # use that to skip packages that do not have any files included, which will
-    # otherwise cause go vet to fail.
-    for module, packages in by_mod.items():
-        with ctx.cd(module):
-            # -find skips listing package dependencies
-            # -f {{.Dir}} outputs the absolute dir containing the package
-            res = ctx.run("go list -find -f '{{.Dir}}' ./...", hide=True)
-
-        valid_packages = set()
-        for line in res.stdout.splitlines():
-            if line:
-                relative = relpath(line, module)
-                if relative != '.':
-                    relative = f'./{relative}'
-            valid_packages.add(relative)
-        for package in packages - valid_packages:
-            print(f"Skipping {package} in {module}: not a valid package or all files are excluded by build tags")
-            packages.remove(package)
-
-    go_tags_arg = '-tags ' + ','.join(GO_TAGS) if GO_TAGS else ''
-    for module, packages in by_mod.items():
-        if not packages:
-            continue
-
-        with ctx.cd(module):
-            ctx.run(f"go vet {go_tags_arg} {' '.join(packages)}")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the inv task `linter.go-vet` and the pre commit hook. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are using the `govet` linter as part of our linter configuration

https://github.com/DataDog/datadog-agent/blob/20cf8be8d9c63fe34419aa29f049d09ba4cad658/.golangci.yml#L76

According to the golangci-lint [doc](https://golangci-lint.run/usage/linters/#govet) it uses all the passes from `go vet`

Having a single way to run checks in the codebase lead to less confusion 😄 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
