### PR TITLE
[windows][usm] change default value on windows for process inference …

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -44,7 +45,14 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("max_concurrent_requests"), cfg.GetInt(spNS("max_tracked_connections")))
 	deprecateBool(cfg, smNS("process_service_inference", "enabled"), spNS("process_service_inference", "enabled"))
 	deprecateBool(cfg, smNS("process_service_inference", "use_windows_service_name"), spNS("process_service_inference", "use_windows_service_name"))
-	applyDefault(cfg, spNS("process_service_inference", "enabled"), false)
+
+	// default on windows is now enabled; default on linux is still disabled
+	if runtime.GOOS == "windows" {
+		applyDefault(cfg, spNS("process_service_inference", "enabled"), true)
+	} else {
+		applyDefault(cfg, spNS("process_service_inference", "enabled"), false)
+	}
+
 	applyDefault(cfg, spNS("process_service_inference", "use_windows_service_name"), true)
 	applyDefault(cfg, smNS("enable_ring_buffers"), true)
 	applyDefault(cfg, smNS("max_postgres_stats_buffered"), 100000)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -1697,6 +1698,24 @@ system_probe_config:
   process_service_inference:
     enabled: true`)
 		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+	})
+
+	t.Run("test platform specific defaults", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		// usm or npm must be enabled for the process_service_inference to be enabled
+		cfg := modelCfgFromYAML(t, `
+service_monitoring_config:
+  enabled: true`)
+		sysconfig.Adjust(cfg)
+
+		var expected bool
+		if runtime.GOOS == "windows" {
+			expected = true
+		} else {
+			expected = false
+		}
+
+		require.Equal(t, expected, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 }
 

--- a/releasenotes/notes/winserviceinferencedefault-d7cf74082c7b6fcb.yaml
+++ b/releasenotes/notes/winserviceinferencedefault-d7cf74082c7b6fcb.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    On Windows, the default value for the service inference feature is now enabled.


### PR DESCRIPTION
…to be true

On Windows, the process service inference should be enabled by default if either usm or npm is enabled.


### Motivation

feature request

### Additional Notes

change will only affect windows.


### Describe how to test/QA your changes

Tests provided.