### PR TITLE
fix(linter): reno link updated

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -406,7 +406,7 @@ def releasenote(ctx):
             if not github.contains_release_note(pr_id):
                 print(
                     f"{color_message('Error', 'red')}: No releasenote was found for this PR. Please add one using 'reno'"
-                    ", see https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno"
+                    ", see https://github.com/DataDog/datadog-agent/blob/main/docs/public/guidelines/contributing.md#reno"
                     ", or apply the label 'changelog/no-changelog' to the PR.",
                     file=sys.stderr,
                 )

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -406,7 +406,7 @@ def releasenote(ctx):
             if not github.contains_release_note(pr_id):
                 print(
                     f"{color_message('Error', 'red')}: No releasenote was found for this PR. Please add one using 'reno'"
-                    ", see https://github.com/DataDog/datadog-agent/blob/main/docs/public/guidelines/contributing.md#reno"
+                    ", see https://datadoghq.dev/datadog-agent/guidelines/contributing/#reno"
                     ", or apply the label 'changelog/no-changelog' to the PR.",
                     file=sys.stderr,
                 )


### PR DESCRIPTION
Noticed in CI failures (https://github.com/DataDog/datadog-agent/actions/runs/9864112674/job/27238371401?pr=27379) that the link pointed to in  the docs was to the wrong place, the docs for reno now live here: https://github.com/DataDog/datadog-agent/blob/main/docs/public/guidelines/contributing.md#reno, so updated the linter accordingly.
