### PR TITLE
[oracle] Fix wrong sample durations for cloud databases (DBMON-4026)

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -380,7 +380,7 @@ func (c *Check) SampleSession() error {
 
 	payload := ActivitySnapshot{
 		Metadata: Metadata{
-			Timestamp:      float64(time.Now().UnixMilli()),
+			Timestamp:      float64(c.clock.Now().UnixMilli()),
 			Host:           c.dbHostname,
 			Source:         common.IntegrationName,
 			DBMType:        "activity",

--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -170,7 +170,7 @@ func (c *Check) SampleSession() error {
 	sessionSamples := []OracleActivityRowDB{}
 	var activityQuery string
 	maxSQLTextLength := c.sqlSubstringLength
-	if c.hostingType == selfManaged {
+	if c.hostingType == selfManaged && !c.config.QuerySamples.ForceDirectQuery {
 		if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
 			activityQuery = activityQueryOnView12
 		} else {
@@ -180,8 +180,12 @@ func (c *Check) SampleSession() error {
 		activityQuery = activityQueryDirect
 	}
 
-	if c.config.QuerySamples.IncludeAllSessions {
-		activityQuery = fmt.Sprintf("%s %s", activityQuery, " OR 1=1")
+	if !c.config.QuerySamples.IncludeAllSessions {
+		activityQuery = fmt.Sprintf("%s %s", activityQuery, ` AND (
+	NOT (state = 'WAITING' AND wait_class = 'Idle')
+	OR state = 'WAITING' AND event = 'fbar timer' AND type = 'USER'
+)
+AND status = 'ACTIVE'`)
 	}
 
 	err := selectWrapper(c, &sessionSamples, activityQuery, maxSQLTextLength, maxSQLTextLength)

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -92,3 +92,20 @@ func TestCurrentTime(t *testing.T) {
 		assert.WithinDuration(t, time.Now(), fetchedNowTime, 10*time.Second)
 	}
 }
+
+func TestIdleWaits(t *testing.T) {
+	c, _ := newDefaultCheck(t, "", "")
+	defer c.Teardown()
+
+	c.dbmEnabled = true
+
+	err := c.Run()
+	assert.NoError(t, err, "check run")
+
+	err = c.SampleSession()
+	require.NoError(t, err, "activity sample failed")
+
+	for _, r := range c.lastOracleActivityRows {
+		assert.NotEqual(t, r.WaitEventClass, "Idle", "Idle wait class not sampled")
+	}
+}

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,4 +63,32 @@ sessions:
 	}
 	assert.True(t, found, "test query not found in samples")
 	assert.Equal(t, 1000, c.sqlSubstringLength, "sql substring length should be 1000")
+}
+
+func TestCurrentTime(t *testing.T) {
+	c, _ := newDefaultCheck(t, "", "")
+	defer c.Teardown()
+
+	c.dbmEnabled = true
+	// This is to ensure that query samples return rows
+	c.config.QuerySamples.IncludeAllSessions = true
+
+	err := c.Run()
+	assert.NoError(t, err, "check run")
+	mockClock := clock.NewMock()
+	mockClock.Now().UTC()
+	c.clock = mockClock
+
+	c.config.QuerySamples.ForceDirectQuery = true
+	for _, directQuery := range []bool{true, false} {
+		c.config.QuerySamples.ForceDirectQuery = directQuery
+		err = c.SampleSession()
+		require.NoError(t, err, "activity sample failed")
+
+		fetchedNow := c.lastOracleActivityRows[0].Now
+		fetchedNowTime, err := time.Parse(time.RFC3339, fetchedNow)
+		require.NoErrorf(t, err, "couldn't parse now from activity sample for direct query: %t", directQuery)
+
+		assert.WithinDuration(t, time.Now(), fetchedNowTime, 10*time.Second)
+	}
 }

--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -72,12 +72,7 @@ const activityQueryOnView12 = `SELECT /* DD_ACTIVITY_SAMPLING */
 	command_name
 FROM sys.dd_session
 WHERE
-	( sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sql_text is NULL )
-	AND (
-		NOT (state = 'WAITING' AND wait_class = 'Idle')
-		OR state = 'WAITING' AND event = 'fbar timer' AND type = 'USER'
-	)
-	AND status = 'ACTIVE'`
+	( sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sql_text is NULL )`
 
 const activityQueryOnView11 = `SELECT /* DD_ACTIVITY_SAMPLING */
 	SYSDATE as now,
@@ -143,14 +138,10 @@ const activityQueryOnView11 = `SELECT /* DD_ACTIVITY_SAMPLING */
 	command_name
 FROM sys.dd_session
 WHERE
-	( sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sql_text is NULL )
-	AND (
-		NOT (state = 'WAITING' AND wait_class = 'Idle')
-		OR state = 'WAITING' AND event = 'fbar timer' AND type = 'USER'
-	)
-	AND status = 'ACTIVE'`
+	( sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sql_text is NULL )`
 
 const activityQueryDirect = `SELECT /*+ push_pred(sq) push_pred(sq_prev) */ /* DD_ACTIVITY_SAMPLING */
+SYSDATE as now,
 s.sid,
 s.serial#,
 s.username,
@@ -223,10 +214,5 @@ AND sq.child_number(+) = s.sql_child_number
 AND sq_prev.sql_id(+)   = s.prev_sql_id
 AND sq_prev.child_number(+) = s.prev_child_number
 AND ( sq.sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sq.sql_text is NULL )
-AND (
-	NOT (state = 'WAITING' AND wait_class = 'Idle')
-	OR state = 'WAITING' AND event = 'fbar timer' AND type = 'USER'
-)
-AND status = 'ACTIVE'
 AND s.con_id = c.con_id(+)
 AND s.command = comm.command_type(+)`

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -35,6 +35,7 @@ type InitConfig struct {
 type QuerySamplesConfig struct {
 	Enabled            bool `yaml:"enabled"`
 	IncludeAllSessions bool `yaml:"include_all_sessions"`
+	ForceDirectQuery   bool `yaml:"force_direct_query"`
 }
 
 type queryMetricsTrackerConfig struct {

--- a/releasenotes/notes/oracle-wrong-durations-c814d98b99d7b552.yaml
+++ b/releasenotes/notes/oracle-wrong-durations-c814d98b99d7b552.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix wrong durations for cloud databases.
+    [oracle] Fix wrong durations for cloud databases.

--- a/releasenotes/notes/oracle-wrong-durations-c814d98b99d7b552.yaml
+++ b/releasenotes/notes/oracle-wrong-durations-c814d98b99d7b552.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix wrong durations for cloud databases.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix wrong sample durations for cloud databases.

### Motivation

Activity sample query for cloud databases didn't select the current time from the database. Consequently, current time was initialized with the agent host time. That led to wrong durations when the agent host was running in a different time zone as the database.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
