### PR TITLE
Fix ExtraTags mapping for CollectorManifest

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
@@ -50,6 +50,7 @@ type ManifestBufferConfig struct {
 	BufferedManifestEnabled     bool
 	MaxBufferedManifests        int
 	ManifestBufferFlushInterval time.Duration
+	ExtraTags                   []string
 }
 
 // ManifestBuffer is a buffer of manifest sent from all collectors
@@ -76,6 +77,7 @@ func NewManifestBuffer(chk *OrchestratorCheck) *ManifestBuffer {
 			BufferedManifestEnabled:     chk.orchestratorConfig.BufferedManifestEnabled,
 			MaxBufferedManifests:        chk.orchestratorConfig.MaxPerMessage,
 			ManifestBufferFlushInterval: chk.orchestratorConfig.ManifestBufferFlushInterval,
+			ExtraTags:                   chk.orchestratorConfig.ExtraTags,
 		},
 		ManifestChan: make(chan interface{}),
 		stopCh:       make(chan struct{}),
@@ -95,6 +97,7 @@ func (cb *ManifestBuffer) flushManifest(sender sender.Sender) {
 				KubeClusterName:          cb.Cfg.KubeClusterName,
 				MaxPerMessage:            cb.Cfg.MaxPerMessage,
 				MaxWeightPerMessageBytes: cb.Cfg.MaxWeightPerMessageBytes,
+				ExtraTags:                cb.Cfg.ExtraTags,
 			},
 			ClusterID: cb.Cfg.ClusterID,
 		},

--- a/releasenotes/notes/fix-extra-tags-48b9ba73793de430.yaml
+++ b/releasenotes/notes/fix-extra-tags-48b9ba73793de430.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix ExtraTags mapping for CollectorManifest.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We need to include tags such as `datacenter` `env` and `cloud_provider` in our manifests
A mapping of our ExtraTags was missing, I fixed it in this pull.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
