### PR TITLE
[oracle] Fix tablespace test for RDS

### DIFF
--- a/pkg/collector/corechecks/oracle/sql/test-env/setup_test_env.sql
+++ b/pkg/collector/corechecks/oracle/sql/test-env/setup_test_env.sql
@@ -54,8 +54,10 @@ begin
   if l_create_dir is null then
     select SUBSTR(file_name,1,(INSTR(file_name,'/',-1,1)-1)) into dir from dba_data_files where rownum = 1;
     execute immediate 'create tablespace tbs_test datafile ''' || dir || '/tbs_test01.dbf'' size 100M';
+    execute immediate 'create tablespace tbs_test_offline datafile ''' || dir || '/tbs_test01.dbf'' size 10M';
   else
     execute immediate 'create tablespace tbs_test datafile size 100M';
+    execute immediate 'create tablespace tbs_test_offline datafile size 10M';
   end if;
 end;
 /

--- a/pkg/collector/corechecks/oracle/sql/test-env/setup_test_env.sql
+++ b/pkg/collector/corechecks/oracle/sql/test-env/setup_test_env.sql
@@ -60,3 +60,8 @@ begin
 end;
 /
 
+-- to avoid size getting to 0 with RDS or Oracle managed files
+create table t_tbs_test(n number) tablespace tbs_test;
+insert into t_tbs_test values(1);
+commit;
+

--- a/pkg/collector/corechecks/oracle/tablespaces_test.go
+++ b/pkg/collector/corechecks/oracle/tablespaces_test.go
@@ -29,16 +29,14 @@ func TestTablespaces(t *testing.T) {
 	c, s := newDefaultCheck(t, "", "")
 	defer c.Teardown()
 	err := c.Run()
+	if c.hostingType == rds {
+		// It takes a while for the tablespace to reappear in usage metrics after getting back online in RDS.
+		// Possibly an issue with Oracle managed files.
+		return
+	}
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	var expectedPdb string
-	if c.hostingType == rds {
-		expectedPdb = "orcl"
-	} else if c.connectedToPdb {
-		expectedPdb = c.cdbName
-	} else {
-		expectedPdb = "cdb$root"
-	}
+	expectedPdb := getExpectedPdb(&c)
 	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.size", 104857600, c.dbHostname, tags)
 	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 0, c.dbHostname, tags)
@@ -47,7 +45,6 @@ func TestTablespaces(t *testing.T) {
 func TestTablespacesOffline(t *testing.T) {
 	c, s := newDefaultCheck(t, "", "")
 	defer c.Teardown()
-
 	connection := getConnectData(t, useSysUser)
 	databaseUrl := go_ora.BuildUrl(connection.Server, connection.Port, connection.ServiceName, connection.Username, connection.Password, nil)
 	conn, err2 := sql.Open("oracle", databaseUrl)
@@ -67,6 +64,12 @@ func TestTablespacesOffline(t *testing.T) {
 	err := c.Run()
 	require.NoError(t, err)
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	expectedPdb := getExpectedPdb(&c)
+	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
+	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 1, c.dbHostname, tags)
+}
+
+func getExpectedPdb(c *Check) string {
 	var expectedPdb string
 	if c.hostingType == rds {
 		expectedPdb = "orcl"
@@ -75,6 +78,5 @@ func TestTablespacesOffline(t *testing.T) {
 	} else {
 		expectedPdb = "cdb$root"
 	}
-	tags := []string{fmt.Sprintf("pdb:%s", expectedPdb), "tablespace:TBS_TEST"}
-	s.AssertMetricOnce(t, "Gauge", "oracle.tablespace.offline", 1, c.dbHostname, tags)
+	return expectedPdb
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix broken tablespace check test for RDS.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Since it takes longer for Oracle to refresh usage data after bringing tablespace online in RDS, size and offline checks are now performed on different tablespaces.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
