### PR TITLE
[ASCII-2082] Avoid adding middlewares recursively at every call to the api

### DIFF
--- a/comp/api/api/apiimpl/observability/logging.go
+++ b/comp/api/api/apiimpl/observability/logging.go
@@ -41,7 +41,9 @@ func logResponseHandler(serverName string, getLogFunc func(int) logFunc, clock c
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int
-			next = extractStatusCodeHandler(&statusCode)(next)
+			// the next argument is defined outside this function so it must not be written to,
+			// otherwise every use will add a new layer of middlewares
+			next := extractStatusCodeHandler(&statusCode)(next)
 
 			var duration time.Duration
 			next = timeHandler(clock, &duration)(next)

--- a/comp/api/api/apiimpl/observability/logging.go
+++ b/comp/api/api/apiimpl/observability/logging.go
@@ -41,8 +41,9 @@ func logResponseHandler(serverName string, getLogFunc func(int) logFunc, clock c
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int
-			// the next argument is defined outside this function so it must not be written to,
-			// otherwise every use will add a new layer of middlewares
+			// next is an argument of the MiddlewareFunc, it is defined outside the HandlerFunc so it is shared between calls,
+			// and so it must not be updated otherwise every call of the HandlerFunc will add a new layer of middlewares
+			// (and the HandlerFunc is called multiple times)
 			next := extractStatusCodeHandler(&statusCode)(next)
 
 			var duration time.Duration

--- a/comp/api/api/apiimpl/observability/telemetry.go
+++ b/comp/api/api/apiimpl/observability/telemetry.go
@@ -38,8 +38,9 @@ func (th *telemetryMiddlewareFactory) Middleware(serverName string) mux.Middlewa
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int
-			// the next argument is defined outside this function so it must not be written to,
-			// otherwise every use will add a new layer of middlewares
+			// next is an argument of the MiddlewareFunc, it is defined outside the HandlerFunc so it is shared between calls,
+			// and so it must not be updated otherwise every call of the HandlerFunc will add a new layer of middlewares
+			// (and the HandlerFunc is called multiple times)
 			next := extractStatusCodeHandler(&statusCode)(next)
 
 			var duration time.Duration

--- a/comp/api/api/apiimpl/observability/telemetry.go
+++ b/comp/api/api/apiimpl/observability/telemetry.go
@@ -38,7 +38,9 @@ func (th *telemetryMiddlewareFactory) Middleware(serverName string) mux.Middlewa
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var statusCode int
-			next = extractStatusCodeHandler(&statusCode)(next)
+			// the next argument is defined outside this function so it must not be written to,
+			// otherwise every use will add a new layer of middlewares
+			next := extractStatusCodeHandler(&statusCode)(next)
 
 			var duration time.Duration
 			next = timeHandler(th.clock, &duration)(next)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix the API observability middlewares to avoid adding them recursively at every request to the API.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This was causing a slow memory leak.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Leak introduced by https://github.com/DataDog/datadog-agent/pull/27018.

The `next` argument of the `MiddlewareFunc` was being updated in the `HandlerFunc`.
Since the `HandlerFunc` is called once per request to the API, this results in each request adding new observability middlewares, which are never freed.
The stack grows over time, resulting in a leak.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
There is no functional bug so catching this with unit tests is complex.
Did QA manually to make sure fix works as expected:
- Start the agent
- Make a lot of calls to the API, eg. `for e in "$(seq 1 100)"; do datadog-agent status; done`
- Create a flare
- Check the `go-routine-dump.log`, find the routine handling the flare request and make sure it doesn't have hundreds of layers of observability middleware
