### PR TITLE
Avoid binding to 0.0.0.0 in OTEL test to fix popup on macos

### DIFF
--- a/comp/otelcol/otlp/integrationtest/integration_test_config.yaml
+++ b/comp/otelcol/otlp/integrationtest/integration_test_config.yaml
@@ -53,3 +53,6 @@ service:
     metrics:
       receivers: [datadog/connector]
       exporters: [datadog, debug]
+  telemetry:
+    metrics:
+      address: 127.0.0.1:8888


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Override an address in Otel integration test to avoid binding to 0.0.0.0, which causes a popup on MacOS.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Not have a popup when running tests locally.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
