### PR TITLE
[E2e] Mark the agent_pods_are_ready_and_not_restarting tests as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -12,6 +12,10 @@ test/new-e2e/tests/containers:
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestECSSuite
+  - TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting
+  - TestEKSSuite/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting
+  - TestKindSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting
+  - TestKindSuite/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting
 
 test/new-e2e/tests/installer:
   - TestPackages/upgrade_scenario_ubuntu_22_04_x86_64/TestUpgradeSuccessful


### PR DESCRIPTION
### What does this PR do?

Mark the `Test*Suite/Test*UpAndRunning/agent_pods_are_ready_and_not_restarting` e2e test as flaky.

### Motivation

We have currently have crashes of the cluster-agent.
We currently miss its logs for investigating the crash.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes