### PR TITLE
[NDM] Add BGP neigbors query method to the Cisco SD-WAN client

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
@@ -345,6 +345,20 @@ func (client *Client) GetCloudExpressMetrics() ([]CloudXStatistics, error) {
 	return cloudApplications.Data, nil
 }
 
+// GetBGPNeighbors gets BGP neighbors
+func (client *Client) GetBGPNeighbors() ([]BGPNeighbor, error) {
+	params := map[string]string{
+		"count": client.maxCount,
+	}
+
+	bgpNeighbors, err := getAllEntries[BGPNeighbor](client, "/dataservice/data/device/state/BGPNeighbor", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return bgpNeighbors.Data, nil
+}
+
 func (client *Client) statisticsTimeRange() (string, string) {
 	endDate := timeNow().UTC()
 	startDate := endDate.Add(-client.lookback)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
@@ -436,3 +436,26 @@ const GetCloudExpressMetrics = `
 	}
 ]
 `
+
+// GetBGPNeighbors /dataservice/data/device/state/BGPNeighbor
+const GetBGPNeighbors = `
+[
+	{
+		"recordId": "0:BGPNeighborNode:1000:500",
+		"vdevice-name": "10.10.1.11",
+		"afi": "ipv4-unicast",
+		"createTimeStamp": 1707919131595,
+		"last-uptime": "Thu Jul 25 13:48:17 2024",
+		"vpn-id": 1,
+		"vdevice-host-name": "DC-cEdge01",
+		"peer-addr": "10.60.1.1",
+		"as": 2024,
+		"vdevice-dataKey": "10.10.1.11-10.60.1.1",
+		"@rid": 100,
+		"vmanage-system-ip": "10.10.1.11",
+		"afi-id": 0,
+		"lastupdated": 1708940180703,
+		"state": "established"
+	}
+]
+`

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
@@ -108,6 +108,7 @@ func SetupMockAPIServer() *httptest.Server {
 	mux.HandleFunc("/dataservice/data/device/state/BFDSessions", fixtureHandler(fixtures.GetBFDSessionsState))
 	mux.HandleFunc("/dataservice/data/device/state/HardwareEnvironment", fixtureHandler(fixtures.GetHardwareStates))
 	mux.HandleFunc("/dataservice/data/device/statistics/cloudxstatistics", fixtureHandler(fixtures.GetCloudExpressMetrics))
+	mux.HandleFunc("/dataservice/data/device/state/BGPNeighbor", fixtureHandler(fixtures.GetBGPNeighbors))
 
 	return httptest.NewServer(mux)
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -60,7 +60,8 @@ type Content interface {
 		OMPPeer |
 		BFDSession |
 		HardwareEnvironment |
-		CloudXStatistics
+		CloudXStatistics |
+		BGPNeighbor
 }
 
 // Response is a generic struct for API responses
@@ -438,4 +439,22 @@ type CloudXStatistics struct {
 	VpnID            float64 `json:"vpn_id"`
 	AppURLHostIP     string  `json:"app_url_host_ip"`
 	ID               string  `json:"id"`
+}
+
+// BGPNeighbor /dataservice/data/device/state/BGPNeighbor
+type BGPNeighbor struct {
+	RecordID        string  `json:"recordId"`
+	VdeviceName     string  `json:"vdevice-name"`
+	Afi             string  `json:"afi"`
+	CreateTimeStamp float64 `json:"createTimeStamp"`
+	VpnID           float64 `json:"vpn-id"`
+	VdeviceHostName string  `json:"vdevice-host-name"`
+	PeerAddr        string  `json:"peer-addr"`
+	AS              float64 `json:"as"`
+	VdeviceDataKey  string  `json:"vdevice-dataKey"`
+	Rid             float64 `json:"@rid"`
+	VmanageSystemIP string  `json:"vmanage-system-ip"`
+	AfiID           float64 `json:"afi-id"`
+	Lastupdated     float64 `json:"lastupdated"`
+	State           string  `json:"state"`
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add ability to query BGP neighbors in the Cisco SD-WAN client

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
