### PR TITLE
[ASCII-2039] Add telemetry counter for secret resolving errors

### DIFF
--- a/comp/core/config/go.sum
+++ b/comp/core/config/go.sum
@@ -228,6 +228,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0 h1:jwV9iQdvp38fxXi8ZC+lNpxjK16MRcZlpDYvbuO1FiA=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0/go.mod h1:f3bYiqNqhoPxkvI2LrXqQVC546K7BuRDL/kKuxkujhA=
 go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
 go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
 go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kTWmI=

--- a/comp/core/secrets/go.mod
+++ b/comp/core/secrets/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/otel v1.27.0 // indirect
+	go.opentelemetry.io/otel/exporters/prometheus v0.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.27.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.27.0 // indirect

--- a/comp/core/secrets/go.sum
+++ b/comp/core/secrets/go.sum
@@ -52,6 +52,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0 h1:jwV9iQdvp38fxXi8ZC+lNpxjK16MRcZlpDYvbuO1FiA=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0/go.mod h1:f3bYiqNqhoPxkvI2LrXqQVC546K7BuRDL/kKuxkujhA=
 go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
 go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
 go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kTWmI=

--- a/comp/core/secrets/secretsimpl/fetch_secret.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret.go
@@ -121,9 +121,7 @@ func (r *secretResolver) fetchSecret(secretsHandle []string) (map[string]string,
 	secrets := map[string]secrets.SecretVal{}
 	err = json.Unmarshal(output, &secrets)
 	if err != nil {
-		for _, sec := range secretsHandle {
-			r.tlmSecretResolveError.Inc("unmarshal", sec)
-		}
+		r.tlmSecretUnmarshalError.Inc()
 		return nil, fmt.Errorf("could not unmarshal 'secret_backend_command' output: %s", err)
 	}
 

--- a/comp/core/secrets/secretsimpl/fetch_secret.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret.go
@@ -121,6 +121,9 @@ func (r *secretResolver) fetchSecret(secretsHandle []string) (map[string]string,
 	secrets := map[string]secrets.SecretVal{}
 	err = json.Unmarshal(output, &secrets)
 	if err != nil {
+		for _, sec := range secretsHandle {
+			r.tlmSecretResolveError.Inc("unmarshal", sec)
+		}
 		return nil, fmt.Errorf("could not unmarshal 'secret_backend_command' output: %s", err)
 	}
 
@@ -128,10 +131,12 @@ func (r *secretResolver) fetchSecret(secretsHandle []string) (map[string]string,
 	for _, sec := range secretsHandle {
 		v, ok := secrets[sec]
 		if !ok {
+			r.tlmSecretResolveError.Inc("missing", sec)
 			return nil, fmt.Errorf("secret handle '%s' was not resolved by the secret_backend_command", sec)
 		}
 
 		if v.ErrorMsg != "" {
+			r.tlmSecretResolveError.Inc("error", sec)
 			return nil, fmt.Errorf("an error occurred while resolving '%s': %s", sec, v.ErrorMsg)
 		}
 
@@ -140,6 +145,7 @@ func (r *secretResolver) fetchSecret(secretsHandle []string) (map[string]string,
 		}
 
 		if v.Value == "" {
+			r.tlmSecretResolveError.Inc("empty", sec)
 			return nil, fmt.Errorf("resolved secret for '%s' is empty", sec)
 		}
 		res[sec] = v.Value

--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -8,10 +8,12 @@ package secretsimpl
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"testing"
 	"time"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -28,7 +31,7 @@ var (
 	binExtension = ""
 )
 
-func build(m *testing.M, outBin, pkg string) { //nolint:revive // TODO fix revive unused-parameter
+func build(_ *testing.M, outBin, pkg string) {
 	_, err := exec.Command("go", "build", "-o", outBin+binExtension, pkg).Output()
 	if err != nil {
 		fmt.Printf("Could not compile test secretBackendCommand: %s", err)
@@ -185,7 +188,7 @@ func TestExecCommandError(t *testing.T) {
 	})
 }
 
-func TestFetchSecretExeceError(t *testing.T) {
+func TestFetchSecretExecError(t *testing.T) {
 	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
 	resolver := newEnabledSecretResolver(tel)
 	resolver.commandHookFunc = func(string) ([]byte, error) { return nil, fmt.Errorf("some error") }
@@ -193,26 +196,43 @@ func TestFetchSecretExeceError(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func checkErrorCountMetric(t *testing.T, tel telemetry.Mock, expected int, errorKind, handle string) {
+	metrics, err := tel.GetCountMetric("secret_backend", "resolve_errors_count")
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics)
+	assert.EqualValues(t, expected, metrics[0].Value())
+	expectedTags := map[string]string{
+		"error_kind": errorKind,
+		"handle":     handle,
+	}
+	assert.NotEqual(t, -1, slices.IndexFunc(metrics, func(m telemetry.Metric) bool {
+		return int(m.Value()) == expected && maps.Equal(m.Tags(), expectedTags)
+	}))
+}
+
 func TestFetchSecretUnmarshalError(t *testing.T) {
-	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
+	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	resolver := newEnabledSecretResolver(tel)
 	resolver.commandHookFunc = func(string) ([]byte, error) { return []byte("{"), nil }
 	_, err := resolver.fetchSecret([]string{"handle1", "handle2"})
 	assert.NotNil(t, err)
+	checkErrorCountMetric(t, tel, 1, "unmarshal", "handle1")
+	checkErrorCountMetric(t, tel, 1, "unmarshal", "handle2")
 }
 
 func TestFetchSecretMissingSecret(t *testing.T) {
-	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
+	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	secrets := []string{"handle1", "handle2"}
 	resolver := newEnabledSecretResolver(tel)
 	resolver.commandHookFunc = func(string) ([]byte, error) { return []byte("{}"), nil }
 	_, err := resolver.fetchSecret(secrets)
 	assert.NotNil(t, err)
 	assert.Equal(t, "secret handle 'handle1' was not resolved by the secret_backend_command", err.Error())
+	checkErrorCountMetric(t, tel, 1, "missing", "handle1")
 }
 
 func TestFetchSecretErrorForHandle(t *testing.T) {
-	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
+	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	resolver := newEnabledSecretResolver(tel)
 	resolver.commandHookFunc = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": null, \"error\": \"some error\"}}"), nil
@@ -220,10 +240,11 @@ func TestFetchSecretErrorForHandle(t *testing.T) {
 	_, err := resolver.fetchSecret([]string{"handle1"})
 	assert.NotNil(t, err)
 	assert.Equal(t, "an error occurred while resolving 'handle1': some error", err.Error())
+	checkErrorCountMetric(t, tel, 1, "error", "handle1")
 }
 
 func TestFetchSecretEmptyValue(t *testing.T) {
-	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
+	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	resolver := newEnabledSecretResolver(tel)
 	resolver.commandHookFunc = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": null}}"), nil
@@ -231,6 +252,7 @@ func TestFetchSecretEmptyValue(t *testing.T) {
 	_, err := resolver.fetchSecret([]string{"handle1"})
 	assert.NotNil(t, err)
 	assert.Equal(t, "resolved secret for 'handle1' is empty", err.Error())
+	checkErrorCountMetric(t, tel, 1, "empty", "handle1")
 
 	resolver.commandHookFunc = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": \"\"}}"), nil
@@ -238,6 +260,7 @@ func TestFetchSecretEmptyValue(t *testing.T) {
 	_, err = resolver.fetchSecret([]string{"handle1"})
 	assert.NotNil(t, err)
 	assert.Equal(t, "resolved secret for 'handle1' is empty", err.Error())
+	checkErrorCountMetric(t, tel, 2, "empty", "handle1")
 }
 
 func TestFetchSecret(t *testing.T) {

--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -216,8 +216,12 @@ func TestFetchSecretUnmarshalError(t *testing.T) {
 	resolver.commandHookFunc = func(string) ([]byte, error) { return []byte("{"), nil }
 	_, err := resolver.fetchSecret([]string{"handle1", "handle2"})
 	assert.NotNil(t, err)
-	checkErrorCountMetric(t, tel, 1, "unmarshal", "handle1")
-	checkErrorCountMetric(t, tel, 1, "unmarshal", "handle2")
+
+	metrics, err := tel.GetCountMetric("secret_backend", "unmarshal_errors_count")
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+	assert.EqualValues(t, 1, metrics[0].Value())
 }
 
 func TestFetchSecretMissingSecret(t *testing.T) {

--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -196,20 +196,6 @@ func TestFetchSecretExecError(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func checkErrorCountMetric(t *testing.T, tel telemetry.Mock, expected int, errorKind, handle string) {
-	metrics, err := tel.GetCountMetric("secret_backend", "resolve_errors_count")
-	require.NoError(t, err)
-	require.NotEmpty(t, metrics)
-	assert.EqualValues(t, expected, metrics[0].Value())
-	expectedTags := map[string]string{
-		"error_kind": errorKind,
-		"handle":     handle,
-	}
-	assert.NotEqual(t, -1, slices.IndexFunc(metrics, func(m telemetry.Metric) bool {
-		return int(m.Value()) == expected && maps.Equal(m.Tags(), expectedTags)
-	}))
-}
-
 func TestFetchSecretUnmarshalError(t *testing.T) {
 	tel := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 	resolver := newEnabledSecretResolver(tel)
@@ -265,6 +251,20 @@ func TestFetchSecretEmptyValue(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "resolved secret for 'handle1' is empty", err.Error())
 	checkErrorCountMetric(t, tel, 2, "empty", "handle1")
+}
+
+func checkErrorCountMetric(t *testing.T, tel telemetry.Mock, expected int, errorKind, handle string) {
+	metrics, err := tel.GetCountMetric("secret_backend", "resolve_errors_count")
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics)
+	assert.EqualValues(t, expected, metrics[0].Value())
+	expectedTags := map[string]string{
+		"error_kind": errorKind,
+		"handle":     handle,
+	}
+	assert.NotEqual(t, -1, slices.IndexFunc(metrics, func(m telemetry.Metric) bool {
+		return int(m.Value()) == expected && maps.Equal(m.Tags(), expectedTags)
+	}))
 }
 
 func TestFetchSecret(t *testing.T) {

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -104,6 +104,7 @@ type secretResolver struct {
 
 	// Telemetry
 	tlmSecretBackendElapsed telemetry.Gauge
+	tlmSecretUnmarshalError telemetry.Counter
 	tlmSecretResolveError   telemetry.Counter
 }
 
@@ -115,6 +116,7 @@ func newEnabledSecretResolver(telemetry telemetry.Component) *secretResolver {
 		origin:                  make(handleToContext),
 		enabled:                 true,
 		tlmSecretBackendElapsed: telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation"),
+		tlmSecretUnmarshalError: telemetry.NewCounter("secret_backend", "unmarshal_errors_count", []string{}, "Count of errors when unmarshalling the output of the secret binary"),
 		tlmSecretResolveError:   telemetry.NewCounter("secret_backend", "resolve_errors_count", []string{"error_kind", "handle"}, "Count of errors when resolving a secret"),
 	}
 }

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -104,6 +104,7 @@ type secretResolver struct {
 
 	// Telemetry
 	tlmSecretBackendElapsed telemetry.Gauge
+	tlmSecretResolveError   telemetry.Counter
 }
 
 var _ secrets.Component = (*secretResolver)(nil)
@@ -114,6 +115,7 @@ func newEnabledSecretResolver(telemetry telemetry.Component) *secretResolver {
 		origin:                  make(handleToContext),
 		enabled:                 true,
 		tlmSecretBackendElapsed: telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation"),
+		tlmSecretResolveError:   telemetry.NewCounter("secret_backend", "resolve_errors_count", []string{"error_kind", "handle"}, "Count of errors when resolving a secret"),
 	}
 }
 

--- a/pkg/config/setup/go.sum
+++ b/pkg/config/setup/go.sum
@@ -225,6 +225,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0 h1:jwV9iQdvp38fxXi8ZC+lNpxjK16MRcZlpDYvbuO1FiA=
+go.opentelemetry.io/otel/exporters/prometheus v0.42.0/go.mod h1:f3bYiqNqhoPxkvI2LrXqQVC546K7BuRDL/kKuxkujhA=
 go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
 go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
 go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kTWmI=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a new telemetry counter in secret component for errors when resolving a given handle.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Create monitors to be notified when the agent can't resolve a secret, and possibly gate agent deployments with it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
QA done manually on a VM.
Triggered each case using a custom secret backend, and checked that the metrics were properly generated using the `telemetry` api endpoint:
```
# HELP secret_backend__resolve_errors_count Count of errors when resolving a secret
# TYPE secret_backend__resolve_errors_count counter
secret_backend__resolve_errors_count{error_kind="empty",handle="api_key"} 1
secret_backend__resolve_errors_count{error_kind="error",handle="api_key"} 1
secret_backend__resolve_errors_count{error_kind="missing",handle="api_key"} 1
# HELP secret_backend__unmarshal_errors_count Count of errors when unmarshalling the output of the secret binary
# TYPE secret_backend__unmarshal_errors_count counter
secret_backend__unmarshal_errors_count 1
```

