### PR TITLE
[notify] Send non-main deploy pipelines to dedicated channel

### DIFF
--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -3,7 +3,7 @@ import re
 
 from tasks.libs.ciproviders.gitlab_api import get_commit, get_pipeline
 from tasks.libs.common.constants import DEFAULT_BRANCH
-from tasks.libs.notify.utils import PIPELINES_CHANNEL, PROJECT_NAME
+from tasks.libs.notify.utils import DEPLOY_PIPELINES_CHANNEL, PIPELINES_CHANNEL, PROJECT_NAME
 from tasks.libs.pipeline.data import get_failed_jobs
 from tasks.libs.pipeline.notifications import (
     base_message,
@@ -37,7 +37,11 @@ def send_message(ctx, notification_type, dry_run):
         header_icon = ":host-green:"
         state = "succeeded"
 
+    # For deploy pipelines not on the main branch, send notifications in a
+    # dedicated channel.
     slack_channel = PIPELINES_CHANNEL
+    if notification_type == "deploy" and pipeline.ref != DEFAULT_BRANCH:
+        slack_channel = DEPLOY_PIPELINES_CHANNEL
 
     header = ""
     if notification_type == "merge":

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -9,6 +9,7 @@ CI_VISIBILITY_JOB_URL = 'https://app.datadoghq.com/ci/pipeline-executions?query=
 NOTIFICATION_DISCLAIMER = "If there is something wrong with the notification please contact #agent-devx-help"
 CHANNEL_BROADCAST = '#agent-devx-ops'
 PIPELINES_CHANNEL = '#datadog-agent-pipelines'
+DEPLOY_PIPELINES_CHANNEL = '#datadog-agent-deploy-pipelines'
 AWS_S3_CP_CMD = "aws s3 cp --only-show-errors --region us-east-1 --sse AES256"
 AWS_S3_LS_CMD = "aws s3api list-objects-v2 --bucket '{bucket}' --prefix '{prefix}/' --delimiter /"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Send notifications about deploy pipelines on a new, separate channel, `#datadog-agent-deploy-pipelines`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Keep `#datadog-agent-pipelines` for `main` branch notifications only. Give dedicated channel for other deploys.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Dry runs:
```
$ CI_PIPELINE_ID=39050456  inv -e notify.send-message --notification-type "deploy"  --dry-run
Would send to #datadog-agent-deploy-pipelines:
:host-red: :rocket: datadog-agent deploy pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/39050456|39050456> for 7.55.1 failed.
Final updates for release.json and Go modules for 7.55.1 release (<https://github.com/DataDog/datadog-agent/pull/27544|#27544>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/8ec9dffc0f9806f20183061059474d3e027ea7c9|027ea7c9>)(:github: <https://github.com/DataDog/datadog-agent/commit/8ec9dffc0f9806f20183061059474d3e027ea7c9|link>) by Nicolas Schweitzer
Failed jobs:
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/571991676|trigger_auto_staging_release> (`trigger_release` stage)
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/571990924|new-e2e-containers> (`e2e` stage)
```

```
$ CI_PIPELINE_ID=40301698  inv -e notify.send-message --notification-type "deploy"  --dry-run
Would send to #datadog-agent-pipelines:
:host-green: :rocket: datadog-agent deploy pipeline <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/40301698|40301698> for main succeeded.
ignore microsoft.net in system path tester (<https://github.com/DataDog/datadog-agent/pull/27989|#27989>) (<https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/1bdd5ac7c4c769ec9eb45517d9db3b23b3d45cf7|b3d45cf7>)(:github: <https://github.com/DataDog/datadog-agent/commit/1bdd5ac7c4c769ec9eb45517d9db3b23b3d45cf7|link>) by Branden Clark
```
