### PR TITLE
Install datadog-agent in KMT VMs

### DIFF
--- a/tasks/kernel_matrix_testing/ddagent-build-layout.json
+++ b/tasks/kernel_matrix_testing/ddagent-build-layout.json
@@ -1,0 +1,7 @@
+{
+    "layout": [],
+    "copy": {
+        "tasks/kernel_matrix_testing/default-openmetrics.yaml": "/etc/datadog-agent/conf.d/openmetrics.d/conf.yaml"
+    },
+    "run": []
+}

--- a/tasks/kernel_matrix_testing/default-datadog.yaml
+++ b/tasks/kernel_matrix_testing/default-datadog.yaml
@@ -1,4 +1,3 @@
-hostname: ddvm
 dd_url: https://dddev.datadoghq.com
 tags:
   - "service:kernel-matrix-testing"

--- a/tasks/kernel_matrix_testing/default-datadog.yaml
+++ b/tasks/kernel_matrix_testing/default-datadog.yaml
@@ -1,0 +1,5 @@
+hostname: ddvm
+dd_url: https://dddev.datadoghq.com
+tags:
+  - "service:kernel-matrix-testing"
+

--- a/tasks/kernel_matrix_testing/default-openmetrics.yaml
+++ b/tasks/kernel_matrix_testing/default-openmetrics.yaml
@@ -1,0 +1,8 @@
+init_config:
+instances:
+  -
+    openmetrics_endpoint: http://localhost:6666/telemetry
+    namespace: datadog.system-probe
+    metrics: [".*"]
+    tags:
+      - "image_tag:kernel-matrix-testing"

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -146,7 +146,7 @@ class LibvirtDomain:
     ):
         run = self._get_rsync_base(exclude) + f" root@{self.ip}:{source} {target}"
         res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
-        if res :
+        if res:
             info(f"[+] (VM: {source}) => (HOST: {target})")
         return res
 

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -130,7 +130,11 @@ class LibvirtDomain:
         self.run_cmd(ctx, f"mkdir -p {os.path.dirname(target)}", verbose=verbose)
 
         run = self._get_rsync_base(exclude) + f" {source} root@{self.ip}:{target}"
-        return self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
+        res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
+        if res:
+            info(f"[+] (HOST: {source}) => (VM: {target})")
+
+        return res
 
     def download(
         self,
@@ -141,7 +145,10 @@ class LibvirtDomain:
         verbose: bool = False,
     ):
         run = self._get_rsync_base(exclude) + f" root@{self.ip}:{source} {target}"
-        return self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
+        res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
+        if res :
+            info(f"[+] (VM: {source}) => (HOST: {target})")
+        return res
 
     def __repr__(self):
         return f"<LibvirtDomain> {self.name} {self.ip}"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1960,7 +1960,7 @@ def wait_for_setup_job(ctx: Context, pipeline_id: int, arch: str | Arch, compone
 # starting the agent. The following solution is taken from
 # https://stackoverflow.com/questions/25108581/python-yaml-dump-bad-indentation
 class IndentedDumper(yaml.Dumper):
-    def increase_indent(self, flow=False, indentless=False):
+    def increase_indent(self, flow=False):
         return super().increase_indent(flow, False)
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR provides a task to install the datadog-agent on KMT VMs.
It also provides an option in `kmt.build` to override the system-probe/security-agent binary in the datadog-agent package. This allows a user to run the full datadog-agent with a local copy of system-probe/security-agent.

The PR also provides an option to allow the user to specify a script to run after VM creation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Allow system-probe running in KMT VMs to send data to the backend.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
