### PR TITLE
[NDM] [SNMP] Add integration value to device metadata

### DIFF
--- a/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
@@ -370,6 +370,7 @@ profiles:
       "os_name":"LINUX (3.10.0-862.14.4.el7.ve.x86_64)",
       "os_version":"3.10.0-862.14.4.el7.ve.x86_64",
       "os_hostname":"my-linux-f5-server",
+	  "integration": "snmp",
 	  "device_type": "load_balancer"
     }
   ],

--- a/pkg/collector/corechecks/snmp/integration_topology_test.go
+++ b/pkg/collector/corechecks/snmp/integration_topology_test.go
@@ -616,6 +616,7 @@ profiles:
       "os_name":"LINUX (3.10.0-862.14.4.el7.ve.x86_64)",
       "os_version":"3.10.0-862.14.4.el7.ve.x86_64",
       "os_hostname":"my-linux-f5-server",
+	  "integration": "snmp",
 	  "device_type": "load_balancer"
     }
   ],
@@ -1317,6 +1318,7 @@ profiles:
       "os_name":"LINUX (3.10.0-862.14.4.el7.ve.x86_64)",
       "os_version":"3.10.0-862.14.4.el7.ve.x86_64",
       "os_hostname":"my-linux-f5-server",
+	  "integration": "snmp",
 	  "device_type": "load_balancer"
     }
   ],
@@ -2009,6 +2011,7 @@ profiles:
       "os_name":"LINUX (3.10.0-862.14.4.el7.ve.x86_64)",
       "os_version":"3.10.0-862.14.4.el7.ve.x86_64",
       "os_hostname":"my-linux-f5-server",
+	  "integration": "snmp",
 	  "device_type": "load_balancer"
     }
   ],

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/utils"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/lldp"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/metadata"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
@@ -236,6 +237,7 @@ func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkc
 		OsVersion:      osVersion,
 		OsHostname:     osHostname,
 		DeviceType:     deviceType,
+		Integration:    common.SnmpIntegrationName,
 	}
 }
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -155,6 +155,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
             "profile": "my-profile",
             "profile_version": 10,
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "router"
         }
     ],
@@ -234,6 +235,7 @@ profiles:
             "profile": "f5-big-ip",
             "vendor": "f5",
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "load_balancer"
         }
     ],
@@ -375,6 +377,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
             "status":1,
 			"ping_status":2,
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "switch"
         }
     ],
@@ -485,6 +488,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "firewall"
         }
     ],
@@ -555,6 +559,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_Nil(t *testing
             "status":1,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "other"
         }
     ],
@@ -626,6 +631,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
 			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "other"
         }
     ],
@@ -697,6 +703,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
 			"ping_status":2,
             "name": "my-fallback-value",
             "subnet": "127.0.0.0/29",
+			"integration": "snmp",
 			"device_type": "other"
         }
     ],

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -897,6 +897,7 @@ profiles:
       "vendor": "f5",
       "subnet": "127.0.0.0/30",
       "serial_number": "a-serial-num",
+	  "integration": "snmp",
 	  "device_type": "load_balancer"
     }
   ],
@@ -1550,6 +1551,7 @@ tags:
       "description": "my_desc",
       "sys_object_id": "1.2.3.4",
       "subnet": "127.0.0.0/30",
+	  "integration": "snmp",
 	  "device_type": "other"
     }
   ],
@@ -1694,6 +1696,7 @@ tags:
       "ip_address": "1.2.3.5",
       "status": 2,
       "subnet": "127.0.0.0/30",
+	  "integration": "snmp",
 	  "device_type": "other"
     }
   ],
@@ -2010,6 +2013,7 @@ metric_tags:
       "status": 1,
       "name": "foo_sys_name",
       "subnet": "10.10.0.0/30",
+	  "integration": "snmp",
 	  "device_type": "other"
     }
   ],

--- a/releasenotes/notes/add-snmp-integration-to-device-metadata-2d04dbd076c699ab.yaml
+++ b/releasenotes/notes/add-snmp-integration-to-device-metadata-2d04dbd076c699ab.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add `integration` value for device metadata.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
https://datadoghq.atlassian.net/browse/NDMII-2964
Add value for `integration` field when sending device metadata during the SNMP device check. We added the integration facet to the NDM `/devices` page recently, this is to make any devices run via the SNMP integration to be able to be accommodated with this facet (we have only sent from other integration sources so far)

Slack [thread](https://dd.slack.com/archives/G01DX2UE2HL/p1721312157057279) for additional context

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
* Run the SNMP integration check by `ddev` or via a VM
* Verify that the run submits the device metadata with the field incl. `integration` and the value is `snmp`