### PR TITLE
Disable k8s 1.19 e2e suite

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -165,7 +165,9 @@ new-e2e-containers:
     TEAM: container-integrations
   parallel:
     matrix:
-      - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
+      # Temporarily disable old version of Kubernetes
+      # On this version, the reported kubernetes CPU usage appears to be significantly off
+      # - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.22"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.27"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"


### PR DESCRIPTION
### What does this PR do?

Disable k8s 1.19 e2e test suite

### Motivation

The test `TestKindSuite/TestCPU/metric___kubernetes.cpu.usage.total{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}` is consistently failing ever since this test suite was enabled with [this PR](https://github.com/DataDog/datadog-agent/pull/27600)

[CI Test failures](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40test.name%3A%22TestKindSuite%2FTestCPU%2Fmetric___kubernetes.cpu.usage.total%7B%5Ekube_deployment%3Astress-ng%24%2C%5Ekube_namespace%3Aworkload-cpustress%24%7D%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40ci.job.name%2C%40test.suite%3A269%2C%40test.name%3A326%2C%40duration%3A139%2C%40git.commit.sha%2C%40test.service%2C%40git.branch%2Cbranch&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1719264135478&end=1721856135478&paused=false)

When it is broken, [it is pretty broken](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?fromUser=false&fullscreen_end_ts=1721845041696&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1721844369770&fullscreen_widget=5717020205158046&refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-583517560-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-583517560-4670-kind-cluster&view=spans&from_ts=1721844369770&to_ts=1721845041696&live=false)

[And when it succeeds, it is also pretty broken](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?fromUser=false&fullscreen_end_ts=1721831585365&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1721830483326&fullscreen_widget=5717020205158046&refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-583032125-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-583032125-4670-kind-cluster&view=spans&from_ts=1721830483326&to_ts=1721831585365&live=false)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
