### PR TITLE
merge 3 ecs feature flags to 1

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -116,7 +116,7 @@ func (c *Check) Run() error {
 	)
 
 	var taskEventsCh chan workloadmeta.EventBundle
-	if ddConfig.Datadog().GetBool("container_lifecycle.ecs_task_event.enabled") {
+	if ddConfig.Datadog().GetBool("ecs_task_collection_enabled") {
 
 		taskFilter := workloadmeta.NewFilterBuilder().
 			SetSource(workloadmeta.SourceNodeOrchestrator).
@@ -185,7 +185,7 @@ func Factory(store workloadmeta.Component) optional.Option[func() check.Check] {
 
 // sendFargateTaskEvent sends Fargate task lifecycle event at the end of the check
 func (c *Check) sendFargateTaskEvent() {
-	if !ddConfig.Datadog().GetBool("container_lifecycle.ecs_task_event.enabled") ||
+	if !ddConfig.Datadog().GetBool("ecs_task_collection_enabled") ||
 		!ddConfig.IsECSFargate() {
 		return
 	}

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -168,7 +168,7 @@ func detectAWSEnvironments(features FeatureMap, cfg model.Reader) {
 	if IsECSFargate() {
 		features[ECSFargate] = struct{}{}
 		if cfg.GetBool("orchestrator_explorer.enabled") &&
-			cfg.GetBool("orchestrator_explorer.ecs_collection.enabled") {
+			cfg.GetBool("ecs_task_collection_enabled") {
 			features[ECSOrchestratorExplorer] = struct{}{}
 		}
 		return
@@ -183,7 +183,7 @@ func detectAWSEnvironments(features FeatureMap, cfg model.Reader) {
 	if IsECS() {
 		features[ECSEC2] = struct{}{}
 		if cfg.GetBool("orchestrator_explorer.enabled") &&
-			cfg.GetBool("orchestrator_explorer.ecs_collection.enabled") {
+			cfg.GetBool("ecs_task_collection_enabled") {
 			features[ECSOrchestratorExplorer] = struct{}{}
 		}
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -768,11 +768,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_manifest", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_flush_interval", 20*time.Second)
-	config.BindEnvAndSetDefault("orchestrator_explorer.ecs_collection.enabled", false)
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", true)
-	config.BindEnvAndSetDefault("container_lifecycle.ecs_task_event.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "container_lifecycle.")
 
 	// Container image configuration


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Currently users need to set three feature flags to enable ecs task collection.
* `DD_CONTAINER_LIFECYCLE_ECS_TASK_EVENT_ENABLED`
* `DD_ORCHESTRATOR_EXPLORER_ECS_COLLECTION_ENABLED` 
* `DD_ECS_TASK_COLLECTION_ENABLED`

This PR deletes first 2 feature flags and update agent to only rely on the last one to simplify the setup.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create an ECS Cluster and Deploy the Datadog Agent:

Set up an ECS cluster and deploy the Datadog agent.
Update the agent's task definition by adding the following environment variables:
```
{
"name": "DD_ECS_TASK_COLLECTION_ENABLED",
"value": "true"
},
```
Verify Agent:

Ensure the agent is correctly sending task payloads.
Use the agent status command to check and confirm the number of tasks being sent.
