### PR TITLE
[ASCII-1983] Remove global variable from diagnose e2e test to enable running in parallel

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -203,9 +203,7 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)HealthSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)HostnameSuite"
-      # TODO: To regroup when the DiagnoseSuite support parallel #ASCII-1983
-      - EXTRA_PARAMS: --run "TestLinuxDiagnoseSuite"
-      - EXTRA_PARAMS: --run "TestWindowsDiagnoseSuite"
+      - EXTRA_PARAMS: --run "Test(Linux|Windows)DiagnoseSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)ConfigCheckSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)FlareSuite"
       - EXTRA_PARAMS: --run "Test(Linux|Windows)SecretSuite"

--- a/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_common_test.go
@@ -22,9 +22,11 @@ import (
 
 type baseDiagnoseSuite struct {
 	e2e.BaseSuite[environments.Host]
+
+	suites []string
 }
 
-var allSuites = []string{
+var commonSuites = []string{
 	"check-datadog",
 	"connectivity-datadog-autodiscovery",
 	"connectivity-datadog-core-endpoints",
@@ -61,7 +63,7 @@ func (v *baseDiagnoseSuite) TestDiagnoseLocal() {
 
 func (v *baseDiagnoseSuite) TestDiagnoseList() {
 	diagnose := getDiagnoseOutput(v, agentclient.WithArgs([]string{"--list"}))
-	for _, suite := range allSuites {
+	for _, suite := range v.suites {
 		assert.Contains(v.T(), diagnose, suite)
 	}
 }
@@ -69,7 +71,7 @@ func (v *baseDiagnoseSuite) TestDiagnoseList() {
 func (v *baseDiagnoseSuite) AssertDiagnoseInclude() {
 	diagnose := getDiagnoseOutput(v)
 	diagnoseSummary := getDiagnoseSummary(diagnose)
-	for _, suite := range allSuites {
+	for _, suite := range v.suites {
 		diagnoseInclude := getDiagnoseOutput(v, agentclient.WithArgs([]string{"--include", suite}))
 		resultInclude := getDiagnoseSummary(diagnoseInclude)
 
@@ -79,7 +81,7 @@ func (v *baseDiagnoseSuite) AssertDiagnoseInclude() {
 	}
 
 	// Create an args array to include all suites
-	includeArgs := strings.Split("--include "+strings.Join(allSuites, " --include "), " ")
+	includeArgs := strings.Split("--include "+strings.Join(v.suites, " --include "), " ")
 
 	// Diagnose with all suites included should be equal to diagnose without args
 	diagnoseIncludeEverySuite := getDiagnoseOutput(v, agentclient.WithArgs(includeArgs))
@@ -88,7 +90,7 @@ func (v *baseDiagnoseSuite) AssertDiagnoseInclude() {
 }
 
 func (v *baseDiagnoseSuite) AssertDiagnoseExclude() {
-	for _, suite := range allSuites {
+	for _, suite := range v.suites {
 		diagnoseExclude := getDiagnoseOutput(v, agentclient.WithArgs([]string{"--exclude", suite}))
 		resultExclude := getDiagnoseSummary(diagnoseExclude)
 
@@ -97,7 +99,7 @@ func (v *baseDiagnoseSuite) AssertDiagnoseExclude() {
 	}
 
 	// Create an args array to exclude all suites
-	excludeArgs := strings.Split("--exclude "+strings.Join(allSuites, " --exclude "), " ")
+	excludeArgs := strings.Split("--exclude "+strings.Join(v.suites, " --exclude "), " ")
 
 	// Diagnose with all suites excluded should do nothing
 	diagnoseExcludeEverySuite := getDiagnoseOutput(v, agentclient.WithArgs(excludeArgs))

--- a/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_nix_test.go
@@ -7,7 +7,6 @@
 package diagnose
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
@@ -24,7 +23,10 @@ type linuxDiagnoseSuite struct {
 
 func TestLinuxDiagnoseSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &linuxDiagnoseSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
+	var suite linuxDiagnoseSuite
+	suite.suites = append(suite.suites, commonSuites...)
+	suite.suites = append(suite.suites, "port-conflict")
+	e2e.Run(t, &suite, e2e.WithProvisioner(awshost.Provisioner()))
 }
 
 func (v *linuxDiagnoseSuite) TestDiagnoseOtherCmdPort() {
@@ -47,15 +49,9 @@ func (v *linuxDiagnoseSuite) TestDiagnoseLocalFallback() {
 }
 
 func (v *linuxDiagnoseSuite) TestDiagnoseInclude() {
-	if !slices.Contains(allSuites, "port-conflict") {
-		allSuites = append(allSuites, "port-conflict")
-	}
 	v.AssertDiagnoseInclude()
 }
 
 func (v *linuxDiagnoseSuite) TestDiagnoseExclude() {
-	if !slices.Contains(allSuites, "port-conflict") {
-		allSuites = append(allSuites, "port-conflict")
-	}
 	v.AssertDiagnoseInclude()
 }

--- a/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/diagnose/diagnose_win_test.go
@@ -23,7 +23,9 @@ type windowsDiagnoseSuite struct {
 
 func TestWindowsDiagnoseSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &windowsDiagnoseSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
+	var suite windowsDiagnoseSuite
+	suite.suites = append(suite.suites, commonSuites...)
+	e2e.Run(t, &suite, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 
 func (v *windowsDiagnoseSuite) TestDiagnoseOtherCmdPort() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove a global variable from the diagnose e2e test, and enable running the test in parallel on Windows and Linux.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Run the diagnose e2e test in parallel on Windows and Linux.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
