### PR TITLE
fix(installer): Allow tracing libraries OCI installation without the injector

### DIFF
--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -34,13 +34,7 @@ var PackagesList = []Package{
 	{Name: "datadog-agent", version: agentVersion, released: false, releasedWithRemoteUpdates: true},
 }
 
-var packageDependencies = map[string][]string{
-	"datadog-apm-library-java":   {"datadog-apm-inject"},
-	"datadog-apm-library-ruby":   {"datadog-apm-inject"},
-	"datadog-apm-library-js":     {"datadog-apm-inject"},
-	"datadog-apm-library-dotnet": {"datadog-apm-inject"},
-	"datadog-apm-library-python": {"datadog-apm-inject"},
-}
+var packageDependencies = map[string][]string{}
 
 // DefaultPackages resolves the default packages URLs to install based on the environment.
 func DefaultPackages(env *env.Env) []string {
@@ -84,9 +78,6 @@ func apmInjectEnabled(_ Package, e *env.Env) bool {
 }
 
 func apmLanguageEnabled(p Package, e *env.Env) bool {
-	if !apmInjectEnabled(p, e) {
-		return false
-	}
 	if _, ok := e.ApmLibraries[packageToLanguage(p.Name)]; ok {
 		return true
 	}
@@ -95,7 +86,7 @@ func apmLanguageEnabled(p Package, e *env.Env) bool {
 	}
 	// If the ApmLibraries env is left empty but apm injection is
 	// enabled, we install all languages
-	if len(e.ApmLibraries) == 0 {
+	if len(e.ApmLibraries) == 0 && apmInjectEnabled(p, e) {
 		return true
 	}
 	return false

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -246,6 +246,22 @@ func TestDefaultPackages(t *testing.T) {
 				{n: "datadog-apm-library-ruby", v: "1.2"},
 			},
 		},
+		{
+			name: "Install libraries without the injector",
+			packages: []Package{
+				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+			},
+			env: &env.Env{
+				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{
+					"java": "1.2.3",
+				},
+				InstallScript: env.InstallScriptEnv{},
+			},
+			expected: []pkg{
+				{n: "datadog-apm-library-java", v: "1.2.3-1"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -13,7 +13,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,10 +51,6 @@ func (i *testPackageManager) ConfigFS(f fixtures.Fixture) fs.FS {
 }
 
 func TestInstallStable(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26965")
-	}
-
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
 
@@ -71,10 +66,6 @@ func TestInstallStable(t *testing.T) {
 }
 
 func TestInstallExperiment(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26965")
-	}
-
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
 
@@ -93,10 +84,6 @@ func TestInstallExperiment(t *testing.T) {
 }
 
 func TestInstallPromoteExperiment(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26965")
-	}
-
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
 
@@ -116,10 +103,6 @@ func TestInstallPromoteExperiment(t *testing.T) {
 }
 
 func TestUninstallExperiment(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: Failing test on macOS - #incident-26965")
-	}
-
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
 

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,10 +47,6 @@ func TestCreateFresh(t *testing.T) {
 }
 
 func TestCreateOverwrite(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: broken on darwin")
-	}
-
 	dir := t.TempDir()
 	oldRepository := createTestRepository(t, dir, "old")
 
@@ -123,9 +118,6 @@ func TestSetExperimentBeforeStable(t *testing.T) {
 }
 
 func TestPromoteExperiment(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: broken on darwin")
-	}
 	dir := t.TempDir()
 	repository := createTestRepository(t, dir, "v1")
 	experimentDownloadPackagePath := createTestDownloadedPackage(t, dir, "v2")
@@ -147,10 +139,6 @@ func TestPromoteExperimentWithoutExperiment(t *testing.T) {
 }
 
 func TestDeleteExperiment(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("FIXME: broken on darwin")
-	}
-
 	dir := t.TempDir()
 	repository := createTestRepository(t, dir, "v1")
 	experimentDownloadPackagePath := createTestDownloadedPackage(t, dir, "v2")

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -220,7 +220,6 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 }
 
 func (s *packageApmInjectSuite) TestVersionBump() {
-	s.T().Skip("Requires a fix in the install script") // TODO(baptiste): FIXME
 	s.host.InstallDocker()
 	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
@@ -297,7 +296,6 @@ func (s *packageApmInjectSuite) TestInstrument() {
 }
 
 func (s *packageApmInjectSuite) TestPackagePinning() {
-	s.T().Skip("Requires a fix in the install script") // TODO(baptiste): FIXME
 	s.host.InstallDocker()
 
 	// Deb install using today's defaults
@@ -396,15 +394,6 @@ func (s *packageApmInjectSuite) TestInstrumentDockerInactive() {
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath()
 	s.assertDockerdInstrumented(injectOCIPath)
-}
-
-func (s *packageApmInjectSuite) TestInstallDependencies() {
-	s.RunInstallScript()
-	defer s.Purge()
-	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-inject")
-	_, err := s.Env().RemoteHost.Execute("sudo datadog-installer install oci://gcr.io/datadoghq/apm-library-python-package:2.8.2-dev-1")
-	assert.Error(s.T(), err)
-	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
 }
 
 func (s *packageApmInjectSuite) TestInstallStandaloneLib() {

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -407,6 +407,13 @@ func (s *packageApmInjectSuite) TestInstallDependencies() {
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
 }
 
+func (s *packageApmInjectSuite) TestInstallStandaloneLib() {
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_LIBRARIES=python")
+	defer s.Purge()
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
+	s.host.AssertPackageInstalledByInstaller("datadog-apm-library-python")
+}
+
 func (s *packageApmInjectSuite) assertTraceReceived(traceID uint64) {
 	found := assert.Eventually(s.T(), func() bool {
 		tracePayloads, err := s.Env().FakeIntake.Client().GetTraces()


### PR DESCRIPTION
### What does this PR do?
Today there's a path when a user sets `DD_APM_INSTRUMENTATION_LIBRARIES` but not `DD_APM_INSTRUMENTATION_ENABLED` and the deb/rpm of the tracer is installed. We shouldn't have a deb/rpm path as these won't be released anymore in the near future.

Thus this PR allows installing the OCI tracing libraries without the injector.

Also fixes some tests:
- Re-enable tracer version pinning tests
- Removes skips on darwin unit tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
