### PR TITLE
APM: prevent connection to core agent in case of existing agent

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -319,7 +319,10 @@ func TestConfigHostname(t *testing.T) {
 	})
 
 	t.Run("fallback", func(t *testing.T) {
-
+		overrides := map[string]interface{}{
+			"apm_config.dd_agent_bin": "/not/exist",
+			"cmd_port":                "-1",
+		}
 		host, err := os.Hostname()
 		if err != nil || host == "" {
 			// can't say
@@ -331,6 +334,7 @@ func TestConfigHostname(t *testing.T) {
 			fx.Replace(corecomp.MockParams{
 				Params:      corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
 				SetupConfig: true,
+				Overrides:   overrides,
 			}),
 			MockModule(),
 		))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Explicitly break connection to core-agent so that we can verify we use the OS hostname fallback.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Some new CI runners have an agent available, this test previously assumed no agent would be available. Make this assumption explicit so the test passes on these new runners (as well as on local dev mac machines that may have an agent running)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Does the test pass on the new runners
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
