### PR TITLE
[agent] Add deprecation warnings when running the process checks on the process agent

### DIFF
--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -8,12 +8,13 @@
 package agent
 
 import (
+	"slices"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"slices"
 )
 
 // List of check names for process checks

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -26,10 +26,15 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 	runInCoreAgent := config.GetBool("process_config.run_in_core_agent.enabled")
 
 	var npmEnabled bool
+	// var sdbfsdf bool
+	// ProcessCheckName       = "process"
+	// ContainerCheckName     = "container"
+	// DiscoveryCheckName     = "process_discovery"
+	// if any of those chekcs enabled and running core agent = false, log warning to use running core agent flag runInCoreAgent
 	for _, check := range checkComponents {
 		if check.Object().Name() == checks.ConnectionsCheckName && check.Object().IsEnabled() {
 			npmEnabled = true
-			break
+			break // get rid
 		}
 	}
 
@@ -45,6 +50,9 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 
 		if runInCoreAgent {
 			log.Info("The process checks will run in the core agent")
+		} else {
+			// else for if not runInCoreAgen to see what checks running
+			log.Info("temp")
 		}
 
 		return !runInCoreAgent

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -41,8 +41,9 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 
 	switch flavor.GetFlavor() {
 	case flavor.ProcessAgent:
+		// can also change return of npm enabled to allow for if else for runincoreagent
 		if !runInCoreAgent && processEnabled {
-			// process checks enabled but not running in core agent, warn about depreciation
+			// process checks enabled but not running in core agent, warn about deprecation
 			log.Info("temporary warning for depreciation")
 		}
 

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -47,7 +47,6 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 
 	switch flavor.GetFlavor() {
 	case flavor.ProcessAgent:
-
 		if npmEnabled {
 			if runInCoreAgent {
 				log.Info("Network Performance Monitoring is not supported in the core agent. " +

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -26,20 +26,26 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 	runInCoreAgent := config.GetBool("process_config.run_in_core_agent.enabled")
 
 	var npmEnabled bool
-	// var sdbfsdf bool
-	// ProcessCheckName       = "process"
-	// ContainerCheckName     = "container"
-	// DiscoveryCheckName     = "process_discovery"
-	// if any of those chekcs enabled and running core agent = false, log warning to use running core agent flag runInCoreAgent
+	var processEnabled bool
 	for _, check := range checkComponents {
 		if check.Object().Name() == checks.ConnectionsCheckName && check.Object().IsEnabled() {
 			npmEnabled = true
-			break // get rid
+		}
+		if (check.Object().Name() == checks.ProcessCheckName ||
+			check.Object().Name() == checks.ContainerCheckName ||
+			check.Object().Name() == checks.DiscoveryCheckName) &&
+			check.Object().IsEnabled() {
+			processEnabled = true
 		}
 	}
 
 	switch flavor.GetFlavor() {
 	case flavor.ProcessAgent:
+		if !runInCoreAgent && processEnabled {
+			// process checks enabled but not running in core agent, warn about depreciation
+			log.Info("temporary warning for depreciation")
+		}
+
 		if npmEnabled {
 			if runInCoreAgent {
 				log.Info("Network Performance Monitoring is not supported in the core agent. " +
@@ -50,9 +56,6 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 
 		if runInCoreAgent {
 			log.Info("The process checks will run in the core agent")
-		} else {
-			// else for if not runInCoreAgen to see what checks running
-			log.Info("temp")
 		}
 
 		return !runInCoreAgent

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -13,7 +13,15 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"slices"
 )
+
+// List of check names for process checks
+var processCheckNames = []string{
+	checks.ProcessCheckName,
+	checks.ContainerCheckName,
+	checks.DiscoveryCheckName,
+}
 
 // Enabled determines whether the process agent is enabled based on the configuration.
 // The process-agent component on linux can be run in the core agent or as a standalone process-agent
@@ -31,35 +39,30 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 		if check.Object().Name() == checks.ConnectionsCheckName && check.Object().IsEnabled() {
 			npmEnabled = true
 		}
-		if (check.Object().Name() == checks.ProcessCheckName ||
-			check.Object().Name() == checks.ContainerCheckName ||
-			check.Object().Name() == checks.DiscoveryCheckName) &&
-			check.Object().IsEnabled() {
+		if slices.Contains(processCheckNames, check.Object().Name()) && check.Object().IsEnabled() {
 			processEnabled = true
 		}
 	}
 
 	switch flavor.GetFlavor() {
 	case flavor.ProcessAgent:
-		// can also change return of npm enabled to allow for if else for runincoreagent
-		if !runInCoreAgent && processEnabled {
-			// process checks enabled but not running in core agent, warn about deprecation
-			log.Info("temporary warning for depreciation")
-		}
 
 		if npmEnabled {
 			if runInCoreAgent {
 				log.Info("Network Performance Monitoring is not supported in the core agent. " +
 					"The process-agent will be enabled as a standalone agent")
 			}
-			return true
 		}
 
 		if runInCoreAgent {
 			log.Info("The process checks will run in the core agent")
+		} else if processEnabled {
+			log.Info("Process/Container Collection in the Process Agent will be deprecated in a future release " +
+				"and will instead be run in the Core Agent. " +
+				"Set process_config.run_in_core_agent.enabled to true to switch now.")
 		}
 
-		return !runInCoreAgent
+		return !runInCoreAgent || npmEnabled
 	case flavor.DefaultAgent:
 		if npmEnabled && runInCoreAgent {
 			log.Info("Network Performance Monitoring is not supported in the core agent. " +

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -72,6 +72,14 @@ func TestProcessAgentComponentOnLinux(t *testing.T) {
 			expected:             true,
 		},
 		{
+			name:                 "process-agent with connections check enabled and run in core-agent mode disabled",
+			agentFlavor:          flavor.ProcessAgent,
+			checksEnabled:        true,
+			checkName:            checks.ConnectionsCheckName,
+			runInCoreAgentConfig: false,
+			expected:             true,
+		},
+		{
 			name:                 "core agent with process check enabled and run in core-agent mode enabled",
 			agentFlavor:          flavor.DefaultAgent,
 			checksEnabled:        true,

--- a/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
+++ b/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
@@ -1,14 +1,5 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
-enhancements:
-  - |
-    Add deprecation warnings when running process checks on the process agent in linux.
 other:
   - |
+    Add deprecation warnings when running process checks on the process agent in linux.
     Change prepares for the deprecation of Process/Container Collection in the Process Agent, occurring in a future release.

--- a/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
+++ b/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add deprecation warnings when running process checks on the process agent in linux.
+other:
+  - |
+    Change prepares for the deprecation of Process/Container Collection in the Process Agent, occurring in a future release.

--- a/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
+++ b/releasenotes/notes/[agent]-Add-deprecation-warnings-9a3eb8622e86e39e.yaml
@@ -1,5 +1,5 @@
 ---
 other:
   - |
-    Add deprecation warnings when running process checks on the process agent in linux.
-    Change prepares for the deprecation of Process/Container Collection in the Process Agent, occurring in a future release.
+    Add deprecation warnings when running process checks on the Process Agent in Linux.
+    This change prepares for the deprecation of processes and container collection in the Process Agent, occurring in a future release.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
- Add deprecation warnings when running the process checks on the process agent, and advise on switch to core agent (for linux only).
- As process checks will be moving to core agent regardless, for deprecation purposes this log warning will be emitted even if NPM is enabled.
  - This PR adds minor refactoring to allow this behavior. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4206

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Local unit testing by running the `agent_linux_test.go` tests (primarily `TestProcessAgentComponentOnLinux`),  in a linux environment. Can set breakpoints to ensure log message is being output for conditional branches.
2. Run process agent to ensure new log message is being output.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.