### PR TITLE
Create function to access system probe config

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -248,8 +248,8 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port"), traceCpusec)
 	}
 
-	if pkgconfig.SystemProbe.GetBool("system_probe_config.enabled") {
-		probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+	if pkgconfig.SystemProbe().GetBool("system_probe_config.enabled") {
+		probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 
 		if !errors.Is(probeUtilErr, net.ErrNotImplemented) {
 			sysProbeGet := func() pprofGetter {

--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -44,8 +44,8 @@ var subservices = []Servicedef{
 			"process_config.process_collection.enabled":   config.Datadog(),
 			"process_config.container_collection.enabled": config.Datadog(),
 			"process_config.process_discovery.enabled":    config.Datadog(),
-			"network_config.enabled":                      config.SystemProbe,
-			"system_probe_config.enabled":                 config.SystemProbe,
+			"network_config.enabled":                      config.SystemProbe(),
+			"system_probe_config.enabled":                 config.SystemProbe(),
 		},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
@@ -53,10 +53,10 @@ var subservices = []Servicedef{
 	{
 		name: "sysprobe",
 		configKeys: map[string]config.Config{
-			"network_config.enabled":          config.SystemProbe,
-			"system_probe_config.enabled":     config.SystemProbe,
-			"windows_crash_detection.enabled": config.SystemProbe,
-			"runtime_security_config.enabled": config.SystemProbe,
+			"network_config.enabled":          config.SystemProbe(),
+			"system_probe_config.enabled":     config.SystemProbe(),
+			"windows_crash_detection.enabled": config.SystemProbe(),
+			"runtime_security_config.enabled": config.SystemProbe(),
 		},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,
@@ -64,7 +64,7 @@ var subservices = []Servicedef{
 	{
 		name: "cws",
 		configKeys: map[string]config.Config{
-			"runtime_security_config.enabled": config.SystemProbe,
+			"runtime_security_config.enabled": config.SystemProbe(),
 		},
 		serviceName: "datadog-security-agent",
 		serviceInit: securityInit,

--- a/cmd/system-probe/config/adjust_npm_test.go
+++ b/cmd/system-probe/config/adjust_npm_test.go
@@ -29,7 +29,7 @@ func TestAdjustConnectionRollup(t *testing.T) {
 	for _, te := range tests {
 		t.Run(fmt.Sprintf("npm_enabled_%t_usm_enabled_%t", te.npmEnabled, te.usmEnabled), func(t *testing.T) {
 			config.ResetSystemProbeConfig(t)
-			cfg := config.SystemProbe
+			cfg := config.SystemProbe()
 			cfg.Set(netNS("enable_connection_rollup"), te.npmEnabled, model.SourceUnknown)
 			cfg.Set(smNS("enable_connection_rollup"), te.usmEnabled, model.SourceUnknown)
 			Adjust(cfg)

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -51,22 +51,22 @@ func New(configPath string, fleetPoliciesDirPath string) (*types.Config, error) 
 }
 
 func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.Config, error) {
-	aconfig.SystemProbe.SetConfigName("system-probe")
+	aconfig.SystemProbe().SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {
 		// if the configuration file path was supplied on the command line,
 		// add that first, so it's first in line
-		aconfig.SystemProbe.AddConfigPath(configPath)
+		aconfig.SystemProbe().AddConfigPath(configPath)
 		// If they set a config file directly, let's try to honor that
 		if strings.HasSuffix(configPath, ".yaml") {
-			aconfig.SystemProbe.SetConfigFile(configPath)
+			aconfig.SystemProbe().SetConfigFile(configPath)
 		}
 	} else {
 		// only add default if a custom configPath was not supplied
-		aconfig.SystemProbe.AddConfigPath(defaultConfigDir)
+		aconfig.SystemProbe().AddConfigPath(defaultConfigDir)
 	}
 	// load the configuration
-	err := aconfig.LoadCustom(aconfig.SystemProbe, aconfig.Datadog().GetEnvVars())
+	err := aconfig.LoadCustom(aconfig.SystemProbe(), aconfig.Datadog().GetEnvVars())
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			// special-case permission-denied with a clearer error message
@@ -84,7 +84,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 
 	// Load the remote configuration
 	if fleetPoliciesDirPath != "" {
-		err := aconfig.SystemProbe.MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "system-probe.yaml"))
+		err := aconfig.SystemProbe().MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "system-probe.yaml"))
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +94,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 }
 
 func load() (*types.Config, error) {
-	cfg := aconfig.SystemProbe
+	cfg := aconfig.SystemProbe()
 	Adjust(cfg)
 
 	c := &types.Config{
@@ -183,7 +183,7 @@ func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
 		aconfig.Datadog().SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), aconfig.SystemProbe.GetEnvVars())
+	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), aconfig.SystemProbe().GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
 	if err != nil && !errors.As(err, &e) {

--- a/cmd/system-probe/config/config_linux_test.go
+++ b/cmd/system-probe/config/config_linux_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNetworkProcessEventMonitoring(t *testing.T) {
-	newConfig(t)
+	config.MockSystemProbe(t)
 
 	for i, te := range []struct {
 		network, netProcEvents bool
@@ -44,7 +44,7 @@ func TestNetworkProcessEventMonitoring(t *testing.T) {
 }
 
 func TestDynamicInstrumentation(t *testing.T) {
-	newConfig(t)
+	config.MockSystemProbe(t)
 	os.Setenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED", "true")
 	defer os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED")
 
@@ -62,8 +62,7 @@ func TestDynamicInstrumentation(t *testing.T) {
 func TestEventStreamEnabledForSupportedKernelsLinux(t *testing.T) {
 	config.ResetSystemProbeConfig(t)
 	t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-
-	cfg := config.SystemProbe
+	cfg := config.SystemProbe()
 	Adjust(cfg)
 
 	if ProcessEventDataStreamSupported() {
@@ -88,7 +87,7 @@ func TestNPMEnabled(t *testing.T) {
 		{true, true, true, true},
 	}
 
-	newConfig(t)
+	config.MockSystemProbe(t)
 	for _, te := range tests {
 		t.Run("", func(t *testing.T) {
 			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(te.npm))

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,17 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func newConfig(t *testing.T) {
-	originalConfig := config.SystemProbe
-	t.Cleanup(func() {
-		config.SystemProbe = originalConfig
-	})
-	config.SystemProbe = config.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
-	config.InitSystemProbeConfig(config.SystemProbe)
-}
-
 func TestEventMonitor(t *testing.T) {
-	newConfig(t)
+	config.MockSystemProbe(t)
 
 	for i, tc := range []struct {
 		cws, fim, processEvents, networkEvents bool
@@ -77,8 +67,7 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 		}
 		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-
-		cfg := config.SystemProbe
+		cfg := config.SystemProbe()
 		Adjust(cfg)
 
 		require.False(t, cfg.GetBool("event_monitoring_config.network_process.enabled"))
@@ -89,8 +78,7 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 		}
 		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-
-		cfg := config.SystemProbe
+		cfg := config.SystemProbe()
 		Adjust(cfg)
 
 		require.False(t, cfg.GetBool("event_monitoring_config.network_process.enabled"))
@@ -110,16 +98,12 @@ discovery:
 	t.Run("via ENV variable", func(t *testing.T) {
 		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_DISCOVERY_ENABLED", "true")
-		cfg := config.SystemProbe
-
-		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
+		assert.True(t, config.SystemProbe().GetBool(discoveryNS("enabled")))
 	})
 
 	t.Run("default", func(t *testing.T) {
 		config.ResetSystemProbeConfig(t)
-		cfg := config.SystemProbe
-
-		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
+		assert.False(t, config.SystemProbe().GetBool(discoveryNS("enabled")))
 	})
 }
 

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -135,5 +135,5 @@ func configurationFromYAML(t *testing.T, yaml string) config.Config {
 	f.Sync()
 
 	_, _ = New(f.Name(), "")
-	return config.SystemProbe
+	return config.SystemProbe()
 }

--- a/cmd/system-probe/modules/eventmonitor_linux.go
+++ b/cmd/system-probe/modules/eventmonitor_linux.go
@@ -23,7 +23,7 @@ var EventMonitor = module.Factory{
 	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
 	Fn:               createEventMonitorModule,
 	NeedsEBPF: func() bool {
-		return !coreconfig.SystemProbe.GetBool("runtime_security_config.ebpfless.enabled")
+		return !coreconfig.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled")
 	},
 }
 

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -148,7 +148,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/http_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe.GetBool("service_monitoring_config.enable_http_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_http_monitoring") {
 			writeDisabledProtocolMessage("http", w)
 			return
 		}
@@ -164,7 +164,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/kafka_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe.GetBool("service_monitoring_config.enable_kafka_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_kafka_monitoring") {
 			writeDisabledProtocolMessage("kafka", w)
 			return
 		}
@@ -180,7 +180,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/postgres_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe.GetBool("service_monitoring_config.enable_postgres_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_postgres_monitoring") {
 			writeDisabledProtocolMessage("postgres", w)
 			return
 		}
@@ -196,7 +196,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/redis_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe.GetBool("service_monitoring_config.enable_redis_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_redis_monitoring") {
 			writeDisabledProtocolMessage("redis", w)
 			return
 		}
@@ -212,7 +212,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/http2_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_http2_monitoring") {
 			writeDisabledProtocolMessage("http2", w)
 			return
 		}

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -55,9 +55,9 @@ func setupConfig(config pkgconfigmodel.Config, deps configDependencies) (*pkgcon
 	var err error
 	var warnings *pkgconfigmodel.Warnings
 	if resolver, ok := deps.getSecretResolver(); ok {
-		warnings, err = pkgconfigsetup.LoadWithSecret(config, resolver, pkgconfigsetup.SystemProbe.GetEnvVars())
+		warnings, err = pkgconfigsetup.LoadWithSecret(config, resolver, pkgconfigsetup.SystemProbe().GetEnvVars())
 	} else {
-		warnings, err = pkgconfigsetup.LoadWithoutSecret(config, pkgconfigsetup.SystemProbe.GetEnvVars())
+		warnings, err = pkgconfigsetup.LoadWithoutSecret(config, pkgconfigsetup.SystemProbe().GetEnvVars())
 	}
 
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -64,7 +64,7 @@ func newConfig(deps dependencies) (sysprobeconfig.Component, error) {
 		return nil, err
 	}
 
-	return &cfg{Config: config.SystemProbe, syscfg: syscfg}, nil
+	return &cfg{Config: config.SystemProbe(), syscfg: syscfg}, nil
 }
 
 func (c *cfg) Warnings() *config.Warnings {

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config_mock.go
@@ -13,7 +13,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"go.uber.org/fx"
 )
@@ -38,15 +39,15 @@ func MockModule() fxutil.Module {
 }
 
 func newMock(deps mockDependencies, t testing.TB) sysprobeconfig.Component {
-	old := config.SystemProbe
-	config.SystemProbe = config.NewConfig("mock", "XXXX", strings.NewReplacer())
+	old := setup.SystemProbe()
+	setup.SetSystemProbe(model.NewConfig("mock", "XXXX", strings.NewReplacer()))
 	c := &cfg{
-		warnings: &config.Warnings{},
-		Config:   config.SystemProbe,
+		warnings: &model.Warnings{},
+		Config:   setup.SystemProbe(),
 	}
 
 	// call InitSystemProbeConfig to set defaults.
-	config.InitSystemProbeConfig(config.SystemProbe)
+	setup.InitSystemProbeConfig(setup.SystemProbe())
 
 	// Viper's `GetXxx` methods read environment variables at the time they are
 	// called, if those names were passed explicitly to BindEnv*(), so we must
@@ -68,11 +69,11 @@ func newMock(deps mockDependencies, t testing.TB) sysprobeconfig.Component {
 	// Overrides are explicit and will take precedence over any other
 	// setting
 	for k, v := range deps.Params.Overrides {
-		config.SystemProbe.SetWithoutSource(k, v)
+		setup.SystemProbe().SetWithoutSource(k, v)
 	}
 
 	// swap the existing config back at the end of the test.
-	t.Cleanup(func() { config.SystemProbe = old })
+	t.Cleanup(func() { setup.SetSystemProbe(old) })
 
 	syscfg, err := setupConfig(deps)
 	if err != nil {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -50,7 +50,7 @@ type collector struct {
 // NewCollector returns a new local process collector provider and an error.
 // Currently, this is only used on Linux when language detection and run in core agent are enabled.
 func NewCollector() (workloadmeta.CollectorProvider, error) {
-	wlmExtractor := processwlm.GetSharedWorkloadMetaExtractor(config.SystemProbe)
+	wlmExtractor := processwlm.GetSharedWorkloadMetaExtractor(config.SystemProbe())
 	processData := NewProcessData()
 	processData.Register(wlmExtractor)
 

--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -68,7 +68,7 @@ func (m *EBPFCheck) Configure(senderManager sender.SenderManager, _ uint64, conf
 	if err := m.config.Parse(config); err != nil {
 		return fmt.Errorf("ebpf check config: %s", err)
 	}
-	if err := processnet.CheckPath(ddconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket")); err != nil {
+	if err := processnet.CheckPath(ddconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket")); err != nil {
 		return fmt.Errorf("sysprobe socket: %s", err)
 	}
 
@@ -80,7 +80,7 @@ func (m *EBPFCheck) Run() error {
 	if m.sysProbeUtil == nil {
 		var err error
 		m.sysProbeUtil, err = processnet.GetRemoteSystemProbeUtil(
-			ddconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket"),
+			ddconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket"),
 		)
 		if err != nil {
 			return fmt.Errorf("sysprobe connection: %s", err)

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -87,7 +87,7 @@ func (m *OOMKillCheck) Run() error {
 	}
 
 	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -86,17 +86,17 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 
-	if ddconfig.SystemProbe.GetBool("ebpf_check.kernel_bpf_stats") {
+	if ddconfig.SystemProbe().GetBool("ebpf_check.kernel_bpf_stats") {
 		probe.statsFD, err = ebpf.EnableStats(unix.BPF_STATS_RUN_TIME)
 		if err != nil {
 			log.Warnf("kernel ebpf stats failed to enable, program runtime and run count will be unavailable: %s", err)
 		}
 	}
 
-	probe.mapBuffers.keysBufferSizeLimit = uint32(ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.max_keys_buffer_size_bytes"))
-	probe.mapBuffers.valuesBufferSizeLimit = uint32(ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.max_values_buffer_size_bytes"))
-	probe.mapBuffers.iterationRestartDetectionEntries = ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.entries_for_iteration_restart_detection")
-	probe.entryCountMaxRestarts = ddconfig.SystemProbe.GetInt("ebpf_check.entry_count.max_restarts")
+	probe.mapBuffers.keysBufferSizeLimit = uint32(ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_keys_buffer_size_bytes"))
+	probe.mapBuffers.valuesBufferSizeLimit = uint32(ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_values_buffer_size_bytes"))
+	probe.mapBuffers.iterationRestartDetectionEntries = ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.entries_for_iteration_restart_detection")
+	probe.entryCountMaxRestarts = ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_restarts")
 
 	if isForEachElemHelperAvailable() {
 		probe.mphCache = newMapProgHelperCache()

--- a/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
@@ -84,7 +84,7 @@ func (t *TCPQueueLengthCheck) Run() error {
 	}
 
 	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/servicediscovery/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux.go
@@ -269,6 +269,6 @@ type systemProbeClient interface {
 
 func getSysProbeClient() (systemProbeClient, error) {
 	return processnet.GetRemoteSystemProbeUtil(
-		ddconfig.SystemProbe.GetString("system_probe_config.sysprobe_socket"),
+		ddconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket"),
 	)
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
@@ -61,7 +61,7 @@ func TestWinCrashReporting(t *testing.T) {
 	listener, closefunc := createSystemProbeListener()
 	defer closefunc()
 
-	config.InitSystemProbeConfig(config.SystemProbe)
+	config.InitSystemProbeConfig(config.SystemProbe())
 
 	mux := http.NewServeMux()
 	server := http.Server{
@@ -70,7 +70,7 @@ func TestWinCrashReporting(t *testing.T) {
 	defer server.Close()
 
 	sock := fmt.Sprintf("localhost:%d", listener.Addr().(*net.TCPAddr).Port)
-	config.SystemProbe.SetWithoutSource("system_probe_config.sysprobe_socket", sock)
+	config.SystemProbe().SetWithoutSource("system_probe_config.sysprobe_socket", sock)
 
 	/*
 	 * the underlying system probe connector is a singleton.  Therefore, we can't set up different

--- a/pkg/config/aliases.go
+++ b/pkg/config/aliases.go
@@ -252,7 +252,7 @@ var (
 
 // LoadWithoutSecret Alias using Datadog config
 func LoadWithoutSecret() (*model.Warnings, error) {
-	return pkgconfigsetup.LoadDatadogCustom(Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), SystemProbe.GetEnvVars())
+	return pkgconfigsetup.LoadDatadogCustom(Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), SystemProbe().GetEnvVars())
 }
 
 // GetProcessAPIAddressPort Alias using Datadog config

--- a/pkg/config/mock.go
+++ b/pkg/config/mock.go
@@ -49,22 +49,22 @@ func MockSystemProbe(t testing.TB) model.Config {
 		defer m.Unlock()
 		if isSystemProbeConfigMocked {
 			// The configuration is already mocked.
-			return &mockConfig{SystemProbe}
+			return &mockConfig{pkgconfigsetup.SystemProbe()}
 		}
 
 		isSystemProbeConfigMocked = true
-		originalConfig := SystemProbe
+		originalConfig := pkgconfigsetup.SystemProbe()
 		t.Cleanup(func() {
 			m.Lock()
 			defer m.Unlock()
 			isSystemProbeConfigMocked = false
-			SystemProbe = originalConfig
+			pkgconfigsetup.SetSystemProbe(originalConfig)
 		})
 	}
 
 	// Configure Datadog global configuration
-	SystemProbe = NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
+	pkgconfigsetup.SetSystemProbe(NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")))
 	// Configuration defaults
-	pkgconfigsetup.InitSystemProbeConfig(SystemProbe)
-	return &mockConfig{SystemProbe}
+	pkgconfigsetup.InitSystemProbeConfig(pkgconfigsetup.SystemProbe())
+	return &mockConfig{pkgconfigsetup.SystemProbe()}
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -107,7 +107,7 @@ const (
 // datadog is the global configuration object
 var (
 	datadog     pkgconfigmodel.Config
-	SystemProbe pkgconfigmodel.Config
+	systemProbe pkgconfigmodel.Config
 )
 
 // Datadog returns the current agent configuration
@@ -120,6 +120,18 @@ func Datadog() pkgconfigmodel.Config {
 // legacy converter and mock have been migrated we will remove this function.
 func SetDatadog(cfg pkgconfigmodel.Config) {
 	datadog = cfg
+}
+
+// SystemProbe returns the current SystemProbe configuration
+func SystemProbe() pkgconfigmodel.Config {
+	return systemProbe
+}
+
+// SetSystemProbe sets the the reference to the systemProbe configuration.
+// This is currently used by the config mocks and should not be user anywhere else. Once the mocks have been migrated we
+// will remove this function.
+func SetSystemProbe(cfg pkgconfigmodel.Config) {
+	systemProbe = cfg
 }
 
 // Variables to initialize at build time
@@ -239,7 +251,7 @@ func init() {
 	osinit()
 	// Configure Datadog global configuration
 	datadog = pkgconfigmodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
-	SystemProbe = pkgconfigmodel.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
+	systemProbe = pkgconfigmodel.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
 
 	// Configuration defaults
 	initConfig()

--- a/pkg/config/setup/config_init.go
+++ b/pkg/config/setup/config_init.go
@@ -9,5 +9,5 @@ package setup
 
 func initConfig() {
 	InitConfig(Datadog())
-	InitSystemProbeConfig(SystemProbe)
+	InitSystemProbeConfig(SystemProbe())
 }

--- a/pkg/config/test_helpers.go
+++ b/pkg/config/test_helpers.go
@@ -30,10 +30,10 @@ var (
 
 // ResetSystemProbeConfig resets the configuration.
 func ResetSystemProbeConfig(t *testing.T) {
-	originalConfig := SystemProbe
+	originalConfig := pkgconfigsetup.SystemProbe()
 	t.Cleanup(func() {
-		SystemProbe = originalConfig
+		pkgconfigsetup.SetSystemProbe(originalConfig)
 	})
-	SystemProbe = NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
-	pkgconfigsetup.InitSystemProbeConfig(SystemProbe)
+	pkgconfigsetup.SetSystemProbe(NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")))
+	pkgconfigsetup.InitSystemProbeConfig(pkgconfigsetup.SystemProbe())
 }

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -83,7 +83,7 @@ func key(pieces ...string) string {
 
 // NewConfig creates a config with ebpf-related settings
 func NewConfig() *Config {
-	cfg := aconfig.SystemProbe
+	cfg := aconfig.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	c := &Config{

--- a/pkg/ebpf/telemetry/errors_telemetry_test.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_test.go
@@ -48,7 +48,7 @@ type config struct {
 }
 
 func testConfig() *config {
-	cfg := aconfig.SystemProbe
+	cfg := aconfig.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	return &config{

--- a/pkg/eventmonitor/config/config.go
+++ b/pkg/eventmonitor/config/config.go
@@ -34,8 +34,8 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		// event server
-		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),
-		EventServerBurst: coreconfig.SystemProbe.GetInt(join(evNS, "event_server.burst")),
+		SocketPath:       coreconfig.SystemProbe().GetString(join(evNS, "socket")),
+		EventServerBurst: coreconfig.SystemProbe().GetInt(join(evNS, "event_server.burst")),
 
 		// consumers
 		ProcessConsumerEnabled: getBool("process.enabled"),
@@ -54,9 +54,9 @@ func getAllKeys(key string) (string, string) {
 
 func getBool(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe.IsSet(deprecatedKey) {
+	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe.GetBool(deprecatedKey)
+		return coreconfig.SystemProbe().GetBool(deprecatedKey)
 	}
-	return coreconfig.SystemProbe.GetBool(newKey)
+	return coreconfig.SystemProbe().GetBool(newKey)
 }

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -68,30 +68,30 @@ func CompleteFlare(fb flaretypes.FlareBuilder, diagnoseDeps diagnose.SuitesDeps)
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath(config.Datadog()))
 
-	systemProbeConfigBPFDir := config.SystemProbe.GetString("system_probe_config.bpf_dir")
+	systemProbeConfigBPFDir := config.SystemProbe().GetString("system_probe_config.bpf_dir")
 	if systemProbeConfigBPFDir != "" {
 		fb.RegisterDirPerm(systemProbeConfigBPFDir)
 	}
 	addSystemProbePlatformSpecificEntries(fb)
 
-	if config.SystemProbe.GetBool("system_probe_config.enabled") {
+	if config.SystemProbe().GetBool("system_probe_config.enabled") {
 		fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats) //nolint:errcheck
 	}
 
 	pprofURL := fmt.Sprintf("http://127.0.0.1:%s/debug/pprof/goroutine?debug=2",
 		config.Datadog().GetString("expvar_port"))
 
-	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)                                                       //nolint:errcheck
-	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.Datadog().AllSettings()) })                //nolint:errcheck
-	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.SystemProbe.AllSettings()) }) //nolint:errcheck
-	fb.AddFileFromFunc("diagnose.log", getDiagnoses(fb.IsLocal(), diagnoseDeps))                                                                  //nolint:errcheck
-	fb.AddFileFromFunc("envvars.log", getEnvVars)                                                                                                 //nolint:errcheck
-	fb.AddFileFromFunc("health.yaml", getHealth)                                                                                                  //nolint:errcheck
-	fb.AddFileFromFunc("go-routine-dump.log", func() ([]byte, error) { return getHTTPCallContent(pprofURL) })                                     //nolint:errcheck
-	fb.AddFileFromFunc("docker_inspect.log", func() ([]byte, error) { return getDockerSelfInspect(diagnoseDeps.GetWMeta()) })                     //nolint:errcheck
-	fb.AddFileFromFunc("docker_ps.log", getDockerPs)                                                                                              //nolint:errcheck
-	fb.AddFileFromFunc("k8s/kubelet_config.yaml", getKubeletConfig)                                                                               //nolint:errcheck
-	fb.AddFileFromFunc("k8s/kubelet_pods.yaml", getKubeletPods)                                                                                   //nolint:errcheck
+	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)                                                         //nolint:errcheck
+	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.Datadog().AllSettings()) })                  //nolint:errcheck
+	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.SystemProbe().AllSettings()) }) //nolint:errcheck
+	fb.AddFileFromFunc("diagnose.log", getDiagnoses(fb.IsLocal(), diagnoseDeps))                                                                    //nolint:errcheck
+	fb.AddFileFromFunc("envvars.log", getEnvVars)                                                                                                   //nolint:errcheck
+	fb.AddFileFromFunc("health.yaml", getHealth)                                                                                                    //nolint:errcheck
+	fb.AddFileFromFunc("go-routine-dump.log", func() ([]byte, error) { return getHTTPCallContent(pprofURL) })                                       //nolint:errcheck
+	fb.AddFileFromFunc("docker_inspect.log", func() ([]byte, error) { return getDockerSelfInspect(diagnoseDeps.GetWMeta()) })                       //nolint:errcheck
+	fb.AddFileFromFunc("docker_ps.log", getDockerPs)                                                                                                //nolint:errcheck
+	fb.AddFileFromFunc("k8s/kubelet_config.yaml", getKubeletConfig)                                                                                 //nolint:errcheck
+	fb.AddFileFromFunc("k8s/kubelet_pods.yaml", getKubeletPods)                                                                                     //nolint:errcheck
 
 	getRegistryJSON(fb)
 
@@ -182,7 +182,7 @@ func getExpVar(fb flaretypes.FlareBuilder) error {
 func getSystemProbeStats() ([]byte, error) {
 	// TODO: (components) - Temporary until we can use the status component to extract the system probe status from it.
 	stats := map[string]interface{}{}
-	systemprobeStatus.GetStatus(stats, config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+	systemprobeStatus.GetStatus(stats, config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	sysProbeBuf, err := yaml.Marshal(stats["systemProbeStats"])
 	if err != nil {
 		return nil, err

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -22,7 +22,7 @@ import (
 )
 
 func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {
-	sysprobeSocketLocation := config.SystemProbe.GetString("system_probe_config.sysprobe_socket")
+	sysprobeSocketLocation := config.SystemProbe().GetString("system_probe_config.sysprobe_socket")
 	if sysprobeSocketLocation != "" {
 		fb.RegisterDirPerm(filepath.Dir(sysprobeSocketLocation))
 	}

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -73,7 +73,7 @@ func getComplianceFiles(fb flaretypes.FlareBuilder) error {
 }
 
 func getRuntimeFiles(fb flaretypes.FlareBuilder) error {
-	runtimeDir := config.SystemProbe.GetString("runtime_security_config.policies.dir")
+	runtimeDir := config.SystemProbe().GetString("runtime_security_config.policies.dir")
 
 	return fb.CopyDirTo(runtimeDir, "runtime-security.d", func(path string) bool {
 		f, err := os.Lstat(path)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -321,7 +321,7 @@ func join(pieces ...string) string {
 
 // New creates a config for the network tracer
 func New() *Config {
-	cfg := ddconfig.SystemProbe
+	cfg := ddconfig.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	c := &Config{

--- a/pkg/network/config/config_bpf_linux_test.go
+++ b/pkg/network/config/config_bpf_linux_test.go
@@ -9,7 +9,6 @@ package config
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,21 +25,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
-func newSystemProbeConfig(t *testing.T) {
-	originalConfig := aconfig.SystemProbe
-	t.Cleanup(func() {
-		aconfig.SystemProbe = originalConfig
-	})
-	aconfig.SystemProbe = aconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
-	aconfig.InitSystemProbeConfig(aconfig.SystemProbe)
-}
-
 func TestEventStreamEnabledForSupportedKernelsLinux(t *testing.T) {
-
 	newSystemProbeConfig(t)
 	t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-
-	cfg := aconfig.SystemProbe
+	cfg := aconfig.MockSystemProbe(t)
 	sysconfig.Adjust(cfg)
 
 	if sysconfig.ProcessEventDataStreamSupported() {

--- a/pkg/network/config/config_bpf_linux_test.go
+++ b/pkg/network/config/config_bpf_linux_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestEventStreamEnabledForSupportedKernelsLinux(t *testing.T) {
-	newSystemProbeConfig(t)
 	t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
 	cfg := aconfig.MockSystemProbe(t)
 	sysconfig.Adjust(cfg)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1722,8 +1722,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
 		t.Setenv("DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED", "true")
-
-		cfg := aconfig.SystemProbe
+		cfg := aconfig.SystemProbe()
 		sysconfig.Adjust(cfg)
 
 		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
@@ -1834,8 +1833,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
 		t.Setenv("DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_USE_WINDOWS_SERVICE_NAME", "true")
-
-		cfg := aconfig.SystemProbe
+		cfg := aconfig.SystemProbe()
 		sysconfig.Adjust(cfg)
 
 		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
@@ -1938,7 +1936,7 @@ func modelCfgFromYAML(t *testing.T, yaml string) model.Config {
 	_, err = sysconfig.New(f.Name(), "")
 
 	require.NoError(t, err)
-	cfg := aconfig.SystemProbe
+	cfg := aconfig.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	return cfg

--- a/pkg/network/config/replace_rules.go
+++ b/pkg/network/config/replace_rules.go
@@ -28,7 +28,7 @@ type ReplaceRule struct {
 }
 
 func parseReplaceRules(cfg ddconfig.Config, key string) ([]*ReplaceRule, error) {
-	if !config.SystemProbe.IsSet(key) {
+	if !config.SystemProbe().IsSet(key) {
 		return nil, nil
 	}
 

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -40,15 +39,6 @@ const (
 	tagOpenSSL connTag = 0x02 // network.ConnTagOpenSSL
 	tagTLS     connTag = 0x10 // network.ConnTagTLS
 )
-
-func newConfig(t *testing.T) {
-	originalConfig := config.SystemProbe
-	t.Cleanup(func() {
-		config.SystemProbe = originalConfig
-	})
-	config.SystemProbe = config.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))
-	config.InitSystemProbeConfig(config.SystemProbe)
-}
 
 func getBlobWriter(t *testing.T, assert *assert.Assertions, in *network.Connections, marshalerType string) *bytes.Buffer {
 	marshaler := marshal.GetMarshaler(marshalerType)
@@ -332,8 +322,8 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 	require.NoError(t, err)
 
 	t.Run("requesting application/json serialization (no query types)", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 		assert := assert.New(t)
 		blobWriter := getBlobWriter(t, assert, in, "application/json")
@@ -354,9 +344,9 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 	})
 
 	t.Run("requesting application/json serialization (with query types)", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
-		config.SystemProbe.SetWithoutSource("network_config.enable_dns_by_querytype", true)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.SystemProbe().SetWithoutSource("network_config.enable_dns_by_querytype", true)
 		out := getExpectedConnections(true, httpOutBlob)
 		assert := assert.New(t)
 
@@ -378,8 +368,8 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 	})
 
 	t.Run("requesting empty serialization", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 		assert := assert.New(t)
 
@@ -409,8 +399,8 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 	})
 
 	t.Run("requesting unsupported serialization format", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 
 		assert := assert.New(t)
@@ -465,8 +455,8 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 	})
 
 	t.Run("requesting application/protobuf serialization (no query types)", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 
 		assert := assert.New(t)
@@ -481,9 +471,9 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 		assertConnsEqual(t, out, result)
 	})
 	t.Run("requesting application/protobuf serialization (with query types)", func(t *testing.T) {
-		newConfig(t)
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
-		config.SystemProbe.SetWithoutSource("network_config.enable_dns_by_querytype", true)
+		config.MockSystemProbe(t)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		config.SystemProbe().SetWithoutSource("network_config.enable_dns_by_querytype", true)
 		out := getExpectedConnections(true, httpOutBlob)
 
 		assert := assert.New(t)

--- a/pkg/network/encoding/marshal/dns.go
+++ b/pkg/network/encoding/marshal/dns.go
@@ -28,8 +28,8 @@ func newDNSFormatter(conns *network.Connections, ipc ipCache) *dnsFormatter {
 		conns:             conns,
 		ipc:               ipc,
 		domainSet:         make(map[string]int),
-		queryTypeEnabled:  config.SystemProbe.GetBool("network_config.enable_dns_by_querytype"),
-		dnsDomainsEnabled: config.SystemProbe.GetBool("system_probe_config.collect_dns_domains"),
+		queryTypeEnabled:  config.SystemProbe().GetBool("network_config.enable_dns_by_querytype"),
+		dnsDomainsEnabled: config.SystemProbe().GetBool("system_probe_config.collect_dns_domains"),
 	}
 }
 

--- a/pkg/network/encoding/marshal/dns_test.go
+++ b/pkg/network/encoding/marshal/dns_test.go
@@ -50,8 +50,8 @@ func TestFormatConnectionDNS(t *testing.T) {
 	}
 
 	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=false", func(t *testing.T) {
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", true)
-		config.SystemProbe.SetWithoutSource("network_config.enable_dns_by_querytype", false)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", true)
+		config.SystemProbe().SetWithoutSource("network_config.enable_dns_by_querytype", false)
 
 		ipc := make(ipCache)
 		formatter := newDNSFormatter(payload, ipc)
@@ -80,8 +80,8 @@ func TestFormatConnectionDNS(t *testing.T) {
 	})
 
 	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=true", func(t *testing.T) {
-		config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", true)
-		config.SystemProbe.SetWithoutSource("network_config.enable_dns_by_querytype", true)
+		config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", true)
+		config.SystemProbe().SetWithoutSource("network_config.enable_dns_by_querytype", true)
 
 		ipc := make(ipCache)
 		formatter := newDNSFormatter(payload, ipc)

--- a/pkg/network/encoding/marshal/modeler.go
+++ b/pkg/network/encoding/marshal/modeler.go
@@ -64,9 +64,9 @@ func (c *ConnectionsModeler) Close() {
 func (c *ConnectionsModeler) modelConnections(builder *model.ConnectionsBuilder, conns *network.Connections) {
 	cfgOnce.Do(func() {
 		agentCfg = &model.AgentConfiguration{
-			NpmEnabled: config.SystemProbe.GetBool("network_config.enabled"),
-			UsmEnabled: config.SystemProbe.GetBool("service_monitoring_config.enabled"),
-			CcmEnabled: config.SystemProbe.GetBool("ccm_network_config.enabled"),
+			NpmEnabled: config.SystemProbe().GetBool("network_config.enabled"),
+			UsmEnabled: config.SystemProbe().GetBool("service_monitoring_config.enabled"),
+			CcmEnabled: config.SystemProbe().GetBool("ccm_network_config.enabled"),
 		}
 	})
 

--- a/pkg/network/encoding/marshal/usm.go
+++ b/pkg/network/encoding/marshal/usm.go
@@ -56,7 +56,7 @@ func GroupByConnection[K comparable, V any](protocol string, data map[K]V, keyGe
 		lookupFn: USMLookup[K, V],
 
 		// Experimental: Connection Rollups
-		enableConnectionRollup: config.SystemProbe.GetBool("service_monitoring_config.enable_connection_rollup"),
+		enableConnectionRollup: config.SystemProbe().GetBool("service_monitoring_config.enable_connection_rollup"),
 	}
 
 	// The map intended to calculate how many entries we actually need in byConnection.data, and for each entry

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -2859,8 +2859,8 @@ func TestDNSPIDCollision(t *testing.T) {
 		},
 	}
 
-	config.SystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", true)
-	config.SystemProbe.SetWithoutSource("network_config.enable_dns_by_querytype", false)
+	config.SystemProbe().SetWithoutSource("system_probe_config.collect_dns_domains", true)
+	config.SystemProbe().SetWithoutSource("network_config.enable_dns_by_querytype", false)
 
 	state := newDefaultState()
 	state.RegisterClient("foo")

--- a/pkg/networkdevice/pinger/pinger_linux.go
+++ b/pkg/networkdevice/pinger/pinger_linux.go
@@ -42,7 +42,7 @@ func (p *LinuxPinger) Ping(host string) (*Result, error) {
 	}
 
 	tu, err := net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		log.Warnf("could not initialize system-probe connection: %s", err.Error())
 		return nil, err

--- a/pkg/networkpath/traceroute/traceroute_linux.go
+++ b/pkg/networkpath/traceroute/traceroute_linux.go
@@ -41,7 +41,7 @@ func New(cfg Config, _ telemetry.Component) (*LinuxTraceroute, error) {
 // Run executes a traceroute
 func (l *LinuxTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
 	tu, err := net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		log.Warnf("could not initialize system-probe connection: %s", err.Error())
 		return payload.NetworkPath{}, err

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -41,7 +41,7 @@ func New(cfg Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 // Run executes a traceroute
 func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
 	tu, err := net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		log.Warnf("could not initialize system-probe connection: %s", err.Error())
 		return payload.NetworkPath{}, err

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -164,7 +164,7 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo, oneShot bool
 	p.extractors = append(p.extractors, p.serviceExtractor)
 
 	if !oneShot && workloadmeta.Enabled(p.config) {
-		p.workloadMetaExtractor = workloadmeta.NewWorkloadMetaExtractor(ddconfig.SystemProbe)
+		p.workloadMetaExtractor = workloadmeta.NewWorkloadMetaExtractor(ddconfig.SystemProbe())
 		p.workloadMetaServer = workloadmeta.NewGRPCServer(p.config, p.workloadMetaExtractor)
 		err = p.workloadMetaServer.Start()
 		if err != nil {

--- a/pkg/process/events/listener_linux.go
+++ b/pkg/process/events/listener_linux.go
@@ -45,7 +45,7 @@ type SysProbeListener struct {
 
 // NewListener returns a new SysProbeListener to listen for process events
 func NewListener(handler EventHandler) (*SysProbeListener, error) {
-	socketPath := ddconfig.SystemProbe.GetString("event_monitoring_config.socket")
+	socketPath := ddconfig.SystemProbe().GetString("event_monitoring_config.socket")
 	if socketPath == "" {
 		return nil, errors.New("event_monitoring_config.socket must be set")
 	}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -283,7 +283,7 @@ func NewConfig() (*Config, error) {
 
 // NewRuntimeSecurityConfig returns the runtime security (CWS) config, build from the system probe one
 func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
-	sysconfig.Adjust(coreconfig.SystemProbe)
+	sysconfig.Adjust(coreconfig.SystemProbe())
 
 	eventTypeStrings := map[string]model.EventType{}
 
@@ -305,65 +305,65 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	rsConfig := &RuntimeSecurityConfig{
-		RuntimeEnabled:                 coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),
-		FIMEnabled:                     coreconfig.SystemProbe.GetBool("runtime_security_config.fim_enabled"),
-		WindowsFilenameCacheSize:       coreconfig.SystemProbe.GetInt("runtime_security_config.windows_filename_cache_max"),
-		WindowsRegistryCacheSize:       coreconfig.SystemProbe.GetInt("runtime_security_config.windows_registry_cache_max"),
-		ETWEventsChannelSize:           coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_channel_size"),
-		ETWEventsMaxBuffers:            coreconfig.SystemProbe.GetInt("runtime_security_config.etw_events_max_buffers"),
-		WindowsProbeBlockOnChannelSend: coreconfig.SystemProbe.GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
+		RuntimeEnabled:                 coreconfig.SystemProbe().GetBool("runtime_security_config.enabled"),
+		FIMEnabled:                     coreconfig.SystemProbe().GetBool("runtime_security_config.fim_enabled"),
+		WindowsFilenameCacheSize:       coreconfig.SystemProbe().GetInt("runtime_security_config.windows_filename_cache_max"),
+		WindowsRegistryCacheSize:       coreconfig.SystemProbe().GetInt("runtime_security_config.windows_registry_cache_max"),
+		ETWEventsChannelSize:           coreconfig.SystemProbe().GetInt("runtime_security_config.etw_events_channel_size"),
+		ETWEventsMaxBuffers:            coreconfig.SystemProbe().GetInt("runtime_security_config.etw_events_max_buffers"),
+		WindowsProbeBlockOnChannelSend: coreconfig.SystemProbe().GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
 
-		SocketPath:           coreconfig.SystemProbe.GetString("runtime_security_config.socket"),
-		EventServerBurst:     coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.burst"),
-		EventServerRate:      coreconfig.SystemProbe.GetInt("runtime_security_config.event_server.rate"),
-		EventServerRetention: coreconfig.SystemProbe.GetDuration("runtime_security_config.event_server.retention"),
+		SocketPath:           coreconfig.SystemProbe().GetString("runtime_security_config.socket"),
+		EventServerBurst:     coreconfig.SystemProbe().GetInt("runtime_security_config.event_server.burst"),
+		EventServerRate:      coreconfig.SystemProbe().GetInt("runtime_security_config.event_server.rate"),
+		EventServerRetention: coreconfig.SystemProbe().GetDuration("runtime_security_config.event_server.retention"),
 
-		SelfTestEnabled:                 coreconfig.SystemProbe.GetBool("runtime_security_config.self_test.enabled"),
-		SelfTestSendReport:              coreconfig.SystemProbe.GetBool("runtime_security_config.self_test.send_report"),
+		SelfTestEnabled:                 coreconfig.SystemProbe().GetBool("runtime_security_config.self_test.enabled"),
+		SelfTestSendReport:              coreconfig.SystemProbe().GetBool("runtime_security_config.self_test.send_report"),
 		RemoteConfigurationEnabled:      isRemoteConfigEnabled(),
-		RemoteConfigurationDumpPolicies: coreconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.dump_policies"),
+		RemoteConfigurationDumpPolicies: coreconfig.SystemProbe().GetBool("runtime_security_config.remote_configuration.dump_policies"),
 
-		OnDemandEnabled:            coreconfig.SystemProbe.GetBool("runtime_security_config.on_demand.enabled"),
-		OnDemandRateLimiterEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.on_demand.rate_limiter.enabled"),
+		OnDemandEnabled:            coreconfig.SystemProbe().GetBool("runtime_security_config.on_demand.enabled"),
+		OnDemandRateLimiterEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.on_demand.rate_limiter.enabled"),
 
 		// policy & ruleset
-		PoliciesDir:                         coreconfig.SystemProbe.GetString("runtime_security_config.policies.dir"),
-		WatchPoliciesDir:                    coreconfig.SystemProbe.GetBool("runtime_security_config.policies.watch_dir"),
-		PolicyMonitorEnabled:                coreconfig.SystemProbe.GetBool("runtime_security_config.policies.monitor.enabled"),
-		PolicyMonitorPerRuleEnabled:         coreconfig.SystemProbe.GetBool("runtime_security_config.policies.monitor.per_rule_enabled"),
-		PolicyMonitorReportInternalPolicies: coreconfig.SystemProbe.GetBool("runtime_security_config.policies.monitor.report_internal_policies"),
+		PoliciesDir:                         coreconfig.SystemProbe().GetString("runtime_security_config.policies.dir"),
+		WatchPoliciesDir:                    coreconfig.SystemProbe().GetBool("runtime_security_config.policies.watch_dir"),
+		PolicyMonitorEnabled:                coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.enabled"),
+		PolicyMonitorPerRuleEnabled:         coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.per_rule_enabled"),
+		PolicyMonitorReportInternalPolicies: coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.report_internal_policies"),
 
-		LogPatterns: coreconfig.SystemProbe.GetStringSlice("runtime_security_config.log_patterns"),
-		LogTags:     coreconfig.SystemProbe.GetStringSlice("runtime_security_config.log_tags"),
+		LogPatterns: coreconfig.SystemProbe().GetStringSlice("runtime_security_config.log_patterns"),
+		LogTags:     coreconfig.SystemProbe().GetStringSlice("runtime_security_config.log_tags"),
 
 		// custom events
-		InternalMonitoringEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.internal_monitoring.enabled"),
+		InternalMonitoringEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.internal_monitoring.enabled"),
 
 		// activity dump
-		ActivityDumpEnabled:                   coreconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled"),
-		ActivityDumpCleanupPeriod:             coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.cleanup_period"),
-		ActivityDumpTagsResolutionPeriod:      coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.tags_resolution_period"),
-		ActivityDumpLoadControlPeriod:         coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.load_controller_period"),
-		ActivityDumpLoadControlMinDumpTimeout: coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.min_timeout"),
-		ActivityDumpTracedCgroupsCount:        coreconfig.SystemProbe.GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
-		ActivityDumpTracedEventTypes:          parseEventTypeStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
-		ActivityDumpCgroupDumpTimeout:         coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.dump_duration"),
-		ActivityDumpRateLimiter:               coreconfig.SystemProbe.GetInt("runtime_security_config.activity_dump.rate_limiter"),
-		ActivityDumpCgroupWaitListTimeout:     coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.cgroup_wait_list_timeout"),
-		ActivityDumpCgroupDifferentiateArgs:   coreconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
-		ActivityDumpLocalStorageDirectory:     coreconfig.SystemProbe.GetString("runtime_security_config.activity_dump.local_storage.output_directory"),
-		ActivityDumpLocalStorageMaxDumpsCount: coreconfig.SystemProbe.GetInt("runtime_security_config.activity_dump.local_storage.max_dumps_count"),
-		ActivityDumpLocalStorageCompression:   coreconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.local_storage.compression"),
-		ActivityDumpSyscallMonitorPeriod:      coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.syscall_monitor.period"),
-		ActivityDumpMaxDumpCountPerWorkload:   coreconfig.SystemProbe.GetInt("runtime_security_config.activity_dump.max_dump_count_per_workload"),
-		ActivityDumpTagRulesEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.tag_rules.enabled"),
-		ActivityDumpSilentWorkloadsDelay:      coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.silent_workloads.delay"),
-		ActivityDumpSilentWorkloadsTicker:     coreconfig.SystemProbe.GetDuration("runtime_security_config.activity_dump.silent_workloads.ticker"),
-		ActivityDumpWorkloadDenyList:          coreconfig.SystemProbe.GetStringSlice("runtime_security_config.activity_dump.workload_deny_list"),
-		ActivityDumpAutoSuppressionEnabled:    coreconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.auto_suppression.enabled"),
+		ActivityDumpEnabled:                   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.enabled"),
+		ActivityDumpCleanupPeriod:             coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.cleanup_period"),
+		ActivityDumpTagsResolutionPeriod:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.tags_resolution_period"),
+		ActivityDumpLoadControlPeriod:         coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.load_controller_period"),
+		ActivityDumpLoadControlMinDumpTimeout: coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.min_timeout"),
+		ActivityDumpTracedCgroupsCount:        coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
+		ActivityDumpTracedEventTypes:          parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
+		ActivityDumpCgroupDumpTimeout:         coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.dump_duration"),
+		ActivityDumpRateLimiter:               coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter"),
+		ActivityDumpCgroupWaitListTimeout:     coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.cgroup_wait_list_timeout"),
+		ActivityDumpCgroupDifferentiateArgs:   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
+		ActivityDumpLocalStorageDirectory:     coreconfig.SystemProbe().GetString("runtime_security_config.activity_dump.local_storage.output_directory"),
+		ActivityDumpLocalStorageMaxDumpsCount: coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.local_storage.max_dumps_count"),
+		ActivityDumpLocalStorageCompression:   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.local_storage.compression"),
+		ActivityDumpSyscallMonitorPeriod:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.syscall_monitor.period"),
+		ActivityDumpMaxDumpCountPerWorkload:   coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_count_per_workload"),
+		ActivityDumpTagRulesEnabled:           coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.tag_rules.enabled"),
+		ActivityDumpSilentWorkloadsDelay:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.delay"),
+		ActivityDumpSilentWorkloadsTicker:     coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.ticker"),
+		ActivityDumpWorkloadDenyList:          coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.workload_deny_list"),
+		ActivityDumpAutoSuppressionEnabled:    coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.auto_suppression.enabled"),
 		// activity dump dynamic fields
 		ActivityDumpMaxDumpSize: func() int {
-			mds := coreconfig.SystemProbe.GetInt("runtime_security_config.activity_dump.max_dump_size")
+			mds := coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_size")
 			if mds < ADMinMaxDumSize {
 				mds = ADMinMaxDumSize
 			}
@@ -371,58 +371,58 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		},
 
 		// SBOM resolver
-		SBOMResolverEnabled:            coreconfig.SystemProbe.GetBool("runtime_security_config.sbom.enabled"),
-		SBOMResolverWorkloadsCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.sbom.workloads_cache_size"),
-		SBOMResolverHostEnabled:        coreconfig.SystemProbe.GetBool("runtime_security_config.sbom.host.enabled"),
+		SBOMResolverEnabled:            coreconfig.SystemProbe().GetBool("runtime_security_config.sbom.enabled"),
+		SBOMResolverWorkloadsCacheSize: coreconfig.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
+		SBOMResolverHostEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
 
 		// Hash resolver
-		HashResolverEnabled:        coreconfig.SystemProbe.GetBool("runtime_security_config.hash_resolver.enabled"),
-		HashResolverEventTypes:     parseEventTypeStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.hash_resolver.event_types")),
-		HashResolverMaxFileSize:    coreconfig.SystemProbe.GetInt64("runtime_security_config.hash_resolver.max_file_size"),
-		HashResolverHashAlgorithms: parseHashAlgorithmStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.hash_resolver.hash_algorithms")),
-		HashResolverMaxHashBurst:   coreconfig.SystemProbe.GetInt("runtime_security_config.hash_resolver.max_hash_burst"),
-		HashResolverMaxHashRate:    coreconfig.SystemProbe.GetInt("runtime_security_config.hash_resolver.max_hash_rate"),
-		HashResolverCacheSize:      coreconfig.SystemProbe.GetInt("runtime_security_config.hash_resolver.cache_size"),
-		HashResolverReplace:        coreconfig.SystemProbe.GetStringMapString("runtime_security_config.hash_resolver.replace"),
+		HashResolverEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.hash_resolver.enabled"),
+		HashResolverEventTypes:     parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.event_types")),
+		HashResolverMaxFileSize:    coreconfig.SystemProbe().GetInt64("runtime_security_config.hash_resolver.max_file_size"),
+		HashResolverHashAlgorithms: parseHashAlgorithmStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.hash_algorithms")),
+		HashResolverMaxHashBurst:   coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_burst"),
+		HashResolverMaxHashRate:    coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_rate"),
+		HashResolverCacheSize:      coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.cache_size"),
+		HashResolverReplace:        coreconfig.SystemProbe().GetStringMapString("runtime_security_config.hash_resolver.replace"),
 
 		// security profiles
-		SecurityProfileEnabled:          coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.enabled"),
-		SecurityProfileMaxImageTags:     coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_image_tags"),
-		SecurityProfileDir:              coreconfig.SystemProbe.GetString("runtime_security_config.security_profile.dir"),
-		SecurityProfileWatchDir:         coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.watch_dir"),
-		SecurityProfileCacheSize:        coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.cache_size"),
-		SecurityProfileMaxCount:         coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_count"),
-		SecurityProfileRCEnabled:        coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
-		SecurityProfileDNSMatchMaxDepth: coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.dns_match_max_depth"),
+		SecurityProfileEnabled:          coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),
+		SecurityProfileMaxImageTags:     coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.max_image_tags"),
+		SecurityProfileDir:              coreconfig.SystemProbe().GetString("runtime_security_config.security_profile.dir"),
+		SecurityProfileWatchDir:         coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.watch_dir"),
+		SecurityProfileCacheSize:        coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.cache_size"),
+		SecurityProfileMaxCount:         coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.max_count"),
+		SecurityProfileRCEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
+		SecurityProfileDNSMatchMaxDepth: coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.dns_match_max_depth"),
 
 		// auto suppression
-		SecurityProfileAutoSuppressionEnabled:    coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.auto_suppression.enabled"),
-		SecurityProfileAutoSuppressionEventTypes: parseEventTypeStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.security_profile.auto_suppression.event_types")),
+		SecurityProfileAutoSuppressionEnabled:    coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.auto_suppression.enabled"),
+		SecurityProfileAutoSuppressionEventTypes: parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.security_profile.auto_suppression.event_types")),
 
 		// anomaly detection
-		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),
-		AnomalyDetectionDefaultMinimumStablePeriod:   coreconfig.SystemProbe.GetDuration("runtime_security_config.security_profile.anomaly_detection.default_minimum_stable_period"),
-		AnomalyDetectionMinimumStablePeriods:         parseEventTypeDurations(coreconfig.SystemProbe, "runtime_security_config.security_profile.anomaly_detection.minimum_stable_period"),
-		AnomalyDetectionWorkloadWarmupPeriod:         coreconfig.SystemProbe.GetDuration("runtime_security_config.security_profile.anomaly_detection.workload_warmup_period"),
-		AnomalyDetectionUnstableProfileTimeThreshold: coreconfig.SystemProbe.GetDuration("runtime_security_config.security_profile.anomaly_detection.unstable_profile_time_threshold"),
-		AnomalyDetectionUnstableProfileSizeThreshold: coreconfig.SystemProbe.GetInt64("runtime_security_config.security_profile.anomaly_detection.unstable_profile_size_threshold"),
-		AnomalyDetectionRateLimiterPeriod:            coreconfig.SystemProbe.GetDuration("runtime_security_config.security_profile.anomaly_detection.rate_limiter.period"),
-		AnomalyDetectionRateLimiterNumKeys:           coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_keys"),
-		AnomalyDetectionRateLimiterNumEventsAllowed:  coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_events_allowed"),
-		AnomalyDetectionTagRulesEnabled:              coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled"),
-		AnomalyDetectionSilentRuleEventsEnabled:      coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled"),
-		AnomalyDetectionEnabled:                      coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.enabled"),
+		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),
+		AnomalyDetectionDefaultMinimumStablePeriod:   coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.default_minimum_stable_period"),
+		AnomalyDetectionMinimumStablePeriods:         parseEventTypeDurations(coreconfig.SystemProbe(), "runtime_security_config.security_profile.anomaly_detection.minimum_stable_period"),
+		AnomalyDetectionWorkloadWarmupPeriod:         coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.workload_warmup_period"),
+		AnomalyDetectionUnstableProfileTimeThreshold: coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.unstable_profile_time_threshold"),
+		AnomalyDetectionUnstableProfileSizeThreshold: coreconfig.SystemProbe().GetInt64("runtime_security_config.security_profile.anomaly_detection.unstable_profile_size_threshold"),
+		AnomalyDetectionRateLimiterPeriod:            coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.rate_limiter.period"),
+		AnomalyDetectionRateLimiterNumKeys:           coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_keys"),
+		AnomalyDetectionRateLimiterNumEventsAllowed:  coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_events_allowed"),
+		AnomalyDetectionTagRulesEnabled:              coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled"),
+		AnomalyDetectionSilentRuleEventsEnabled:      coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled"),
+		AnomalyDetectionEnabled:                      coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.enabled"),
 
 		// enforcement
-		EnforcementEnabled:           coreconfig.SystemProbe.GetBool("runtime_security_config.enforcement.enabled"),
-		EnforcementRawSyscallEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.enforcement.raw_syscall.enabled"),
+		EnforcementEnabled:           coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.enabled"),
+		EnforcementRawSyscallEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.raw_syscall.enabled"),
 
 		// User Sessions
-		UserSessionsCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.user_sessions.cache_size"),
+		UserSessionsCacheSize: coreconfig.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
 
 		// ebpf less
-		EBPFLessEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.ebpfless.enabled"),
-		EBPFLessSocket:  coreconfig.SystemProbe.GetString("runtime_security_config.ebpfless.socket"),
+		EBPFLessEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled"),
+		EBPFLessSocket:  coreconfig.SystemProbe().GetString("runtime_security_config.ebpfless.socket"),
 
 		// IMDS
 		IMDSIPv4: parseIMDSIPv4(),
@@ -442,7 +442,7 @@ func (c *RuntimeSecurityConfig) IsRuntimeEnabled() bool {
 
 // parseIMDSIPv4 returns the uint32 representation of the IMDS IP set by the configuration
 func parseIMDSIPv4() uint32 {
-	ip := coreconfig.SystemProbe.GetString("runtime_security_config.imds_ipv4")
+	ip := coreconfig.SystemProbe().GetString("runtime_security_config.imds_ipv4")
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
 		return 0
@@ -453,7 +453,7 @@ func parseIMDSIPv4() uint32 {
 // If RC is globally enabled, RC is enabled for CWS, unless the CWS-specific RC value is explicitly set to false
 func isRemoteConfigEnabled() bool {
 	// This value defaults to true
-	rcEnabledInSysprobeConfig := coreconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.enabled")
+	rcEnabledInSysprobeConfig := coreconfig.SystemProbe().GetBool("runtime_security_config.remote_configuration.enabled")
 
 	if !rcEnabledInSysprobeConfig {
 		return false
@@ -482,7 +482,7 @@ func (c *RuntimeSecurityConfig) sanitize() error {
 	}
 
 	if c.IMDSIPv4 == 0 {
-		return fmt.Errorf("invalid IPv4 address: got %v", coreconfig.SystemProbe.GetString("runtime_security_config.imds_ipv4"))
+		return fmt.Errorf("invalid IPv4 address: got %v", coreconfig.SystemProbe().GetString("runtime_security_config.imds_ipv4"))
 	}
 
 	return c.sanitizeRuntimeSecurityConfigActivityDump()
@@ -501,7 +501,7 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 		c.ActivityDumpTracedEventTypes = append(c.ActivityDumpTracedEventTypes, model.ExecEventType)
 	}
 
-	if formats := coreconfig.SystemProbe.GetStringSlice("runtime_security_config.activity_dump.local_storage.formats"); len(formats) > 0 {
+	if formats := coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.local_storage.formats"); len(formats) > 0 {
 		var err error
 		c.ActivityDumpLocalStorageFormats, err = ParseStorageFormats(formats)
 		if err != nil {

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -73,7 +73,7 @@ func (ds *DirectMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.Secur
 
 // NewDirectMsgSender returns a new direct sender
 func NewDirectMsgSender(stopper startstop.Stopper) (*DirectMsgSender, error) {
-	useSecRuntimeTrack := pkgconfig.SystemProbe.GetBool("runtime_security_config.use_secruntime_track")
+	useSecRuntimeTrack := pkgconfig.SystemProbe().GetBool("runtime_security_config.use_secruntime_track")
 
 	endpoints, destinationsCtx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
 	if err != nil {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -508,7 +508,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	}
 
 	if as.msgSender == nil {
-		if pkgconfig.SystemProbe.GetBool("runtime_security_config.direct_send_from_system_probe") {
+		if pkgconfig.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe") {
 			msgSender, err := NewDirectMsgSender(stopper)
 			if err != nil {
 				log.Errorf("failed to setup direct reporter: %v", err)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -140,7 +140,7 @@ type Config struct {
 
 // NewConfig returns a new Config object
 func NewConfig() (*Config, error) {
-	sysconfig.Adjust(coreconfig.SystemProbe)
+	sysconfig.Adjust(coreconfig.SystemProbe())
 
 	setEnv()
 
@@ -172,8 +172,8 @@ func NewConfig() (*Config, error) {
 		SyscallsMonitorEnabled:       getBool("syscalls_monitor.enabled"),
 
 		// event server
-		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),
-		EventServerBurst: coreconfig.SystemProbe.GetInt(join(evNS, "event_server.burst")),
+		SocketPath:       coreconfig.SystemProbe().GetString(join(evNS, "socket")),
+		EventServerBurst: coreconfig.SystemProbe().GetInt(join(evNS, "event_server.burst")),
 
 		// runtime compilation
 		RuntimeCompilationEnabled:       getBool("runtime_compilation.enabled"),
@@ -266,41 +266,41 @@ func getAllKeys(key string) (string, string) {
 
 func isSet(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	return coreconfig.SystemProbe.IsSet(deprecatedKey) || coreconfig.SystemProbe.IsSet(newKey)
+	return coreconfig.SystemProbe().IsSet(deprecatedKey) || coreconfig.SystemProbe().IsSet(newKey)
 }
 
 func getBool(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe.IsSet(deprecatedKey) {
+	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe.GetBool(deprecatedKey)
+		return coreconfig.SystemProbe().GetBool(deprecatedKey)
 	}
-	return coreconfig.SystemProbe.GetBool(newKey)
+	return coreconfig.SystemProbe().GetBool(newKey)
 }
 
 func getInt(key string) int {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe.IsSet(deprecatedKey) {
+	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe.GetInt(deprecatedKey)
+		return coreconfig.SystemProbe().GetInt(deprecatedKey)
 	}
-	return coreconfig.SystemProbe.GetInt(newKey)
+	return coreconfig.SystemProbe().GetInt(newKey)
 }
 
 func getString(key string) string {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe.IsSet(deprecatedKey) {
+	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe.GetString(deprecatedKey)
+		return coreconfig.SystemProbe().GetString(deprecatedKey)
 	}
-	return coreconfig.SystemProbe.GetString(newKey)
+	return coreconfig.SystemProbe().GetString(newKey)
 }
 
 func getStringSlice(key string) []string {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe.IsSet(deprecatedKey) {
+	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe.GetStringSlice(deprecatedKey)
+		return coreconfig.SystemProbe().GetStringSlice(deprecatedKey)
 	}
-	return coreconfig.SystemProbe.GetStringSlice(newKey)
+	return coreconfig.SystemProbe().GetStringSlice(newKey)
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -153,7 +153,7 @@ type Resolver struct {
 
 // NewSBOMResolver returns a new instance of Resolver
 func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, wmeta optional.Option[workloadmeta.Component]) (*Resolver, error) {
-	sbomScanner, err := sbomscanner.CreateGlobalScanner(coreconfig.SystemProbe, wmeta)
+	sbomScanner, err := sbomscanner.CreateGlobalScanner(coreconfig.SystemProbe(), wmeta)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/crashreport/crashreport.go
+++ b/pkg/util/crashreport/crashreport.go
@@ -102,7 +102,7 @@ func (wcr *WinCrashReporter) CheckForCrash() (*probe.WinCrashStatus, error) {
 		return nil, nil
 	}
 	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
+		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return nil, wcr.handleStartupError(err)
 	}


### PR DESCRIPTION
### What does this PR do?

Migrate the config.SystemProbe global to a function to access the config
    
This remove the duplicate config between pkg/config and pkg/config/setup. Removeing this duplication solves bugs where the mock would not be consistant.

This also paves the way to migrate the SystemProbe mock to its own package and at some point use the component instead of the package.

*The PR might seems huge but most of the change were done automatically using `gopathc`*
Gopatch changes are contained in the second commits which should not require review.

### Describe how to test/QA your changes

Unit tests are enough to QA this change.