### PR TITLE
[EBPF] Fixes in `kmt.gen-config` 

### DIFF
--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -10,7 +10,7 @@ from invoke.context import Context
 
 from tasks.kernel_matrix_testing.config import ConfigManager
 from tasks.kernel_matrix_testing.kmt_os import get_kmt_os
-from tasks.kernel_matrix_testing.tool import Exit, ask, error, info
+from tasks.kernel_matrix_testing.tool import Exit, error, info
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import KMTArchNameOrLocal, PathOrStr, SSHKey, StackOutput
@@ -200,15 +200,6 @@ def build_infrastructure(stack: str, ssh_key_obj: SSHKey | None = None):
         infra[arch] = instance
 
     return infra
-
-
-def ask_for_ssh() -> bool:
-    return (
-        ask(
-            "You may want to provide ssh key, since the given config launches a remote instance.\nContinue without a ssh key?[Y/n]"
-        )
-        != "y"
-    )
 
 
 def get_ssh_key_name(pubkey: Path) -> str | None:

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -9,7 +9,6 @@ from invoke.context import Context
 from invoke.runners import Result
 
 from tasks.kernel_matrix_testing.infra import (
-    ask_for_ssh,
     build_infrastructure,
     ensure_key_in_agent,
     ensure_key_in_ec2,
@@ -199,12 +198,11 @@ def launch_stack(
     ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
 
     if remote_vms_in_config(vm_config):
-        if ssh_key_obj is None and ask_for_ssh():
+        if ssh_key_obj is None:
             raise Exit("No ssh key provided. Pass with '--ssh-key=<key-name>' or configure it with kmt.config-ssh-key")
 
-        if ssh_key_obj is not None:
-            ensure_key_in_agent(ctx, ssh_key_obj)
-            ensure_key_in_ec2(ctx, ssh_key_obj)
+        ensure_key_in_agent(ctx, ssh_key_obj)
+        ensure_key_in_ec2(ctx, ssh_key_obj)
 
     env = [
         "TEAM=ebpf-platform",

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -716,6 +716,7 @@ def gen_config(
     memory: str,
     new: bool,
     ci: bool,
+    arch: str,
     output_file: PathOrStr,
     template: Component,
     yes: bool = False,
@@ -733,7 +734,11 @@ def gen_config(
             ctx, stack, vms, set_ls, init_stack, ls_to_int(vcpu_ls), ls_to_int(memory_ls), new, ci, template, yes=yes
         )
 
-    vms_to_generate = list_all_distro_normalized_vms(KMT_SUPPORTED_ARCHS, template)
+    arch_ls: list[KMTArchName] = KMT_SUPPORTED_ARCHS
+    if arch != "":
+        arch_ls = [Arch.from_str(arch).kmt_arch]
+
+    vms_to_generate = list_all_distro_normalized_vms(arch_ls, template)
     vm_config = generate_vmconfig(
         {"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, template
     )

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -716,7 +716,6 @@ def gen_config(
     memory: str,
     new: bool,
     ci: bool,
-    arch: str,
     output_file: PathOrStr,
     template: Component,
     yes: bool = False,
@@ -734,11 +733,7 @@ def gen_config(
             ctx, stack, vms, set_ls, init_stack, ls_to_int(vcpu_ls), ls_to_int(memory_ls), new, ci, template, yes=yes
         )
 
-    arch_ls: list[KMTArchName] = KMT_SUPPORTED_ARCHS
-    if arch != "":
-        arch_ls = [Arch.from_str(arch).kmt_arch]
-
-    vms_to_generate = list_all_distro_normalized_vms(arch_ls, template)
+    vms_to_generate = list_all_distro_normalized_vms(KMT_SUPPORTED_ARCHS, template)
     vm_config = generate_vmconfig(
         {"vmsets": []}, vms_to_generate, ls_to_int(vcpu_ls), ls_to_int(memory_ls), set_ls, ci, template
     )

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -123,7 +123,6 @@ def gen_config(
     memory: str | None = None,
     new=False,
     ci=False,
-    arch: str = "",
     output_file: str = "vmconfig.json",
     from_ci_pipeline: str | None = None,
     use_local_if_possible=False,
@@ -143,7 +142,6 @@ def gen_config(
             memory=memory,
             new=new,
             ci=ci,
-            arch=arch,
             output_file=output_file,
             use_local_if_possible=use_local_if_possible,
             vmconfig_template=vmconfig_template,
@@ -153,7 +151,7 @@ def gen_config(
         vcpu = DEFAULT_VCPU if vcpu is None else vcpu
         memory = DEFAULT_MEMORY if memory is None else memory
         vmconfig.gen_config(
-            ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, vmconfig_template, yes=yes
+            ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, output_file, vmconfig_template, yes=yes
         )
 
 
@@ -167,7 +165,6 @@ def gen_config_from_ci_pipeline(
     new=False,
     ci=False,
     use_local_if_possible=False,
-    arch: str = "",
     output_file="vmconfig.json",
     vmconfig_template: Component = "system-probe",
     yes=False,
@@ -213,7 +210,7 @@ def gen_config_from_ci_pipeline(
     vcpu = DEFAULT_VCPU if vcpu is None else vcpu
     memory = DEFAULT_MEMORY if memory is None else memory
     vmconfig.gen_config(
-        ctx, stack, ",".join(vms), "", init_stack, vcpu, memory, new, ci, arch, output_file, vmconfig_template, yes=yes
+        ctx, stack, ",".join(vms), "", init_stack, vcpu, memory, new, ci, output_file, vmconfig_template, yes=yes
     )
     info("[+] You can run the following command to execute only packages with failed tests")
     print(f"inv kmt.test --packages=\"{' '.join(failed_packages)}\"")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -133,6 +133,12 @@ def gen_config(
     """
     Generate a vmconfig.json file with the given VMs.
     """
+    if not ci and arch != "":
+        raise Exit(
+            "Error: Architecture (--arch argument) can only be specified when generating from a CI pipeline (--ci argument). "
+            "To specify the architecture of the VMs, use the VM specifier (e.g., x64-ubuntu_22-distro or local-ubuntu_22-distro for local VMs)"
+        )
+
     if from_ci_pipeline is not None:
         return gen_config_from_ci_pipeline(
             ctx,

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -111,6 +111,8 @@ def create_stack(ctx, stack=None):
         "use-local-if-possible": "(Only when --from-ci-pipeline is used) If the VM is for the same architecture as the host, use the local VM instead of the remote one.",
         "vmconfig_template": "Template to use for the generated vmconfig.json file. Defaults to 'system-probe'. A file named 'vmconfig-<vmconfig_template>.json' must exist in 'tasks/new-e2e/system-probe/config/'",
         "yes": "Do not ask for confirmation",
+        "ci": "Generate a vmconfig.json file for the KMT CI, that is, with all available VMs for the given architecture.",
+        "arch": "(Only when --ci is used) Architecture to select when generating the vmconfig for all posible VMs.",
     }
 )
 def gen_config(
@@ -134,6 +136,7 @@ def gen_config(
     Generate a vmconfig.json file with the given VMs.
     """
     if not ci and arch != "":
+        # The argument is not used later on, so better notify the user early to avoid confusion
         raise Exit(
             "Error: Architecture (--arch argument) can only be specified when generating from a CI pipeline (--ci argument). "
             "To specify the architecture of the VMs, use the VM specifier (e.g., x64-ubuntu_22-distro or local-ubuntu_22-distro for local VMs)"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -204,7 +204,12 @@ def gen_config_from_ci_pipeline(
 
             failed_tests = test_job.get_test_results()
             failed_packages.update({test.split(':')[0] for test in failed_tests.keys()})
-            vms.add(f"{vm_arch}-{test_job.distro}-distro")
+            vm_name = f"{vm_arch}-{test_job.distro}-distro"
+            info(f"[+] Adding {vm_name} from failed job {test_job.name}")
+            vms.add(vm_name)
+
+    if len(vms) == 0:
+        raise Exit(f"No failed jobs found in pipeline {pipeline}")
 
     info(f"[+] generating {output_file} file for VMs {vms}")
     vcpu = DEFAULT_VCPU if vcpu is None else vcpu

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -123,6 +123,7 @@ def gen_config(
     memory: str | None = None,
     new=False,
     ci=False,
+    arch: str = "",
     output_file: str = "vmconfig.json",
     from_ci_pipeline: str | None = None,
     use_local_if_possible=False,
@@ -142,6 +143,7 @@ def gen_config(
             memory=memory,
             new=new,
             ci=ci,
+            arch=arch,
             output_file=output_file,
             use_local_if_possible=use_local_if_possible,
             vmconfig_template=vmconfig_template,
@@ -151,7 +153,7 @@ def gen_config(
         vcpu = DEFAULT_VCPU if vcpu is None else vcpu
         memory = DEFAULT_MEMORY if memory is None else memory
         vmconfig.gen_config(
-            ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, output_file, vmconfig_template, yes=yes
+            ctx, stack, vms, sets, init_stack, vcpu, memory, new, ci, arch, output_file, vmconfig_template, yes=yes
         )
 
 
@@ -165,6 +167,7 @@ def gen_config_from_ci_pipeline(
     new=False,
     ci=False,
     use_local_if_possible=False,
+    arch: str = "",
     output_file="vmconfig.json",
     vmconfig_template: Component = "system-probe",
     yes=False,
@@ -215,7 +218,7 @@ def gen_config_from_ci_pipeline(
     vcpu = DEFAULT_VCPU if vcpu is None else vcpu
     memory = DEFAULT_MEMORY if memory is None else memory
     vmconfig.gen_config(
-        ctx, stack, ",".join(vms), "", init_stack, vcpu, memory, new, ci, output_file, vmconfig_template, yes=yes
+        ctx, stack, ",".join(vms), "", init_stack, vcpu, memory, new, ci, arch, output_file, vmconfig_template, yes=yes
     )
     info("[+] You can run the following command to execute only packages with failed tests")
     print(f"inv kmt.test --packages=\"{' '.join(failed_packages)}\"")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Some minor fixes for generating KMT config and instances

- Notify the user when `--arch` is used without `--ci` in `kmt.gen-config`, as in that case the value is unused and can lead to confusion
- Improved UX when using `kmt.gen-config --from-ci-pipeline`, showing which failed jobs are selected and notifying when there are no failed jobs to use.
- Raise an error when the user tries to launch a stack without a SSH key, as that will render the instance inaccesible.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
