### PR TITLE
[APM] Disable receiver on OTLP agent

### DIFF
--- a/comp/otelcol/otlp/components/statsprocessor/agent.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent.go
@@ -73,7 +73,7 @@ func NewAgent(ctx context.Context, out chan *pb.StatsPayload, metricsClient stat
 // NewAgentWithConfig creates a new traceagent with the given config cfg. Used in tests; use newAgent instead.
 func NewAgentWithConfig(ctx context.Context, cfg *traceconfig.AgentConfig, out chan *pb.StatsPayload, metricsClient statsd.ClientInterface, timingReporter timing.Reporter) *TraceAgent {
 	// disable the HTTP receiver
-	cfg.ReceiverPort = 0
+	cfg.ReceiverEnabled = false
 	// set the API key to succeed startup; it is never used nor needed
 	cfg.Endpoints[0].APIKey = "skip_check"
 	// set the default hostname to the translator's placeholder; in the case where no hostname

--- a/comp/otelcol/otlp/components/statsprocessor/agent_test.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent_test.go
@@ -32,11 +32,12 @@ func setupMetricClient() (*metric.ManualReader, statsd.ClientInterface, timing.R
 func TestTraceAgentConfig(t *testing.T) {
 	cfg := traceconfig.New()
 	require.NotZero(t, cfg.ReceiverPort)
+	require.True(t, cfg.ReceiverEnabled)
 
 	out := make(chan *pb.StatsPayload)
 	_, metricClient, timingReporter := setupMetricClient()
 	_ = NewAgentWithConfig(context.Background(), cfg, out, metricClient, timingReporter)
-	require.Zero(t, cfg.ReceiverPort)
+	require.False(t, cfg.ReceiverEnabled)
 	require.NotEmpty(t, cfg.Endpoints[0].APIKey)
 	require.Equal(t, "__unset__", cfg.Hostname)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This is a small follow up on https://github.com/DataDog/datadog-agent/pull/26969

`ReceiverEnabled` can now be used instead of setting the `ReveiverPort` to 0. This will ensure the UDS listener is also not created, which now defaults to `/var/run/datadog/apm.socket`


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

OTLP agent doesn't require to run the HTTP receiver. This setting entirely disabled it (both TCP and UDS listeners).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

N/A

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
