### PR TITLE
V2 Auto Multiline Detection Foundation - Aggregator, Labeler, and Refactoring

### DIFF
--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -156,6 +156,7 @@ github.com/DataDog/datadog-agent/pkg/logs/client/http
 github.com/DataDog/datadog-agent/pkg/logs/client/tcp
 github.com/DataDog/datadog-agent/pkg/logs/diagnostic
 github.com/DataDog/datadog-agent/pkg/logs/internal/decoder
+github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection
 github.com/DataDog/datadog-agent/pkg/logs/internal/framer
 github.com/DataDog/datadog-agent/pkg/logs/internal/parsers
 github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -156,6 +156,7 @@ github.com/DataDog/datadog-agent/pkg/logs/client/http
 github.com/DataDog/datadog-agent/pkg/logs/client/tcp
 github.com/DataDog/datadog-agent/pkg/logs/diagnostic
 github.com/DataDog/datadog-agent/pkg/logs/internal/decoder
+github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection
 github.com/DataDog/datadog-agent/pkg/logs/internal/framer
 github.com/DataDog/datadog-agent/pkg/logs/internal/parsers
 github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1441,6 +1441,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// maximum time that the windows tailer will hold a log file open, while waiting for
 	// the downstream logs pipeline to be ready to accept more data
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
+	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_extra_patterns", []string{})
 	// The following auto_multi_line settings are experimental and may change

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+type bucket struct {
+	message   *message.Message
+	buffer    *bytes.Buffer
+	lineCount int
+}
+
+func (b *bucket) add(msg *message.Message) {
+	if b.message == nil {
+		b.message = msg
+	}
+	if b.buffer.Len() > 0 {
+		b.buffer.Write(message.EscapedLineFeed)
+	}
+	b.buffer.Write(msg.GetContent())
+	b.lineCount++
+}
+
+func (b *bucket) isEmpty() bool {
+	return b.buffer.Len() == 0
+}
+
+func (b *bucket) flush() *message.Message {
+	defer func() {
+		b.buffer.Reset()
+		b.message = nil
+		b.lineCount = 0
+	}()
+
+	originalLen := b.buffer.Len()
+	data := bytes.TrimSpace(b.buffer.Bytes())
+	content := make([]byte, len(data))
+	copy(content, data)
+
+	if b.lineCount > 1 {
+		return message.NewRawMultiLineMessage(content, b.message.Status, originalLen, b.message.ParsingExtra.Timestamp)
+	}
+	return message.NewRawMessage(content, b.message.Status, originalLen, b.message.ParsingExtra.Timestamp)
+}
+
+// Aggregator aggregates multiline logs with a given label.
+type Aggregator struct {
+	outputFn       func(m *message.Message)
+	bucket         *bucket
+	maxContentSize int
+	flushTimeout   time.Duration
+	flushTimer     *time.Timer
+}
+
+// NewAggregator creates a new aggregator.
+func NewAggregator(outputFn func(m *message.Message), maxContentSize int, flushTimeout time.Duration) *Aggregator {
+	return &Aggregator{
+		outputFn:       outputFn,
+		bucket:         &bucket{buffer: bytes.NewBuffer(nil)},
+		maxContentSize: maxContentSize,
+		flushTimeout:   flushTimeout,
+	}
+}
+
+// Aggregate aggregates a multiline log using a label.
+func (a *Aggregator) Aggregate(msg *message.Message, label Label) {
+
+	a.stopFlushTimerIfNeeded()
+	defer a.startFlushTimerIfNeeded()
+
+	// If `noAggregate` - flush the bucket immediately and then flush the next message.
+	if label == noAggregate {
+		a.Flush()
+		a.outputFn(msg)
+		return
+	}
+
+	// If `aggregate` and the bucket is empty - flush the next message.
+	if label == aggregate && a.bucket.isEmpty() {
+		a.outputFn(msg)
+		return
+	}
+
+	// If `startGroup` - flush the bucket.
+	if label == startGroup {
+		a.Flush()
+	}
+
+	// At this point we either have `startGroup` with an empty bucket or `aggregate` with a non-empty bucket
+	// so we add the message to the bucket or flush if the bucket will overflow the max content size.
+
+	if msg.RawDataLen+a.bucket.buffer.Len() > a.maxContentSize {
+		a.bucket.flush()
+	}
+
+	a.bucket.add(msg)
+}
+
+func (a *Aggregator) stopFlushTimerIfNeeded() {
+	if a.flushTimer == nil || a.bucket.isEmpty() {
+		return
+	}
+	// stop the flush timer, as we now have data
+	if !a.flushTimer.Stop() {
+		<-a.flushTimer.C
+	}
+}
+
+func (a *Aggregator) startFlushTimerIfNeeded() {
+	if a.bucket.isEmpty() {
+		return
+	}
+	// since there's buffered data, start the flush timer to flush it
+	if a.flushTimer == nil {
+		a.flushTimer = time.NewTimer(a.flushTimeout)
+	} else {
+		a.flushTimer.Reset(a.flushTimeout)
+	}
+}
+
+// FlushChan returns the flush timer channel.
+func (a *Aggregator) FlushChan() <-chan time.Time {
+	if a.flushTimer != nil {
+		return a.flushTimer.C
+	}
+	return nil
+}
+
+// Flush flushes the aggregator.
+func (a *Aggregator) Flush() {
+	if a.bucket.isEmpty() {
+		return
+	}
+	a.outputFn(a.bucket.flush())
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+func makeHandler() (chan *message.Message, func(*message.Message)) {
+	ch := make(chan *message.Message, 20)
+	return ch, func(m *message.Message) {
+		ch <- m
+	}
+}
+
+func newMessage(content string) *message.Message {
+	return message.NewRawMessage([]byte(content), message.StatusInfo, len([]byte(content)), "")
+}
+
+func assertMessageContent(t *testing.T, m *message.Message, content string) {
+	isMultiLine := len(strings.Split(content, "\\n")) > 1
+	assert.Equal(t, content, string(m.GetContent()))
+	assert.Equal(t, m.IsMultiLine, isMultiLine)
+}
+
+func TestNoAggregate(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	ag.Aggregate(newMessage("1"), noAggregate)
+	ag.Aggregate(newMessage("2"), noAggregate)
+	ag.Aggregate(newMessage("3"), noAggregate)
+
+	assertMessageContent(t, <-outputChan, "1")
+	assertMessageContent(t, <-outputChan, "2")
+	assertMessageContent(t, <-outputChan, "3")
+}
+
+func TestNoAggregateEndsGroup(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	ag.Aggregate(newMessage("1"), startGroup)
+	ag.Aggregate(newMessage("2"), startGroup)
+	ag.Aggregate(newMessage("3"), noAggregate) // Causes flush or last group, and flush of noAggregate message
+
+	assertMessageContent(t, <-outputChan, "1")
+	assertMessageContent(t, <-outputChan, "2")
+	assertMessageContent(t, <-outputChan, "3")
+}
+
+func TestAggregateGroups(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	// Aggregated log
+	ag.Aggregate(newMessage("1"), startGroup)
+	ag.Aggregate(newMessage("2"), aggregate)
+	ag.Aggregate(newMessage("3"), aggregate)
+
+	// Aggregated log
+	ag.Aggregate(newMessage("4"), startGroup)
+
+	// Aggregated log
+	ag.Aggregate(newMessage("5"), noAggregate)
+
+	assertMessageContent(t, <-outputChan, "1\\n2\\n3")
+	assertMessageContent(t, <-outputChan, "4")
+	assertMessageContent(t, <-outputChan, "5")
+}
+
+func TestAggregateDoesntStartGroup(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	ag.Aggregate(newMessage("1"), aggregate)
+	ag.Aggregate(newMessage("2"), aggregate)
+	ag.Aggregate(newMessage("3"), aggregate)
+
+	assertMessageContent(t, <-outputChan, "1")
+	assertMessageContent(t, <-outputChan, "2")
+	assertMessageContent(t, <-outputChan, "3")
+}
+
+func TestForceFlush(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	ag.Aggregate(newMessage("1"), startGroup)
+	ag.Aggregate(newMessage("2"), aggregate)
+	ag.Aggregate(newMessage("3"), aggregate)
+	ag.Flush()
+
+	assertMessageContent(t, <-outputChan, "1\\n2\\n3")
+}
+
+func TestAggregationTimer(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+
+	assert.Nil(t, ag.FlushChan())
+	ag.Aggregate(newMessage("1"), startGroup)
+	assert.NotNil(t, ag.FlushChan())
+
+	ag.Aggregate(newMessage("2"), startGroup)
+	assert.NotNil(t, ag.FlushChan())
+
+	ag.Flush()
+
+	assertMessageContent(t, <-outputChan, "1")
+	assertMessageContent(t, <-outputChan, "2")
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -8,7 +8,7 @@ package automultilinedetection
 
 import "regexp"
 
-var jsonRegexp = regexp.MustCompile(`^^\s*\{\s*(\"|})`)
+var jsonRegexp = regexp.MustCompile(`^\s*\{\s*["}]`)
 
 // JSONDetector is a heuristic to detect JSON messages.
 type JSONDetector struct{}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -8,7 +8,7 @@ package automultilinedetection
 
 import "regexp"
 
-var jsonRegexp = regexp.MustCompile(`^\s*\{\s*\"`)
+var jsonRegexp = regexp.MustCompile(`^^\s*\{\s*(\"|})`)
 
 // JSONDetector is a heuristic to detect JSON messages.
 type JSONDetector struct{}
@@ -19,6 +19,7 @@ func NewJSONDetector() *JSONDetector {
 }
 
 // Process checks if a message is a JSON message.
+// This implements the Herustic interface - so we should stop processing if we detect a JSON message by returning false.
 func (j *JSONDetector) Process(context *messageContext) bool {
 	if jsonRegexp.Match(context.rawMessage) {
 		context.label = noAggregate

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import "regexp"
+
+var jsonRegexp = regexp.MustCompile(`^\s*\{\s*\"`)
+
+// JSONDetector is a heuristic to detect JSON messages.
+type JSONDetector struct{}
+
+// NewJSONDetector returns a new JSON detection heuristic.
+func NewJSONDetector() *JSONDetector {
+	return &JSONDetector{}
+}
+
+// Process checks if a message is a JSON message.
+func (j *JSONDetector) Process(context *messageContext) bool {
+	if jsonRegexp.Match(context.rawMessage) {
+		context.label = noAggregate
+		return false
+	}
+	return true
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonDetector(t *testing.T) {
+	jsonDetector := NewJSONDetector()
+	testCases := []struct {
+		rawMessage    string
+		expectedLabel Label
+	}{
+		{`{"key": "value"}`, noAggregate},
+		{`    {"key": "value"}`, noAggregate},
+		{`    { "key": "value"}`, noAggregate},
+		{`    {."key": "value"}`, aggregate},
+		{`.{"key": "value"}`, aggregate},
+		{`{"another_key": "another_value"}`, noAggregate},
+		{`{"key": 12345}`, noAggregate},
+		{`{"array": [1,2,3]}`, noAggregate},
+		{`not json`, aggregate},
+		{`{foo}`, aggregate},
+		{`{bar"}`, aggregate},
+		{`"FOO"}`, aggregate},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.rawMessage), func(t *testing.T) {
+			messageContext := &messageContext{
+				rawMessage: []byte(tc.rawMessage),
+				label:      aggregate,
+			}
+			jsonDetector.Process(messageContext)
+			assert.Equal(t, tc.expectedLabel, messageContext.label)
+		})
+	}
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
@@ -15,21 +15,26 @@ import (
 func TestJsonDetector(t *testing.T) {
 	jsonDetector := NewJSONDetector()
 	testCases := []struct {
-		rawMessage    string
-		expectedLabel Label
+		rawMessage     string
+		expectedLabel  Label
+		expectedResult bool
 	}{
-		{`{"key": "value"}`, noAggregate},
-		{`    {"key": "value"}`, noAggregate},
-		{`    { "key": "value"}`, noAggregate},
-		{`    {."key": "value"}`, aggregate},
-		{`.{"key": "value"}`, aggregate},
-		{`{"another_key": "another_value"}`, noAggregate},
-		{`{"key": 12345}`, noAggregate},
-		{`{"array": [1,2,3]}`, noAggregate},
-		{`not json`, aggregate},
-		{`{foo}`, aggregate},
-		{`{bar"}`, aggregate},
-		{`"FOO"}`, aggregate},
+		{`{"key": "value"}`, noAggregate, false},
+		{`    {"key": "value"}`, noAggregate, false},
+		{`    { "key": "value"}`, noAggregate, false},
+		{`    {."key": "value"}`, aggregate, true},
+		{`.{"key": "value"}`, aggregate, true},
+		{`{"another_key": "another_value"}`, noAggregate, false},
+		{`{"key": 12345}`, noAggregate, false},
+		{`{"array": [1,2,3]}`, noAggregate, false},
+		{`not json`, aggregate, true},
+		{`{foo}`, aggregate, true},
+		{`{bar"}`, aggregate, true},
+		{`"FOO"}`, aggregate, true},
+		{`{}`, noAggregate, false},
+		{` {}`, noAggregate, false},
+		{` {    }`, noAggregate, false},
+		{`{    }`, noAggregate, false},
 	}
 
 	for _, tc := range testCases {
@@ -38,7 +43,7 @@ func TestJsonDetector(t *testing.T) {
 				rawMessage: []byte(tc.rawMessage),
 				label:      aggregate,
 			}
-			jsonDetector.Process(messageContext)
+			assert.Equal(t, tc.expectedResult, jsonDetector.Process(messageContext))
 			assert.Equal(t, tc.expectedLabel, messageContext.label)
 		})
 	}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+// TODO: (brian) - This will be implemented in a future PR when the tokenizer is added
+type token uint
+
+// Label is a label for a log message.
+type Label uint32
+
+const (
+	startGroup Label = iota
+	noAggregate
+	aggregate
+)
+
+type messageContext struct {
+	rawMessage []byte
+	// NOTE: tokens can be nil if the heuristic runs before the tokenizer.
+	// Heuristic implementations must check if tokens is nil before using it.
+	tokens []token
+	label  Label
+}
+
+// Heuristic is an interface representing a strategy to label log messages.
+type Heuristic interface {
+	// Process processes a log message and annotates the context with a label. It returns false if the message should be done processing.
+	// Heuristic implementations may mutate the message context but must do so synchronously.
+	Process(*messageContext) bool
+}
+
+// Labeler labels log messages based on a set of heuristics.
+// Each Heuristic operates on the output of the previous heuristic - mutating the message context.
+// A label is chosen when a herusitc signals the labler to stop or when all herustics have been processed.
+type Labeler struct {
+	heuristics []Heuristic
+}
+
+// NewLabler creates a new labeler with the given heuristics.
+func NewLabler(heuristics []Heuristic) *Labeler {
+	return &Labeler{
+		heuristics: heuristics,
+	}
+}
+
+// Label labels a log message.
+func (l *Labeler) Label(rawMessage []byte) Label {
+	context := &messageContext{
+		rawMessage: rawMessage,
+		tokens:     nil,
+		label:      aggregate,
+	}
+	for _, h := range l.heuristics {
+		if !h.Process(context) {
+			return context.label
+		}
+	}
+	return context.label
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -35,13 +35,13 @@ type Heuristic interface {
 
 // Labeler labels log messages based on a set of heuristics.
 // Each Heuristic operates on the output of the previous heuristic - mutating the message context.
-// A label is chosen when a herusitc signals the labler to stop or when all herustics have been processed.
+// A label is chosen when a herusitc signals the labeler to stop or when all herustics have been processed.
 type Labeler struct {
 	heuristics []Heuristic
 }
 
-// NewLabler creates a new labeler with the given heuristics.
-func NewLabler(heuristics []Heuristic) *Labeler {
+// NewLabeler creates a new labeler with the given heuristics.
+func NewLabeler(heuristics []Heuristic) *Labeler {
 	return &Labeler{
 		heuristics: heuristics,
 	}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHeuristic struct {
+	processFunc func(*messageContext) bool
+}
+
+func (m *mockHeuristic) Process(context *messageContext) bool {
+	return m.processFunc(context)
+}
+
+func TestLabelerProceedNextHeuristic(t *testing.T) {
+
+	labeler := NewLabler([]Heuristic{
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				context.label = startGroup
+				return true
+			},
+		},
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				context.label = noAggregate
+				return true
+			},
+		},
+	})
+
+	assert.Equal(t, noAggregate, labeler.Label([]byte("test 123")))
+}
+
+func TestLabelerProceedFirstHeuristicWins(t *testing.T) {
+
+	labeler := NewLabler([]Heuristic{
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				context.label = startGroup
+				return false
+			},
+		},
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				context.label = noAggregate
+				return true
+			},
+		},
+	})
+
+	assert.Equal(t, startGroup, labeler.Label([]byte("test 123")))
+}
+
+func TestLabelerDefaultLabel(t *testing.T) {
+
+	labeler := NewLabler([]Heuristic{
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				return false
+			},
+		},
+	})
+
+	assert.Equal(t, aggregate, labeler.Label([]byte("test 123")))
+}
+
+func TestLabelerPassesAlongMessageContext(t *testing.T) {
+
+	labeler := NewLabler([]Heuristic{
+		&mockHeuristic{
+			processFunc: func(context *messageContext) bool {
+				assert.Equal(t, "test 123", string(context.rawMessage))
+				return false
+			},
+		},
+	})
+
+	labeler.Label([]byte("test 123"))
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
@@ -22,7 +22,7 @@ func (m *mockHeuristic) Process(context *messageContext) bool {
 
 func TestLabelerProceedNextHeuristic(t *testing.T) {
 
-	labeler := NewLabler([]Heuristic{
+	labeler := NewLabeler([]Heuristic{
 		&mockHeuristic{
 			processFunc: func(context *messageContext) bool {
 				context.label = startGroup
@@ -42,7 +42,7 @@ func TestLabelerProceedNextHeuristic(t *testing.T) {
 
 func TestLabelerProceedFirstHeuristicWins(t *testing.T) {
 
-	labeler := NewLabler([]Heuristic{
+	labeler := NewLabeler([]Heuristic{
 		&mockHeuristic{
 			processFunc: func(context *messageContext) bool {
 				context.label = startGroup
@@ -62,7 +62,7 @@ func TestLabelerProceedFirstHeuristicWins(t *testing.T) {
 
 func TestLabelerDefaultLabel(t *testing.T) {
 
-	labeler := NewLabler([]Heuristic{
+	labeler := NewLabeler([]Heuristic{
 		&mockHeuristic{
 			processFunc: func(context *messageContext) bool {
 				return false
@@ -75,7 +75,7 @@ func TestLabelerDefaultLabel(t *testing.T) {
 
 func TestLabelerPassesAlongMessageContext(t *testing.T) {
 
-	labeler := NewLabler([]Heuristic{
+	labeler := NewLabeler([]Heuristic{
 		&mockHeuristic{
 			processFunc: func(context *messageContext) bool {
 				assert.Equal(t, "test 123", string(context.rawMessage))

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -14,7 +14,7 @@ import (
 
 // AutoMultilineHandler aggreagates multiline logs.
 type AutoMultilineHandler struct {
-	labler     *automultilinedetection.Labeler
+	labeler    *automultilinedetection.Labeler
 	aggregator *automultilinedetection.Aggregator
 }
 
@@ -27,13 +27,13 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 	}
 
 	return &AutoMultilineHandler{
-		labler:     automultilinedetection.NewLabler(heuristics),
+		labeler:    automultilinedetection.NewLabeler(heuristics),
 		aggregator: automultilinedetection.NewAggregator(outputFn, maxContentSize, flushTimeout),
 	}
 }
 
 func (a *AutoMultilineHandler) process(msg *message.Message) {
-	label := a.labler.Label(msg.GetContent())
+	label := a.labeler.Label(msg.GetContent())
 	a.aggregator.Aggregate(msg, label)
 }
 

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package decoder
+
+import (
+	"time"
+
+	automultilinedetection "github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// AutoMultilineHandler aggreagates multiline logs.
+type AutoMultilineHandler struct {
+	labler     *automultilinedetection.Labeler
+	aggregator *automultilinedetection.Aggregator
+}
+
+// NewAutoMultilineHandler creates a new auto multiline handler.
+func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize int, flushTimeout time.Duration) *AutoMultilineHandler {
+
+	// Order is important
+	heuristics := []automultilinedetection.Heuristic{
+		automultilinedetection.NewJSONDetector(),
+	}
+
+	return &AutoMultilineHandler{
+		labler:     automultilinedetection.NewLabler(heuristics),
+		aggregator: automultilinedetection.NewAggregator(outputFn, maxContentSize, flushTimeout),
+	}
+}
+
+func (a *AutoMultilineHandler) process(msg *message.Message) {
+	label := a.labler.Label(msg.GetContent())
+	a.aggregator.Aggregate(msg, label)
+}
+
+func (a *AutoMultilineHandler) flushChan() <-chan time.Time {
+	return a.aggregator.FlushChan()
+}
+
+func (a *AutoMultilineHandler) flush() {
+	a.aggregator.Flush()
+}

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -98,7 +98,10 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 		}
 	}
 	if lineHandler == nil {
-		if source.Config().AutoMultiLineEnabled(pkgConfig.Datadog()) {
+		if pkgConfig.Datadog().GetBool("logs_config.experimental_auto_multi_line_detection") {
+			lineHandler = NewAutoMultilineHandler(outputFn, maxContentSize, config.AggregationTimeout(pkgConfig.Datadog()))
+
+		} else if source.Config().AutoMultiLineEnabled(pkgConfig.Datadog()) {
 			log.Infof("Auto multi line log detection enabled")
 
 			if multiLinePattern != nil {

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -29,23 +29,6 @@ func NewInput(content []byte) *message.Message {
 	return message.NewMessage(content, nil, "", time.Now().UnixNano())
 }
 
-// NewMessage returns a new encoded message.
-func NewMessage(content []byte, status string, rawDataLen int, readTimestamp string) *message.Message {
-	msg := message.Message{
-		MessageContent: message.MessageContent{
-			State: message.StateEncoded,
-		},
-		Status:             status,
-		RawDataLen:         rawDataLen,
-		IngestionTimestamp: time.Now().UnixNano(),
-		ParsingExtra: message.ParsingExtra{
-			Timestamp: readTimestamp,
-		},
-	}
-	msg.SetContent(content)
-	return &msg
-}
-
 // Decoder translates a sequence of byte buffers (such as from a file or a
 // network socket) into log messages.
 //
@@ -100,7 +83,7 @@ func syncSourceInfo(source *sources.ReplaceableSource, lh *MultiLineHandler) {
 func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) *Decoder {
 	inputChan := make(chan *message.Message)
 	outputChan := make(chan *message.Message)
-	lineLimit := config.MaxMessageSizeBytes(pkgConfig.Datadog())
+	maxContentSize := config.MaxMessageSizeBytes(pkgConfig.Datadog())
 	detectedPattern := &DetectedPattern{}
 
 	outputFn := func(m *message.Message) { outputChan <- m }
@@ -109,7 +92,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 	var lineHandler LineHandler
 	for _, rule := range source.Config().ProcessingRules {
 		if rule.Type == config.MultiLine {
-			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgConfig.Datadog()), lineLimit, false, tailerInfo)
+			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgConfig.Datadog()), maxContentSize, false, tailerInfo)
 			syncSourceInfo(source, lh)
 			lineHandler = lh
 		}
@@ -124,32 +107,32 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 				// Save the pattern again for the next rotation
 				detectedPattern.Set(multiLinePattern)
 
-				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgConfig.Datadog()), lineLimit, true, tailerInfo)
+				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgConfig.Datadog()), maxContentSize, true, tailerInfo)
 				syncSourceInfo(source, lh)
 				lineHandler = lh
 			} else {
-				lineHandler = buildAutoMultilineHandlerFromConfig(outputFn, lineLimit, source, detectedPattern, tailerInfo)
+				lineHandler = buildLegacyAutoMultilineHandlerFromConfig(outputFn, maxContentSize, source, detectedPattern, tailerInfo)
 			}
 		} else {
-			lineHandler = NewSingleLineHandler(outputFn, lineLimit)
+			lineHandler = NewSingleLineHandler(outputFn, maxContentSize)
 		}
 	}
 
 	// construct the lineParser, wrapping the parser
 	var lineParser LineParser
 	if parser.SupportsPartialLine() {
-		lineParser = NewMultiLineParser(lineHandler.process, config.AggregationTimeout(pkgConfig.Datadog()), parser, lineLimit)
+		lineParser = NewMultiLineParser(lineHandler, config.AggregationTimeout(pkgConfig.Datadog()), parser, maxContentSize)
 	} else {
-		lineParser = NewSingleLineParser(lineHandler.process, parser)
+		lineParser = NewSingleLineParser(lineHandler, parser)
 	}
 
 	// construct the framer
-	framer := framer.NewFramer(lineParser.process, framing, lineLimit)
+	framer := framer.NewFramer(lineParser.process, framing, maxContentSize)
 
 	return New(inputChan, outputChan, framer, lineParser, lineHandler, detectedPattern)
 }
 
-func buildAutoMultilineHandlerFromConfig(outputFn func(*message.Message), lineLimit int, source *sources.ReplaceableSource, detectedPattern *DetectedPattern, tailerInfo *status.InfoRegistry) *AutoMultilineHandler {
+func buildLegacyAutoMultilineHandlerFromConfig(outputFn func(*message.Message), maxContentSize int, source *sources.ReplaceableSource, detectedPattern *DetectedPattern, tailerInfo *status.InfoRegistry) *LegacyAutoMultilineHandler {
 	linesToSample := source.Config().AutoMultiLineSampleSize
 	if linesToSample <= 0 {
 		linesToSample = pkgConfig.Datadog().GetInt("logs_config.auto_multi_line_default_sample_size")
@@ -171,9 +154,9 @@ func buildAutoMultilineHandlerFromConfig(outputFn func(*message.Message), lineLi
 	}
 
 	matchTimeout := time.Second * pkgConfig.Datadog().GetDuration("logs_config.auto_multi_line_default_match_timeout")
-	return NewAutoMultilineHandler(
+	return NewLegacyAutoMultilineHandler(
 		outputFn,
-		lineLimit,
+		maxContentSize,
 		linesToSample,
 		matchThreshold,
 		matchTimeout,

--- a/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
@@ -49,9 +49,9 @@ func (d *DetectedPattern) Get() *regexp.Regexp {
 	return d.pattern
 }
 
-// AutoMultilineHandler can attempts to detect a known/commob pattern (a timestamp) in the logs
+// LegacyAutoMultilineHandler can attempts to detect a known/commob pattern (a timestamp) in the logs
 // and will switch to a MultiLine handler if one is detected and the thresholds are met.
-type AutoMultilineHandler struct {
+type LegacyAutoMultilineHandler struct {
 	multiLineHandler    *MultiLineHandler
 	singleLineHandler   *SingleLineHandler
 	outputFn            func(*message.Message)
@@ -72,8 +72,8 @@ type AutoMultilineHandler struct {
 	tailerInfo          *status.InfoRegistry
 }
 
-// NewAutoMultilineHandler returns a new AutoMultilineHandler.
-func NewAutoMultilineHandler(
+// NewLegacyAutoMultilineHandler returns a new LegacyAutoMultilineHandler.
+func NewLegacyAutoMultilineHandler(
 	outputFn func(*message.Message),
 	lineLimit, linesToAssess int,
 	matchThreshold float64,
@@ -83,7 +83,7 @@ func NewAutoMultilineHandler(
 	additionalPatterns []*regexp.Regexp,
 	detectedPattern *DetectedPattern,
 	tailerInfo *status.InfoRegistry,
-) *AutoMultilineHandler {
+) *LegacyAutoMultilineHandler {
 
 	// Put the user patterns at the beginning of the list so we prioritize them if there is a conflicting match.
 	patterns := append(additionalPatterns, formatsToTry...)
@@ -95,7 +95,7 @@ func NewAutoMultilineHandler(
 			regexp: v,
 		}
 	}
-	h := &AutoMultilineHandler{
+	h := &LegacyAutoMultilineHandler{
 		outputFn:            outputFn,
 		isRunning:           true,
 		lineLimit:           lineLimit,
@@ -120,18 +120,18 @@ func NewAutoMultilineHandler(
 	return h
 }
 
-func (h *AutoMultilineHandler) process(message *message.Message) {
+func (h *LegacyAutoMultilineHandler) process(message *message.Message) {
 	h.processFunc(message)
 }
 
-func (h *AutoMultilineHandler) flushChan() <-chan time.Time {
+func (h *LegacyAutoMultilineHandler) flushChan() <-chan time.Time {
 	if h.singleLineHandler != nil {
 		return h.singleLineHandler.flushChan()
 	}
 	return h.multiLineHandler.flushChan()
 }
 
-func (h *AutoMultilineHandler) flush() {
+func (h *LegacyAutoMultilineHandler) flush() {
 	if h.singleLineHandler != nil {
 		h.singleLineHandler.flush()
 	} else {
@@ -139,7 +139,7 @@ func (h *AutoMultilineHandler) flush() {
 	}
 }
 
-func (h *AutoMultilineHandler) processAndTry(message *message.Message) {
+func (h *LegacyAutoMultilineHandler) processAndTry(message *message.Message) {
 	// Process message before anything else
 	h.singleLineHandler.process(message)
 
@@ -202,7 +202,7 @@ func (h *AutoMultilineHandler) processAndTry(message *message.Message) {
 	}
 }
 
-func (h *AutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) {
+func (h *LegacyAutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) {
 	h.isRunning = false
 	h.singleLineHandler = nil
 

--- a/pkg/logs/internal/decoder/line_handler.go
+++ b/pkg/logs/internal/decoder/line_handler.go
@@ -11,16 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-// truncatedFlag is the flag that is added at the beginning
-// or/and at the end of every trucated lines.
-var truncatedFlag = []byte("...TRUNCATED...")
-
-// escapedLineFeed is used to escape new line character
-// for multiline message.
-// New line character needs to be escaped because they are used
-// as delimiter for transport.
-var escapedLineFeed = []byte(`\n`)
-
 // LineHandler handles raw lines to form structured lines.
 type LineHandler interface {
 	// process handles a new line (message)

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -41,7 +41,7 @@ func benchmarkAutoMultiLineHandler(b *testing.B, logs int, line string) {
 	}
 
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
-	h := NewAutoMultilineHandler(func(*message.Message) {}, coreConfig.DefaultMaxMessageSizeBytes, 1000, 0.9, 30*time.Second, 1000*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
+	h := NewLegacyAutoMultilineHandler(func(*message.Message) {}, coreConfig.DefaultMaxMessageSizeBytes, 1000, 0.9, 30*time.Second, 1000*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -75,7 +75,7 @@ func (h *MultiLineHandler) flush() {
 // It also makes sure that the content will never exceed the limit
 // and that the length of the lines is properly tracked
 // so that the agent restarts tailing from the right place.
-func (h *MultiLineHandler) process(message *message.Message) {
+func (h *MultiLineHandler) process(msg *message.Message) {
 	if h.flushTimer != nil && h.buffer.Len() > 0 {
 		// stop the flush timer, as we now have data
 		if !h.flushTimer.Stop() {
@@ -83,7 +83,7 @@ func (h *MultiLineHandler) process(message *message.Message) {
 		}
 	}
 
-	if h.newContentRe.Match(message.GetContent()) {
+	if h.newContentRe.Match(msg.GetContent()) {
 		h.countInfo.Add(1)
 		// the current line is part of a new message,
 		// send the buffer
@@ -95,30 +95,30 @@ func (h *MultiLineHandler) process(message *message.Message) {
 
 	// track the raw data length and the timestamp so that the agent tails
 	// from the right place at restart
-	h.linesLen += message.RawDataLen
-	h.timestamp = message.ParsingExtra.Timestamp
-	h.status = message.Status
+	h.linesLen += msg.RawDataLen
+	h.timestamp = msg.ParsingExtra.Timestamp
+	h.status = msg.Status
 	h.linesCombined++
 
 	if h.buffer.Len() > 0 {
 		// the buffer already contains some data which means that
 		// the current line is not the first line of the message
-		h.buffer.Write(escapedLineFeed)
+		h.buffer.Write(message.EscapedLineFeed)
 	}
 
 	if isTruncated {
 		// the previous line has been truncated because it was too long,
 		// the new line is just a remainder,
 		// adding the truncated flag at the beginning of the content
-		h.buffer.Write(truncatedFlag)
+		h.buffer.Write(message.TruncatedFlag)
 	}
 
-	h.buffer.Write(message.GetContent())
+	h.buffer.Write(msg.GetContent())
 
 	if h.buffer.Len() >= h.lineLimit {
 		// the multiline message is too long, it needs to be cut off and send,
 		// adding the truncated flag the end of the content
-		h.buffer.Write(truncatedFlag)
+		h.buffer.Write(message.TruncatedFlag)
 		h.sendBuffer()
 		h.shouldTruncate = true
 	}
@@ -157,6 +157,6 @@ func (h *MultiLineHandler) sendBuffer() {
 			}
 		}
 
-		h.outputFn(NewMessage(content, h.status, h.linesLen, h.timestamp))
+		h.outputFn(message.NewRawMessage(content, h.status, h.linesLen, h.timestamp))
 	}
 }

--- a/pkg/logs/internal/decoder/single_line_handler.go
+++ b/pkg/logs/internal/decoder/single_line_handler.go
@@ -40,30 +40,30 @@ func (h *SingleLineHandler) flush() {
 // it guarantees that the content of the line won't exceed
 // the limit and that the length of the line is properly tracked
 // so that the agent restarts tailing from the right place.
-func (h *SingleLineHandler) process(message *message.Message) {
+func (h *SingleLineHandler) process(msg *message.Message) {
 	isTruncated := h.shouldTruncate
 	h.shouldTruncate = false
 
-	content := message.GetContent()
+	content := msg.GetContent()
 	content = bytes.TrimSpace(content)
 
 	if isTruncated {
 		// the previous line has been truncated because it was too long,
 		// the new line is just a remainder,
 		// adding the truncated flag at the beginning of the content
-		content = append(truncatedFlag, content...)
+		content = append(message.TruncatedFlag, content...)
 	}
 
 	// how should we detect logs which are too long before rendering them?
 	if len(content) < h.lineLimit {
-		message.SetContent(content) // refresh the content in the message
-		h.outputFn(message)
+		msg.SetContent(content) // refresh the content in the message
+		h.outputFn(msg)
 	} else {
 		// the line is too long, it needs to be cut off and send,
 		// adding the truncated flag the end of the content
-		content = append(content, truncatedFlag...)
-		message.SetContent(content) // refresh the content in the message
-		h.outputFn(message)
+		content = append(content, message.TruncatedFlag...)
+		msg.SetContent(content) // refresh the content in the message
+		h.outputFn(msg)
 		// make sure the following part of the line will be cut off as well
 		h.shouldTruncate = true
 	}

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -222,6 +222,24 @@ func NewRawMessage(content []byte, status string, rawDataLen int, readTimestamp 
 		IsMultiLine: false,
 	}
 }
+
+// NewRawMultiLineMessage returns a new encoded message.
+func NewRawMultiLineMessage(content []byte, status string, rawDataLen int, readTimestamp string) *Message {
+	return &Message{
+		MessageContent: MessageContent{
+			content: content,
+			State:   StateUnstructured,
+		},
+		Status:             status,
+		RawDataLen:         rawDataLen,
+		IngestionTimestamp: time.Now().UnixNano(),
+		ParsingExtra: ParsingExtra{
+			Timestamp: readTimestamp,
+		},
+		IsMultiLine: true,
+	}
+}
+
 // NewStructuredMessage creates a new message that had some structure the moment
 // it has been captured through a tailer.
 // e.g. a journald message which is a JSON object containing extra information, including

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -15,6 +15,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// TruncatedFlag is the flag that is added at the beginning
+// or/and at the end of every trucated lines.
+var TruncatedFlag = []byte("...TRUNCATED...")
+
+// EscapedLineFeed is used to escape new line character
+// for multiline message.
+// New line character needs to be escaped because they are used
+// as delimiter for transport.
+var EscapedLineFeed = []byte(`\n`)
+
 // Payload represents an encoded collection of messages ready to be sent to the intake
 type Payload struct {
 	// The slice of sources messages encoded in the payload
@@ -34,7 +44,10 @@ type Message struct {
 	Origin             *Origin
 	Status             string
 	IngestionTimestamp int64
-	RawDataLen         int
+	// RawDataLen tracks the original size of the message content before any trimming/transformation.
+	// This is used when calculating the tailer offset - so this will NOT always be equal to `len(Content)`.
+	RawDataLen  int
+	IsMultiLine bool
 	// Tags added on processing
 	ProcessingTags []string
 	// Extra information from the parsers
@@ -193,6 +206,22 @@ func NewMessage(content []byte, origin *Origin, status string, ingestionTimestam
 	}
 }
 
+// NewRawMessage returns a new encoded message.
+func NewRawMessage(content []byte, status string, rawDataLen int, readTimestamp string) *Message {
+	return &Message{
+		MessageContent: MessageContent{
+			content: content,
+			State:   StateUnstructured,
+		},
+		Status:             status,
+		RawDataLen:         rawDataLen,
+		IngestionTimestamp: time.Now().UnixNano(),
+		ParsingExtra: ParsingExtra{
+			Timestamp: readTimestamp,
+		},
+		IsMultiLine: false,
+	}
+}
 // NewStructuredMessage creates a new message that had some structure the moment
 // it has been captured through a tailer.
 // e.g. a journald message which is a JSON object containing extra information, including


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR lays the foundation for v2 auto multiline detection in the logs agent. It introduces the core concepts needed to continue developing the feature as a minimum but functional set of changes. 

The major components of this architecture form a pipeline where logs are processed by an ordered set of heuristics. Heuristics add labels or mutate the `messageContext` in order determine a label in a future step. Once a label is assigned, the aggregator aggregates the log only on the assigned label. 

Each component can be reviewed in it's own commit within this PR: 

- [Refactoring](https://github.com/DataDog/datadog-agent/pull/27881/commits/ecedeefe388b657524cee4eadb37b4c79b782709)
  - Move `TruncationFlag` and `EscapeLineFeed` into `message.go`
  - move `NewMessage` and rename to `NewRawMessage` into `message.go`
  - Line parser uses `LineHandler` interface instead of `outputFn`
  - `auto_multiline_handler` -> `legacy_auto_multiline_handler`
- [Add Labeler](https://github.com/DataDog/datadog-agent/pull/27881/commits/f6cbcccd0fc423df1cb9c6d74b3569ddb7c2b47d)
- [Add JSON detector](https://github.com/DataDog/datadog-agent/pull/27881/commits/b99fb871f3b667b15e77acfe83a831abb7865a39)
- [Add Aggregator](https://github.com/DataDog/datadog-agent/pull/27881/commits/0cbddf47ab74186e26da52589e212e7a2d52503e)
- [Add auto multiline handler + config updates](https://github.com/DataDog/datadog-agent/pull/27881/commits/eb47048b17e51a9dc6bda710336264f4a297135c)

When `logs_config.experimental_auto_multi_line_detection` is enabled - this new pipeline currently only implements one aggregation heuristic - the JSON detector which prevents structured logs from being aggregated. I chose to start with the JSON detector since it's implementation is trivial. 

More heuristic implementations and features will come in future PRs. 
This PR has no functional changes on existing features. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->


### Describe how to test/QA your changes

Ive tested this locally. So `qa-done` however there isn't much to test at the moment. Complete QA steps will be added with future PRs that introduce components that flesh out the full functionality. 