### PR TITLE
[NDM] Add Cloud application metrics query to the Cisco SD-WAN client

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
@@ -326,6 +326,25 @@ func (client *Client) GetHardwareStates() ([]HardwareEnvironment, error) {
 	return hardwareStates.Data, nil
 }
 
+// GetCloudExpressMetrics gets cloud applications metrics
+func (client *Client) GetCloudExpressMetrics() ([]CloudXStatistics, error) {
+	startDate, endDate := client.statisticsTimeRange()
+
+	params := map[string]string{
+		"startDate": startDate,
+		"endDate":   endDate,
+		"timeZone":  "UTC",
+		"count":     client.maxCount,
+	}
+
+	cloudApplications, err := getAllEntries[CloudXStatistics](client, "/dataservice/data/device/statistics/cloudxstatistics", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return cloudApplications.Data, nil
+}
+
 func (client *Client) statisticsTimeRange() (string, string) {
 	endDate := timeNow().UTC()
 	startDate := endDate.Add(-client.lookback)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
@@ -538,3 +538,52 @@ func TestGetHardwareStates(t *testing.T) {
 	// Ensure endpoint has been called 1 times
 	require.Equal(t, 1, handler.numberOfCalls())
 }
+
+func TestGetCloudExpressMetrics(t *testing.T) {
+	timeNow = mockTimeNow
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, r *http.Request, calls int32) {
+		query := r.URL.Query()
+		count := query.Get("count")
+		timeZone := query.Get("timeZone")
+		startDate := query.Get("startDate")
+		endDate := query.Get("endDate")
+
+		require.Equal(t, "2000", count)
+		require.Equal(t, "UTC", timeZone)
+		require.Equal(t, "1999-12-31T23:50:00", startDate)
+		require.Equal(t, "2000-01-01T00:00:00", endDate)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fixtures.FakePayload(fixtures.GetCloudExpressMetrics)))
+	})
+
+	mux.HandleFunc("/dataservice/data/device/statistics/cloudxstatistics", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	devices, err := client.GetCloudExpressMetrics()
+	require.NoError(t, err)
+
+	require.Equal(t, "10.10.1.13", devices[0].VmanageSystemIP)
+	require.Equal(t, "10.10.1.13", devices[0].LocalSystemIP)
+	require.Equal(t, "10.10.1.11", devices[0].GatewaySystemIP)
+	require.Equal(t, "mpls", devices[0].LocalColor)
+	require.Equal(t, "mpls", devices[0].RemoteColor)
+	require.Equal(t, "FALSE", devices[0].BestPath)
+	require.Equal(t, "amazon_aws", devices[0].Application)
+	require.Equal(t, "amazon-group", devices[0].NbarAppGroupName)
+	require.Equal(t, float64(1), devices[0].VpnID)
+	require.Equal(t, float64(1721819993833), devices[0].EntryTime)
+	require.Equal(t, float64(404), devices[0].Latency)
+	require.Equal(t, float64(0), devices[0].Loss)
+	require.Equal(t, "5.0", devices[0].VqeScore)
+
+	// Ensure endpoint has been called 1 times
+	require.Equal(t, 1, handler.numberOfCalls())
+}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
@@ -400,3 +400,39 @@ const GetHardwareStates = `
     }
 ]
 `
+
+// CloudXStatistics /dataservice/data/device/statistics/cloudxstatistics
+const GetCloudExpressMetrics = `
+[
+	{
+		"remote_color": "mpls",
+		"device_model": "vedge-C8000V",
+		"latency": 404,
+		"interface": "-",
+		"local_color": "mpls",
+		"loss": 0,
+		"gateway_system_ip": "10.10.1.11",
+		"source_public_ip": "-",
+		"statcycletime": 1721820600114,
+		"local_system_ip": "10.10.1.13",
+		"tenant": "default",
+		"entry_time": 1721819993833,
+		"vqe_status": "averageSites",
+		"exit_type": "Remote",
+		"vip_time": 1721819993833,
+		"vmanage_system_ip": "10.10.1.13",
+		"nbar_app_group_name": "amazon-group",
+		"application": "amazon_aws",
+		"vdevice_name": "10.10.1.13",
+		"best_path": "FALSE",
+		"vip_idx": 9789,
+		"site_id": 1001,
+		"vqe_score": "5.0",
+		"service_area": "-",
+		"host_name": "Site1-cEdge01",
+		"vpn_id": 1,
+		"app_url_host_ip": "-",
+		"id": "1DKB5JAB5928XahrV_c7"
+	}
+]
+`

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
@@ -401,7 +401,7 @@ const GetHardwareStates = `
 ]
 `
 
-// CloudXStatistics /dataservice/data/device/statistics/cloudxstatistics
+// GetCloudExpressMetrics /dataservice/data/device/statistics/cloudxstatistics
 const GetCloudExpressMetrics = `
 [
 	{

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
@@ -107,6 +107,7 @@ func SetupMockAPIServer() *httptest.Server {
 	mux.HandleFunc("/dataservice/data/device/state/OMPPeer", fixtureHandler(fixtures.GetOMPPeersState))
 	mux.HandleFunc("/dataservice/data/device/state/BFDSessions", fixtureHandler(fixtures.GetBFDSessionsState))
 	mux.HandleFunc("/dataservice/data/device/state/HardwareEnvironment", fixtureHandler(fixtures.GetHardwareStates))
+	mux.HandleFunc("/dataservice/data/device/statistics/cloudxstatistics", fixtureHandler(fixtures.GetCloudExpressMetrics))
 
 	return httptest.NewServer(mux)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -436,6 +436,6 @@ type CloudXStatistics struct {
 	ServiceArea      string  `json:"service_area"`
 	HostName         string  `json:"host_name"`
 	VpnID            float64 `json:"vpn_id"`
-	AppUrlHostIp     string  `json:"app_url_host_ip"`
-	Id               string  `json:"id"`
+	AppURLHostIP     string  `json:"app_url_host_ip"`
+	ID               string  `json:"id"`
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -59,7 +59,8 @@ type Content interface {
 		ControlConnections |
 		OMPPeer |
 		BFDSession |
-		HardwareEnvironment
+		HardwareEnvironment |
+		CloudXStatistics
 }
 
 // Response is a generic struct for API responses
@@ -405,4 +406,36 @@ type HardwareEnvironment struct {
 	HwClass         string `json:"hw-class"`
 	Lastupdated     int64  `json:"lastupdated"`
 	Status          string `json:"status"`
+}
+
+// CloudXStatistics /dataservice/data/device/statistics/cloudxstatistics
+type CloudXStatistics struct {
+	RemoteColor      string  `json:"remote_color"`
+	DeviceModel      string  `json:"device_model"`
+	Latency          float64 `json:"latency"`
+	Interface        string  `json:"interface"`
+	LocalColor       string  `json:"local_color"`
+	Loss             float64 `json:"loss"`
+	GatewaySystemIP  string  `json:"gateway_system_ip"`
+	SourcePublicIP   string  `json:"source_public_ip"`
+	Statcycletime    float64 `json:"statcycletime"`
+	LocalSystemIP    string  `json:"local_system_ip"`
+	Tenant           string  `json:"tenant"`
+	EntryTime        float64 `json:"entry_time"`
+	VqeStatus        string  `json:"vqe_status"`
+	ExitType         string  `json:"exit_type"`
+	VipTime          float64 `json:"vip_time"`
+	VmanageSystemIP  string  `json:"vmanage_system_ip"`
+	NbarAppGroupName string  `json:"nbar_app_group_name"`
+	Application      string  `json:"application"`
+	VdeviceName      string  `json:"vdevice_name"`
+	BestPath         string  `json:"best_path"`
+	VipIdx           float64 `json:"vip_idx"`
+	SiteID           float64 `json:"site_id"`
+	VqeScore         string  `json:"vqe_score"`
+	ServiceArea      string  `json:"service_area"`
+	HostName         string  `json:"host_name"`
+	VpnID            float64 `json:"vpn_id"`
+	AppUrlHostIp     string  `json:"app_url_host_ip"`
+	Id               string  `json:"id"`
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add ability to query Cloud application metrics in the Cisco SD-WAN client

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
