### PR TITLE
[notify] Fix GitHub URLs

### DIFF
--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -34,7 +34,7 @@ def load_and_validate(
     return result
 
 
-DATADOG_AGENT_GITHUB_ORG_URL = "https://github.com/DataDog"
+GITHUB_BASE_URL = "https://github.com"
 DEFAULT_SLACK_CHANNEL = "#agent-devx-ops"
 DEFAULT_JIRA_PROJECT = "AGNTR"
 # Map keys in lowercase
@@ -118,7 +118,7 @@ def get_pr_from_commit(commit_title, project_title) -> tuple[str, str] | None:
 
     parsed_pr_id = parsed_pr_id_found.group(1)
 
-    return parsed_pr_id, f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
+    return parsed_pr_id, f"{GITHUB_BASE_URL}/{project_title}/pull/{parsed_pr_id}"
 
 
 def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCommit, header: str, state: str):
@@ -127,7 +127,7 @@ def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCo
     pipeline_id = pipeline.id
     commit_ref_name = pipeline.ref
     commit_url_gitlab = commit.web_url
-    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_name}/commit/{commit.id}"
+    commit_url_github = f"{GITHUB_BASE_URL}/{project_name}/commit/{commit.id}"
     commit_short_sha = commit.id[-8:]
     author = commit.author_name
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes the GitHub URLs used in the notification message. Since `project_name` already has the `DataDog` prefix, it is not needed in the base url.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix notification messages. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test and verify that GitHub URLs do not have a double `DataDog/`:
```
$ CI_PIPELINE_ID=39644667  inv -e notify.send-message --notification-type "merge"  --dry-run
Would send to #datadog-agent-pipelines:
:host-green: :merged: datadog-agent merge pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39644667|39644667> for main succeeded.
[EBPF] Do not send API key to KMT microVMs (<https://github.com/DataDog/datadog-agent/pull/27635|#27635>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/6d0c5780c03aaf3a0eddb66febcd779233de194f|33de194f>)(:github: <https://github.com/DataDog/datadog-agent/commit/6d0c5780c03aaf3a0eddb66febcd779233de194f|link>) by Guillermo Julián
```