### PR TITLE
Update e2e test as IMDSv1 is disabled by default

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
@@ -6,6 +6,7 @@
 package hostname
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -46,13 +47,11 @@ func (v *linuxHostnameSuite) TestAgentConfigPreferImdsv2() {
 }
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/util/hostname/README.md#the-current-logic
-func (v *linuxHostnameSuite) TestAgentHostnameDefaultsToNotInstanceId() {
+func (v *linuxHostnameSuite) TestAgentDefaultHostnameIMDSv1() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(v.GetOs(), awshost.WithAgentOptions(agentparams.WithAgentConfig("ec2_prefer_imdsv2: false"))))
 
-	metadata := client.NewEC2Metadata(v.T(), v.Env().RemoteHost.Host, v.Env().RemoteHost.OSFamily)
 	hostname := v.Env().Agent.Client.Hostname()
-
-	instanceID := metadata.Get("instance-id")
-	// As IMDSv1 is disabled by default, the hostname should not be the instance ID
-	assert.NotEqual(v.T(), instanceID, hostname)
+	osHostname := v.Env().RemoteHost.Host.MustExecute("hostname")
+	osHostname = strings.TrimSpace(osHostname)
+	assert.Equal(v.T(), osHostname, hostname)
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -21,9 +21,9 @@ type linuxStatusSuite struct {
 }
 
 func TestLinuxStatusSuite(t *testing.T) {
-	t.Skip("Skipping due to a bug on the latest ubuntu AMI #incident-29343")
+	enableImdsv2 := awshost.WithAgentOptions(agentparams.WithAgentConfig("ec2_prefer_imdsv2: true"))
 	t.Parallel()
-	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
+	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(enableImdsv2)))
 }
 
 func (v *linuxStatusSuite) TestStatusHostname() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes E2E tests that rely on the hostname. IMDSv1 was disabled on the latest Ubuntu AMI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Ran the failing e2e test.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
