### PR TITLE
[CWS] make sure we check if the trace pipe is closed before sending

### DIFF
--- a/pkg/security/tests/trace_pipe.go
+++ b/pkg/security/tests/trace_pipe.go
@@ -117,9 +117,19 @@ func (t *TracePipe) Channel() (<-chan *TraceEvent, <-chan error) {
 				if err == io.EOF {
 					continue
 				}
-				channelErrors <- err
+				select {
+				case <-t.stop:
+					return
+				case channelErrors <- err:
+					// do nothing
+				}
 			} else {
-				channelEvents <- traceEvent
+				select {
+				case <-t.stop:
+					return
+				case channelEvents <- traceEvent:
+					// do nothing
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

`ReadLine` can block on io, meaning that the information about the closed state of the trace pipe is "stale" when we send the error or the event back to the logger. This PR improves this by re-checking the close state before sending.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
