### PR TITLE
[IR-28891] Bug Fix for serverless-init logging

### DIFF
--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -67,11 +67,5 @@ func (a *logAgent) SetupPipeline(
 
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(coreConfig pkgConfig.Reader) (*config.Endpoints, error) {
-	config, err := config.BuildServerlessEndpoints(coreConfig, intakeTrackType, config.DefaultIntakeProtocol)
-	if err != nil {
-		return nil, err
-	}
-	// in serverless mode, we never want the batch strategy to flush with a tick
-	config.BatchWait = 365 * 24 * time.Hour
-	return config, nil
+	return config.BuildServerlessEndpoints(coreConfig, intakeTrackType, config.DefaultIntakeProtocol)
 }

--- a/comp/logs/agent/agentimpl/agent_serverless_init_test.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init_test.go
@@ -9,12 +9,12 @@ package agentimpl
 
 import (
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 )
 
 func TestBuildServerlessEndpoints(t *testing.T) {
@@ -26,5 +26,4 @@ func TestBuildServerlessEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
 	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
-	assert.True(t, endpoints.Main.BatchWait > config.BatchWait*time.Second)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes a bug where logs were no longer being submitted from serverless-init unless a container was restarted or stopped.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[[BUG] serverless init 1.2.3 is not sending logs](https://github.com/DataDog/datadog-agent/issues/27502)
[IR-28891](https://app.datadoghq.com/incidents/28891)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Unit tests and deployed to self-monitoring apps
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
