### PR TITLE
usm: http2: tests: Fix flaky test

### DIFF
--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -565,10 +565,13 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate max interesting frames limit",
-			// The purpose of this test is to verify our ability to reach the limit set by HTTP2_MAX_FRAMES_ITERATIONS, which
+			// The purpose of this test is to verify our ability to reach almost to the limit set by HTTP2_MAX_FRAMES_ITERATIONS, which
 			// determines the maximum number of "interesting frames" we can process.
+			// Not testing the max number of frame (240), as the server response can contain other frames, so we might miss EOS
+			// coming after a server side frame, and by that miss a request.
 			messageBuilder: func() [][]byte {
-				const iterations = 120
+				// Generates 119 (requests) * 2 (number of frames per request) = 238 frames
+				const iterations = 119
 				framer := newFramer()
 				for i := 0; i < iterations; i++ {
 					streamID := getStreamID(i)
@@ -582,7 +585,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				{
 					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
 					Method: usmhttp.MethodPost,
-				}: 120,
+				}: 119,
 			},
 		},
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Changes the number of requests sent in a test to eliminate flakiness.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We control the client side, which sends 120 requests which is equal to 240 frames, but we don't control the server side, which might send ping/setting frames inbetween the other frames. The server responsds with at least 120 responses (240 frames), so any additional server frame can make us exceed our own limit, and by that, miss a response and not capturing everything we sent

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
