### PR TITLE
feat(fleet): Add "remote config file" config layer

### DIFF
--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -44,6 +44,10 @@ type GlobalParams struct {
 	// LogStreamFilePath holds the path to the logstream log path
 	LogStreamFilePath string
 
+	// FleetPoliciesDirPath holds the path to the folder containing the remotely received agent
+	// configuration files, to allow overrides from the command line
+	FleetPoliciesDirPath string
+
 	// NoColor is a flag to disable color output
 	NoColor bool
 }
@@ -55,7 +59,7 @@ type SubcommandFactory func(globalParams *GlobalParams) []*cobra.Command
 // without secrets and logger disabled).
 func GetDefaultCoreBundleParams(globalParams *GlobalParams) core.BundleParams {
 	return core.BundleParams{
-		ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+		ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 		LogParams:    log.ForOneShot(LoggerName, "off", true)}
 }
 
@@ -82,6 +86,7 @@ monitoring and performance data.`,
 	agentCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 	agentCmd.PersistentFlags().StringArrayVarP(&globalParams.ExtraConfFilePath, "extracfgpath", "E", []string{}, "specify additional configuration files to be loaded sequentially after the main datadog.yaml")
 	agentCmd.PersistentFlags().StringVarP(&globalParams.SysProbeConfFilePath, "sysprobecfgpath", "", "", "path to directory containing system-probe.yaml")
+	agentCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
 
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when

--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -20,6 +20,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfFilePath:         globalParams.ConfFilePath,
 			ExtraConfFilePaths:   globalParams.ExtraConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
+			FleetPoliciesDirPath: globalParams.FleetPoliciesDirPath,
 			ConfigName:           command.ConfigName,
 			LoggerName:           command.LoggerName,
 		}

--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -48,7 +48,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(cliParams.ExtraConfFilePath)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(cliParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot("CORE", "off", true)}),
 				core.Bundle(),

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(cmdDiagnose,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot("CORE", "off", true),
 				}),
 				core.Bundle(),

--- a/cmd/agent/subcommands/dogstatsd/command.go
+++ b/cmd/agent/subcommands/dogstatsd/command.go
@@ -51,7 +51,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(topContexts,
 				fx.Supply(&topFlags),
 				fx.Supply(core.BundleParams{
-					ConfigParams: cconfig.NewAgentParams(globalParams.ConfFilePath, cconfig.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: cconfig.NewAgentParams(globalParams.ConfFilePath, cconfig.WithExtraConfFiles(globalParams.ExtraConfFilePath), cconfig.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
 			)
@@ -69,7 +69,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(dumpContexts,
 				fx.Supply(core.BundleParams{
-					ConfigParams: cconfig.NewAgentParams(globalParams.ConfFilePath, cconfig.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: cconfig.NewAgentParams(globalParams.ConfFilePath, cconfig.WithExtraConfFiles(globalParams.ExtraConfFilePath), cconfig.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
 			)

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -96,14 +96,16 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				config.WithConfigLoadSecurityAgent(true),
 				config.WithIgnoreErrors(true),
-				config.WithExtraConfFiles(globalParams.ExtraConfFilePath))
+				config.WithExtraConfFiles(globalParams.ExtraConfFilePath),
+				config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath),
+			)
 
 			return fxutil.OneShot(makeFlare,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config,
 					SecretParams:         secrets.NewEnabledParams(),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", false),
 				}),
 				fx.Supply(flare.NewLocalParams(

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -39,7 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(getHostname,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}), // never output anything but hostname
 				core.Bundle(),
 			)

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -112,7 +112,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		return fxutil.OneShot(callback,
 			fx.Supply(cliParams),
 			fx.Supply(core.BundleParams{
-				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigMissingOK(true), config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigMissingOK(true), config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 				LogParams:    log.ForOneShot(command.LoggerName, "off", true),
 			}),
 			core.Bundle(),

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -116,7 +116,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.jmxLogLevel = "debug"
 		}
 		params := core.BundleParams{
-			ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+			ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 			SecretParams: secrets.NewEnabledParams(),
 			LogParams:    log.ForOneShot(command.LoggerName, cliParams.jmxLogLevel, false)}
 		if cliParams.logFile != "" {

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -24,6 +24,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfFilePath:         globalParams.ConfFilePath,
 			ExtraConfFilePath:    globalParams.ExtraConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
+			FleetPoliciesDirPath: globalParams.FleetPoliciesDirPath,
 		}
 	},
 		"processchecks",

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -46,7 +46,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(state,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath))}),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath))}),
 				core.Bundle(),
 			)
 		},

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -178,9 +178,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				ddruntime.SetMaxProcs()
 			}),
 			fx.Supply(core.BundleParams{
-				ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(cliParams.ExtraConfFilePath)),
+				ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(cliParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath)),
 				SecretParams:         secrets.NewEnabledParams(),
-				SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+				SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath)),
 				LogParams:            log.ForDaemon(command.LoggerName, "log_file", path.DefaultLogFile),
 			}),
 			fx.Supply(pidimpl.NewParams(cliParams.pidfilePath)),

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -138,7 +138,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(connParams, globalParams, cmd),
 				fx.Provide(func() argsType { return args }),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
@@ -185,7 +185,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(connParams, globalParams, cmd),
 				fx.Provide(func() argsType { return args }),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -52,7 +52,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Use:   "status [section]",
 		Short: "Display the current status",
 		Long: `Display the current status.
-If no section is specified, this command will display all status sections. 
+If no section is specified, this command will display all status sections.
 If a specific section is provided, such as 'collector', it will only display the status of that section.
 The --list flag can be used to list all available status sections.`,
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -67,8 +67,8 @@ The --list flag can be used to list all available status sections.`,
 			return fxutil.OneShot(statusCmd,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+					ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
 			)

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -47,6 +47,9 @@ type GlobalParams struct {
 	// configuration file, to allow overrides from the command line
 	SysProbeConfFilePath string
 
+	// FleetPoliciesDirPath holds the path to the folder containing the fleet policies
+	FleetPoliciesDirPath string
+
 	// PidFilePath specifies the path to the pid file
 	PidFilePath string
 
@@ -84,6 +87,7 @@ func MakeCommand(subcommandFactories []SubcommandFactory, winParams bool, rootCm
 	}
 
 	rootCmd.PersistentFlags().StringVar(&globalParams.ConfFilePath, flags.CfgPath, flags.DefaultConfPath, "Path to datadog.yaml config")
+	rootCmd.PersistentFlags().StringVar(&globalParams.FleetPoliciesDirPath, flags.FleetCfgPath, "", "Path to the directory containing fleet policies")
 
 	if flags.DefaultSysProbeConfPath != "" {
 		rootCmd.PersistentFlags().StringVar(&globalParams.SysProbeConfFilePath, flags.SysProbeConfig, flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -108,8 +108,9 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			core.BundleParams{
 				SysprobeConfigParams: sysprobeconfigimpl.NewParams(
 					sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath),
+					sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath),
 				),
-				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
+				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 				SecretParams: secrets.NewEnabledParams(),
 				LogParams:    DaemonLogParams,
 			},

--- a/cmd/process-agent/flags/flags_common.go
+++ b/cmd/process-agent/flags/flags_common.go
@@ -11,4 +11,6 @@ const (
 	CfgPath = "cfgpath"
 	// SysProbeConfig defines the sysprobe-config flag
 	SysProbeConfig = "sysprobe-config"
+	// FleetCfgPath defines the fleetcfgpath flag
+	FleetCfgPath = "fleetcfgpath"
 )

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -87,6 +87,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfFilePath:         globalParams.ConfFilePath,
 			ExtraConfFilePath:    globalParams.ExtraConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
+			FleetPoliciesDirPath: globalParams.FleetPoliciesDirPath,
 		}
 	}, "check", checkAllowlist)}
 }

--- a/cmd/security-agent/command/command.go
+++ b/cmd/security-agent/command/command.go
@@ -23,6 +23,7 @@ import (
 type GlobalParams struct {
 	ConfigFilePaths      []string
 	SysProbeConfFilePath string
+	FleetPoliciesDirPath string
 
 	// NoColor is a flag to disable color output
 	NoColor bool
@@ -68,6 +69,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfigFilePaths, "cfgpath", "c", defaultSecurityAgentConfigFilePaths, "paths to yaml configuration files")
 	SecurityAgentCmd.PersistentFlags().StringVar(&globalParams.SysProbeConfFilePath, "sysprobe-config", defaultSysProbeConfPath, "path to system-probe.yaml config")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
+	SecurityAgentCmd.PersistentFlags().StringVar(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "path to the directory containing fleet policies")
 
 	for _, factory := range subcommandFactories {
 		for _, subcmd := range factory(&globalParams) {

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -59,9 +59,9 @@ type CliParams struct {
 func SecurityAgentCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	return commandsWrapped(func() core.BundleParams {
 		return core.BundleParams{
-			ConfigParams:         config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+			ConfigParams:         config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 			SecretParams:         secrets.NewEnabledParams(),
-			SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+			SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 			LogParams:            log.ForOneShot(command.LoggerName, "info", true),
 		}
 	})

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -77,7 +77,7 @@ func complianceLoadCommand(globalParams *command.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(loadRun,
 				fx.Supply(loadArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
 				}),
@@ -155,7 +155,7 @@ func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
 				}),

--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -57,7 +57,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				showRuntimeConfiguration,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
@@ -75,7 +75,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					showRuntimeConfigurationBySource,
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
-						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle(),
@@ -95,7 +95,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					listRuntimeConfigurableValue,
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
-						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle(),
@@ -115,7 +115,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					setConfigValue,
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
-						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle(),
@@ -135,7 +135,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					getConfigValue,
 					fx.Supply(cliParams),
 					fx.Supply(core.BundleParams{
-						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 						SecretParams: secrets.NewEnabledParams(),
 						LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 					core.Bundle(),

--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -65,7 +65,7 @@ func listCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -88,7 +88,7 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -135,7 +135,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -202,7 +202,7 @@ func diffCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(diffActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -97,7 +97,7 @@ func evalCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
@@ -130,7 +130,7 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
@@ -154,7 +154,7 @@ func commonReloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.C
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -172,7 +172,7 @@ func selfTestCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -203,7 +203,7 @@ func downloadPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
@@ -238,7 +238,7 @@ func processCacheCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -276,7 +276,7 @@ func networkNamespaceCommands(globalParams *command.GlobalParams) []*cobra.Comma
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -303,7 +303,7 @@ func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),

--- a/cmd/security-agent/subcommands/runtime/deprecated_commands.go
+++ b/cmd/security-agent/subcommands/runtime/deprecated_commands.go
@@ -33,7 +33,7 @@ func checkPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command 
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
@@ -55,7 +55,7 @@ func reloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),

--- a/cmd/security-agent/subcommands/runtime/security_profile.go
+++ b/cmd/security-agent/subcommands/runtime/security_profile.go
@@ -60,7 +60,7 @@ func securityProfileShowCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(showSecurityProfile,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -106,7 +106,7 @@ func listSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(listSecurityProfiles,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
@@ -213,7 +213,7 @@ func saveSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(saveSecurityProfile,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -94,8 +94,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			// the service initialization in ../../main_windows.go
 			return fxutil.OneShot(start,
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewSecurityAgentParams(params.ConfigFilePaths),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+					ConfigParams:         config.NewSecurityAgentParams(params.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams:         secrets.NewEnabledParams(),
 					LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", setup.DefaultSecurityAgentLogFile),
 				}),

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -47,7 +47,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),

--- a/cmd/security-agent/subcommands/version/command.go
+++ b/cmd/security-agent/subcommands/version/command.go
@@ -32,7 +32,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(displayVersion,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
 			)

--- a/cmd/security-agent/subcommands/workloadlist/command.go
+++ b/cmd/security-agent/subcommands/workloadlist/command.go
@@ -42,7 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true),
 				}),
 				core.Bundle(),

--- a/cmd/system-probe/command/command.go
+++ b/cmd/system-probe/command/command.go
@@ -23,6 +23,9 @@ type GlobalParams struct {
 	// ConfFilePath holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line
 	ConfFilePath string
+
+	// FleetPoliciesDirPath holds the path to the folder containing the fleet policies
+	FleetPoliciesDirPath string
 }
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
@@ -44,6 +47,7 @@ Runtime Security Monitoring, Universal Service Monitoring, and others.`,
 	}
 
 	sysprobeCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to directory containing system-probe.yaml")
+	sysprobeCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
 
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"runtime"
 	"strings"
 
@@ -45,11 +46,11 @@ const (
 )
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
-func New(configPath string) (*types.Config, error) {
-	return newSysprobeConfig(configPath)
+func New(configPath string, fleetPoliciesDirPath string) (*types.Config, error) {
+	return newSysprobeConfig(configPath, fleetPoliciesDirPath)
 }
 
-func newSysprobeConfig(configPath string) (*types.Config, error) {
+func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.Config, error) {
 	aconfig.SystemProbe.SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {
@@ -80,6 +81,15 @@ func newSysprobeConfig(configPath string) (*types.Config, error) {
 			return nil, fmt.Errorf("unable to load system-probe config file: %w", err)
 		}
 	}
+
+	// Load the remote configuration
+	if fleetPoliciesDirPath != "" {
+		err := aconfig.SystemProbe.MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "system-probe.yaml"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return load()
 }
 

--- a/cmd/system-probe/config/config_linux_test.go
+++ b/cmd/system-probe/config/config_linux_test.go
@@ -35,7 +35,7 @@ func TestNetworkProcessEventMonitoring(t *testing.T) {
 			defer os.Unsetenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
 			defer os.Unsetenv("DD_SYSTEM_PROBE_NETWORK_ENABLED")
 
-			cfg, err := New("")
+			cfg, err := New("", "")
 			require.NoError(t, err)
 			assert.Equal(t, te.enabled, cfg.ModuleIsEnabled(EventMonitorModule))
 		})
@@ -48,12 +48,12 @@ func TestDynamicInstrumentation(t *testing.T) {
 	os.Setenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED", "true")
 	defer os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED")
 
-	cfg, err := New("")
+	cfg, err := New("", "")
 	require.NoError(t, err)
 	assert.Equal(t, true, cfg.ModuleIsEnabled(DynamicInstrumentationModule))
 
 	os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED")
-	cfg, err = New("")
+	cfg, err = New("", "")
 	require.NoError(t, err)
 	assert.Equal(t, false, cfg.ModuleIsEnabled(DynamicInstrumentationModule))
 
@@ -94,7 +94,7 @@ func TestNPMEnabled(t *testing.T) {
 			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(te.npm))
 			t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", strconv.FormatBool(te.usm))
 			t.Setenv("DD_CCM_NETWORK_CONFIG_ENABLED", strconv.FormatBool(te.ccm))
-			cfg, err := New("")
+			cfg, err := New("", "")
 			require.NoError(t, err)
 			assert.Equal(t, te.npmEnabled, cfg.ModuleIsEnabled(NetworkTracerModule), "unexpected network tracer module enablement: npm: %v, usm: %v, ccm: %v", te.npm, te.usm, te.ccm)
 		})

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -62,7 +62,7 @@ func TestEventMonitor(t *testing.T) {
 			t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(tc.networkEvents))
 			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(tc.networkEvents))
 
-			cfg, err := New("/doesnotexist")
+			cfg, err := New("/doesnotexist", "")
 			t.Logf("%+v\n", cfg)
 			require.NoError(t, err)
 			assert.Equal(t, tc.enabled, cfg.ModuleIsEnabled(EventMonitorModule))
@@ -134,6 +134,6 @@ func configurationFromYAML(t *testing.T, yaml string) config.Config {
 	require.Equal(t, len(b), n)
 	f.Sync()
 
-	_, _ = New(f.Name())
+	_, _ = New(f.Name(), "")
 	return config.SystemProbe
 }

--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -48,7 +48,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParams("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot("SYS-PROBE", "off", true),
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values

--- a/cmd/system-probe/subcommands/debug/command.go
+++ b/cmd/system-probe/subcommands/debug/command.go
@@ -49,7 +49,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParams("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot("SYS-PROBE", "off", false),
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values

--- a/cmd/system-probe/subcommands/modrestart/command.go
+++ b/cmd/system-probe/subcommands/modrestart/command.go
@@ -47,7 +47,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParams("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot("SYS-PROBE", "off", false),
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -87,7 +87,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(run,
 				fx.Supply(config.NewAgentParams("", config.WithConfigMissingOK(true))),
-				fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath))),
+				fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath))),
 				fx.Supply(log.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
 				fx.Supply(rcclient.Params{AgentName: "system-probe", AgentVersion: version.AgentVersion}),
 				fx.Supply(optional.NewNoneOption[secrets.Component]()),

--- a/cmd/trace-agent/subcommands/config/command.go
+++ b/cmd/trace-agent/subcommands/config/command.go
@@ -28,7 +28,7 @@ func MakeCommand(globalParamsGetter func() *subcommands.GlobalParams) *cobra.Com
 		Long:  ``,
 		RunE: func(*cobra.Command, []string) error {
 			return fxutil.OneShot(printConfig,
-				fx.Supply(config.NewAgentParams(globalParamsGetter().ConfPath)),
+				fx.Supply(config.NewAgentParams(globalParamsGetter().ConfPath, config.WithFleetPoliciesDirPath(globalParamsGetter().FleetPoliciesDirPath))),
 				fx.Supply(optional.NewNoneOption[secrets.Component]()),
 				config.Module(),
 			)

--- a/cmd/trace-agent/subcommands/info/command.go
+++ b/cmd/trace-agent/subcommands/info/command.go
@@ -40,7 +40,7 @@ func MakeCommand(globalParamsGetter func() *subcommands.GlobalParams) *cobra.Com
 func runTraceAgentInfoFct(params *subcommands.GlobalParams, fct interface{}) error {
 	return fxutil.OneShot(fct,
 		config.Module(),
-		fx.Supply(coreconfig.NewAgentParams(params.ConfPath)),
+		fx.Supply(coreconfig.NewAgentParams(params.ConfPath, coreconfig.WithFleetPoliciesDirPath(params.FleetPoliciesDirPath))),
 		fx.Supply(optional.NewNoneOption[secrets.Component]()),
 		fx.Supply(secrets.NewEnabledParams()),
 		coreconfig.Module(),

--- a/cmd/trace-agent/subcommands/params.go
+++ b/cmd/trace-agent/subcommands/params.go
@@ -11,7 +11,8 @@ package subcommands
 // A pointer to this type is passed to SubcommandFactory's, but its contents
 // are not valid until Cobra calls the subcommand's Run or RunE function.
 type GlobalParams struct {
-	ConfPath   string
-	ConfigName string
-	LoggerName string
+	ConfPath             string
+	ConfigName           string
+	LoggerName           string
+	FleetPoliciesDirPath string
 }

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -80,7 +80,7 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 		// ctx is required to be supplied from here, as Windows needs to inject its own context
 		// to allow the agent to work as a service.
 		fx.Provide(func() context.Context { return ctx }), // fx.Supply(ctx) fails with a missing type error.
-		fx.Supply(coreconfig.NewAgentParams(cliParams.ConfPath)),
+		fx.Supply(coreconfig.NewAgentParams(cliParams.ConfPath, coreconfig.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath))),
 		secretsimpl.Module(),
 		fx.Provide(func(comp secrets.Component) optional.Option[secrets.Component] {
 			return optional.NewOption[secrets.Component](comp)

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -55,7 +55,7 @@ func (d dependencies) getParams() *Params {
 }
 
 func setupConfig(deps sysprobeconfigDependencies) (*sysconfigtypes.Config, error) {
-	return sysconfig.New(deps.getParams().sysProbeConfFilePath)
+	return sysconfig.New(deps.getParams().sysProbeConfFilePath, deps.getParams().fleetPoliciesDirPath)
 }
 
 func newConfig(deps dependencies) (sysprobeconfig.Component, error) {

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/params.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/params.go
@@ -10,6 +10,9 @@ type Params struct {
 	// sysProbeConfFilePath is the path at which to look for configuration, usually
 	// given by the --sysprobecfgpath command-line flag.
 	sysProbeConfFilePath string
+
+	// fleetPoliciesDirPath is the path at which to look for remote configuration files
+	fleetPoliciesDirPath string
 }
 
 // NewParams creates a new instance of Params
@@ -25,5 +28,12 @@ func NewParams(options ...func(*Params)) Params {
 func WithSysProbeConfFilePath(confFilePath string) func(*Params) {
 	return func(b *Params) {
 		b.sysProbeConfFilePath = confFilePath
+	}
+}
+
+// WithFleetPoliciesDirPath specifies the path to the remote config directory
+func WithFleetPoliciesDirPath(fleetPoliciesDirPath string) func(*Params) {
+	return func(b *Params) {
+		b.fleetPoliciesDirPath = fleetPoliciesDirPath
 	}
 }

--- a/comp/metadata/systemprobe/README.md
+++ b/comp/metadata/systemprobe/README.md
@@ -34,6 +34,8 @@ The payload is a JSON dict with the following fields
     Only the settings set by the agent itself are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
   - `remote_configuration` - **string**: the System-Probe configuration specified by the Remote Configuration (scrubbed), as a YAML string.
     Only the settings currently used by Remote Configuration are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+  - `fleet_policies_configuration` - **string**: the Security-Agent configuration specified by the Fleet Automation Policies (scrubbed), as a YAML string.
+    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
   - `cli_configuration` - **string**: the System-Probe configuration specified by the CLI (scrubbed), as a YAML string.
     Only the settings set in the CLI are included.
   - `source_local_configuration` - **string**: the System-Probe configuration synchronized from the local Agent process, as a YAML string.

--- a/comp/metadata/systemprobe/impl/system_probe.go
+++ b/comp/metadata/systemprobe/impl/system_probe.go
@@ -149,6 +149,7 @@ func (sb *systemprobe) getConfigLayers() map[string]interface{} {
 		model.SourceAgentRuntime:       "agent_runtime_configuration",
 		model.SourceLocalConfigProcess: "source_local_configuration",
 		model.SourceRC:                 "remote_configuration",
+		model.SourceFleetPolicies:      "fleet_policies_configuration",
 		model.SourceCLI:                "cli_configuration",
 		model.SourceProvided:           "provided_configuration",
 	}

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -131,6 +131,7 @@ type GlobalParams struct {
 	ConfFilePath         string
 	ExtraConfFilePaths   []string
 	SysProbeConfFilePath string
+	FleetPoliciesDirPath string
 	ConfigName           string
 	LoggerName           string
 }
@@ -155,9 +156,9 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths)),
+					ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams:         secrets.NewEnabledParams(),
-					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle(),
 

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -37,11 +37,12 @@ type cliParams struct {
 // A pointer to this type is passed to SubcommandFactory's, but its contents
 // are not valid until Cobra calls the subcommand's Run or RunE function.
 type GlobalParams struct {
-	ConfFilePath       string
-	ExtraConfFilePaths []string
-	ConfigName         string
-	LoggerName         string
-	SettingsClient     func() (settings.Client, error)
+	ConfFilePath         string
+	ExtraConfFilePaths   []string
+	ConfigName           string
+	LoggerName           string
+	SettingsClient       func() (settings.Client, error)
+	FleetPoliciesDirPath string
 }
 
 // MakeCommand returns a `config` command to be used by agent binaries.
@@ -59,7 +60,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle(),
 			)

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -38,10 +38,11 @@ type cliParams struct {
 // A pointer to this type is passed to SubcommandFactory's, but its contents
 // are not valid until Cobra calls the subcommand's Run or RunE function.
 type GlobalParams struct {
-	ConfFilePath       string
-	ExtraConfFilePaths []string
-	ConfigName         string
-	LoggerName         string
+	ConfFilePath         string
+	ExtraConfFilePaths   []string
+	ConfigName           string
+	LoggerName           string
+	FleetPoliciesDirPath string
 }
 
 // MakeCommand returns a `health` command to be used by agent binaries.
@@ -57,7 +58,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			return fxutil.OneShot(requestHealth,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths)),
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName), config.WithExtraConfFiles(globalParams.ExtraConfFilePaths), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle(),
 			)

--- a/pkg/cli/subcommands/taggerlist/command.go
+++ b/pkg/cli/subcommands/taggerlist/command.go
@@ -34,10 +34,11 @@ type cliParams struct {
 // A pointer to this type is passed to SubcommandFactory's, but its contents
 // are not valid until Cobra calls the subcommand's Run or RunE function.
 type GlobalParams struct {
-	ConfFilePath       string
-	ExtraConfFilePaths []string
-	ConfigName         string
-	LoggerName         string
+	ConfFilePath         string
+	ExtraConfFilePaths   []string
+	ConfigName           string
+	LoggerName           string
+	FleetPoliciesDirPath string
 }
 
 // MakeCommand returns a `tagger-list` command to be used by agent binaries.
@@ -60,6 +61,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 						globalParams.ConfFilePath,
 						config.WithConfigName(globalParams.ConfigName),
 						config.WithExtraConfFiles(globalParams.ExtraConfFilePaths),
+						config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath),
 					),
 					LogParams: log.ForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle(),

--- a/pkg/cli/subcommands/workloadlist/command.go
+++ b/pkg/cli/subcommands/workloadlist/command.go
@@ -37,10 +37,11 @@ type cliParams struct {
 // A pointer to this type is passed to SubcommandFactory's, but its contents
 // are not valid until Cobra calls the subcommand's Run or RunE function.
 type GlobalParams struct {
-	ConfFilePath       string
-	ExtraConfFilePaths []string
-	ConfigName         string
-	LoggerName         string
+	ConfFilePath         string
+	ExtraConfFilePaths   []string
+	ConfigName           string
+	LoggerName           string
+	FleetPoliciesDirPath string
 }
 
 // MakeCommand returns a `workload-list` command to be used by agent binaries.
@@ -63,6 +64,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 						globalParams.ConfFilePath,
 						config.WithConfigName(globalParams.ConfigName),
 						config.WithExtraConfFiles(globalParams.ExtraConfFilePaths),
+						config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath),
 					),
 					LogParams: log.ForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle(),

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -51,7 +51,7 @@ system_probe_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_DISABLE_DNS_INSPECTION", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -73,7 +73,7 @@ network_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_ENABLE_PROTOCOL_CLASSIFICATION", "false")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -95,7 +95,7 @@ service_monitoring_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_STATS_BY_STATUS_CODE", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -118,7 +118,7 @@ network_config:
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
 
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -139,7 +139,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
 
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -151,7 +151,7 @@ service_monitoring_config:
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "false")
 
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -163,7 +163,7 @@ service_monitoring_config:
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "false")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
 
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -175,7 +175,7 @@ service_monitoring_config:
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
 
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -227,7 +227,7 @@ service_monitoring_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -249,7 +249,7 @@ service_monitoring_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_KAFKA_MONITORING", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -271,7 +271,7 @@ service_monitoring_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_POSTGRES_MONITORING", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -300,7 +300,7 @@ service_monitoring_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_REDIS_MONITORING", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -318,7 +318,7 @@ service_monitoring_config:
 func TestDefaultDisabledJavaTLSSupport(t *testing.T) {
 	aconfig.ResetSystemProbeConfig(t)
 
-	_, err := sysconfig.New("")
+	_, err := sysconfig.New("", "")
 	require.NoError(t, err)
 	cfg := New()
 
@@ -328,7 +328,7 @@ func TestDefaultDisabledJavaTLSSupport(t *testing.T) {
 func TestDefaultDisabledHTTP2Support(t *testing.T) {
 	aconfig.ResetSystemProbeConfig(t)
 
-	_, err := sysconfig.New("")
+	_, err := sysconfig.New("", "")
 	require.NoError(t, err)
 	cfg := New()
 
@@ -339,7 +339,7 @@ func TestDisableGatewayLookup(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		// default config
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -357,7 +357,7 @@ network_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "false")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -379,7 +379,7 @@ network_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE", "true")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -402,7 +402,7 @@ system_probe_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_COLLECT_DNS_STATS", "false")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -410,7 +410,7 @@ system_probe_config:
 
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_COLLECT_DNS_STATS", "true")
-		_, err = sysconfig.New("")
+		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg = New()
 
@@ -433,7 +433,7 @@ system_probe_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_COLLECT_DNS_DOMAINS", "false")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -441,7 +441,7 @@ system_probe_config:
 
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_COLLECT_DNS_DOMAINS", "true")
-		_, err = sysconfig.New("")
+		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg = New()
 
@@ -464,7 +464,7 @@ system_probe_config:
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		os.Unsetenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS")
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg := New()
 
@@ -472,7 +472,7 @@ system_probe_config:
 
 		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS", "10000")
-		_, err = sysconfig.New("")
+		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg = New()
 
@@ -1380,7 +1380,7 @@ func TestNetworkConfigEnabled(t *testing.T) {
 			}
 
 			aconfig.ResetSystemProbeConfig(t)
-			_, err = sysconfig.New(f.Name())
+			_, err = sysconfig.New(f.Name(), "")
 			require.NoError(t, err)
 			cfg := New()
 			assert.Equal(t, tc.npmEnabled, cfg.NPMEnabled, "npm state")
@@ -1919,7 +1919,7 @@ func configurationFromYAML(t *testing.T, yaml string) *Config {
 	require.Equal(t, len(b), n)
 	f.Sync()
 
-	_, err = sysconfig.New(f.Name())
+	_, err = sysconfig.New(f.Name(), "")
 	require.NoError(t, err)
 	return New()
 }
@@ -1935,7 +1935,7 @@ func modelCfgFromYAML(t *testing.T, yaml string) model.Config {
 	require.Equal(t, len(b), n)
 	f.Sync()
 
-	_, err = sysconfig.New(f.Name())
+	_, err = sysconfig.New(f.Name(), "")
 
 	require.NoError(t, err)
 	cfg := aconfig.SystemProbe

--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -36,7 +36,7 @@ func assertNotContainsCheck(t *testing.T, checks []string, name string) {
 }
 
 func getEnabledChecks(t *testing.T, cfg, sysprobeYamlConfig config.ReaderWriter, wmeta workloadmeta.Component, npCollector npcollector.Component) []string {
-	sysprobeConfigStruct, err := sysconfig.New("")
+	sysprobeConfigStruct, err := sysconfig.New("", "")
 	require.NoError(t, err)
 
 	var enabledChecks []string

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -806,7 +806,7 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		return nil, nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}
 
-	_, err = spconfig.New(sysprobeConfigName)
+	_, err = spconfig.New(sysprobeConfigName, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?
- Adds a `fleetcfgpath` parameter on all commands where a configuration path is used. This parameter sets the Fleet policies directory path that was added in https://github.com/DataDog/datadog-agent/pull/28096 so we can set configuration through Fleet Automation
- Mirrors https://github.com/DataDog/datadog-agent/pull/28096 for the system probe configuration

### Motivation
Fleet policies

### Additional Notes
For reviewers: this PR updates a lot of files, so you can review your files only by selecting "file filters" -> "only files owned by you"
![Screenshot 2024-08-06 at 10 51 45](https://github.com/user-attachments/assets/7fca191c-d106-42d5-9882-be74ce6527a8)


### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Testing with a running agent process:
1. Set `log_level: INFO` in your main `datadog.yaml` (resp. `system-probe.yaml`) 
2. Create a new directory in a different path than your `datadog.yaml` (resp. `system-probe.yaml`) 
3. In that new directory, add a `datadog.yaml` (resp. `system-probe.yaml`) that contains `log_level: DEBUG`
4. Run the agent process with the `--fleetcfgpath <your_dir>` flag. It should point to the directory, not the created file.

The same steps can be followed with a different config entry for other agent commands.
