### PR TITLE
[USM] Increased USM Postgres buffer size

### DIFF
--- a/pkg/network/ebpf/c/protocols/postgres/types.h
+++ b/pkg/network/ebpf/c/protocols/postgres/types.h
@@ -4,10 +4,10 @@
 #include "conn_tuple.h"
 
 // Controls the number of Postgres transactions read from userspace at a time.
-#define POSTGRES_BATCH_SIZE 25
+#define POSTGRES_BATCH_SIZE 17
 
-// Maximum length of postgres query to send to userspace.
-#define POSTGRES_BUFFER_SIZE 64
+// Maximum length of Postgres query to send to userspace.
+#define POSTGRES_BUFFER_SIZE 160
 
 // Maximum number of Postgres messages we can parse for a single packet.
 #define POSTGRES_MAX_MESSAGES 80

--- a/pkg/network/protocols/postgres/telemetry_test.go
+++ b/pkg/network/protocols/postgres/telemetry_test.go
@@ -23,35 +23,26 @@ type telemetryResults struct {
 }
 
 func Test_getBucketIndex(t *testing.T) {
-	for i := 0; i <= 34; i++ {
-		require.Equal(t, 0, getBucketIndex(i))
+	// We want to validate that the bucket index is calculated correctly, given the BufferSize and the bucketLength.
+	testCases := []struct {
+		start, end, expected int
+	}{
+		{0, BufferSize - 2*bucketLength, 0},
+		{BufferSize - 2*bucketLength + 1, BufferSize - bucketLength, 1},
+		{BufferSize - bucketLength + 1, BufferSize, 2},
+		{BufferSize + 1, BufferSize + bucketLength, 3},
+		{BufferSize + bucketLength + 1, BufferSize + 2*bucketLength, 4},
+		{BufferSize + 2*bucketLength + 1, BufferSize + 3*bucketLength, 5},
+		{BufferSize + 3*bucketLength + 1, BufferSize + 4*bucketLength, 6},
+		{BufferSize + 4*bucketLength + 1, BufferSize + 5*bucketLength, 7},
+		{BufferSize + 5*bucketLength + 1, BufferSize + 6*bucketLength, 8},
+		{BufferSize + 6*bucketLength + 1, BufferSize + 7*bucketLength, 9},
 	}
-	for i := 35; i <= 49; i++ {
-		require.Equal(t, 1, getBucketIndex(i))
-	}
-	for i := 50; i <= 64; i++ {
-		require.Equal(t, 2, getBucketIndex(i))
-	}
-	for i := 65; i <= 79; i++ {
-		require.Equal(t, 3, getBucketIndex(i))
-	}
-	for i := 80; i <= 94; i++ {
-		require.Equal(t, 4, getBucketIndex(i))
-	}
-	for i := 95; i <= 109; i++ {
-		require.Equal(t, 5, getBucketIndex(i))
-	}
-	for i := 110; i <= 124; i++ {
-		require.Equal(t, 6, getBucketIndex(i))
-	}
-	for i := 125; i <= 139; i++ {
-		require.Equal(t, 7, getBucketIndex(i))
-	}
-	for i := 140; i <= 154; i++ {
-		require.Equal(t, 8, getBucketIndex(i))
-	}
-	for i := 155; i <= 1000; i++ {
-		require.Equal(t, 9, getBucketIndex(i))
+
+	for _, tc := range testCases {
+		for i := tc.start; i <= tc.end; i++ {
+			require.Equal(t, tc.expected, getBucketIndex(i), "query length %d should be in bucket %d", i, tc.expected)
+		}
 	}
 }
 
@@ -65,56 +56,16 @@ func TestTelemetry_Count(t *testing.T) {
 		{
 			name: "exceeded query length bucket for each bucket ones",
 			tx: []*EbpfEvent{
-				{
-					Tx: EbpfTx{
-						Original_query_size: 19,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 35,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 64,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 65,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 80,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 95,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 110,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 125,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 140,
-					},
-				},
-				{
-					Tx: EbpfTx{
-						Original_query_size: 200,
-					},
-				},
+				createEbpfEvent(BufferSize - 2*bucketLength),
+				createEbpfEvent(BufferSize - bucketLength),
+				createEbpfEvent(BufferSize),
+				createEbpfEvent(BufferSize + 1),
+				createEbpfEvent(BufferSize + bucketLength + 1),
+				createEbpfEvent(BufferSize + 2*bucketLength + 1),
+				createEbpfEvent(BufferSize + 3*bucketLength + 1),
+				createEbpfEvent(BufferSize + 4*bucketLength + 1),
+				createEbpfEvent(BufferSize + 5*bucketLength + 1),
+				createEbpfEvent(BufferSize + 6*bucketLength + 1),
 			},
 
 			expectedTelemetry: telemetryResults{
@@ -166,6 +117,14 @@ func TestTelemetry_Count(t *testing.T) {
 			}
 			verifyTelemetry(t, tel, tt.expectedTelemetry)
 		})
+	}
+}
+
+func createEbpfEvent(querySize int) *EbpfEvent {
+	return &EbpfEvent{
+		Tx: EbpfTx{
+			Original_query_size: uint32(querySize),
+		},
 	}
 }
 

--- a/pkg/network/protocols/postgres/types_linux.go
+++ b/pkg/network/protocols/postgres/types_linux.go
@@ -20,7 +20,7 @@ type EbpfEvent struct {
 	Tx    EbpfTx
 }
 type EbpfTx struct {
-	Request_fragment    [64]byte
+	Request_fragment    [160]byte
 	Request_started     uint64
 	Response_last_seen  uint64
 	Original_query_size uint32
@@ -29,5 +29,5 @@ type EbpfTx struct {
 }
 
 const (
-	BufferSize = 0x40
+	BufferSize = 0xa0
 )

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	postgresPort           = "5432"
+	repeatCount            = postgres.BufferSize / len("table_")
 	createTableQuery       = "CREATE TABLE dummy (id SERIAL PRIMARY KEY, foo TEXT)"
 	updateSingleValueQuery = "UPDATE dummy SET foo = 'updated' WHERE id = 1"
 	selectAllQuery         = "SELECT * FROM dummy"
@@ -42,6 +43,11 @@ const (
 	deleteTableQuery       = "DELETE FROM dummy WHERE id = 1"
 	alterTableQuery        = "ALTER TABLE dummy ADD test VARCHAR(255);"
 	truncateTableQuery     = "TRUNCATE TABLE dummy"
+)
+
+var (
+	longCreateQuery = fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, foo TEXT)", strings.Repeat("table_", repeatCount))
+	longDropeQuery  = fmt.Sprintf("DROP TABLE IF EXISTS %s", strings.Repeat("table_", repeatCount))
 )
 
 func createInsertQuery(values ...string) string {
@@ -179,7 +185,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 
 	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
 	if isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid())
 	}
 
 	tests := []postgresParsingTestAttributes{
@@ -429,16 +435,15 @@ func testDecoding(t *testing.T, isTLS bool) {
 			},
 			postMonitorSetup: func(t *testing.T, ctx pgTestContext) {
 				pg := ctx.extras["pg"].(*postgres.PGXClient)
-				longTableName := strings.Repeat("table_", 15)
-				require.NoError(t, pg.RunQuery(fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, foo TEXT)", longTableName)))
-				require.NoError(t, pg.RunQuery(fmt.Sprintf("DROP TABLE IF EXISTS %s", longTableName)))
+				require.NoError(t, pg.RunQuery(longCreateQuery))
+				require.NoError(t, pg.RunQuery(longDropeQuery))
 			},
 			validation: func(t *testing.T, ctx pgTestContext, monitor *Monitor) {
 				validatePostgres(t, monitor, map[string]map[postgres.Operation]int{
-					"table_table_table_table_table_table_table_table_tab": {
+					getTruncatedTableName(longCreateQuery, 13): {
 						postgres.CreateTableOP: adjustCount(1),
 					},
-					"table_table_table_table_table_table_table_t": {
+					getTruncatedTableName(longDropeQuery, 21): {
 						postgres.DropTableOP: adjustCount(1),
 					},
 				}, isTLS)
@@ -511,6 +516,12 @@ func testDecoding(t *testing.T, isTLS bool) {
 			tt.validation(t, tt.context, monitor)
 		})
 	}
+}
+
+// getTruncatedTableName returns the truncated table name by reducing the operation and extracting the remaining
+// table name by the current max buffer size.
+func getTruncatedTableName(query string, tableNameIndex int) string {
+	return query[tableNameIndex:postgres.BufferSize]
 }
 
 // getPostgresInFlightEntries returns the entries in the in-flight map.

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -185,7 +185,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 
 	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
 	if isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid())
+		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
 	}
 
 	tests := []postgresParsingTestAttributes{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

* Increase the Postgres query buffer from 64 to 160.
* Change the Postgres query tests to use the buffer size instead of using constants.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Support longer queries and increase Postgres accuracy.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The image was tested on the staging cluster, and no negative impact was observed on the cluster.

**Performance impact:**

**RSS:**
No negative impact after the change: 
<img width="1604" alt="Screenshot 2024-07-23 at 15 54 32" src="https://github.com/user-attachments/assets/236d6585-5923-4267-920f-0415f75d0dc5">

**Working set:**
No negative impact after the change: 
<img width="1603" alt="Screenshot 2024-07-23 at 16 02 26" src="https://github.com/user-attachments/assets/510a9de8-d758-4b34-9587-c4813b574a08">

**CPU usage:**
No negative impact after the change: 
<img width="1611" alt="Screenshot 2024-07-23 at 16 01 37" src="https://github.com/user-attachments/assets/10b631bf-9fe3-40f7-8e8d-2acc5bbf5829">
<img width="1614" alt="Screenshot 2024-07-23 at 16 05 52" src="https://github.com/user-attachments/assets/aee0b900-124b-4300-8584-45ddaeb1b2be">


There was around a 5% improvement in extracting table names. On the tested cluster, the percentage of unknown tables was 99.84%, which improved to around 94% after the change.

**Map status:**
**Summary**:
* in_flight map max memory and RSS increased from ~25Kib to ~38Kib

<img width="1842" alt="Screenshot 2024-07-23 at 16 08 12" src="https://github.com/user-attachments/assets/41da8e44-5b3d-4429-9cb8-4e21e43f2413">


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
