### PR TITLE
[NPM-3543] Split RTT offset guessing test to its own flaky test

### DIFF
--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	tracertestutil "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/offsetguess-test.c pkg/ebpf/bytecode/build/runtime/offsetguess-test.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
@@ -276,32 +278,52 @@ func testOffsetGuess(t *testing.T) {
 		}
 	}
 
-	for o := offsetSaddr; o < offsetMax; o++ {
-		switch o {
-		case offsetSkBuffHead, offsetSkBuffSock, offsetSkBuffTransportHeader:
-			if kv < kernel.VersionCode(4, 7, 0) {
+	testOffsets := func(t *testing.T, includeOffsets, excludeOffsets []offsetT) {
+		for o := offsetSaddr; o < offsetMax; o++ {
+			if slices.Contains(excludeOffsets, o) {
 				continue
 			}
-		case offsetSaddrFl6, offsetDaddrFl6, offsetSportFl6, offsetDportFl6:
-			// TODO: offset guessing for these fields is currently broken on kernels 5.18+
-			// see https://datadoghq.atlassian.net/browse/NET-2984
-			if kv >= kernel.VersionCode(5, 18, 0) {
-				continue
-			}
-		case offsetCtOrigin, offsetCtIno, offsetCtNetns, offsetCtReply:
-			// offset guessing for conntrack fields is broken on pre-4.14 kernels
-			if !ebpfPrebuiltConntrackerSupportedOnKernelT(t) {
-				continue
-			}
-		}
 
-		var offset uint64
-		//nolint:revive // TODO(NET) Fix revive linter
-		var name offsetT = o
-		require.NoError(t, mp.Lookup(&name, &offset))
-		assert.Equal(t, offset, consts[o], "unexpected offset for %s", o)
-		t.Logf("offset %s expected: %d guessed: %d", o, offset, consts[o])
+			if len(includeOffsets) > 0 && !slices.Contains(includeOffsets, o) {
+				continue
+			}
+
+			switch o {
+			case offsetSkBuffHead, offsetSkBuffSock, offsetSkBuffTransportHeader:
+				if kv < kernel.VersionCode(4, 7, 0) {
+					continue
+				}
+			case offsetSaddrFl6, offsetDaddrFl6, offsetSportFl6, offsetDportFl6:
+				// TODO: offset guessing for these fields is currently broken on kernels 5.18+
+				// see https://datadoghq.atlassian.net/browse/NET-2984
+				if kv >= kernel.VersionCode(5, 18, 0) {
+					continue
+				}
+			case offsetCtOrigin, offsetCtIno, offsetCtNetns, offsetCtReply:
+				// offset guessing for conntrack fields is broken on pre-4.14 kernels
+				if !ebpfPrebuiltConntrackerSupportedOnKernelT(t) {
+					continue
+				}
+			}
+
+			var offset uint64
+			//nolint:revive // TODO(NET) Fix revive linter
+			var name offsetT = o
+			require.NoError(t, mp.Lookup(&name, &offset))
+			assert.Equal(t, offset, consts[o], "unexpected offset for %s", o)
+			t.Logf("offset %s expected: %d guessed: %d", o, offset, consts[o])
+		}
 	}
+
+	t.Run("without RTT offsets", func(t *testing.T) {
+		testOffsets(t, nil, []offsetT{offsetRtt, offsetRttVar})
+	})
+
+	t.Run("only RTT offsets", func(t *testing.T) {
+		flake.Mark(t)
+		testOffsets(t, []offsetT{offsetRtt, offsetRttVar}, nil)
+	})
+
 }
 
 func TestOffsetGuessPortIPv6Overlap(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Splits the offset guessing test into one that does not verify RTT offsets and another than only verifies RTT offsets, marking the latter as flaky. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
