### PR TITLE
[USMON-1135] discovery module skeleton

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -41,6 +41,7 @@ const (
 	ComplianceModule             types.ModuleName = "compliance"
 	PingModule                   types.ModuleName = "ping"
 	TracerouteModule             types.ModuleName = "traceroute"
+	DiscoveryModule              types.ModuleName = "discovery"
 )
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -144,7 +145,9 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(tracerouteNS("enabled")) {
 		c.EnabledModules[TracerouteModule] = struct{}{}
 	}
-
+	if cfg.GetBool(discoveryNS("enabled")) {
+		c.EnabledModules[DiscoveryModule] = struct{}{}
+	}
 	if cfg.GetBool(wcdNS("enabled")) {
 		c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
 	}

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -127,7 +127,6 @@ func configurationFromYAML(t *testing.T, yaml string) config.Config {
 	f, err := os.CreateTemp(t.TempDir(), "system-probe.*.yaml")
 	require.NoError(t, err)
 	defer f.Close()
-	defer os.Remove(f.Name())
 
 	b := []byte(yaml)
 	n, err := f.Write(b)

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -9,6 +9,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -96,11 +97,11 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 	})
 }
 
-func TestEnableServiceDiscovery(t *testing.T) {
+func TestEnableDiscovery(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		config.ResetSystemProbeConfig(t)
 		cfg := configurationFromYAML(t, `
-service_discovery:
+discovery:
   enabled: true
 `)
 		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
@@ -108,7 +109,7 @@ service_discovery:
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		config.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_DISCOVERY_ENABLED", "true")
+		t.Setenv("DD_DISCOVERY_ENABLED", "true")
 		cfg := config.SystemProbe
 
 		assert.True(t, cfg.GetBool(discoveryNS("enabled")))

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -124,7 +124,7 @@ discovery:
 }
 
 func configurationFromYAML(t *testing.T, yaml string) config.Config {
-	f, err := os.CreateTemp("", "system-probe.*.yaml")
+	f, err := os.CreateTemp(t.TempDir(), "system-probe.*.yaml")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -95,3 +95,44 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 		require.False(t, cfg.GetBool("event_monitoring_config.network_process.enabled"))
 	})
 }
+
+func TestEnableServiceDiscovery(t *testing.T) {
+	t.Run("via YAML", func(t *testing.T) {
+		config.ResetSystemProbeConfig(t)
+		cfg := configurationFromYAML(t, `
+service_discovery:
+  enabled: true
+`)
+		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		config.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_DISCOVERY_ENABLED", "true")
+		cfg := config.SystemProbe
+
+		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
+	})
+
+	t.Run("default", func(t *testing.T) {
+		config.ResetSystemProbeConfig(t)
+		cfg := config.SystemProbe
+
+		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
+	})
+}
+
+func configurationFromYAML(t *testing.T, yaml string) config.Config {
+	f, err := os.CreateTemp("", "system-probe.*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	b := []byte(yaml)
+	n, err := f.Write(b)
+	require.NoError(t, err)
+	require.Equal(t, len(b), n)
+	f.Sync()
+
+	_, _ = New(f.Name())
+	return config.SystemProbe
+}

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -126,6 +126,7 @@ discovery:
 func configurationFromYAML(t *testing.T, yaml string) config.Config {
 	f, err := os.CreateTemp(t.TempDir(), "system-probe.*.yaml")
 	require.NoError(t, err)
+	defer f.Close()
 	defer os.Remove(f.Name())
 
 	b := []byte(yaml)

--- a/cmd/system-probe/config/ns.go
+++ b/cmd/system-probe/config/ns.go
@@ -60,3 +60,8 @@ func pngNS(k ...string) string {
 func tracerouteNS(k ...string) string {
 	return nskey("traceroute", k...)
 }
+
+// discoveryNS adds `discovery` namespace to config key
+func discoveryNS(k ...string) string {
+	return nskey("discovery", k...)
+}

--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -28,6 +28,7 @@ var All = []module.Factory{
 	ComplianceModule,
 	Pinger,
 	Traceroute,
+	DiscoveryModule,
 }
 
 func inactivityEventLog(_ time.Duration) {

--- a/cmd/system-probe/modules/all_linux_arm64.go
+++ b/cmd/system-probe/modules/all_linux_arm64.go
@@ -29,6 +29,7 @@ var All = []module.Factory{
 	ComplianceModule,
 	Pinger,
 	Traceroute,
+	DiscoveryModule,
 }
 
 func inactivityEventLog(_ time.Duration) {

--- a/cmd/system-probe/modules/discovery_linux.go
+++ b/cmd/system-probe/modules/discovery_linux.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	discoverymodule "github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/module"
+)
+
+// DiscoveryModule is the discovery module factory.
+var DiscoveryModule = module.Factory{
+	Name:             config.DiscoveryModule,
+	ConfigNamespaces: []string{"discovery"},
+	Fn:               discoverymodule.NewDiscoveryModule,
+	NeedsEBPF: func() bool {
+		return false
+	},
+}

--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -85,6 +85,7 @@ The payload is a JSON dict with the following fields
   - `feature_usm_redis_enabled` - **bool**: True if Redis monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_redis_monitoring` config option in `system-probe.yaml`)
   - `feature_usm_java_tls_enabled` - **bool**: True if HTTPS monitoring through java TLS is enabled for Universal Service Monitoring (see: `service_monitoring_config.tls.java.enabled` config option in `system-probe.yaml`).
   - `feature_usm_go_tls_enabled` - **bool**: True if HTTPS monitoring through GoTLS is enabled for Universal Service Monitoring (see: `service_monitoring_config.tls.go.enabled` config option in `system-probe.yaml`).
+  - `feature_discovery_enabled` - **bool**: True if discovery module is enabled (see: `discovery.enabled` config option).
   - `feature_dynamic_instrumentation_enabled` - **bool**: True if dynamic instrumentation module is enabled (see: `dynamic_instrumentation.enabled` config option).
   - `feature_logs_enabled` - **bool**: True if the logs collection is enabled (see: `logs_enabled` config option).
   - `feature_cspm_enabled` - **bool**: True if the Cloud Security Posture Management is enabled (see:

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -299,6 +299,10 @@ func (ia *inventoryagent) fetchSystemProbeMetadata() {
 	ia.data["feature_usm_http_by_status_code_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_http_stats_by_status_code")
 	ia.data["feature_usm_go_tls_enabled"] = sysProbeConf.GetBool("service_monitoring_config.tls.go.enabled")
 
+	// Discovery module / system-probe
+
+	ia.data["feature_discovery_enabled"] = sysProbeConf.GetBool("discovery.enabled")
+
 	// miscellaneous / system-probe
 
 	ia.data["feature_tcp_queue_length_enabled"] = sysProbeConf.GetBool("system_probe_config.enable_tcp_queue_length")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -126,6 +126,7 @@ func TestInitData(t *testing.T) {
 		"service_monitoring_config.tls.istio.enabled":                true,
 		"service_monitoring_config.enable_http_stats_by_status_code": true,
 		"service_monitoring_config.tls.go.enabled":                   true,
+		"discovery.enabled":                                          true,
 		"system_probe_config.enable_tcp_queue_length":                true,
 		"system_probe_config.enable_oom_kill":                        true,
 		"windows_crash_detection.enabled":                            true,
@@ -220,6 +221,7 @@ func TestInitData(t *testing.T) {
 		"feature_usm_istio_enabled":                    true,
 		"feature_usm_http_by_status_code_enabled":      true,
 		"feature_usm_go_tls_enabled":                   true,
+		"feature_discovery_enabled":                    true,
 		"feature_tcp_queue_length_enabled":             true,
 		"feature_oom_kill_enabled":                     true,
 		"feature_windows_crash_detection_enabled":      true,
@@ -493,6 +495,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_usm_istio_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_discovery_enabled"].(bool))
 	assert.False(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
 	assert.False(t, ia.data["feature_oom_kill_enabled"].(bool))
 	assert.False(t, ia.data["feature_windows_crash_detection_enabled"].(bool))
@@ -545,6 +548,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_usm_istio_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.False(t, ia.data["feature_discovery_enabled"].(bool))
 	assert.False(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
 	assert.False(t, ia.data["feature_oom_kill_enabled"].(bool))
 	assert.False(t, ia.data["feature_windows_crash_detection_enabled"].(bool))
@@ -605,6 +609,9 @@ service_monitoring_config:
   enable_http2_monitoring: true
   enable_http_stats_by_status_code: true
 
+discovery:
+  enabled: true
+
 windows_crash_detection:
   enabled: true
 
@@ -642,6 +649,7 @@ dynamic_instrumentation:
 	assert.True(t, ia.data["feature_usm_istio_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_http_by_status_code_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_go_tls_enabled"].(bool))
+	assert.True(t, ia.data["feature_discovery_enabled"].(bool))
 	assert.True(t, ia.data["feature_tcp_queue_length_enabled"].(bool))
 	assert.True(t, ia.data["feature_oom_kill_enabled"].(bool))
 	assert.True(t, ia.data["feature_windows_crash_detection_enabled"].(bool))

--- a/pkg/collector/corechecks/servicediscovery/module/doc.go
+++ b/pkg/collector/corechecks/servicediscovery/module/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package module implements a system-probe Module interface for the discovery component.
+package module

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -15,10 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
-const (
-	status = "/status"
-)
-
 // Ensure discovery implements the module.Module interface.
 var _ module.Module = &discovery{}
 
@@ -37,7 +33,7 @@ func (s *discovery) GetStats() map[string]interface{} {
 
 // Register registers the discovery module with the provided HTTP mux.
 func (s *discovery) Register(httpMux *module.Router) error {
-	httpMux.HandleFunc(status, s.handleStatusEndpoint)
+	httpMux.HandleFunc("/status", s.handleStatusEndpoint)
 	return nil
 }
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package module
+
+import (
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+)
+
+const (
+	status = "/status"
+)
+
+// Ensure discovery implements the module.Module interface.
+var _ module.Module = &discovery{}
+
+// discovery is an implementation of the Module interface for the discovery module.
+type discovery struct{}
+
+// NewDiscoveryModule creates a new discovery system probe module.
+func NewDiscoveryModule(*sysconfigtypes.Config, optional.Option[workloadmeta.Component], telemetry.Component) (module.Module, error) {
+	return &discovery{}, nil
+}
+
+// GetStats returns the stats of the discovery module.
+func (s *discovery) GetStats() map[string]interface{} {
+	return nil
+}
+
+// Register registers the discovery module with the provided HTTP mux.
+func (s *discovery) Register(httpMux *module.Router) error {
+	httpMux.HandleFunc(status, s.handleStatusEndpoint)
+	return nil
+}
+
+// Close cleans resources used by the discovery module.
+// Currently, a no-op.
+func (s *discovery) Close() {}
+
+// handleStatusEndpoint is the handler for the /status endpoint.
+// Reports the status of the discovery module.
+func (s *discovery) handleStatusEndpoint(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte("Discovery Module is running"))
+}

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -30,6 +30,7 @@ const (
 	wcdNS                        = "windows_crash_detection"
 	pngNS                        = "ping"
 	tracerouteNS                 = "traceroute"
+	discoveryNS                  = "discovery"
 	defaultConnsMessageBatchSize = 600
 
 	// defaultServiceMonitoringJavaAgentArgs is default arguments that are passing to the injected java USM agent
@@ -382,6 +383,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// CCM config
 	cfg.BindEnvAndSetDefault(join(ccmNS, "enabled"), false)
+
+	// Discovery config
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
 
 	initCWSSystemProbeConfig(cfg)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Creates a new system-probe module (linux only) to collect information for the new discovery initiative.
The current module is empty and does not perform logic, the actual collection will be done in a separate PRs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Setting the baseline for the new discovery module.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Enable module
  Run system-probe with the following environment variable `DD_DISCOVERY_ENABLED=true`, or
  Add the following entry to the system-probe configuration file:
  ```yaml
  discovery:
    enabled: true
  ```
3. Run system-probe
4. Query status of the new module 
  ```shell
  curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/status
  ```
5. expect to see 
  ```shell
  Discovery Module is running
  ``` 




<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
