### PR TITLE
[Fleet Automation] Fix windows artifact name

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -68,7 +68,7 @@ deploy_staging_windows_tags-7:
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # Datadog Installer
-deploy_datadog_installer_packages_windows-x64:
+deploy_installer_packages_windows-x64:
   rules:
     !reference [.on_deploy]
   stage: deploy_packages
@@ -81,7 +81,7 @@ deploy_datadog_installer_packages_windows-x64:
     - $S3_CP_CMD
       --recursive
       --exclude "*"
-      --include "datadog-installer-1-x86_64.msi"
+      --include "datadog-installer-*-1-x86_64.msi"
       --include "datadog-installer-*-1-x86_64.debug.zip"
       --include "datadog-installer-*-1-x86_64.zip"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_INSTALLER_ARTIFACTS_URI/msi/x86_64/

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -310,7 +310,7 @@ deploy_windows_testing-a7:
       --recursive
       --exclude "*"
       --include "datadog-agent-7.*.msi"
-      --include "datadog-installer-1-x86_64.msi"
+      --include "datadog-installer-*-1-x86_64.msi"
       $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A7
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -337,7 +337,7 @@ def build_installer(ctx, vstudio_root=None, arch="x64", debug=False):
         )
 
     with timed("Building MSI"):
-        msi_name = "datadog-installer-1-x86_64"
+        msi_name = f"datadog-installer-{env['PACKAGE_VERSION']}-1-x86_64"
         _build_msi(ctx, env, build_outdir, msi_name, DATADOG_INSTALLER_MSI_ALLOW_LIST)
 
         # And copy it to the final output path as a build artifact

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -312,6 +312,9 @@ def build_installer(ctx, vstudio_root=None, arch="x64", debug=False):
     Build the MSI installer for the agent
     """
     env = {}
+    env['PACKAGE_VERSION'] = get_version(
+        ctx, include_git=True, url_safe=True, major_version=7, include_pipeline_id=True
+    )
     env['NUGET_PACKAGES_DIR'] = f'{NUGET_PACKAGES_DIR}'
     env['AGENT_INSTALLER_OUTPUT_DIR'] = f'{BUILD_OUTPUT_DIR}'
     configuration = _msbuild_configuration(debug=debug)

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -313,7 +313,7 @@ def build_installer(ctx, vstudio_root=None, arch="x64", debug=False):
     """
     env = {}
     env['PACKAGE_VERSION'] = get_version(
-        ctx, include_git=True, url_safe=True, major_version=7, include_pipeline_id=True
+        ctx, include_git=True, url_safe=True, major_version="7", include_pipeline_id=True
     )
     env['NUGET_PACKAGES_DIR'] = f'{NUGET_PACKAGES_DIR}'
     env['AGENT_INSTALLER_OUTPUT_DIR'] = f'{BUILD_OUTPUT_DIR}'

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Windows;
 using NineDigit.WixSharpExtensions;
+using WixSetup.Datadog_Agent;
 using WixSharp;
 using WixSharp.CommonTasks;
 using Condition = WixSharp.Condition;
@@ -28,6 +29,7 @@ namespace WixSetup.Datadog_Installer
         private static readonly string InstallerBannerImagePath = Path.Combine("assets", "banner_background.bmp");
 
         private readonly DatadogInstallerCustomActions _installerCustomActions = new();
+        private readonly AgentVersion _agentVersion = new();
 
         public Project Configure()
         {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
@@ -129,7 +129,7 @@ namespace WixSetup.Datadog_Installer
                 // Set custom output directory (WixSharp defaults to current directory)
                 project.OutDir = Environment.GetEnvironmentVariable("AGENT_MSI_OUTDIR");
             }
-            project.OutFileName = "datadog-installer-1-x86_64";
+            project.OutFileName = $"datadog-installer-{_agentVersion.PackageVersion}-1-x86_64";
             project.Package.AttributesDefinition = $"Comments={ProductComment}";
             project.UI = WUI.WixUI_Common;
             project.CustomUI = new DatadogInstallerUI(this, _installerCustomActions);


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a version information to the Datadog Agent installer for Windows.
It also fixes the S3 bucket where the artifact was uploaded to match the bucket used by the Fleet Automation installer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Working release management.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
We will have to update the E2E tests to use the new artifact name.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
