### PR TITLE
Create dedicated mock for system-probe config in the mock package

### DIFF
--- a/pkg/config/mock.go
+++ b/pkg/config/mock.go
@@ -39,7 +39,9 @@ func (c *mockConfig) SetKnown(key string) {
 	c.Config.SetKnown(key)
 }
 
-// MockSystemProbe is creating and returning a mock system-probe config
+// MockSystemProbe is creating and returning a mock system-probe Config
+//
+// This method is deprecated and will soon be removed. Use pkg/config/mock.NewSystemProbe instead.
 func MockSystemProbe(t testing.TB) model.Config {
 	// We only check isSystemProbeConfigMocked when registering a cleanup function. 'isSystemProbeConfigMocked'
 	// avoids nested calls to Mock to reset the config to a blank state. This way we have only one mock per test and

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	isConfigMocked = false
-	m              = sync.Mutex{}
+	isConfigMocked            = false
+	isSystemProbeConfigMocked = false
+	m                         = sync.Mutex{}
 )
 
 // mockConfig should only be used in tests
@@ -40,7 +41,7 @@ func (c *mockConfig) SetKnown(key string) {
 	c.Config.SetKnown(key)
 }
 
-// New is creating and returning a mock config
+// New creates a mock for the config
 func New(t testing.TB) model.Config {
 	// We only check isConfigMocked when registering a cleanup function. 'isConfigMocked' avoids nested calls to
 	// Mock to reset the config to a blank state. This way we have only one mock per test and test helpers can call
@@ -69,4 +70,34 @@ func New(t testing.TB) model.Config {
 	setup.SetDatadog(newCfg)
 	setup.InitConfig(newCfg)
 	return &mockConfig{newCfg}
+}
+
+// NewSystemProbe creates a mock for the system-probe config
+func NewSystemProbe(t testing.TB) model.Config {
+	// We only check isSystemProbeConfigMocked when registering a cleanup function. 'isSystemProbeConfigMocked'
+	// avoids nested calls to Mock to reset the config to a blank state. This way we have only one mock per test and
+	// test helpers can call Mock.
+	if t != nil {
+		m.Lock()
+		defer m.Unlock()
+		if isSystemProbeConfigMocked {
+			// The configuration is already mocked.
+			return &mockConfig{setup.SystemProbe()}
+		}
+
+		isSystemProbeConfigMocked = true
+		originalConfig := setup.SystemProbe()
+		t.Cleanup(func() {
+			m.Lock()
+			defer m.Unlock()
+			isSystemProbeConfigMocked = false
+			setup.SetSystemProbe(originalConfig)
+		})
+	}
+
+	// Configure Datadog global configuration
+	setup.SetSystemProbe(model.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")))
+	// Configuration defaults
+	setup.InitSystemProbeConfig(setup.SystemProbe())
+	return &mockConfig{setup.SystemProbe()}
 }


### PR DESCRIPTION
### What does this PR do?

Starting the migration of the system-probe mock into the dedicated mock package.