### PR TITLE
[ASCII-1982][ASCII-1986] Send HTTP requests over ssh connection to avoid running commands

### DIFF
--- a/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
@@ -6,12 +6,10 @@
 package configrefresh
 
 import (
-	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"strconv"
-
-	osComp "github.com/DataDog/test-infra-definitions/components/os"
 )
 
 type agentConfigEndpointInfo struct {
@@ -41,32 +39,12 @@ func (endpointInfo *agentConfigEndpointInfo) url() *url.URL {
 	}
 }
 
-func (endpointInfo *agentConfigEndpointInfo) fetchCommand(authtoken string, osFamily osComp.Family) string {
-	if osFamily == osComp.WindowsFamily {
-		// This piece of code is here to mimic -SkipCertificateCheck option which is only available with PowerShell 6.0+
-		return fmt.Sprintf(
-			`class TrustAllCertsPolicy : System.Net.ICertificatePolicy {
-				[bool] CheckValidationResult([System.Net.ServicePoint] $a,
-											 [System.Security.Cryptography.X509Certificates.X509Certificate] $b,
-											 [System.Net.WebRequest] $c,
-											 [int] $d) {
-					return $true
-				}
-			}
-			[System.Net.ServicePointManager]::CertificatePolicy = [TrustAllCertsPolicy]::new()
-			(Invoke-WebRequest -Uri "%s" -Headers @{"authorization"="Bearer %s"} -Method GET -UseBasicParsing).Content`,
-			endpointInfo.url().String(),
-			authtoken,
-		)
+func (endpointInfo *agentConfigEndpointInfo) httpRequest(authtoken string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, endpointInfo.url().String(), nil)
+	if err != nil {
+		return nil, err
 	}
 
-	// -L: follow redirects
-	// -s: silent
-	// -k: allow insecure server connections
-	// -H: add a header
-	return fmt.Sprintf(
-		`curl -L -s -k -H "authorization: Bearer %s" --fail-with-body "%s"`,
-		authtoken,
-		endpointInfo.url().String(),
-	)
+	req.Header.Set("Authorization", "Bearer "+authtoken)
+	return req, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Use the feature added in https://github.com/DataDog/datadog-agent/pull/27586 in the config sync e2e test.
Replace executing `curl` or `Invoke-WebRequest` commands with native Go HTTP requests, over the ssh connection.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
See https://github.com/DataDog/datadog-agent/pull/27586.
TLDR: avoid running commands when possible as they can take surprisingly long in some cases.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
