### PR TITLE
[gitlab] otel images internal publishing + automatic deploys

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -93,6 +93,9 @@ deploy_containers-ot:
   rules:
     - when: manual
       allow_failure: true
+      variables:
+        AGENT_REPOSITORY: agent
+        IMG_REGISTRIES: public
   dependencies: []
   before_script:
     - source /root/.bashrc

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -96,12 +96,11 @@ deploy_containers-ot:
       variables:
         AGENT_REPOSITORY: agent
         IMG_REGISTRIES: public
+        VERSION: 7
   dependencies: []
   before_script:
     - source /root/.bashrc
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
-    - echo "version: ${VERSION}"
-    - echo "repo: ${AGENT_REPOSITORY}"
+    - echo "image: ${AGENT_REPOSITORY}:${VERSION}-ot-beta"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -99,7 +99,9 @@ deploy_containers-ot:
   dependencies: []
   before_script:
     - source /root/.bashrc
-    - export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
+    - echo "version: ${VERSION}"
+    - echo "repo: ${AGENT_REPOSITORY}"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -93,14 +93,13 @@ deploy_containers-ot:
   rules:
     - when: manual
       allow_failure: true
-      variables:
-        AGENT_REPOSITORY: agent
-        IMG_REGISTRIES: public
-        VERSION: 7
+  variables:
+    AGENT_REPOSITORY: agent
+    IMG_REGISTRIES: public
+    VERSION: 7
   dependencies: []
   before_script:
     - source /root/.bashrc
-    - echo "image: ${AGENT_REPOSITORY}:${VERSION}-ot-beta"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64

--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -21,9 +21,7 @@ qa_agent_ot:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    # incident-28463: this job is currently broken
-    # - !reference [.on_container_or_e2e_changes]
-    - !reference [.manual]
+    - !reference [.on_container_or_e2e_changes]
   needs:
     - docker_build_ot_agent7
     - docker_build_ot_agent7_arm64

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -48,6 +48,54 @@ docker_trigger_internal:
       --variable TARGET_ENV
       --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
 
+docker_trigger_internal-ot:
+  stage: internal_image_deploy
+  rules:
+    - when: manual
+      allow_failure: true
+  needs:
+    - job: docker_build_ot_agent7_jmx
+      artifacts: false
+    - job: docker_build_ot_agent7_jmx_arm64
+      artifacts: false
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  variables:
+    DYNAMIC_BUILD_RENDER_RULES: agent-build-only # fake rule to not trigger the ones in the images repo
+    IMAGE_VERSION: tmpl-v9
+    IMAGE_NAME: datadog-agent
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx
+    TMPL_SRC_REPO: ci/datadog-agent/agent
+    RELEASE_STAGING: "true"
+  script:
+    - source /root/.bashrc
+    - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $GITLAB_SCHEDULER_TOKEN_SSM_NAME)
+    - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
+    - |
+      if [ "$BUCKET_BRANCH" = "nightly" ]; then
+        RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"
+        TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
+      fi
+    - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
+    - "inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600
+      --variable IMAGE_VERSION
+      --variable IMAGE_NAME
+      --variable RELEASE_TAG
+      --variable BUILD_TAG
+      --variable TMPL_SRC_IMAGE
+      --variable TMPL_SRC_REPO
+      --variable RELEASE_STAGING
+      --variable RELEASE_PROD
+      --variable DYNAMIC_BUILD_RENDER_RULES
+      --variable APPS
+      --variable BAZEL_TARGET
+      --variable DDR
+      --variable DDR_WORKFLOW_ID
+      --variable TARGET_ENV
+      --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+
 docker_trigger_cluster_agent_internal:
   stage: internal_image_deploy
   rules: !reference [.on_deploy]

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -50,9 +50,7 @@ docker_trigger_internal:
 
 docker_trigger_internal-ot:
   stage: internal_image_deploy
-  rules:
-    - when: manual
-      allow_failure: true
+  rules: !reference [.on_deploy_internal_or_manual]
   needs:
     - job: docker_build_ot_agent7_jmx
       artifacts: false


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR addresses some issues with the OT image deployments; ensuring proper deployment to internal registries on nightlies and relevant builds, as well automatic e2e deployments.

Related issue: https://datadoghq.atlassian.net/browse/OTEL-1938

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Nightlies required to be automatically built and deployed to internal registries. Likewise for e2e images on test or image changes. Additionally, fix deploy to public registries. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
