### PR TITLE
[npcollector] Skip loopback IPs

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -97,22 +97,22 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
 
 	npCollector.runTraceroute = func(cfg traceroute.Config, _ telemetry.Component) (payload.NetworkPath, error) {
 		var p payload.NetworkPath
-		if cfg.DestHostname == "127.0.0.2" {
+		if cfg.DestHostname == "10.0.0.2" {
 			p = payload.NetworkPath{
 				Protocol:    payload.ProtocolUDP,
 				Source:      payload.NetworkPathSource{Hostname: "abc"},
-				Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "127.0.0.2", Port: 80},
+				Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "10.0.0.2", Port: 80},
 				Hops: []payload.NetworkPathHop{
 					{Hostname: "hop_1", IPAddress: "1.1.1.1"},
 					{Hostname: "hop_2", IPAddress: "1.1.1.2"},
 				},
 			}
 		}
-		if cfg.DestHostname == "127.0.0.4" {
+		if cfg.DestHostname == "10.0.0.4" {
 			p = payload.NetworkPath{
 				Protocol:    payload.ProtocolUDP,
 				Source:      payload.NetworkPathSource{Hostname: "abc"},
-				Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "127.0.0.4", Port: 80},
+				Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "10.0.0.4", Port: 80},
 				Hops: []payload.NetworkPathHop{
 					{Hostname: "hop_1", IPAddress: "1.1.1.3"},
 					{Hostname: "hop_2", IPAddress: "1.1.1.4"},
@@ -136,7 +136,7 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
     },
     "destination": {
         "hostname": "abc",
-        "ip_address": "127.0.0.2",
+        "ip_address": "10.0.0.2",
         "port": 80
     },
     "hops": [
@@ -168,7 +168,7 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
     },
     "destination": {
         "hostname": "abc",
-        "ip_address": "127.0.0.4",
+        "ip_address": "10.0.0.4",
         "port": 80
     },
     "hops": [
@@ -200,14 +200,14 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
 	// WHEN
 	conns := []*model.Connection{
 		{
-			Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000), ContainerId: "testId1"},
-			Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+			Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000), ContainerId: "testId1"},
+			Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 			Direction: model.ConnectionDirection_outgoing,
 			Type:      model.ConnectionType_tcp,
 		},
 		{
-			Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId2"},
-			Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+			Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId2"},
+			Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 			Direction: model.ConnectionDirection_outgoing,
 			Type:      model.ConnectionType_udp,
 		},
@@ -245,14 +245,14 @@ func Test_NpCollector_ScheduleConns_ScheduleDurationMetric(t *testing.T) {
 
 	conns := []*model.Connection{
 		{
-			Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000), ContainerId: "testId1"},
-			Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+			Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000), ContainerId: "testId1"},
+			Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 			Direction: model.ConnectionDirection_outgoing,
 			Type:      model.ConnectionType_tcp,
 		},
 		{
-			Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId2"},
-			Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+			Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId2"},
+			Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 			Direction: model.ConnectionDirection_outgoing,
 			Type:      model.ConnectionType_udp,
 		},
@@ -337,14 +337,14 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			agentConfigs: defaultagentConfigs,
 			conns: []*model.Connection{
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId1"},
-					Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId1"},
+					Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 					Direction: model.ConnectionDirection_outgoing,
 					Type:      model.ConnectionType_tcp,
 				},
 			},
 			expectedPathtests: []*common.Pathtest{
-				{Hostname: "127.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId1"},
+				{Hostname: "10.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId1"},
 			},
 		},
 		{
@@ -352,14 +352,14 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			agentConfigs: defaultagentConfigs,
 			conns: []*model.Connection{
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.5", Port: int32(30000), ContainerId: "testId1"},
-					Raddr:     &model.Addr{Ip: "127.0.0.6", Port: int32(161)},
+					Laddr:     &model.Addr{Ip: "10.0.0.5", Port: int32(30000), ContainerId: "testId1"},
+					Raddr:     &model.Addr{Ip: "10.0.0.6", Port: int32(161)},
 					Direction: model.ConnectionDirection_outgoing,
 					Type:      model.ConnectionType_udp,
 				},
 			},
 			expectedPathtests: []*common.Pathtest{
-				{Hostname: "127.0.0.6", Port: uint16(161), Protocol: "udp", SourceContainerID: "testId1"},
+				{Hostname: "10.0.0.6", Port: uint16(161), Protocol: "udp", SourceContainerID: "testId1"},
 			},
 		},
 		{
@@ -367,14 +367,14 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			agentConfigs: defaultagentConfigs,
 			conns: []*model.Connection{
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000), ContainerId: "testId1"},
-					Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000), ContainerId: "testId1"},
+					Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 					Direction: model.ConnectionDirection_incoming,
 					Type:      model.ConnectionType_tcp,
 				},
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId2"},
-					Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId2"},
+					Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 					Direction: model.ConnectionDirection_incoming,
 					Type:      model.ConnectionType_tcp,
 				},
@@ -386,20 +386,20 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			agentConfigs: defaultagentConfigs,
 			conns: []*model.Connection{
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000), ContainerId: "testId1"},
-					Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000), ContainerId: "testId1"},
+					Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 					Direction: model.ConnectionDirection_incoming,
 					Type:      model.ConnectionType_tcp,
 				},
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId2"},
-					Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId2"},
+					Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 					Direction: model.ConnectionDirection_outgoing,
 					Type:      model.ConnectionType_tcp,
 				},
 			},
 			expectedPathtests: []*common.Pathtest{
-				{Hostname: "127.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId2"},
+				{Hostname: "10.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId2"},
 			},
 		},
 		{
@@ -408,8 +408,8 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			noInputChan:  true,
 			conns: []*model.Connection{
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId1"},
-					Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId1"},
+					Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 					Direction: model.ConnectionDirection_outgoing,
 					Type:      model.ConnectionType_tcp,
 				},
@@ -450,14 +450,14 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 					Type:      model.ConnectionType_tcp,
 				},
 				{
-					Laddr:     &model.Addr{Ip: "127.0.0.3", Port: int32(30000), ContainerId: "testId3"},
-					Raddr:     &model.Addr{Ip: "127.0.0.4", Port: int32(80)},
+					Laddr:     &model.Addr{Ip: "10.0.0.3", Port: int32(30000), ContainerId: "testId3"},
+					Raddr:     &model.Addr{Ip: "10.0.0.4", Port: int32(80)},
 					Direction: model.ConnectionDirection_outgoing,
 					Type:      model.ConnectionType_tcp,
 				},
 			},
 			expectedPathtests: []*common.Pathtest{
-				{Hostname: "127.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId3"},
+				{Hostname: "10.0.0.4", Port: uint16(80), Protocol: "tcp", SourceContainerID: "testId3"},
 			},
 			expectedLogs: []logCount{},
 		},
@@ -647,14 +647,14 @@ func Test_npCollectorImpl_sendTelemetry(t *testing.T) {
 	npCollector.metricSender = metricsender.NewMetricSenderStatsd(stats)
 	path := payload.NetworkPath{
 		Source:      payload.NetworkPathSource{Hostname: "abc"},
-		Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "127.0.0.2", Port: 80},
+		Destination: payload.NetworkPathDestination{Hostname: "abc", IPAddress: "10.0.0.2", Port: 80},
 		Hops: []payload.NetworkPathHop{
 			{Hostname: "hop_1", IPAddress: "1.1.1.1"},
 			{Hostname: "hop_2", IPAddress: "1.1.1.2"},
 		},
 	}
 	ptestCtx := &pathteststore.PathtestContext{
-		Pathtest: &common.Pathtest{Hostname: "127.0.0.2", Port: 80},
+		Pathtest: &common.Pathtest{Hostname: "10.0.0.2", Port: 80},
 	}
 	ptestCtx.SetLastFlushInterval(2 * time.Minute)
 	npCollector.TimeNowFn = MockTimeNow

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
@@ -62,8 +62,8 @@ func createConns(numberOfConns int) []*model.Connection {
 	var conns []*model.Connection
 	for i := 0; i < numberOfConns; i++ {
 		conns = append(conns, &model.Connection{
-			Laddr:     &model.Addr{Ip: fmt.Sprintf("127.0.0.%d", i), Port: int32(30000)},
-			Raddr:     &model.Addr{Ip: fmt.Sprintf("127.0.1.%d", i), Port: int32(80)},
+			Laddr:     &model.Addr{Ip: fmt.Sprintf("10.0.0.%d", i), Port: int32(30000)},
+			Raddr:     &model.Addr{Ip: fmt.Sprintf("10.0.1.%d", i), Port: int32(80)},
 			Direction: model.ConnectionDirection_outgoing,
 		})
 	}

--- a/comp/networkpath/npcollector/npcollectorimpl/utils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils.go
@@ -15,8 +15,8 @@ func shouldScheduleNetworkPathForConn(conn *model.Connection) bool {
 	if conn == nil || conn.Direction != model.ConnectionDirection_outgoing {
 		return false
 	}
-	ip := net.ParseIP(conn.Raddr.Ip)
-	if ip.IsLoopback() {
+	remoteIP := net.ParseIP(conn.Raddr.Ip)
+	if remoteIP.IsLoopback() {
 		return false
 	}
 	return conn.Family == model.ConnectionFamily_v4

--- a/comp/networkpath/npcollector/npcollectorimpl/utils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils.go
@@ -5,10 +5,18 @@
 
 package npcollectorimpl
 
-import model "github.com/DataDog/agent-payload/v5/process"
+import (
+	"net"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+)
 
 func shouldScheduleNetworkPathForConn(conn *model.Connection) bool {
 	if conn == nil || conn.Direction != model.ConnectionDirection_outgoing {
+		return false
+	}
+	ip := net.ParseIP(conn.Raddr.Ip)
+	if ip.IsLoopback() {
 		return false
 	}
 	return conn.Family == model.ConnectionFamily_v4

--- a/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
@@ -63,6 +63,7 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 				Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000)},
 				Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
+				Family:    model.ConnectionFamily_v4,
 			},
 			shouldSchedule: false,
 		},

--- a/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
@@ -21,8 +21,8 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 		{
 			name: "should schedule",
 			conn: &model.Connection{
-				Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000)},
-				Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
 			},
 			shouldSchedule: true,
@@ -30,8 +30,8 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 		{
 			name: "should not schedule incoming conn",
 			conn: &model.Connection{
-				Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000)},
-				Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_incoming,
 				Family:    model.ConnectionFamily_v4,
 			},
@@ -40,8 +40,8 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 		{
 			name: "should not schedule conn with none direction",
 			conn: &model.Connection{
-				Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000)},
-				Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_none,
 				Family:    model.ConnectionFamily_v4,
 			},
@@ -50,10 +50,19 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 		{
 			name: "should not schedule ipv6",
 			conn: &model.Connection{
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
+				Direction: model.ConnectionDirection_outgoing,
+				Family:    model.ConnectionFamily_v6,
+			},
+			shouldSchedule: false,
+		},
+		{
+			name: "should not schedule for loopback",
+			conn: &model.Connection{
 				Laddr:     &model.Addr{Ip: "127.0.0.1", Port: int32(30000)},
 				Raddr:     &model.Addr{Ip: "127.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
-				Family:    model.ConnectionFamily_v6,
 			},
 			shouldSchedule: false,
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

[npcollector] Skip loopback IPs

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

1/ Tracerouting lookback IPs has low value, hence we are skipping them for now.

2/ Tracerouting leads to sending IPv4 payload like `"NSMNC\x00E\x8e"` crafted by dublin-traceroute (https://github.com/insomniacslk/dublin-traceroute/blob/master/go/dublintraceroute/probes/probev4/udpv4.go#L81) and causes error logs in Dogstatsd.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
