### PR TITLE
fix(fleet): Close layer io.ReadCloser after extraction

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -241,6 +241,7 @@ func (d *DownloadedPackage) ExtractLayers(mediaType types.MediaType, dir string)
 			if err != nil {
 				return fmt.Errorf("could not uncompress layer: %w", err)
 			}
+			defer uncompressedLayer.Close()
 			err = tar.Extract(uncompressedLayer, dir, layerMaxSize)
 			if err != nil {
 				return fmt.Errorf("could not extract layer: %w", err)


### PR DESCRIPTION
### What does this PR do?
When extracting a layer we sometimes hit `stream error: stream ID x; INTERNAL_ERROR`. This is likely due to the OCI layer extraction not closing its reader (that comes from a request body).

This PR fixes it.

### Motivation
Less errors when pulling packages

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
