### PR TITLE
[CI] Run macOS linters on every branch on macOS amd64 Gitlab runners

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -93,9 +93,6 @@ lint_macos:
 .lint_macos_gitlab:
   stage: source_test
   allow_failure: true
-  rules:
-    - !reference [.on_main]
-    - !reference [.manual]
   extends: .macos_gitlab
   needs: ["setup_agent_version"]
   script:
@@ -122,6 +119,9 @@ lint_macos_gitlab_amd64:
 
 lint_macos_gitlab_arm64:
   extends: .lint_macos_gitlab
+  rules:
+    - !reference [.on_main]
+    - !reference [.manual]
   tags: ["macos:monterey-arm64", "specific:true"]
 
 tests_macos_gitlab_amd64:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds the macOS linters on every branch on macOS amd64 Gitlab runners.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Until now the linters were just running on `main` and on manual triggers. Now:
- the job is stable enough to run it on all branches,
- we have enough runners to run them on all branches.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-301

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
