### PR TITLE
[Fleet Automation] Enable installer_test on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@ go.sum -diff -merge linguist-generated=true
 *_easyjson.go -diff -merge
 *_easyjson.go linguist-generated=true
 pkg/security/probe/constantfetch/btfhub/constants.json -diff -merge linguist-generated=true
+# Fixtures should have LF line endings because they are checked against OCI packages built on Linux
+pkg/fleet/internal/fixtures/** text=auto eol=lf
 
 # Fix `git diff` when running on the below file formats.
 # Our windows build image uses MinGit which tries to use the astextplain diff algorithm (https://git-scm.com/docs/gitattributes#_setting_the_internal_diff_algorithm).

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// for now the installer is not supported on windows
-//go:build !windows
-
 package installer
 
 import (

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -7,12 +7,11 @@ package installer
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
@@ -50,6 +49,7 @@ func (i *testPackageManager) ConfigFS(f fixtures.Fixture) fs.FS {
 func TestInstallStable(t *testing.T) {
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
 
 	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 	assert.NoError(t, err)
@@ -65,6 +65,7 @@ func TestInstallStable(t *testing.T) {
 func TestInstallExperiment(t *testing.T) {
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
 
 	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 	assert.NoError(t, err)
@@ -83,6 +84,7 @@ func TestInstallExperiment(t *testing.T) {
 func TestInstallPromoteExperiment(t *testing.T) {
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
 
 	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 	assert.NoError(t, err)
@@ -102,6 +104,7 @@ func TestInstallPromoteExperiment(t *testing.T) {
 func TestUninstallExperiment(t *testing.T) {
 	s := fixtures.NewServer(t)
 	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
 
 	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 	assert.NoError(t, err)

--- a/pkg/fleet/internal/fixtures/fs.go
+++ b/pkg/fleet/internal/fixtures/fs.go
@@ -31,10 +31,22 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 			return err
 		}
 		entryA, err := a.Open(path)
+		defer func() {
+			cerr := entryA.Close()
+			if cerr != nil {
+				err = fmt.Errorf("close entryA %v: %w", cerr, err)
+			}
+		}()
 		if err != nil {
 			return err
 		}
 		entryB, err := b.Open(path)
+		defer func() {
+			cerr := entryB.Close()
+			if cerr != nil {
+				err = fmt.Errorf("close entryB %v: %w", cerr, err)
+			}
+		}()
 		if err != nil {
 			return err
 		}

--- a/pkg/fleet/internal/fixtures/fs.go
+++ b/pkg/fleet/internal/fixtures/fs.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,11 +59,6 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 		contentB, err := io.ReadAll(entryB)
 		if err != nil {
 			return err
-		}
-		// On Windows we have pesky \r that will mess our test result.
-		if runtime.GOOS == "windows" {
-			contentA = bytes.ReplaceAll(contentA, []byte{'\r'}, nil)
-			contentB = bytes.ReplaceAll(contentB, []byte{'\r'}, nil)
 		}
 		if !bytes.Equal(contentA, contentB) {
 			return fmt.Errorf("files %s do not have the same content: %s != %s", path, contentA, contentB)

--- a/pkg/fleet/internal/fixtures/fs.go
+++ b/pkg/fleet/internal/fixtures/fs.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,16 +63,8 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 		}
 		// On Windows we have pesky \r that will mess our test result.
 		if runtime.GOOS == "windows" {
-			for i, c := range contentA {
-				if c == '\r' {
-					contentA = append(contentA[:i], contentA[i+1:]...)
-				}
-			}
-			for i, c := range contentB {
-				if c == '\r' {
-					contentB = append(contentB[:i], contentB[i+1:]...)
-				}
-			}
+			contentA = bytes.ReplaceAll(contentA, []byte{'\r'}, nil)
+			contentB = bytes.ReplaceAll(contentB, []byte{'\r'}, nil)
 		}
 		if !bytes.Equal(contentA, contentB) {
 			return fmt.Errorf("files %s do not have the same content: %s != %s", path, contentA, contentB)

--- a/pkg/fleet/internal/fixtures/fs.go
+++ b/pkg/fleet/internal/fixtures/fs.go
@@ -60,6 +60,19 @@ func fsContainsAll(a fs.FS, b fs.FS) error {
 		if err != nil {
 			return err
 		}
+		// On Windows we have pesky \r that will mess our test result.
+		if runtime.GOOS == "windows" {
+			for i, c := range contentA {
+				if c == '\r' {
+					contentA = append(contentA[:i], contentA[i+1:]...)
+				}
+			}
+			for i, c := range contentB {
+				if c == '\r' {
+					contentB = append(contentB[:i], contentB[i+1:]...)
+				}
+			}
+		}
 		if !bytes.Equal(contentA, contentB) {
 			return fmt.Errorf("files %s do not have the same content: %s != %s", path, contentA, contentB)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR lets running the installer tests on Windows. It has to remove the "\r" return from the files produced on Windows for the tests to pass.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/WINA-883
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
