### PR TITLE
fix(OCI): Add auth to internal Go packages in build pipeline

### DIFF
--- a/.gitlab/deploy_packages/oci.yml
+++ b/.gitlab/deploy_packages/oci.yml
@@ -21,6 +21,9 @@ include:
     - export VERSION=$(inv agent.version --url-safe)-1
     - git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; };f'
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh git clone -v --depth=1 https://github.com/DataDog/datadog-packages /tmp/datadog-packages
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    - export GOPROXY="binaries.ddbuild.io,proxy.golang.org,direct"
+    - export GONOSUMDB="github.com/DataDog,go.ddbuild.io"
     - cd /tmp/datadog-packages/cmd/datadog-package
     - go build .
     - ./datadog-package push registry.ddbuild.io/ci/remote-updates/${OCI_PRODUCT}:${VERSION} ${OMNIBUS_PACKAGE_DIR}/${OCI_PRODUCT}-${VERSION}.oci.tar

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -24,6 +24,9 @@
     - git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; };f'
     - cd /tmp/
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh git clone --depth=1 https://github.com/DataDog/datadog-packages
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    - export GOPROXY="binaries.ddbuild.io,proxy.golang.org,direct"
+    - export GONOSUMDB="github.com/DataDog,go.ddbuild.io"
     - cd datadog-packages/cmd/datadog-package
     - go build .
     - OUTPUT_DIR="/tmp/oci_output"


### PR DESCRIPTION
### What does this PR do?
`datadog-packages` has a change pending that imports other private repositories to authenticate to internal registries. This PR allows the agent CI to pull them.

### Motivation
ROSYS-468

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
