### PR TITLE
use protobuf-generate getter method to get cardinality in remote tagger instead of direct field access

### DIFF
--- a/comp/core/tagger/taggerimpl/server/server.go
+++ b/comp/core/tagger/taggerimpl/server/server.go
@@ -42,7 +42,7 @@ func NewServer(t tagger.Component) *Server {
 // and streams them to clients as pb.StreamTagsResponse events. Filtering is as
 // of yet not implemented.
 func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecure_TaggerStreamEntitiesServer) error {
-	cardinality, err := proto.Pb2TaggerCardinality(in.Cardinality)
+	cardinality, err := proto.Pb2TaggerCardinality(in.GetCardinality())
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (s *Server) TaggerFetchEntity(ctx context.Context, in *pb.FetchEntityReques
 	}
 
 	entityID := fmt.Sprintf("%s://%s", in.Id.Prefix, in.Id.Uid)
-	cardinality, err := proto.Pb2TaggerCardinality(in.Cardinality)
+	cardinality, err := proto.Pb2TaggerCardinality(in.GetCardinality())
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *Server) TaggerFetchEntity(ctx context.Context, in *pb.FetchEntityReques
 
 	return &pb.FetchEntityResponse{
 		Id:          in.Id,
-		Cardinality: in.Cardinality,
+		Cardinality: in.GetCardinality(),
 		Tags:        tags,
 	}, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR modifies the remote tagger server to use the getter method generated by protobuf to access the tagger stream request cardinality instead of directly accessing the field on the stream object.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Using getter method is a best practice as compared to direct field access.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None, behaviour should not change.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No need for qa, sanity check and e2e are enough.
