### PR TITLE
Decrease Serverless Perf Threshold Back to 20s

### DIFF
--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-STARTUP_TIME_THRESHOLD=40
+STARTUP_TIME_THRESHOLD=20
 
 calculate_median() {
     local sorted=($(printf "%s\n" "${@}" | sort -n))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Decrease startup time threshold in Serverless Cold Start Integration test from 40s to 20s.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Follows https://github.com/DataDog/datadog-agent/pull/25199

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Threshold was increased temporarily to reduce noise. Now that these tests are stable again we can decrease back to the previous threshold.

<img width="1766" alt="Screenshot 2024-07-16 at 3 21 32 PM" src="https://github.com/user-attachments/assets/fabec4b0-ae56-4209-a045-3820ebdf0d00">

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
