### PR TITLE
[CWS] add ebpfless attach pid-per-trace option

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -9,9 +9,13 @@
 package tracecmd
 
 import (
+	"bufio"
 	"fmt"
+	"math"
 	"os"
+	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -55,6 +59,8 @@ const (
 	disableSeccompOpt = "disable-seccomp"
 	// pidOpt attach mode
 	pidOpt = "pid"
+	// pidPerTracer number of pid per tracer
+	pidPerTracer = "pid-per-tracer"
 )
 
 type traceCliParams struct {
@@ -69,6 +75,7 @@ type traceCliParams struct {
 	ScanProcEvery    string
 	SeccompDisabled  bool
 	PIDs             []int
+	PIDPerTracer     int
 }
 
 func envToBool(name string) bool {
@@ -111,8 +118,91 @@ func Command() []*cobra.Command {
 				opts.ScanProcEvery = every
 			}
 
-			if len(params.PIDs) > 0 {
-				return ptracer.Attach(params.PIDs, params.ProbeAddr, opts)
+			// attach mode
+			if n := len(params.PIDs); n > 0 {
+				if n < params.PIDPerTracer {
+					return ptracer.Attach(params.PIDs, params.ProbeAddr, opts)
+				}
+
+				executable, err := os.Executable()
+				if err != nil {
+					return err
+				}
+
+				var (
+					wg   sync.WaitGroup
+					pids = params.PIDs
+					size int
+				)
+
+				for {
+					size = params.PIDPerTracer
+					if n := len(pids); n < params.PIDPerTracer {
+						size = n
+					}
+
+					wg.Add(1)
+					go func(set []int) {
+						defer wg.Done()
+
+						args := []string{"trace"}
+
+						if params.ProcScanDisabled {
+							args = append(args, fmt.Sprintf(`--%s`, disableProcScanOpt))
+						}
+						if params.Async {
+							args = append(args, fmt.Sprintf(`--%s`, asyncOpt))
+						}
+						if params.Verbose {
+							args = append(args, fmt.Sprintf(`--%s`, verboseOpt))
+						}
+						if params.StatsDisabled {
+							args = append(args, fmt.Sprintf(`--%s`, disableStatsOpt))
+						}
+						if params.UID != -1 {
+							args = append(args, fmt.Sprintf(`--%s`, uidOpt), fmt.Sprintf(`%d`, params.UID))
+						}
+						if params.GID != -1 {
+							args = append(args, fmt.Sprintf(`--%s`, gidOpt), fmt.Sprintf(`%d`, params.GID))
+						}
+						args = append(args, fmt.Sprintf(`--%s`, probeAddrOpt), params.ProbeAddr)
+
+						for _, pid := range set {
+							args = append(args, fmt.Sprintf(`--%s`, pidOpt), fmt.Sprintf(`%d`, pid))
+						}
+
+						cmd := exec.Command(executable, args...)
+						stderr, err := cmd.StderrPipe()
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "unable to start: %s", err)
+							return
+						}
+						if err = cmd.Start(); err != nil {
+							fmt.Fprintf(os.Stderr, "unable to start: %s", err)
+							return
+						}
+
+						scanner := bufio.NewScanner(stderr)
+						scanner.Split(bufio.ScanLines)
+						for scanner.Scan() {
+							fmt.Println(scanner.Text())
+						}
+
+						if err = cmd.Wait(); err != nil {
+							fmt.Fprintf(os.Stderr, "unable to start: %s", err)
+							return
+						}
+					}(pids[:size])
+
+					if len(pids) <= params.PIDPerTracer {
+						break
+					}
+					pids = pids[params.PIDPerTracer:]
+				}
+
+				wg.Wait()
+
+				return nil
 			}
 			return ptracer.Wrap(args, os.Environ(), params.ProbeAddr, opts)
 		},
@@ -129,6 +219,7 @@ func Command() []*cobra.Command {
 	traceCmd.Flags().StringVar(&params.ScanProcEvery, scanProcEveryOpt, os.Getenv(envProcScanRate), "proc scan rate")
 	traceCmd.Flags().BoolVar(&params.SeccompDisabled, disableSeccompOpt, envToBool(envSeccompDisabled), "disable seccomp")
 	traceCmd.Flags().IntSliceVar(&params.PIDs, pidOpt, nil, "attach tracer to pid")
+	traceCmd.Flags().IntVar(&params.PIDPerTracer, pidPerTracer, math.MaxInt, "maximum number of pid per tracer")
 
 	traceCmd.AddCommand(selftestscmd.Command()...)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add a way to instantiate multiple tracers for a set of pids. The goal is to distribute the load. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
