### PR TITLE
Add Windows agent as a secondary codeowner for Fleet Automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -198,8 +198,8 @@
 /cmd/system-probe/main_windows*.go      @DataDog/windows-kernel-integrations
 /cmd/systray/                           @DataDog/windows-agent
 /cmd/security-agent/                    @DataDog/agent-security
-/cmd/updater/                           @DataDog/fleet
-/cmd/installer/                         @DataDog/fleet
+/cmd/updater/                           @DataDog/fleet @DataDog/windows-agent
+/cmd/installer/                         @DataDog/fleet @DataDog/windows-agent
 
 /dev/                                   @DataDog/agent-devx-loops
 /devenv/                                @DataDog/agent-devx-loops
@@ -260,7 +260,7 @@
 /comp/snmptraps @DataDog/network-device-monitoring
 /comp/systray @DataDog/windows-agent
 /comp/trace @DataDog/agent-apm
-/comp/updater @DataDog/fleet
+/comp/updater @DataDog/fleet @DataDog/windows-agent
 /comp/agent/cloudfoundrycontainer @DataDog/platform-integrations
 /comp/agent/jmxlogger @DataDog/agent-metrics-logs
 /comp/aggregator/diagnosesendermanager @DataDog/agent-shared-components
@@ -380,7 +380,7 @@
 /pkg/flare/*_win.go                     @Datadog/windows-agent
 /pkg/flare/*_windows.go                 @Datadog/windows-agent
 /pkg/flare/*_windows_test.go            @Datadog/windows-agent
-/pkg/fleet/                             @DataDog/fleet
+/pkg/fleet/                             @DataDog/fleet @DataDog/windows-agent
 /pkg/otlp/                              @DataDog/opentelemetry
 /pkg/otlp/*_serverless*.go              @DataDog/serverless
 /pkg/otlp/*_not_serverless*.go          @DataDog/opentelemetry
@@ -595,8 +595,8 @@
 /test/new-e2e/tests/windows                   @DataDog/windows-agent @DataDog/windows-kernel-integrations
 /test/new-e2e/tests/apm                       @DataDog/agent-apm
 /test/new-e2e/tests/remote-config             @DataDog/remote-config
-/test/new-e2e/tests/updater                   @DataDog/fleet
-/test/new-e2e/tests/installer                 @DataDog/fleet
+/test/new-e2e/tests/updater                   @DataDog/fleet @DataDog/windows-agent
+/test/new-e2e/tests/installer                 @DataDog/fleet @DataDog/windows-agent
 /test/otel/                                   @DataDog/opentelemetry
 /test/system/                                 @DataDog/agent-shared-components
 /test/system/dogstatsd/                       @DataDog/agent-metrics-logs

--- a/comp/README.md
+++ b/comp/README.md
@@ -571,7 +571,7 @@ Package status implements the core status component information provider interfa
 
 ## [comp/updater](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater) (Component Bundle)
 
-*Datadog Team*: fleet
+*Datadog Team*: fleet windows-agent
 
 Package updater implements the updater component.
 

--- a/comp/updater/bundle.go
+++ b/comp/updater/bundle.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: fleet
+// team: fleet windows-agent
 
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {

--- a/comp/updater/localapi/component.go
+++ b/comp/updater/localapi/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/daemon"
 )
 
-// team: fleet
+// team: fleet windows-agent
 
 // Component is the interface for the updater local api component.
 type Component interface {

--- a/comp/updater/localapiclient/component.go
+++ b/comp/updater/localapiclient/component.go
@@ -8,7 +8,7 @@ package localapiclient
 
 import "github.com/DataDog/datadog-agent/pkg/fleet/daemon"
 
-// team: fleet
+// team: fleet windows-agent
 
 // Component is the component type.
 type Component interface {

--- a/comp/updater/telemetry/component.go
+++ b/comp/updater/telemetry/component.go
@@ -6,7 +6,7 @@
 // Package telemetry provides the installer telemetry component.
 package telemetry
 
-// team: fleet
+// team: fleet windows-agent
 
 // Component is the component type.
 type Component interface {

--- a/comp/updater/updater/component.go
+++ b/comp/updater/updater/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/daemon"
 )
 
-// team: fleet
+// team: fleet windows-agent
 
 // Component is the interface for the updater component.
 type Component interface {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds the @DataDog/windows-agent as a secondary code owner for some of the Fleet Automation code.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Being a secondary code owner would allow the Windows team to keep track of the changes being made on the Fleet Automation side, and catch things like https://github.com/DataDog/datadog-agent/pull/27521 which broke the Windows installs.

Hopefully this will be less of a problem once https://github.com/DataDog/datadog-agent/pull/27798 is merged.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
