### PR TITLE
chore(fleet): Remove flake mark

### DIFF
--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -47,6 +47,7 @@ func (h *Host) uploadFixtures() {
 
 // StartExamplePythonApp starts an example Python app
 func (h *Host) StartExamplePythonApp() {
+	h.WaitForTraceAgentSocketReady()
 	env := map[string]string{
 		"DD_SERVICE": "example-python-app",
 		"DD_ENV":     "e2e-installer",
@@ -71,6 +72,7 @@ func (h *Host) CallExamplePythonApp(traceID string) {
 
 // StartExamplePythonAppInDocker starts the example Python app in Docker
 func (h *Host) StartExamplePythonAppInDocker() {
+	h.WaitForTraceAgentSocketReady()
 	h.remote.MustExecute(`sudo docker run --name python-app -d -p 8081:8080 -v /opt/fixtures/http_server.py:/usr/src/app/http_server.py public.ecr.aws/docker/library/python:3.8-slim python /usr/src/app/http_server.py`)
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -165,11 +165,11 @@ func (h *Host) WaitForFileExists(useSudo bool, filePaths ...string) {
 	}
 }
 
-// WaitForTraceAgentReady waits for the trace agent to be ready to receive traces
+// WaitForTraceAgentSocketReady waits for the trace agent to be ready to receive traces
 // This is because of a race condition where the trace agent is not ready to receive traces and we send them
 // meaning that the traces are lost
-func (h *Host) WaitForTraceAgentReady() {
-	_, err := h.remote.Execute("timeout=30; while ! grep -q 'Listening for traces at unix://' <(sudo cat /var/log/datadog/trace-agent.log); do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]")
+func (h *Host) WaitForTraceAgentSocketReady() {
+	_, err := h.remote.Execute("timeout=30; while ! grep -q 'Listening for traces at unix://' <(journalctl _PID=`systemctl show -p MainPID datadog-agent-trace | cut -d\"=\" -f2`); do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]")
 	require.NoError(h.t, err, "trace agent did not become ready")
 }
 

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
 )
@@ -222,10 +221,6 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 }
 
 func (s *packageApmInjectSuite) TestVersionBump() {
-	if s.os == e2eos.Debian12 {
-		flake.Mark(s.T()) // TODO(baptiste): FIXME
-	}
-
 	s.host.InstallDocker()
 	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -36,7 +36,6 @@ func (s *packageApmInjectSuite) TestInstall() {
 	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
-	s.host.WaitForTraceAgentReady()
 
 	s.host.StartExamplePythonApp()
 	defer s.host.StopExamplePythonApp()
@@ -230,7 +229,6 @@ func (s *packageApmInjectSuite) TestVersionBump() {
 	)
 	defer s.Purge()
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
-	s.host.WaitForTraceAgentReady()
 
 	state := s.host.State()
 	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.8.5", 0755, "root", "root")
@@ -249,18 +247,17 @@ func (s *packageApmInjectSuite) TestVersionBump() {
 	// Re-run the install script with the latest tracer version
 	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=all",
-		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.8.5",
+		"DD_APM_INSTRUMENTATION_LIBRARIES=python:2.9.2",
 		envForceInstall("datadog-agent"),
 		envForceVersion("datadog-apm-inject", "0.16.0-1"),
 	)
 	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
-	s.host.WaitForTraceAgentReady()
 
 	// Today we expect the previous dir to be fully removed and the new one to be symlinked
 	state = s.host.State()
-	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-apm-library-python/2.8.2-dev")
-	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.8.5", 0755, "root", "root")
-	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-library-python/stable", "/opt/datadog-packages/datadog-apm-library-python/2.8.5", "root", "root")
+	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-apm-library-python/2.8.5")
+	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-python/2.9.2", 0755, "root", "root")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-library-python/stable", "/opt/datadog-packages/datadog-apm-library-python/2.9.2", "root", "root")
 
 	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-apm-inject/0.15.0-1")
 	state.AssertDirExists("/opt/datadog-packages/datadog-apm-inject/0.16.0-1", 0755, "root", "root")


### PR DESCRIPTION
### What does this PR do?
- Remove flake mark added to test
- Uses logs from the latest run of the trace agent to check if the socket is ready - this avoids reading the previous runs' logs.

### Motivation
No flakes

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
