### PR TITLE
[processes] increase the wait interval for the manual process check test in k8s to avoid test flakiness

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -154,6 +154,7 @@ func (s *K8sSuite) TestManualContainerCheck() {
 func execProcessAgentCheck(t *testing.T, cluster *components.KubernetesCluster, check string) string {
 	agent := getAgentPod(t, cluster.Client())
 	// set the wait interval as workloadmeta takes some time to initialize for container data
+	// https://datadoghq.atlassian.net/browse/PROCS-4157
 	cmd := fmt.Sprintf("DD_LOG_LEVEL=OFF process-agent check %s -w 10s --json", check)
 
 	// The log level needs to be overridden as the pod has an ENV var set.

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -153,7 +153,8 @@ func (s *K8sSuite) TestManualContainerCheck() {
 
 func execProcessAgentCheck(t *testing.T, cluster *components.KubernetesCluster, check string) string {
 	agent := getAgentPod(t, cluster.Client())
-	cmd := fmt.Sprintf("DD_LOG_LEVEL=OFF process-agent check %s -w 5s --json", check)
+	// set the wait interval as workloadmeta takes some time to initialize for container data
+	cmd := fmt.Sprintf("DD_LOG_LEVEL=OFF process-agent check %s -w 10s --json", check)
 
 	// The log level needs to be overridden as the pod has an ENV var set.
 	// This is so we get just json back from the check


### PR DESCRIPTION
### What does this PR do?
This increases the wait interval in the manual process check in the k8s end to end tests. This is because the workloadmeta module may not be ready when we fetch containers leading to missing container data.

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4157

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
