### PR TITLE
Fix unknown config keys when initializing the logger in system probe

### DIFF
--- a/pkg/config/logs/go.mod
+++ b/pkg/config/logs/go.mod
@@ -11,12 +11,12 @@ replace (
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.56.0-rc.3
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/stretchr/testify v1.9.0
 )
 
 require (
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.56.0-rc.3 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/pkg/config/logs/log.go
+++ b/pkg/config/logs/log.go
@@ -15,18 +15,15 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cihub/seelog"
 
+	seelogCfg "github.com/DataDog/datadog-agent/pkg/config/logs/internal/seelog"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
-
-	seelogCfg "github.com/DataDog/datadog-agent/pkg/config/logs/internal/seelog"
 )
 
 // LoggerName specifies the name of an instantiated logger.
@@ -110,23 +107,7 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 	}
 	_ = seelog.ReplaceLogger(loggerInterface)
 	log.SetupLogger(loggerInterface, seelogLogLevel)
-	flareStrippedKeys := cfg.GetStringSlice("flare_stripped_keys")
-	if len(flareStrippedKeys) > 0 {
-		log.Warn("flare_stripped_keys is deprecated, please use scrubber.additional_keys instead.")
-	}
-	scrubber.AddStrippedKeys(mergeAdditionalKeysToScrubber(
-		flareStrippedKeys,
-		cfg.GetStringSlice("scrubber.additional_keys")))
 	return nil
-}
-
-// mergeAdditionalKeysToScrubber merges multiple slices of keys into a single slice
-func mergeAdditionalKeysToScrubber(elems ...[]string) []string {
-	set := []string{}
-	for _, elem := range elems {
-		set = append(set, elem...)
-	}
-	return slices.Compact(set)
 }
 
 // SetupJMXLogger sets up a logger with JMX logger name and log level

--- a/pkg/config/logs/log_test.go
+++ b/pkg/config/logs/log_test.go
@@ -8,15 +8,12 @@ package logs
 import (
 	"bufio"
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 
 	seelogCfg "github.com/DataDog/datadog-agent/pkg/config/logs/internal/seelog"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
 func TestExtractShortPathFromFullPath(t *testing.T) {
@@ -104,47 +101,4 @@ func BenchmarkLogFormatWithoutContextFormatting(b *testing.B) {
 
 func BenchmarkLogFormatWithContextFormatting(b *testing.B) {
 	benchmarkLogFormatWithContext("%Date(%s) | %LEVEL | (%ShortFilePath:%Line in %FuncShort) | %Msg %ExtraJSONContext", b)
-}
-
-func TestMergedKeys(t *testing.T) {
-	// Test that the merged keys are correctly computed
-	s1 := []string{"foo", "bar"}
-	s2 := []string{"bar", "buzz"}
-	assert.Equal(t, []string{"foo", "bar", "buzz"}, mergeAdditionalKeysToScrubber(s1, s2))
-}
-
-func TestENVAdditionalKeysToScrubber(t *testing.T) {
-	// Test that the scrubber is correctly configured with the expected keys
-	cfg := pkgconfigmodel.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
-
-	cfg.SetWithoutSource("scrubber.additional_keys", []string{"yet_another_key"})
-	cfg.SetWithoutSource("flare_stripped_keys", []string{"some_other_key"})
-
-	pathDir := t.TempDir()
-
-	// Add a log file at the end of pathDir string
-	pathDir = pathDir + "/tests.log"
-
-	SetupLogger(
-		"TestENVAdditionalKeysToScrubberLogger",
-		"info",
-		pathDir,
-		"",
-		false,
-		false,
-		false,
-		cfg)
-
-	stringToScrub := `api_key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-some_other_key: 'bbbb'
-app_key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacccc'
-yet_another_key: 'dddd'`
-
-	scrubbed, err := scrubber.ScrubYamlString(stringToScrub)
-	assert.Nil(t, err)
-	expected := `api_key: '***************************aaaaa'
-some_other_key: "********"
-app_key: '***********************************acccc'
-yet_another_key: "********"`
-	assert.YAMLEq(t, expected, scrubbed)
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
@@ -1884,6 +1885,17 @@ func LoadDatadogCustom(config pkgconfigmodel.Config, origin string, secretResolv
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)
 	setNumWorkers(config)
+
+	flareStrippedKeys := config.GetStringSlice("flare_stripped_keys")
+	if len(flareStrippedKeys) > 0 {
+		log.Warn("flare_stripped_keys is deprecated, please use scrubber.additional_keys instead.")
+		scrubber.AddStrippedKeys(flareStrippedKeys)
+	}
+	scrubberAdditionalKeys := config.GetStringSlice("scrubber.additional_keys")
+	if len(scrubberAdditionalKeys) > 0 {
+		scrubber.AddStrippedKeys(scrubberAdditionalKeys)
+	}
+
 	return warnings, setupFipsEndpoints(config)
 }
 

--- a/pkg/config/setup/go.mod
+++ b/pkg/config/setup/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/optional v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/system v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.56.0-rc.3
 	github.com/stretchr/testify v1.9.0
@@ -55,7 +56,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.56.0-rc.3 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -97,6 +97,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("log_format_json", false)
 	cfg.BindEnvAndSetDefault("log_file_max_size", "10Mb")
 	cfg.BindEnvAndSetDefault("log_file_max_rolls", 1)
+	cfg.BindEnvAndSetDefault("disable_file_logging", false)
+	cfg.BindEnvAndSetDefault("log_format_rfc3339", false)
 
 	// secrets backend
 	cfg.BindEnvAndSetDefault("secret_backend_command", "")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix some unknown config warnings related to initializing the logger for the system probe agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Not have any unknown config key warnings.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I moved the handling of `flare_stripped_keys` and `scrubber.additional_keys` from the logger to the config.
It doesn't really make sense to handle those in the logger since they are not used to scrub things in the logger but rather in the flare and metadata payloads.
The config is initialized after the scrubber and before the logger, so I don't expect any timing issue. 

I checked manually, the following logs are removed with this fix:
```
WARN | (pkg/util/log/log.go:871 in func1) | config key disable_file_logging is unknown
WARN | (pkg/util/log/log.go:871 in func1) | config key log_format_rfc3339 is unknown
WARN | (pkg/config/model/viper.go:221 in checkKnownKey) | config key flare_stripped_keys is unknown
WARN | (pkg/config/model/viper.go:394 in GetStringSlice) | failed to get configuration value for key "flare_stripped_keys": unable to cast <nil> of type <nil> to []string
WARN | (pkg/config/model/viper.go:221 in checkKnownKey) | config key scrubber.additional_keys is unknown
WARN | (pkg/config/model/viper.go:394 in GetStringSlice) | failed to get configuration value for key "scrubber.additional_keys": unable to cast <nil> of type <nil> to []string
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Checked manually that the config is still scrubbed properly when using `scrubber.additional_keys`, both in payloads and in flares.
I expect CI to catch any other kind of functional issue.
