### PR TITLE
[E2e] Add basic e2e tests for agent CLI

### DIFF
--- a/cmd/cluster-agent/subcommands/status/command.go
+++ b/cmd/cluster-agent/subcommands/status/command.go
@@ -64,7 +64,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 //nolint:revive // TODO(CINT) Fix revive linter
 func run(log log.Component, config config.Component, cliParams *cliParams) error {
-	fmt.Printf("Getting the status from the agent.\n")
+	if !cliParams.prettyPrintJSON && !cliParams.jsonStatus {
+		fmt.Printf("Getting the status from the agent.\n")
+	}
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -248,21 +248,95 @@ func (suite *k8sSuite) TestVersion() {
 	}
 }
 
-func (suite *k8sSuite) TestClusterAgentConfigCheck() {
-	ctx := context.Background()
-	suite.Run("cluster agent pods return the right information for the config check command", func() {
-		appSelector := suite.AgentLinuxHelmInstallName + "-datadog-cluster-agent"
+func (suite *k8sSuite) TestCLI() {
+	suite.Run("agent CLI", func() { suite.testAgentCLI() })
+	suite.Run("cluster agent CLI", func() { suite.testClusterAgentCLI() })
+}
 
-		linuxPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("app", appSelector).String(),
-			Limit:         1,
-		})
+func (suite *k8sSuite) testAgentCLI() {
+	ctx := context.Background()
+
+	pod, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog").String(),
+		Limit:         1,
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(pod.Items, 1)
+
+	suite.Run("agent status", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "status"})
 		suite.Require().NoError(err)
-		suite.Require().Len(linuxPods.Items, 1)
-		stdout, stderr, err := suite.podExec("datadog", linuxPods.Items[0].Name, "cluster-agent", []string{"agent", "configcheck"})
+		suite.Empty(stderr, "Standard error of `agent status` should be empty")
+		suite.Contains(stdout, "Collector")
+		suite.Contains(stdout, "Running Checks")
+		suite.Contains(stdout, "Instance ID: container [OK]")
+	})
+
+	suite.Run("agent checkconfig", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "checkconfig"})
 		suite.Require().NoError(err)
-		suite.Empty(stderr, "Standard error of `agent configcheck` should be empty")
-		suite.Contains(stdout, "=== kubernetes_apiserver check ===")
+		suite.Empty(stderr, "Standard error of `agent checkconfig` should be empty")
+		suite.Contains(stdout, "=== container check ===")
+		suite.Contains(stdout, "Config for instance ID: container:")
+	})
+
+	suite.Run("agent check -r container", func() {
+		stdout, _, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "check", "-r", "container", "--table", "--delay", "1000"})
+		suite.Require().NoError(err)
+		suite.Contains(stdout, "container.memory.usage        gauge")
+	})
+
+	suite.Run("agent workload-list", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "workload-list", "-v"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `agent workload-list` should be empty")
+		suite.Contains(stdout, "=== Entity container sources(merged):[node_orchestrator runtime] id: ")
+		suite.Contains(stdout, "=== Entity kubernetes_pod sources(merged):[cluster_orchestrator node_orchestrator] id: ")
+	})
+
+	suite.Run("agent tagger-list", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "tagger-list"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `agent tagger-list` should be empty")
+		suite.Contains(stdout, "=== Entity container_id://")
+		suite.Contains(stdout, "=== Entity kubernetes_pod_uid://")
+	})
+}
+
+func (suite *k8sSuite) testClusterAgentCLI() {
+	ctx := context.Background()
+
+	pod, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-cluster-agent").String(),
+		Limit:         1,
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(pod.Items, 1)
+
+	suite.Run("cluster-agent status", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "cluster-agent", []string{"datadog-cluster-agent", "status"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `datadog-cluster-agent status` should be empty")
+		suite.Contains(stdout, "Collector")
+		suite.Contains(stdout, "Running Checks")
+		suite.Contains(stdout, "kubernetes_state_core")
+	})
+
+	suite.Run("cluster-agent checkconfig", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "cluster-agent", []string{"datadog-cluster-agent", "checkconfig"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `datadog-cluster-agent checkconfig` should be empty")
+		suite.Contains(stdout, "=== kubernetes_state_core check ===")
+		suite.Contains(stdout, "Config for instance ID: kubernetes_state_core:")
+	})
+
+	suite.Run("cluster-agent clusterchecks", func() {
+		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "cluster-agent", []string{"datadog-cluster-agent", "clusterchecks"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `datadog-cluster-agent clusterchecks` should be empty")
+		suite.Contains(stdout, "agents reporting ===")
+		suite.Contains(stdout, "===== Checks on ")
+		suite.Contains(stdout, "=== helm check ===")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Add basic e2e tests to validate that the agent CLI are working from Kubernetes pods.

### Motivation

We recently faced a bug linked to colors and TTY detection that hasn’t been caught before merge.

### Additional Notes

The goal isn’t to exhaustively validate the full human-readable formatting of each command, but only to quickly validate that they work.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
