### PR TITLE
[CWS] clean up the truncate/ftruncate test

### DIFF
--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -32,18 +32,29 @@ import (
 func TestOpen(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_rule",
+			Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
+		},
+		{
+			ID:         "test_rule_truncate",
+			Expression: `open.file.path == "{{.Root}}/test-truncate" && open.flags & O_TRUNC != 0`,
+		},
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer test.Close()
 
 	testFile, testFilePtr, err := test.Path("test-open")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testFileTrunc, testFileTruncPtr, err := test.Path("test-truncate")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,25 +153,24 @@ func TestOpen(t *testing.T) {
 	t.Run("truncate", func(t *testing.T) {
 		SkipIfNotAvailable(t)
 
+		f, err := os.OpenFile(testFileTrunc, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := f.Write([]byte("this data will soon be truncated\n")); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
 		defer os.Remove(testFile)
 
 		test.WaitSignal(t, func() error {
-			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
-			if err != nil {
-				return err
-			}
-
-			_, err = syscall.Write(int(f.Fd()), []byte("this data will soon be truncated\n"))
-			if err != nil {
-				return err
-			}
-
-			return f.Close()
-		}, func(event *model.Event, r *rules.Rule) {})
-
-		test.WaitSignal(t, func() error {
 			// truncate
-			_, _, errno := syscall.Syscall(syscall.SYS_TRUNCATE, uintptr(testFilePtr), 4, 0)
+			_, _, errno := syscall.Syscall(syscall.SYS_TRUNCATE, uintptr(testFileTruncPtr), 4, 0)
 			if errno != 0 {
 				return error(errno)
 			}
@@ -168,7 +178,7 @@ func TestOpen(t *testing.T) {
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
-			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
+			assert.Equal(t, getInode(t, testFileTrunc), event.Open.File.Inode, "wrong inode")
 
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)


### PR DESCRIPTION
### What does this PR do?

When setting up the file for the truncate test the operation matches the open rule in the current module so we need to wrap this in an empty `WaitSignal` to not break the actual test. This is sub-optimal and not super clear. This PR cleans this by adding a truncate specific rule, and a truncate specific file so that the setup operation will not match any rule and can be done normally.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
