### PR TITLE
[OASIS-81] Remove build tag test in otel testutil

### DIFF
--- a/comp/otelcol/otlp/testutil/testutil.go
+++ b/comp/otelcol/otlp/testutil/testutil.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
-//go:build test
-
 package testutil
 
 import (

--- a/comp/otelcol/otlp/testutil/testutil_test.go
+++ b/comp/otelcol/otlp/testutil/testutil_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
-//go:build test
-
 package testutil
 
 import (


### PR DESCRIPTION
OSS collector does not respect the build tag `test`. Need to remove it if we want to reuse the testutil in OSS.