### PR TITLE
[ASCII-2057] Use Header for authorizing flare api requests instead of query param

### DIFF
--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -111,7 +111,7 @@ func getFlareReader(multipartBoundary, archivePath, caseID, email, hostname stri
 	return bodyReader
 }
 
-func readAndPostFlareFile(archivePath, caseID, email, hostname, url string, source FlareSource, client *http.Client) (*http.Response, error) {
+func readAndPostFlareFile(archivePath, caseID, email, hostname, url string, source FlareSource, client *http.Client, apiKey string) (*http.Response, error) {
 	// Having resolved the POST URL, we do not expect to see further redirects, so do not
 	// handle them.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -122,6 +122,7 @@ func readAndPostFlareFile(archivePath, caseID, email, hostname, url string, sour
 	if err != nil {
 		return nil, err
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 
 	// We need to set the Content-Type header here, but we still haven't created the writer
 	// to obtain it from. Here we create one which only purpose is to give us a proper
@@ -192,11 +193,12 @@ func analyzeResponse(r *http.Response, apiKey string) (string, error) {
 // Resolve a flare URL to the URL at which a POST should be made.  This uses a HEAD request
 // to follow any redirects, avoiding the problematic behavior of a POST that results in a
 // redirect (and often in an early termination of the connection).
-func resolveFlarePOSTURL(url string, client *http.Client) (string, error) {
+func resolveFlarePOSTURL(url string, client *http.Client, apiKey string) (string, error) {
 	request, err := http.NewRequest("HEAD", url, nil)
 	if err != nil {
 		return "", err
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 
 	r, err := client.Do(request)
 	if err != nil {
@@ -214,12 +216,12 @@ func resolveFlarePOSTURL(url string, client *http.Client) (string, error) {
 	return r.Request.URL.String(), nil
 }
 
-func mkURL(baseURL string, caseID string, apiKey string) string {
+func mkURL(baseURL string, caseID string) string {
 	url := baseURL + datadogSupportURL
 	if caseID != "" {
 		url += "/" + caseID
 	}
-	return url + "?api_key=" + apiKey
+	return url
 }
 
 // SendTo sends a flare file to the backend. This is part of the "helpers" package while all the code is moved to
@@ -239,14 +241,14 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 		Timeout:   httpTimeout,
 	}
 
-	url = mkURL(baseURL, caseID, apiKey)
+	url = mkURL(baseURL, caseID)
 
-	url, err = resolveFlarePOSTURL(url, client)
+	url, err = resolveFlarePOSTURL(url, client, apiKey)
 	if err != nil {
 		return "", err
 	}
 
-	r, err := readAndPostFlareFile(archivePath, caseID, email, hostname, url, source, client)
+	r, err := readAndPostFlareFile(archivePath, caseID, email, hostname, url, source, client, apiKey)
 	if err != nil {
 		return "", err
 	}

--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -122,7 +122,7 @@ func readAndPostFlareFile(archivePath, caseID, email, hostname, url string, sour
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	request.Header.Add("DD-API-KEY", apiKey)
 
 	// We need to set the Content-Type header here, but we still haven't created the writer
 	// to obtain it from. Here we create one which only purpose is to give us a proper
@@ -198,7 +198,7 @@ func resolveFlarePOSTURL(url string, client *http.Client, apiKey string) (string
 	if err != nil {
 		return "", err
 	}
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	request.Header.Add("DD-API-KEY", apiKey)
 
 	r, err := client.Do(request)
 	if err != nil {

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestMkURL(t *testing.T) {
-	assert.Equal(t, "https://example.com/support/flare/999?api_key=123456", mkURL("https://example.com", "999", "123456"))
-	assert.Equal(t, "https://example.com/support/flare?api_key=123456", mkURL("https://example.com", "", "123456"))
+	assert.Equal(t, "https://example.com/support/flare/999", mkURL("https://example.com", "999"))
+	assert.Equal(t, "https://example.com/support/flare", mkURL("https://example.com", ""))
 }
 
 func TestFlareHasRightForm(t *testing.T) {
@@ -47,8 +47,12 @@ func TestFlareHasRightForm(t *testing.T) {
 				//  * the original flare request URL, which redirects on HEAD to /post-target
 				//  * HEAD /post-target - responds with 200 OK
 				//  * POST /post-target - the final POST
+				if r.Header.Get("Authorization") != "Bearer abcdef" {
+					w.WriteHeader(403)
+					io.WriteString(w, "request missing Authorization header")
+				}
 
-				if r.Method == "HEAD" && r.RequestURI == "/support/flare/12345?api_key=abcdef" {
+				if r.Method == "HEAD" && r.RequestURI == "/support/flare/12345" {
 					// redirect to /post-target.
 					w.Header().Set("Location", "/post-target")
 					w.WriteHeader(307)
@@ -97,7 +101,7 @@ func TestFlareHasRightForm(t *testing.T) {
 			if testCase.fail {
 				assert.Error(t, err)
 				expectedErrorMessage := "We couldn't reach the flare backend " +
-					scrubber.ScrubLine(mkURL(ddURL, caseID, apiKey)) +
+					scrubber.ScrubLine(mkURL(ddURL, caseID)) +
 					" via redirects: 503 Service Unavailable"
 				assert.Equal(t, expectedErrorMessage, err.Error())
 			} else {

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -47,9 +47,9 @@ func TestFlareHasRightForm(t *testing.T) {
 				//  * the original flare request URL, which redirects on HEAD to /post-target
 				//  * HEAD /post-target - responds with 200 OK
 				//  * POST /post-target - the final POST
-				if r.Header.Get("Authorization") != "Bearer abcdef" {
+				if r.Header.Get("DD-API-KEY") != "abcdef" {
 					w.WriteHeader(403)
-					io.WriteString(w, "request missing Authorization header")
+					io.WriteString(w, "request missing DD-API-KEY header")
 				}
 
 				if r.Method == "HEAD" && r.RequestURI == "/support/flare/12345" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Sending keys in query params is bad practice and can incidentally leak to logs if not configured correctly. 

Better practice is using the Authorization header

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* we'll need to ensure the new RAPID backend service will correctly authorize this endpoint with the change
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
