### PR TITLE
[USM]: Better wait for process monitor

### DIFF
--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -181,24 +181,24 @@ func (s *processMonitorSuite) TestProcessRegisterMultipleCallbacks() {
 	cmd := exec.Command("/bin/sleep", "1")
 	require.NoError(t, cmd.Run())
 	require.Eventuallyf(t, func() bool {
+		// Instead of breaking immediately when we don't find the event, we want logs to be printed for all iterations.
+		found := true
 		for i := 0; i < iterations; i++ {
 			execCountersMutexes[i].RLock()
 			if _, captured := execCounters[i][uint32(cmd.Process.Pid)]; !captured {
-				execCountersMutexes[i].RUnlock()
 				t.Logf("iter %d didn't capture exec event", i)
-				return false
+				found = false
 			}
 			execCountersMutexes[i].RUnlock()
 
 			exitCountersMutexes[i].RLock()
 			if _, captured := exitCounters[i][uint32(cmd.Process.Pid)]; !captured {
-				exitCountersMutexes[i].RUnlock()
 				t.Logf("iter %d didn't capture exit event", i)
-				return false
+				found = false
 			}
 			exitCountersMutexes[i].RUnlock()
 		}
-		return true
+		return found
 	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
 
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Changes the way we wait for process monitor to be initialized.
Instead of just sleeping, we register exit and exec callbacks, and repeatedly create events (by creating a short living process), and we stop waiting if we got at least one exec event and one exit event.
After we know process monitor initialized successfully, we can deep dive and run the different scenarios to test different use cases.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Test flakiness

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
