### PR TITLE
fix(fleet): Remove tests race condition for the APM socket

### DIFF
--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -36,6 +36,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
+	s.host.WaitForFileExists(true, "/var/run/datadog/apm.socket")
 
 	s.host.StartExamplePythonApp()
 	defer s.host.StopExamplePythonApp()
@@ -213,7 +214,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 	)
 	defer s.purgeInjectorDebInstall()
 
-	// OCI musn't be overridden
+	// OCI mustn't be overridden
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath()
 	s.assertDockerdInstrumented(injectOCIPath)
@@ -229,6 +230,7 @@ func (s *packageApmInjectSuite) TestVersionBump() {
 	)
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
+	s.host.WaitForFileExists(true, "/var/run/datadog/apm.socket")
 
 	state := s.host.State()
 	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.8.5", 0755, "root", "root")
@@ -251,6 +253,8 @@ func (s *packageApmInjectSuite) TestVersionBump() {
 		envForceInstall("datadog-agent"),
 		envForceVersion("datadog-apm-inject", "0.16.0-1"),
 	)
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
+	s.host.WaitForFileExists(true, "/var/run/datadog/apm.socket")
 
 	// Today we expect the previous dir to be fully removed and the new one to be symlinked
 	state = s.host.State()


### PR DESCRIPTION
### What does this PR do?
Fixes a race condition where we start an app expecting it to send traces before the trace agent has had the time to create the APM socket

### Motivation
Flaky tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
