### PR TITLE
(fleet) fix a race between catalog and tasks

### DIFF
--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	previousVersionLink   = "previous"
 	stableVersionLink     = "stable"
 	experimentVersionLink = "experiment"
 )


### PR DESCRIPTION
When the installer is started there is a potential for the following race:
1. RC makes its first poll
2. We subscribe to Catalog and Task products
3. Task gets applied, fails because catalog is not there
4. Catalog gets applied

This PR fixes this race by waiting for a first catalog applied to subscribe to tasks.
