### PR TITLE
Mark the `TestConfigRefreshWindowsSuite/TestConfigRefresh` flaky

### DIFF
--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
@@ -5,6 +5,7 @@
 package configrefresh
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,6 +33,8 @@ func TestConfigRefreshWindowsSuite(t *testing.T) {
 }
 
 func (v *configRefreshWindowsSuite) TestConfigRefresh() {
+	flake.Mark(v.T()) // #incident-28883
+
 	rootDir := "C:/tmp/" + v.T().Name()
 	v.Env().RemoteHost.MkdirAll(rootDir)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Mark the `TestConfigRefreshWindowsSuite/TestConfigRefresh` flaky

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- #incident-28883
- The Windows AMI changed last night and the test is now consistently failing, we'll investigate after main is fixed

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
