### PR TITLE
[notify] Simplify Slack notifications code

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -11,7 +11,7 @@ from difflib import Differ
 
 import gitlab
 import yaml
-from gitlab.v4.objects import Project, ProjectPipeline
+from gitlab.v4.objects import Project, ProjectCommit, ProjectPipeline
 from invoke.exceptions import Exit
 
 from tasks.libs.common.color import Color, color_message
@@ -78,6 +78,22 @@ def get_gitlab_repo(repo='DataDog/datadog-agent', token=None) -> Project:
     repo = api.projects.get(repo)
 
     return repo
+
+
+def get_commit(project_name: str, git_ref: str) -> ProjectCommit:
+    """
+    Retrieves the commit for a given git ref a given project.
+    """
+    repo = get_gitlab_repo(project_name)
+    return repo.commits.get(git_ref)
+
+
+def get_pipeline(project_name: str, pipeline_id: str) -> ProjectPipeline:
+    """
+    Retrieves the pipeline for a given pipeline id in a given project.
+    """
+    repo = get_gitlab_repo(project_name)
+    return repo.pipelines.get(pipeline_id)
 
 
 @retry_function('refresh pipeline #{0.id}')

--- a/tasks/libs/notify/alerts.py
+++ b/tasks/libs/notify/alerts.py
@@ -17,7 +17,7 @@ from tasks.libs.notify.utils import (
     PROJECT_TITLE,
     get_ci_visibility_job_url,
 )
-from tasks.libs.pipeline.data import get_failed_jobs
+from tasks.libs.pipeline.data import get_failed_jobs, get_pipeline
 from tasks.libs.pipeline.notifications import (
     get_pr_from_commit,
     send_slack_message,
@@ -188,7 +188,7 @@ def update_statistics(job_executions: PipelineRuns):
     cumulative_alerts = {}
 
     # Update statistics and collect consecutive failed jobs
-    failed_jobs = get_failed_jobs(PROJECT_NAME, os.environ["CI_PIPELINE_ID"])
+    failed_jobs = get_failed_jobs(get_pipeline(PROJECT_NAME, os.environ["CI_PIPELINE_ID"]))
     commit_sha = os.getenv("CI_COMMIT_SHA")
     failed_dict = {job.name: ExecutionsJobInfo(job.id, True, commit_sha) for job in failed_jobs.all_failures()}
 

--- a/tasks/libs/notify/alerts.py
+++ b/tasks/libs/notify/alerts.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from invoke.context import Context
 from invoke.exceptions import UnexpectedExit
 
-from tasks.libs.ciproviders.gitlab_api import BASE_URL
+from tasks.libs.ciproviders.gitlab_api import BASE_URL, get_pipeline
 from tasks.libs.common.datadog_api import create_count, send_metrics
 from tasks.libs.notify.utils import (
     AWS_S3_CP_CMD,
@@ -17,7 +17,7 @@ from tasks.libs.notify.utils import (
     PROJECT_TITLE,
     get_ci_visibility_job_url,
 )
-from tasks.libs.pipeline.data import get_failed_jobs, get_pipeline
+from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.pipeline.notifications import (
     get_pr_from_commit,
     send_slack_message,

--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -1,9 +1,10 @@
 import os
 import re
 
+from tasks.libs.ciproviders.gitlab_api import get_commit, get_pipeline
 from tasks.libs.common.constants import DEFAULT_BRANCH
 from tasks.libs.notify.utils import PIPELINES_CHANNEL, PROJECT_NAME
-from tasks.libs.pipeline.data import get_commit, get_failed_jobs, get_pipeline
+from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.pipeline.notifications import (
     base_message,
     email_to_slackid,

--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -1,74 +1,42 @@
 import os
 import re
-from collections import defaultdict
-from datetime import datetime, timezone
 
-from tasks.libs.common.datadog_api import create_count, send_metrics
-from tasks.libs.notify.utils import CHANNEL_PIPELINES, NOTIFICATION_DISCLAIMER
+from tasks.libs.common.constants import DEFAULT_BRANCH
+from tasks.libs.notify.utils import PIPELINES_CHANNEL, PROJECT_NAME
+from tasks.libs.pipeline.data import get_commit, get_failed_jobs, get_pipeline
 from tasks.libs.pipeline.notifications import (
-    GITHUB_SLACK_MAP,
     base_message,
     email_to_slackid,
-    find_job_owners,
     get_failed_tests,
-    get_git_author,
     send_slack_message,
 )
-from tasks.libs.types.types import FailedJobs, SlackMessage, TeamMessage
-
-UNKNOWN_OWNER_TEMPLATE = """The owner `{owner}` is not mapped to any slack channel.
-Please check for typos in the JOBOWNERS file and/or add them to the Github <-> Slack map.
-"""
+from tasks.libs.types.types import SlackMessage
 
 
-def should_send_message_to_channel(git_ref: str, default_branch: str) -> bool:
+def should_send_message_to_author(git_ref: str, default_branch: str) -> bool:
     # Must match X.Y.Z, X.Y.x, W.X.Y-rc.Z
     # Must not match W.X.Y-rc.Z-some-feature
     release_ref_regex = re.compile(r"^[0-9]+\.[0-9]+\.(x|[0-9]+)$")
     release_ref_regex_rc = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]-rc.[0-9]+$")
 
-    return git_ref == default_branch or release_ref_regex.match(git_ref) or release_ref_regex_rc.match(git_ref)
+    return not (git_ref == default_branch or release_ref_regex.match(git_ref) or release_ref_regex_rc.match(git_ref))
 
 
-def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> dict[str, SlackMessage]:
-    all_teams = "@DataDog/agent-all"
+def send_message(ctx, notification_type, dry_run):
+    pipeline = get_pipeline(PROJECT_NAME, os.environ["CI_PIPELINE_ID"])
+    commit = get_commit(PROJECT_NAME, pipeline.ref)
+    failed_jobs = get_failed_jobs(pipeline)
 
-    # Generate messages for each team
-    messages_to_send = defaultdict(TeamMessage)
-    messages_to_send[all_teams] = SlackMessage(jobs=failed_jobs)
-
-    failed_job_owners = find_job_owners(failed_jobs)
-    for owner, jobs in failed_job_owners.items():
-        if owner == "@DataDog/multiple":
-            for job in jobs.all_non_infra_failures():
-                for test in get_failed_tests(project_name, job):
-                    messages_to_send[all_teams].add_test_failure(test, job)
-                    for owner in test.owners:
-                        messages_to_send[owner].add_test_failure(test, job)
-        elif owner == "@DataDog/do-not-notify":
-            # Jobs owned by @DataDog/do-not-notify do not send team messages
-            pass
-        elif owner == all_teams:
-            # Jobs owned by @DataDog/agent-all will already be in the global
-            # message, do not overwrite the failed jobs list
-            pass
-        else:
-            messages_to_send[owner].failed_jobs = jobs
-
-    return messages_to_send
-
-
-def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_type, dry_run):
     # From the job failures, set whether the pipeline succeeded or failed and craft the
     # base message that will be sent.
     if failed_jobs.all_mandatory_failures():  # At least one mandatory job failed
         header_icon = ":host-red:"
         state = "failed"
-        coda = NOTIFICATION_DISCLAIMER
     else:
         header_icon = ":host-green:"
         state = "succeeded"
-        coda = ""
+
+    slack_channel = PIPELINES_CHANNEL
 
     header = ""
     if notification_type == "merge":
@@ -77,48 +45,24 @@ def send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_ty
         header = f"{header_icon} :rocket: datadog-agent deploy"
     elif notification_type == "trigger":
         header = f"{header_icon} :arrow_forward: datadog-agent triggered"
-    base = base_message(header, state)
+
+    message = SlackMessage(jobs=failed_jobs)
+    message.base_message = base_message(PROJECT_NAME, pipeline, commit, header, state)
+
+    for job in failed_jobs.all_non_infra_failures():
+        for test in get_failed_tests(PROJECT_NAME, job):
+            message.add_test_failure(test, job)
 
     # Send messages
-    metrics = []
-    timestamp = int(datetime.now(timezone.utc).timestamp())
-    for owner, message in messages_to_send.items():
-        channel = GITHUB_SLACK_MAP.get(owner.lower(), None)
-        message.base_message = base
-        if channel is None:
-            channel = CHANNEL_PIPELINES
-            message.base_message += UNKNOWN_OWNER_TEMPLATE.format(owner=owner)
-        message.coda = coda
+    if dry_run:
+        print(f"Would send to {slack_channel}:\n{str(message)}")
+    else:
+        send_slack_message(slack_channel, str(message))
+
+    if should_send_message_to_author(pipeline.ref, DEFAULT_BRANCH):
+        author_email = commit.author_email
         if dry_run:
-            print(f"Would send to {channel}:\n{str(message)}")
+            print(f"Would send to {author_email}:\n{str(message)}")
         else:
-            all_teams = channel == CHANNEL_PIPELINES
-            default_branch = os.environ["CI_DEFAULT_BRANCH"]
-            git_ref = os.environ["CI_COMMIT_REF_NAME"]
-            send_dm = not should_send_message_to_channel(git_ref, default_branch) and all_teams
-
-            if all_teams:
-                recipient = channel
-                send_slack_message(recipient, str(message))
-                metrics.append(
-                    create_count(
-                        metric_name="datadog.ci.failed_job_notifications",
-                        timestamp=timestamp,
-                        tags=[
-                            f"team:{owner}",
-                            "repository:datadog-agent",
-                            f"git_ref:{git_ref}",
-                        ],
-                        unit="notification",
-                        value=1,
-                    )
-                )
-
-            # DM author
-            if send_dm:
-                author_email = get_git_author(email=True)
-                recipient = email_to_slackid(ctx, author_email)
-                send_slack_message(recipient, str(message))
-
-    if metrics and not dry_run:
-        send_metrics(metrics)
+            recipient = email_to_slackid(ctx, author_email)
+            send_slack_message(recipient, str(message))

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -8,7 +8,7 @@ PROJECT_TITLE = PROJECT_NAME.removeprefix("DataDog/")
 CI_VISIBILITY_JOB_URL = 'https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A{name}{extra_flags}&agg_m=count'
 NOTIFICATION_DISCLAIMER = "If there is something wrong with the notification please contact #agent-devx-help"
 CHANNEL_BROADCAST = '#agent-devx-ops'
-CHANNEL_PIPELINES = '#datadog-agent-pipelines'
+PIPELINES_CHANNEL = '#datadog-agent-pipelines'
 AWS_S3_CP_CMD = "aws s3 cp --only-show-errors --region us-east-1 --sse AES256"
 AWS_S3_LS_CMD = "aws s3api list-objects-v2 --bucket '{bucket}' --prefix '{prefix}/' --delimiter /"
 

--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -1,26 +1,10 @@
 import re
 from collections import defaultdict
 
-from gitlab.v4.objects import ProjectCommit, ProjectJob, ProjectPipeline
+from gitlab.v4.objects import ProjectJob, ProjectPipeline
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.types.types import FailedJobReason, FailedJobs, FailedJobType
-
-
-def get_commit(project_name: str, git_ref: str) -> ProjectCommit:
-    """
-    Retrieves the git ref for a given pipeline id in a given project.
-    """
-    repo = get_gitlab_repo(project_name)
-    return repo.commits.get(git_ref)
-
-
-def get_pipeline(project_name: str, pipeline_id: str) -> ProjectPipeline:
-    """
-    Retrieves the git ref for a given pipeline id in a given project.
-    """
-    repo = get_gitlab_repo(project_name)
-    return repo.pipelines.get(pipeline_id)
 
 
 def get_failed_jobs(pipeline: ProjectPipeline) -> FailedJobs:

--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -1,18 +1,33 @@
 import re
 from collections import defaultdict
 
-from gitlab.v4.objects import ProjectJob
+from gitlab.v4.objects import ProjectCommit, ProjectJob, ProjectPipeline
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.types.types import FailedJobReason, FailedJobs, FailedJobType
 
 
-def get_failed_jobs(project_name: str, pipeline_id: str) -> FailedJobs:
+def get_commit(project_name: str, git_ref: str) -> ProjectCommit:
+    """
+    Retrieves the git ref for a given pipeline id in a given project.
+    """
+    repo = get_gitlab_repo(project_name)
+    return repo.commits.get(git_ref)
+
+
+def get_pipeline(project_name: str, pipeline_id: str) -> ProjectPipeline:
+    """
+    Retrieves the git ref for a given pipeline id in a given project.
+    """
+    repo = get_gitlab_repo(project_name)
+    return repo.pipelines.get(pipeline_id)
+
+
+def get_failed_jobs(pipeline: ProjectPipeline) -> FailedJobs:
     """
     Retrieves the list of failed jobs for a given pipeline id in a given project.
     """
-    repo = get_gitlab_repo(project_name)
-    pipeline = repo.pipelines.get(pipeline_id)
+    repo = get_gitlab_repo(pipeline.project_id)
     jobs = pipeline.jobs.list(per_page=100, all=True)
 
     # Get instances of failed jobs grouped by name

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -121,20 +121,18 @@ def get_pr_from_commit(commit_title, project_title) -> tuple[str, str] | None:
     return parsed_pr_id, f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
 
 
-def base_message(header, state):
-    project_title = os.getenv("CI_PROJECT_TITLE")
-    # commit_title needs a default string value, otherwise the re.search line below crashes
-    commit_title = os.getenv("CI_COMMIT_TITLE", "")
-    pipeline_url = os.getenv("CI_PIPELINE_URL")
-    pipeline_id = os.getenv("CI_PIPELINE_ID")
-    commit_ref_name = os.getenv("CI_COMMIT_REF_NAME")
-    commit_url_gitlab = f"{os.getenv('CI_PROJECT_URL')}/commit/{os.getenv('CI_COMMIT_SHA')}"
-    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/commit/{os.getenv('CI_COMMIT_SHA')}"
-    commit_short_sha = os.getenv("CI_COMMIT_SHORT_SHA")
-    author = get_git_author()
+def base_message(project_name, pipeline, commit, header, state):
+    commit_title = commit.title
+    pipeline_url = pipeline.web_url
+    pipeline_id = pipeline.id
+    commit_ref_name = pipeline.ref
+    commit_url_gitlab = commit.web_url
+    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_name}/commit/{commit.id}"
+    commit_short_sha = commit.id[-8:]
+    author = commit.author_name
 
     # Try to find a PR id (e.g #12345) in the commit title and add a link to it in the message if found.
-    pr_info = get_pr_from_commit(commit_title, project_title)
+    pr_info = get_pr_from_commit(commit_title, project_name)
     enhanced_commit_title = commit_title
     if pr_info:
         parsed_pr_id, pr_url_github = pr_info
@@ -142,17 +140,6 @@ def base_message(header, state):
 
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
 {enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""
-
-
-def get_git_author(email=False):
-    format = 'ae' if email else 'an'
-
-    return (
-        subprocess.check_output(["git", "show", "-s", f"--format='%{format}'", "HEAD"])
-        .decode('utf-8')
-        .strip()
-        .replace("'", "")
-    )
 
 
 def send_slack_message(recipient, message):

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 import gitlab
 import yaml
-from gitlab.v4.objects import ProjectJob
+from gitlab.v4.objects import ProjectCommit, ProjectJob, ProjectPipeline
 from invoke.context import Context
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
@@ -121,7 +121,7 @@ def get_pr_from_commit(commit_title, project_title) -> tuple[str, str] | None:
     return parsed_pr_id, f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
 
 
-def base_message(project_name, pipeline, commit, header, state):
+def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCommit, header: str, state: str):
     commit_title = commit.title
     pipeline_url = pipeline.web_url
     pipeline_id = pipeline.id

--- a/tasks/libs/pipeline/stats.py
+++ b/tasks/libs/pipeline/stats.py
@@ -5,9 +5,9 @@ from datetime import datetime
 
 from invoke import Exit
 
-from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
+from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo, get_pipeline
 from tasks.libs.common.datadog_api import create_count, create_gauge
-from tasks.libs.pipeline.data import get_failed_jobs, get_pipeline
+from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.types.types import FailedJobType
 
 REQUIRED_JOBS = [

--- a/tasks/libs/pipeline/stats.py
+++ b/tasks/libs/pipeline/stats.py
@@ -7,7 +7,7 @@ from invoke import Exit
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.datadog_api import create_count, create_gauge
-from tasks.libs.pipeline.data import get_failed_jobs
+from tasks.libs.pipeline.data import get_failed_jobs, get_pipeline
 from tasks.libs.types.types import FailedJobType
 
 REQUIRED_JOBS = [
@@ -108,7 +108,7 @@ def get_failed_jobs_stats(project_name, pipeline_id):
     # }
     job_failure_stats = Counter()
 
-    failed_jobs = get_failed_jobs(project_name, pipeline_id)
+    failed_jobs = get_failed_jobs(get_pipeline(project_name, pipeline_id))
 
     # This stores the reason why a pipeline ultimately failed.
     # The goal is to have a statistic of the number of pipelines that fail

--- a/tasks/libs/types/types.py
+++ b/tasks/libs/types/types.py
@@ -106,7 +106,7 @@ class FailedJobs:
 class SlackMessage:
     JOBS_SECTION_HEADER = "Failed jobs:"
     INFRA_SECTION_HEADER = "Infrastructure failures:"
-    TEST_SECTION_HEADER = "Failed unit tests:"
+    TEST_SECTION_HEADER = "Failed tests:"
     MAX_JOBS_PER_TEST = 2
 
     def __init__(self, base: str = "", jobs: FailedJobs = None):
@@ -171,8 +171,3 @@ class SlackMessage:
         if self.coda:
             print(self.coda, file=buffer)
         return buffer.getvalue()
-
-
-class TeamMessage(SlackMessage):
-    JOBS_SECTION_HEADER = "Failed jobs you own:"
-    TEST_SECTION_HEADER = "Failed unit tests you own:"

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import io
 import os
 import sys
-import traceback
 from datetime import timedelta
 
 from invoke import Context, task
@@ -22,9 +20,7 @@ from tasks.libs.common.datadog_api import send_metrics
 from tasks.libs.common.utils import gitlab_section
 from tasks.libs.notify import alerts, failure_summary, pipeline_status
 from tasks.libs.notify.utils import PROJECT_NAME
-from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.pipeline.notifications import (
-    base_message,
     check_for_missing_owners_slack_and_jira,
 )
 from tasks.libs.pipeline.stats import compute_failed_jobs_series, compute_required_jobs_max_duration
@@ -50,23 +46,7 @@ def send_message(ctx: Context, notification_type: str = "merge", dry_run: bool =
     Use the --dry-run option to test this locally, without sending
     real slack messages.
     """
-
-    try:
-        failed_jobs = get_failed_jobs(PROJECT_NAME, os.environ["CI_PIPELINE_ID"])
-        messages_to_send = pipeline_status.generate_failure_messages(PROJECT_NAME, failed_jobs)
-    except Exception as e:
-        buffer = io.StringIO()
-        print(base_message("datadog-agent", "is in an unknown state"), file=buffer)
-        print("Found exception when generating notification:", file=buffer)
-        traceback.print_exc(limit=-1, file=buffer)
-        print("See the notify job log for the full exception traceback.", file=buffer)
-
-        # Print traceback on job log
-        print(e)
-        traceback.print_exc()
-        raise Exit(code=1) from e
-
-    pipeline_status.send_message_and_metrics(ctx, failed_jobs, messages_to_send, notification_type, dry_run)
+    pipeline_status.send_message(ctx, notification_type, dry_run)
 
 
 @task

--- a/tasks/unit_tests/libs/notify/alerts_tests.py
+++ b/tasks/unit_tests/libs/notify/alerts_tests.py
@@ -86,6 +86,7 @@ class TestAlertsRetrieveJobExecutions(unittest.TestCase):
 
 class TestAlertsUpdateStatistics(unittest.TestCase):
     @patch("tasks.libs.notify.alerts.get_failed_jobs")
+    @patch("tasks.libs.notify.alerts.get_pipeline", new=MagicMock())
     def test_nominal(self, mock_get_failed):
         failed_jobs = mock_get_failed.return_value
         failed_jobs.all_failures.return_value = [
@@ -141,6 +142,7 @@ class TestAlertsUpdateStatistics(unittest.TestCase):
         mock_get_failed.assert_called()
 
     @patch("tasks.libs.notify.alerts.get_failed_jobs")
+    @patch("tasks.libs.notify.alerts.get_pipeline", new=MagicMock())
     def test_multiple_failures(self, mock_get_failed):
         failed_jobs = mock_get_failed.return_value
         fail = {"id": 42, "failing": True, 'commit': 'abcdef42'}

--- a/tasks/unit_tests/libs/notify/failure_summary_tests.py
+++ b/tasks/unit_tests/libs/notify/failure_summary_tests.py
@@ -10,7 +10,7 @@ from invoke.context import Context, MockContext
 
 from tasks.libs.notify import failure_summary
 from tasks.libs.notify.failure_summary import SummaryData, SummaryStats
-from tasks.libs.notify.utils import CHANNEL_PIPELINES
+from tasks.libs.notify.utils import PIPELINES_CHANNEL
 from tasks.libs.pipeline.notifications import load_and_validate
 
 TEST_DIR = '/tmp/summary'
@@ -200,13 +200,13 @@ class TestSummaryStats(TestFailureSummary):
                 '#channel-a',
                 '#channel-b',
                 ALL_TEAMS_CHANNEL,
-                CHANNEL_PIPELINES,
+                PIPELINES_CHANNEL,
             },
         )
         self.assertEqual(len(results['#channel-a']), 2)
         self.assertEqual(len(results['#channel-b']), 2)
         self.assertEqual(len(results[ALL_TEAMS_CHANNEL]), 1)
-        self.assertEqual(len(results[CHANNEL_PIPELINES]), 4)
+        self.assertEqual(len(results[PIPELINES_CHANNEL]), 4)
 
 
 class TestModule(TestFailureSummary):
@@ -253,7 +253,7 @@ class TestModule(TestFailureSummary):
     @patch("tasks.libs.notify.failure_summary.send_summary_slack_notification")
     def test_send_summary_messages(self, mock_slack: MagicMock = None):
         # Verify that we send the right number of jobs per channel
-        expected_team_njobs = {'#channel-a': 2, '#channel-b': 3, ALL_TEAMS_CHANNEL: 1, CHANNEL_PIPELINES: 5}
+        expected_team_njobs = {'#channel-a': 2, '#channel-b': 3, ALL_TEAMS_CHANNEL: 1, PIPELINES_CHANNEL: 5}
 
         summary = SummaryData(
             MagicMock(),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Following changes to the notifications behavior (removal of team-level channel notifications) and addition of the gitlab Python package, and before making further modifications to the task's behavior, I took the opportunity to remove some dead code, remove use of environment variables, and add utility functions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Simplify the notification code, removing unneeded sections.
Avoid relying on environment variables, make use of the info given by the Gitlab API as much as possible.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Some implementation notes:
- I removed the exception handling code in `tasks/notify.py` because I don't think it does anything except re-print the traceback? If I'm wrong, I can add it back in
- I introduced the `get_pipeline` and `get_commit` utilities to get more kinds of objects from the Gitlab API, which were needed to remove the use of environment variables
- I then changed `get_failed_jobs` to take the result of `get_pipeline` as argument, to limit the number of calls to the API
- I renamed `CHANNEL_PIPELINES` to `PIPELINES_CHANNEL` for consistency with the rest of variable names (like `ALL_TEAMS_CHANNEL`)

Future changes:
- Pass the pipeline id as a proper parameter instead of an environment variable (I didn't want to change task signatures here)
- Target a different Slack channel on non-main deploy pipelines (I didn't want to change the behavior of the task here)
- Find the pipeline type without having to pass it as an explicit parameter

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Ran the following within the container used in CI, with various cases (failing `main`, successful `7.56.x`, failing dev branch deploy pipeline with failed tests):
```
$ CI_PIPELINE_ID=39628099 invoke -e notify.send-message --notification-type "merge" --dry-run
Would send to #datadog-agent-pipelines:
:host-red: :merged: datadog-agent merge pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39628099|39628099> for main failed.
Fix the admission controller on old versions of Kubernetes (<https://github.com/DataDog/DataDog/datadog-agent/pull/27600|#27600>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/6e5a91dbd42dc27c6ad882d7933e3d29ba44db77|ba44db77>)(:github: <https://github.com/DataDog/DataDog/datadog-agent/commit/6e5a91dbd42dc27c6ad882d7933e3d29ba44db77|link>) by Lénaïc Huard
Failed jobs:
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/577972220|new-e2e-installer> (`e2e` stage)
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/577972176|trigger_auto_staging_release> (`trigger_release` stage)
```

```
$ CI_PIPELINE_ID=39629659  invoke -e notify.send-message --notification-type "merge" --dry-run
Would send to #datadog-agent-pipelines:
:host-green: :merged: datadog-agent merge pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39629659|39629659> for 7.56.x succeeded.
bump omnibus software commit to include cURL update (<https://github.com/DataDog/DataDog/datadog-agent/pull/27713|#27713>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/27a6961d79f5aaba05bb553ee50df23ff0bea5b5|f0bea5b5>)(:github: <https://github.com/DataDog/DataDog/datadog-agent/commit/27a6961d79f5aaba05bb553ee50df23ff0bea5b5|link>) by Hugo Beauzée-Luyssen
```

```
$ CI_PIPELINE_ID=39528120 invoke -e notify.send-message --notification-type "deploy" --dry-run
Would send to #datadog-agent-pipelines:
:host-red: :rocket: datadog-agent deploy pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39528120|39528120> for test-revert-metadata-dup-v3 failed.
don't set annotations and labels on kubemetadata entities for pods and deployments (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/ac669ad51b5af44e1310b9af914f8d859c5431e9|9c5431e9>)(:github: <https://github.com/DataDog/DataDog/datadog-agent/commit/ac669ad51b5af44e1310b9af914f8d859c5431e9|link>) by adel121
Failed jobs:
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880832|tests_rpm-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880819|tests_deb-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880812|tests_rpm-x64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880785|tests_deb-x64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880776|prepare_sysprobe_ebpf_functional_tests_x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880775|prepare_sysprobe_ebpf_functional_tests_arm64> (`source_test` stage)
Failed tests:
- `TestDeploymentParser_Parse` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `Test_DeploymentsFakeKubernetesClient` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `TestPodParser_Parse` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `Test_PodsFakeKubernetesClient` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)

Would send to adel.hajhassan@datadoghq.com:
:host-red: :rocket: datadog-agent deploy pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39528120|39528120> for test-revert-metadata-dup-v3 failed.
don't set annotations and labels on kubemetadata entities for pods and deployments (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/ac669ad51b5af44e1310b9af914f8d859c5431e9|9c5431e9>)(:github: <https://github.com/DataDog/DataDog/datadog-agent/commit/ac669ad51b5af44e1310b9af914f8d859c5431e9|link>) by adel121
Failed jobs:
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880832|tests_rpm-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880819|tests_deb-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880812|tests_rpm-x64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880785|tests_deb-x64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880776|prepare_sysprobe_ebpf_functional_tests_x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880775|prepare_sysprobe_ebpf_functional_tests_arm64> (`source_test` stage)
Failed tests:
- `TestDeploymentParser_Parse` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `Test_DeploymentsFakeKubernetesClient` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `TestPodParser_Parse` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
- `Test_PodsFakeKubernetesClient` from package `comp/core/workloadmeta/collectors/internal/kubeapiserver` (in <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880862|tests_windows-x64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/576880842|tests_macos> and 4 more)
```