### PR TITLE
[CI] Don't upload coverage on non base flavors unit tests

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -51,10 +51,11 @@
 .upload_junit_source:
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
 
-.linux_tests_with_upload:
-  extends: .linux_tests
-  after_script:
-    - !reference [.upload_junit_source]
+.upload_coverage:
+  # Upload coverage files to Codecov. Never fail on coverage upload.
+  - export CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $CODECOV_TOKEN_SSM_NAME)
+  - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
+
 
 .linux_lint:
   stage: source_test
@@ -93,8 +94,11 @@ tests_deb-x64-py2:
 tests_deb-x64-py3:
   extends:
     - .rtloader_tests
-    - .linux_tests_with_upload
+    - .linux_tests
     - .linux_x64
+  after_script:
+    - !reference [.upload_junit_source]
+    - !reference [.upload_coverage]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -103,11 +107,14 @@ lint_linux-x64:
   extends:
     - .linux_lint
     - .linux_x64
+
 tests_flavor_iot_deb-x64:
   extends:
     - .rtloader_tests
-    - .linux_tests_with_upload
+    - .linux_tests
     - .linux_x64
+  after_script:
+    - !reference [.upload_junit_source]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -123,8 +130,10 @@ lint_flavor_iot_linux-x64:
 tests_flavor_dogstatsd_deb-x64:
   extends:
     - .rtloader_tests
-    - .linux_tests_with_upload
+    - .linux_tests
     - .linux_x64
+  after_script:
+    - !reference [.upload_junit_source]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -140,8 +149,10 @@ lint_flavor_dogstatsd_linux-x64:
 tests_flavor_heroku_deb-x64:
   extends:
     - .rtloader_tests
-    - .linux_tests_with_upload
+    - .linux_tests
     - .linux_x64
+  after_script:
+    - !reference [.upload_junit_source]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -173,7 +184,10 @@ tests_rpm-x64-py2:
 tests_rpm-x64-py3:
   extends:
     - .rtloader_tests
-    - .linux_tests_with_upload
+    - .linux_tests
+  after_script:
+    - !reference [.upload_junit_source]
+    - !reference [.upload_coverage]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -197,6 +211,8 @@ tests_deb-arm64-py3:
   extends:
     - .rtloader_tests
     - .linux_tests
+  after_script:
+    - !reference [.upload_coverage]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:
@@ -225,6 +241,8 @@ tests_rpm-arm64-py3:
   extends:
     - .rtloader_tests
     - .linux_tests
+  after_script:
+    - !reference [.upload_coverage]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:
@@ -249,7 +267,7 @@ go_mod_tidy_check:
     KUBERNETES_MEMORY_LIMIT: "16Gi"
 
 new-e2e-unit-tests:
-  extends: .linux_tests_with_upload
+  extends: .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
   before_script:
@@ -263,7 +281,7 @@ new-e2e-unit-tests:
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - inv -e new-e2e-tests.run --targets ./pkg/utils --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
   after_script:
-    - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
+    - !reference [.upload_junit_source]
   variables:
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -53,7 +53,6 @@
   - export CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $CODECOV_TOKEN_SSM_NAME)
   - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
 
-
 .linux_lint:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -34,9 +34,6 @@
     - inv -e sds.build-library
     - inv -e agent.build
     - inv -e test $FLAVORS --include-sds --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --coverage --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --save-result-json $TEST_OUTPUT_FILE --junit-tar "junit-${CI_JOB_NAME}.tgz" --build-stdlib $FAST_TESTS_FLAG --test-washer
-    # Upload coverage files to Codecov. Never fail on coverage upload.
-    - export CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $CODECOV_TOKEN_SSM_NAME)
-    - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -50,6 +50,7 @@
 
 .upload_coverage:
   # Upload coverage files to Codecov. Never fail on coverage upload.
+  - source /root/.bashrc
   - export CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $CODECOV_TOKEN_SSM_NAME)
   - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
 

--- a/tools/ci/junit_upload.sh
+++ b/tools/ci/junit_upload.sh
@@ -21,6 +21,6 @@ for file in $junit_files; do
 done
 # Never fail on Junit upload failure since it would prevent the other after scripts to run.
 if [ $error -eq 1 ]; then
-    echo "Junit upload failed"
+    echo "Error: Junit upload failed"
 fi
 exit 0

--- a/tools/ci/junit_upload.sh
+++ b/tools/ci/junit_upload.sh
@@ -19,4 +19,8 @@ for file in $junit_files; do
     fi
     inv -e junit-upload --tgz-path "$file" || error=1
 done
-exit $error
+# Never fail on Junit upload failure since it would prevent the other after scripts to run.
+if [ $error -eq 1 ]; then
+    echo "Junit upload failed"
+fi
+exit 0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes coverage uploads on heroku, iot and dogstatsd linux unit tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We don't need them and they're polluting the cache

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-312
https://datadoghq.atlassian.net/browse/ACIX-289

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
