### PR TITLE
wait for tags to be populated

### DIFF
--- a/test/new-e2e/tests/cws/windows_test.go
+++ b/test/new-e2e/tests/cws/windows_test.go
@@ -96,6 +96,7 @@ func (a *agentSuiteWindows) Test01RulesetLoadedDefaultRC() {
 }
 
 func (a *agentSuiteWindows) Test02Selftests() {
+	time.Sleep(time.Minute)
 	assert.EventuallyWithT(a.T(), func(c *assert.CollectT) {
 		testSelftestsEvent(c, a, func(event *api.SelftestsEvent) {
 			assert.Contains(c, event.SucceededTests, "datadog_agent_cws_self_test_rule_windows_create_file", "missing selftest result")
@@ -161,6 +162,9 @@ func (a *agentSuiteWindows) Test03CreateFileSignal() {
 		}
 		assert.Contains(c, output, securityStartLog, "security-agent could not start")
 	}, 30*time.Second, 1*time.Second)
+
+	// Wait for host tags
+	time.Sleep(3 * time.Minute)
 
 	// Download policies
 	apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR aims to fix the windows e2e tests by adding a wait so that the hosts can be populated. It should considerably reduce the failure rate. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
