### PR TITLE
fix(fleet): Fix APM E2E

### DIFF
--- a/pkg/fleet/env/env.go
+++ b/pkg/fleet/env/env.go
@@ -55,7 +55,7 @@ type ApmLibLanguage string
 // ApmLibVersion is the version of the library defined in DD_APM_INSTRUMENTATION_LIBRARIES env var
 type ApmLibVersion string
 
-var fullSemverRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+var fullSemverRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`)
 
 // AsVersionTag returns the version tag associated with the version of the library defined in DD_APM_INSTRUMENTATION_LIBRARIES
 // if the value is empty we return latest

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -209,7 +209,7 @@ func TestDefaultPackages(t *testing.T) {
 		{
 			name: "Strip leading v in version",
 			packages: []Package{
-				{Name: "datadog-apm-library-java", released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{
@@ -226,9 +226,9 @@ func TestDefaultPackages(t *testing.T) {
 		{
 			name: "Add -1 prefix only for full version pin",
 			packages: []Package{
-				{Name: "datadog-apm-library-java", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-python", released: true, condition: apmLanguageEnabled},
-				{Name: "datadog-apm-library-ruby", released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-python", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{

--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -110,9 +110,6 @@ func TestPackages(t *testing.T) {
 				if flavor.Flavor == e2eos.Fedora {
 					flake.Mark(t)
 				}
-				if strings.Contains(t.Name(), "apm") {
-					flake.Mark(t)
-				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),
@@ -170,13 +167,12 @@ func (s *packageBaseSuite) SetupSuite() {
 func (s *packageBaseSuite) RunInstallScriptProdOci(params ...string) error {
 	env := map[string]string{}
 	installScriptPackageManagerEnv(env, s.arch)
-	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://storage.googleapis.com/updater-dev/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(env))
+	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(env))
 	return err
 }
 
 func (s *packageBaseSuite) RunInstallScriptWithError(params ...string) error {
-	// FIXME: use the official install script
-	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://storage.googleapis.com/updater-dev/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(installScriptEnv(s.arch)))
+	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(installScriptEnv(s.arch)))
 	return err
 }
 

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -7,12 +7,11 @@ package installer
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
 )
@@ -108,41 +107,36 @@ func (s *packageApmInjectSuite) TestDockerBrokenJSON() {
 
 func (s *packageApmInjectSuite) TestInstrumentDocker() {
 	s.host.InstallDocker()
-	err := s.RunInstallScriptWithError("DD_APM_INSTRUMENTATION_ENABLED=docker", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=docker", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
-	assert.NoError(s.T(), err)
 	s.assertLDPreloadNotInstrumented()
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
 func (s *packageApmInjectSuite) TestInstrumentHost() {
-	err := s.RunInstallScriptWithError("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
-	assert.NoError(s.T(), err)
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertDockerdNotInstrumented()
 }
 
 func (s *packageApmInjectSuite) TestInstrumentDefault() {
 	s.host.InstallDocker()
-	err := s.RunInstallScriptWithError("DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
-	assert.NoError(s.T(), err)
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
 func (s *packageApmInjectSuite) TestSystemdReload() {
 	s.host.InstallDocker()
-	err := s.RunInstallScriptWithError()
+	s.RunInstallScript()
 	defer s.Purge()
-	assert.NoError(s.T(), err)
 
-	err = s.RunInstallScriptWithError("DD_APM_INSTRUMENTATION_LIBRARIES=python")
-	assert.NoError(s.T(), err)
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python")
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath()
@@ -175,7 +169,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 	s.assertDockerdInstrumented(injectDebPath)
 
 	// OCI install
-	s.RunInstallScriptWithError(
+	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
 		"DD_APM_INSTRUMENTATION_LIBRARIES=python",
 		envForceInstall("datadog-agent"),
@@ -193,7 +187,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 	s.host.InstallDocker()
 
 	// OCI install
-	s.RunInstallScriptWithError(
+	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
 		"DD_APM_INSTRUMENTATION_LIBRARIES=python",
 		envForceInstall("datadog-agent"),
@@ -205,7 +199,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 	s.assertDockerdInstrumented(injectOCIPath)
 
 	// Deb install using today's defaults
-	s.RunInstallScriptWithError(
+	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
 		"DD_APM_INSTRUMENTATION_LIBRARIES=python",
 		envForceNoInstall("datadog-apm-inject"),
@@ -226,14 +220,11 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 }
 
 func (s *packageApmInjectSuite) TestVersionBump() {
-	if s.os.Flavor == e2eos.Debian {
-		flake.Mark(s.T())
-	}
-
+	s.T().Skip("Requires a fix in the install script") // TODO(baptiste): FIXME
 	s.host.InstallDocker()
 	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
-		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.8.2-dev",
+		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.8.5",
 		envForceInstall("datadog-agent"),
 		envForceVersion("datadog-apm-inject", "0.14.0-beta1-dev.b0d6e40.glci528580195.g068abe2b-1"),
 	)
@@ -241,8 +232,8 @@ func (s *packageApmInjectSuite) TestVersionBump() {
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	state := s.host.State()
-	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.8.2-dev", 0755, "root", "root")
-	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-library-python/stable", "/opt/datadog-packages/datadog-apm-library-python/2.8.2-dev", "root", "root")
+	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.8.5", 0755, "root", "root")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-library-python/stable", "/opt/datadog-packages/datadog-apm-library-python/2.8.5", "root", "root")
 
 	state.AssertDirExists("/opt/datadog-packages/datadog-apm-inject/0.14.0-beta1-dev.b0d6e40.glci528580195.g068abe2b-1", 0755, "root", "root")
 	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-inject/stable", "/opt/datadog-packages/datadog-apm-inject/0.14.0-beta1-dev.b0d6e40.glci528580195.g068abe2b-1", "root", "root")
@@ -306,27 +297,29 @@ func (s *packageApmInjectSuite) TestInstrument() {
 }
 
 func (s *packageApmInjectSuite) TestPackagePinning() {
+	s.T().Skip("Requires a fix in the install script") // TODO(baptiste): FIXME
+	s.host.InstallDocker()
+
 	// Deb install using today's defaults
-	err := s.RunInstallScriptWithError(
+	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
-		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.8.2-dev,dotnet",
+		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.8.5,dotnet",
 		envForceInstall("datadog-agent"),
 	)
 	defer s.Purge()
 	defer s.purgeInjectorDebInstall()
-	assert.NoError(s.T(), err)
 
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath()
 	s.assertDockerdInstrumented(injectOCIPath)
 
 	s.host.AssertPackageInstalledByInstaller("datadog-apm-library-python", "datadog-apm-library-dotnet")
-	s.host.AssertPackageVersion("datadog-apm-library-python", "2.8.2-dev")
+	s.host.AssertPackageVersion("datadog-apm-library-python", "2.8.5")
 }
 
 func (s *packageApmInjectSuite) TestUninstrument() {
 	s.host.InstallDocker()
-	s.RunInstallScriptWithError(
+	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
 		"DD_APM_INSTRUMENTATION_LIBRARIES=python",
 		envForceInstall("datadog-agent"),
@@ -446,8 +439,8 @@ func (s *packageApmInjectSuite) assertLDPreloadInstrumented(libPath string) {
 }
 
 func (s *packageApmInjectSuite) assertSocketPath() {
-	output := s.host.Run("sh -c 'DD_APM_INSTRUMENTATION_DEBUG=true python3 --version 2>&1'")
-	assert.Contains(s.T(), output, "DD_INJECTION_ENABLED=tracer") // this is an env var set by the injector, it should always be in the debug logs
+	output := s.host.Run("sh -c 'python3 -c \"import os; print(os.environ)\"'")
+	assert.Contains(s.T(), output, "'DD_INJECTION_ENABLED': 'tracer'") // this is an env var set by the injector
 }
 
 func (s *packageApmInjectSuite) assertLDPreloadNotInstrumented() {
@@ -459,8 +452,8 @@ func (s *packageApmInjectSuite) assertLDPreloadNotInstrumented() {
 		assert.NotContains(s.T(), string(content), injectOCIPath)
 		assert.NotContains(s.T(), string(content), injectDebPath)
 	}
-	output := s.host.Run("sh -c 'DD_APM_INSTRUMENTATION_DEBUG=true python3 --version 2>&1'")
-	assert.NotContains(s.T(), output, "DD_INJECTION_ENABLED=tracer")
+	output := s.host.Run("sh -c 'python3 -c \"import os; print(os.environ)\"'")
+	assert.NotContains(s.T(), output, "'DD_INJECTION_ENABLED': 'tracer'")
 }
 
 func (s *packageApmInjectSuite) assertDockerdInstrumented(path string) {


### PR DESCRIPTION
### What does this PR do?
- Fixes APM E2E after the OCI migration
  - Env vars may not be dumped by the injector debug mode, so we make python do it instead
- Fixes a small bug in the pinning to allow dev versions to be pinned
- Uses the official install script in tests
- Fixes a unit test

### Motivation
Working tests not skipped because of their flakiness

### Additional Notes
There are two APM tests still skipped while waiting for https://github.com/DataDog/agent-linux-install-script/pull/234 to be released

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
