### PR TITLE
[agent] Fix logging in process agent component's Enabled() method

### DIFF
--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	// enabled variable to ensure value returned by Enabled() persists when Enabled() is called multiple times
-	// during agent start up, instead of resorting to default value
 	enabled bool
 	// Once module variable, exported for testing
 	Once              sync.Once

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -21,8 +21,11 @@ import (
 // List of check names for process checks
 
 var (
-	enabled           bool
-	once              sync.Once
+	// enabled variable to ensure value returned by Enabled() persists when Enabled() is called multiple times
+	// during agent start up, instead of resorting to default value
+	enabled bool
+	// Once module variable, exported for testing
+	Once              sync.Once
 	processCheckNames = []string{
 		checks.ProcessCheckName,
 		checks.ContainerCheckName,
@@ -74,6 +77,7 @@ func enabledHelper(config config.Component, checkComponents []types.CheckCompone
 }
 
 // Enabled determines whether the process agent is enabled based on the configuration.
+// Enabled will only be run once, to prevent duplicate logging.
 // The process-agent component on linux can be run in the core agent or as a standalone process-agent
 // depending on the configuration.
 // It will run as a standalone Process-agent if 'run_in_core_agent' is not enabled or the connections/NPM check is
@@ -81,7 +85,7 @@ func enabledHelper(config config.Component, checkComponents []types.CheckCompone
 // If 'run_in_core_agent' flag is enabled and the connections/NPM check is not enabled, the process-agent will run in
 // the core agent.
 func Enabled(config config.Component, checkComponents []types.CheckComponent, log logComponent.Component) bool {
-	once.Do(func() {
+	Once.Do(func() {
 		enabled = enabledHelper(config, checkComponents, log)
 	})
 	return enabled

--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -9,6 +9,7 @@ package agent
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
@@ -18,20 +19,18 @@ import (
 )
 
 // List of check names for process checks
-var processCheckNames = []string{
-	checks.ProcessCheckName,
-	checks.ContainerCheckName,
-	checks.DiscoveryCheckName,
-}
 
-// Enabled determines whether the process agent is enabled based on the configuration.
-// The process-agent component on linux can be run in the core agent or as a standalone process-agent
-// depending on the configuration.
-// It will run as a standalone Process-agent if 'run_in_core_agent' is not enabled or the connections/NPM check is
-// enabled.
-// If 'run_in_core_agent' flag is enabled and the connections/NPM check is not enabled, the process-agent will run in
-// the core agent.
-func Enabled(config config.Component, checkComponents []types.CheckComponent, log logComponent.Component) bool {
+var (
+	enabled           bool
+	once              sync.Once
+	processCheckNames = []string{
+		checks.ProcessCheckName,
+		checks.ContainerCheckName,
+		checks.DiscoveryCheckName,
+	}
+)
+
+func enabledHelper(config config.Component, checkComponents []types.CheckComponent, log logComponent.Component) bool {
 	runInCoreAgent := config.GetBool("process_config.run_in_core_agent.enabled")
 
 	var npmEnabled bool
@@ -72,4 +71,18 @@ func Enabled(config config.Component, checkComponents []types.CheckComponent, lo
 	default:
 		return false
 	}
+}
+
+// Enabled determines whether the process agent is enabled based on the configuration.
+// The process-agent component on linux can be run in the core agent or as a standalone process-agent
+// depending on the configuration.
+// It will run as a standalone Process-agent if 'run_in_core_agent' is not enabled or the connections/NPM check is
+// enabled.
+// If 'run_in_core_agent' flag is enabled and the connections/NPM check is not enabled, the process-agent will run in
+// the core agent.
+func Enabled(config config.Component, checkComponents []types.CheckComponent, log logComponent.Component) bool {
+	once.Do(func() {
+		enabled = enabledHelper(config, checkComponents, log)
+	})
+	return enabled
 }

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -209,6 +209,10 @@ func TestStatusProvider(t *testing.T) {
 					}
 				}),
 			))
+
+			// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
+			agent.Once = sync.Once{}
+
 			provides, err := newProcessAgent(deps)
 			assert.IsType(t, tc.expected, provides.StatusProvider.Provider)
 			assert.NoError(t, err)
@@ -249,6 +253,10 @@ func TestTelemetryCoreAgent(t *testing.T) {
 			}
 		}),
 	))
+
+	// reset agent module global variable "Once" to ensure Enabled() function runs for this unit test
+	agent.Once = sync.Once{}
+
 	_, err := newProcessAgent(deps)
 	assert.NoError(t, err)
 

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -119,6 +119,8 @@ func TestProcessAgentComponentOnLinux(t *testing.T) {
 			flavor.SetFlavor(tc.agentFlavor)
 			defer func() {
 				flavor.SetFlavor(originalFlavor)
+				// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
+				agent.Once = sync.Once{}
 			}()
 
 			opts := []fx.Option{
@@ -150,9 +152,6 @@ func TestProcessAgentComponentOnLinux(t *testing.T) {
 				}))
 			}
 
-			// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
-			agent.Once = sync.Once{}
-
 			agentComponent := fxutil.Test[agent.Component](t, fx.Options(opts...))
 			assert.Equal(t, tc.expected, agentComponent.Enabled())
 		})
@@ -183,6 +182,8 @@ func TestStatusProvider(t *testing.T) {
 			flavor.SetFlavor(tc.agentFlavor)
 			defer func() {
 				flavor.SetFlavor(originalFlavor)
+				// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
+				agent.Once = sync.Once{}
 			}()
 
 			deps := fxutil.Test[dependencies](t, fx.Options(
@@ -210,9 +211,6 @@ func TestStatusProvider(t *testing.T) {
 				}),
 			))
 
-			// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
-			agent.Once = sync.Once{}
-
 			provides, err := newProcessAgent(deps)
 			assert.IsType(t, tc.expected, provides.StatusProvider.Provider)
 			assert.NoError(t, err)
@@ -225,8 +223,12 @@ func TestTelemetryCoreAgent(t *testing.T) {
 	// registered to help avoid introducing panics.
 
 	originalFlavor := flavor.GetFlavor()
-	defer flavor.SetFlavor(originalFlavor)
 	flavor.SetFlavor("agent")
+	defer func() {
+		flavor.SetFlavor(originalFlavor)
+		// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
+		agent.Once = sync.Once{}
+	}()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		runnerimpl.Module(),
@@ -253,9 +255,6 @@ func TestTelemetryCoreAgent(t *testing.T) {
 			}
 		}),
 	))
-
-	// reset agent module global variable "Once" to ensure Enabled() function runs for this unit test
-	agent.Once = sync.Once{}
 
 	_, err := newProcessAgent(deps)
 	assert.NoError(t, err)

--- a/comp/process/agent/agentimpl/agent_linux_test.go
+++ b/comp/process/agent/agentimpl/agent_linux_test.go
@@ -9,6 +9,7 @@ package agentimpl
 
 import (
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,6 +149,9 @@ func TestProcessAgentComponentOnLinux(t *testing.T) {
 					}
 				}))
 			}
+
+			// reset agent module global variable "Once" to ensure Enabled() function runs for each unit test
+			agent.Once = sync.Once{}
 
 			agentComponent := fxutil.Test[agent.Component](t, fx.Options(opts...))
 			assert.Equal(t, tc.expected, agentComponent.Enabled())

--- a/releasenotes/notes/fix-process-agent-logging-c5408468685cb7eb.yaml
+++ b/releasenotes/notes/fix-process-agent-logging-c5408468685cb7eb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix duplicate logging in Process Agent component's Enabled() method.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
- Remove duplicate logging in process agent component's `Enabled()` method.
  - `Enabled()` method will only be invoked once per `Sync.once()` object instance (as Enabled() depends on configuration that should not change during one run).
- Add compatibility with above changes to process agent unit tests.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4223

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- Will need to create a new `Sync.once` instance if Enabled() configuration changes across one run.
### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Local unit testing by running the `agent_linux_test.go` tests (`TestProcessAgentComponentOnLinux`, `TestStatusProvider`,  `TestTelemetryCoreAgent`),  in a linux environment to ensure all tests pass.
2. Run process agent to ensure only unique log message is being output, as shown in the following:

**Before**:
```
2024-07-15 14:08:35 UTC | PROCESS | INFO | (comp/process/agent/agent_linux.go:60 in Enabled) | Process/Container Collection in the Process Agent will be deprecated in a future release and will instead be run in the Core Agent. Set process_config.run_in_core_agent.enabled to true to switch now.
2024-07-15 14:08:35 UTC | PROCESS | INFO | (comp/process/agent/agent_linux.go:60 in Enabled) | Process/Container Collection in the Process Agent will be deprecated in a future release and will instead be run in the Core Agent. Set process_config.run_in_core_agent.enabled to true to switch now.
2024-07-15 14:08:35 UTC | PROCESS | INFO | (comp/process/agent/agent_linux.go:60 in Enabled) | Process/Container Collection in the Process Agent will be deprecated in a future release and will instead be run in the Core Agent. Set process_config.run_in_core_agent.enabled to true to switch now.
```
**After** (there are different log messages before and after this message):
<img width="1019" alt="Screenshot 2024-07-22 at 12 22 58 PM" src="https://github.com/user-attachments/assets/096a9165-d065-43ca-8793-461a944ff504">


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
