### PR TITLE
[ASCII-1985] Allow to fetch config check information and do not scrub the configuration information

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -196,7 +196,7 @@ func (ac *AutoConfig) serviceListening() {
 }
 
 func (ac *AutoConfig) writeConfigCheck(w http.ResponseWriter, r *http.Request) {
-	raw := r.URL.Query().Get("raw") == "true"
+	raw := r != nil && r.URL.Query().Get("raw") == "true"
 
 	var configCheckResponse integration.ConfigCheckResponse
 	if raw {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -195,8 +195,15 @@ func (ac *AutoConfig) serviceListening() {
 	}
 }
 
-func (ac *AutoConfig) writeConfigCheck(w http.ResponseWriter, _ *http.Request) {
-	configCheckResponse := ac.GetConfigCheck()
+func (ac *AutoConfig) writeConfigCheck(w http.ResponseWriter, r *http.Request) {
+	raw := r.URL.Query().Get("raw") == "true"
+
+	var configCheckResponse integration.ConfigCheckResponse
+	if raw {
+		configCheckResponse = ac.getRawConfigCheck()
+	} else {
+		configCheckResponse = ac.GetConfigCheck()
+	}
 
 	jsonConfig, err := json.Marshal(configCheckResponse)
 	if err != nil {
@@ -231,6 +238,24 @@ func (ac *AutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
 	}
 
 	response.Unresolved = scrubbedUnresolved
+
+	return response
+}
+
+// getRawConfigCheck returns information from all configuration providers
+func (ac *AutoConfig) getRawConfigCheck() integration.ConfigCheckResponse {
+	var response integration.ConfigCheckResponse
+
+	configSlice := ac.LoadedConfigs()
+	sort.Slice(configSlice, func(i, j int) bool {
+		return configSlice[i].Name < configSlice[j].Name
+	})
+
+	response.Configs = configSlice
+
+	response.ResolveWarnings = GetResolveWarnings()
+	response.ConfigErrors = GetConfigErrors()
+	response.Unresolved = ac.GetUnresolvedTemplates()
 
 	return response
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -7,7 +7,10 @@ package autodiscoveryimpl
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -529,6 +532,55 @@ func TestProcessClusterCheckConfigWithSecrets(t *testing.T) {
 	originalCheckID := checkid.BuildID(tpl.Name, tpl.FastDigest(), tpl.Instances[0], tpl.InitConfig)
 	newCheckID := checkid.BuildID(resolved.Name, resolved.FastDigest(), resolved.Instances[0], resolved.InitConfig)
 	assert.Equal(t, originalCheckID, ac.GetIDOfCheckWithEncryptedSecrets(newCheckID))
+}
+
+func TestWriteConfigEndpoint(t *testing.T) {
+	deps := createDeps(t)
+	configName := "testConfig"
+
+	mockResolver := MockSecretResolver{t, nil}
+	ac := getAutoConfig(scheduler.NewController(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp)
+
+	tpl := integration.Config{
+		Provider:     names.ClusterChecks,
+		Name:         configName,
+		InitConfig:   integration.Data{},
+		Instances:    []integration.Data{integration.Data("pass: 1234567")},
+		MetricConfig: integration.Data{},
+		LogsConfig:   integration.Data{},
+	}
+	changes := ac.processNewConfig(tpl)
+
+	require.Len(t, changes.Schedule, 1)
+
+	testCases := []struct {
+		name           string
+		request        *http.Request
+		expectedResult string
+	}{
+		{
+			name:           "With configuration scrubbed",
+			request:        httptest.NewRequest("GET", "http://example.com", nil),
+			expectedResult: "pass: \"********\"",
+		},
+		{
+			name:           "Without scrubbing configuration",
+			request:        httptest.NewRequest("GET", "http://example.com?raw=true", nil),
+			expectedResult: "pass: 1234567",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			responseRecorder := httptest.NewRecorder()
+			ac.writeConfigCheck(responseRecorder, tc.request)
+			var result integration.ConfigCheckResponse
+			out := responseRecorder.Body.Bytes()
+			err := json.Unmarshal(out, &result)
+			require.NoError(t, err)
+			assert.Equal(t, string(result.Configs[0].Instances[0]), tc.expectedResult)
+		})
+	}
 }
 
 type Deps struct {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -564,6 +564,11 @@ func TestWriteConfigEndpoint(t *testing.T) {
 			expectedResult: "pass: \"********\"",
 		},
 		{
+			name:           "With nil Requet",
+			request:        nil,
+			expectedResult: "pass: \"********\"",
+		},
+		{
 			name:           "Without scrubbing configuration",
 			request:        httptest.NewRequest("GET", "http://example.com?raw=true", nil),
 			expectedResult: "pass: 1234567",

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"reflect"
 
 	yaml "gopkg.in/yaml.v2"
@@ -144,12 +145,14 @@ func GetConfigCheckSnmp(conf config.Component) ([]SNMPConfig, error) {
 	// TODO: change the URL if the snmp check is a cluster check
 	// add /agent/config-check to cluster agent API
 	// Copy the code from comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go#writeConfigCheck
-	endpoint, err := apiutil.NewIPCEndpoint(conf, "/agent/config-check?raw=true")
+	endpoint, err := apiutil.NewIPCEndpoint(conf, "/agent/config-check")
 	if err != nil {
 		return nil, err
 	}
+	urlValues := url.Values{}
+	urlValues.Set("raw", "true")
 
-	res, err := endpoint.DoGet()
+	res, err := endpoint.DoGet(apiutil.WithValues(urlValues))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -144,7 +144,7 @@ func GetConfigCheckSnmp(conf config.Component) ([]SNMPConfig, error) {
 	// TODO: change the URL if the snmp check is a cluster check
 	// add /agent/config-check to cluster agent API
 	// Copy the code from comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go#writeConfigCheck
-	endpoint, err := apiutil.NewIPCEndpoint(conf, "/agent/config-check")
+	endpoint, err := apiutil.NewIPCEndpoint(conf, "/agent/config-check?raw=true")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add a the `raw` URL param to the `config-check` endpoint. Using the URL param allow us to teel the server if the configuration should be scrubbed or not.

The SNMP walk command needs the community strings to not being scrubbed so they can perform an snmpwalk like calls.

The regression was introduced in this PR https://github.com/DataDog/datadog-agent/pull/27389

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Ensure CLI command agent `snmp walk` works as expected.


