### PR TITLE
APM: Reduce metrics flaky test

### DIFF
--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -181,7 +181,7 @@ func setupMetrics(statsd statsd.Component, cfg config.Component, telemetryCollec
 
 	err = client.Count("datadog.trace_agent.started", 1, nil, 1)
 	if err != nil {
-		log.Error("Failed to emit datadog.trace_agent.started metric: %v", err)
+		log.Error("Failed to emit datadog.trace_agent.started metric: ", err)
 	}
 	return client, nil
 }

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -179,7 +179,10 @@ func setupMetrics(statsd statsd.Component, cfg config.Component, telemetryCollec
 		return nil, fmt.Errorf("cannot configure dogstatsd: %v", err)
 	}
 
-	_ = client.Count("datadog.trace_agent.started", 1, nil, 1)
+	err = client.Count("datadog.trace_agent.started", 1, nil, 1)
+	if err != nil {
+		log.Error("Failed to emit datadog.trace_agent.started metric: %v", err)
+	}
 	return client, nil
 }
 

--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -209,7 +209,6 @@ func hasContainerTag(payloads []*aggregator.TracePayload, tag string) bool {
 func testTraceAgentMetrics(t *testing.T, c *assert.CollectT, intake *components.FakeIntake) {
 	t.Helper()
 	expected := map[string]struct{}{
-		"datadog.trace_agent.started":                          {},
 		"datadog.trace_agent.heartbeat":                        {},
 		"datadog.trace_agent.heap_alloc":                       {},
 		"datadog.trace_agent.cpu_percent":                      {},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove trace_agent.started from e2e metrics test to reduce flakiness of this test. Adds a log for if we fail to emit this metric.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Flakiness is bad and expensive.
I believe the source of flakiness here is related to the fact that we only emit this metric exactly once at startup, but at the beginning of the test we clear any outstanding payloads in the "fakeintake". This means that this test will miss the started metric depending on the ordering of when tests run. A TODO out of this is to "truly" fix this test / behavior so we can assert on this metric again. For now, this change will unblock folks who have flaky failing pipelines.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
N/A
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
