### PR TITLE
Revert TLS version comparison byte order fix (PR#26591) - backmerge

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/tls.h
@@ -58,7 +58,7 @@ static __always_inline bool is_valid_tls_version(__u16 version) {
 // - the payload length + the size of the record header is less than the size
 //   of the skb
 static __always_inline bool is_valid_tls_app_data(tls_record_header_t *hdr, __u32 buf_size, __u32 skb_len) {
-    if (!is_valid_tls_version(bpf_ntohs(hdr->version))) {
+    if (!is_valid_tls_version(hdr->version)) {
         return false;
     }
 
@@ -78,7 +78,7 @@ static __always_inline bool is_tls_handshake(tls_hello_message_t *msg) {
     switch (msg->handshake_type) {
     case TLS_HANDSHAKE_CLIENT_HELLO:
     case TLS_HANDSHAKE_SERVER_HELLO:
-        return is_valid_tls_version(bpf_ntohs(msg->version));
+        return is_valid_tls_version(msg->version);
     }
 
     return false;

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -339,6 +339,10 @@ func (s *USMSuite) TestTLSClassification() {
 	tests := make([]tlsTest, 0, len(scenarios))
 	for _, scenario := range scenarios {
 		scenario := scenario
+		if scenario.version == tls.VersionTLS10 || scenario.version == tls.VersionTLS11 {
+			// Only tests for TLS 1.2 and 1.3 are expected to pass until PR#26591 is reintroduced.
+			continue
+		}
 		tests = append(tests, tlsTest{
 			name: strings.Replace(tls.VersionName(scenario.version), " ", "-", 1) + "_docker",
 			postTracerSetup: func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Reverts https://github.com/DataDog/datadog-agent/pull/26591

### Motivation

The decision regarding #incident-29097 is to revert PR#26591. While the PR holds value for us, it unintentionally revealed a bug that impacts Kafka monitoring accuracy by incorrectly classifying connections as TLS. Due to the imminent release of agent 7.56, we will temporarily revert the PR. In order to tackle this issue in the long run, our focus will be on fixing the bug before reintegrating the PR.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
