### PR TITLE
fix(installer): Change OCI agent symlink to /usr/local/bin

### DIFF
--- a/pkg/fleet/installer/service/datadog_agent.go
+++ b/pkg/fleet/installer/service/datadog_agent.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	pathOldAgent      = "/opt/datadog-agent"
-	agentSymlink      = "/usr/bin/datadog-agent"
+	agentSymlink      = "/usr/local/bin/datadog-agent"
 	agentUnit         = "datadog-agent.service"
 	traceAgentUnit    = "datadog-agent-trace.service"
 	processAgentUnit  = "datadog-agent-process.service"

--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -100,6 +100,9 @@ func (s *packageAgentSuite) TestUpgrade_AgentDebRPM_to_OCI() {
 	s.assertUnits(state, false)
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
+
+	symlinkPath := strings.TrimSpace(s.Env().RemoteHost.MustExecute("which datadog-agent"))
+	assert.Equal(s.T(), symlinkPath, "/usr/local/bin/datadog-agent")
 }
 
 // TestUpgrade_Agent_OCI_then_DebRpm agent deb/rpm install while OCI one is installed
@@ -125,6 +128,9 @@ func (s *packageAgentSuite) TestUpgrade_Agent_OCI_then_DebRpm() {
 	s.assertUnits(state, false)
 	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+
+	symlinkPath := strings.TrimSpace(s.Env().RemoteHost.MustExecute("which datadog-agent"))
+	assert.Equal(s.T(), symlinkPath, "/usr/local/bin/datadog-agent")
 }
 
 func (s *packageAgentSuite) TestExperimentTimeout() {


### PR DESCRIPTION
### What does this PR do?
Replaces the OCI agent symlink from `/usr/bin/datadog-agent` to `/usr/bin/local/datadog-agent`. The new one has a higher priority, which will avoid the deb being reinstalled from overriding the symlink.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
