### PR TITLE
[notify] Fix use of git ref vs. git sha

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -80,12 +80,12 @@ def get_gitlab_repo(repo='DataDog/datadog-agent', token=None) -> Project:
     return repo
 
 
-def get_commit(project_name: str, git_ref: str) -> ProjectCommit:
+def get_commit(project_name: str, git_sha: str) -> ProjectCommit:
     """
-    Retrieves the commit for a given git ref a given project.
+    Retrieves the commit for a given git sha a given project.
     """
     repo = get_gitlab_repo(project_name)
-    return repo.commits.get(git_ref)
+    return repo.commits.get(git_sha)
 
 
 def get_pipeline(project_name: str, pipeline_id: str) -> ProjectPipeline:

--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -25,7 +25,7 @@ def should_send_message_to_author(git_ref: str, default_branch: str) -> bool:
 
 def send_message(ctx, notification_type, dry_run):
     pipeline = get_pipeline(PROJECT_NAME, os.environ["CI_PIPELINE_ID"])
-    commit = get_commit(PROJECT_NAME, pipeline.ref)
+    commit = get_commit(PROJECT_NAME, pipeline.sha)
     failed_jobs = get_failed_jobs(pipeline)
 
     # From the job failures, set whether the pipeline succeeded or failed and craft the


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of #27731 - use `pipeline.sha` instead of `pipeline.ref` when searching the commit object.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix notification issues that were showing the commit details of the last commit on a ref, instead of the commit on which the pipeline ran.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test with an older pipeline, and verify that it is not using :
```
$ CI_PIPELINE_ID=39637042 inv -e notify.send-message --notification-type "merge"  --dry-run
Would send to #datadog-agent-pipelines:
:host-green: :merged: datadog-agent merge pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39637042|39637042> for main succeeded.
(installer): pin default versions of APM libraries (<https://github.com/DataDog/DataDog/datadog-agent/pull/27522|#27522>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/069de5c1edacdd35ea16644a83915825ce39a94d|ce39a94d>)(:github: <https://github.com/DataDog/DataDog/datadog-agent/commit/069de5c1edacdd35ea16644a83915825ce39a94d|link>) by paullegranddc
```
