### PR TITLE
[windows][e2e] Port security agent functional tests to e2e

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -583,6 +583,7 @@
 /test/new-e2e/tests/orchestrator              @DataDog/container-app
 /test/new-e2e/tests/process                   @DataDog/processes
 /test/new-e2e/tests/sysprobe-functional     @DataDog/windows-kernel-integrations
+/test/new-e2e/tests/security-agent-functional     @DataDog/windows-kernel-integrations
 /test/new-e2e/tests/cws                       @DataDog/agent-security
 /test/new-e2e/tests/agent-metrics-logs   @DataDog/agent-metrics-logs
 /test/new-e2e/tests/windows                   @DataDog/windows-agent @DataDog/windows-kernel-integrations

--- a/test/new-e2e/tests/security-agent-functional/security_agent_test.go
+++ b/test/new-e2e/tests/security-agent-functional/security_agent_test.go
@@ -54,7 +54,7 @@ func (v *vmSuite) SetupSuite() {
 	v.testspath = filepath.Join(kitchenDir, "dd-security-agent-check", "files", "tests")
 }
 
-func (v *vmSuite) TestSystemProbeSuite() {
+func (v *vmSuite) TestSystemProbeCWSSuite() {
 	v.BaseSuite.SetupSuite()
 	t := v.T()
 	// get the remote host

--- a/test/new-e2e/tests/security-agent-functional/security_agent_test.go
+++ b/test/new-e2e/tests/security-agent-functional/security_agent_test.go
@@ -3,14 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package sysprobefunctional
+package secagentfunctional
 
 import (
 	"flag"
 	"os"
-	"path"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -53,7 +51,7 @@ func (v *vmSuite) SetupSuite() {
 
 	reporoot, _ := filepath.Abs(filepath.Join(currDir, "..", "..", "..", ".."))
 	kitchenDir := filepath.Join(reporoot, "test", "kitchen", "site-cookbooks")
-	v.testspath = filepath.Join(kitchenDir, "dd-system-probe-check", "files", "default", "tests")
+	v.testspath = filepath.Join(kitchenDir, "dd-security-agent-check", "files", "tests")
 }
 
 func (v *vmSuite) TestSystemProbeSuite() {
@@ -62,39 +60,8 @@ func (v *vmSuite) TestSystemProbeSuite() {
 	// get the remote host
 	vm := v.Env().RemoteHost
 
-	err := windows.InstallIIS(vm)
-	require.NoError(t, err)
-	// HEADSUP the paths are windows, but this will execute in linux. So fix the paths
-	t.Log("IIS Installed, continuing")
-
-	t.Log("Creating sites")
-	// figure out where we're being executed from.  These paths should be in
-	// native path separators (i.e. not windows paths if executing in ci/on linux)
-
-	_, srcfile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-	exPath := filepath.Dir(srcfile)
-
-	sites := []windows.IISSiteDefinition{
-		{
-			Name:        "TestSite1",
-			BindingPort: "*:8081:",
-			AssetsDir:   path.Join(exPath, "assets"),
-		},
-		{
-			Name:        "TestSite2",
-			BindingPort: "*:8082:",
-			AssetsDir:   path.Join(exPath, "assets"),
-		},
-	}
-
-	t.Logf("AssetsDir: %s", sites[0].AssetsDir)
-	err = windows.CreateIISSite(vm, sites)
-	require.NoError(t, err)
-	t.Log("Sites created, continuing")
-
 	rs := windows.NewRemoteExecutable(vm, t, "testsuite.exe", v.testspath)
-	err = rs.FindTestPrograms()
+	err := rs.FindTestPrograms()
 	require.NoError(t, err)
 
 	err = rs.CreateRemotePaths()
@@ -127,5 +94,5 @@ func (v *vmSuite) TestSystemProbeSuite() {
 	_, err = vm.Execute("start-service ddnpm")
 	require.NoError(t, err)
 
-	rs.RunTests("")
+	rs.RunTests("5m") // security agent tests can take a while waiting for ETW to start.
 }

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -56,7 +56,7 @@ func (v *vmSuite) SetupSuite() {
 	v.testspath = filepath.Join(kitchenDir, "dd-system-probe-check", "files", "default", "tests")
 }
 
-func (v *vmSuite) TestSystemProbeSuite() {
+func (v *vmSuite) TestSystemProbeNPMSuite() {
 	v.BaseSuite.SetupSuite()
 	t := v.T()
 	// get the remote host

--- a/test/new-e2e/tests/windows/remoteexecutable.go
+++ b/test/new-e2e/tests/windows/remoteexecutable.go
@@ -115,7 +115,12 @@ func (rs *RemoteExecutable) CopyFiles() error {
 
 // RunTests iterates through all of the tests that were copied and executes them one by one.
 // it captures the output, and logs it.
-func (rs *RemoteExecutable) RunTests() error {
+func (rs *RemoteExecutable) RunTests(timeoutarg string) error {
+
+	if timeoutarg == "" {
+		timeoutarg = "2m"
+	}
+	tmo := "\"-test.timeout=" + timeoutarg + "\""
 
 	for _, testsuite := range rs.testfiles {
 		rs.t.Logf("Running testsuite: %s", testsuite)
@@ -123,7 +128,7 @@ func (rs *RemoteExecutable) RunTests() error {
 
 		// google test programs compiled in this way run with no timeout by default.
 		// don't allow an individual test to take too long
-		executeAndLogOutput(rs.t, rs.vm, remotePath, "\"-test.v\"", "\"-test.timeout=2m\"")
+		executeAndLogOutput(rs.t, rs.vm, remotePath, "\"-test.v\"", tmo)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR creates E2E tests for the security agent functional tests, replacing kitchen as the driver.

Adds a configurable timeout to the executed `testsuite`, as those tests take longer than the previously hard-coded 2 minutes.

### Motivation

convert tests to e2e

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

None.  This PR is creating automated tests.