### PR TITLE
[gitlab] Temporarily disable publish_fakeintake_latest

### DIFF
--- a/.gitlab/dev_container_deploy/fakeintake.yml
+++ b/.gitlab/dev_container_deploy/fakeintake.yml
@@ -14,17 +14,17 @@ publish_fakeintake:
     IMG_REGISTRIES: public
     IMG_SIGNING: "false"
 
-publish_fakeintake_latest:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.on_fakeintake_changes_on_main]
-  needs:
-    - job: docker_build_fakeintake
-      optional: false
-  variables:
-    IMG_SOURCES: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/fakeintake:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    IMG_DESTINATIONS: fakeintake:latest
-    IMG_REGISTRIES: public
-    IMG_SIGNING: "false"
+# publish_fakeintake_latest:
+#   extends: .docker_publish_job_definition
+#   stage: dev_container_deploy
+#   rules:
+#     - !reference [.except_mergequeue]
+#     - !reference [.on_fakeintake_changes_on_main]
+#   needs:
+#     - job: docker_build_fakeintake
+#       optional: false
+#   variables:
+#     IMG_SOURCES: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/fakeintake:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+#     IMG_DESTINATIONS: fakeintake:latest
+#     IMG_REGISTRIES: public
+#     IMG_SIGNING: "false"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Disables the `publish_fakeintake_latest` job.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We suspect that recent changes to the fakeintake are causing issues in the containers E2E tests. We want to revert the `fakeintake:latest` tag to a previous version. For this to work, we need to disable the `publish_fakeintake_latest` job on `main`, to avoid it overriding the tag again with a more recent, possibly buggy version.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

#incident-29258

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
