### PR TITLE
Register otlp_config.metrics.sums.initial_cumulative_monotonic_value with Viper

### DIFF
--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -90,6 +90,7 @@ func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 	config.BindEnv(OTLPSection + ".metrics.histograms.send_count_sum_metrics")
 	config.BindEnv(OTLPSection + ".metrics.histograms.send_aggregation_metrics")
 	config.BindEnv(OTLPSection + ".metrics.sums.cumulative_monotonic_mode")
+	config.BindEnv(OTLPSection + ".metrics.sums.initial_cumulative_monotonic_value")
 	config.BindEnv(OTLPSection + ".metrics.summaries.mode")
 
 	// Debug settings


### PR DESCRIPTION
### What does this PR do?
Register this value with Viper - prevents spurious error messages when the config is used.
Refers to https://github.com/DataDog/datadog-agent/blob/d6018ecd552a78170c67acc509a5839a1cd53079/comp/otelcol/otlp/components/exporter/serializerexporter/config.go#L192
