### PR TITLE
[USM] Fix get all blocked process debug endpoint

### DIFF
--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -131,7 +131,7 @@ func (d *tlsDebugger) GetAllBlockedPathIDs() []BlockedProcess {
 	// Examples of this would be: "shared_libraries", "istio", "goTLS" etc
 	for _, registry := range d.registries {
 		blockedPathIdentifiers := d.GetBlockedPathIDsWithSamplePath(registry.telemetry.programName)
-		if len(blockedPathIdentifiers) != 0 {
+		if len(blockedPathIdentifiers) > 0 {
 			all = append(all, BlockedProcess{
 				ProgramType:     registry.telemetry.programName,
 				PathIdentifiers: blockedPathIdentifiers,
@@ -172,9 +172,6 @@ func (d *tlsDebugger) GetBlockedPathIDsWithSamplePath(programType string) []Path
 		if registry.telemetry.programName != programType {
 			continue
 		}
-
-		registry.m.Lock()
-		defer registry.m.Unlock()
 
 		blockedIDsWithSampleFile := make([]PathIdentifierWithSamplePath, 0, len(registry.blocklistByID.Keys()))
 		for _, pathIdentifier := range registry.blocklistByID.Keys() {

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -173,6 +173,9 @@ func (d *tlsDebugger) GetBlockedPathIDsWithSamplePath(programType string) []Path
 			continue
 		}
 
+		registry.m.Lock()
+		defer registry.m.Unlock()
+
 		blockedIDsWithSampleFile := make([]PathIdentifierWithSamplePath, 0, len(registry.blocklistByID.Keys()))
 		for _, pathIdentifier := range registry.blocklistByID.Keys() {
 			samplePath, ok := registry.blocklistByID.Get(pathIdentifier)

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -130,10 +130,13 @@ func (d *tlsDebugger) GetAllBlockedPathIDs() []BlockedProcess {
 	// Iterate over each `FileRegistry` instance:
 	// Examples of this would be: "shared_libraries", "istio", "goTLS" etc
 	for _, registry := range d.registries {
-		all = append(all, BlockedProcess{
-			ProgramType:     registry.telemetry.programName,
-			PathIdentifiers: d.GetBlockedPathIDsWithSamplePath(registry.telemetry.programName),
-		})
+		blockedPathIdentifiers := d.GetBlockedPathIDsWithSamplePath(registry.telemetry.programName)
+		if len(blockedPathIdentifiers) != 0 {
+			all = append(all, BlockedProcess{
+				ProgramType:     registry.telemetry.programName,
+				PathIdentifiers: blockedPathIdentifiers,
+			})
+		}
 	}
 
 	return all


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes a bug in the blocked process debug endpoint that affects the agent status as well.

<!--
* A brief description of the change being made with this pull request.
-->

### Motivation

Fix a bug to include the correct blocked process for the debug endpoint. This PR affects the endpoint in two ways:

* When there are no blocked PIDs, the program name will not be shown at all in the `blocked_processes` section.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

**Example of the endpoint result before the change:**
```Blocked Processes: [
      {
        "PathIdentifiers": [],
        "ProgramType": "shared_libraries"
      },
      {
        "PathIdentifiers": [
          {
            "Dev": 64768,
            "Inode": 398470,
            "SamplePath": "/proc/1/root/usr/lib/systemd/systemd"
          },
          {
            "Dev": 64768,
            "Inode": 398484,
            "SamplePath": "/proc/443/root/usr/lib/systemd/systemd-journald"
          },
          .
          .
          .
]
```
**After the change:**
```
Blocked Processes: [
  {
    "ProgramType": "shared_libraries",
    "PathIdentifiers": [
      {
        "Dev": 64768,
        "Inode": 413168,
        "SamplePath": "/proc/36403/root/lib/aarch64-linux-gnu/libssl.so.3"
      }
    ]
  },
  {
    "ProgramType": "go-tls",
    "PathIdentifiers": [
      {
        "Dev": 64768,
        "Inode": 398484,
        "SamplePath": "/proc/442/root/usr/lib/systemd/systemd-journald"
      },
      {
        "Dev": 64768,
        "Inode": 407458,
        "SamplePath": "/proc/481/root/usr/sbin/multipathd"
      },
      .
      .
      .
]      
```  

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

To do:

**Benchmark results:** 
 my branch: BenchmarkGetUSMStats-4   	 5507845	       213.4 ns/op
 main:           BenchmarkGetUSMStats-4   	 6427843	       176.3 ns/op
 
 As well deployed on staging cluster and did not observe any negative impact. 

QA steps:
Enable system-probe with TLS monitoring:
```yaml
service_monitoring_config:
  enabled: true
  tls:
    go:
      enabled: true
    native:
      enabled: true
  enable_http_monitoring: true
```

Step 1: Run the agent

Step 2: Run agent status command

Expect to see

```bash
============
System Probe
============

  Status: Running
  Uptime: 209ns
  Last Updated: 2024-07-11 06:05:07 PDT / 2024-07-11 13:05:07 UTC (1720703107000)

  USM
  ===
    Status: running
    Last Check: 2024-07-11 06:05:04 PDT / 2024-07-11 13:05:04 UTC (1720703104000)
    Traced Programs: [
      {
        "FilePath": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3",
        "PIDs": [
          44672,
          442,
          801,
          38280,
          40305,
          40458,
          41612
        ],
        "ProgramType": "shared_libraries"
      },
      {
        "FilePath": "/usr/lib/aarch64-linux-gnu/libgnutls.so.30.31.0",
        "PIDs": [
          22165,
          723
        ],
        "ProgramType": "shared_libraries"
      },
      {
        "FilePath": "/usr/bin/dockerd",
        "PIDs": [
          954
        ],
        "ProgramType": "go-tls"
      }
    ]
    Blocked Processes: [
      {
        "PathIdentifiers": [
          {
            "Dev": 64768,
            "Inode": 398484,
            "SamplePath": "/proc/442/root/usr/lib/systemd/systemd-journald"
          },
          {
            "Dev": 64768,
            "Inode": 407458,
            "SamplePath": "/proc/481/root/usr/sbin/multipathd"
          },
          {
            "Dev": 64768,
            "Inode": 405991,
            "SamplePath": "/proc/486/root/usr/bin/udevadm"
          },
          {
            "Dev": 64768,
            "Inode": 397805,
            "SamplePath": "/proc/683/root/usr/lib/systemd/systemd-timesyncd"
          },
          {
            "Dev": 64768,
            "Inode": 398490,
            "SamplePath": "/proc/721/root/usr/lib/systemd/systemd-networkd"
          },
          {
            "Dev": 64768,
            "Inode": 398497,
            "SamplePath": "/proc/723/root/usr/lib/systemd/systemd-resolved"
          },
          {
            "Dev": 64768,
            "Inode": 407355,
            "SamplePath": "/proc/740/root/usr/sbin/cron"
          },
          {
            "Dev": 64768,
            "Inode": 393913,
            "SamplePath": "/proc/741/root/usr/bin/dbus-daemon"
          },
          {
            "Dev": 64768,
            "Inode": 407417,
            "SamplePath": "/proc/745/root/usr/sbin/irqbalance"
          },
          {
            "Dev": 64768,
            "Inode": 407001,
            "SamplePath": "/proc/748/root/usr/libexec/polkitd"
          },
          {
            "Dev": 64768,
            "Inode": 407488,
            "SamplePath": "/proc/750/root/usr/sbin/rsyslogd"
          },
          {
            "Dev": 1797,
            "Inode": 568,
            "SamplePath": "/proc/756/root/snap/snapd/21761/usr/lib/snapd/snapd"
          },
          {
            "Dev": 64768,
            "Inode": 398486,
            "SamplePath": "/proc/759/root/usr/lib/systemd/systemd-logind"
          },
          {
            "Dev": 64768,
            "Inode": 410335,
            "SamplePath": "/proc/783/root/usr/sbin/ModemManager"
          },
        ],
        "ProgramType": "go-tls"
      }
    ]

  NPM
  ===
    Status: Running
    Last Check: 2024-07-11 06:05:02 PDT / 2024-07-11 13:05:02 UTC (1720703102000)

  Event Monitor
  ================
    Status: Running

  Process
  =======
    Status: Running


========================
Transport Proxy Warnings
========================

  No Transport Proxy Warnings
```
Step 3: Validate that all of the programs types inside the `Blocked Processes` part, are not empty.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
