### PR TITLE
[E2e] Get logs of containers that have restarted

### DIFF
--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -25,8 +25,11 @@ import (
 	awsekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubectlget "k8s.io/kubectl/pkg/cmd/get"
@@ -285,5 +288,56 @@ func dumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, o
 	if err := getCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(out, "Failed to execute Get command: %v\n", err)
 		return
+	}
+
+	// Get the logs of containers that have restarted
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile.Name())
+	if err != nil {
+		fmt.Fprintf(out, "Failed to build Kubernetes config: %v\n", err)
+		return
+	}
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Fprintf(out, "Failed to create Kubernetes client: %v\n", err)
+		return
+	}
+
+	continueToken := "start"
+	for continueToken != "" {
+		if continueToken == "start" {
+			continueToken = ""
+		}
+		pods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			Continue: continueToken,
+		})
+		if err != nil {
+			fmt.Fprintf(out, "Failed to list pods: %v\n", err)
+			return
+		}
+		continueToken = pods.Continue
+
+		for _, pod := range pods.Items {
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.RestartCount > 0 {
+					fmt.Fprintf(out, "\nLOGS FOR POD %s/%s CONTAINER %s:\n", pod.Namespace, pod.Name, containerStatus.Name)
+					logs, err := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+						Container: containerStatus.Name,
+						Previous:  true,
+						TailLines: pointer.Ptr(int64(20)),
+					}).Stream(ctx)
+					if err != nil {
+						fmt.Fprintf(out, "Failed to get logs: %v\n", err)
+						continue
+					}
+					defer logs.Close()
+
+					_, err = io.Copy(out, logs)
+					if err != nil {
+						fmt.Fprintf(out, "Failed to copy logs: %v\n", err)
+						continue
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Print the last log lines of containers that have restarted during the execution of containers e2e tests.

### Motivation

It sometimes happens that a container restarts during the execution of containers e2e tests.
If it’s a fake app workload, it can be a clue for a failing test.
If it’s an agent container, it will make the `Test00UpAndRunning` test fail.

So far, the best way to investigate such container restarts was too look at their logs on the `dddev` org as the agent dual-ships all the collected data there.
Unfortunately, there are some cases where this doesn’t work and we can’t find the logs of the restarted container:
* When the container has restarted before the datadog agent was up and running.
* When the datadog agent itself is in `CrashLoopBackOff`.

For those situations, it would be valuable to directly collect the container’s logs from k8s.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

