### PR TITLE
[ASCII-1979] add FxLoggingOption() fx option to our testing utility functions to ensure logs are not being written by default

### DIFF
--- a/pkg/util/fxutil/test.go
+++ b/pkg/util/fxutil/test.go
@@ -35,6 +35,7 @@ func Test[T any](t testing.TB, opts ...fx.Option) T {
 
 	app := fxtest.New(
 		t,
+		FxLoggingOption(),
 		fx.Provide(newFxLifecycleAdapter),
 		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
 		delayed.option(),
@@ -64,6 +65,7 @@ func TestApp[T any](opts ...fx.Option) (*fx.App, T, error) {
 	})
 
 	app := fx.New(
+		FxLoggingOption(),
 		delayed.option(),
 		fx.Provide(newFxLifecycleAdapter),
 		fx.Options(opts...),
@@ -97,6 +99,7 @@ type appAssertFn func(testing.TB, *fx.App)
 func TestStart(t testing.TB, opts fx.Option, appAssert appAssertFn, fn interface{}) {
 	delayed := newDelayedFxInvocation(fn)
 	app := fx.New(
+		FxLoggingOption(),
 		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
 		fx.Provide(newFxLifecycleAdapter),
 		delayed.option(),
@@ -169,6 +172,7 @@ func TestOneShotSubcommand(
 		// build an app without the oneShotFunc, and with verifyFn
 		app := fxtest.New(t,
 			append(opts,
+				FxLoggingOption(),
 				fx.Provide(newFxLifecycleAdapter),
 				fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
 				fx.Invoke(verifyFn))...)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add `FxLoggingOption()` to the testing utility functioins

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

To avoid spamming with logs during testing 

```
=== RUN   TestChmod
[2024-07-10 22:16:59.087] [WARN] github.com/DataDog/datadog-agent/pkg/config/model.(*safeConfig).checkKnownKey:221 config key fips.enabled is unknown
[2024-07-10 22:16:59.088] [WARN] github.com/DataDog/datadog-agent/pkg/config/model.(*safeConfig).checkKnownKey:221 config key use_proxy_for_cloud_metadata is unknown
    module_tester_linux.go:750: Instantiating a new security module
    writer.go:40: [Fx] PROVIDE	compdef.Lifecycle <= github.com/DataDog/datadog-agent/pkg/util/fxutil.newFxLifecycleAdapter()
    writer.go:40: [Fx] SUPPLY	*testing.T
    writer.go:40: [Fx] PROVIDE	telemetry.Mock <= github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.newMock() from module "comp/core/telemetry"
    writer.go:40: [Fx] PROVIDE	telemetry.Component <= github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.MockModule.func1() from module "comp/core/telemetry"
    writer.go:40: [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
    writer.go:40: [Fx] PROVIDE	fx.Shutdowner <= go.uber.org/fx.(*App).shutdowner-fm()
    writer.go:40: [Fx] PROVIDE	fx.DotGraph <= go.uber.org/fx.(*App).dotGraph-fm()
    writer.go:40: [Fx] LOGGER	Initialized custom logger from go.uber.org/fx/fxtest.New.func1()
    writer.go:40: [Fx] INVOKE		reflect.makeFuncStub()
    writer.go:40: [Fx] RUNNING
[2024-07-10 22:17:09.510] [WARN] github.com/DataDog/datadog-agent/pkg/security/ebpf.(*ProbeLoader).Load:57 error compiling runtime-security probe, falling back to pre-compiled: runtime compilation unsupported
[2024-07-10 22:17:13.046] [ERROR] github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).SendEvent.QueryAccountIDTag.func1:66 failed to query account id: no cloud provider detected
=== RUN   TestChmod/fchmod
=== RUN   TestChmod/fchmodat
=== RUN   TestChmod/fchmodat2
=== RUN   TestChmod/chmod
    chmod_test.go:124: SYS_CHMOD is not supported
=== NAME  TestChmod
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.newMock.func1() executing (caller: github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.newMock)
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.newMock.func1() called by github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl.newMock ran successfully in 1.494004ms
--- PASS: TestChmod (15.15s)
    --- PASS: TestChmod/fchmod (0.04s)
    --- PASS: TestChmod/fchmodat (0.04s)
    --- PASS: TestChmod/fchmodat2 (0.02s)
    --- SKIP: TestChmod/chmod (0.00s)
PASS
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
