### PR TITLE
upgrade(CI): Add --deploy-installer option to only deploy the installer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,6 +276,9 @@ variables:
 .if_not_deploy: &if_not_deploy
   if: $DEPLOY_AGENT != "true" && $DDR_WORKFLOW_ID == null
 
+.if_deploy_installer: &if_deploy_installer
+  if: $DEPLOY_INSTALLER == "true" || $DDR_WORKFLOW_ID != null
+
 .if_tagged_commit: &if_tagged_commit
   if: $CI_COMMIT_TAG != null
 
@@ -435,6 +438,9 @@ workflow:
 
 .on_deploy:
   - <<: *if_deploy
+
+.on_deploy_installer:
+  - <<: *if_deploy_installer
 
 .on_deploy_failure:
   - <<: *if_deploy

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -81,7 +81,7 @@
 # include datadog-agent as a product
 .deploy_installer_deb:
   rules:
-    !reference [.on_deploy]
+    !reference [.on_deploy_installer]
   resource_group: deb_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
@@ -93,7 +93,7 @@
 
 .deploy_installer_rpm:
   rules:
-    !reference [.on_deploy]
+    !reference [.on_deploy_installer]
   resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
@@ -110,4 +110,3 @@
   variables:
     ARTIFACTS_PREFIX: suse_
     OMNIBUS_PACKAGE_DIR: $OMNIBUS_PACKAGE_DIR_SUSE
-

--- a/.gitlab/deploy_packages/oci.yml
+++ b/.gitlab/deploy_packages/oci.yml
@@ -8,6 +8,7 @@ include:
   stage: deploy_packages
   rules:
     - !reference [.on_deploy]
+    - !reference [.on_deploy_installer]
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
   before_script:

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -70,7 +70,7 @@ deploy_staging_windows_tags-7:
 # Datadog Installer
 deploy_installer_packages_windows-x64:
   rules:
-    !reference [.on_deploy]
+    !reference [.on_deploy_installer]
   stage: deploy_packages
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -120,6 +120,7 @@ def trigger_agent_pipeline(
     release_version_7="nightly-a7",
     branch="nightly",
     deploy=False,
+    deploy_installer=False,
     all_builds=False,
     e2e_tests=False,
     kmt_tests=False,
@@ -137,6 +138,8 @@ def trigger_agent_pipeline(
 
     if deploy:
         args["DEPLOY_AGENT"] = "true"
+    if deploy_installer:
+        args["DEPLOY_INSTALLER"] = "true"
 
     # The RUN_ALL_BUILDS option can be selectively enabled. However, it cannot be explicitly
     # disabled on pipelines where they're activated by default (default branch & deploy pipelines)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -227,6 +227,7 @@ def run(
     major_versions=None,
     repo_branch="dev",
     deploy=False,
+    deploy_installer=False,
     all_builds=True,
     e2e_tests=True,
     kmt_tests=True,
@@ -236,7 +237,8 @@ def run(
     """
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
     By default, this pipeline will run all builds & tests, including all kitchen tests, but is not a deploy pipeline.
-    Use --deploy to make this pipeline a deploy pipeline, which will upload artifacts to the staging repositories.
+    Use --deploy to make this pipeline a deploy pipeline for the agent, which will upload artifacts to the staging repositories.
+    Use --deploy_installer to make this pipeline a deploy pipeline for the installer, which will upload artifacts to the staging repositories.
     Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
     Use --no-kitchen-tests to not run all kitchen tests on the pipeline.
     Use --e2e-tests to run all e2e tests on the pipeline.
@@ -295,7 +297,7 @@ def run(
     if here:
         git_ref = get_current_branch(ctx)
 
-    if deploy:
+    if deploy or deploy_installer:
         # Check the validity of the deploy pipeline
         check_deploy_pipeline(repo, git_ref, release_version_6, release_version_7, repo_branch)
         # Force all builds and kitchen tests to be run
@@ -336,6 +338,7 @@ def run(
             release_version_7,
             repo_branch,
             deploy=deploy,
+            deploy_installer=deploy_installer,
             all_builds=all_builds,
             e2e_tests=e2e_tests,
             kmt_tests=kmt_tests,

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -238,7 +238,7 @@ def run(
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
     By default, this pipeline will run all builds & tests, including all kitchen tests, but is not a deploy pipeline.
     Use --deploy to make this pipeline a deploy pipeline for the agent, which will upload artifacts to the staging repositories.
-    Use --deploy_installer to make this pipeline a deploy pipeline for the installer, which will upload artifacts to the staging repositories.
+    Use --deploy-installer to make this pipeline a deploy pipeline for the installer, which will upload artifacts to the staging repositories.
     Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
     Use --no-kitchen-tests to not run all kitchen tests on the pipeline.
     Use --e2e-tests to run all e2e tests on the pipeline.


### PR DESCRIPTION
### What does this PR do?
Adds a `--deploy-installer` option to the `inv pipeline.run` command to only run installer deployment

### Motivation
Avoid accidentally deploying the agent when releasing the installer

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Run `inv -e pipeline.run --deploy --git-ref="a git ref" --repo-branch="beta"`
  - Check that the pipeline builds correctly up to `trigger_auto_staging_release`
  - Cancel the pipeline
- Run `inv -e pipeline.run --deploy-installer --git-ref="a git ref" --repo-branch="beta"`
  - Check that `deploy_installer*` jobs are set
  - Check that `trigger_auto_staging_release` isn't set
  - Cancel the pipeline
