### PR TITLE
[ASCII-2047] Adding "inventories" expvar in metadata inventorychecks component

### DIFF
--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -9,6 +9,7 @@ package inventorychecksimpl
 import (
 	"context"
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -131,6 +132,14 @@ func newInventoryChecksProvider(deps dependencies) provides {
 
 	if logAgent, isSet := deps.LogAgent.Get(); isSet {
 		ic.sources.Set(logAgent.GetSources())
+	}
+
+	// Set the expvar callback to the current inventorycheck
+	// This should be removed when migrated to collector component
+	if icExpvar := expvar.Get("inventories"); icExpvar == nil {
+		expvar.Publish("inventories", expvar.Func(func() interface{} {
+			return ic.getPayload()
+		}))
 	}
 
 	return provides{

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -6,6 +6,7 @@
 package inventorychecksimpl
 
 import (
+	"expvar"
 	"fmt"
 	"testing"
 
@@ -247,4 +248,12 @@ func TestFlareProviderFilename(t *testing.T) {
 		t, optional.NewNoneOption[collector.Component](), optional.Option[logagent.Component]{}, nil,
 	)
 	assert.Equal(t, "checks.json", ic.FlareFileName)
+}
+
+// TODO (Component): This test will be removed when the inventorychecks component will be move into the collector component
+func TestExpvarExist(t *testing.T) {
+	getTestInventoryChecks(
+		t, optional.NewNoneOption[collector.Component](), optional.Option[logagent.Component]{}, nil,
+	)
+	assert.NotNil(t, expvar.Get("inventories"))
 }

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -6,8 +6,6 @@
 package inventorychecksimpl
 
 import (
-	"encoding/json"
-	"expvar"
 	"fmt"
 	"testing"
 
@@ -50,58 +48,6 @@ func getTestInventoryChecks(t *testing.T, coll optional.Option[collector.Compone
 		),
 	)
 	return p.Comp.(*inventorychecksImpl)
-}
-
-// This test must be the first one executed because it is testing the expvar functionality of the inventoryChecks component
-// The ic expvar is only initialized if no other instance have published it before.
-func TestExpvar(t *testing.T) {
-	cInfo := []check.Info{
-		check.MockInfo{
-			Name:         "check1",
-			CheckID:      checkid.ID("check1_instance1"),
-			Source:       "provider1",
-			InitConf:     "",
-			InstanceConf: "{\"test\":21}",
-		},
-	}
-
-	mockColl := fxutil.Test[collector.Component](t,
-		fx.Replace(collectorimpl.MockParams{
-			ChecksInfo: cInfo,
-		}),
-		collectorimpl.MockModule(),
-		core.MockBundle(),
-		workloadmetafxmock.MockModule(),
-		fx.Supply(workloadmeta.NewParams()),
-	)
-
-	ic := getTestInventoryChecks(t,
-		optional.NewOption[collector.Component](mockColl),
-		optional.NewNoneOption[logagent.Component](),
-		nil,
-	)
-
-	ic.Set("check1_instance1", "check_provided_key1", 123.4)
-	ic.Set("check1_instance1", "check_provided_key2", "Hi")
-	ic.Set("non_running_checkid", "check_provided_key1", "this_should_not_be_kept")
-
-	// Retrieving the current inventorycheck metadata payload from expvar
-	inventories := expvar.Get("inventories")
-	assert.NotNil(t, inventories)
-	var inventoriesStats Payload
-	inventoriesStatsJSON := []byte(inventories.String())
-	err := json.Unmarshal(inventoriesStatsJSON, &inventoriesStats) //nolint:errcheck
-	assert.NoError(t, err)
-
-	// Retrieving the current inventorycheck metadata payload from ic component
-	var expectedPayload Payload = *ic.getPayload().(*Payload)
-
-	// We set both timestamp to 0 to avoid timing issues
-	inventoriesStats.Timestamp = 0
-	expectedPayload.Timestamp = 0
-
-	// We check that payloads are equals
-	assert.Equal(t, expectedPayload, inventoriesStats)
 }
 
 func TestSet(t *testing.T) {

--- a/releasenotes/notes/fix-missing-checks-metadata-a0fe0f878438bb6a.yaml
+++ b/releasenotes/notes/fix-missing-checks-metadata-a0fe0f878438bb6a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Re-enable printing of checks metadata in the ``datadog-agent status`` collector section.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR add an `expvar` to serve latest inventorychecks metadata payload to the [`collector` status provider](https://github.com/DataDog/datadog-agent/blob/97bb994bdf9f35803fdbf44fa9ec48d2675190ea/pkg/status/collector/status.go).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This PR addresses a regression introduced in version 7.51 that prevented the `metadata` fields from being returned in the `Running Checks` subsection of the `collector` section in the output of the `datadog-agent status` subcommand.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
This PR have been tested manually and covered by unit-tests.
Further e2e tests will be implemented to catch the issue that fix this PR (https://datadoghq.atlassian.net/jira/software/c/projects/ASCII/boards/5292)
