### PR TITLE
[CWS] add fallback on /proc for ebpf-less fd resolution

### DIFF
--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -162,6 +162,11 @@ type DupSyscallFakeMsg struct {
 	OldFd int32
 }
 
+// PipeSyscallFakeMsg defines a pipe message
+type PipeSyscallFakeMsg struct {
+	FdsPtr uint64
+}
+
 // ChdirSyscallMsg defines a chdir message
 type ChdirSyscallMsg struct {
 	Dir FileSyscallMsg
@@ -326,7 +331,8 @@ type SyscallMsg struct {
 	Umount       *UmountSyscallMsg       `json:",omitempty"`
 
 	// internals
-	Dup *DupSyscallFakeMsg `json:",omitempty"`
+	Dup  *DupSyscallFakeMsg  `json:",omitempty"`
+	Pipe *PipeSyscallFakeMsg `json:",omitempty"`
 }
 
 // String returns string representation

--- a/pkg/security/ptracer/fim_handlers.go
+++ b/pkg/security/ptracer/fim_handlers.go
@@ -252,6 +252,11 @@ func registerFIMHandlers(handlers map[int]syscallHandler) []string {
 			RetFunc:    nil,
 		},
 		{
+			ID:      syscallID{ID: PipeNr, Name: "pipe"},
+			Func:    handlePipe2,
+			RetFunc: handlePipe2Ret,
+		},
+		{
 			ID:      syscallID{ID: Pipe2Nr, Name: "pipe2"},
 			Func:    handlePipe2,
 			RetFunc: handlePipe2Ret,

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -9,6 +9,8 @@
 package ptracer
 
 import (
+	"fmt"
+	"os"
 	"slices"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
@@ -56,6 +58,21 @@ func NewProcess(pid int) *Process {
 		},
 		FsRes: &FSResources{},
 	}
+}
+
+func (p *Process) GetFilenameFromFd(fd int32) (string, error) {
+	filename, ok := p.FdRes.Fd[fd]
+	if ok {
+		return filename, nil
+	}
+
+	procPath := fmt.Sprintf("/proc/%d/fd/%d", p.Pid, fd)
+	filename, err := os.Readlink(procPath)
+	if err != nil {
+		return "", err
+	}
+
+	return filename, nil
 }
 
 // ProcessCache defines a thread cache

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -62,8 +62,9 @@ func NewProcess(pid int) *Process {
 	}
 }
 
-var pipeFdErr = errors.New("pipe fd")
+var errPipeFd = errors.New("pipe fd")
 
+// GetFilenameFromFd returns the filename for the given fd
 func (p *Process) GetFilenameFromFd(fd int32) (string, error) {
 	raw, err := p.getFilenameFromFdRaw(fd)
 	if err != nil {
@@ -71,7 +72,7 @@ func (p *Process) GetFilenameFromFd(fd int32) (string, error) {
 	}
 
 	if strings.HasPrefix(raw, "pipe:") {
-		return "", pipeFdErr
+		return "", errPipeFd
 	}
 
 	return raw, nil

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -89,6 +89,9 @@ func (p *Process) getFilenameFromFdRaw(fd int32) (string, error) {
 		return "", err
 	}
 
+	// fill the cache for next time
+	p.FdRes.Fd[fd] = filename
+
 	return filename, nil
 }
 

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -65,6 +65,19 @@ func NewProcess(pid int) *Process {
 var pipeFdErr = errors.New("pipe fd")
 
 func (p *Process) GetFilenameFromFd(fd int32) (string, error) {
+	raw, err := p.getFilenameFromFdRaw(fd)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(raw, "pipe:") {
+		return "", pipeFdErr
+	}
+
+	return raw, nil
+}
+
+func (p *Process) getFilenameFromFdRaw(fd int32) (string, error) {
 	filename, ok := p.FdRes.Fd[fd]
 	if ok {
 		return filename, nil
@@ -74,10 +87,6 @@ func (p *Process) GetFilenameFromFd(fd int32) (string, error) {
 	filename, err := os.Readlink(procPath)
 	if err != nil {
 		return "", err
-	}
-
-	if strings.HasPrefix(filename, "pipe:") {
-		return "", pipeFdErr
 	}
 
 	return filename, nil

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -74,6 +74,7 @@ const (
 	IoctlNr          = unix.SYS_IOCTL             // IoctlNr defines the syscall ID for amd64
 	MountNr          = unix.SYS_MOUNT             // MountNr defines the syscall ID for amd64
 	Umount2Nr        = unix.SYS_UMOUNT2           // Umount2Nr defines the syscall ID for amd64
+	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for arm64
 )
 
 // https://github.com/torvalds/linux/blob/v5.0/arch/x86/entry/entry_64.S#L126

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -74,6 +74,7 @@ const (
 	IoctlNr          = unix.SYS_IOCTL             // IoctlNr defines the syscall ID for amd64
 	MountNr          = unix.SYS_MOUNT             // MountNr defines the syscall ID for amd64
 	Umount2Nr        = unix.SYS_UMOUNT2           // Umount2Nr defines the syscall ID for amd64
+	PipeNr           = unix.SYS_PIPE              // PipeNr defines the syscall ID for arm64
 	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for arm64
 )
 

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -76,6 +76,7 @@ const (
 	ChmodNr     = -15 // ChmodNr not available on arm64
 	ChownNr     = -16 // ChownNr not available on arm64
 	LchownNr    = -17 // LchownNr not available on arm64
+	PipeNr      = -18 // PipeNr not available on arm64
 )
 
 func (t *Tracer) argToRegValue(regs syscall.PtraceRegs, arg int) uint64 {

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -57,6 +57,7 @@ const (
 	IoctlNr          = unix.SYS_IOCTL             // IoctlNr defines the syscall ID for arm64
 	MountNr          = unix.SYS_MOUNT             // MountNr defines the syscall ID for arm64
 	Umount2Nr        = unix.SYS_UMOUNT2           // Umount2Nr defines the syscall ID for arm64
+	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for arm64
 
 	OpenNr      = -1  // OpenNr not available on arm64
 	ForkNr      = -2  // ForkNr not available on arm64

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -180,11 +180,12 @@ func getFullPathFromFd(process *Process, filename string, fd int32) (string, err
 				return "", errors.New("fillProcessCwd failed")
 			}
 		} else { // if using another dir, prefix it, we should have it in cache
-			if path, exists := process.FdRes.Fd[fd]; exists {
-				filename = filepath.Join(path, filename)
-			} else {
-				return "", errors.New("process FD cache incomplete during path resolution")
+			path, err := process.GetFilenameFromFd(fd)
+			if err != nil {
+				return "", fmt.Errorf("process FD cache incomplete during path resolution: %w", err)
 			}
+
+			filename = filepath.Join(path, filename)
 		}
 	}
 	return filename, nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When running in wrap mode we should hopefully collect all file descriptor (or it's a bug), but when running in attach mode not having all fds in the cache is the regular mode of operation. To fight this this PR adds a fallback on /proc to query the latest fd path when it's not in the cache.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
