### PR TITLE
Rename test suites to disambiguate from other suites.

### DIFF
--- a/test/new-e2e/tests/security-agent-functional/security_agent_test.go
+++ b/test/new-e2e/tests/security-agent-functional/security_agent_test.go
@@ -33,7 +33,7 @@ var (
 	devMode = flag.Bool("devmode", false, "run tests in dev mode")
 )
 
-func TestVMSuite(t *testing.T) {
+func TestSysprobeWindowsCWSFunctionalSuite(t *testing.T) {
 	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -35,7 +35,7 @@ var (
 	devMode = flag.Bool("devmode", false, "run tests in dev mode")
 )
 
-func TestVMSuite(t *testing.T) {
+func TestSysprobeWindowsNetworkFunctionalSuite(t *testing.T) {
 	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())


### PR DESCRIPTION
### What does this PR do?

Renames test suite to disambiguate between other test suites of the same name.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

this change is test only