### PR TITLE
[kubernetes/apiserver/events] Filter events per integration

### DIFF
--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -25,25 +25,31 @@ instances:
     # bundle_unspecified_events: true
 
     ## @param collected_event_types - map of array of strings - optional
-    ## Specify which events to be collected by kind, source, and reasons.
+    ## Specify custom events to be collected by kind, source, and reasons.
     ## Either kind or source are required, reasons is optional. Only effective
     ## when unbundle_events is true.
     #
-    collected_event_types:
-      - kind: Pod
-        reasons:
-          - Failed
-          - BackOff
-          - Unhealthy
-          - FailedScheduling
-          - FailedMount
-          - FailedAttachVolume
-      - kind: Node
-        reasons:
-          - TerminatingEvictedPod
-          - NodeNotReady
-          - Rebooted
-          - HostPortConflict
+    # collected_event_types:
+    #  - kind: Pod
+    #    reasons:
+    #      - Failed
+    #      - BackOff
+    #      - Unhealthy
+    #      - FailedScheduling
+    #      - FailedMount
+    #      - FailedAttachVolume
+    #  - kind: Node
+    #    reasons:
+    #      - TerminatingEvictedPod
+    #      - NodeNotReady
+    #      - Rebooted
+    #      - HostPortConflict
+
+    ## @param filtering_enabled - boolean - optional - default: false
+    ## Enable filtering of events to only include supported events. This will cause only events that match the pre-defined allowed event
+    ## types to be sent to Datadog.
+    #
+    # filtering_enabled: true
 
     ## @param filtered_event_types - array of strings - optional
     ## Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
@@ -14,16 +14,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 )
 
-func newBundledTransformer(clusterName string, taggerInstance tagger.Component) eventTransformer {
+func newBundledTransformer(clusterName string, taggerInstance tagger.Component, collectedTypes []collectedEventType, filteringEnabled bool) eventTransformer {
 	return &bundledTransformer{
-		clusterName:    clusterName,
-		taggerInstance: taggerInstance,
+		clusterName:      clusterName,
+		taggerInstance:   taggerInstance,
+		collectedTypes:   collectedTypes,
+		filteringEnabled: filteringEnabled,
 	}
 }
 
 type bundledTransformer struct {
-	clusterName    string
-	taggerInstance tagger.Component
+	clusterName      string
+	taggerInstance   tagger.Component
+	collectedTypes   []collectedEventType
+	filteringEnabled bool
 }
 
 func (c *bundledTransformer) Transform(events []*v1.Event) ([]event.Event, []error) {
@@ -46,6 +50,12 @@ func (c *bundledTransformer) Transform(events []*v1.Event) ([]event.Event, []err
 			event.Reason,
 			getEventSource(event.ReportingController, event.Source.Component),
 		)
+
+		if c.filteringEnabled {
+			if !shouldCollect(event, c.collectedTypes) {
+				continue
+			}
+		}
 
 		id := buildBundleID(event)
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events.go
@@ -52,7 +52,7 @@ func (c *bundledTransformer) Transform(events []*v1.Event) ([]event.Event, []err
 		)
 
 		if c.filteringEnabled {
-			if !shouldCollect(event, c.collectedTypes) {
+			if !(shouldCollectByDefault(event) || shouldCollect(event, c.collectedTypes)) {
 				continue
 			}
 		}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 //go:build kubeapiserver
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/bundled_events_test.go
@@ -1,0 +1,305 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubernetesapiserver
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+)
+
+func TestBundledEventsTransform(t *testing.T) {
+	ts := metav1.Time{Time: time.Date(2024, 5, 29, 6, 0, 51, 0, time.Now().Location())}
+	incomingEvents := []*v1.Event{
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "wartortle-8fff95dbb-tsc7v",
+				UID:       "17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+			},
+			Type:    "Warning",
+			Reason:  "Failed",
+			Message: "All containers terminated",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "squirtle-8fff95dbb-tsc7v",
+				UID:       "43b7e0d3-9212-4355-a957-4ac15ce3a7f7",
+			},
+			Type:    "Normal",
+			Reason:  "Pulled",
+			Message: "Successfully pulled image \"pokemon/squirtle:latest\" in 1.263s (1.263s including waiting)",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "ReplicaSet",
+				Namespace: "default",
+				Name:      "blastoise-759fd559f7",
+				UID:       "b96b5c25-6282-4e6f-a2fb-010196a284d9",
+			},
+			Type:    "Normal",
+			Reason:  "Killing",
+			Message: "Stopping container blastoise",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp:      ts,
+			LastTimestamp:       ts,
+			Count:               1,
+			ReportingController: "disruption-budget-manager",
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "ReplicaSet",
+				Namespace: "default",
+				Name:      "blastoise-759fd559f7",
+				UID:       "b96b5c25-6282-4e6f-a2fb-010196a284d9",
+			},
+			Type:    "Normal",
+			Reason:  "SuccessfulDelete",
+			Message: "Deleted pod: blastoise-759fd559f7-5wtqr",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "PodDisruptionBudget",
+				Namespace: "default",
+				Name:      "otel-demo-opensearch-pdb",
+				UID:       "b63ccea1-89bd-403c-8a06-d189bb01deff",
+			},
+			Type:    "Warning",
+			Reason:  "CalculateExpectedPodCountFailed",
+			Message: "Failed to calculate the number of expected pods: found no controllers for pod \"otel-demo-opensearch-0\"",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+	}
+
+	taggerInstance := taggerimpl.SetupFakeTagger(t)
+
+	tests := []struct {
+		name             string
+		filteringEnabled bool
+		expected         []event.Event
+	}{
+		{
+			name:             "all events are bundled",
+			filteringEnabled: false,
+			expected: []event.Event{
+				{
+					Title: "Events from the Pod default/squirtle-8fff95dbb-tsc7v",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Pulled**: Successfully pulled image "pokemon/squirtle:latest" in 1.263s (1.263s including waiting)
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Tags: []string{
+						"kube_kind:Pod",
+						"kube_name:squirtle-8fff95dbb-tsc7v",
+						"kubernetes_kind:Pod",
+						"name:squirtle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"namespace:default",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:",
+						"pod_name:squirtle-8fff95dbb-tsc7v",
+					},
+					AlertType:      event.AlertTypeInfo,
+					AggregationKey: "kubernetes_apiserver:43b7e0d3-9212-4355-a957-4ac15ce3a7f7",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+					Host:           "test-host-test-cluster",
+				},
+				{
+					Title: "Events from the Pod default/wartortle-8fff95dbb-tsc7v",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Failed**: All containers terminated
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+				{
+					Title: "Events from the PodDisruptionBudget default/otel-demo-opensearch-pdb",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **CalculateExpectedPodCountFailed**: Failed to calculate the number of expected pods: found no controllers for pod "otel-demo-opensearch-0"
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Tags: []string{
+						"kube_kind:PodDisruptionBudget",
+						"kube_name:otel-demo-opensearch-pdb",
+						"kubernetes_kind:PodDisruptionBudget",
+						"name:otel-demo-opensearch-pdb",
+						"kube_namespace:default",
+						"namespace:default",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:b63ccea1-89bd-403c-8a06-d189bb01deff",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+				{
+					Title: "Events from the ReplicaSet default/blastoise-759fd559f7",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Killing**: Stopping container blastoise
+ 1 **SuccessfulDelete**: Deleted pod: blastoise-759fd559f7-5wtqr
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "",
+					Tags: []string{
+						"kube_kind:ReplicaSet",
+						"kube_name:blastoise-759fd559f7",
+						"kubernetes_kind:ReplicaSet",
+						"name:blastoise-759fd559f7",
+						"kube_namespace:default",
+						"namespace:default",
+						"kube_replica_set:blastoise-759fd559f7",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:disruption-budget-manager",
+					},
+					AlertType:      event.AlertTypeInfo,
+					AggregationKey: "kubernetes_apiserver:b96b5c25-6282-4e6f-a2fb-010196a284d9",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+		{
+			name:             "default filtering enabled",
+			filteringEnabled: true,
+			expected: []event.Event{
+				{
+					Title: "Events from the Pod default/wartortle-8fff95dbb-tsc7v",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Failed**: All containers terminated
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := newBundledTransformer("test-cluster", taggerInstance, []collectedEventType{}, tt.filteringEnabled)
+
+			events, errors := transformer.Transform(incomingEvents)
+
+			// Sort events by title for easier comparison
+			sort.Slice(events, func(i, j int) bool {
+				return events[i].Title < events[j].Title
+			})
+
+			assert.Empty(t, errors)
+			for i := range events {
+				assert.Equal(t, tt.expected[i].Ts, events[i].Ts)
+				assert.Equal(t, tt.expected[i].Title, events[i].Title)
+				assert.Equal(t, tt.expected[i].Text, events[i].Text)
+				assert.Equal(t, tt.expected[i].Priority, events[i].Priority)
+				assert.Equal(t, tt.expected[i].Host, events[i].Host)
+				assert.Equal(t, tt.expected[i].AlertType, events[i].AlertType)
+				assert.Equal(t, tt.expected[i].AggregationKey, events[i].AggregationKey)
+				assert.Equal(t, tt.expected[i].SourceTypeName, events[i].SourceTypeName)
+				assert.Equal(t, tt.expected[i].EventType, events[i].EventType)
+				assert.ElementsMatch(t, tt.expected[i].Tags, events[i].Tags)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -118,6 +118,109 @@ const defaultEventSource = "kubernetes"
 // kubernetesEventSource is the name of the source for kubernetes events
 const kubernetesEventSource = "kubernetes"
 
+var integrationToCollectedEventTypes = map[string][]collectedEventType{
+	"kubernetes": {
+		{
+			Kind:    "Pod",
+			Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+		},
+		{
+			Kind:    "Node",
+			Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+		},
+		{
+			Kind:    "CronJob",
+			Reasons: []string{"SawCompletedJob"},
+		},
+	},
+	"kube_scheduler": {
+		{
+			Kind:    "Pod",
+			Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+		},
+		{
+			Kind:    "Node",
+			Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+		},
+		{
+			Kind:    "CronJob",
+			Reasons: []string{"SawCompletedJob"},
+		},
+	},
+	"kubernetes controller manager": {
+		{
+			Kind:    "Pod",
+			Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+		},
+		{
+			Kind:    "Node",
+			Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+		},
+		{
+			Kind:    "CronJob",
+			Reasons: []string{"SawCompletedJob"},
+		},
+	},
+	"karpenter": {
+		{
+			Source: "karpenter",
+			Reasons: []string{
+				"DisruptionBlocked",
+				"DisruptionLaunching",
+				"DisruptionTerminating",
+				"DisruptionWaitingReadiness",
+				"FailedDraining",
+				"InstanceTerminating",
+				"SpotInterrupted",
+				"SpotRebalanceRecommendation",
+				"TerminatingOnInterruption",
+			},
+		},
+	},
+	"datadog-operator": {
+		{
+			Source: "datadog-operator",
+		},
+	},
+	"amazon elb": {
+		{
+			Source: "amazon elb",
+		},
+	},
+	"cilium": {
+		{
+			Source: "cilium",
+		},
+	},
+	"fluxcd": {
+		{
+			Source: "fluxcd",
+		},
+	},
+	"kubernetes cluster autoscaler": {
+		{
+
+			Source: "kubernetes cluster autoscaler",
+		},
+	},
+	"spark": {
+		{
+			Source: "spark",
+		},
+	},
+	"vault": {
+
+		{
+			Source: "vault",
+		},
+	},
+	"default": {
+		{
+			Reasons: []string{"BackOff"}, // Change tracking consumes all CLB events
+		},
+	},
+}
+
 // getDDAlertType converts kubernetes event types into datadog alert types
 func getDDAlertType(k8sType string) event.AlertType {
 	switch k8sType {
@@ -289,6 +392,13 @@ func getEventSource(controllerName string, sourceComponent string) string {
 		return v
 	}
 	return defaultEventSource
+}
+
+func shouldCollectByDefault(ev *v1.Event) bool {
+	if v, ok := integrationToCollectedEventTypes[getEventSource(ev.ReportingController, ev.Source.Component)]; ok {
+		return shouldCollect(ev, append(v, integrationToCollectedEventTypes["default"]...))
+	}
+	return shouldCollect(ev, integrationToCollectedEventTypes["default"])
 }
 
 func shouldCollect(ev *v1.Event, collectedTypes []collectedEventType) bool {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -290,3 +290,29 @@ func getEventSource(controllerName string, sourceComponent string) string {
 	}
 	return defaultEventSource
 }
+
+func shouldCollect(ev *v1.Event, collectedTypes []collectedEventType) bool {
+	involvedObject := ev.InvolvedObject
+
+	for _, f := range collectedTypes {
+		if f.Kind != "" && f.Kind != involvedObject.Kind {
+			continue
+		}
+
+		if f.Source != "" && f.Source != ev.Source.Component {
+			continue
+		}
+
+		if len(f.Reasons) == 0 {
+			return true
+		}
+
+		for _, r := range f.Reasons {
+			if ev.Reason == r {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -262,3 +262,176 @@ func Test_getEventSource(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldCollect(t *testing.T) {
+	tests := []struct {
+		name           string
+		ev             *v1.Event
+		collectedTypes []collectedEventType
+		shouldCollect  bool
+	}{
+		{
+			name: "kubernetes event collection matches based on kind",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Kind: "Pod",
+				},
+			},
+			shouldCollect: true,
+		},
+		{
+			name: "kubernetes event collection filters based on kind",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Kind: "Node",
+				},
+			},
+			shouldCollect: false,
+		},
+		{
+			name: "kubernetes event collection filters based on source",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Source: "kubernetes",
+				},
+			},
+			shouldCollect: false,
+		},
+		{
+			name: "kubernetes event collection matches based on reason",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+				Reason: "CrashLoopBackOff",
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Reasons: []string{"CrashLoopBackOff"},
+				},
+			},
+			shouldCollect: true,
+		},
+		{
+			name: "kubernetes event collection filters based on reason",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+				Reason: "CrashLoopBackOff",
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Reasons: []string{"Failed"},
+				},
+			},
+			shouldCollect: false,
+		},
+		{
+			name: "kubernetes event collection matches by kind and reason",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+				Reason: "CrashLoopBackOff",
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Kind:    "Pod",
+					Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+				},
+				{
+					Kind:    "Node",
+					Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+				},
+				{
+					Kind:    "CronJob",
+					Reasons: []string{"SawCompletedJob"},
+				},
+				{
+					Reasons: []string{"CrashLoopBackOff"},
+				},
+			},
+			shouldCollect: true,
+		},
+		{
+			name: "kubernetes event collection filters by kind and reason",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
+				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+					Host:      "my-node-1",
+				},
+				Reason: "CrashLoopBackOff",
+			},
+			collectedTypes: []collectedEventType{
+				{
+					Kind:    "Pod",
+					Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+				},
+				{
+					Kind:    "Node",
+					Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+				},
+				{
+					Kind:    "CronJob",
+					Reasons: []string{"SawCompletedJob"},
+				},
+			},
+			shouldCollect: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.shouldCollect, shouldCollect(tt.ev, tt.collectedTypes))
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -290,7 +290,7 @@ func Test_shouldCollect(t *testing.T) {
 			shouldCollect: true,
 		},
 		{
-			name: "kubernetes event collection filters based on kind",
+			name: "kubernetes event collection matches based on source",
 			ev: &v1.Event{
 				InvolvedObject: v1.ObjectReference{
 					Name: "my-pod-1",
@@ -303,29 +303,10 @@ func Test_shouldCollect(t *testing.T) {
 			},
 			collectedTypes: []collectedEventType{
 				{
-					Kind: "Node",
+					Source: "kubelet",
 				},
 			},
-			shouldCollect: false,
-		},
-		{
-			name: "kubernetes event collection filters based on source",
-			ev: &v1.Event{
-				InvolvedObject: v1.ObjectReference{
-					Name: "my-pod-1",
-					Kind: podKind,
-				},
-				Source: v1.EventSource{
-					Component: "kubelet",
-					Host:      "my-node-1",
-				},
-			},
-			collectedTypes: []collectedEventType{
-				{
-					Source: "kubernetes",
-				},
-			},
-			shouldCollect: false,
+			shouldCollect: true,
 		},
 		{
 			name: "kubernetes event collection matches based on reason",
@@ -346,26 +327,6 @@ func Test_shouldCollect(t *testing.T) {
 				},
 			},
 			shouldCollect: true,
-		},
-		{
-			name: "kubernetes event collection filters based on reason",
-			ev: &v1.Event{
-				InvolvedObject: v1.ObjectReference{
-					Name: "my-pod-1",
-					Kind: podKind,
-				},
-				Source: v1.EventSource{
-					Component: "kubelet",
-					Host:      "my-node-1",
-				},
-				Reason: "CrashLoopBackOff",
-			},
-			collectedTypes: []collectedEventType{
-				{
-					Reasons: []string{"Failed"},
-				},
-			},
-			shouldCollect: false,
 		},
 		{
 			name: "kubernetes event collection matches by kind and reason",
@@ -400,7 +361,7 @@ func Test_shouldCollect(t *testing.T) {
 			shouldCollect: true,
 		},
 		{
-			name: "kubernetes event collection filters by kind and reason",
+			name: "kubernetes event collection matches by source and reason",
 			ev: &v1.Event{
 				InvolvedObject: v1.ObjectReference{
 					Name: "my-pod-1",
@@ -414,16 +375,28 @@ func Test_shouldCollect(t *testing.T) {
 			},
 			collectedTypes: []collectedEventType{
 				{
-					Kind:    "Pod",
-					Reasons: []string{"Failed", "BackOff", "Unhealthy", "FailedScheduling", "FailedMount", "FailedAttachVolume"},
+					Source:  "kubelet",
+					Reasons: []string{"CrashLoopBackOff"},
 				},
-				{
-					Kind:    "Node",
-					Reasons: []string{"TerminatingEvictedPod", "NodeNotReady", "Rebooted", "HostPortConflict"},
+			},
+			shouldCollect: true,
+		},
+		{
+			name: "kubernetes event collection matches none",
+			ev: &v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: "my-pod-1",
+					Kind: podKind,
 				},
+				Source: v1.EventSource{
+					Component: "kubelet",
+				},
+				Reason: "something",
+			},
+			collectedTypes: []collectedEventType{
 				{
-					Kind:    "CronJob",
-					Reasons: []string{"SawCompletedJob"},
+					Source:  "kubelet",
+					Reasons: []string{"CrashLoopBackOff"},
 				},
 			},
 			shouldCollect: false,

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -228,9 +228,6 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 	hostnameDetected, _ := hostname.Get(context.TODO())
 	clusterName := clustername.GetRFC1123CompliantClusterName(context.TODO(), hostnameDetected)
 
-	// TODO: prior to appending events to k.instance.CollectedEventTypes, we need a way to identify
-	// events in the config as added by the user (i.e. user should be billed for collection)
-
 	// Automatically add events based on activated Datadog products
 	if ddConfig.Datadog().GetBool("autoscaling.workload.enabled") {
 		k.instance.CollectedEventTypes = append(k.instance.CollectedEventTypes, collectedEventType{
@@ -238,6 +235,8 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 		})
 	}
 
+	// TODO: prior to appending events to k.instance.CollectedEventTypes, we need a way to distinguish between
+	// default allowed events and events added by the user
 	if k.instance.FilteringEnabled {
 		k.instance.CollectedEventTypes = append(k.instance.CollectedEventTypes, integrationCollectedEventTypes...)
 	}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -139,7 +139,17 @@ var integrationCollectedEventTypes = []collectedEventType{
 	// Integrations
 	{
 		Source: "karpenter",
-		// Reasons: []string{},
+		Reasons: []string{
+			"DisruptionBlocked",
+			"DisruptionLaunching",
+			"DisruptionTerminating",
+			"DisruptionWaitingReadiness",
+			"FailedDraining",
+			"InstanceTerminating",
+			"SpotInterrupted",
+			"SpotRebalanceRecommendation",
+			"TerminatingOnInterruption",
+		},
 	},
 	{
 		Source: "datadog-operator",

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -32,7 +32,7 @@ func newUnbundledTransformer(clusterName string, taggerInstance tagger.Component
 
 	var t eventTransformer = noopEventTransformer{}
 	if bundleUnspecifiedEvents {
-		t = newBundledTransformer(clusterName, taggerInstance)
+		t = newBundledTransformer(clusterName, taggerInstance, collectedTypes, false)
 	}
 
 	return &unbundledTransformer{
@@ -166,27 +166,5 @@ func (c *unbundledTransformer) getTagsFromTagger(obj v1.ObjectReference, tagsAcc
 }
 
 func (c *unbundledTransformer) shouldCollect(ev *v1.Event) bool {
-	involvedObject := ev.InvolvedObject
-
-	for _, f := range c.collectedTypes {
-		if f.Kind != "" && f.Kind != involvedObject.Kind {
-			continue
-		}
-
-		if f.Source != "" && f.Source != ev.Source.Component {
-			continue
-		}
-
-		if len(f.Reasons) == 0 {
-			return true
-		}
-
-		for _, r := range f.Reasons {
-			if ev.Reason == r {
-				return true
-			}
-		}
-	}
-
-	return false
+	return shouldCollect(ev, c.collectedTypes)
 }

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -438,7 +438,286 @@ func TestUnbundledEventsTransform(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transformer := newUnbundledTransformer("test-cluster", taggerInstance, tt.collectedEventTypes, tt.bundleUnspecifiedEvents)
+			transformer := newUnbundledTransformer("test-cluster", taggerInstance, tt.collectedEventTypes, tt.bundleUnspecifiedEvents, false)
+
+			events, errors := transformer.Transform(incomingEvents)
+
+			// Sort events by title for easier comparison
+			sort.Slice(events, func(i, j int) bool {
+				return events[i].Title < events[j].Title
+			})
+
+			assert.Empty(t, errors)
+			for i := range events {
+				assert.Equal(t, tt.expected[i].Ts, events[i].Ts)
+				assert.Equal(t, tt.expected[i].Title, events[i].Title)
+				assert.Equal(t, tt.expected[i].Text, events[i].Text)
+				assert.Equal(t, tt.expected[i].Priority, events[i].Priority)
+				assert.Equal(t, tt.expected[i].Host, events[i].Host)
+				assert.Equal(t, tt.expected[i].AlertType, events[i].AlertType)
+				assert.Equal(t, tt.expected[i].AggregationKey, events[i].AggregationKey)
+				assert.Equal(t, tt.expected[i].SourceTypeName, events[i].SourceTypeName)
+				assert.Equal(t, tt.expected[i].EventType, events[i].EventType)
+				assert.ElementsMatch(t, tt.expected[i].Tags, events[i].Tags)
+			}
+		})
+	}
+}
+
+func TestUnbundledEventsTransformFiltering(t *testing.T) {
+	ts := metav1.Time{Time: time.Date(2024, 5, 29, 6, 0, 51, 0, time.Now().Location())}
+
+	incomingEvents := []*v1.Event{
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "wartortle-8fff95dbb-tsc7v",
+				UID:       "17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+			},
+			Type:    "Warning",
+			Reason:  "Failed",
+			Message: "All containers terminated",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "squirtle-8fff95dbb-tsc7v",
+				UID:       "43b7e0d3-9212-4355-a957-4ac15ce3a7f7",
+			},
+			Type:    "Normal",
+			Reason:  "Pulled",
+			Message: "Successfully pulled image \"pokemon/squirtle:latest\" in 1.263s (1.263s including waiting)",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "ReplicaSet",
+				Namespace: "default",
+				Name:      "blastoise-759fd559f7",
+				UID:       "b96b5c25-6282-4e6f-a2fb-010196a284d9",
+			},
+			Type:    "Normal",
+			Reason:  "Killing",
+			Message: "Stopping container blastoise",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp:      ts,
+			LastTimestamp:       ts,
+			Count:               1,
+			ReportingController: "disruption-budget-manager",
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "ReplicaSet",
+				Namespace: "default",
+				Name:      "blastoise-759fd559f7",
+				UID:       "b96b5c25-6282-4e6f-a2fb-010196a284d9",
+			},
+			Type:    "Normal",
+			Reason:  "SuccessfulDelete",
+			Message: "Deleted pod: blastoise-759fd559f7-5wtqr",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+		{
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "PodDisruptionBudget",
+				Namespace: "default",
+				Name:      "otel-demo-opensearch-pdb",
+				UID:       "b63ccea1-89bd-403c-8a06-d189bb01deff",
+			},
+			Type:    "Warning",
+			Reason:  "CalculateExpectedPodCountFailed",
+			Message: "Failed to calculate the number of expected pods: found no controllers for pod \"otel-demo-opensearch-0\"",
+			Source: v1.EventSource{
+				Component: "kubelet",
+				Host:      "test-host",
+			},
+			FirstTimestamp: ts,
+			LastTimestamp:  ts,
+			Count:          1,
+		},
+	}
+
+	taggerInstance := taggerimpl.SetupFakeTagger(t)
+
+	tests := []struct {
+		name                   string
+		bundleUnspecifedEvents bool
+		filteringEnabled       bool
+		expected               []event.Event
+	}{
+		{
+			name:                   "default filtering enabled, bundle unspecified events disabled",
+			bundleUnspecifedEvents: false,
+			filteringEnabled:       true,
+			expected: []event.Event{
+				{
+					Title:    "Pod default/wartortle-8fff95dbb-tsc7v: Failed",
+					Text:     "All containers terminated",
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"event_reason:Failed",
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+		{
+			name:                   "default filtering and bundle unspecified events enabled",
+			bundleUnspecifedEvents: true,
+			filteringEnabled:       true,
+			expected: []event.Event{
+				{
+					Title: "Events from the Pod default/squirtle-8fff95dbb-tsc7v",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Pulled**: Successfully pulled image "pokemon/squirtle:latest" in 1.263s (1.263s including waiting)
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Tags: []string{
+						"kube_kind:Pod",
+						"kube_name:squirtle-8fff95dbb-tsc7v",
+						"kubernetes_kind:Pod",
+						"name:squirtle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"namespace:default",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:",
+						"pod_name:squirtle-8fff95dbb-tsc7v",
+					},
+					AlertType:      event.AlertTypeInfo,
+					AggregationKey: "kubernetes_apiserver:43b7e0d3-9212-4355-a957-4ac15ce3a7f7",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+					Host:           "test-host-test-cluster",
+				},
+				{
+					Title: "Events from the PodDisruptionBudget default/otel-demo-opensearch-pdb",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **CalculateExpectedPodCountFailed**: Failed to calculate the number of expected pods: found no controllers for pod "otel-demo-opensearch-0"
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Tags: []string{
+						"kube_kind:PodDisruptionBudget",
+						"kube_name:otel-demo-opensearch-pdb",
+						"kubernetes_kind:PodDisruptionBudget",
+						"name:otel-demo-opensearch-pdb",
+						"kube_namespace:default",
+						"namespace:default",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:b63ccea1-89bd-403c-8a06-d189bb01deff",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+				{
+					Title: "Events from the ReplicaSet default/blastoise-759fd559f7",
+					Text: fmt.Sprintf(`%%%%%%%[1]s
+1 **Killing**: Stopping container blastoise
+ 1 **SuccessfulDelete**: Deleted pod: blastoise-759fd559f7-5wtqr
+%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+
+ %%%%%%`, " ", ts.String()),
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "",
+					Tags: []string{
+						"kube_kind:ReplicaSet",
+						"kube_name:blastoise-759fd559f7",
+						"kubernetes_kind:ReplicaSet",
+						"name:blastoise-759fd559f7",
+						"kube_namespace:default",
+						"namespace:default",
+						"kube_replica_set:blastoise-759fd559f7",
+						"orchestrator:kubernetes",
+						"source_component:kubelet",
+						"reporting_controller:disruption-budget-manager",
+					},
+					AlertType:      event.AlertTypeInfo,
+					AggregationKey: "kubernetes_apiserver:b96b5c25-6282-4e6f-a2fb-010196a284d9",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+				{
+					Title:    "Pod default/wartortle-8fff95dbb-tsc7v: Failed",
+					Text:     "All containers terminated",
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"event_reason:Failed",
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := newUnbundledTransformer("test-cluster", taggerInstance, []collectedEventType{}, tt.bundleUnspecifedEvents, tt.filteringEnabled)
 
 			events, errors := transformer.Transform(incomingEvents)
 
@@ -501,7 +780,7 @@ func TestGetTagsFromTagger(t *testing.T) {
 			collectedTypes := []collectedEventType{
 				{Kind: "Pod", Reasons: []string{}},
 			}
-			transformer := newUnbundledTransformer("test-cluster", taggerInstance, collectedTypes, false)
+			transformer := newUnbundledTransformer("test-cluster", taggerInstance, collectedTypes, false, false)
 			accumulator := tagset.NewHashlessTagsAccumulator()
 			transformer.(*unbundledTransformer).getTagsFromTagger(tt.obj, accumulator)
 			assert.Equal(t, tt.expectedTags, accumulator)
@@ -583,7 +862,7 @@ func TestUnbundledEventsShouldCollect(t *testing.T) {
 				},
 			}
 
-			transformer := newUnbundledTransformer("test-cluster", taggerInstance, collectedTypes, false)
+			transformer := newUnbundledTransformer("test-cluster", taggerInstance, collectedTypes, false, false)
 			got := transformer.(*unbundledTransformer).shouldCollect(tt.event)
 			assert.Equal(t, tt.expected, got)
 		})

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1521,7 +1521,6 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubelet_core_check_enabled", true)
 	config.BindEnvAndSetDefault("collect_kubernetes_events", false)
 	config.BindEnvAndSetDefault("kubernetes_events_source_detection.enabled", false)
-	config.BindEnvAndSetDefault("kubernetes_events_filtering.enabled", false)
 	config.BindEnvAndSetDefault("kubelet_client_ca", "")
 
 	config.BindEnvAndSetDefault("kubelet_auth_token_path", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1521,6 +1521,7 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubelet_core_check_enabled", true)
 	config.BindEnvAndSetDefault("collect_kubernetes_events", false)
 	config.BindEnvAndSetDefault("kubernetes_events_source_detection.enabled", false)
+	config.BindEnvAndSetDefault("kubernetes_events_filtering.enabled", false)
 	config.BindEnvAndSetDefault("kubelet_client_ca", "")
 
 	config.BindEnvAndSetDefault("kubelet_auth_token_path", "")

--- a/releasenotes/notes/implement-static-event-allow-list-6414077102a8f01f.yaml
+++ b/releasenotes/notes/implement-static-event-allow-list-6414077102a8f01f.yaml
@@ -8,6 +8,6 @@
 ---
 features:
   - |
-    Implement static allow list of kubernetes events to send by default.
+    Implement static allowlist of Kubernetes events to send by default.
     This feature is only enabled when ``filtering_enabled`` is set to
     ``true`` in the ``kubernetes_apiserver`` integration configuration.

--- a/releasenotes/notes/implement-static-event-allow-list-6414077102a8f01f.yaml
+++ b/releasenotes/notes/implement-static-event-allow-list-6414077102a8f01f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Implement static allow list of kubernetes events to send by default.
+    This feature is only enabled when ``filtering_enabled`` is set to
+    ``true`` in the ``kubernetes_apiserver`` integration configuration.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Implement filtering of events for different integrations. When enabled, only events specified in the static list will be visible.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We added the ability to set the source of kubernetes events to different integration names in  https://github.com/DataDog/datadog-agent/pull/26975. To avoid filtering out all of these events by default, a static allow list of kubernetes events (by source/kind/reason) is defined. The event types previously listed as `collected_event_types` by default are now included in this static list; `collected_event_types` can still be set by the user to change the events that are collected.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
<!--
* What are the possible side-effects or negative impacts of the code change?
-->
There is currently duplication between `collected_event_types` [defined by default in helm](https://github.com/DataDog/helm-charts/blob/e1ec85127de74c8b876eef6a81bb1579d17b49bf/charts/datadog/values.yaml#L375-L396) and the static allow list introduced in this PR. This will need to be removed to avoid unnecessary iterations over the collected events. We will also need a way to differentiate between events included via this static list and events included in `collected_event_types`.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Deploy the agent and cluster agent with the following configuration for the kube apiserver check
```
...
clusterAgent:
  ...
  confd:
    kubernetes_apiserver.yaml: |
      init_config:
      instances:
      - filtering_enabled: true
```
2. Check that only events with reasons specified in the static list are visible in the event management platform (e.g. `Failed`), and events that are not specified are filtered out by default (e.g. `Scheduled`)