### PR TITLE
fix: register metric filtering config to avoid warnings

### DIFF
--- a/pkg/config/setup/multi_region_failover.go
+++ b/pkg/config/setup/multi_region_failover.go
@@ -15,6 +15,7 @@ func setupMultiRegionFailover(config pkgconfigmodel.Setup) {
 	config.BindEnv("multi_region_failover.api_key")
 	config.BindEnv("multi_region_failover.site")
 	config.BindEnv("multi_region_failover.dd_url")
+	config.BindEnv("multi_region_failover.metric_allowlist")
 	config.BindEnvAndSetDefault("multi_region_failover.enabled", false)
 	config.BindEnvAndSetDefault("multi_region_failover.failover_metrics", false)
 	config.BindEnvAndSetDefault("multi_region_failover.failover_logs", false)


### PR DESCRIPTION
### What does this PR do?

Registers the new `multi_region_failover.metric_allowlist` configuration.

### Motivation

While the configuration works fine without this, registering it avoids a number of warning log messages that are printed at agent startup.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Boot up the agent with this configured and look for the absence of warnings about unknown config values.

APR-98