### PR TITLE
Implement interface for developer environments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,6 +215,7 @@
 /cmd/installer/                         @DataDog/fleet @DataDog/windows-agent
 
 /dev/                                   @DataDog/agent-devx-loops
+/deva/                                  @DataDog/agent-devx-loops
 /devenv/                                @DataDog/agent-devx-loops
 
 /Dockerfiles/                            @DataDog/container-integrations

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ Dockerfiles/cluster-agent/nosys-seccomp
 
 # Utility tools
 devagent
-deva
+/deva
+!/deva/
 
 # go-generated files
 datadog.yaml

--- a/deva/LICENSE.txt
+++ b/deva/LICENSE.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2024-present Datadog, Inc. <dev@datadoghq.com>.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deva/README.md
+++ b/deva/README.md
@@ -1,0 +1,20 @@
+# datadog-agent-dev
+
+-----
+
+***Table of Contents***
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+Follow the [standard instructions](https://datadoghq.dev/datadog-agent/setup/#deva-recommended) or install by itself with:
+
+```console
+pip install -e deva
+```
+
+## License
+
+`datadog-agent-dev` is distributed under the terms of the [BSD 3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) license.

--- a/deva/pyproject.toml
+++ b/deva/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-agent-dev"
+dynamic = ["version"]
+description = "Tool for developing the Datadog Agent"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "BSD-3-Clause"
+authors = [
+  { name = "Datadog, Inc.", email = "dev@datadoghq.com" },
+]
+dependencies = [
+  "click~=8.1",
+  "find-exe~=0.1",
+  "msgspec~=0.18",
+  "msgspec-click~=0.2",
+  "platformdirs~=4.2",
+  "rich~=13.7",
+  "rich-click~=1.8",
+]
+
+[project.urls]
+Homepage = "https://github.com/DataDog/datadog-agent/tree/main/deva"
+
+[project.scripts]
+deva = "deva.cli:main"
+
+[tool.hatch.version]
+path = "src/deva/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/deva"]

--- a/deva/src/deva/__init__.py
+++ b/deva/src/deva/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+__version__ = '0.0.1'

--- a/deva/src/deva/__main__.py
+++ b/deva/src/deva/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+if __name__ == '__main__':
+    from deva.cli import main
+
+    main()

--- a/deva/src/deva/cli/__init__.py
+++ b/deva/src/deva/cli/__init__.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from functools import partial
+
+import rich_click as click
+
+from deva import __version__
+from deva.cli.application import Application
+from deva.cli.base import DynamicGroup
+
+click.group = partial(click.group, cls=DynamicGroup)
+click.rich_click.USE_MARKDOWN = True
+click.rich_click.SHOW_METAVARS_COLUMN = False
+click.rich_click.APPEND_METAVARS_HELP = True
+click.rich_click.STYLE_OPTION = 'purple'
+click.rich_click.STYLE_ARGUMENT = 'purple'
+click.rich_click.STYLE_COMMAND = 'purple'
+
+
+@click.group(
+    context_settings={'help_option_names': ['-h', '--help']},
+    invoke_without_command=True,
+    external_plugins=True,
+    subcommands=('env',),
+)
+@click.version_option(version=__version__, prog_name='deva')
+@click.pass_context
+def deva(ctx: click.Context) -> None:
+    """
+    ```
+         _
+      __| | _____   ____ _
+     / _` |/ _ \\ \\ / / _` |
+    | (_| |  __/\\ V / (_| |
+     \\__,_|\\___| \\_/ \\__,_|
+    ```
+    """
+    app = Application(terminator=ctx.exit)
+    if not ctx.invoked_subcommand:
+        click.echo(ctx.get_help())
+        app.abort()
+
+    # Persist app data for sub-commands
+    ctx.obj = app
+
+
+def main():
+    try:
+        deva(prog_name='deva', windows_expand_args=False)
+    except Exception:  # noqa: BLE001
+        import os
+        import sys
+
+        import click as click_core
+        from rich.console import Console
+
+        console = Console()
+        deva_debug = os.getenv('DEVA_DEBUG') in {'1', 'true'}
+        console.print_exception(suppress=[click, click_core], show_locals=deva_debug)
+        sys.exit(1)

--- a/deva/src/deva/cli/application.py
+++ b/deva/src/deva/cli/application.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deva.config.models import PlatformDirs
+
+
+class Application:
+    def __init__(self, *, terminator: Callable[[int], NoReturn]) -> None:
+        self.__terminator = terminator
+
+    def abort(self, code: int = 0) -> NoReturn:
+        self.__terminator(code)
+
+    @cached_property
+    def platform_dirs(self) -> PlatformDirs:
+        import platformdirs
+
+        from deva.config.models import PlatformDirs
+        from deva.utils.fs import Path
+
+        return PlatformDirs(
+            data=Path(platformdirs.user_data_dir('deva', appauthor=False)),
+            cache=Path(platformdirs.user_cache_dir('deva', appauthor=False)),
+        )

--- a/deva/src/deva/cli/base.py
+++ b/deva/src/deva/cli/base.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import importlib
+from functools import cached_property
+
+import rich_click as click
+
+
+class DynamicGroup(click.RichGroup):
+    def __init__(self, *args, external_plugins: bool | None = None, subcommands: tuple[str], **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._external_plugins = external_plugins
+        # e.g. ('dev', 'runtime', 'qa')
+        self._subcommands = subcommands
+
+    @property
+    def _module(self) -> str:
+        # e.g. deva.cli.env
+        return self.callback.__module__
+
+    @cached_property
+    def _plugins(self) -> dict[str, str]:
+        import os
+
+        import find_exe
+
+        plugin_prefix = self.callback.__module__.replace('deva.cli', 'deva', 1).replace('.', '-')
+        plugin_prefix = f'{plugin_prefix}-'
+        exe_pattern = f'^{plugin_prefix}[^-]+$'
+
+        plugins: dict[str, str] = {}
+        for executable in find_exe.with_pattern(exe_pattern):
+            exe_name = os.path.splitext(os.path.basename(executable))[0]
+            plugin_name = exe_name[len(plugin_prefix) :]
+            plugins[plugin_name] = executable
+
+        return plugins
+
+    def _create_module_meta_key(self, module: str) -> str:
+        return f'{module}.plugins'
+
+    def _external_plugins_allowed(self, ctx) -> bool:
+        if self._external_plugins is not None:
+            return self._external_plugins
+
+        parent_module_parts = self._module.split('.')[:-1]
+        parent_key = self._create_module_meta_key('.'.join(parent_module_parts))
+        return bool(ctx.meta[parent_key])
+
+    def list_commands(self, ctx):
+        commands = super().list_commands(ctx)
+        commands.extend(self._subcommands)
+        if self._external_plugins_allowed(ctx):
+            commands.extend(self._plugins)
+        return sorted(commands)
+
+    def get_command(self, ctx, cmd_name):
+        # Pass down the default setting for allowing external plugins, see:
+        # https://click.palletsprojects.com/en/8.1.x/api/#click.Context.meta
+        ctx.meta[self._create_module_meta_key(self._module)] = self._external_plugins_allowed(ctx)
+
+        if cmd_name in self._subcommands:
+            return self._lazy_load(cmd_name)
+
+        if cmd_name in self._plugins:
+            return _get_external_plugin_callback(cmd_name, self._plugins[cmd_name])
+
+        return super().get_command(ctx, cmd_name)
+
+    def _lazy_load(self, cmd_name):
+        import_path = f'{self._module}.{cmd_name}'
+        mod = importlib.import_module(import_path)
+        cmd_object = getattr(mod, 'cmd', None)
+        if not isinstance(cmd_object, click.BaseCommand):
+            message = f'Unable to lazily load command: {import_path}.cmd'
+            raise ValueError(message)
+
+        return cmd_object
+
+
+def _get_external_plugin_callback(cmd_name: str, executable: str):
+
+    @click.command(
+        name=cmd_name,
+        short_help='[external plugin]',
+        context_settings={'help_option_names': [], 'ignore_unknown_options': True},
+    )
+    @click.argument('args', required=True, nargs=-1)
+    @click.pass_context
+    def _external_plugin_callback(ctx: click.Context, args: tuple[str, ...]):
+        import subprocess
+
+        process = subprocess.run([executable, *args])
+        ctx.exit(process.returncode)
+
+    return _external_plugin_callback

--- a/deva/src/deva/cli/env/__init__.py
+++ b/deva/src/deva/cli/env/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import rich_click as click
+
+
+@click.group(
+    short_help='Work with environments',
+    subcommands=('dev',),
+)
+def cmd() -> None:
+    pass

--- a/deva/src/deva/cli/env/dev/__init__.py
+++ b/deva/src/deva/cli/env/dev/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import rich_click as click
+
+
+@click.group(
+    short_help='Work with developer environments',
+    subcommands=('run', 'shell', 'start', 'status', 'stop'),
+)
+def cmd() -> None:
+    pass

--- a/deva/src/deva/cli/env/dev/run/__init__.py
+++ b/deva/src/deva/cli/env/dev/run/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import rich_click as click
+
+from deva.env.dev import AVAILABLE_DEV_ENVS, DEFAULT_DEV_ENV, get_dev_env
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+@click.command(
+    short_help='Run a command within a developer environment',
+    context_settings={'help_option_names': [], 'ignore_unknown_options': True},
+)
+@click.argument('args', required=True, nargs=-1)
+@click.option(
+    '--type',
+    '-t',
+    'env_type',
+    type=click.Choice(AVAILABLE_DEV_ENVS),
+    default=DEFAULT_DEV_ENV,
+    show_default=True,
+    help='The type of developer environment',
+)
+@click.pass_context
+def cmd(ctx: click.Context, args: tuple[str, ...], env_type: str) -> None:
+    """
+    Run a command within a developer environment.
+    """
+    app: Application = ctx.obj
+    first_arg = args[0]
+    if first_arg in {'-h', '--help'}:
+        click.echo(ctx.get_help())
+        app.abort()
+
+    env_class: type[DeveloperEnvironmentInterface] = get_dev_env(env_type)
+    env = env_class(
+        name=env_type,
+        platform_dirs=app.platform_dirs,
+        config=env_class.config_class()(),
+    )
+    env.run(list(args))

--- a/deva/src/deva/cli/env/dev/shell/__init__.py
+++ b/deva/src/deva/cli/env/dev/shell/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import rich_click as click
+
+from deva.env.dev import AVAILABLE_DEV_ENVS, DEFAULT_DEV_ENV, get_dev_env
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+@click.command(short_help='Enter a developer environment')
+@click.option(
+    '--type',
+    '-t',
+    'env_type',
+    type=click.Choice(AVAILABLE_DEV_ENVS),
+    default=DEFAULT_DEV_ENV,
+    show_default=True,
+    help='The type of developer environment',
+)
+@click.pass_obj
+def cmd(app: Application, env_type: str) -> None:
+    """
+    Enter a developer environment.
+    """
+    env_class: type[DeveloperEnvironmentInterface] = get_dev_env(env_type)
+    env = env_class(
+        name=env_type,
+        platform_dirs=app.platform_dirs,
+        config=env_class.config_class()(),
+    )
+    env.shell()

--- a/deva/src/deva/cli/env/dev/start/__init__.py
+++ b/deva/src/deva/cli/env/dev/start/__init__.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import rich_click as click
+
+from deva.env.dev import AVAILABLE_DEV_ENVS, DEFAULT_DEV_ENV, get_dev_env
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+def resolve_environment(ctx, param, value):
+    from msgspec_click import generate_options
+
+    dev_env_class: type[DeveloperEnvironmentInterface] = get_dev_env(value)
+    ctx.params['env_class'] = dev_env_class
+    ctx.command.params.extend(generate_options(dev_env_class.config_class()))
+    return value
+
+
+@click.command(short_help='Start a developer environment', context_settings={'ignore_unknown_options': True})
+@click.option(
+    '--type',
+    '-t',
+    'env_type',
+    type=click.Choice(AVAILABLE_DEV_ENVS),
+    default=DEFAULT_DEV_ENV,
+    show_default=True,
+    is_eager=True,
+    callback=resolve_environment,
+    help='The type of developer environment',
+)
+@click.pass_context
+def cmd(ctx: click.Context, env_type: str, **kwargs: Any) -> None:
+    """
+    Start a developer environment.
+    """
+    import msgspec
+
+    from deva.env.models import EnvironmentStage
+
+    app: Application = ctx.obj
+
+    env_class: type[DeveloperEnvironmentInterface] = ctx.params['env_class']
+    config = msgspec.convert(kwargs, env_class.config_class())
+    env: DeveloperEnvironmentInterface = env_class(
+        name=env_type,
+        platform_dirs=app.platform_dirs,
+        config=config,
+    )
+
+    status = env.status()
+    expected_stage = EnvironmentStage.INACTIVE
+    if status.stage != expected_stage:
+        click.echo(
+            f'Cannot start developer environment {env_type} in stage {status.stage.value}, '
+            f'must be {expected_stage.value}'
+        )
+        app.abort(1)
+
+    env.start()

--- a/deva/src/deva/cli/env/dev/status/__init__.py
+++ b/deva/src/deva/cli/env/dev/status/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import rich_click as click
+
+from deva.env.dev import AVAILABLE_DEV_ENVS, DEFAULT_DEV_ENV, get_dev_env
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+@click.command(short_help='Check the status of a developer environment')
+@click.option(
+    '--type',
+    '-t',
+    'env_type',
+    type=click.Choice(AVAILABLE_DEV_ENVS),
+    default=DEFAULT_DEV_ENV,
+    show_default=True,
+    help='The type of developer environment',
+)
+@click.pass_obj
+def cmd(app: Application, env_type: str) -> None:
+    """
+    Check the status of a developer environment.
+    """
+    env_class: type[DeveloperEnvironmentInterface] = get_dev_env(env_type)
+    env = env_class(
+        name=env_type,
+        platform_dirs=app.platform_dirs,
+        config=env_class.config_class()(),
+    )
+
+    status = env.status()
+    click.echo(f'Stage: {status.stage.value}')
+    if status.info:
+        click.echo(status.info)

--- a/deva/src/deva/cli/env/dev/stop/__init__.py
+++ b/deva/src/deva/cli/env/dev/stop/__init__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import rich_click as click
+
+from deva.env.dev import AVAILABLE_DEV_ENVS, DEFAULT_DEV_ENV, get_dev_env
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+@click.command(short_help='Stop a developer environment')
+@click.option(
+    '--type',
+    '-t',
+    'env_type',
+    type=click.Choice(AVAILABLE_DEV_ENVS),
+    default=DEFAULT_DEV_ENV,
+    show_default=True,
+    help='The type of developer environment',
+)
+@click.pass_obj
+def cmd(app: Application, env_type: str) -> None:
+    """
+    Stop a developer environment.
+    """
+    from deva.env.models import EnvironmentStage
+
+    env_class: type[DeveloperEnvironmentInterface] = get_dev_env(env_type)
+    env = env_class(
+        name=env_type,
+        platform_dirs=app.platform_dirs,
+        config=env_class.config_class()(),
+    )
+
+    status = env.status()
+    expected_stage = EnvironmentStage.ACTIVE
+    if status.stage != expected_stage:
+        click.echo(
+            f'Cannot stop developer environment {env_type} in stage {status.stage.value}, '
+            f'must be {expected_stage.value}'
+        )
+        app.abort(1)
+
+    env.stop()

--- a/deva/src/deva/config/__init__.py
+++ b/deva/src/deva/config/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/deva/src/deva/config/models.py
+++ b/deva/src/deva/config/models.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from msgspec import Struct
+
+if TYPE_CHECKING:
+    from deva.utils.fs import Path
+
+
+class PlatformDirs(Struct, frozen=True, forbid_unknown_fields=True):
+    data: Path
+    cache: Path
+
+    def join(self, *parts: Any) -> PlatformDirs:
+        return PlatformDirs(
+            data=self.data.joinpath(*parts),
+            cache=self.cache.joinpath(*parts),
+        )

--- a/deva/src/deva/env/__init__.py
+++ b/deva/src/deva/env/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/deva/src/deva/env/dev/__init__.py
+++ b/deva/src/deva/env/dev/__init__.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deva.env.dev.interface import DeveloperEnvironmentInterface
+
+
+DEFAULT_DEV_ENV = 'windows-container' if sys.platform == 'win32' else 'linux-container'
+
+
+def get_dev_env(env_type: str) -> type[DeveloperEnvironmentInterface]:
+    getter = __DEV_ENVS.get(env_type)
+    if getter is None:
+        message = f'Unknown developer environment: {env_type}'
+        raise ValueError(message)
+
+    return getter()
+
+
+def __get_windows_container() -> type[DeveloperEnvironmentInterface]:
+    raise NotImplementedError
+
+
+def __get_windows_cloud() -> type[DeveloperEnvironmentInterface]:
+    raise NotImplementedError
+
+
+def __get_linux_container() -> type[DeveloperEnvironmentInterface]:
+    raise NotImplementedError
+
+
+if sys.platform == 'win32':
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+        'windows-container': __get_windows_container,
+        'windows-cloud': __get_windows_cloud,
+        'linux-container': __get_linux_container,
+    }
+elif sys.platform == 'darwin':
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+        'linux-container': __get_linux_container,
+        'windows-cloud': __get_windows_cloud,
+    }
+else:
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+        'linux-container': __get_linux_container,
+        'windows-cloud': __get_windows_cloud,
+    }
+
+AVAILABLE_DEV_ENVS: list[str] = sorted(__DEV_ENVS)

--- a/deva/src/deva/env/dev/interface.py
+++ b/deva/src/deva/env/dev/interface.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, NoReturn, TypeVar
+
+import msgspec
+
+if TYPE_CHECKING:
+    from deva.config.models import PlatformDirs
+    from deva.env.models import EnvironmentStatus
+
+
+DeveloperEnvironmentConfig = TypeVar('DeveloperEnvironmentConfig', bound=msgspec.Struct)
+
+
+class DeveloperEnvironmentInterface(ABC):
+    """
+    This interface defines the behavior of a developer environment.
+    """
+
+    def __init__(self, *, name: str, platform_dirs: PlatformDirs, config: DeveloperEnvironmentConfig) -> None:
+        self.__name = name
+        self.__storage_dirs = platform_dirs.join('env', 'dev', self.__name)
+        self.__config = config
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @property
+    def storage_dirs(self) -> PlatformDirs:
+        return self.__storage_dirs
+
+    @property
+    def config(self) -> DeveloperEnvironmentConfig:
+        return self.__config
+
+    @classmethod
+    def config_class(self) -> type[DeveloperEnvironmentConfig]:
+        return msgspec.Struct
+
+    @abstractmethod
+    def start(self) -> None:
+        """
+        This method starts the developer environment. If this method returns early, the `status`
+        method should contain information about the startup progress.
+
+        This method will never be called if the environment is already running.
+        """
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        This method stops the developer environment. If this method returns early, the `status`
+        method should contain information about the shutdown progress.
+        """
+
+    @abstractmethod
+    def status(self) -> EnvironmentStatus:
+        """
+        This method returns the current status of the developer environment.
+        """
+
+    @abstractmethod
+    def shell(self) -> NoReturn:
+        """
+        This method starts an interactive shell inside the developer environment.
+        """
+
+    @abstractmethod
+    def run_command(self, command: list[str]) -> None:
+        """
+        This method runs a command inside the developer environment.
+        """

--- a/deva/src/deva/env/models.py
+++ b/deva/src/deva/env/models.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from enum import Enum
+
+from msgspec import Struct
+
+
+class EnvironmentStage(str, Enum):
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'
+    STARTING = 'starting'
+    STOPPING = 'stopping'
+
+
+class EnvironmentStatus(Struct, frozen=True, forbid_unknown_fields=True):
+    stage: EnvironmentStage
+    info: str = ''

--- a/deva/src/deva/utils/__init__.py
+++ b/deva/src/deva/utils/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/deva/src/deva/utils/fs.py
+++ b/deva/src/deva/utils/fs.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+from contextlib import contextmanager
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from _typeshed import FileDescriptorLike
+
+# There is special recognition in Mypy for `sys.platform`, not `os.name`
+# https://github.com/python/cpython/blob/09d7319bfe0006d9aa3fc14833b69c24ccafdca6/Lib/pathlib.py#L957
+if sys.platform == 'win32':
+    _PathBase = pathlib.WindowsPath
+else:
+    _PathBase = pathlib.PosixPath
+
+disk_sync = os.fsync
+# https://mjtsai.com/blog/2022/02/17/apple-ssd-benchmarks-and-f_fullsync/
+# https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fsync.2.html
+if sys.platform == 'darwin':
+    import fcntl
+
+    if hasattr(fcntl, 'F_FULLFSYNC'):
+
+        def disk_sync(fd: FileDescriptorLike) -> None:
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+
+
+# TODO: Inherit directly from pathlib.Path when we upgrade to Python 3.12
+# https://docs.python.org/3/whatsnew/3.12.html#pathlib
+class Path(_PathBase):
+    @cached_property
+    def long_id(self) -> str:
+        """
+        Returns a unique identifier for the current path.
+        """
+        from base64 import urlsafe_b64encode
+        from hashlib import sha256
+
+        path = str(self)
+        # Handle case-insensitive filesystems
+        if sys.platform == 'win32' or sys.platform == 'darwin':
+            path = path.casefold()
+
+        digest = sha256(path.encode('utf-8')).digest()
+        return urlsafe_b64encode(digest).decode('utf-8')
+
+    @cached_property
+    def id(self) -> str:
+        return self.long_id[:8]
+
+    def ensure_dir(self) -> None:
+        self.mkdir(parents=True, exist_ok=True)
+
+    def expand(self) -> Path:
+        return Path(os.path.expanduser(os.path.expandvars(self)))
+
+    def write_atomic(self, data: str | bytes, *args: Any, **kwargs: Any) -> None:
+        from tempfile import mkstemp
+
+        fd, path = mkstemp(dir=self.parent)
+        with os.fdopen(fd, *args, **kwargs) as f:
+            f.write(data)
+            f.flush()
+            disk_sync(fd)
+
+        os.replace(path, self)
+
+    @contextmanager
+    def as_cwd(self) -> Generator[Path, None, None]:
+        origin = os.getcwd()
+        os.chdir(self)
+
+        try:
+            yield self
+        finally:
+            os.chdir(origin)
+
+
+@contextmanager
+def temp_directory() -> Generator[Path, None, None]:
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as d:
+        yield Path(d).resolve()

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -101,6 +101,7 @@ from tasks.install_tasks import (
 )
 from tasks.junit_tasks import junit_upload
 from tasks.libs.common.go_workspaces import handle_go_work
+from tasks.ng import ng
 from tasks.show_linters_issues.show_linters_issues import show_linters_issues
 from tasks.update_go import go_version, update_go
 from tasks.windows_resources import build_messagetable
@@ -111,6 +112,7 @@ Task.__call__ = custom__call__
 ns = Collection()
 
 # add single tasks to the root
+ns.add_task(ng)
 ns.add_task(test)
 ns.add_task(integration_tests)
 ns.add_task(deps)

--- a/tasks/ng.py
+++ b/tasks/ng.py
@@ -1,0 +1,17 @@
+"""
+Tools for working with the next-gen version of the CLI
+"""
+from __future__ import annotations
+
+from invoke import task
+
+
+@task
+def ng(ctx, args: str = '') -> None:
+    """
+    Invoke the next-gen version of the CLI
+    """
+    from deva.cli import deva
+
+    argument_list = args.split() if args else []
+    deva(args=argument_list, prog_name='deva', windows_expand_args=False)

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,3 +1,4 @@
+-e ./deva
 -r libs/requirements-github.txt
 -r libs/requirements-notifications.txt
 -r show_linters_issues/requirements.txt


### PR DESCRIPTION
### What does this PR do?

- Creates a `DeveloperEnvironmentInterface` which will be used as the base class for all dev envs. There will be another `build` abstract method which will be added during the first implementation of the interface.
- Creates the scaffolding for a CLI migration from Invoke to Click. I have only committed what was necessary for this PR (except for some parts of `deva.utils.fs` which will be used in subsequent PRs).
- Added this new package to the installation files of our existing tooling.
- Added a new `ng` task which is a wrapper around the new CLI to ease the migration. Invoke is very limited in what you can do so you must pass arguments as a flag with a single string e.g. `invoke ng -a "env dev"`

### Motivation

We want to provide a standardized UX for working with environments. This introduces the developer environment interface but in future there will be other environment types like QA.

Since this is somewhat of a greenfield project in scope I've taken the opportunity to create a dedicated package for our tooling using modern Python techniques. Notably, this uses Click instead of Invoke which is what other tooling across the company does such as [ddev](https://github.com/DataDog/integrations-core/tree/master/ddev), [apigentools](https://github.com/DataDog/apigentools), [ddqa](https://github.com/DataDog/ddqa), devtools, dd-source, dogweb, etc.

There are a number of benefits to such a migration:

1. Opportunity to make deliberate design decisions with the UX now that we have years of Agent development experience
2. A centralized place for dependencies whereas right now we have random files that reference each other in a nested fashion
3. Hierarchical command structure rather than only top level dot-separated commands
4. Allows for easier testing of the tooling itself, currently we only have [unit tests](https://github.com/DataDog/datadog-agent/tree/main/tasks/unit_tests) which almost exclusively rely on mocking
5. Far better response time, as shown here:
    ![Screenshot 2024-07-16 154056](https://github.com/user-attachments/assets/1a5dc902-52d0-4b49-8633-d15b26e736e0)
6. Click is the standard Python CLI framework and is well maintained whereas Invoke has a bus factor of 1 and was designed with different goals in mind

### Additional Notes

- There are 3 types of environments that I think satisfy all of our use cases:
	1. Developer environments (this PR) which is the machine where one performs builds, tests, linter checks, etc.
	2. Sandbox (name TBD) environments which are used to actually run the Agent that was built within the developer environment
	3. QA environments which are an extension of 2 with monitoring and non-ephemeral
- I've chosen to use a [Click plugin](https://github.com/ewels/rich-click) to render help text and I've enabled Markdown support:
	![image](https://github.com/user-attachments/assets/d6682696-499c-4b4e-b137-67fbb67600d8)

### Describe how to test/QA your changes

Go through the installation process and try the new command or the new task wrapper