### PR TITLE
ExplicitPodMutation private & using a flag instead of multiple bools.

### DIFF
--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 
-	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -162,31 +161,6 @@ func containsVolumeMount(volumeMounts []corev1.VolumeMount, element corev1.Volum
 		}
 	}
 	return false
-}
-
-// ShouldMutateUnlabelledPods returns true if we should mutate unlabelled pods.
-func ShouldMutateUnlabelledPods() bool {
-	return config.Datadog().GetBool("admission_controller.mutate_unlabelled")
-}
-
-// IsExplicitPodMutationEnabled returns true if the pod mutation is opted into
-// by a pod label. It returns a second bool to show whether or not the value was
-// specified or not in the first place.
-func IsExplicitPodMutationEnabled(pod *corev1.Pod) (bool, bool) {
-	// If a pod explicitly sets the label admission.datadoghq.com/enabled,
-	// make a decision based on its value.
-	if val, found := pod.GetLabels()[admCommon.EnabledLabelKey]; found {
-		switch val {
-		case "true":
-			return true, true
-		case "false":
-			return false, true
-		default:
-			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it", admCommon.EnabledLabelKey, val, PodString(pod))
-		}
-	}
-
-	return false, false
 }
 
 // ContainerRegistry gets the container registry config using the specified

--- a/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
@@ -9,6 +9,10 @@ package common
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // InjectionFilter encapsulates the logic for deciding whether
@@ -21,15 +25,48 @@ type InjectionFilter struct {
 // ShouldMutatePod checks if a pod is mutable per explicit rules and
 // the NSFilter if InjectionFilter has one.
 func (f InjectionFilter) ShouldMutatePod(pod *corev1.Pod) bool {
-	if val, ok := IsExplicitPodMutationEnabled(pod); ok {
-		return val
+	switch getPodMutationLabelFlag(pod) {
+	case podMutationDisabled:
+		return false
+	case podMutationEnabled:
+		return true
 	}
 
 	if f.NSFilter != nil && f.NSFilter.IsNamespaceEligible(pod.Namespace) {
 		return true
 	}
 
-	return ShouldMutateUnlabelledPods()
+	return config.Datadog().GetBool("admission_controller.mutate_unlabelled")
+}
+
+type podMutationLabelFlag int
+
+const (
+	podMutationUnspecified podMutationLabelFlag = iota
+	podMutationEnabled
+	podMutationDisabled
+)
+
+// getPodMutationLabelFlag returns podMutationUnspecified if the label is not
+// set or if the label is set to an invalid value.
+func getPodMutationLabelFlag(pod *corev1.Pod) podMutationLabelFlag {
+	if val, found := pod.GetLabels()[common.EnabledLabelKey]; found {
+		switch val {
+		case "true":
+			return podMutationEnabled
+		case "false":
+			return podMutationDisabled
+		default:
+			log.Warnf(
+				"Invalid label value '%s=%s' on pod %s should be either 'true' or 'false', ignoring it",
+				common.EnabledLabelKey,
+				val,
+				PodString(pod),
+			)
+		}
+	}
+
+	return podMutationUnspecified
 }
 
 // NamespaceInjectionFilter represents a contract to be able to filter out which pods are


### PR DESCRIPTION
### What does this PR do?

The two functions `IsExplicitPodMutationEnabled` and `ShouldMutateUnlabelledPods` were only used in the one function `InjectionFilter.ShouldMutatePod` so making sure they are not used outside of the `InjectionFilter` itself.

### Motivation

There are two functions in the `common` package that are only used in one place, but they are exported as public in the package. If someone uses them without using the full `InjectionFilter` by mistake, because they exist, we would introduce inconsistent injection behavior.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

These were public, but only recently introduced into the agent. I'm not sure if we have a BC policy about the functions packages export in case they are used by external (non-agent) code.

### Describe how to test/QA your changes

These two functions have test coverage through the `InjectionFilter` tests as well as the `auto_instrumentation` tests. There were no other tests for this behavior.
