### PR TITLE
[FA] Fix installer exp unit parsing

### DIFF
--- a/pkg/fleet/installer/service/embedded/datadog-installer-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-installer-exp.service
@@ -3,7 +3,7 @@ Description=Datadog Installer Experiment
 After=network.target
 OnFailure=datadog-installer.service
 Conflicts=datadog-installer.service
-JobTimeoutSec=3000 #50 minutes
+JobTimeoutSec=3000
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Inline comment are not parsed correctly by systemd:
```
/etc/systemd/system/datadog-installer-exp.service:6: Failed to parse JobTimeoutSec= parameter, ignoring: 3000 #50 minutes
```
https://www.freedesktop.org/software/systemd/man/latest/systemd.syntax.html

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
