### PR TITLE
[CWS-2802] link action report to ruleID instead of global event

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -318,6 +318,14 @@ func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func()
 		ruleID = rule.Definition.GroupID
 	}
 
+	eventActionReports := e.GetActionReports()
+	actionReports := make([]model.ActionReport, 0, len(eventActionReports))
+	for _, ar := range eventActionReports {
+		if ar.IsMatchingRule(rule.ID) {
+			actionReports = append(actionReports, ar)
+		}
+	}
+
 	msg := &pendingMsg{
 		ruleID:        ruleID,
 		backendEvent:  backendEvent,
@@ -326,7 +334,7 @@ func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func()
 		service:       service,
 		sendAfter:     time.Now().Add(retention),
 		tags:          make([]string, 0, 1+len(rule.Tags)+len(eventTags)+1),
-		actionReports: e.GetActionReports(),
+		actionReports: actionReports,
 	}
 
 	msg.tags = append(msg.tags, "rule_id:"+ruleID)

--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
@@ -27,6 +28,7 @@ type KillActionReport struct {
 	DetectedAt time.Time
 	KilledAt   time.Time
 	ExitedAt   time.Time
+	Rule       *rules.Rule
 
 	// internal
 	resolved bool
@@ -73,4 +75,12 @@ func (k *KillActionReport) ToJSON() ([]byte, bool, error) {
 	}
 
 	return data, resolved, nil
+}
+
+// IsMatchingRule returns true if this action report is targeted at the given rule ID
+func (k *KillActionReport) IsMatchingRule(ruleID eval.RuleID) bool {
+	k.RLock()
+	defer k.RUnlock()
+
+	return k.Rule.ID == ruleID
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2129,7 +2129,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, ev, func(pid uint32, sig uint32) error {
+			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				if p.supportsBPFSendSignal {
 					if err := p.killListMap.Put(uint32(pid), uint32(sig)); err != nil {
 						seclog.Warnf("failed to kill process with eBPF %d: %s", pid, err)

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -589,7 +589,7 @@ func (p *EBPFLessProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, ev, func(pid uint32, sig uint32) error {
+			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
 			})
 		case action.Hash != nil:

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1352,7 +1352,7 @@ func (p *WindowsProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, ev, func(pid uint32, sig uint32) error {
+			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
 			})
 		}

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -79,7 +80,7 @@ func (p *ProcessKiller) HandleProcessExited(event *model.Event) {
 }
 
 // KillAndReport kill and report
-func (p *ProcessKiller) KillAndReport(scope string, signal string, ev *model.Event, killFnc func(pid uint32, sig uint32) error) {
+func (p *ProcessKiller) KillAndReport(scope string, signal string, rule *rules.Rule, ev *model.Event, killFnc func(pid uint32, sig uint32) error) {
 	entry, exists := ev.ResolveProcessCacheEntry()
 	if !exists {
 		return
@@ -122,6 +123,7 @@ func (p *ProcessKiller) KillAndReport(scope string, signal string, ev *model.Eve
 		CreatedAt:  ev.ProcessContext.ExecTime,
 		DetectedAt: ev.ResolveEventTime(),
 		KilledAt:   killedAt,
+		Rule:       rule,
 	}
 	ev.ActionReports = append(ev.ActionReports, report)
 	p.pendingReports = append(p.pendingReports, report)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -321,6 +321,7 @@ type MatchedRule struct {
 // ActionReport defines an action report
 type ActionReport interface {
 	ToJSON() ([]byte, bool, error)
+	IsMatchingRule(ruleID eval.RuleID) bool
 }
 
 // NewMatchedRule return a new MatchedRule instance


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Currently action reports are linked to an event. This means that if you have 2 rules matching the same event, if only one of them has a kill action then the kill report will be applied to both CWS events generated which can be surprising (you end up with a kill report on an event matching a rule with no kill action).

This PR solves this by attaching reports with rule ID (not rules directly because of go import cycle issues..), and then filtering to only apply reports on the correct event.

A functional test is added to ensure this.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
