### PR TITLE
fix: apply transaction destination logic to sketch payloads

### DIFF
--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -291,11 +291,11 @@ func (f *domainForwarder) sendHTTPTransactions(t transaction.Transaction) {
 	}
 
 	// Check for primary/secondary only transactions and compare with our own MRF state.
-	if t.GetKind() == transaction.Series && t.GetDestination() == transaction.PrimaryOnly && f.isMRF {
+	if (t.GetKind() == transaction.Series || t.GetKind() == transaction.Sketches) && t.GetDestination() == transaction.PrimaryOnly && f.isMRF {
 		f.log.Debugf("Transaction for domain %v is marked as primary only, but the forwarder is in MRF mode; dropping transaction.", t.GetTarget())
 		return
 	}
-	if t.GetKind() == transaction.Series && t.GetDestination() == transaction.SecondaryOnly && !f.isMRF {
+	if (t.GetKind() == transaction.Series || t.GetKind() == transaction.Sketches) && t.GetDestination() == transaction.SecondaryOnly && !f.isMRF {
 		f.log.Debugf("Transaction for domain %v is marked as secondary only, but the forwarder is not in MRF mode; dropping transaction.", t.GetTarget())
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where we weren't applying the destination logic for filtering sketch payloads.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The conditional here on the transaction type is probably something we could get rid of entirely, as long as we're confident relying on destination being defaulted and/or set correctly for other payload types. That's something we can discuss and potentially change separately.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same setup as #26351, but we will need to manually send distribution metrics to the agent:

```
echo -n "my_sketch:60|d|#filtering" | nc -4u -w1 127.0.0.1 8125
```

Include at least one sketch name in the metric allowlist, ensure that it is passed to R2, and ensure that any other sketch names are not.

APR-98