### PR TITLE
Do not notify when jobs are allowed to fail - ACIX-324

### DIFF
--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -58,7 +58,7 @@ def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> dic
     return messages_to_send
 
 
-def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_type, print_to_stdout):
+def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_type, dry_run):
     # From the job failures, set whether the pipeline succeeded or failed and craft the
     # base message that will be sent.
     if failed_jobs.all_mandatory_failures():  # At least one mandatory job failed
@@ -89,7 +89,7 @@ def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_ty
             channel = CHANNEL_PIPELINES
             message.base_message += UNKNOWN_OWNER_TEMPLATE.format(owner=owner)
         message.coda = coda
-        if print_to_stdout:
+        if dry_run:
             print(f"Would send to {channel}:\n{str(message)}")
         else:
             all_teams = channel == CHANNEL_PIPELINES
@@ -120,5 +120,5 @@ def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_ty
                 recipient = email_to_slackid(ctx, author_email)
                 send_slack_message(recipient, str(message))
 
-    if metrics:
+    if metrics and not dry_run:
         send_metrics(metrics)

--- a/tasks/libs/types/types.py
+++ b/tasks/libs/types/types.py
@@ -105,9 +105,7 @@ class FailedJobs:
 
 class SlackMessage:
     JOBS_SECTION_HEADER = "Failed jobs:"
-    OPTIONAL_JOBS_SECTION_HEADER = "Failed jobs (allowed to fail):"
     INFRA_SECTION_HEADER = "Infrastructure failures:"
-    OPTIONAL_INFRA_SECTION_HEADER = "Infrastructure failures (allowed to fail):"
     TEST_SECTION_HEADER = "Failed unit tests:"
     MAX_JOBS_PER_TEST = 2
 
@@ -164,18 +162,8 @@ class SlackMessage:
             buffer,
         )
         self.__render_jobs_section(
-            self.OPTIONAL_JOBS_SECTION_HEADER,
-            self.failed_jobs.optional_job_failures,
-            buffer,
-        )
-        self.__render_jobs_section(
             self.INFRA_SECTION_HEADER,
             self.failed_jobs.mandatory_infra_job_failures,
-            buffer,
-        )
-        self.__render_jobs_section(
-            self.OPTIONAL_INFRA_SECTION_HEADER,
-            self.failed_jobs.optional_infra_job_failures,
             buffer,
         )
         if self.failed_tests:
@@ -187,5 +175,4 @@ class SlackMessage:
 
 class TeamMessage(SlackMessage):
     JOBS_SECTION_HEADER = "Failed jobs you own:"
-    OPTIONAL_JOBS_SECTION_HEADER = "Failed jobs (allowed to fail) you own:"
     TEST_SECTION_HEADER = "Failed unit tests you own:"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Removes notifications for allowed to fail jobs for `#datadog-agent-pipelines`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
