### PR TITLE
[CWS] don't make network fields dns fields

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -128,6 +128,15 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`event.os`](#event-os-doc) | Operating system of the event |
 | [`event.service`](#event-service-doc) | Service associated with the event |
 | [`event.timestamp`](#event-timestamp-doc) | Timestamp of the event |
+| [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
+| [`network.device.ifindex`](#network-device-ifindex-doc) | Interface ifindex |
+| [`network.device.ifname`](#network-device-ifname-doc) | Interface ifname |
+| [`network.l3_protocol`](#network-l3_protocol-doc) | L3 protocol of the network packet |
+| [`network.l4_protocol`](#network-l4_protocol-doc) | L4 protocol of the network packet |
+| [`network.size`](#network-size-doc) | Size in bytes of the network packet |
+| [`network.source.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.source.port`](#common-ipportcontext-port-doc) | Port number |
 | [`process.ancestors.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`process.ancestors.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`process.ancestors.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -504,15 +513,6 @@ A DNS request was sent
 | [`dns.question.name`](#dns-question-name-doc) | the queried domain name |
 | [`dns.question.name.length`](#common-string-length-doc) | Length of the corresponding string |
 | [`dns.question.type`](#dns-question-type-doc) | a two octet code which specifies the DNS question type |
-| [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
-| [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
-| [`network.device.ifindex`](#network-device-ifindex-doc) | interface ifindex |
-| [`network.device.ifname`](#network-device-ifname-doc) | interface ifname |
-| [`network.l3_protocol`](#network-l3_protocol-doc) | l3 protocol of the network packet |
-| [`network.l4_protocol`](#network-l4_protocol-doc) | l4 protocol of the network packet |
-| [`network.size`](#network-size-doc) | size in bytes of the network packet |
-| [`network.source.ip`](#common-ipportcontext-ip-doc) | IP address |
-| [`network.source.port`](#common-ipportcontext-port-doc) | Port number |
 
 ### Event `exec`
 
@@ -2833,21 +2833,21 @@ Constants: [Virtual Memory flags](#virtual-memory-flags)
 ### `network.device.ifindex` {#network-device-ifindex-doc}
 Type: int
 
-Definition: interface ifindex
+Definition: Interface ifindex
 
 
 
 ### `network.device.ifname` {#network-device-ifname-doc}
 Type: string
 
-Definition: interface ifname
+Definition: Interface ifname
 
 
 
 ### `network.l3_protocol` {#network-l3_protocol-doc}
 Type: int
 
-Definition: l3 protocol of the network packet
+Definition: L3 protocol of the network packet
 
 
 Constants: [L3 protocols](#l3-protocols)
@@ -2857,7 +2857,7 @@ Constants: [L3 protocols](#l3-protocols)
 ### `network.l4_protocol` {#network-l4_protocol-doc}
 Type: int
 
-Definition: l4 protocol of the network packet
+Definition: L4 protocol of the network packet
 
 
 Constants: [L4 protocols](#l4-protocols)
@@ -2867,7 +2867,7 @@ Constants: [L4 protocols](#l4-protocols)
 ### `network.size` {#network-size-doc}
 Type: int
 
-Definition: size in bytes of the network packet
+Definition: Size in bytes of the network packet
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -63,6 +63,51 @@
           "property_doc_link": "event-timestamp-doc"
         },
         {
+          "name": "network.destination.ip",
+          "definition": "IP address",
+          "property_doc_link": "common-ipportcontext-ip-doc"
+        },
+        {
+          "name": "network.destination.port",
+          "definition": "Port number",
+          "property_doc_link": "common-ipportcontext-port-doc"
+        },
+        {
+          "name": "network.device.ifindex",
+          "definition": "Interface ifindex",
+          "property_doc_link": "network-device-ifindex-doc"
+        },
+        {
+          "name": "network.device.ifname",
+          "definition": "Interface ifname",
+          "property_doc_link": "network-device-ifname-doc"
+        },
+        {
+          "name": "network.l3_protocol",
+          "definition": "L3 protocol of the network packet",
+          "property_doc_link": "network-l3_protocol-doc"
+        },
+        {
+          "name": "network.l4_protocol",
+          "definition": "L4 protocol of the network packet",
+          "property_doc_link": "network-l4_protocol-doc"
+        },
+        {
+          "name": "network.size",
+          "definition": "Size in bytes of the network packet",
+          "property_doc_link": "network-size-doc"
+        },
+        {
+          "name": "network.source.ip",
+          "definition": "IP address",
+          "property_doc_link": "common-ipportcontext-ip-doc"
+        },
+        {
+          "name": "network.source.port",
+          "definition": "Port number",
+          "property_doc_link": "common-ipportcontext-port-doc"
+        },
+        {
           "name": "process.ancestors.args",
           "definition": "Arguments of the process (as a string, excluding argv0)",
           "property_doc_link": "common-process-args-doc"
@@ -1749,51 +1794,6 @@
           "name": "dns.question.type",
           "definition": "a two octet code which specifies the DNS question type",
           "property_doc_link": "dns-question-type-doc"
-        },
-        {
-          "name": "network.destination.ip",
-          "definition": "IP address",
-          "property_doc_link": "common-ipportcontext-ip-doc"
-        },
-        {
-          "name": "network.destination.port",
-          "definition": "Port number",
-          "property_doc_link": "common-ipportcontext-port-doc"
-        },
-        {
-          "name": "network.device.ifindex",
-          "definition": "interface ifindex",
-          "property_doc_link": "network-device-ifindex-doc"
-        },
-        {
-          "name": "network.device.ifname",
-          "definition": "interface ifname",
-          "property_doc_link": "network-device-ifname-doc"
-        },
-        {
-          "name": "network.l3_protocol",
-          "definition": "l3 protocol of the network packet",
-          "property_doc_link": "network-l3_protocol-doc"
-        },
-        {
-          "name": "network.l4_protocol",
-          "definition": "l4 protocol of the network packet",
-          "property_doc_link": "network-l4_protocol-doc"
-        },
-        {
-          "name": "network.size",
-          "definition": "size in bytes of the network packet",
-          "property_doc_link": "network-size-doc"
-        },
-        {
-          "name": "network.source.ip",
-          "definition": "IP address",
-          "property_doc_link": "common-ipportcontext-ip-doc"
-        },
-        {
-          "name": "network.source.port",
-          "definition": "Port number",
-          "property_doc_link": "common-ipportcontext-port-doc"
         }
       ]
     },
@@ -9633,7 +9633,7 @@
       "name": "network.device.ifindex",
       "link": "network-device-ifindex-doc",
       "type": "int",
-      "definition": "interface ifindex",
+      "definition": "Interface ifindex",
       "prefixes": [
         "network.device"
       ],
@@ -9645,7 +9645,7 @@
       "name": "network.device.ifname",
       "link": "network-device-ifname-doc",
       "type": "string",
-      "definition": "interface ifname",
+      "definition": "Interface ifname",
       "prefixes": [
         "network.device"
       ],
@@ -9657,7 +9657,7 @@
       "name": "network.l3_protocol",
       "link": "network-l3_protocol-doc",
       "type": "int",
-      "definition": "l3 protocol of the network packet",
+      "definition": "L3 protocol of the network packet",
       "prefixes": [
         "network"
       ],
@@ -9669,7 +9669,7 @@
       "name": "network.l4_protocol",
       "link": "network-l4_protocol-doc",
       "type": "int",
-      "definition": "l4 protocol of the network packet",
+      "definition": "L4 protocol of the network packet",
       "prefixes": [
         "network"
       ],
@@ -9681,7 +9681,7 @@
       "name": "network.size",
       "link": "network-size-doc",
       "type": "int",
-      "definition": "size in bytes of the network packet",
+      "definition": "Size in bytes of the network packet",
       "prefixes": [
         "network"
       ],

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -25448,23 +25448,23 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mprotect.vm_protection":
 		return "mprotect", nil
 	case "network.destination.ip":
-		return "dns", nil
+		return "*", nil
 	case "network.destination.port":
-		return "dns", nil
+		return "*", nil
 	case "network.device.ifindex":
-		return "dns", nil
+		return "*", nil
 	case "network.device.ifname":
-		return "dns", nil
+		return "*", nil
 	case "network.l3_protocol":
-		return "dns", nil
+		return "*", nil
 	case "network.l4_protocol":
-		return "dns", nil
+		return "*", nil
 	case "network.size":
-		return "dns", nil
+		return "*", nil
 	case "network.source.ip":
-		return "dns", nil
+		return "*", nil
 	case "network.source.port":
-		return "dns", nil
+		return "*", nil
 	case "ondemand.arg1.str":
 		return "ondemand", nil
 	case "ondemand.arg1.uint":

--- a/pkg/security/secl/model/field_accessors_unix.go
+++ b/pkg/security/secl/model/field_accessors_unix.go
@@ -4263,73 +4263,46 @@ func (ev *Event) GetMprotectVmProtection() int {
 
 // GetNetworkDestinationIp returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkDestinationIp() net.IPNet {
-	if ev.GetEventType().String() != "dns" {
-		return net.IPNet{}
-	}
 	return ev.NetworkContext.Destination.IPNet
 }
 
 // GetNetworkDestinationPort returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkDestinationPort() uint16 {
-	if ev.GetEventType().String() != "dns" {
-		return uint16(0)
-	}
 	return ev.NetworkContext.Destination.Port
 }
 
 // GetNetworkDeviceIfindex returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkDeviceIfindex() uint32 {
-	if ev.GetEventType().String() != "dns" {
-		return uint32(0)
-	}
 	return ev.NetworkContext.Device.IfIndex
 }
 
 // GetNetworkDeviceIfname returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkDeviceIfname() string {
-	if ev.GetEventType().String() != "dns" {
-		return ""
-	}
 	return ev.FieldHandlers.ResolveNetworkDeviceIfName(ev, &ev.NetworkContext.Device)
 }
 
 // GetNetworkL3Protocol returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkL3Protocol() uint16 {
-	if ev.GetEventType().String() != "dns" {
-		return uint16(0)
-	}
 	return ev.NetworkContext.L3Protocol
 }
 
 // GetNetworkL4Protocol returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkL4Protocol() uint16 {
-	if ev.GetEventType().String() != "dns" {
-		return uint16(0)
-	}
 	return ev.NetworkContext.L4Protocol
 }
 
 // GetNetworkSize returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkSize() uint32 {
-	if ev.GetEventType().String() != "dns" {
-		return uint32(0)
-	}
 	return ev.NetworkContext.Size
 }
 
 // GetNetworkSourceIp returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkSourceIp() net.IPNet {
-	if ev.GetEventType().String() != "dns" {
-		return net.IPNet{}
-	}
 	return ev.NetworkContext.Source.IPNet
 }
 
 // GetNetworkSourcePort returns the value of the field, resolving if necessary
 func (ev *Event) GetNetworkSourcePort() uint16 {
-	if ev.GetEventType().String() != "dns" {
-		return uint16(0)
-	}
 	return ev.NetworkContext.Source.Port
 }
 

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -34,6 +34,7 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
+	_ = ev.FieldHandlers.ResolveNetworkDeviceIfName(ev, &ev.NetworkContext.Device)
 	_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessArgsTruncated(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -279,7 +280,6 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveSyscallCtxArgsInt3(ev, &ev.Chown.SyscallContext)
 		}
 	case "dns":
-		_ = ev.FieldHandlers.ResolveNetworkDeviceIfName(ev, &ev.NetworkContext.Device)
 	case "exec":
 		if ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Exec.Process.FileEvent.FileFields)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -99,11 +99,11 @@ type IPPortContext struct {
 type NetworkContext struct {
 	Device NetworkDeviceContext `field:"device"` // network device on which the network packet was captured
 
-	L3Protocol  uint16        `field:"l3_protocol"` // SECLDoc[l3_protocol] Definition:`l3 protocol of the network packet` Constants:`L3 protocols`
-	L4Protocol  uint16        `field:"l4_protocol"` // SECLDoc[l4_protocol] Definition:`l4 protocol of the network packet` Constants:`L4 protocols`
+	L3Protocol  uint16        `field:"l3_protocol"` // SECLDoc[l3_protocol] Definition:`L3 protocol of the network packet` Constants:`L3 protocols`
+	L4Protocol  uint16        `field:"l4_protocol"` // SECLDoc[l4_protocol] Definition:`L4 protocol of the network packet` Constants:`L4 protocols`
 	Source      IPPortContext `field:"source"`      // source of the network packet
 	Destination IPPortContext `field:"destination"` // destination of the network packet
-	Size        uint32        `field:"size"`        // SECLDoc[size] Definition:`size in bytes of the network packet`
+	Size        uint32        `field:"size"`        // SECLDoc[size] Definition:`Size in bytes of the network packet`
 }
 
 // SpanContext describes a span context

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -26,7 +26,7 @@ type Event struct {
 
 	// context
 	SpanContext    SpanContext    `field:"-"`
-	NetworkContext NetworkContext `field:"network" event:"dns"`
+	NetworkContext NetworkContext `field:"network"` // [7.36] [Network] Network context
 	CGroupContext  CGroupContext  `field:"cgroup" event:"*"`
 
 	// fim events
@@ -609,8 +609,8 @@ type ActivityDumpLoadConfig struct {
 // NetworkDeviceContext represents the network device context of a network event
 type NetworkDeviceContext struct {
 	NetNS   uint32 `field:"-"`
-	IfIndex uint32 `field:"ifindex"`                                   // SECLDoc[ifindex] Definition:`interface ifindex`
-	IfName  string `field:"ifname,handler:ResolveNetworkDeviceIfName"` // SECLDoc[ifname] Definition:`interface ifname`
+	IfIndex uint32 `field:"ifindex"`                                   // SECLDoc[ifindex] Definition:`Interface ifindex`
+	IfName  string `field:"ifname,handler:ResolveNetworkDeviceIfName"` // SECLDoc[ifname] Definition:`Interface ifname`
 }
 
 // BindEvent represents a bind event


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

network fields are context field not event field. This PR remove the event tags so that we can't write rules with only `network.*` that will be seen as dns rules.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
