### PR TITLE
usm: tests: Wait for docker compose down to finish on cleanup

### DIFF
--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -84,8 +84,8 @@ func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 
 		c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
 		c.Env = append(c.Env, env...)
-		// Not waiting for its finish.
 		_ = c.Start()
+		_ = c.Wait() // We need to wait for the command to finish so that the docker containers get cleaned up properly before another docker-compose up call
 	})
 
 	for {

--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -81,11 +81,12 @@ func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 	t.Cleanup(func() {
 		cancel()
 		_ = cmd.Wait()
+		timedContext, cancel := context.WithTimeout(context.Background(), timeout)
 
-		c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
+		c := exec.CommandContext(timedContext, "docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
 		c.Env = append(c.Env, env...)
-		_ = c.Start()
-		_ = c.Wait() // We need to wait for the command to finish so that the docker containers get cleaned up properly before another docker-compose up call
+		_ = c.Run() // We need to wait for the command to finish so that the docker containers get cleaned up properly before another docker-compose up call
+		cancel()
 	})
 
 	for {

--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -82,11 +82,11 @@ func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 		cancel()
 		_ = cmd.Wait()
 		timedContext, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 
 		c := exec.CommandContext(timedContext, "docker-compose", "-f", dockerPath, "down", "--remove-orphans", "--volumes")
 		c.Env = append(c.Env, env...)
 		_ = c.Run() // We need to wait for the command to finish so that the docker containers get cleaned up properly before another docker-compose up call
-		cancel()
 	})
 
 	for {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Changes how the docker services are terminated, by forcing to wait on the `docker-compose down` command until it's finished.

### Motivation

The `TestDecoding` tests are flaking in CI, and after an investigation we could reproduce the problem when calling `docker-compose down` without waiting for it to finish, and then calling another `docker-compose` command. This seems to leave the container in a state where it cannot be brought up again. With this PR, we force all `docker-compose` operations to be done in order to avoid this situation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
