### PR TITLE
fix: check for metric allowlist config to avoid spurious warning message

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -387,7 +387,7 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 func (s *Serializer) getFailoverAllowlist() (bool, map[string]struct{}) {
 	failoverActive := s.config.GetBool("multi_region_failover.enabled") && s.config.GetBool("multi_region_failover.failover_metrics")
 	var allowlist map[string]struct{}
-	if failoverActive {
+	if failoverActive && s.config.IsSet("multi_region_failover.metric_allowlist") {
 		rawList := s.config.GetStringSlice("multi_region_failover.metric_allowlist")
 		allowlist = make(map[string]struct{}, len(rawList))
 		for _, allowed := range rawList {


### PR DESCRIPTION
### What does this PR do?

Avoids loading metric allowlist when the configuration is not set.

### Motivation

This avoids outputting a warning message from viper about casting nil when the allowlist is not configured at all. This doesn't affect functionality at all, since it already works as intended, it just avoids triggering the log line.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Like #26351, but ensure we do not encounter the logged warning when `metric_allowlist` is completely removed from the configuration.

APR-98