### PR TITLE
[CWS] add lock to pid list in tracer / fix race

### DIFF
--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -440,7 +440,7 @@ func ptrace(tracer *Tracer, probeAddr string, syscallHandlers map[int]syscallHan
 			// introduce a delay before starting to scan procfs to let the tracer event first
 			time.Sleep(2 * time.Second)
 
-			scanProcfs(ctx, tracer.PIDs, send, every, logger)
+			scanProcfs(ctx, tracer, send, every, logger)
 		}()
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes a race on the pid list in tracer

```
=================[0m
       [32m[5.8.0-1038-aws][el] WARNING: DATA RACE[0m
       [32m[5.8.0-1038-aws][el] Read at 0x00c0003c4c60 by goroutine 53:[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.ptrace.func6()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:443 +0xb0[0m
       [32m[5.8.0-1038-aws][el] [0m
       [32m[5.8.0-1038-aws][el] Previous write at 0x00c0003c4c60 by main goroutine:[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.(*Tracer).pidExited()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/ptracer.go:261 +0x98[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.(*Tracer).trace()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/ptracer.go:291 +0x1dc[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.(*Tracer).Trace()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/ptracer.go:467 +0x48[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.ptrace()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:644 +0x12e8[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.Wrap()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:235 +0x388[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/tests.preTestsHook()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_linux.go:142 +0x1c8[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:25 +0x9c[0m
       [32m[5.8.0-1038-aws][el] main.main()[0m
       [32m[5.8.0-1038-aws][el] _testmain.go:345 +0x294[0m
       [32m[5.8.0-1038-aws][el] [0m
       [32m[5.8.0-1038-aws][el] Goroutine 53 (running) created at:[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.ptrace()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:437 +0x11b0[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/ptracer.Wrap()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:235 +0x388[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/tests.preTestsHook()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_linux.go:142 +0x1c8[0m
       [32m[5.8.0-1038-aws][el] github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()[0m
       [32m[5.8.0-1038-aws][el] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:25 +0x9c[0m
       [32m[5.8.0-1038-aws][el] main.main()[0m
       [32m[5.8.0-1038-aws][el] _testmain.go:345 +0x294[0m
       [32m[5.8.0-1038-aws][el] ==================[0m
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
