### PR TITLE
k8s auto-instrumentation v2

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var sourceVolume = volume{
+	Volume: corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
+}
+
+var v1VolumeMount = sourceVolume.mount(corev1.VolumeMount{
+	MountPath: mountPath,
+})
+
+var v2VolumeMountInjector = sourceVolume.mount(corev1.VolumeMount{
+	MountPath: "/opt/datadog-packages/datadog-apm-inject",
+	SubPath:   "opt/datadog-packages/datadog-apm-inject",
+})
+
+var v2VolumeMountLibrary = sourceVolume.mount(corev1.VolumeMount{
+	MountPath: "/opt/datadog/apm/library",
+	SubPath:   "opt/datadog/apm/library",
+})
+
+type injector struct {
+	image      string
+	registry   string
+	injected   bool
+	injectTime time.Time
+}
+
+func (i *injector) initContainer() initContainer {
+	var (
+		name  = "datadog-init-apm-inject"
+		mount = corev1.VolumeMount{
+			MountPath: "/datadog-inject",
+			SubPath:   v2VolumeMountInjector.SubPath,
+			Name:      v2VolumeMountInjector.Name,
+		}
+		tsFilePath = mount.MountPath + "/c-init-time." + name
+	)
+	return initContainer{
+		Prepend: true,
+		Container: corev1.Container{
+			Name:    name,
+			Image:   i.image,
+			Command: []string{"/bin/sh", "-c", "--"},
+			Args: []string{
+				fmt.Sprintf(
+					`cp -r /%s/* %s && echo $(date +%%s) >> %s`,
+					mount.SubPath, mount.MountPath, tsFilePath,
+				),
+			},
+			VolumeMounts: []corev1.VolumeMount{mount},
+		},
+	}
+}
+
+func (i *injector) requirements() libRequirement {
+	return libRequirement{
+		initContainers: []initContainer{i.initContainer()},
+		volumes:        []volume{sourceVolume},
+		volumeMounts:   []volumeMount{v2VolumeMountInjector.readOnly().prepended()},
+		envVars: []envVar{
+			{
+				key: "LD_PRELOAD",
+				valFunc: identityValFunc(
+					"/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
+				),
+			},
+			{
+				key: "DD_INJECT_SENDER_TYPE",
+				valFunc: identityValFunc(
+					"k8s",
+				),
+			},
+			{
+				key:     "DD_INJECT_START_TIME",
+				valFunc: identityValFunc(strconv.FormatInt(i.injectTime.Unix(), 10)),
+			},
+		},
+	}
+}
+
+type injectorOption func(*injector)
+
+var injectorVersionAnnotationExtractor = annotationExtractor[injectorOption]{
+	key: "admission.datadoghq.com/apm-inject.version",
+	do:  infallibleFn(injectorWithImageTag),
+}
+
+var injectorImageAnnotationExtractor = annotationExtractor[injectorOption]{
+	key: "admission.datadoghq.com/apm-inject.custom-image",
+	do:  infallibleFn(injectorWithImageName),
+}
+
+func injectorWithImageName(name string) injectorOption {
+	return func(i *injector) {
+		i.image = name
+	}
+}
+
+func injectorWithImageTag(tag string) injectorOption {
+	return func(i *injector) {
+		i.image = fmt.Sprintf("%s/apm-inject:%s", i.registry, tag)
+	}
+}
+
+func newInjector(startTime time.Time, registry, imageTag string, opts ...injectorOption) *injector {
+	i := &injector{
+		registry:   registry,
+		injectTime: startTime,
+	}
+
+	for _, opt := range opts {
+		opt(i)
+	}
+
+	// if the options didn't override the image, we set it.
+	if i.image == "" {
+		injectorWithImageTag(imageTag)(i)
+	}
+
+	return i
+}
+
+func (i *injector) podMutator(v version) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		if i.injected {
+			return nil
+		}
+
+		if !v.usesInjector() {
+			return nil
+		}
+
+		if err := i.requirements().injectPod(pod, ""); err != nil {
+			return err
+		}
+
+		i.injected = true
+		return nil
+	})
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectorOptions(t *testing.T) {
+	i := newInjector(time.Now(), "registry", "1")
+	require.Equal(t, "registry/apm-inject:1", i.image)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -75,12 +75,9 @@ type volume struct {
 
 var _ podMutator = (*volume)(nil)
 
-func (v volume) mount(mount corev1.VolumeMount, prepend bool) volumeMount {
+func (v volume) mount(mount corev1.VolumeMount) volumeMount {
 	mount.Name = v.Name
-	return volumeMount{
-		VolumeMount: mount,
-		Prepend:     prepend,
-	}
+	return volumeMount{VolumeMount: mount}
 }
 
 // mutatePod implements podMutator for volume.
@@ -119,6 +116,18 @@ func (v volumeMount) mutateContainer(c *corev1.Container) error {
 
 	c.VolumeMounts = appendOrPrepend(mnt, c.VolumeMounts, v.Prepend)
 	return nil
+}
+
+func (v volumeMount) readOnly() volumeMount {
+	m := v.VolumeMount
+	m.ReadOnly = true
+	return volumeMount{m, v.Prepend}
+}
+
+func (v volumeMount) prepended() volumeMount {
+	v2 := v
+	v2.Prepend = true
+	return v2
 }
 
 func appendOrPrepend[T any](item T, toList []T, prepend bool) []T {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+)
+
+type version int
+
+const (
+	instrumentationVersionInvalid version = iota
+	instrumentationV1
+	instrumentationV2
+)
+
+func instrumentationVersion(v string) (version, error) {
+	switch v {
+	case "v1":
+		return instrumentationV1, nil
+	case "v2":
+		return instrumentationV2, nil
+	default:
+		return instrumentationVersionInvalid, fmt.Errorf("invalid version: %v", v)
+	}
+}
+
+func (v version) usesInjector() bool {
+	switch v {
+	case instrumentationV1:
+		return false
+	case instrumentationV2:
+		return true
+	default:
+		// N.B. version is validated on construction.
+		// So this code is _generally_ unreachable within the webhook.
+		//
+		// Another would have been to pick a default value, but then we might have
+		// a weird code path somewhere.
+		panic(fmt.Errorf("invalid instrumentation version %v", v))
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		version        string
+		expectsVersion version
+		expectsErr     bool
+		expectsPanic   bool
+		usesInjector   bool
+	}{
+		{
+			name:           "v1 is valid",
+			version:        "v1",
+			expectsVersion: instrumentationV1,
+		},
+		{
+			name:           "v2 uses injector",
+			version:        "v2",
+			expectsVersion: instrumentationV2,
+			usesInjector:   true,
+		},
+		{
+			name:           "invalid version is invalid",
+			version:        "something else",
+			expectsVersion: instrumentationVersionInvalid,
+			expectsErr:     true,
+			expectsPanic:   true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := instrumentationVersion(tt.version)
+			require.Equal(t, tt.expectsVersion, v)
+			require.Equal(t, tt.expectsErr, err != nil)
+			usesInjector := func() {
+				require.Equal(t, tt.usesInjector, v.usesInjector())
+			}
+			if tt.expectsPanic {
+				require.Panics(t, usesInjector)
+			} else {
+				require.NotPanics(t, usesInjector)
+			}
+		})
+
+	}
+
+}

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -84,6 +84,15 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.disabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.lib_versions", map[string]string{}, "DD_APM_INSTRUMENTATION_LIB_VERSIONS")
+	// Note(stanistan): The flag "DD_APM_INSTRUMENTATION_VERSION"
+	//                  will remain undocumented for the duration of the beta.
+	//                  We intend to only switch back to v1 if beta customers have issues
+	//                  to troubleshoot. v1 will be dropped (and possibly the flag)
+	//                  in 7.58 or 7.59 (this is going out in 7.57).
+	config.BindEnvAndSetDefault("apm_config.instrumentation.version", "v2", "DD_APM_INSTRUMENTATION_VERSION")
+	// Default Image Tag for the APM Inject package (https://hub.docker.com/r/datadog/apm-inject/tags).
+	// We pin to a major version by default.
+	config.BindEnvAndSetDefault("apm_config.instrumentation.injector_image_tag", "0", "DD_APM_INSTRUMENTATION_INJECTOR_IMAGE_TAG")
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")

--- a/releasenotes-dca/notes/auto-instru-beta-2-56963fba2f6cb928.yaml
+++ b/releasenotes-dca/notes/auto-instru-beta-2-56963fba2f6cb928.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The auto-instrumentation webhook (beta) uses a new injector library.


### PR DESCRIPTION
### What does this PR do?

This PR builds out a new version of k8s auto-instrumentation.

https://datadoghq.atlassian.net/browse/APMON-1265
https://datadoghq.atlassian.net/browse/APMON-1267

We first refactor the original code to make this kind of change easy to make and then make the change. This branch supports both the _current_ auto-instrumentation approach and `v2`.

Dependent on: 

- [x] #27594 
- [x] #27959 
- [x] A published injector version: [datadog/apm-inject:0
](https://hub.docker.com/layers/datadog/apm-inject/0/images/sha256-72266285781ee9d76311cca84293354e2f5ca8fff3e5887ec1b6259d97efca5c?context)

### Motivation

Implementation of k8s-auto-instrumentation-v2.

### Additional Notes

- https://docs.google.com/document/d/1pqYmrP93-TLGH935LjHxyrUmz7RRUIEOjSfn5_szMj4/edit
- RFC: https://docs.google.com/document/d/1cixviWcSECp35OpfHS1DN3cQwYIfGwUNwaaj_1Ksp8I/edit

### Possible Drawbacks / Trade-offs

See: RFC

### Describe how to test/QA your changes

- All refactors pass the old tests, and adding new tests for v2 implementation as well.

- Using a developer sandbox to run this version of the cluster-agent and test sample apps across supported languages to end-to-end see traces for the sample apps. [link](https://github.com/DataDog/k8s-ssi-v2-testing) and validating that we get traces


<img width="1240" alt="Screenshot 2024-08-05 at 4 34 41 PM" src="https://github.com/user-attachments/assets/a3318bd6-424d-43a1-99ce-3a353b0f5500">


