### PR TITLE
fix(fleet): Fix tests on CentOS after EOL

### DIFF
--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -415,7 +415,7 @@ func (s *packageAgentSuite) installDebRPMAgent() {
 	case "apt":
 		s.Env().RemoteHost.Execute("sudo apt-get install -y --force-yes datadog-agent")
 	case "yum":
-		s.Env().RemoteHost.Execute("sudo yum -y install datadog-agent")
+		s.Env().RemoteHost.Execute("sudo yum -y install --disablerepo=* --enablerepo=datadog datadog-agent")
 	case "zypper":
 		s.Env().RemoteHost.Execute("sudo zypper install -y datadog-agent")
 	default:


### PR DESCRIPTION
### What does this PR do?
Somehow we can't just `yum install datadog-agent` on centos anymore without specifying the repository. This PR does just that in E2E tests

### Motivation
CentOS tests failing

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
