### PR TITLE
[omnibus] Package SysVInit files

### DIFF
--- a/omnibus/config/software/init-scripts-agent.rb
+++ b/omnibus/config/software/init-scripts-agent.rb
@@ -50,6 +50,11 @@ build do
           dest: "/etc/init.d/datadog-agent-security",
           mode: 0755,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
+
+      project.extra_package_file '/etc/init.d/datadog-agent'
+      project.extra_package_file '/etc/init.d/datadog-agent-process'
+      project.extra_package_file '/etc/init.d/datadog-agent-trace'
+      project.extra_package_file '/etc/init.d/datadog-agent-security'
     elsif redhat_target? || suse_target?
       systemd_directory = "/usr/lib/systemd/system"
       # Ship a different upstart job definition on RHEL to accommodate the old


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Reintroduces the SysVInit service files in the debian package of the Agent, that were removed from the package in https://github.com/DataDog/datadog-agent/pull/25885.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes the debian package on SysVInit systems. See #27523.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

I checked the debian Agent 7 package produced by the CI:

```
$ root@9d628bb236d5:/mount# dpkg -c datadog-agent_7.56.0~rc.2.git.9.54fd928.pipeline.38985799-1_amd64.deb | grep /etc/init.d
-rw-r--r-- root/root      1026 2024-07-11 20:22 ./etc/init/datadog-agent-sysprobe.conf
-rw-r--r-- root/root       769 2024-07-11 20:22 ./etc/init/datadog-agent-process.conf
-rw-r--r-- root/root       947 2024-07-11 20:22 ./etc/init/datadog-agent-security.conf
-rw-r--r-- root/root       607 2024-07-11 20:22 ./etc/init/datadog-agent.conf
-rw-r--r-- root/root       709 2024-07-11 20:22 ./etc/init/datadog-agent-trace.conf
drwxr-xr-x root/root         0 2024-07-11 20:22 ./etc/init.d/
-rwxr-xr-x root/root      3271 2024-07-11 20:22 ./etc/init.d/datadog-agent-trace
-rwxr-xr-x root/root      3570 2024-07-11 20:22 ./etc/init.d/datadog-agent
-rwxr-xr-x root/root      3266 2024-07-11 20:22 ./etc/init.d/datadog-agent-process
-rwxr-xr-x root/root      3470 2024-07-11 20:22 ./etc/init.d/datadog-agent-security
```

Upon installing the package, the `datadog-agent` service is present and can be started with `service datadog-agent start`.
