### PR TITLE
fix(fleet): Skip broken tests in 7.55.x

### DIFF
--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -104,6 +104,7 @@ func (s *packageAgentSuite) TestUpgrade_AgentDebRPM_to_OCI() {
 
 // TestUpgrade_Agent_OCI_then_DebRpm agent deb/rpm install while OCI one is installed
 func (s *packageAgentSuite) TestUpgrade_Agent_OCI_then_DebRpm() {
+	s.T().Skip("Old CentOS version with expired mirrors")
 	// install OCI agent
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()

--- a/test/new-e2e/tests/installer/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/package_apm_inject_test.go
@@ -32,6 +32,7 @@ func testApmInjectAgent(os e2eos.Descriptor, arch e2eos.Architecture) packageSui
 }
 
 func (s *packageApmInjectSuite) TestInstall() {
+	s.T().Skip("Test failing after OCI migration")
 	s.host.InstallDocker()
 	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python", envForceInstall("datadog-agent"), envForceInstall("datadog-apm-inject"), envForceInstall("datadog-apm-library-python"))
 	defer s.Purge()
@@ -99,6 +100,7 @@ func (s *packageApmInjectSuite) TestDockerBrokenJSON() {
 // TestUpgrade_InjectorDeb_To_InjectorOCI tests the upgrade from the DEB injector to the OCI injector.
 // Library package is OCI.
 func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
+	s.T().Skip("Test failing after OCI migration")
 	s.host.InstallDocker()
 
 	// Deb install using today's defaults
@@ -141,6 +143,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 // TestUpgrade_InjectorOCI_To_InjectorDeb tests the upgrade from the OCI injector to the DEB injector.
 // Library package is OCI.
 func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
+	s.T().Skip("Test failing after OCI migration")
 	s.host.InstallDocker()
 
 	// OCI install


### PR DESCRIPTION
### What does this PR do?
Skips broken tests:
- These work on the latest main
- They are related to either:
  - The datadog installer and have no functional impact on the agent
  - The image itself: CentOS got EOL and its mirrors were deactivated. This was fixed in test-infra-definitions in a later version that isn't referenced in this branch

### Motivation
Fix broken tests

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
N/A
