### PR TITLE
[Backport 7.55.x] Partial revert of #25515 as issues have been identified

### DIFF
--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -51,7 +51,7 @@ type systemCollector struct {
 	hostCgroupNamespace bool
 }
 
-func newSystemCollector(cache *provider.Cache, wlm optional.Option[workloadmeta.Component]) (provider.CollectorMetadata, error) {
+func newSystemCollector(cache *provider.Cache, _ optional.Option[workloadmeta.Component]) (provider.CollectorMetadata, error) {
 	var err error
 	var hostPrefix string
 	var collectorMetadata provider.CollectorMetadata
@@ -61,18 +61,11 @@ func newSystemCollector(cache *provider.Cache, wlm optional.Option[workloadmeta.
 		hostPrefix = "/host"
 	}
 
-	var w workloadmeta.Component
-	unwrapped, ok := wlm.Get()
-	if ok {
-		w = unwrapped
-	}
-	cf := newContainerFilter(w)
-	go cf.start()
 	reader, err := cgroups.NewReader(
 		cgroups.WithCgroupV1BaseController(cgroupV1BaseController),
 		cgroups.WithProcPath(procPath),
 		cgroups.WithHostPrefix(hostPrefix),
-		cgroups.WithReaderFilter(cf.ContainerFilter),
+		cgroups.WithReaderFilter(cgroups.ContainerFilter),
 	)
 	if err != nil {
 		// Cgroup provider is pretty static. Except not having required mounts, it should always work.

--- a/releasenotes/notes/incorrect-container-metrics-8b553efd1de55334.yaml
+++ b/releasenotes/notes/incorrect-container-metrics-8b553efd1de55334.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an issue introduced in `7.55.0` with container metrics. In some rare cases, container metrics (cpu, memory, limits, etc.) could be incorrect and not reflect actual resources usage.


### PR DESCRIPTION
Backport 0a6888e710c68b60317d28be53b5d7964d6f0d6f from #27680.

___

### What does this PR do?

Revert #25515 

### Motivation

Issues identified with this code.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

We don't have a reproducer, so it's essentially impossible to QA, however we do have cases that came up in different scenarios that should not appear again.