### PR TITLE
[CSM] Fix syscall dirty flag after execve

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -513,16 +513,7 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 		c.ActivityDumpTracedCgroupsCount = model.MaxTracedCgroupsCount
 	}
 
-	hasProfileStorageFormat := false
-	for _, format := range c.ActivityDumpLocalStorageFormats {
-		hasProfileStorageFormat = hasProfileStorageFormat || format == Profile
-	}
-
-	if c.SecurityProfileEnabled && !hasProfileStorageFormat {
-		return fmt.Errorf("'profile' storage format has to be enabled when using security profiles, got only formats: %v", c.ActivityDumpLocalStorageFormats)
-	}
-
-	if c.SecurityProfileEnabled && c.ActivityDumpLocalStorageDirectory != c.SecurityProfileDir {
+	if c.SecurityProfileEnabled && c.ActivityDumpEnabled && c.ActivityDumpLocalStorageDirectory != c.SecurityProfileDir {
 		return fmt.Errorf("activity dumps storage directory '%s' has to be the same than security profile storage directory '%s'", c.ActivityDumpLocalStorageDirectory, c.SecurityProfileDir)
 	}
 

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -303,10 +303,8 @@ struct syscall_monitor_event_t {
     struct span_context_t span;
     struct container_context_t container;
 
-    union {
-        struct syscall_monitor_entry_t syscalls;
-        long syscall_id;
-    } syscall_data;
+    u64 event_reason;
+    char syscalls[SYSCALL_ENCODING_TABLE_SIZE];
 };
 
 struct rename_event_t {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -54,6 +54,7 @@ type PlatformProbe interface {
 	DumpProcessCache(_ bool) (string, error)
 	AddDiscarderPushedCallback(_ DiscarderPushedCallback)
 	GetEventTags(_ string) []string
+	GetProfileManager() interface{}
 }
 
 // EventHandler represents a handler for events sent by the probe that needs access to all the fields in the SECL model

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -80,6 +80,11 @@ type EBPFLessProbe struct {
 	wg            sync.WaitGroup
 }
 
+// GetProfileManager returns the Profile Managers
+func (p *EBPFLessProbe) GetProfileManager() interface{} {
+	return nil
+}
+
 func (p *EBPFLessProbe) handleClientMsg(cl *client, msg *ebpfless.Message) {
 	switch msg.Type {
 	case ebpfless.MessageTypeHello:

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -207,6 +207,11 @@ func (p *WindowsProbe) Init() error {
 	return p.initEtwFIM()
 }
 
+// GetProfileManager returns the Profile Managers
+func (p *WindowsProbe) GetProfileManager() interface{} {
+	return nil
+}
+
 func (p *WindowsProbe) initEtwFIM() error {
 
 	if !p.config.RuntimeSecurity.FIMEnabled {

--- a/pkg/security/probe/security_profile.go
+++ b/pkg/security/probe/security_profile.go
@@ -134,6 +134,11 @@ func (spm *SecurityProfileManagers) GetActivityDumpTracedEventTypes() []model.Ev
 	return spm.config.RuntimeSecurity.ActivityDumpTracedEventTypes
 }
 
+// GetAnomalyDetectionEventTypes returns the event types that may generate anomaly detections
+func (spm *SecurityProfileManagers) GetAnomalyDetectionEventTypes() []model.EventType {
+	return spm.config.RuntimeSecurity.AnomalyDetectionEventTypes
+}
+
 // SnapshotTracedCgroups snapshots traced cgroups
 func (spm *SecurityProfileManagers) SnapshotTracedCgroups() {
 	spm.activityDumpManager.SnapshotTracedCgroups()

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -342,6 +342,30 @@ const (
 	UpperLayer
 )
 
+// SyscallDriftEventReason describes why a syscall drift event was sent
+type SyscallDriftEventReason uint64
+
+const (
+	// SyscallMonitorPeriodReason means that the event was sent because the syscall cache entry was dirty for longer than syscall_monitor.period
+	SyscallMonitorPeriodReason SyscallDriftEventReason = iota + 1
+	// ExitReason means that the event was sent because a pid that was about to exit had a dirty cache entry
+	ExitReason
+	// ExecveReason means that the event was sent because an execve syscall was detected on a pid with a dirty cache entry
+	ExecveReason
+)
+
+func (r SyscallDriftEventReason) String() string {
+	switch r {
+	case SyscallMonitorPeriodReason:
+		return "MonitorPeriod"
+	case ExecveReason:
+		return "Execve"
+	case ExitReason:
+		return "Exit"
+	}
+	return "Unknown"
+}
+
 func initErrorConstants() {
 	for k, v := range errorConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: v}

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -1037,30 +1037,6 @@ func bitmaskU64ToString(bitmask uint64, intToStrMap map[uint64]string) string {
 	return strings.Join(bitmaskU64ToStringArray(bitmask, intToStrMap), " | ")
 }
 
-// SyscallDriftEventReason describes why a syscall drift event was sent
-type SyscallDriftEventReason uint64
-
-const (
-	// SyscallMonitorPeriodReason means that the event was sent because the syscall cache entry was dirty for longer than syscall_monitor.period
-	SyscallMonitorPeriodReason SyscallDriftEventReason = iota + 1
-	// ExitReason means that the event was sent because a pid that was about to exit had a dirty cache entry
-	ExitReason
-	// ExecveReason means that the event was sent because an execve syscall was detected on a pid with a dirty cache entry
-	ExecveReason
-)
-
-func (r SyscallDriftEventReason) String() string {
-	switch r {
-	case SyscallMonitorPeriodReason:
-		return "MonitorPeriod"
-	case ExecveReason:
-		return "Execve"
-	case ExitReason:
-		return "Exit"
-	}
-	return "Unknown"
-}
-
 // OpenFlags represents an open flags bitmask value
 type OpenFlags int
 

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -1037,6 +1037,30 @@ func bitmaskU64ToString(bitmask uint64, intToStrMap map[uint64]string) string {
 	return strings.Join(bitmaskU64ToStringArray(bitmask, intToStrMap), " | ")
 }
 
+// SyscallDriftEventReason describes why a syscall drift event was sent
+type SyscallDriftEventReason uint64
+
+const (
+	// SyscallMonitorPeriodReason means that the event was sent because the syscall cache entry was dirty for longer than syscall_monitor.period
+	SyscallMonitorPeriodReason SyscallDriftEventReason = iota + 1
+	// ExitReason means that the event was sent because a pid that was about to exit had a dirty cache entry
+	ExitReason
+	// ExecveReason means that the event was sent because an execve syscall was detected on a pid with a dirty cache entry
+	ExecveReason
+)
+
+func (r SyscallDriftEventReason) String() string {
+	switch r {
+	case SyscallMonitorPeriodReason:
+		return "MonitorPeriod"
+	case ExecveReason:
+		return "Execve"
+	case ExitReason:
+		return "Exit"
+	}
+	return "Unknown"
+}
+
 // OpenFlags represents an open flags bitmask value
 type OpenFlags int
 

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -54,9 +54,6 @@ type Event struct {
 	Exit     ExitEvent     `field:"exit" event:"exit"`     // [7.38] [Process] A process was terminated
 	Syscalls SyscallsEvent `field:"-"`
 
-	// anomaly detection related events
-	AnomalyDetectionSyscallEvent AnomalyDetectionSyscallEvent `field:"-"`
-
 	// kernel events
 	SELinux      SELinuxEvent      `field:"selinux" event:"selinux"`             // [7.30] [Kernel] An SELinux operation was run
 	BPF          BPFEvent          `field:"bpf" event:"bpf"`                     // [7.33] [Kernel] A BPF command was executed
@@ -647,12 +644,8 @@ type VethPairEvent struct {
 
 // SyscallsEvent represents a syscalls event
 type SyscallsEvent struct {
-	Syscalls []Syscall // 64 * 8 = 512 > 450, bytes should be enough to hold all 450 syscalls
-}
-
-// AnomalyDetectionSyscallEvent represents an anomaly detection for a syscall event
-type AnomalyDetectionSyscallEvent struct {
-	SyscallID Syscall
+	EventReason SyscallDriftEventReason
+	Syscalls    []Syscall // 64 * 8 = 512 > 450, bytes should be enough to hold all 450 syscalls
 }
 
 // PathKey identifies an entry in the dentry cache

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1230,11 +1230,13 @@ func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *SyscallsEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 64 {
+	if len(data) < 72 {
 		return 0, ErrNotEnoughData
 	}
 
-	for i, b := range data[:64] {
+	e.EventReason = SyscallDriftEventReason(binary.NativeEndian.Uint64(data[0:8]))
+
+	for i, b := range data[8:72] {
 		// compute the ID of the syscall
 		for j := 0; j < 8; j++ {
 			if b&(1<<j) > 0 {
@@ -1242,17 +1244,7 @@ func (e *SyscallsEvent) UnmarshalBinary(data []byte) (int, error) {
 			}
 		}
 	}
-	return 64, nil
-}
-
-// UnmarshalBinary unmarshalls a binary representation of itself
-func (e *AnomalyDetectionSyscallEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 8 {
-		return 0, ErrNotEnoughData
-	}
-
-	e.SyscallID = Syscall(binary.NativeEndian.Uint64(data[0:8]))
-	return 8, nil
+	return 72, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers_test.go
+++ b/pkg/security/secl/model/unmarshallers_test.go
@@ -33,7 +33,7 @@ mainLoop:
 func allSyscallsTest() syscallsEventTest {
 	all := syscallsEventTest{
 		name: "all_syscalls",
-		args: make([]byte, syscallsEventByteCount),
+		args: make([]byte, syscallsEventByteCount+8),
 	}
 
 	for i := 0; i < syscallsEventByteCount*8; i++ {
@@ -42,7 +42,7 @@ func allSyscallsTest() syscallsEventTest {
 		// should be tested in eBPF...
 		index := i / 8
 		bit := byte(1 << (i % 8))
-		all.args[index] |= bit
+		all.args[index+8] |= bit
 	}
 
 	return all
@@ -51,13 +51,13 @@ func allSyscallsTest() syscallsEventTest {
 func oneSyscallTest(s Syscall) syscallsEventTest {
 	one := syscallsEventTest{
 		name: s.String(),
-		args: make([]byte, syscallsEventByteCount),
+		args: make([]byte, syscallsEventByteCount+8),
 	}
 
 	// should be tested in eBPF ...
 	index := s / 8
 	bit := byte(1 << (s % 8))
-	one.args[index] |= bit
+	one.args[index+8] |= bit
 
 	one.want = []Syscall{s}
 	return one
@@ -78,7 +78,7 @@ func TestSyscallsEvent_UnmarshalBinary(t *testing.T) {
 		},
 		{
 			name: "no_syscall",
-			args: make([]byte, 64),
+			args: make([]byte, 72),
 		},
 		allSyscallsTest(),
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -726,6 +726,10 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		runtimeSecurityEnabled = false
 	}
 
+	if opts.activityDumpSyscallMonitorPeriod == time.Duration(0) {
+		opts.activityDumpSyscallMonitorPeriod = 60 * time.Second
+	}
+
 	buffer := new(bytes.Buffer)
 	if err := tmpl.Execute(buffer, map[string]interface{}{
 		"TestPoliciesDir":                            cfgDir,
@@ -745,6 +749,7 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		"ActivityDumpLocalStorageDirectory":          opts.activityDumpLocalStorageDirectory,
 		"ActivityDumpLocalStorageCompression":        opts.activityDumpLocalStorageCompression,
 		"ActivityDumpLocalStorageFormats":            opts.activityDumpLocalStorageFormats,
+		"ActivityDumpSyscallMonitorPeriod":           opts.activityDumpSyscallMonitorPeriod,
 		"EnableSecurityProfile":                      opts.enableSecurityProfile,
 		"SecurityProfileMaxImageTags":                opts.securityProfileMaxImageTags,
 		"SecurityProfileDir":                         opts.securityProfileDir,

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -118,6 +118,8 @@ runtime_security_config:
       enabled: {{ .HostSBOMEnabled }}
   activity_dump:
     enabled: {{ .EnableActivityDump }}
+    syscall_monitor:
+      period: {{ .ActivityDumpSyscallMonitorPeriod }}
 {{if .EnableActivityDump}}
     rate_limiter: {{ .ActivityDumpRateLimiter }}
     tag_rules:

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -10,6 +10,9 @@ package tests
 
 import (
 	"errors"
+	"github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"os"
 	"slices"
 	"strings"
@@ -2072,5 +2075,468 @@ func TestSecurityProfilePersistence(t *testing.T) {
 				t.Fatal(otherErr)
 			}
 		}
+	})
+}
+
+func generateSyscallTestProfile(add ...model.Syscall) *dumpsv1.SecurityProfile {
+	syscallProfile := &dumpsv1.SecurityProfile{
+		Selector: &dumpsv1.ProfileSelector{
+			ImageName: "fake_ubuntu",
+			ImageTag:  "latest",
+		},
+		ProfileContexts: map[string]*dumpsv1.ProfileContext{
+			"latest": {
+				Syscalls: []uint32{
+					5,   // SysFstat
+					10,  // SysMprotect
+					11,  // SysMunmap
+					12,  // SysBrk
+					13,  // SysRtSigaction
+					14,  // SysRtSigprocmask
+					15,  // SysRtSigreturn
+					17,  // SysPread64
+					24,  // SysSchedYield
+					28,  // SysMadvise
+					35,  // SysNanosleep
+					39,  // SysGetpid
+					56,  // SysClone
+					63,  // SysUname
+					72,  // SysFcntl
+					79,  // SysGetcwd
+					80,  // SysChdir
+					97,  // SysGetrlimit
+					102, // SysGetuid
+					105, // SysSetuid
+					106, // SysSetgid
+					116, // SysSetgroups
+					125, // SysCapget
+					126, // SysCapset
+					131, // SysSigaltstack
+					137, // SysStatfs
+					138, // SysFstatfs
+					157, // SysPrctl
+					158, // SysArchPrctl
+					186, // SysGettid
+					202, // SysFutex
+					204, // SysSchedGetaffinity
+					217, // SysGetdents64
+					218, // SysSetTidAddress
+					233, // SysEpollCtl
+					234, // SysTgkill
+					250, // SysKeyctl
+					257, // SysOpenat
+					262, // SysNewfstatat
+					267, // SysReadlinkat
+					273, // SysSetRobustList
+					281, // SysEpollPwait
+					291, // SysEpollCreate1
+					293, // SysPipe2
+					317, // SysSeccomp
+					334, // SysRseq
+					435, // SysClone3
+					439, // SysFaccessat2
+				},
+			},
+		},
+	}
+	for _, toAdd := range add {
+		syscallProfile.ProfileContexts["latest"].Syscalls = append(syscallProfile.ProfileContexts["latest"].Syscalls, uint32(toAdd))
+	}
+	return syscallProfile
+}
+
+func TestSecurityProfileSyscallDrift(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// this test is only available on amd64
+	if utils.RuntimeArch() != "x64" {
+		t.Skip("Skip test when not running on amd64")
+	}
+
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNodeForAD() {
+		t.Skip("Skip test when not run in dedicated env")
+	}
+
+	outputDir := t.TempDir()
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
+		activityDumpSyscallMonitorPeriod:           3 * time.Second,
+		anomalyDetectionDefaultMinimumStablePeriod: 1 * time.Second,
+		anomalyDetectionEventTypes:                 []string{"exec", "syscalls"},
+		anomalyDetectionWarmupPeriod:               1 * time.Second,
+		enableSecurityProfile:                      true,
+		enableAnomalyDetection:                     true,
+		securityProfileDir:                         outputDir,
+		tagsResolver:                               NewFakeMonoResolver(),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	goSyscallTester, err := loadSyscallTester(t, test, "syscall_go_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dockerInstance *dockerCmdWrapper
+	dockerInstance, err = test.StartADocker()
+	if err != nil {
+		t.Fatalf("failed to start a Docker instance: %v", err)
+	}
+
+	testOutput := map[model.SyscallDriftEventReason]bool{
+		model.ExecveReason:               false,
+		model.ExitReason:                 false,
+		model.SyscallMonitorPeriodReason: false,
+	}
+
+	t.Run("activity-dump-syscall-drift", func(t *testing.T) {
+		if err = test.GetProbeEvent(func() error {
+			secProfileManager := test.probe.PlatformProbe.GetProfileManager().(*probe.SecurityProfileManagers).GetSecurityProfileManager()
+			secProfileManager.OnNewProfileEvent(cgroupModel.WorkloadSelector{
+				Image: "fake_ubuntu",
+				Tag:   "latest",
+			}, generateSyscallTestProfile())
+
+			time.Sleep(1 * time.Second) // ensure the profile has time to be pushed kernel space
+
+			// run the syscall drift test command
+			cmd := dockerInstance.Command(goSyscallTester, []string{"-syscall-drift-test"}, []string{})
+			_, err = cmd.CombinedOutput()
+			return err
+		}, func(event *model.Event) bool {
+			if event.GetType() == "syscalls" {
+				switch event.Syscalls.EventReason {
+				case model.ExecveReason:
+					// Context: this syscall drift event should be sent when `runc.XXXX` execs into the syscall tester.
+					// Only basic syscalls performed to prepare the execution of the syscall tester, and that are
+					// not in the profile should be here. This includes the Execve syscall itself
+					expectedSyscalls := []model.Syscall{
+						model.SysRead,
+						model.SysWrite,
+						model.SysClose,
+						model.SysMmap,
+						model.SysExecve,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A ExecveReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A ExecveReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.ExecveReason] = true
+				case model.SyscallMonitorPeriodReason:
+					// Context: this event should be sent by the openat syscall made by the syscall tester while creating the
+					// temporary file. The openat syscall itself shouldn't be in the list, since it is already in the profile.
+					// Thus, only basic syscalls performed during the start of the execution of the syscall tester, and that are
+					// not in the profile should be here.
+					expectedSyscalls := []model.Syscall{
+						model.SysRead,
+						model.SysClose,
+						model.SysMmap,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A SyscallMonitorPeriodReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A SyscallMonitorPeriodReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.SyscallMonitorPeriodReason] = true
+				case model.ExitReason:
+					// Context: this event should be sent when the syscall tester exits and the last dirty syscall cache entry
+					// is flushed to user space. This event should include only the file management syscalls that
+					// are performed by the syscall tester after the sleep, and that aren't in the profile.
+					expectedSyscalls := []model.Syscall{
+						model.SysWrite,
+						model.SysClose,
+						model.SysExitGroup,
+						model.SysUnlinkat,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A ExitReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A ExitReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.ExitReason] = true
+				default:
+					t.Errorf("unknown syscall drift event reason: %v", event.Syscalls.EventReason)
+				}
+
+				// If all 3 syscalls are OK, exit early
+				return testOutput[model.ExecveReason] && testOutput[model.ExitReason] && testOutput[model.SyscallMonitorPeriodReason]
+			}
+			return false
+		}, 20*time.Second); err != nil {
+			t.Error(err)
+		}
+
+		// Make sure all 3 syscall drift events were received
+		for key, value := range testOutput {
+			if !value {
+				t.Errorf("missing syscall drift event reason: %v", key)
+			}
+		}
+
+		dockerInstance.stop()
+	})
+}
+
+func TestSecurityProfileSyscallDriftExecExitInProfile(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// this test is only available on amd64
+	if utils.RuntimeArch() != "x64" {
+		t.Skip("Skip test when not running on amd64")
+	}
+
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNodeForAD() {
+		t.Skip("Skip test when not run in dedicated env")
+	}
+
+	outputDir := t.TempDir()
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
+		activityDumpSyscallMonitorPeriod:           3 * time.Second,
+		anomalyDetectionDefaultMinimumStablePeriod: 1 * time.Second,
+		anomalyDetectionEventTypes:                 []string{"exec", "syscalls"},
+		anomalyDetectionWarmupPeriod:               1 * time.Second,
+		enableSecurityProfile:                      true,
+		enableAnomalyDetection:                     true,
+		securityProfileDir:                         outputDir,
+		tagsResolver:                               NewFakeMonoResolver(),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	goSyscallTester, err := loadSyscallTester(t, test, "syscall_go_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dockerInstance *dockerCmdWrapper
+	dockerInstance, err = test.StartADocker()
+	if err != nil {
+		t.Fatalf("failed to start a Docker instance: %v", err)
+	}
+
+	testOutput := map[model.SyscallDriftEventReason]bool{
+		model.ExecveReason:               false,
+		model.ExitReason:                 false,
+		model.SyscallMonitorPeriodReason: false,
+	}
+
+	t.Run("activity-dump-syscall-drift", func(t *testing.T) {
+		if err = test.GetProbeEvent(func() error {
+			secProfileManager := test.probe.PlatformProbe.GetProfileManager().(*probe.SecurityProfileManagers).GetSecurityProfileManager()
+			secProfileManager.OnNewProfileEvent(cgroupModel.WorkloadSelector{
+				Image: "fake_ubuntu",
+				Tag:   "latest",
+			}, generateSyscallTestProfile(model.SysExecve, model.SysExit, model.SysExitGroup))
+
+			time.Sleep(1 * time.Second) // ensure the profile has time to be pushed kernel space
+
+			// run the syscall drift test command
+			cmd := dockerInstance.Command(goSyscallTester, []string{"-syscall-drift-test"}, []string{})
+			_, err = cmd.CombinedOutput()
+			return err
+		}, func(event *model.Event) bool {
+			if event.GetType() == "syscalls" {
+				switch event.Syscalls.EventReason {
+				case model.ExecveReason:
+					// Context: this syscall drift event should be sent when `runc.XXXX` execs into the syscall tester.
+					// Only basic syscalls performed to prepare the execution of the syscall tester, and that are
+					// not in the profile should be here. This includes the Execve syscall itself
+					expectedSyscalls := []model.Syscall{
+						model.SysRead,
+						model.SysWrite,
+						model.SysClose,
+						model.SysMmap,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A ExecveReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A ExecveReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.ExecveReason] = true
+				case model.SyscallMonitorPeriodReason:
+					// Context: this event should be sent by the openat syscall made by the syscall tester while creating the
+					// temporary file. The openat syscall itself shouldn't be in the list, since it is already in the profile.
+					// Thus, only basic syscalls performed during the start of the execution of the syscall tester, and that are
+					// not in the profile should be here.
+					expectedSyscalls := []model.Syscall{
+						model.SysRead,
+						model.SysClose,
+						model.SysMmap,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A SyscallMonitorPeriodReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A SyscallMonitorPeriodReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.SyscallMonitorPeriodReason] = true
+				case model.ExitReason:
+					// Context: this event should be sent when the syscall tester exits and the last dirty syscall cache entry
+					// is flushed to user space. This event should include only the file management syscalls that
+					// are performed by the syscall tester after the sleep, and that aren't in the profile.
+					expectedSyscalls := []model.Syscall{
+						model.SysWrite,
+						model.SysClose,
+						model.SysUnlinkat,
+					}
+					for _, s := range expectedSyscalls {
+						if !slices.Contains(event.Syscalls.Syscalls, s) {
+							t.Logf("A ExitReason syscall drift event was received with the wrong list of syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+							return false
+						}
+					}
+					if len(event.Syscalls.Syscalls) != len(expectedSyscalls) {
+						t.Logf("A ExitReason syscall drift event was received with additional syscalls. Expected %v, got %v", expectedSyscalls, event.Syscalls.Syscalls)
+						return false
+					}
+					testOutput[model.ExitReason] = true
+				default:
+					t.Errorf("unknown syscall drift event reason: %v", event.Syscalls.EventReason)
+				}
+
+				// If all 3 syscalls are OK, exit early
+				return testOutput[model.ExecveReason] && testOutput[model.ExitReason] && testOutput[model.SyscallMonitorPeriodReason]
+			}
+			return false
+		}, 20*time.Second); err != nil {
+			t.Error(err)
+		}
+
+		// Make sure all 3 syscall drift events were received
+		for key, value := range testOutput {
+			if !value {
+				t.Errorf("missing syscall drift event reason: %v", key)
+			}
+		}
+
+		dockerInstance.stop()
+	})
+}
+
+func TestSecurityProfileSyscallDriftNoNewSyscall(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// this test is only available on amd64
+	if utils.RuntimeArch() != "x64" {
+		t.Skip("Skip test when not running on amd64")
+	}
+
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNodeForAD() {
+		t.Skip("Skip test when not run in dedicated env")
+	}
+
+	outputDir := t.TempDir()
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
+		activityDumpSyscallMonitorPeriod:           3 * time.Second,
+		anomalyDetectionDefaultMinimumStablePeriod: 1 * time.Second,
+		anomalyDetectionEventTypes:                 []string{"exec", "syscalls"},
+		anomalyDetectionWarmupPeriod:               1 * time.Second,
+		enableSecurityProfile:                      true,
+		enableAnomalyDetection:                     true,
+		securityProfileDir:                         outputDir,
+		tagsResolver:                               NewFakeMonoResolver(),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	goSyscallTester, err := loadSyscallTester(t, test, "syscall_go_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dockerInstance *dockerCmdWrapper
+	dockerInstance, err = test.StartADocker()
+	if err != nil {
+		t.Fatalf("failed to start a Docker instance: %v", err)
+	}
+
+	t.Run("activity-dump-syscall-drift", func(t *testing.T) {
+		if err = test.GetProbeEvent(func() error {
+			secProfileManager := test.probe.PlatformProbe.GetProfileManager().(*probe.SecurityProfileManagers).GetSecurityProfileManager()
+			secProfileManager.OnNewProfileEvent(cgroupModel.WorkloadSelector{
+				Image: "fake_ubuntu",
+				Tag:   "latest",
+			}, generateSyscallTestProfile(
+				model.SysExecve,
+				model.SysExit,
+				model.SysExitGroup,
+				model.SysRead,
+				model.SysWrite,
+				model.SysClose,
+				model.SysMmap,
+				model.SysUnlinkat,
+			))
+
+			time.Sleep(1 * time.Second) // ensure the profile has time to be pushed kernel space
+
+			// run the syscall drift test command
+			cmd := dockerInstance.Command(goSyscallTester, []string{"-syscall-drift-test"}, []string{})
+			_, err = cmd.CombinedOutput()
+			return err
+		}, func(event *model.Event) bool {
+			if event.GetType() == "syscalls" {
+				t.Errorf("shouldn't get an event, got: syscalls:%v reason:%v", event.Syscalls.Syscalls, event.Syscalls.EventReason)
+				return true
+			}
+			return false
+		}, 20*time.Second); err != nil && errors.Is(err, ErrTimeout{}) {
+			t.Error(err)
+		}
+
+		dockerInstance.stop()
 	})
 }

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -35,6 +35,7 @@ type testOpts struct {
 	activityDumpLocalStorageDirectory          string
 	activityDumpLocalStorageCompression        bool
 	activityDumpLocalStorageFormats            []string
+	activityDumpSyscallMonitorPeriod           time.Duration
 	enableSecurityProfile                      bool
 	securityProfileMaxImageTags                int
 	securityProfileDir                         string
@@ -107,6 +108,7 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.activityDumpCgroupDifferentiateArgs == opts.activityDumpCgroupDifferentiateArgs &&
 		to.activityDumpAutoSuppressionEnabled == opts.activityDumpAutoSuppressionEnabled &&
 		to.activityDumpLoadControllerTimeout == opts.activityDumpLoadControllerTimeout &&
+		to.activityDumpSyscallMonitorPeriod == opts.activityDumpSyscallMonitorPeriod &&
 		reflect.DeepEqual(to.activityDumpTracedEventTypes, opts.activityDumpTracedEventTypes) &&
 		to.activityDumpLocalStorageDirectory == opts.activityDumpLocalStorageDirectory &&
 		to.activityDumpLocalStorageCompression == opts.activityDumpLocalStorageCompression &&

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -80,7 +80,7 @@ shared_examples "passes" do |bundle, env|
           "docker-testsuite"])
         output_line_tag = "d"
       elsif bundle == "ad"
-        testsuite_args.concat(["-test.run", "TestActivityDump"])
+        testsuite_args.concat(["-test.run", "(TestActivityDump|TestSecurityProfile)"])
         output_line_tag = "ad"
       elsif bundle == "ebpfless"
         testsuite_args.concat(["-trace"])


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the syscall "dirty" flag after an execve and adds functional tests to make sure we don't forget why it's there.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Before this fix, some syscall drift events could have an empty list of syscalls.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
