### PR TITLE
Fix pod status for pod using native sidecars CAP-1810

### DIFF
--- a/releasenotes/notes/status-sidecar-2c0f26c6adc63ab2.yaml
+++ b/releasenotes/notes/status-sidecar-2c0f26c6adc63ab2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix pod status for pods using native sidecars.


### PR DESCRIPTION
### What does this PR do?

Sync latest changes on the print pod function, mostly for https://github.com/kubernetes/kubernetes/commit/0a9870791289f9aa638fc0fc891b41d56068daf2


### Motivation

Pod status stays in `Init: ...` otherwise

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
