### PR TITLE
[CONTINT-4278] Fix a race condition in `pkg/sbom/scanner/TestRetryLogic_Error`

### DIFF
--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -117,6 +117,7 @@ func TestRetryLogic_Error(t *testing.T) {
 			mockCollector.On("Scan", mock.Anything, mock.Anything).Return(expectedResult).Once()
 			mockCollector.On("Channel").Return(resultCh)
 			shutdown := mockCollector.On("Shutdown")
+			shutdown.After(5 * time.Second)
 			mockCollector.On("Type").Return(tt.st)
 
 			// Set up the configuration as the default one is too slow
@@ -150,7 +151,6 @@ func TestRetryLogic_Error(t *testing.T) {
 			case <-time.After(time.Second):
 			}
 			cancel()
-			shutdown.WaitUntil(time.After(5 * time.Second))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the following race condition:
```
==================
WARNING: DATA RACE
Write at 0x00c0006886a8 by goroutine 125:
  github.com/stretchr/testify/mock.(*Call).WaitUntil()
      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:161 +0xbd
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.TestRetryLogic_Error.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner_test.go:153 +0x136b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44
Previous read at 0x00c0006886a8 by goroutine 130:
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:536 +0x1199
  github.com/stretchr/testify/mock.(*Mock).Called()
      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:466 +0x195
  github.com/DataDog/datadog-agent/pkg/sbom/collectors.(*MockCollector).Shutdown()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/collectors/mock.go:70 +0x2f
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.(*Scanner).startScanRequestHandler.func2()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:222 +0x1d4
Goroutine 125 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1648 +0x845
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.TestRetryLogic_Error()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner_test.go:108 +0x6f8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44
Goroutine 130 (running) created at:
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.(*Scanner).startScanRequestHandler()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:212 +0x1e6
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.(*Scanner).start()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:204 +0xfa
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.TestRetryLogic_Error.func1.(*Scanner).Start.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:119 +0x58
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:65 +0x44
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.(*Scanner).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:118 +0xb4e
  github.com/DataDog/datadog-agent/pkg/sbom/scanner.TestRetryLogic_Error.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner_test.go:131 +0xa70
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44
==================
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/workloadmeta/impl.NewWorkloadMeta.func2() executing (caller: github.com/DataDog/datadog-agent/comp/core/workloadmeta/impl.NewWorkloadMeta)
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/workloadmeta/impl.NewWorkloadMeta.func2() called by github.com/DataDog/datadog-agent/comp/core/workloadmeta/impl.NewWorkloadMeta ran successfully in 523ns
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/log/logimpl.newMockLogger.func1() executing (caller: github.com/DataDog/datadog-agent/comp/core/log/logimpl.newMockLogger)
    writer.go:40: [Fx] HOOK OnStop		github.com/DataDog/datadog-agent/comp/core/log/logimpl.newMockLogger.func1() called by github.com/DataDog/datadog-agent/comp/core/log/logimpl.newMockLogger ran successfully in 14.703µs
    testing.go:1465: race detected during execution of test
```

#### Write

`  github.com/stretchr/testify/mock.(*Call).WaitUntil()`
[`      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:161`](https://github.com/stretchr/testify/blob/bb548d0473d4e1c9b7bbfd6602c7bf12f7a84dd2/mock/mock.go#L158-L163)
```go
func (c *Call) WaitUntil(w <-chan time.Time) *Call {
	c.lock()
	defer c.unlock()
	c.WaitFor = w  // <=====
	return c
}
```

`  github.com/DataDog/datadog-agent/pkg/sbom/scanner.TestRetryLogic_Error.func1()`
[`      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner_test.go:153`](https://github.com/DataDog/datadog-agent/blob/6d0c5780c03aaf3a0eddb66febcd779233de194f/pkg/sbom/scanner/scanner_test.go#L153)
```go
			shutdown := mockCollector.On("Shutdown")
[…]

			// Create a scanner and start it
			scanner := NewScanner(cfg, map[string]collectors.Collector{collName: mockCollector}, optional.NewOption[workloadmeta.Component](workloadmetaStore))
			ctx, cancel := context.WithCancel(context.Background())
			scanner.Start(ctx)  // This is were is eventually started the goroutine that will issue the read below.

[…]
			cancel()
			shutdown.WaitUntil(time.After(5 * time.Second))  // <=====
                                                                         // This is setting a field on the `shutdown` object too late.
                                                                         // This should be done before the goroutine doing the read is spawn at the `scanner.Start(ctx)` step.
		})
	}
}
```


#### Read

`  github.com/stretchr/testify/mock.(*Mock).MethodCalled()`
[`      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:536`](https://github.com/stretchr/testify/blob/bb548d0473d4e1c9b7bbfd6602c7bf12f7a84dd2/mock/mock.go#L535-L540)
```go
	// block if specified
	if call.WaitFor != nil {  // <=====
                                  // Although the writes to this field is protected by a mutex, the read isn’t !
		<-call.WaitFor
	} else {
		time.Sleep(call.waitTime)
	}
```
`  github.com/stretchr/testify/mock.(*Mock).Called()`
[`      /go/pkg/mod/github.com/stretchr/testify@v1.9.0/mock/mock.go:466`](https://github.com/stretchr/testify/blob/bb548d0473d4e1c9b7bbfd6602c7bf12f7a84dd2/mock/mock.go#L466)
```go
	return m.MethodCalled(functionName, arguments...)
```
`  github.com/DataDog/datadog-agent/pkg/sbom/collectors.(*MockCollector).Shutdown()`
[`      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/collectors/mock.go:70`](https://github.com/DataDog/datadog-agent/blob/65f5d07889819be40849ccff466a076e8777a542/pkg/sbom/collectors/mock.go#L68-L71)
```go
// Shutdown shuts down the collector
func (m *MockCollector) Shutdown() {
	m.Called()  // <=====
}
```
`  github.com/DataDog/datadog-agent/pkg/sbom/scanner.(*Scanner).startScanRequestHandler.func2()`
[`      /go/src/github.com/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:222`](https://github.com/DataDog/datadog-agent/blob/65f5d07889819be40849ccff466a076e8777a542/pkg/sbom/scanner/scanner.go#L212-L224)
```go
	go func() {
		for {
			r, shutdown := s.scanQueue.Get()
			if shutdown {
				break
			}
			s.handleScanRequest(ctx, r)
			s.scanQueue.Done(r)
		}
		for _, collector := range s.collectors {
			collector.Shutdown()  // <=====
		}
	}()
```


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
