### PR TITLE
Refactoring autoinstrumentation webhook in prep for auto-instrumentation-v2

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// annotationExtractor extracts and transforms a kubernetes objects annotation
+// per a callback.
+type annotationExtractor[T any] struct {
+	key string
+	do  func(string) (T, error)
+}
+
+var errAnnotationNotFound = errors.New("annotation not found")
+
+func isErrAnnotationNotFound(err error) bool {
+	return errors.Is(err, errAnnotationNotFound)
+}
+
+// extract extracts annotation data from the kubernetes Object.
+func (e annotationExtractor[T]) extract(o metav1.Object) (T, error) {
+	if val, found := o.GetAnnotations()[e.key]; found {
+		log.Debugf("Found annotation for %s=%s Single Step Instrumentation.", e.key, val)
+		out, err := e.do(val)
+		return out, err
+	}
+
+	var empty T
+	return empty, errAnnotationNotFound
+}
+
+func infallibleFn[T any](f func(string) T) func(string) (T, error) {
+	return func(in string) (T, error) { return f(in), nil }
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotationExtractor(t *testing.T) {
+	var (
+		identityExtractor = annotationExtractor[string]{
+			key: "foo",
+			do: func(in string) (string, error) {
+				return in, nil
+			},
+		}
+		validatingExtractor = annotationExtractor[string]{
+			key: "foo",
+			do: func(in string) (string, error) {
+				if in != "bar" {
+					return "", errors.New("invalid")
+				}
+				return in, nil
+			},
+		}
+	)
+
+	var testData = []struct {
+		name        string
+		annotations map[string]string
+		extractor   annotationExtractor[string]
+		err         bool
+		ok          bool
+		out         string
+	}{
+		{
+			name:      "missing annotation",
+			extractor: identityExtractor,
+			ok:        false,
+		},
+		{
+			name:        "key exists",
+			extractor:   identityExtractor,
+			ok:          true,
+			out:         "bar",
+			annotations: map[string]string{"foo": "bar"},
+		},
+		{
+			name:        "errors work",
+			extractor:   validatingExtractor,
+			annotations: map[string]string{"foo": "nope"},
+			err:         true,
+			ok:          true,
+		},
+		{
+			name: "transformers work & infallible",
+			extractor: annotationExtractor[string]{
+				key: "foo",
+				do:  infallibleFn(strings.ToUpper),
+			},
+			annotations: map[string]string{"foo": "bar"},
+			ok:          true,
+			out:         "BAR",
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := common.FakePodSpec{Annotations: tt.annotations}.Create()
+			data, err := tt.extractor.extract(pod)
+			if tt.err {
+				require.Error(t, err)
+			} else if !tt.ok {
+				require.True(t, isErrAnnotationNotFound(err))
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.out, data)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -32,143 +31,33 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 const (
-	// Shared config
 	volumeName = "datadog-auto-instrumentation"
 	mountPath  = "/datadog-lib"
-
-	// Java config
-	javaToolOptionsKey   = "JAVA_TOOL_OPTIONS"
-	javaToolOptionsValue = " -javaagent:/datadog-lib/dd-java-agent.jar -XX:OnError=/datadog-lib/java/continuousprofiler/tmp/dd_crash_uploader.sh -XX:ErrorFile=/datadog-lib/java/continuousprofiler/tmp/hs_err_pid_%p.log"
-
-	// Node config
-	nodeOptionsKey   = "NODE_OPTIONS"
-	nodeOptionsValue = " --require=/datadog-lib/node_modules/dd-trace/init"
-
-	// Python config
-	pythonPathKey   = "PYTHONPATH"
-	pythonPathValue = "/datadog-lib/"
-
-	// Dotnet config
-	dotnetClrEnableProfilingKey   = "CORECLR_ENABLE_PROFILING"
-	dotnetClrEnableProfilingValue = "1"
-
-	dotnetClrProfilerIDKey   = "CORECLR_PROFILER"
-	dotnetClrProfilerIDValue = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-
-	dotnetClrProfilerPathKey   = "CORECLR_PROFILER_PATH"
-	dotnetClrProfilerPathValue = "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so"
-
-	dotnetTracerHomeKey   = "DD_DOTNET_TRACER_HOME"
-	dotnetTracerHomeValue = "/datadog-lib"
-
-	dotnetTracerLogDirectoryKey   = "DD_TRACE_LOG_DIRECTORY"
-	dotnetTracerLogDirectoryValue = "/datadog-lib/logs"
-
-	dotnetProfilingLdPreloadKey   = "LD_PRELOAD"
-	dotnetProfilingLdPreloadValue = "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"
-
-	// Ruby config
-	rubyOptKey   = "RUBYOPT"
-	rubyOptValue = " -r/datadog-lib/auto_inject"
-)
-
-type language string
-
-const (
-	java   language = "java"
-	js     language = "js"
-	python language = "python"
-	dotnet language = "dotnet"
-	ruby   language = "ruby"
-	php    language = "php"
-
-	libVersionAnnotationKeyFormat    = "admission.datadoghq.com/%s-lib.version"
-	customLibAnnotationKeyFormat     = "admission.datadoghq.com/%s-lib.custom-image"
-	libVersionAnnotationKeyCtrFormat = "admission.datadoghq.com/%s.%s-lib.version"
-	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
 
 	// defaultMilliCPURequest defines default milli cpu request number.
 	defaultMilliCPURequest int64 = 50 // 0.05 core
 	// defaultMemoryRequest defines default memory request size.
 	defaultMemoryRequest int64 = 20 * 1024 * 1024 // 20 MB
 
-	// Env vars
-	instrumentationInstallTypeEnvVarName = "DD_INSTRUMENTATION_INSTALL_TYPE"
-	instrumentationInstallTimeEnvVarName = "DD_INSTRUMENTATION_INSTALL_TIME"
-	instrumentationInstallIDEnvVarName   = "DD_INSTRUMENTATION_INSTALL_ID"
-
-	// Values for Env variable DD_INSTRUMENTATION_INSTALL_TYPE
-	singleStepInstrumentationInstallType   = "k8s_single_step"
-	localLibraryInstrumentationInstallType = "k8s_lib_injection"
-
 	webhookName = "lib_injection"
 )
 
-var (
-	supportedLanguages = []language{
-		java,
-		js,
-		python,
-		dotnet,
-		ruby,
-	}
-
-	// languageVersions defines the major library versions we consider "default" for each
-	// supported language. If not set, we will default to "latest", see defaultLibVersion.
-	//
-	// If this language does not appear in supportedLanguages, it will not be injected.
-	languageVersions = map[language]string{
-		java:   "v1", // https://datadoghq.atlassian.net/browse/APMON-1064
-		dotnet: "v2", // https://datadoghq.atlassian.net/browse/APMON-1067
-		python: "v2", // https://datadoghq.atlassian.net/browse/APMON-1068
-		ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
-		js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
-		php:    "v2", // https://datadoghq.atlassian.net/browse/APMON-1128
-	}
-
-	singleStepInstrumentationInstallTypeEnvVar = corev1.EnvVar{
-		Name:  instrumentationInstallTypeEnvVarName,
-		Value: singleStepInstrumentationInstallType,
-	}
-
-	localLibraryInstrumentationInstallTypeEnvVar = corev1.EnvVar{
-		Name:  instrumentationInstallTypeEnvVarName,
-		Value: localLibraryInstrumentationInstallType,
-	}
-)
-
-func (l language) defaultLibInfo(registry, ctrName string) libInfo {
-	return libInfo{
-		lang:    l,
-		ctrName: ctrName,
-		image:   libImageName(registry, l, l.defaultLibVersion()),
-	}
-}
-
-func (l language) defaultLibVersion() string {
-	langVersion, ok := languageVersions[l]
-	if !ok {
-		return "latest"
-	}
-	return langVersion
-}
-
 // Webhook is the auto instrumentation webhook
 type Webhook struct {
-	name                string
-	isEnabled           bool
-	endpoint            string
-	resources           []string
-	operations          []admiv1.OperationType
-	initSecurityContext *corev1.SecurityContext
-	containerRegistry   string
-	injectionFilter     mutatecommon.InjectionFilter
-	pinnedLibraries     []libInfo
-	wmeta               workloadmeta.Component
+	name                     string
+	isEnabled                bool
+	endpoint                 string
+	resources                []string
+	operations               []admiv1.OperationType
+	initSecurityContext      *corev1.SecurityContext
+	initResourceRequirements corev1.ResourceRequirements
+	containerRegistry        string
+	injectionFilter          mutatecommon.InjectionFilter
+	pinnedLibraries          []libInfo
+	wmeta                    workloadmeta.Component
 }
 
 // NewWebhook returns a new Webhook dependent on the injection filter.
@@ -182,24 +71,30 @@ func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilte
 		return nil, err
 	}
 
-	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.auto_instrumentation.container_registry")
-
 	initSecurityContext, err := parseInitSecurityContext()
 	if err != nil {
 		return nil, err
 	}
 
+	initResourceRequirements, err := initResources()
+	if err != nil {
+		return nil, err
+	}
+
+	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.auto_instrumentation.container_registry")
+
 	return &Webhook{
-		name:                webhookName,
-		isEnabled:           config.Datadog().GetBool("admission_controller.auto_instrumentation.enabled"),
-		endpoint:            config.Datadog().GetString("admission_controller.auto_instrumentation.endpoint"),
-		resources:           []string{"pods"},
-		operations:          []admiv1.OperationType{admiv1.Create},
-		initSecurityContext: initSecurityContext,
-		injectionFilter:     filter,
-		containerRegistry:   containerRegistry,
-		pinnedLibraries:     getPinnedLibraries(containerRegistry),
-		wmeta:               wmeta,
+		name:                     webhookName,
+		isEnabled:                config.Datadog().GetBool("admission_controller.auto_instrumentation.enabled"),
+		endpoint:                 config.Datadog().GetString("admission_controller.auto_instrumentation.endpoint"),
+		resources:                []string{"pods"},
+		operations:               []admiv1.OperationType{admiv1.Create},
+		initSecurityContext:      initSecurityContext,
+		initResourceRequirements: initResourceRequirements,
+		injectionFilter:          filter,
+		containerRegistry:        containerRegistry,
+		pinnedLibraries:          getPinnedLibraries(containerRegistry),
+		wmeta:                    wmeta,
 	}, nil
 }
 
@@ -250,11 +145,6 @@ func initContainerName(lang language) string {
 	return fmt.Sprintf("datadog-lib-%s-init", lang)
 }
 
-func libImageName(registry string, lang language, tag string) string {
-	imageFormat := "%s/dd-lib-%s-init:%s"
-	return fmt.Sprintf(imageFormat, registry, lang, tag)
-}
-
 func (w *Webhook) isPodEligible(pod *corev1.Pod) bool {
 	return w.injectionFilter.ShouldMutatePod(pod)
 }
@@ -289,8 +179,19 @@ func (w *Webhook) inject(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool,
 	if len(libsToInject) == 0 {
 		return false, nil
 	}
-	injectSecurityClientLibraryConfig(pod)
-	injectProfilingClientLibraryConfig(pod)
+
+	for _, mutator := range securityClientLibraryConfigMutators() {
+		if err := mutator.mutatePod(pod); err != nil {
+			return false, fmt.Errorf("error mutating pod for security client: %w", err)
+		}
+	}
+
+	for _, mutator := range profilingClientLibraryConfigMutators() {
+		if err := mutator.mutatePod(pod); err != nil {
+			return false, fmt.Errorf("error mutating pod for profiling client: %w", err)
+		}
+	}
+
 	// Inject env variables used for Onboarding KPIs propagation
 	var injectionType string
 	if w.isEnabledInNamespace(pod.Namespace) {
@@ -316,10 +217,27 @@ func (w *Webhook) inject(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool,
 // * <unset> - product disactivated but can be activated remotely
 // * true - product activated, not overridable remotely
 // * false - product disactivated, not overridable remotely
-func injectSecurityClientLibraryConfig(pod *corev1.Pod) {
-	injectEnvVarIfBoolConfigKeySet(pod, "admission_controller.auto_instrumentation.asm.enabled", "DD_APPSEC_ENABLED")
-	injectEnvVarIfBoolConfigKeySet(pod, "admission_controller.auto_instrumentation.iast.enabled", "DD_IAST_ENABLED")
-	injectEnvVarIfBoolConfigKeySet(pod, "admission_controller.auto_instrumentation.asm_sca.enabled", "DD_APPSEC_SCA_ENABLED")
+func securityClientLibraryConfigMutators() []podMutator {
+	boolVal := func(key string) string {
+		return strconv.FormatBool(config.Datadog().GetBool(key))
+	}
+	return []podMutator{
+		configKeyEnvVarMutator{
+			envKey:    "DD_APPSEC_ENABLED",
+			configKey: "admission_controller.auto_instrumentation.asm.enabled",
+			getVal:    boolVal,
+		},
+		configKeyEnvVarMutator{
+			envKey:    "DD_IAST_ENABLED",
+			configKey: "admission_controller.auto_instrumentation.iast.enabled",
+			getVal:    boolVal,
+		},
+		configKeyEnvVarMutator{
+			envKey:    "DD_APPSEC_SCA_ENABLED",
+			configKey: "admission_controller.auto_instrumentation.asm_sca.enabled",
+			getVal:    boolVal,
+		},
+	}
 }
 
 // The config for profiling has four states: <unset> | "auto" | "true" | "false".
@@ -327,27 +245,13 @@ func injectSecurityClientLibraryConfig(pod *corev1.Pod) {
 // * "true" - profiling activated unconditionally, not overridable remotely
 // * "false" - profiling deactivated, not overridable remotely
 // * "auto" - profiling activates per-process heuristically, not overridable remotely
-func injectProfilingClientLibraryConfig(pod *corev1.Pod) {
-	injectEnvVarIfStringConfigKeySet(pod, "admission_controller.auto_instrumentation.profiling.enabled", "DD_PROFILING_ENABLED")
-}
-
-func injectEnvVarIfBoolConfigKeySet(pod *corev1.Pod, configKey string, envVarKey string) {
-	if config.Datadog().IsSet(configKey) {
-		enabledValue := config.Datadog().GetBool(configKey)
-		_ = mutatecommon.InjectEnv(pod, corev1.EnvVar{
-			Name:  envVarKey,
-			Value: strconv.FormatBool(enabledValue),
-		})
-	}
-}
-
-func injectEnvVarIfStringConfigKeySet(pod *corev1.Pod, configKey string, envVarKey string) {
-	if config.Datadog().IsSet(configKey) {
-		configValue := config.Datadog().GetString(configKey)
-		_ = mutatecommon.InjectEnv(pod, corev1.EnvVar{
-			Name:  envVarKey,
-			Value: configValue,
-		})
+func profilingClientLibraryConfigMutators() []podMutator {
+	return []podMutator{
+		configKeyEnvVarMutator{
+			envKey:    "DD_PROFILING_ENABLED",
+			configKey: "admission_controller.auto_instrumentation.profiling.enabled",
+			getVal:    config.Datadog().GetString,
+		},
 	}
 }
 
@@ -372,21 +276,23 @@ func injectApmTelemetryConfig(pod *corev1.Pod) {
 }
 
 // getPinnedLibraries returns tracing libraries to inject as configured by apm_config.instrumentation.lib_versions
+// given a registry.
 func getPinnedLibraries(registry string) []libInfo {
+	// If APM Instrumentation is enabled and configuration apm_config.instrumentation.lib_versions specified,
+	// inject only the libraries from the configuration
+	singleStepLibraryVersions := config.Datadog().
+		GetStringMapString("apm_config.instrumentation.lib_versions")
+
 	var res []libInfo
-
-	var libVersion string
-	singleStepLibraryVersions := config.Datadog().GetStringMapString("apm_config.instrumentation.lib_versions")
-
-	// If APM Instrumentation is enabled and configuration apm_config.instrumentation.lib_versions specified, inject only the libraries from the configuration
 	for lang, version := range singleStepLibraryVersions {
-		if !slices.Contains(supportedLanguages, language(lang)) {
+		l := language(lang)
+		if !l.isSupported() {
 			log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)
 			continue
 		}
+
 		log.Infof("Library version %s is specified for language %s", version, lang)
-		libVersion = version
-		res = append(res, libInfo{lang: language(lang), image: libImageName(registry, language(lang), libVersion)})
+		res = append(res, l.libInfo("", l.libImageName(registry, version)))
 	}
 
 	return res
@@ -411,12 +317,6 @@ func (w *Webhook) getAllLatestLibraries() []libInfo {
 	}
 
 	return libsToInject
-}
-
-type libInfo struct {
-	ctrName string // empty means all containers
-	lang    language
-	image   string
 }
 
 // extractLibInfo returns the language, the image,
@@ -491,57 +391,52 @@ func (w *Webhook) getAutoDetectedLibraries(pod *corev1.Pod) []libInfo {
 }
 
 func (w *Webhook) extractLibrariesFromAnnotations(pod *corev1.Pod) []libInfo {
-	annotations := pod.Annotations
-	var libList []libInfo
-	for _, lang := range supportedLanguages {
-		customLibAnnotation := strings.ToLower(fmt.Sprintf(customLibAnnotationKeyFormat, lang))
-		if image, found := annotations[customLibAnnotation]; found {
-			log.Debugf(
-				"Found %s library annotation %s, will overwrite %s injected with Single Step Instrumentation",
-				string(lang), customLibAnnotation, image,
-			)
-			libList = append(libList, libInfo{lang: lang, image: image})
+	var (
+		libList        []libInfo
+		extractLibInfo = func(e annotationExtractor[libInfo]) {
+			i, err := e.extract(pod)
+			if err != nil {
+				if !isErrAnnotationNotFound(err) {
+					log.Warnf("error extracting annotation for key %s", e.key)
+				}
+			} else {
+				libList = append(libList, i)
+			}
 		}
+	)
 
-		libVersionAnnotation := strings.ToLower(fmt.Sprintf(libVersionAnnotationKeyFormat, lang))
-		if version, found := annotations[libVersionAnnotation]; found {
-			image := fmt.Sprintf("%s/dd-lib-%s-init:%s", w.containerRegistry, lang, version)
-			log.Debugf(
-				"Found %s library annotation for version %s, will overwrite %s injected with Single Step Instrumentation",
-				string(lang), version, image,
-			)
-			libList = append(libList, libInfo{lang: lang, image: image})
-		}
-
+	for _, l := range supportedLanguages {
+		extractLibInfo(l.customLibAnnotationExtractor())
+		extractLibInfo(l.libVersionAnnotationExtractor(w.containerRegistry))
 		for _, ctr := range pod.Spec.Containers {
-			customLibAnnotation := strings.ToLower(fmt.Sprintf(customLibAnnotationKeyCtrFormat, ctr.Name, lang))
-			if image, found := annotations[customLibAnnotation]; found {
-				log.Debugf(
-					"Found custom library annotation for %s, will inject %s to container %s",
-					string(lang), image, ctr.Name,
-				)
-				libList = append(libList, libInfo{ctrName: ctr.Name, lang: lang, image: image})
-			}
-
-			libVersionAnnotation := strings.ToLower(fmt.Sprintf(libVersionAnnotationKeyCtrFormat, ctr.Name, lang))
-			if version, found := annotations[libVersionAnnotation]; found {
-				image := libImageName(w.containerRegistry, lang, version)
-				log.Debugf(
-					"Found version library annotation for %s, will inject %s to container %s",
-					string(lang), image, ctr.Name,
-				)
-				libList = append(libList, libInfo{ctrName: ctr.Name, lang: lang, image: image})
-			}
+			extractLibInfo(l.ctrCustomLibAnnotationExtractor(ctr.Name))
+			extractLibInfo(l.ctrLibVersionAnnotationExtractor(ctr.Name, w.containerRegistry))
 		}
 	}
 
 	return libList
 }
 
-func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetected bool, injectionType string) error {
-	var lastError error
+func (w *Webhook) initContainerMutators() []containerMutator {
+	return []containerMutator{
+		containerResourceRequirements{w.initResourceRequirements},
+		containerSecurityContext{w.initSecurityContext},
+	}
+}
 
-	initContainerToInject := make(map[language]string)
+func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetected bool, injectionType string) error {
+	if len(libsToInject) == 0 {
+		return nil
+	}
+
+	// inject the env for the pod.
+	_ = mutatecommon.InjectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)
+
+	var (
+		lastError             error
+		configInjector        = &libConfigInjector{}
+		initContainerMutators = w.initContainerMutators()
+	)
 
 	for _, lib := range libsToInject {
 		injected := false
@@ -550,148 +445,28 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo
 			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
 		}()
 
-		_ = mutatecommon.InjectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)
-		var err error
-		switch lib.lang {
-		case java:
-			err = injectLibRequirements(pod, lib.ctrName, []envVar{
-				{
-					key:     javaToolOptionsKey,
-					valFunc: javaEnvValFunc,
-				}})
-		case js:
-			err = injectLibRequirements(pod, lib.ctrName, []envVar{
-				{
-					key:     nodeOptionsKey,
-					valFunc: jsEnvValFunc,
-				}})
-		case python:
-			err = injectLibRequirements(pod, lib.ctrName, []envVar{
-				{
-					key:     pythonPathKey,
-					valFunc: pythonEnvValFunc,
-				},
-			})
-		case dotnet:
-			err = injectLibRequirements(pod, lib.ctrName, []envVar{
-				{
-					key:     dotnetClrEnableProfilingKey,
-					valFunc: identityValFunc(dotnetClrEnableProfilingValue),
-				},
-				{
-					key:     dotnetClrProfilerIDKey,
-					valFunc: identityValFunc(dotnetClrProfilerIDValue),
-				},
-				{
-					key:     dotnetClrProfilerPathKey,
-					valFunc: identityValFunc(dotnetClrProfilerPathValue),
-				},
-				{
-					key:     dotnetTracerHomeKey,
-					valFunc: identityValFunc(dotnetTracerHomeValue),
-				},
-				{
-					key:     dotnetTracerLogDirectoryKey,
-					valFunc: identityValFunc(dotnetTracerLogDirectoryValue),
-				},
-				{
-					key:     dotnetProfilingLdPreloadKey,
-					valFunc: dotnetProfilingLdPreloadEnvValFunc,
-					isEligibleToInject: func(_ corev1.Container) bool {
-						// N.B. Always disabled for now until we have a better mechanism to inject
-						//      this safely.
-						return false
-					},
-				},
-			})
-		case ruby:
-			err = injectLibRequirements(pod, lib.ctrName, []envVar{
-				{
-					key:     rubyOptKey,
-					valFunc: rubyEnvValFunc,
-				}})
-		default:
-			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			lastError = fmt.Errorf("language %q is not supported. Supported languages are %v", lib.lang, supportedLanguages)
-			continue
-		}
-
-		if err != nil {
+		if err := lib.podMutator(initContainerMutators, []podMutator{
+			configInjector.podMutator(lib.lang),
+		}).mutatePod(pod); err != nil {
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
 			lastError = err
-			log.Errorf("Error injecting library config requirements: %s", err)
+			continue
 		}
-
-		initContainerToInject[lib.lang] = lib.image
 
 		injected = true
 	}
 
-	for lang, image := range initContainerToInject {
-		err := injectLibInitContainer(pod, image, lang, w.initSecurityContext)
-		if err != nil {
-			langStr := string(lang)
-			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			lastError = err
-			log.Errorf("Cannot inject init container into pod %s: %s", mutatecommon.PodString(pod), err)
-		}
-		err = injectLibConfig(pod, lang)
-		if err != nil {
-			langStr := string(lang)
-			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
-			lastError = err
-			log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
-		}
-	}
-
-	// try to inject all if the annotation is set
-	if err := injectLibConfig(pod, "all"); err != nil {
+	if err := configInjector.podMutator(language("all")).mutatePod(pod); err != nil {
 		metrics.LibInjectionErrors.Inc("all", strconv.FormatBool(autoDetected), injectionType)
 		lastError = err
 		log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
 	}
 
-	injectLibVolume(pod)
-
 	if w.isEnabledInNamespace(pod.Namespace) {
-		libConfig := basicConfig()
-		if name, err := getServiceNameFromPod(pod); err == nil {
-			// Set service name if it can be derived from a pod
-			libConfig.ServiceName = pointer.Ptr(name)
-		}
-		for _, env := range libConfig.ToEnvs() {
-			_ = mutatecommon.InjectEnv(pod, env)
-		}
+		_ = basicLibConfigInjector{}.mutatePod(pod)
 	}
 
 	return lastError
-}
-
-func injectLibInitContainer(pod *corev1.Pod, image string, lang language, securityContext *corev1.SecurityContext) error {
-	initCtrName := initContainerName(lang)
-	log.Debugf("Injecting init container named %q with image %q into pod %s", initCtrName, image, mutatecommon.PodString(pod))
-	initContainer := corev1.Container{
-		Name:    initCtrName,
-		Image:   image,
-		Command: []string{"sh", "copy-lib.sh", mountPath},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      volumeName,
-				MountPath: mountPath,
-			},
-		},
-	}
-
-	resources, err := initResources()
-	if err != nil {
-		return err
-	}
-	initContainer.Resources = resources
-
-	initContainer.SecurityContext = securityContext
-
-	pod.Spec.InitContainers = append([]corev1.Container{initContainer}, pod.Spec.InitContainers...)
-	return nil
 }
 
 func initResources() (corev1.ResourceRequirements, error) {
@@ -740,48 +515,6 @@ func parseInitSecurityContext() (*corev1.SecurityContext, error) {
 	return &securityContext, nil
 }
 
-// injectLibRequirements injects the minimal config requirements (env vars and volume mounts) to enable instrumentation
-func injectLibRequirements(pod *corev1.Pod, ctrName string, envVars []envVar) error {
-	for i, ctr := range pod.Spec.Containers {
-		if ctrName != "" && ctrName != ctr.Name {
-			continue
-		}
-
-		for _, envVarPair := range envVars {
-			if envVarPair.isEligibleToInject != nil && !envVarPair.isEligibleToInject(ctr) {
-				continue
-			}
-
-			index := mutatecommon.EnvIndex(ctr.Env, envVarPair.key)
-			if index < 0 {
-				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
-					Name:  envVarPair.key,
-					Value: envVarPair.valFunc(""),
-				})
-			} else {
-				if pod.Spec.Containers[i].Env[index].ValueFrom != nil {
-					return fmt.Errorf("%q is defined via ValueFrom", envVarPair.key)
-				}
-
-				pod.Spec.Containers[i].Env[index].Value = envVarPair.valFunc(pod.Spec.Containers[i].Env[index].Value)
-			}
-		}
-
-		volumeAlreadyMounted := false
-		for _, vol := range pod.Spec.Containers[i].VolumeMounts {
-			if vol.Name == volumeName {
-				volumeAlreadyMounted = true
-				break
-			}
-		}
-		if !volumeAlreadyMounted {
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{Name: volumeName, MountPath: mountPath})
-		}
-	}
-
-	return nil
-}
-
 // Returns the name of Kubernetes resource that owns the pod
 func getServiceNameFromPod(pod *corev1.Pod) (string, error) {
 	ownerReferences := pod.ObjectMeta.OwnerReferences
@@ -805,47 +538,6 @@ func getServiceNameFromPod(pod *corev1.Pod) (string, error) {
 	return "", nil
 }
 
-// basicConfig returns the default tracing config to inject into application pods
-// when no other config has been provided.
-func basicConfig() common.LibConfig {
-	return common.LibConfig{
-		Tracing:        pointer.Ptr(true),
-		LogInjection:   pointer.Ptr(true),
-		HealthMetrics:  pointer.Ptr(true),
-		RuntimeMetrics: pointer.Ptr(true),
-	}
-}
-
-// injectLibConfig injects additional library configuration extracted from pod annotations
-func injectLibConfig(pod *corev1.Pod, lang language) error {
-	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, lang)
-	confString, found := pod.GetAnnotations()[configAnnotKey]
-	if !found {
-		log.Tracef("Config annotation key %q not found on pod %s, skipping config injection", configAnnotKey, mutatecommon.PodString(pod))
-		return nil
-	}
-	log.Infof("Config annotation key %q found on pod %s, config: %q", configAnnotKey, mutatecommon.PodString(pod), confString)
-	var libConfig common.LibConfig
-	err := json.Unmarshal([]byte(confString), &libConfig)
-	if err != nil {
-		return fmt.Errorf("invalid json config in annotation %s=%s: %w", configAnnotKey, confString, err)
-	}
-	for _, env := range libConfig.ToEnvs() {
-		_ = mutatecommon.InjectEnv(pod, env)
-	}
-
-	return nil
-}
-
-func injectLibVolume(pod *corev1.Pod) {
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: volumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
-}
-
 func containsInitContainer(pod *corev1.Pod, initContainerName string) bool {
 	for _, container := range pod.Spec.InitContainers {
 		if container.Name == initContainerName {
@@ -854,42 +546,4 @@ func containsInitContainer(pod *corev1.Pod, initContainerName string) bool {
 	}
 
 	return false
-}
-
-type envVar struct {
-	key                string
-	valFunc            envValFunc
-	isEligibleToInject func(corev1.Container) bool
-}
-
-type envValFunc func(string) string
-
-func identityValFunc(s string) envValFunc {
-	return func(string) string { return s }
-}
-
-func javaEnvValFunc(predefinedVal string) string {
-	return predefinedVal + javaToolOptionsValue
-}
-
-func jsEnvValFunc(predefinedVal string) string {
-	return predefinedVal + nodeOptionsValue
-}
-
-func pythonEnvValFunc(predefinedVal string) string {
-	if predefinedVal == "" {
-		return pythonPathValue
-	}
-	return fmt.Sprintf("%s:%s", pythonPathValue, predefinedVal)
-}
-
-func dotnetProfilingLdPreloadEnvValFunc(predefinedVal string) string {
-	if predefinedVal == "" {
-		return dotnetProfilingLdPreloadValue
-	}
-	return fmt.Sprintf("%s:%s", dotnetProfilingLdPreloadValue, predefinedVal)
-}
-
-func rubyEnvValFunc(predefinedVal string) string {
-	return predefinedVal + rubyOptValue
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
@@ -42,15 +42,23 @@ func TestGetOwnerNameAndKind(t *testing.T) {
 			wantFound:    false,
 		},
 		{
-			name:         "Pod with replicaset parent, and no deployment grandparent",
-			pod:          common.FakePodWithParent("default", nil, nil, nil, "replicaset", "dummy-rs"),
+			name: "Pod with replicaset parent, and no deployment grandparent",
+			pod: common.FakePodSpec{
+				NS:         "default",
+				ParentKind: "replicaset",
+				ParentName: "dummy-rs",
+			}.Create(),
 			expectedName: "dummy-rs",
 			expectedKind: "ReplicaSet",
 			wantFound:    true,
 		},
 		{
-			name:         "Pod with replicaset parent, and deployment grandparent",
-			pod:          common.FakePodWithParent("default", nil, nil, nil, "replicaset", "dummy-rs-12344"),
+			name: "Pod with replicaset parent, and deployment grandparent",
+			pod: common.FakePodSpec{
+				NS:         "default",
+				ParentKind: "replicaset",
+				ParentName: "dummy-rs-12344",
+			}.Create(),
 			expectedName: "dummy-rs",
 			expectedKind: "Deployment",
 			wantFound:    true,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// Java config
+	javaToolOptionsKey   = "JAVA_TOOL_OPTIONS"
+	javaToolOptionsValue = " -javaagent:/datadog-lib/dd-java-agent.jar -XX:OnError=/datadog-lib/java/continuousprofiler/tmp/dd_crash_uploader.sh -XX:ErrorFile=/datadog-lib/java/continuousprofiler/tmp/hs_err_pid_%p.log"
+
+	// Node config
+	nodeOptionsKey   = "NODE_OPTIONS"
+	nodeOptionsValue = " --require=/datadog-lib/node_modules/dd-trace/init"
+
+	// Python config
+	pythonPathKey   = "PYTHONPATH"
+	pythonPathValue = "/datadog-lib/"
+
+	// Dotnet config
+	dotnetClrEnableProfilingKey   = "CORECLR_ENABLE_PROFILING"
+	dotnetClrEnableProfilingValue = "1"
+
+	dotnetClrProfilerIDKey   = "CORECLR_PROFILER"
+	dotnetClrProfilerIDValue = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+
+	dotnetClrProfilerPathKey   = "CORECLR_PROFILER_PATH"
+	dotnetClrProfilerPathValue = "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so"
+
+	dotnetTracerHomeKey   = "DD_DOTNET_TRACER_HOME"
+	dotnetTracerHomeValue = "/datadog-lib"
+
+	dotnetTracerLogDirectoryKey   = "DD_TRACE_LOG_DIRECTORY"
+	dotnetTracerLogDirectoryValue = "/datadog-lib/logs"
+
+	dotnetProfilingLdPreloadKey   = "LD_PRELOAD"
+	dotnetProfilingLdPreloadValue = "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"
+
+	// Ruby config
+	rubyOptKey   = "RUBYOPT"
+	rubyOptValue = " -r/datadog-lib/auto_inject"
+
+	// EnvNames
+	instrumentationInstallTypeEnvVarName = "DD_INSTRUMENTATION_INSTALL_TYPE"
+	instrumentationInstallTimeEnvVarName = "DD_INSTRUMENTATION_INSTALL_TIME"
+	instrumentationInstallIDEnvVarName   = "DD_INSTRUMENTATION_INSTALL_ID"
+
+	// Values for Env variable DD_INSTRUMENTATION_INSTALL_TYPE
+	singleStepInstrumentationInstallType   = "k8s_single_step"
+	localLibraryInstrumentationInstallType = "k8s_lib_injection"
+)
+
+var (
+	singleStepInstrumentationInstallTypeEnvVar = corev1.EnvVar{
+		Name:  instrumentationInstallTypeEnvVarName,
+		Value: singleStepInstrumentationInstallType,
+	}
+
+	localLibraryInstrumentationInstallTypeEnvVar = corev1.EnvVar{
+		Name:  instrumentationInstallTypeEnvVarName,
+		Value: localLibraryInstrumentationInstallType,
+	}
+)
+
+type envVar struct {
+	key                string
+	valFunc            envValFunc
+	isEligibleToInject func(*corev1.Container) bool
+}
+
+// mutateContainer implements containerMutator for envVar.
+func (e envVar) mutateContainer(c *corev1.Container) error {
+	if e.isEligibleToInject != nil && !e.isEligibleToInject(c) {
+		return nil
+	}
+
+	index := slices.IndexFunc(c.Env, func(ev corev1.EnvVar) bool {
+		return ev.Name == e.key
+	})
+	if index < 0 {
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  e.key,
+			Value: e.valFunc(""),
+		})
+	} else {
+		if c.Env[index].ValueFrom != nil {
+			return fmt.Errorf("%q is defined via ValueFrom", e.key)
+		}
+		c.Env[index].Value = e.valFunc(c.Env[index].Value)
+	}
+
+	return nil
+}
+
+type envValFunc func(string) string
+
+func identityValFunc(s string) envValFunc {
+	return func(string) string { return s }
+}
+
+func javaEnvValFunc(predefinedVal string) string {
+	return predefinedVal + javaToolOptionsValue
+}
+
+func jsEnvValFunc(predefinedVal string) string {
+	return predefinedVal + nodeOptionsValue
+}
+
+func pythonEnvValFunc(predefinedVal string) string {
+	if predefinedVal == "" {
+		return pythonPathValue
+	}
+	return fmt.Sprintf("%s:%s", pythonPathValue, predefinedVal)
+}
+
+func dotnetProfilingLdPreloadEnvValFunc(predefinedVal string) string {
+	if predefinedVal == "" {
+		return dotnetProfilingLdPreloadValue
+	}
+	return fmt.Sprintf("%s:%s", dotnetProfilingLdPreloadValue, predefinedVal)
+}
+
+func rubyEnvValFunc(predefinedVal string) string {
+	return predefinedVal + rubyOptValue
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -1,0 +1,277 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	java   language = "java"
+	js     language = "js"
+	python language = "python"
+	dotnet language = "dotnet"
+	ruby   language = "ruby"
+	php    language = "php"
+)
+
+// language is lang-library we might be injecting.
+type language string
+
+func (l language) defaultLibInfo(registry, ctrName string) libInfo {
+	return l.libInfo(ctrName, l.libImageName(registry, l.defaultLibVersion()))
+}
+
+func (l language) libImageName(registry, tag string) string {
+	return fmt.Sprintf("%s/dd-lib-%s-init:%s", registry, l, tag)
+}
+
+func (l language) libInfo(ctrName, image string) libInfo {
+	return libInfo{
+		lang:    l,
+		ctrName: ctrName,
+		image:   image,
+	}
+}
+
+const (
+	libVersionAnnotationKeyFormat    = "admission.datadoghq.com/%s-lib.version"
+	customLibAnnotationKeyFormat     = "admission.datadoghq.com/%s-lib.custom-image"
+	libVersionAnnotationKeyCtrFormat = "admission.datadoghq.com/%s.%s-lib.version"
+	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
+)
+
+func (l language) customLibAnnotationExtractor() annotationExtractor[libInfo] {
+	return annotationExtractor[libInfo]{
+		key: fmt.Sprintf(customLibAnnotationKeyFormat, l),
+		do: func(image string) (libInfo, error) {
+			return l.libInfo("", image), nil
+		},
+	}
+}
+
+func (l language) libVersionAnnotationExtractor(registry string) annotationExtractor[libInfo] {
+	return annotationExtractor[libInfo]{
+		key: fmt.Sprintf(libVersionAnnotationKeyFormat, l),
+		do: func(version string) (libInfo, error) {
+			return l.libInfo("", l.libImageName(registry, version)), nil
+		},
+	}
+}
+
+func (l language) ctrCustomLibAnnotationExtractor(ctr string) annotationExtractor[libInfo] {
+	return annotationExtractor[libInfo]{
+		key: fmt.Sprintf(customLibAnnotationKeyCtrFormat, ctr, l),
+		do: func(image string) (libInfo, error) {
+			return l.libInfo(ctr, image), nil
+		},
+	}
+}
+
+func (l language) ctrLibVersionAnnotationExtractor(ctr, registry string) annotationExtractor[libInfo] {
+	return annotationExtractor[libInfo]{
+		key: fmt.Sprintf(libVersionAnnotationKeyCtrFormat, ctr, l),
+		do: func(version string) (libInfo, error) {
+			return l.libInfo(ctr, l.libImageName(registry, version)), nil
+		},
+	}
+}
+
+func (l language) libConfigAnnotationExtractor() annotationExtractor[common.LibConfig] {
+	return annotationExtractor[common.LibConfig]{
+		key: fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, l),
+		do:  parseConfigJSON,
+	}
+}
+
+// supportedLanguages defines a list of the languages that we will attempt
+// to do injection on.
+var supportedLanguages = []language{
+	java,
+	js,
+	python,
+	dotnet,
+	ruby,
+}
+
+func (l language) isSupported() bool {
+	return slices.Contains(supportedLanguages, l)
+}
+
+// languageVersions defines the major library versions we consider "default" for each
+// supported language. If not set, we will default to "latest", see defaultLibVersion.
+//
+// If this language does not appear in supportedLanguages, it will not be injected.
+var languageVersions = map[language]string{
+	java:   "v1", // https://datadoghq.atlassian.net/browse/APMON-1064
+	dotnet: "v2", // https://datadoghq.atlassian.net/browse/APMON-1067
+	python: "v2", // https://datadoghq.atlassian.net/browse/APMON-1068
+	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
+	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
+	php:    "v2", // https://datadoghq.atlassian.net/browse/APMON-1128
+}
+
+func (l language) defaultLibVersion() string {
+	langVersion, ok := languageVersions[l]
+	if !ok {
+		return "latest"
+	}
+	return langVersion
+}
+
+type libInfo struct {
+	ctrName string // empty means all containers
+	lang    language
+	image   string
+}
+
+func (i libInfo) podMutator(ics []containerMutator, ms []podMutator) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		reqs, ok := i.libRequirement()
+		if !ok {
+			return fmt.Errorf(
+				"language %q is not supported. Supported languages are %v",
+				i.lang, supportedLanguages,
+			)
+		}
+
+		// set the initContainerMutators on the requirements
+		reqs.initContainerMutators = ics
+
+		if err := reqs.injectPod(pod, i.ctrName); err != nil {
+			return err
+		}
+
+		for _, m := range ms {
+			if err := m.mutatePod(pod); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+var sourceVolume = volume{
+	Volume: corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
+}
+
+var v1VolumeMount = sourceVolume.mount(
+	corev1.VolumeMount{MountPath: mountPath},
+	false,
+)
+
+// initContainers is which initContainers we are injecting
+// into the pod that runs for this language.
+func (i libInfo) initContainers() []initContainer {
+	return []initContainer{
+		{
+			Container: corev1.Container{
+				Name:    initContainerName(i.lang),
+				Image:   i.image,
+				Command: []string{"sh", "copy-lib.sh", mountPath},
+				VolumeMounts: []corev1.VolumeMount{
+					v1VolumeMount.VolumeMount,
+				},
+			},
+		},
+	}
+}
+
+func (i libInfo) volumeMount() volumeMount {
+	return v1VolumeMount
+}
+
+func (i libInfo) envVars() []envVar {
+	switch i.lang {
+	case java:
+		return []envVar{
+			{
+				key:     javaToolOptionsKey,
+				valFunc: javaEnvValFunc,
+			},
+		}
+	case js:
+		return []envVar{
+			{
+				key:     nodeOptionsKey,
+				valFunc: jsEnvValFunc,
+			},
+		}
+	case python:
+		return []envVar{
+			{
+				key:     pythonPathKey,
+				valFunc: pythonEnvValFunc,
+			},
+		}
+	case dotnet:
+		return []envVar{
+			{
+				key:     dotnetClrEnableProfilingKey,
+				valFunc: identityValFunc(dotnetClrEnableProfilingValue),
+			},
+			{
+				key:     dotnetClrProfilerIDKey,
+				valFunc: identityValFunc(dotnetClrProfilerIDValue),
+			},
+			{
+				key:     dotnetClrProfilerPathKey,
+				valFunc: identityValFunc(dotnetClrProfilerPathValue),
+			},
+			{
+				key:     dotnetTracerHomeKey,
+				valFunc: identityValFunc(dotnetTracerHomeValue),
+			},
+			{
+				key:     dotnetTracerLogDirectoryKey,
+				valFunc: identityValFunc(dotnetTracerLogDirectoryValue),
+			},
+			{
+				key:     dotnetProfilingLdPreloadKey,
+				valFunc: dotnetProfilingLdPreloadEnvValFunc,
+				isEligibleToInject: func(_ *corev1.Container) bool {
+					// N.B. Always disabled for now until we have a better mechanism to inject
+					//      this safely.
+					return false
+				},
+			},
+		}
+	case ruby:
+		return []envVar{
+			{
+				key:     rubyOptKey,
+				valFunc: rubyEnvValFunc,
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func (i libInfo) libRequirement() (libRequirement, bool) {
+	if !i.lang.isSupported() {
+		return libRequirement{}, false
+	}
+
+	return libRequirement{
+		envVars:        i.envVars(),
+		initContainers: i.initContainers(),
+		volumeMounts:   []volumeMount{i.volumeMount()},
+		volumes:        []volume{sourceVolume},
+	}, true
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+// basicConfig returns the default tracing config to inject into application pods
+// when no other config has been provided.
+func basicConfig() common.LibConfig {
+	return common.LibConfig{
+		Tracing:        pointer.Ptr(true),
+		LogInjection:   pointer.Ptr(true),
+		HealthMetrics:  pointer.Ptr(true),
+		RuntimeMetrics: pointer.Ptr(true),
+	}
+}
+
+type basicLibConfigInjector struct{}
+
+func (basicLibConfigInjector) mutatePod(pod *corev1.Pod) error {
+	libConfig := basicConfig()
+	if name, err := getServiceNameFromPod(pod); err == nil {
+		// Set service name if it can be derived from a pod
+		libConfig.ServiceName = &name
+	}
+	for _, env := range libConfig.ToEnvs() {
+		_ = mutatecommon.InjectEnv(pod, env)
+	}
+
+	return nil
+}
+
+type libConfigInjector struct{}
+
+func (l *libConfigInjector) podMutator(lang language) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		c, err := lang.libConfigAnnotationExtractor().extract(pod)
+		if err != nil {
+			if isErrAnnotationNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, env := range c.ToEnvs() {
+			_ = mutatecommon.InjectEnv(pod, env)
+		}
+
+		return nil
+	})
+}
+
+// injectLibConfig injects additional library configuration extracted from pod annotations
+func injectLibConfig(pod *corev1.Pod, lang language) error {
+	return (&libConfigInjector{}).podMutator(lang).mutatePod(pod)
+}
+
+func parseConfigJSON(in string) (common.LibConfig, error) {
+	var c common.LibConfig
+	return c, json.Unmarshal([]byte(in), &c)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type libRequirement struct {
+	envVars               []envVar
+	volumeMounts          []volumeMount
+	initContainers        []initContainer
+	volumes               []volume
+	initContainerMutators []containerMutator
+}
+
+func (reqs libRequirement) injectPod(pod *corev1.Pod, ctrName string) error {
+	for i, ctr := range pod.Spec.Containers {
+		if ctrName != "" && ctrName != ctr.Name {
+			continue
+		}
+
+		for _, v := range reqs.envVars {
+			if err := v.mutateContainer(&ctr); err != nil {
+				return err
+			}
+		}
+
+		for _, v := range reqs.volumeMounts {
+			if err := v.mutateContainer(&ctr); err != nil {
+				return err
+			}
+		}
+
+		pod.Spec.Containers[i] = ctr
+	}
+
+	for _, i := range reqs.initContainers {
+		mutator := i
+		mutator.Mutators = reqs.initContainerMutators
+		if err := mutator.mutatePod(pod); err != nil {
+			return err
+		}
+	}
+
+	for _, v := range reqs.volumes {
+		if err := v.mutatePod(pod); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// containerMutator describes something that can mutate a container.
+type containerMutator interface {
+	mutateContainer(*corev1.Container) error
+}
+
+// podMutator describes something that can mutate a pod.
+type podMutator interface {
+	mutatePod(*corev1.Pod) error
+}
+
+// podMutatorFunc is a podMutator as a function.
+type podMutatorFunc func(*corev1.Pod) error
+
+// mutatePod implements podMutator.
+func (f podMutatorFunc) mutatePod(pod *corev1.Pod) error {
+	return f(pod)
+}
+
+// initContainer is a podMutator which adds the container to a pod as an
+// init container. It will only add the container one time based on the
+// container name.
+//
+// This has the option to both append and prepend the container to the list.
+type initContainer struct {
+	corev1.Container
+	Prepend  bool
+	Mutators []containerMutator
+}
+
+var _ podMutator = (*initContainer)(nil)
+
+// mutatePod implements podMutator for initContainer.
+func (i initContainer) mutatePod(pod *corev1.Pod) error {
+	container := i.Container
+	for _, m := range i.Mutators {
+		if err := m.mutateContainer(&container); err != nil {
+			return err
+		}
+	}
+
+	for idx, c := range pod.Spec.InitContainers {
+		if c.Name == container.Name {
+			pod.Spec.InitContainers[idx] = container
+			return nil
+		}
+	}
+
+	pod.Spec.InitContainers = appendOrPrepend(container, pod.Spec.InitContainers, i.Prepend)
+	return nil
+}
+
+// volume is a podMutator which adds the volume to a pod.
+//
+// It will only add the volume one time based on the volume name.
+type volume struct {
+	corev1.Volume
+	Prepend bool
+}
+
+var _ podMutator = (*volume)(nil)
+
+func (v volume) mount(mount corev1.VolumeMount, prepend bool) volumeMount {
+	mount.Name = v.Name
+	return volumeMount{
+		VolumeMount: mount,
+		Prepend:     prepend,
+	}
+}
+
+// mutatePod implements podMutator for volume.
+func (v volume) mutatePod(pod *corev1.Pod) error {
+	vol := v.Volume
+	for idx, i := range pod.Spec.Volumes {
+		if i.Name == v.Volume.Name {
+			pod.Spec.Volumes[idx] = vol
+			return nil
+		}
+	}
+
+	pod.Spec.Volumes = appendOrPrepend(vol, pod.Spec.Volumes, v.Prepend)
+	return nil
+}
+
+// volumeMount is a containerMutator which adds a volume mount to a container.
+//
+// It will only add the volumeMount one time based on Name and MountPath.
+type volumeMount struct {
+	corev1.VolumeMount
+	Prepend bool
+}
+
+var _ containerMutator = (*volumeMount)(nil)
+
+// mutateContainer implements containerMutator for volumeMount.
+func (v volumeMount) mutateContainer(c *corev1.Container) error {
+	mnt := v.VolumeMount
+	for idx, vol := range c.VolumeMounts {
+		if vol.Name == mnt.Name && vol.MountPath == mnt.MountPath {
+			c.VolumeMounts[idx] = mnt
+			return nil
+		}
+	}
+
+	c.VolumeMounts = appendOrPrepend(mnt, c.VolumeMounts, v.Prepend)
+	return nil
+}
+
+func appendOrPrepend[T any](item T, toList []T, prepend bool) []T {
+	if prepend {
+		return append([]T{item}, toList...)
+	}
+
+	return append(toList, item)
+}
+
+type configKeyEnvVarMutator struct {
+	configKey string
+	envKey    string
+	getVal    func(string) string
+}
+
+func (c configKeyEnvVarMutator) mutatePod(pod *corev1.Pod) error {
+	if config.Datadog().IsSet(c.configKey) {
+		_ = common.InjectEnv(pod, corev1.EnvVar{Name: c.envKey, Value: c.getVal(c.configKey)})
+	}
+
+	return nil
+}
+
+type containerSecurityContext struct {
+	*corev1.SecurityContext
+}
+
+func (r containerSecurityContext) mutateContainer(c *corev1.Container) error {
+	c.SecurityContext = r.SecurityContext
+	return nil
+}
+
+type containerResourceRequirements struct {
+	corev1.ResourceRequirements
+}
+
+func (r containerResourceRequirements) mutateContainer(c *corev1.Container) error {
+	c.Resources = r.ResourceRequirements
+	return nil
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVolumeMount(t *testing.T) {
+	mount := volumeMount{
+		VolumeMount: corev1.VolumeMount{
+			Name:      "volume",
+			MountPath: "/banana",
+		},
+	}
+
+	t.Run("initial volume mount", func(t *testing.T) {
+		c := corev1.Container{}
+		require.NoError(t, mount.mutateContainer(&c))
+		require.Equal(t, []corev1.VolumeMount{mount.VolumeMount}, c.VolumeMounts, "attach a volume mount")
+
+		require.NoError(t, mount.mutateContainer(&c))
+		require.Equal(t, []corev1.VolumeMount{mount.VolumeMount}, c.VolumeMounts, "we don't re-attach it")
+	})
+
+	t.Run("we can prepend a volume mount", func(t *testing.T) {
+		m2 := mount
+		m2.Prepend = true
+
+		c := corev1.Container{
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name: "banana",
+				},
+			},
+		}
+
+		require.NoError(t, m2.mutateContainer(&c))
+		require.Equal(t, []corev1.VolumeMount{
+			m2.VolumeMount,
+			{Name: "banana"},
+		}, c.VolumeMounts, "attach a volume mount")
+
+	})
+}
+
+func TestInitContainer(t *testing.T) {
+	resources, err := initResources()
+	require.NoError(t, err)
+
+	c := initContainer{
+		Container: corev1.Container{
+			Name: "foo",
+		},
+		Mutators: []containerMutator{
+			containerResourceRequirements{resources},
+			containerSecurityContext{&corev1.SecurityContext{
+				Privileged: pointer.Ptr(true),
+			}},
+		},
+	}
+
+	pod := common.FakePod("pod")
+	require.NoError(t, c.mutatePod(pod))
+	require.Equal(t, []corev1.Container{
+		{
+			Name:      "foo",
+			Resources: resources,
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: pointer.Ptr(true),
+			},
+		},
+	}, pod.Spec.InitContainers)
+}

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -64,18 +64,6 @@ func contains(envs []corev1.EnvVar, name string) bool {
 	return false
 }
 
-// EnvIndex returns the index of env var in an env var list
-// returns -1 if not found
-func EnvIndex(envs []corev1.EnvVar, name string) int {
-	for i := range envs {
-		if envs[i].Name == name {
-			return i
-		}
-	}
-
-	return -1
-}
-
 // InjectEnv injects an env var into a pod template if it doesn't exist
 func InjectEnv(pod *corev1.Pod, env corev1.EnvVar) bool {
 	injected := false

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -121,11 +121,33 @@ func FakePodWithAnnotation(k, v string) *corev1.Pod {
 	return withContainer(pod, "-container")
 }
 
-// FakePodWithParent returns a pod with the given parent kind and name
-func FakePodWithParent(ns string, as, ls map[string]string, es []corev1.EnvVar, parentKind, parentName string) *corev1.Pod {
+// FakePodSpec describes a pod we are going to create.
+type FakePodSpec struct {
+	NS          string
+	Name        string
+	Labels      map[string]string
+	Annotations map[string]string
+	Envs        []corev1.EnvVar
+	ParentKind  string
+	ParentName  string
+}
+
+// Create makes a Pod from a FakePodSpec setting up sane defaults.
+func (f FakePodSpec) Create() *corev1.Pod {
+	if f.NS == "" {
+		f.NS = "ns"
+	}
+	if f.Name == "" {
+		f.Name = "pod"
+	}
+	return fakePodWithParent(f.NS, f.Name, f.Annotations, f.Labels, f.Envs, f.ParentKind, f.ParentName)
+}
+
+// fakePodWithParent returns a pod with the given parent kind and name
+func fakePodWithParent(ns, name string, as, ls map[string]string, es []corev1.EnvVar, parentKind, parentName string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "pod",
+			Name:            name,
 			Namespace:       ns,
 			Annotations:     as,
 			Labels:          ls,


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/APMON-1267

This change moves around the webhook configuration so that it is easier to change _later_ on.

- Language data belongs with the language_versions.go file instead of in a function -- the functions are now methods on the language type.
- env vars are all in env_vars.go

Introducing the concepts:

1. annotationExtractors: declarative annotation extractors for pods we use these for extracting libInfo from the annotations, libConfig, etc.

2. mutators: podMutators and containerMutators... these are interfaces that are composable and reusable that we can leverage with implementations: volumeMount, volume, initContainer, etc.

3. libRequirements: each language can produce the requirements for each language to be injected.

### Additional Notes

There are some things in this PR that are not actual changes, but moved over from `auto_instrumentation.go` into their respective files.

### Motivation

This decouples the refactor of the webhook to make #27811 possible from the changes to implement auto-instrumentation-v2 itself. This gives us test coverage for the new package-internal types and components and we can see that all tests pass for autoinstrumentation -- functionally this is a no-op.


### Describe how to test/QA your changes

The mutators and extractors have high-level test coverage from the autoinstrumentation tests. Also adding tests for the mutator types and the annotationExtractors specifically.
