### PR TITLE
[CSM] Fix busybox support for cws-instrumentation

### DIFF
--- a/cmd/cws-instrumentation/subcommands/healthcmd/const.go
+++ b/cmd/cws-instrumentation/subcommands/healthcmd/const.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package healthcmd holds the health command of CWS injector
+package healthcmd
+
+const (
+	// HealthCommandOutput is the expected output of the health check
+	HealthCommandOutput = "OK"
+)

--- a/cmd/cws-instrumentation/subcommands/healthcmd/health.go
+++ b/cmd/cws-instrumentation/subcommands/healthcmd/health.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package healthcmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the commands for the setup subcommand
+func Command() []*cobra.Command {
+	healthCmd := &cobra.Command{
+		Use:   "health",
+		Short: "Prints OK to stdout",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Print(HealthCommandOutput)
+			return nil
+		},
+	}
+
+	return []*cobra.Command{healthCmd}
+}

--- a/cmd/cws-instrumentation/subcommands/subcommands.go
+++ b/cmd/cws-instrumentation/subcommands/subcommands.go
@@ -10,6 +10,7 @@ package subcommands
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/command"
+	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/healthcmd"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/injectcmd"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/setupcmd"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/tracecmd"
@@ -22,5 +23,6 @@ func CWSInjectorSubcommands() []command.SubcommandFactory {
 		setupcmd.Command,
 		injectcmd.Command,
 		tracecmd.Command,
+		healthcmd.Command,
 	}
 }

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package k8sexec implements the necessary methods to run commands remotely
+package k8sexec
+
+import (
+	"bytes"
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+// StreamOptions contains option for the remote stream
+type StreamOptions struct {
+	Stdin bool
+	genericiooptions.IOStreams
+}
+
+// Exec performs remote exec operations
+type Exec struct {
+	Container string
+	Namespace string
+
+	APIClient *apiserver.APIClient
+	In        *bytes.Buffer
+	Out       *bytes.Buffer
+	ErrOut    *bytes.Buffer
+}
+
+// NewExec creates a Exec instance
+func NewExec(apiClient *apiserver.APIClient) Exec {
+	return Exec{
+		In:        &bytes.Buffer{},
+		Out:       &bytes.Buffer{},
+		ErrOut:    &bytes.Buffer{},
+		APIClient: apiClient,
+	}
+}
+
+// Execute runs the exec command
+func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOptions) error {
+	restClient, err := e.APIClient.RESTClient(
+		"/api",
+		&schema.GroupVersion{Version: "v1"},
+		serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+	)
+	if err != nil {
+		return err
+	}
+
+	req := restClient.Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec")
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: e.Container,
+		Command:   command,
+		Stdin:     streamOptions.Stdin,
+		Stdout:    streamOptions.Out != nil,
+		Stderr:    streamOptions.ErrOut != nil,
+	}, scheme.ParameterCodec)
+
+	exec, err := e.APIClient.NewSPDYExecutor(
+		"/api",
+		&schema.GroupVersion{Version: "v1"},
+		serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+		"POST",
+		req.URL(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+		Stdin:  streamOptions.In,
+		Stdout: streamOptions.Out,
+		Stderr: streamOptions.ErrOut,
+	})
+}

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package k8sexec
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/healthcmd"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+var (
+	// CWSHealthCommand is the command used to check if cws-instrumentation was properly copied to the target container
+	CWSHealthCommand = "health"
+)
+
+// HealthCommand performs remote exec operations
+type HealthCommand struct {
+	Exec
+}
+
+// NewHealthCommand creates an Exec instance
+func NewHealthCommand(apiClient *apiserver.APIClient) *HealthCommand {
+	return &HealthCommand{
+		Exec: NewExec(apiClient),
+	}
+}
+
+func (hc *HealthCommand) prepareCommand(destFile string) []string {
+	return []string{
+		destFile,
+		CWSHealthCommand,
+	}
+}
+
+// Run runs the cws-instrumentation health command
+func (hc *HealthCommand) Run(remoteFile string, pod *corev1.Pod, container string) error {
+	hc.Container = container
+
+	streamOptions := StreamOptions{
+		IOStreams: genericiooptions.IOStreams{
+			Out:    hc.Out,
+			ErrOut: hc.ErrOut,
+		},
+		Stdin: false,
+	}
+
+	if err := hc.Execute(pod, hc.prepareCommand(remoteFile), streamOptions); err != nil {
+		return err
+	}
+
+	// check stdout and stderr from tar
+	outData := hc.ErrOut.String() + hc.Out.String()
+	if outData != healthcmd.HealthCommandOutput {
+		return fmt.Errorf("unexpected output (\"%s\"): cws-instrumentation might not have been copied properly", outData)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR runs `cws-instrumentation health` on the target container after copying the `cws-instrumentation` binary. The goal of running this command is to make sure that the binary was copied properly and that our admission controller can now safely override the user `kubectl exec` command.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

With [this PR](https://github.com/DataDog/datadog-agent/pull/27117), we introduced a fix that leveraged the `--totals` option of `tar` to ensure that `cws-instrumentation` was properly copied to the target container. Unfortunately, `--totals` isn't available on all versions of `tar` (namely not in the `busybox` implementation of `tar`), meaning that this fix only partially fixed the issue. This new approach should support all environments since we rely on `cws-instrumentation` itself to tell us if it was properly copied to the target directory.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This is a less efficient version of the previous fix, but the only way afaik to check if the binary was properly copied without relying on additional shell or tooling dependencies.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Same as the original [PR](https://github.com/DataDog/datadog-agent/pull/27117). You can also try to exec into a `busybox` container to ensure that they are now properly supported.