### PR TITLE
better detect metadata v4 endpoint

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -121,11 +121,16 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 }
 
 func (c *collector) setTaskCollectionParser() {
-	_, err := ecsmeta.V4FromCurrentTask()
-	if c.taskCollectionEnabled && err == nil {
+	ok, err := ecsmeta.IsMetadataV4Available()
+	if c.taskCollectionEnabled && ok && err == nil {
+		log.Infof("detailed task collection enabled, using metadata v4 endpoint")
 		c.taskCollectionParser = c.parseTasksFromV4Endpoint
 		return
+	} else if c.taskCollectionEnabled && err != nil {
+		log.Warnf("detailed task collection enabled but agent cannot determine if v4 metadata endpoint is available: %s", err.Error())
 	}
+
+	log.Infof("detailed task collection disabled, using metadata v1 endpoint")
 	c.taskCollectionParser = c.parseTasksFromV1Endpoint
 }
 

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -115,23 +115,33 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 		log.Warnf("cannot determine ECS cluster name: %s", err)
 	}
 
-	c.setTaskCollectionParser()
+	c.setTaskCollectionParser(instance.Version)
 
 	return nil
 }
 
-func (c *collector) setTaskCollectionParser() {
-	ok, err := ecsmeta.IsMetadataV4Available()
-	if c.taskCollectionEnabled && ok && err == nil {
-		log.Infof("detailed task collection enabled, using metadata v4 endpoint")
-		c.taskCollectionParser = c.parseTasksFromV4Endpoint
+func (c *collector) setTaskCollectionParser(version string) {
+	if !c.taskCollectionEnabled {
+		log.Infof("detailed task collection disabled, using metadata v1 endpoint")
+		c.taskCollectionParser = c.parseTasksFromV1Endpoint
 		return
-	} else if c.taskCollectionEnabled && err != nil {
-		log.Warnf("detailed task collection enabled but agent cannot determine if v4 metadata endpoint is available: %s", err.Error())
 	}
 
-	log.Infof("detailed task collection disabled, using metadata v1 endpoint")
-	c.taskCollectionParser = c.parseTasksFromV1Endpoint
+	ok, err := ecsmeta.IsMetadataV4Available(util.ParserECSAgentVersion(version))
+	if err != nil {
+		log.Warnf("detailed task collection enabled but agent cannot determine if v4 metadata endpoint is available, using metadata v1 endpoint: %s", err.Error())
+		c.taskCollectionParser = c.parseTasksFromV1Endpoint
+		return
+	}
+
+	if !ok {
+		log.Infof("detailed task collection enabled but v4 metadata endpoint is not available, using metadata v1 endpoint")
+		c.taskCollectionParser = c.parseTasksFromV1Endpoint
+		return
+	}
+
+	log.Infof("detailed task collection enabled, using metadata v4 endpoint")
+	c.taskCollectionParser = c.parseTasksFromV4Endpoint
 }
 
 func (c *collector) Pull(ctx context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -127,7 +127,7 @@ func (c *collector) setTaskCollectionParser(version string) {
 		return
 	}
 
-	ok, err := ecsmeta.IsMetadataV4Available(util.ParserECSAgentVersion(version))
+	ok, err := ecsmeta.IsMetadataV4Available(util.ParseECSAgentVersion(version))
 	if err != nil {
 		log.Warnf("detailed task collection enabled but agent cannot determine if v4 metadata endpoint is available, using metadata v1 endpoint: %s", err.Error())
 		c.taskCollectionParser = c.parseTasksFromV1Endpoint

--- a/comp/core/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/comp/core/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -22,6 +22,7 @@ import (
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -87,9 +88,14 @@ func (c *collector) setTaskCollectionParser() {
 	var err error
 	c.metaV4, err = ecsmeta.V4FromCurrentTask()
 	if c.taskCollectionEnabled && err == nil {
+		log.Infof("detailed task collection enabled, using metadata v4 endpoint")
 		c.taskCollectionParser = c.parseTaskFromV4Endpoint
 		return
+	} else if c.taskCollectionEnabled && err != nil {
+		log.Warnf("failed to initialize metadata v4 client, using metdata v2: %v", err)
 	}
+
+	log.Infof("detailed task collection disabled, using metadata v2 endpoint")
 	c.taskCollectionParser = c.parseTaskFromV2Endpoint
 }
 

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -267,15 +267,15 @@ func parseClusterName(cluster string) string {
 	return parts[1]
 }
 
+// ecsAgentRegexp is a regular expression to match ECS agent versions
+// \d+(?:\.\d+){0,2} for versions like 1.32.0, 1.3 and 1
+// (-\w+)? for optional pre-release tags like -beta
+var ecsAgentVersionRegexp = regexp.MustCompile(`\bv(\d+(?:\.\d+){0,2}(?:-\w+)?)\b`)
+
 // ParseECSAgentVersion parses the ECS agent version from the version string
 // Instance metadata returns the version in the format `Amazon ECS Agent - v1.30.0 (02ff320c)`
 func ParseECSAgentVersion(s string) string {
-	// \d+\.\d+\.\d+ for versions like 1.32.0
-	// (-\w+)? for optional pre-release tags like -beta
-	// |\d+\.\d+ for shorter versions like 0.1
-	// |\d+ for versions like 1
-	re := regexp.MustCompile(`v(\d+\.\d+\.\d+(-\w+)?|\d+\.\d+(-\w+)?|\d+(-\w+)?)`)
-	match := re.FindStringSubmatch(s)
+	match := ecsAgentVersionRegexp.FindStringSubmatch(s)
 	if len(match) > 1 {
 		return match[1]
 	}

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -267,9 +267,9 @@ func parseClusterName(cluster string) string {
 	return parts[1]
 }
 
-// ParserECSAgentVersion parses the ECS agent version from the version string
+// ParseECSAgentVersion parses the ECS agent version from the version string
 // Instance metadata returns the version in the format `Amazon ECS Agent - v1.30.0 (02ff320c)`
-func ParserECSAgentVersion(s string) string {
+func ParseECSAgentVersion(s string) string {
 	// \d+\.\d+\.\d+ for versions like 1.32.0
 	// (-\w+)? for optional pre-release tags like -beta
 	// |\d+\.\d+ for shorter versions like 0.1

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -9,6 +9,7 @@ package util
 
 import (
 	"context"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -264,4 +265,19 @@ func parseClusterName(cluster string) string {
 		return cluster
 	}
 	return parts[1]
+}
+
+// ParserECSAgentVersion parses the ECS agent version from the version string
+// Instance metadata returns the version in the format `Amazon ECS Agent - v1.30.0 (02ff320c)`
+func ParserECSAgentVersion(s string) string {
+	// \d+\.\d+\.\d+ for versions like 1.32.0
+	// (-\w+)? for optional pre-release tags like -beta
+	// |\d+\.\d+ for shorter versions like 0.1
+	// |\d+ for versions like 1
+	re := regexp.MustCompile(`v(\d+\.\d+\.\d+(-\w+)?|\d+\.\d+(-\w+)?|\d+(-\w+)?)`)
+	match := re.FindStringSubmatch(s)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return ""
 }

--- a/comp/core/workloadmeta/collectors/util/ecs_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util_test.go
@@ -53,7 +53,7 @@ func TestParserECSAgentVersion(t *testing.T) {
 			expected: "",
 		},
 	} {
-		version := ParserECSAgentVersion(testCase.version)
+		version := ParseECSAgentVersion(testCase.version)
 		require.Equal(t, testCase.expected, version)
 	}
 }

--- a/comp/core/workloadmeta/collectors/util/ecs_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util_test.go
@@ -26,3 +26,34 @@ func TestParseRegionAndAWSAccountID(t *testing.T) {
 	require.Equal(t, "us-east-1", region)
 	require.Equal(t, 0, awsAccountID)
 }
+
+func TestParserECSAgentVersion(t *testing.T) {
+	for _, testCase := range []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "Amazon ECS Agent - v1.30.0 (02ff320c)",
+			expected: "1.30.0",
+		},
+		{
+			version:  "some prefix v1.30.0-beta some suffix",
+			expected: "1.30.0-beta",
+		},
+		{
+			version:  "some prefix v1 some suffix",
+			expected: "1",
+		},
+		{
+			version:  "some prefix v0.1 some suffix",
+			expected: "0.1",
+		},
+		{
+			version:  "Amazon ECS Agent - (02ff320c)",
+			expected: "",
+		},
+	} {
+		version := ParserECSAgentVersion(testCase.version)
+		require.Equal(t, testCase.expected, version)
+	}
+}

--- a/comp/core/workloadmeta/collectors/util/ecs_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util_test.go
@@ -52,6 +52,10 @@ func TestParserECSAgentVersion(t *testing.T) {
 			version:  "Amazon ECS Agent - (02ff320c)",
 			expected: "",
 		},
+		{
+			version:  "someprefixv0.1somesuffix",
+			expected: "",
+		},
 	} {
 		version := ParseECSAgentVersion(testCase.version)
 		require.Equal(t, testCase.expected, version)

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -168,7 +168,8 @@ func IsMetadataV4Available(ecsAgentVersion string) (bool, error) {
 	}
 
 	if currentECSAgentVersion.LessThan(expectedMinimumECSAgentVersion) {
-		return false, fmt.Errorf("ECS agent version %s is less than the minimum required version %s", currentECSAgentVersion, expectedMinimumECSAgentVersion)
+		log.Debugf("ECS agent version %s is less than the minimum required version %s", currentECSAgentVersion, expectedMinimumECSAgentVersion)
+		return false, nil
 	}
 
 	return true, nil

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -159,19 +159,19 @@ func IsMetadataV4Available() (bool, error) {
 	}
 
 	// Check if agent is deployed directly on EC2
-	du, err := docker.GetDockerUtil()
+	dockerUtil, err := docker.GetDockerUtil()
 	if err != nil {
 		return false, err
 	}
 
-	containers, err := du.RawContainerList(context.Background(), container.ListOptions{})
+	containers, err := dockerUtil.RawContainerList(context.Background(), container.ListOptions{})
 	if err != nil {
 		return false, err
 	}
 
 	// Check if any container has the v4 endpoint env variable
 	for _, c := range containers {
-		if hasMetadataURIv4EnvVariable(du, c.ID) {
+		if hasMetadataURIv4EnvVariable(dockerUtil, c.ID) {
 			return true, nil
 		}
 	}
@@ -179,8 +179,8 @@ func IsMetadataV4Available() (bool, error) {
 	return false, errors.New("v4 endpoint not found in any container")
 }
 
-func hasMetadataURIv4EnvVariable(du *docker.DockerUtil, containerID string) bool {
-	inspect, err := du.Inspect(context.Background(), containerID, false)
+func hasMetadataURIv4EnvVariable(dockerUtil *docker.DockerUtil, containerID string) bool {
+	inspect, err := dockerUtil.Inspect(context.Background(), containerID, false)
 	if err != nil {
 		log.Infof("Unable to inspect container, docker inspect failed: %s", err)
 		return false

--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -111,7 +111,7 @@ func TestIsMetadataV4Available(t *testing.T) {
 	assert.False(t, ok)
 
 	ok, err = IsMetadataV4Available("1.0.0")
-	assert.NotNil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, ok)
 
 	ok, err = IsMetadataV4Available("1.80.0")

--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -104,3 +104,24 @@ func TestGetAgentV1ContainerURLs(t *testing.T) {
 	assert.Contains(t, agentURLS, "http://172.17.0.3:51678/")
 	assert.Equal(t, "http://ip-172-29-167-5:51678/", agentURLS[2])
 }
+
+func TestHasMetadataURIv4EnvVariable(t *testing.T) {
+	co := types.ContainerJSON{
+		Config: &container.Config{
+			Env: []string{
+				"AWS_EXECUTION_ENV=AWS_ECS_EC2",
+				"ECS_CONTAINER_METADATA_URI=http://169.254.170.2/v3/123",
+				"ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/123",
+			},
+		},
+		ContainerJSONBase: &types.ContainerJSONBase{},
+	}
+
+	docker.EnableTestingMode()
+	cacheKey := docker.GetInspectCacheKey("container-id-3bc6d22", false)
+	cache.Cache.Set(cacheKey, co, 10*time.Second)
+
+	du, err := docker.GetDockerUtil()
+	require.NoError(t, err)
+	require.True(t, hasMetadataURIv4EnvVariable(du, "container-id-3bc6d22"))
+}

--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -105,23 +105,16 @@ func TestGetAgentV1ContainerURLs(t *testing.T) {
 	assert.Equal(t, "http://ip-172-29-167-5:51678/", agentURLS[2])
 }
 
-func TestHasMetadataURIv4EnvVariable(t *testing.T) {
-	co := types.ContainerJSON{
-		Config: &container.Config{
-			Env: []string{
-				"AWS_EXECUTION_ENV=AWS_ECS_EC2",
-				"ECS_CONTAINER_METADATA_URI=http://169.254.170.2/v3/123",
-				"ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/123",
-			},
-		},
-		ContainerJSONBase: &types.ContainerJSONBase{},
-	}
+func TestIsMetadataV4Available(t *testing.T) {
+	ok, err := IsMetadataV4Available("")
+	assert.NotNil(t, err)
+	assert.False(t, ok)
 
-	docker.EnableTestingMode()
-	cacheKey := docker.GetInspectCacheKey("container-id-3bc6d22", false)
-	cache.Cache.Set(cacheKey, co, 10*time.Second)
+	ok, err = IsMetadataV4Available("1.0.0")
+	assert.NotNil(t, err)
+	assert.False(t, ok)
 
-	du, err := docker.GetDockerUtil()
-	require.NoError(t, err)
-	require.True(t, hasMetadataURIv4EnvVariable(du, "container-id-3bc6d22"))
+	ok, err = IsMetadataV4Available("1.80.0")
+	assert.NoError(t, err)
+	assert.True(t, ok)
 }

--- a/pkg/util/ecs/metadata/v1/client_test.go
+++ b/pkg/util/ecs/metadata/v1/client_test.go
@@ -33,6 +33,7 @@ func TestGetInstance(t *testing.T) {
 
 	expected := &Instance{
 		Cluster: "ecs_cluster",
+		Version: "Amazon ECS Agent - v1.32.0 (a7f81040)",
 	}
 
 	client := NewClient(ts.URL)

--- a/pkg/util/ecs/metadata/v1/types.go
+++ b/pkg/util/ecs/metadata/v1/types.go
@@ -14,6 +14,7 @@ type Commands struct {
 // See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
 type Instance struct {
 	Cluster string `json:"Cluster"`
+	Version string `json:"Version"`
 }
 
 // Tasks represents the list of task exposed by the ECS introspection endpoint.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Currently, In `WorkloadMeta ECS-EC2 collector`, we detect the v4 endpoint by simply checking the environment variable `ECS_CONTAINER_METADATA_URI_V4`. This method works only if the agent is deployed in a container via ECS. It does not work if the agent is deployed directly on an EC2 instance running in ECS.

The new detection method, `IsMetadataV4Available`, improves upon the check by verifying the ECS agent version. If the agent version satisfies the minimum required version, it will return true.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Create an ECS Cluster and Deploy the Datadog Agent:
* Set up an ECS cluster and deploy the Datadog agent.
* Update the agent's task definition by adding the following environment variables:

```
{
"name": "DD_CONTAINER_LIFECYCLE_ECS_TASK_EVENT_ENABLED",
 "value": "true"
},
{
"name": "DD_ORCHESTRATOR_EXPLORER_ENABLED",
"value": "true"
},
{
"name": "DD_ORCHESTRATOR_EXPLORER_ECS_COLLECTION_ENABLED",
"value": "true"
},
{
"name": "DD_ECS_TASK_COLLECTION_ENABLED",
"value": "true"
},
```

Verify Agent:
* Ensure the agent is correctly sending task payloads.
* Use the agent status command to check and confirm the number of tasks being sent.
