### PR TITLE
[NDM][Cisco SD-WAN] Enable sending cloud application metrics

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -8,6 +8,7 @@ package report
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -250,6 +251,38 @@ func (ms *SDWanSender) SendHardwareMetrics(hardwareEnvironments []client.Hardwar
 	}
 }
 
+// SendCloudApplicationMetrics sends cloud applications metrics
+func (ms *SDWanSender) SendCloudApplicationMetrics(cloudApplications []client.CloudXStatistics) {
+	newTimestamps := make(map[string]float64)
+
+	for _, entry := range cloudApplications {
+		tags := ms.getDeviceTags(entry.VmanageSystemIP)
+		gatewayTags := ms.getPrefixedDeviceTags("gateway_", entry.GatewaySystemIP)
+
+		tags = append(tags, gatewayTags...)
+		tags = append(tags, "local_color:"+entry.LocalColor, "remote_color:"+entry.RemoteColor, "interface:"+entry.Interface, "exit_type:"+entry.ExitType, "application_group:"+entry.NbarAppGroupName, "application:"+entry.Application, "best_path:"+entry.BestPath, "vpn_id:"+fmt.Sprintf("%d", int(entry.VpnID)))
+		key := ms.getMetricKey("application_metrics", tags)
+
+		if !ms.shouldSendEntry(key, entry.EntryTime) {
+			// If the timestamp is before the max timestamp already sent, do not re-send
+			continue
+		}
+		setNewSentTimestamp(newTimestamps, key, entry.EntryTime)
+
+		ts := entry.EntryTime / 1000
+
+		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"application.latency", entry.Latency, tags, ts)
+		ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"application.loss", entry.Loss, tags, ts)
+
+		qoe, err := strconv.ParseFloat(entry.VqeScore, 64)
+		if err == nil {
+			ms.gaugeWithTimestamp(ciscoSDWANMetricPrefix+"application.qoe", qoe, tags, ts)
+		}
+	}
+
+	ms.updateTimestamps(newTimestamps)
+}
+
 // Commit commits to the sender
 func (ms *SDWanSender) Commit() {
 	ms.sender.Commit()
@@ -321,7 +354,7 @@ func (ms *SDWanSender) getDeviceTags(systemIP string) []string {
 	return tags
 }
 
-func (ms *SDWanSender) getRemoteDeviceTags(systemIP string) []string {
+func (ms *SDWanSender) getPrefixedDeviceTags(prefix string, systemIP string) []string {
 	tags := ms.getDeviceTags(systemIP)
 
 	var remoteTags []string
@@ -330,8 +363,12 @@ func (ms *SDWanSender) getRemoteDeviceTags(systemIP string) []string {
 			// No need to tag remote devices by namespace
 			continue
 		}
-		remoteTags = append(remoteTags, "remote_"+tag)
+		remoteTags = append(remoteTags, prefix+tag)
 	}
 
 	return remoteTags
+}
+
+func (ms *SDWanSender) getRemoteDeviceTags(systemIP string) []string {
+	return ms.getPrefixedDeviceTags("remote_", systemIP)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -70,6 +70,7 @@ namespace: test
 min_collection_interval: 180
 collect_bfd_session_status: true
 collect_hardware_status: true
+collect_cloud_applications_metrics: true
 `)
 
 	// Use ID to ensure the mock sender gets registered
@@ -171,6 +172,25 @@ collect_hardware_status: true
 	// Assert hardware status metrics
 	sender.AssertMetric(t, "Gauge", "cisco_sdwan.hardware.status_ok", 1, "", []string{"system_ip:10.10.1.11", "status:OK", "class:Fans", "item:Tray 0 fan", "dev_index:1"})
 
+	// Assert cloud applications metrics
+	ts = float64(1721819993833) / 1000
+	tags = []string{
+		"system_ip:10.10.1.13",
+		"gateway_system_ip:10.10.1.11",
+		"local_color:mpls",
+		"remote_color:mpls",
+		"interface:-",
+		"exit_type:Remote",
+		"application_group:amazon-group",
+		"application:amazon_aws",
+		"best_path:FALSE",
+		"vpn_id:1",
+	}
+
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.latency", 404, "", tags, ts)
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.loss", 0, "", tags, ts)
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.qoe", 5, "", tags, ts)
+
 	// Assert metadata
 	// language=json
 	event := []byte(`
@@ -249,7 +269,7 @@ collect_hardware_status: true
 	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
 }
 
-func TestBFDMetricConfig(t *testing.T) {
+func TestDefaultNotSentConfig(t *testing.T) {
 	payload.TimeNow = mockTimeNow
 	report.TimeNow = mockTimeNow
 
@@ -288,49 +308,16 @@ namespace: test
 	err = chk.Run()
 	require.NoError(t, err)
 
-	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.bfd_session.status", mock.Anything, mock.Anything, mock.Anything)
-}
+	// BFD sessions not enabled by default
+	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.bfd_session.status", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
-func TestHardwareStatusConfig(t *testing.T) {
-	payload.TimeNow = mockTimeNow
-	report.TimeNow = mockTimeNow
+	// Hardware status not enabled by default
+	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.hardware.status_ok", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
-	apiMockServer := client.SetupMockAPIServer()
-	defer apiMockServer.Close()
-
-	deps := createDeps(t)
-	chk := newCheck()
-	senderManager := deps.Demultiplexer
-
-	url := strings.TrimPrefix(apiMockServer.URL, "http://")
-
-	// language=yaml
-	rawInstanceConfig := []byte(`
-vmanage_endpoint: ` + url + `
-username: admin
-password: 'test-password'
-use_http: true
-namespace: test
-`)
-
-	// Use ID to ensure the mock sender gets registered
-	id := checkid.BuildID(CheckName, integration.FakeConfigHash, rawInstanceConfig, []byte(``))
-	sender := mocksender.NewMockSenderWithSenderManager(id, senderManager)
-	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	sender.On("GaugeWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	sender.On("CountWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
-
-	sender.On("Commit").Return()
-
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
-	require.NoError(t, err)
-
-	err = chk.Run()
-	require.NoError(t, err)
-
-	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.hardware.status", mock.Anything, mock.Anything, mock.Anything)
+	// Cloud applications not enabled by default
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.latency", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.loss", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.qoe", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestNoMetricsAndMetadataCollection(t *testing.T) {
@@ -362,6 +349,7 @@ collect_omp_peer_metrics: false
 collect_device_counters_metrics: false
 collect_bfd_session_status: false
 collect_hardware_status: false
+collect_cloud_applications_metrics: false
 `)
 
 	// Use ID to ensure the mock sender gets registered
@@ -382,35 +370,35 @@ collect_hardware_status: false
 	require.NoError(t, err)
 
 	// Assert hardware metrics not sent
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.cpu.usage", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.memory.usage", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.disk.usage", mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.cpu.usage", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.memory.usage", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.disk.usage", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	// Assert interface metrics not sent
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_bits", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_bits", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bps", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bps", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bandwidth_usage", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bandwidth_usage", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_errors", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_errors", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_drops", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_drops", mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_bits", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_bits", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bps", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bps", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.rx_bandwidth_usage", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.interface.tx_bandwidth_usage", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_errors", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_errors", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.rx_drops", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.interface.tx_drops", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	// Assert uptime metrics not sent
 	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.device.uptime", mock.Anything, mock.Anything, mock.Anything)
 
 	// Assert application aware routing metrics not sent
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.status", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.latency", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.jitter", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.loss", 0, mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.qoe", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.rx_bits", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.tx_bits", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.rx_packets", mock.Anything, mock.Anything, mock.Anything)
-	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.tx_packets", mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.status", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.latency", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.jitter", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.loss", 0, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.qoe", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.rx_bits", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.tx_bits", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.rx_packets", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "CountWithTimestamp", "cisco_sdwan.tunnel.tx_packets", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	// Assert control-connection metrics not sent
 	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.control_connection.status", mock.Anything, mock.Anything, mock.Anything)
@@ -430,6 +418,11 @@ collect_hardware_status: false
 
 	// Assert hardware status metrics
 	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.hardware.status_ok", mock.Anything, mock.Anything, mock.Anything)
+
+	// Assert cloud application metrics
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.latency", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.loss", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.qoe", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	sender.AssertNotCalled(t, "EventPlatformEvent", mock.Anything, mock.Anything)
 }

--- a/releasenotes/notes/cisco-sdwan-cloud-application-metrics-25c456dab15a3bfc.yaml
+++ b/releasenotes/notes/cisco-sdwan-cloud-application-metrics-25c456dab15a3bfc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [NDM] Add option to collect cloud application metrics from Cisco SD-WAN.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Enable sending cloud application metrics using `collect_cloud_applications_metrics: true`
NDMII-2950

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
