### PR TITLE
Remove milestone from dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,6 @@ updates:
       - dependencies-go
       - team/triage
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # These dependencies are replaced in the main go.mod file.
       # They are ignored since bumping them would have no effect on the build.
@@ -45,7 +44,6 @@ updates:
       - dependencies-go
       - team/agent-apm
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
@@ -61,7 +59,6 @@ updates:
       - dependencies-go
       - team/agent-shared-components
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
@@ -77,7 +74,6 @@ updates:
       - dependencies-go
       - team/agent-apm
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
@@ -93,7 +89,6 @@ updates:
       - dependencies-go
       - team/agent-security
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
@@ -113,7 +108,6 @@ updates:
       - team/agent-delivery
       - changelog/no-changelog
       - qa/no-code-change
-    milestone: 22
     schedule:
       interval: monthly
     open-pull-requests-limit: 100
@@ -124,7 +118,6 @@ updates:
       - dependencies-go
       - team/network-device-monitoring
       - changelog/no-changelog
-    milestone: 22
     ignore:
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
@@ -140,7 +133,6 @@ updates:
       - changelog/no-changelog
       - qa/no-code-change
       - dev/testing
-    milestone: 22
     ignore:
       # Ignore test-infra-definitions because bumping the GO package inside `go.mod`
       # requires to also bump `TEST_INFRA_DEFINITIONS_BUILDIMAGES` inside `.gitlab/common/test_infra_version.yml`
@@ -162,7 +154,6 @@ updates:
       - changelog/no-changelog
       - qa/no-code-change
       - dev/testing
-    milestone: 22
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
@@ -175,7 +166,6 @@ updates:
       - changelog/no-changelog
       - qa/no-code-change
       - dev/tooling
-    milestone: 22
     schedule:
       interval: monthly
     open-pull-requests-limit: 100
@@ -187,7 +177,6 @@ updates:
       - changelog/no-changelog
       - qa/no-code-change
       - dev/testing
-    milestone: 22
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
@@ -200,7 +189,6 @@ updates:
       - changelog/no-changelog
       - qa/no-code-change
       - dev/tooling
-    milestone: 22
     schedule:
       interval: weekly
     open-pull-requests-limit: 100


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Stop setting `Triage` milestone on dependabot PRs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Milestone is set automatically when merging, so we usually just let the milestone empty while the PR is opened.
I think `Triage` is confusing, it makes it seem like someone will update it to a real value at some point, but that won't happen until after merging.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
