### PR TITLE
Use only gitlab ReferenceTag instead of UserList

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -6,7 +6,6 @@ import platform
 import re
 import subprocess
 import sys
-from collections import UserList
 from copy import deepcopy
 from dataclasses import dataclass
 from difflib import Differ
@@ -439,18 +438,24 @@ class ReferenceTag(yaml.YAMLObject):
     def __init__(self, references):
         self.references = references
 
-    @classmethod
-    def from_yaml(cls, loader, node):
-        return UserList(loader.construct_sequence(node))
+    def __iter__(self):
+        return iter(self.references)
+
+    def __str__(self):
+        return f'{self.yaml_tag} {self.references}'
 
     @classmethod
-    def to_yaml(cls, dumper, data):
-        return dumper.represent_sequence(cls.yaml_tag, data.data, flow_style=True)
+    def from_yaml(cls, loader, node):
+        return ReferenceTag(loader.construct_sequence(node))
+
+    @classmethod
+    def to_yaml(cls, dumper, data: ReferenceTag):
+        return dumper.represent_sequence(cls.yaml_tag, data.references, flow_style=True)
 
 
 # Update loader/dumper to handle !reference tag
 yaml.SafeLoader.add_constructor(ReferenceTag.yaml_tag, ReferenceTag.from_yaml)
-yaml.SafeDumper.add_representer(UserList, ReferenceTag.to_yaml)
+yaml.SafeDumper.add_representer(ReferenceTag, ReferenceTag.to_yaml)
 
 # HACK: The following line is a workaround to prevent yaml dumper from removing quote around comma separated numbers, otherwise Gitlab Lint API will remove the commas
 yaml.SafeDumper.add_implicit_resolver(


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In order to write a `!reference [...]` in a yaml file, we have to use `UserList` which is not explicit.
Used `ReferenceTag` instead of this and added string representation and a way to iterate through it.

No code has to be changed since functions visiting the YAML tree do not need to visit the content of a reference list.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```py
s = StringIO()
yaml.safe_dump(ReferenceTag(['hello', 'world']), s)
print(s.getvalue()) # !reference [hello, world]
```
