### PR TITLE
[CWS][CWS-2532] Add `modified_by` info to rules in `ruleset_loaded` event

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -58,15 +58,6 @@ const (
 	// BrokenProcessLineageErrorRuleDesc is the rule description for events with a broken process lineage
 	BrokenProcessLineageErrorRuleDesc = "Broken process lineage detected"
 
-	// RefreshUserCacheRuleID is the rule ID used to refresh users and groups cache
-	RefreshUserCacheRuleID = "refresh_user_cache"
-
-	// RefreshSBOMRuleID is the rule ID used to refresh SBOM
-	RefreshSBOMRuleID = "refresh_sbom"
-
-	// NeedRefreshSBOMRuleID is the rule ID used to request a SBOM refresh
-	NeedRefreshSBOMRuleID = "need_refresh_sbom"
-
 	// EBPFLessHelloMessageRuleID is the rule ID used when a hello message is received
 	EBPFLessHelloMessageRuleID = "ebpfless_hello_msg"
 	// EBPFLessHelloMessageRuleDesc is the rule description for the hello msg event
@@ -92,8 +83,10 @@ func (commonFields *CustomEventCommonFields) FillCustomEventCommonFields() {
 // NewCustomRule returns a new custom rule
 func NewCustomRule(id eval.RuleID, description string) *rules.Rule {
 	return &rules.Rule{
-		Rule:       &eval.Rule{ID: id},
-		Definition: &rules.RuleDefinition{ID: id, Description: description},
+		Rule: &eval.Rule{ID: id},
+		PolicyRule: &rules.PolicyRule{
+			Def: &rules.RuleDefinition{ID: id, Description: description},
+		},
 	}
 }
 

--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -165,8 +165,8 @@ func (rl *RateLimiter) Apply(ruleSet *rules.RuleSet, customRuleIDs []eval.RuleID
 	rl.applyBaseLimitersFromDefault(newLimiters)
 
 	for id, rule := range ruleSet.GetRules() {
-		if rule.Definition.Every != 0 {
-			newLimiters[id] = NewStdLimiter(rate.Every(rule.Definition.Every), 1)
+		if rule.Def.Every != 0 {
+			newLimiters[id] = NewStdLimiter(rate.Every(rule.Def.Every), 1)
 		} else {
 			newLimiters[id] = NewStdLimiter(defaultLimit, defaultBurst)
 		}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -280,10 +280,10 @@ func (a *APIServer) GetConfig(_ context.Context, _ *api.GetConfigParams) (*api.S
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func() []string, service string) {
 	backendEvent := events.BackendEvent{
-		Title: rule.Definition.Description,
+		Title: rule.Def.Description,
 		AgentContext: events.AgentContext{
-			RuleID:      rule.Definition.ID,
-			RuleVersion: rule.Definition.Version,
+			RuleID:      rule.Def.ID,
+			RuleVersion: rule.Def.Version,
 			Version:     version.AgentVersion,
 			OS:          runtime.GOOS,
 			Arch:        utils.RuntimeArch(),
@@ -291,9 +291,9 @@ func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func()
 		},
 	}
 
-	if policy := rule.Definition.Policy; policy != nil {
+	if policy := rule.Policy; policy != nil {
 		backendEvent.AgentContext.PolicyName = policy.Name
-		backendEvent.AgentContext.PolicyVersion = policy.Version
+		backendEvent.AgentContext.PolicyVersion = policy.Def.Version
 	}
 
 	eventJSON, err := marshalEvent(e, rule.Opts)
@@ -313,9 +313,9 @@ func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func()
 	// get type tags + container tags if already resolved, see ResolveContainerTags
 	eventTags := e.GetTags()
 
-	ruleID := rule.Definition.ID
-	if rule.Definition.GroupID != "" {
-		ruleID = rule.Definition.GroupID
+	ruleID := rule.Def.ID
+	if rule.Def.GroupID != "" {
+		ruleID = rule.Def.GroupID
 	}
 
 	eventActionReports := e.GetActionReports()

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -578,22 +578,22 @@ func (p *EBPFLessProbe) ApplyRuleSet(_ *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 func (p *EBPFLessProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 	ev := ctx.Event.(*model.Event)
 
-	for _, action := range rule.Definition.Actions {
+	for _, action := range rule.Actions {
 		if !action.IsAccepted(ctx) {
 			continue
 		}
 
 		switch {
-		case action.Kill != nil:
+		case action.Def.Kill != nil:
 			// do not handle kill action on event with error
 			if ev.Error != nil {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
+			p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
 			})
-		case action.Hash != nil:
+		case action.Def.Hash != nil:
 			// force the resolution as it will force the hash resolution as well
 			ev.ResolveFields()
 		}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1340,19 +1340,19 @@ func (p *WindowsProbe) NewEvent() *model.Event {
 func (p *WindowsProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 	ev := ctx.Event.(*model.Event)
 
-	for _, action := range rule.Definition.Actions {
+	for _, action := range rule.Actions {
 		if !action.IsAccepted(ctx) {
 			continue
 		}
 
 		switch {
-		case action.Kill != nil:
+		case action.Def.Kill != nil:
 			// do not handle kill action on event with error
 			if ev.Error != nil {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Kill.Scope, action.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
+			p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
 			})
 		}

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -19,7 +19,7 @@ import (
 
 // booleanTagEquals returns true if the given rule has the given tag set to a boolean and its value matches the given value
 func booleanTagEquals(rule *rules.Rule, tag string, value bool) bool {
-	if val, ok := rule.Definition.GetTag(tag); ok {
+	if val, ok := rule.Def.GetTag(tag); ok {
 		b, err := strconv.ParseBool(val)
 		return err == nil && b == value
 	}

--- a/pkg/security/rules/bundled/bundled_policy_provider_linux.go
+++ b/pkg/security/rules/bundled/bundled_policy_provider_linux.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
@@ -20,20 +19,16 @@ func newBundledPolicyRules(cfg *config.RuntimeSecurityConfig) []*rules.RuleDefin
 	}
 
 	ruleDefinitions := []*rules.RuleDefinition{{
-		ID:         events.RefreshUserCacheRuleID,
+		ID:         RefreshUserCacheRuleID,
 		Expression: `rename.file.destination.path in ["/etc/passwd", "/etc/group"]`,
-		Actions: []*rules.ActionDefinition{{
-			InternalCallback: &rules.InternalCallbackDefinition{},
-		}},
-		Silent: true,
+		Silent:     true,
 	}}
 
 	if cfg.SBOMResolverEnabled {
 		ruleDefinitions = append(ruleDefinitions, &rules.RuleDefinition{
-			ID:         events.NeedRefreshSBOMRuleID,
+			ID:         NeedRefreshSBOMRuleID,
 			Expression: `open.file.path in [~"/lib/rpm/*", ~"/lib/dpkg/*", ~"/var/lib/rpm/*", ~"/var/lib/dpkg/*", ~"/lib/apk/*"] && (open.flags & (O_CREAT | O_RDWR | O_WRONLY)) > 0`,
 			Actions: []*rules.ActionDefinition{{
-				InternalCallback: &rules.InternalCallbackDefinition{},
 				Set: &rules.SetDefinition{
 					Name:  needRefreshSBOMVariableName,
 					Scope: needRefreshSBOMVariableScope,
@@ -42,12 +37,9 @@ func newBundledPolicyRules(cfg *config.RuntimeSecurityConfig) []*rules.RuleDefin
 			}},
 			Silent: true,
 		}, &rules.RuleDefinition{
-			ID:         events.RefreshSBOMRuleID,
+			ID:         RefreshSBOMRuleID,
 			Expression: fmt.Sprintf("exit.cause == EXITED && ${%s.%s}", needRefreshSBOMVariableScope, needRefreshSBOMVariableName),
-			Actions: []*rules.ActionDefinition{{
-				InternalCallback: &rules.InternalCallbackDefinition{},
-			}},
-			Silent: true,
+			Silent:     true,
 		})
 	}
 

--- a/pkg/security/rules/bundled/rules.go
+++ b/pkg/security/rules/bundled/rules.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package bundled contains bundled rules
+package bundled
+
+const (
+	// RefreshUserCacheRuleID is the rule ID used to refresh users and groups cache
+	RefreshUserCacheRuleID = "refresh_user_cache"
+
+	// RefreshSBOMRuleID is the rule ID used to refresh SBOM
+	RefreshSBOMRuleID = "refresh_sbom"
+
+	// NeedRefreshSBOMRuleID is the rule ID used to request a SBOM refresh
+	NeedRefreshSBOMRuleID = "need_refresh_sbom"
+)

--- a/pkg/security/rules/bundled/variables.go
+++ b/pkg/security/rules/bundled/variables.go
@@ -6,8 +6,10 @@
 // Package bundled contains bundled rules
 package bundled
 
-const needRefreshSBOMVariableScope = "process"
-const needRefreshSBOMVariableName = "pkg_db_modified"
+const (
+	needRefreshSBOMVariableScope = "process"
+	needRefreshSBOMVariableName  = "pkg_db_modified"
+)
 
 // InternalVariables lists all variables used by internal rules
 var InternalVariables = [...]string{

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -393,7 +393,7 @@ func (e *RuleEngine) RuleMatch(rule *rules.Rule, event eval.Event) bool {
 
 	// add matched rules before any auto suppression check to ensure that this information is available in activity dumps
 	if ev.ContainerContext.ContainerID != "" && (e.config.ActivityDumpTagRulesEnabled || e.config.AnomalyDetectionTagRulesEnabled) {
-		ev.Rules = append(ev.Rules, model.NewMatchedRule(rule.Definition.ID, rule.Definition.Version, rule.Definition.Tags, rule.Definition.Policy.Name, rule.Definition.Policy.Version))
+		ev.Rules = append(ev.Rules, model.NewMatchedRule(rule.Def.ID, rule.Def.Version, rule.Def.Tags, rule.Policy.Name, rule.Policy.Def.Version))
 	}
 
 	if e.AutoSuppression.Suppresses(rule, ev) {
@@ -402,7 +402,7 @@ func (e *RuleEngine) RuleMatch(rule *rules.Rule, event eval.Event) bool {
 
 	e.probe.HandleActions(rule, event)
 
-	if rule.Definition.Silent {
+	if rule.Def.Silent {
 		return false
 	}
 
@@ -546,7 +546,7 @@ func getPoliciesVersions(rs *rules.RuleSet) []string {
 
 	cache := make(map[string]bool)
 	for _, rule := range rs.GetRules() {
-		version := rule.Definition.Policy.Version
+		version := rule.Policy.Def.Version
 		if _, exists := cache[version]; !exists {
 			cache[version] = true
 

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -171,6 +171,7 @@ type RuleState struct {
 	Message    string            `json:"message,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Actions    []RuleAction      `json:"actions,omitempty"`
+	ModifiedBy []*PolicyState    `json:"modified_by,omitempty"`
 }
 
 // PolicyState is used to report policy was loaded
@@ -257,46 +258,50 @@ func PolicyStateFromRule(rule *rules.PolicyRule) *PolicyState {
 	}
 }
 
-// RuleStateFromDefinition returns a rule state based on the rule definition
-func RuleStateFromDefinition(def *rules.RuleDefinition, status string, message string) *RuleState {
+// RuleStateFromRule returns a rule state based on the given rule
+func RuleStateFromRule(rule *rules.PolicyRule, status string, message string) *RuleState {
 	ruleState := &RuleState{
-		ID:         def.ID,
-		Version:    def.Version,
-		Expression: def.Expression,
+		ID:         rule.Def.ID,
+		Version:    rule.Policy.Def.Version,
+		Expression: rule.Def.Expression,
 		Status:     status,
 		Message:    message,
-		Tags:       def.Tags,
+		Tags:       rule.Def.Tags,
 	}
 
-	for _, action := range def.Actions {
-		ruleAction := RuleAction{Filter: action.Filter}
+	for _, action := range rule.Actions {
+		ruleAction := RuleAction{Filter: action.Def.Filter}
 		switch {
-		case action.Kill != nil:
+		case action.Def.Kill != nil:
 			ruleAction.Kill = &RuleKillAction{
-				Scope:  action.Kill.Scope,
-				Signal: action.Kill.Signal,
+				Scope:  action.Def.Kill.Scope,
+				Signal: action.Def.Kill.Signal,
 			}
-		case action.Set != nil:
+		case action.Def.Set != nil:
 			ruleAction.Set = &RuleSetAction{
-				Name:   action.Set.Name,
-				Value:  action.Set.Value,
-				Field:  action.Set.Field,
-				Append: action.Set.Append,
-				Scope:  string(action.Set.Scope),
+				Name:   action.Def.Set.Name,
+				Value:  action.Def.Set.Value,
+				Field:  action.Def.Set.Field,
+				Append: action.Def.Set.Append,
+				Scope:  string(action.Def.Set.Scope),
 			}
-		case action.Hash != nil:
+		case action.Def.Hash != nil:
 			ruleAction.Hash = &HashAction{
 				Enabled: true,
 			}
-		case action.CoreDump != nil:
+		case action.Def.CoreDump != nil:
 			ruleAction.CoreDump = &CoreDumpAction{
-				Process:       action.CoreDump.Process,
-				Mount:         action.CoreDump.Mount,
-				Dentry:        action.CoreDump.Dentry,
-				NoCompression: action.CoreDump.NoCompression,
+				Process:       action.Def.CoreDump.Process,
+				Mount:         action.Def.CoreDump.Mount,
+				Dentry:        action.Def.CoreDump.Dentry,
+				NoCompression: action.Def.CoreDump.NoCompression,
 			}
 		}
 		ruleState.Actions = append(ruleState.Actions, ruleAction)
+	}
+
+	for _, modRule := range rule.ModifiedBy {
+		ruleState.ModifiedBy = append(ruleState.ModifiedBy, PolicyStateFromRule(modRule))
 	}
 
 	return ruleState
@@ -314,14 +319,12 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 			continue
 		}
 
-		ruleDef := rule.Def
 		policyName := rule.Policy.Name
-
 		if policyState, exists = mp[policyName]; !exists {
 			policyState = PolicyStateFromRule(rule.PolicyRule)
 			mp[policyName] = policyState
 		}
-		policyState.Rules = append(policyState.Rules, RuleStateFromDefinition(ruleDef, "loaded", ""))
+		policyState.Rules = append(policyState.Rules, RuleStateFromRule(rule.PolicyRule, "loaded", ""))
 	}
 
 	// rules ignored due to errors
@@ -339,7 +342,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 				} else {
 					policyState = mp[policyName]
 				}
-				policyState.Rules = append(policyState.Rules, RuleStateFromDefinition(rerr.Rule.Def, string(rerr.Type()), rerr.Err.Error()))
+				policyState.Rules = append(policyState.Rules, RuleStateFromRule(rerr.Rule, string(rerr.Type()), rerr.Err.Error()))
 			}
 		}
 	}

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -201,6 +201,37 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 				}
 				in.Delim(']')
 			}
+		case "modified_by":
+			if in.IsNull() {
+				in.Skip()
+				out.ModifiedBy = nil
+			} else {
+				in.Delim('[')
+				if out.ModifiedBy == nil {
+					if !in.IsDelim(']') {
+						out.ModifiedBy = make([]*PolicyState, 0, 8)
+					} else {
+						out.ModifiedBy = []*PolicyState{}
+					}
+				} else {
+					out.ModifiedBy = (out.ModifiedBy)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v6 *PolicyState
+					if in.IsNull() {
+						in.Skip()
+						v6 = nil
+					} else {
+						if v6 == nil {
+							v6 = new(PolicyState)
+						}
+						(*v6).UnmarshalEasyJSON(in)
+					}
+					out.ModifiedBy = append(out.ModifiedBy, v6)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -245,16 +276,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v6First := true
-			for v6Name, v6Value := range in.Tags {
-				if v6First {
-					v6First = false
+			v7First := true
+			for v7Name, v7Value := range in.Tags {
+				if v7First {
+					v7First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v6Name))
+				out.String(string(v7Name))
 				out.RawByte(':')
-				out.String(string(v6Value))
+				out.String(string(v7Value))
 			}
 			out.RawByte('}')
 		}
@@ -264,11 +295,29 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v7, v8 := range in.Actions {
-				if v7 > 0 {
+			for v8, v9 := range in.Actions {
+				if v8 > 0 {
 					out.RawByte(',')
 				}
-				(v8).MarshalEasyJSON(out)
+				(v9).MarshalEasyJSON(out)
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.ModifiedBy) != 0 {
+		const prefix string = ",\"modified_by\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v10, v11 := range in.ModifiedBy {
+				if v10 > 0 {
+					out.RawByte(',')
+				}
+				if v11 == nil {
+					out.RawString("null")
+				} else {
+					(*v11).MarshalEasyJSON(out)
+				}
 			}
 			out.RawByte(']')
 		}
@@ -645,17 +694,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 					out.Rules = (out.Rules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v9 *RuleState
+					var v12 *RuleState
 					if in.IsNull() {
 						in.Skip()
-						v9 = nil
+						v12 = nil
 					} else {
-						if v9 == nil {
-							v9 = new(RuleState)
+						if v12 == nil {
+							v12 = new(RuleState)
 						}
-						(*v9).UnmarshalEasyJSON(in)
+						(*v12).UnmarshalEasyJSON(in)
 					}
-					out.Rules = append(out.Rules, v9)
+					out.Rules = append(out.Rules, v12)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -696,14 +745,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v10, v11 := range in.Rules {
-				if v10 > 0 {
+			for v13, v14 := range in.Rules {
+				if v13 > 0 {
 					out.RawByte(',')
 				}
-				if v11 == nil {
+				if v14 == nil {
 					out.RawString("null")
 				} else {
-					(*v11).MarshalEasyJSON(out)
+					(*v14).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -9,37 +9,23 @@ package rules
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
-// ActionName defines an action name
-type ActionName = string
-
-const (
-	// KillAction name a the kill action
-	KillAction ActionName = "kill"
-)
-
-// ActionDefinition describes a rule action section
-type ActionDefinition struct {
-	Filter   *string             `yaml:"filter"`
-	Set      *SetDefinition      `yaml:"set"`
-	Kill     *KillDefinition     `yaml:"kill"`
-	CoreDump *CoreDumpDefinition `yaml:"coredump"`
-	Hash     *HashDefinition     `yaml:"hash"`
-
-	// internal
+// Action represents the action to take when a rule is triggered
+// It can either come from policy a definition or be an internal callback
+type Action struct {
+	Def              *ActionDefinition
 	InternalCallback *InternalCallbackDefinition
 	FilterEvaluator  *eval.RuleEvaluator
 }
 
 // Check returns an error if the action in invalid
 func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
-	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil && a.Hash == nil && a.CoreDump == nil {
+	if a.Set == nil && a.Kill == nil && a.Hash == nil && a.CoreDump == nil {
 		return errors.New("either 'set', 'kill', 'hash' or 'coredump' section of an action must be specified")
 	}
 
@@ -74,65 +60,32 @@ func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
 }
 
 // CompileFilter compiles the filter expression
-func (a *ActionDefinition) CompileFilter(parsingContext *ast.ParsingContext, model eval.Model, evalOpts *eval.Opts) error {
-	if a.Filter == nil || *a.Filter == "" {
+func (a *Action) CompileFilter(parsingContext *ast.ParsingContext, model eval.Model, evalOpts *eval.Opts) error {
+	if a.Def.Filter == nil || *a.Def.Filter == "" {
 		return nil
 	}
 
-	expression := *a.Filter
+	expression := *a.Def.Filter
 
-	rule := &Rule{
-		Rule: eval.NewRule("action_rule", expression, evalOpts),
-	}
+	eval := eval.NewRule("action_rule", expression, evalOpts)
 
-	if err := rule.Parse(parsingContext); err != nil {
+	if err := eval.Parse(parsingContext); err != nil {
 		return &ErrActionFilter{Expression: expression, Err: err}
 	}
 
-	if err := rule.GenEvaluator(model, parsingContext); err != nil {
+	if err := eval.GenEvaluator(model, parsingContext); err != nil {
 		return &ErrActionFilter{Expression: expression, Err: err}
 	}
 
-	a.FilterEvaluator = rule.GetEvaluator()
+	a.FilterEvaluator = eval.GetEvaluator()
 
 	return nil
 }
 
 // IsAccepted returns whether a filter is accepted and has to be executed
-func (a *ActionDefinition) IsAccepted(ctx *eval.Context) bool {
+func (a *Action) IsAccepted(ctx *eval.Context) bool {
 	return a.FilterEvaluator == nil || a.FilterEvaluator.Eval(ctx)
-}
-
-// Scope describes the scope variables
-type Scope string
-
-// SetDefinition describes the 'set' section of a rule action
-type SetDefinition struct {
-	Name   string        `yaml:"name"`
-	Value  interface{}   `yaml:"value"`
-	Field  string        `yaml:"field"`
-	Append bool          `yaml:"append"`
-	Scope  Scope         `yaml:"scope"`
-	Size   int           `yaml:"size"`
-	TTL    time.Duration `yaml:"ttl"`
 }
 
 // InternalCallbackDefinition describes an internal rule action
 type InternalCallbackDefinition struct{}
-
-// KillDefinition describes the 'kill' section of a rule action
-type KillDefinition struct {
-	Signal string `yaml:"signal"`
-	Scope  string `yaml:"scope"`
-}
-
-// CoreDumpDefinition describes the 'coredump' action
-type CoreDumpDefinition struct {
-	Process       bool `yaml:"process"`
-	Mount         bool `yaml:"mount"`
-	Dentry        bool `yaml:"dentry"`
-	NoCompression bool `yaml:"no_compression"`
-}
-
-// HashDefinition describes the 'hash' section of a rule action
-type HashDefinition struct{}

--- a/pkg/security/secl/rules/bucket.go
+++ b/pkg/security/secl/rules/bucket.go
@@ -21,8 +21,8 @@ type RuleBucket struct {
 // AddRule adds a rule to the bucket
 func (rb *RuleBucket) AddRule(rule *Rule) error {
 	for _, r := range rb.rules {
-		if r.ID == rule.ID {
-			return &ErrRuleLoad{Definition: rule.Definition, Err: ErrDefinitionIDConflict}
+		if r.Def.ID == rule.Def.ID {
+			return &ErrRuleLoad{Rule: rule.PolicyRule, Err: ErrDefinitionIDConflict}
 		}
 	}
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -104,22 +104,22 @@ func (e ErrPolicyLoad) Error() string {
 
 // ErrMacroLoad is on macro definition error
 type ErrMacroLoad struct {
-	Definition *MacroDefinition
-	Err        error
+	Macro *PolicyMacro
+	Err   error
 }
 
 func (e ErrMacroLoad) Error() string {
-	return fmt.Sprintf("macro `%s` definition error: %s", e.Definition.ID, e.Err)
+	return fmt.Sprintf("macro `%s` definition error: %s", e.Macro.Def.ID, e.Err)
 }
 
 // ErrRuleLoad is on rule definition error
 type ErrRuleLoad struct {
-	Definition *RuleDefinition
-	Err        error
+	Rule *PolicyRule
+	Err  error
 }
 
 func (e ErrRuleLoad) Error() string {
-	return fmt.Sprintf("rule `%s` error: %s", e.Definition.ID, e.Err)
+	return fmt.Sprintf("rule `%s` error: %s", e.Rule.Def.ID, e.Err)
 }
 
 // RuleLoadErrType defines an rule error type

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"time"
+)
+
+// MacroID represents the ID of a macro
+type MacroID = string
+
+// CombinePolicy represents the policy to use to combine rules and macros
+type CombinePolicy = string
+
+// Combine policies
+const (
+	NoPolicy       CombinePolicy = ""
+	MergePolicy    CombinePolicy = "merge"
+	OverridePolicy CombinePolicy = "override"
+)
+
+// OverrideField defines a combine field
+type OverrideField = string
+
+const (
+	// OverrideAllFields used to override all the fields
+	OverrideAllFields OverrideField = "all"
+	// OverrideExpressionField used to override the expression
+	OverrideExpressionField OverrideField = "expression"
+	// OverrideActionFields used to override the actions
+	OverrideActionFields OverrideField = "actions"
+	// OverrideEveryField used to override the every field
+	OverrideEveryField OverrideField = "every"
+	// OverrideTagsField used to override the tags
+	OverrideTagsField OverrideField = "tags"
+)
+
+// OverrideOptions defines combine options
+type OverrideOptions struct {
+	Fields []OverrideField `yaml:"fields"`
+}
+
+// MacroDefinition holds the definition of a macro
+type MacroDefinition struct {
+	ID                     MacroID       `yaml:"id"`
+	Expression             string        `yaml:"expression"`
+	Description            string        `yaml:"description"`
+	AgentVersionConstraint string        `yaml:"agent_version"`
+	Filters                []string      `yaml:"filters"`
+	Values                 []string      `yaml:"values"`
+	Combine                CombinePolicy `yaml:"combine"`
+}
+
+// RuleID represents the ID of a rule
+type RuleID = string
+
+// RuleDefinition holds the definition of a rule
+type RuleDefinition struct {
+	ID                     RuleID              `yaml:"id"`
+	Version                string              `yaml:"version"`
+	Expression             string              `yaml:"expression"`
+	Description            string              `yaml:"description"`
+	Tags                   map[string]string   `yaml:"tags"`
+	AgentVersionConstraint string              `yaml:"agent_version"`
+	Filters                []string            `yaml:"filters"`
+	Disabled               bool                `yaml:"disabled"`
+	Combine                CombinePolicy       `yaml:"combine"`
+	OverrideOptions        OverrideOptions     `yaml:"override_options"`
+	Actions                []*ActionDefinition `yaml:"actions"`
+	Every                  time.Duration       `yaml:"every"`
+	Silent                 bool                `yaml:"silent"`
+	GroupID                string              `yaml:"group_id"`
+}
+
+// GetTag returns the tag value associated with a tag key
+func (rd *RuleDefinition) GetTag(tagKey string) (string, bool) {
+	tagValue, ok := rd.Tags[tagKey]
+	if ok {
+		return tagValue, true
+	}
+	return "", false
+}
+
+// ActionName defines an action name
+type ActionName = string
+
+const (
+	// KillAction name a the kill action
+	KillAction ActionName = "kill"
+)
+
+// ActionDefinition describes a rule action section
+type ActionDefinition struct {
+	Filter   *string             `yaml:"filter"`
+	Set      *SetDefinition      `yaml:"set"`
+	Kill     *KillDefinition     `yaml:"kill"`
+	CoreDump *CoreDumpDefinition `yaml:"coredump"`
+	Hash     *HashDefinition     `yaml:"hash"`
+}
+
+// Scope describes the scope variables
+type Scope string
+
+// SetDefinition describes the 'set' section of a rule action
+type SetDefinition struct {
+	Name   string        `yaml:"name"`
+	Value  interface{}   `yaml:"value"`
+	Field  string        `yaml:"field"`
+	Append bool          `yaml:"append"`
+	Scope  Scope         `yaml:"scope"`
+	Size   int           `yaml:"size"`
+	TTL    time.Duration `yaml:"ttl"`
+}
+
+// KillDefinition describes the 'kill' section of a rule action
+type KillDefinition struct {
+	Signal string `yaml:"signal"`
+	Scope  string `yaml:"scope"`
+}
+
+// CoreDumpDefinition describes the 'coredump' action
+type CoreDumpDefinition struct {
+	Process       bool `yaml:"process"`
+	Mount         bool `yaml:"mount"`
+	Dentry        bool `yaml:"dentry"`
+	NoCompression bool `yaml:"no_compression"`
+}
+
+// HashDefinition describes the 'hash' section of a rule action
+type HashDefinition struct{}
+
+// OnDemandHookPoint represents a hook point definition
+type OnDemandHookPoint struct {
+	Name      string         `yaml:"name"`
+	IsSyscall bool           `yaml:"syscall"`
+	Args      []HookPointArg `yaml:"args"`
+}
+
+// HookPointArg represents the definition of a hook point argument
+type HookPointArg struct {
+	N    int    `yaml:"n"`
+	Kind string `yaml:"kind"`
+}
+
+// PolicyDef represents a policy file definition
+type PolicyDef struct {
+	Version            string              `yaml:"version"`
+	Macros             []*MacroDefinition  `yaml:"macros"`
+	Rules              []*RuleDefinition   `yaml:"rules"`
+	OnDemandHookPoints []OnDemandHookPoint `yaml:"hooks"`
+}

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -10,9 +10,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
+
+// compare all Policy fields but the `Def` field
+var policyCmpOpts = []cmp.Option{
+	cmp.AllowUnexported(Policy{}),
+	cmpopts.IgnoreFields(Policy{}, "Def"),
+}
 
 // go test -v github.com/DataDog/datadog-agent/pkg/security/secl/rules --run="TestPolicyLoader_LoadPolicies"
 func TestPolicyLoader_LoadPolicies(t *testing.T) {
@@ -26,7 +34,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    func(t assert.TestingT, fields fields, got []*Policy, msgs ...interface{}) bool
+		want    func(t assert.TestingT, got []*Policy, msgs ...interface{}) bool
 		wantErr func(t assert.TestingT, err *multierror.Error, msgs ...interface{}) bool
 	}{
 		{
@@ -35,122 +43,172 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				Providers: []PolicyProvider{
 					dummyDirProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:   "myLocal.policy",
-								Source: PolicyProviderTypeDir,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-custom/foo\"",
-									},
-									{
-										ID:         "bar",
-										Expression: "open.file.path == \"/etc/local-custom/bar\"",
-									},
-								},
-							}, {
-								Name:   DefaultPolicyName,
-								Source: PolicyProviderTypeDir,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-default/foo\"",
-									},
-									{
-										ID:         "baz",
-										Expression: "open.file.path == \"/etc/local-default/baz\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myLocal.policy",
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-custom/foo\"",
+											},
+											{
+												ID:         "bar",
+												Expression: "open.file.path == \"/etc/local-custom/bar\"",
+											},
+										},
 									},
 								},
-							}}, nil
+								{
+									name:   DefaultPolicyName,
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-default/foo\"",
+											},
+											{
+												ID:         "baz",
+												Expression: "open.file.path == \"/etc/local-default/baz\"",
+											},
+										},
+									},
+								},
+							})
 						},
 					},
 					dummyRCProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:   "myRC.policy",
-								Source: PolicyProviderTypeRC,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
-									},
-									{
-										ID:         "alpha",
-										Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
-									},
-								},
-							}, {
-								Name:   DefaultPolicyName,
-								Source: PolicyProviderTypeRC,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/rc-default/foo\"",
-									},
-									{
-										ID:         "bravo",
-										Expression: "open.file.path == \"/etc/rc-default/bravo\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myRC.policy",
+									source: PolicyProviderTypeRC,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+											},
+											{
+												ID:         "alpha",
+												Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
+											},
+										},
 									},
 								},
-							}}, nil
+								{
+									name:   DefaultPolicyName,
+									source: PolicyProviderTypeRC,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/rc-default/foo\"",
+											},
+											{
+												ID:         "bravo",
+												Expression: "open.file.path == \"/etc/rc-default/bravo\"",
+											},
+										},
+									},
+								},
+							})
 						},
 					},
 				},
 			},
-			want: func(t assert.TestingT, _ fields, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := []*Policy{
+			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
+				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
 					{
 						Name:   DefaultPolicyName,
 						Source: PolicyProviderTypeRC,
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/rc-default/foo\"",
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/rc-default/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bravo",
-								Expression: "open.file.path == \"/etc/rc-default/bravo\"",
+							"bravo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bravo",
+										Expression: "open.file.path == \"/etc/rc-default/bravo\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
 					},
 					{
 						Name:   "myRC.policy",
 						Source: PolicyProviderTypeRC,
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "alpha",
-								Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
+							"alpha": {
+								{
+									Def: &RuleDefinition{
+										ID:         "alpha",
+										Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
 					},
 					{
-						Name:    "myLocal.policy",
-						Source:  PolicyProviderTypeDir,
-						Version: "",
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/local-custom/foo\"",
+						Name:   "myLocal.policy",
+						Source: PolicyProviderTypeDir,
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar",
-								Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							"bar": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar",
+										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
-						Macros: nil,
 					},
-				}
+				})
 
 				defaultPolicyCount, lastSeenDefaultPolicyIdx := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
 
 				assert.Equalf(t, 1, defaultPolicyCount, "There are more than 1 default policies")
 				assert.Equalf(t, PolicyProviderTypeRC, got[lastSeenDefaultPolicyIdx].Source, "The default policy is not from RC")
 
-				return assert.Equalf(t, expectedLoadedPolicies, got, "The loaded policies do not match the expected")
+				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
+					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
+					return false
+				}
+
+				return true
 			},
 			wantErr: func(t assert.TestingT, err *multierror.Error, _ ...interface{}) bool {
 				return assert.Nil(t, err, "Expected no errors but got %+v", err)
@@ -162,78 +220,113 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				Providers: []PolicyProvider{
 					dummyDirProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:   "myLocal.policy",
-								Source: PolicyProviderTypeDir,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-custom/foo\"",
-									},
-									{
-										ID:         "bar",
-										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myLocal.policy",
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-custom/foo\"",
+											},
+											{
+												ID:         "bar",
+												Expression: "open.file.path == \"/etc/local-custom/bar\"",
+											},
+										},
 									},
 								},
-							}}, nil
+							})
 						},
 					},
 					dummyRCProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:   "myRC.policy",
-								Source: PolicyProviderTypeRC,
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
-									},
-									{
-										ID:         "bar3",
-										Expression: "open.file.path == \"/etc/rc-custom/bar\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myRC.policy",
+									source: PolicyProviderTypeRC,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+											},
+											{
+												ID:         "bar3",
+												Expression: "open.file.path == \"/etc/rc-custom/bar\"",
+											},
+										},
 									},
 								},
-							}}, nil
+							})
 						},
 					},
 				},
 			},
-			want: func(t assert.TestingT, _ fields, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := []*Policy{
+			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
+				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
 					{
 						Name:   "myRC.policy",
 						Source: PolicyProviderTypeRC,
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar3",
-								Expression: "open.file.path == \"/etc/rc-custom/bar\"",
+							"bar3": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar3",
+										Expression: "open.file.path == \"/etc/rc-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
 					},
 					{
 						Name:   "myLocal.policy",
 						Source: PolicyProviderTypeDir,
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/local-custom/foo\"",
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar",
-								Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							"bar": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar",
+										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
 					},
-				}
+				})
 
 				defaultPolicyCount, _ := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
-
 				assert.Equalf(t, 0, defaultPolicyCount, "The count of default policies do not match")
-				return assert.Equalf(t, expectedLoadedPolicies, got, "The loaded policies do not match the expected")
+
+				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
+					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
+					return false
+				}
+
+				return true
 			},
 			wantErr: func(t assert.TestingT, err *multierror.Error, _ ...interface{}) bool {
 				return assert.Nil(t, err, "Expected no errors but got %+v", err)
@@ -245,22 +338,25 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				Providers: []PolicyProvider{
 					dummyDirProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:    "myLocal.policy",
-								Source:  PolicyProviderTypeDir,
-								Version: "",
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-custom/foo\"",
-									},
-									{
-										ID:         "bar",
-										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myLocal.policy",
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Version: "",
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-custom/foo\"",
+											},
+											{
+												ID:         "bar",
+												Expression: "open.file.path == \"/etc/local-custom/bar\"",
+											},
+										},
 									},
 								},
-								Macros: nil,
-							}}, nil
+							})
 						},
 					},
 					dummyRCProvider{
@@ -273,30 +369,44 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 				},
 			},
-			want: func(t assert.TestingT, _ fields, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := []*Policy{
+			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
+				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
 					{
-						Name:    "myLocal.policy",
-						Source:  PolicyProviderTypeDir,
-						Version: "",
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/local-custom/foo\"",
+						Name:   "myLocal.policy",
+						Source: PolicyProviderTypeDir,
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar",
-								Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							"bar": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar",
+										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
-						Macros: nil,
 					},
-				}
+				})
 
 				defaultPolicyCount, _ := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
-
 				assert.Equalf(t, 0, defaultPolicyCount, "The count of default policies do not match")
-				return assert.Equalf(t, expectedLoadedPolicies, got, "The loaded policies do not match the expected")
+
+				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
+					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
+					return false
+				}
+
+				return true
 			},
 			wantErr: func(t assert.TestingT, err *multierror.Error, _ ...interface{}) bool {
 				return assert.Equal(t, err, &multierror.Error{Errors: []error{
@@ -310,22 +420,25 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				Providers: []PolicyProvider{
 					dummyDirProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:    "myLocal.policy",
-								Source:  PolicyProviderTypeDir,
-								Version: "",
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-custom/foo\"",
-									},
-									{
-										ID:         "bar",
-										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myLocal.policy",
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Version: "",
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-custom/foo\"",
+											},
+											{
+												ID:         "bar",
+												Expression: "open.file.path == \"/etc/local-custom/bar\"",
+											},
+										},
 									},
 								},
-								Macros: nil,
-							}}, nil
+							})
 						},
 					},
 					dummyRCProvider{
@@ -338,27 +451,41 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 				},
 			},
-			want: func(t assert.TestingT, _ fields, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := []*Policy{
+			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
+				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
 					{
-						Name:    "myLocal.policy",
-						Source:  PolicyProviderTypeDir,
-						Version: "",
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/local-custom/foo\"",
+						Name:   "myLocal.policy",
+						Source: PolicyProviderTypeDir,
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar",
-								Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							"bar": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar",
+										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
-						Macros: nil,
 					},
+				})
+
+				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
+					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
+					return false
 				}
 
-				return assert.Equalf(t, expectedLoadedPolicies, got, "The loaded policies do not match the expected")
+				return true
 			},
 			wantErr: func(t assert.TestingT, err *multierror.Error, _ ...interface{}) bool {
 				return assert.Equal(t, err, &multierror.Error{
@@ -373,61 +500,84 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				Providers: []PolicyProvider{
 					dummyDirProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:    "myLocal.policy",
-								Source:  PolicyProviderTypeDir,
-								Version: "",
-								Rules: []*RuleDefinition{
-									{
-										ID:         "foo",
-										Expression: "open.file.path == \"/etc/local-custom/foo\"",
-									},
-									{
-										ID:         "bar",
-										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myLocal.policy",
+									source: PolicyProviderTypeDir,
+									def: PolicyDef{
+										Version: "",
+										Rules: []*RuleDefinition{
+											{
+												ID:         "foo",
+												Expression: "open.file.path == \"/etc/local-custom/foo\"",
+											},
+											{
+												ID:         "bar",
+												Expression: "open.file.path == \"/etc/local-custom/bar\"",
+											},
+										},
 									},
 								},
-								Macros: nil,
-							}}, nil
+							})
 						},
 					},
 					dummyRCProvider{
 						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
-							return []*Policy{{
-								Name:   "myRC.policy",
-								Source: PolicyProviderTypeRC,
-								Rules:  nil,
-							}}, nil
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:   "myRC.policy",
+									source: PolicyProviderTypeRC,
+									def: PolicyDef{
+										Version: "",
+										Rules:   nil,
+									},
+								},
+							})
 						},
 					},
 				},
 			},
-			want: func(t assert.TestingT, _ fields, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := []*Policy{
+			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
+				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
 					{
 						Name:   "myRC.policy",
 						Source: PolicyProviderTypeRC,
-						Rules:  nil, // TODO: Ensure this doesn't cause a problem with loading rules
+						macros: map[string][]*PolicyMacro{},
+						rules:  map[string][]*PolicyRule{},
 					},
 					{
-						Name:    "myLocal.policy",
-						Source:  PolicyProviderTypeDir,
-						Version: "",
-						Rules: []*RuleDefinition{
-							{
-								ID:         "foo",
-								Expression: "open.file.path == \"/etc/local-custom/foo\"",
+						Name:   "myLocal.policy",
+						Source: PolicyProviderTypeDir,
+						macros: map[string][]*PolicyMacro{},
+						rules: map[string][]*PolicyRule{
+							"foo": {
+								{
+									Def: &RuleDefinition{
+										ID:         "foo",
+										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Accepted: true,
+								},
 							},
-							{
-								ID:         "bar",
-								Expression: "open.file.path == \"/etc/local-custom/bar\"",
+							"bar": {
+								{
+									Def: &RuleDefinition{
+										ID:         "bar",
+										Expression: "open.file.path == \"/etc/local-custom/bar\"",
+									},
+									Accepted: true,
+								},
 							},
 						},
-						Macros: nil,
 					},
+				})
+
+				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
+					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
+					return false
 				}
 
-				return assert.Equalf(t, expectedLoadedPolicies, got, "The loaded policies do not match the expected")
+				return true
 			},
 			wantErr: func(t assert.TestingT, err *multierror.Error, _ ...interface{}) bool {
 				return assert.Nil(t, err, "Expected no errors but got %+v", err)
@@ -442,7 +592,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 			}
 			loadedPolicies, errs := p.LoadPolicies(tt.args.opts)
 
-			tt.want(t, tt.fields, loadedPolicies)
+			tt.want(t, loadedPolicies)
 			tt.wantErr(t, errs)
 		})
 	}
@@ -501,4 +651,51 @@ func (dummyRCProvider) Close() error {
 
 func (dummyRCProvider) Type() string {
 	return PolicyProviderTypeRC
+}
+
+type testPolicyDef struct {
+	def    PolicyDef
+	name   string
+	source string
+}
+
+func testPolicyToPolicy(testPolicy *testPolicyDef) (*Policy, *multierror.Error) {
+	policy, err := LoadPolicyFromDefinition(testPolicy.name, testPolicy.source, &testPolicy.def, nil, nil)
+	if err != nil {
+		return nil, multierror.Append(nil, err)
+	}
+	return policy, nil
+}
+
+func testPoliciesToPolicies(testPolicies []*testPolicyDef) ([]*Policy, *multierror.Error) {
+	var policies []*Policy
+	var errs *multierror.Error
+
+	for _, testPolicy := range testPolicies {
+		p, err := testPolicyToPolicy(testPolicy)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+
+		policies = append(policies, p)
+	}
+
+	return policies, errs
+}
+
+func fixupRulesPolicy(policy *Policy) *Policy {
+	for _, rules := range policy.rules {
+		for _, rule := range rules {
+			rule.Policy = policy
+		}
+	}
+	return policy
+}
+
+func fixupPoliciesRulesPolicy(policies []*Policy) []*Policy {
+	for _, policy := range policies {
+		fixupRulesPolicy(policy)
+	}
+	return policies
 }

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -9,11 +9,12 @@ package rules
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
-	"github.com/Masterminds/semver/v3"
 )
 
 // RuleFilter definition of a rule filter

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/spf13/cast"
 
@@ -25,151 +24,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/utils"
 )
 
-// MacroID represents the ID of a macro
-type MacroID = string
-
-// CombinePolicy represents the policy to use to combine rules and macros
-type CombinePolicy = string
-
-// Combine policies
-const (
-	NoPolicy       CombinePolicy = ""
-	MergePolicy    CombinePolicy = "merge"
-	OverridePolicy CombinePolicy = "override"
-)
-
-// OverrideField defines a combine field
-type OverrideField = string
-
-const (
-	// OverrideAllFields used to override all the fields
-	OverrideAllFields OverrideField = "all"
-	// OverrideExpressionField used to override the expression
-	OverrideExpressionField OverrideField = "expression"
-	// OverrideActionFields used to override the actions
-	OverrideActionFields OverrideField = "actions"
-	// OverrideEveryField used to override the every field
-	OverrideEveryField OverrideField = "every"
-	// OverrideTagsField used to override the tags
-	OverrideTagsField OverrideField = "tags"
-)
-
-// OverrideOptions defines combine options
-type OverrideOptions struct {
-	Fields []OverrideField `yaml:"fields"`
-}
-
-// MacroDefinition holds the definition of a macro
-type MacroDefinition struct {
-	ID                     MacroID       `yaml:"id"`
-	Expression             string        `yaml:"expression"`
-	Description            string        `yaml:"description"`
-	AgentVersionConstraint string        `yaml:"agent_version"`
-	Filters                []string      `yaml:"filters"`
-	Values                 []string      `yaml:"values"`
-	Combine                CombinePolicy `yaml:"combine"`
-}
-
-// MergeWith merges macro m2 into m
-func (m *MacroDefinition) MergeWith(m2 *MacroDefinition) error {
-	switch m2.Combine {
-	case MergePolicy:
-		if m.Expression != "" || m2.Expression != "" {
-			return &ErrMacroLoad{Definition: m2, Err: ErrCannotMergeExpression}
-		}
-		m.Values = append(m.Values, m2.Values...)
-	case OverridePolicy:
-		m.Values = m2.Values
-	default:
-		return &ErrMacroLoad{Definition: m2, Err: ErrDefinitionIDConflict}
-	}
-	return nil
-}
-
-// Macro describes a macro of a ruleset
-type Macro struct {
-	*eval.Macro
-	Definition *MacroDefinition
-}
-
-// RuleID represents the ID of a rule
-type RuleID = string
-
-// RuleDefinition holds the definition of a rule
-type RuleDefinition struct {
-	ID                     RuleID              `yaml:"id"`
-	Version                string              `yaml:"version"`
-	Expression             string              `yaml:"expression"`
-	Description            string              `yaml:"description"`
-	Tags                   map[string]string   `yaml:"tags"`
-	AgentVersionConstraint string              `yaml:"agent_version"`
-	Filters                []string            `yaml:"filters"`
-	Disabled               bool                `yaml:"disabled"`
-	Combine                CombinePolicy       `yaml:"combine"`
-	OverrideOptions        OverrideOptions     `yaml:"override_options"`
-	Actions                []*ActionDefinition `yaml:"actions"`
-	Every                  time.Duration       `yaml:"every"`
-	Silent                 bool                `yaml:"silent"`
-	GroupID                string              `yaml:"group_id"`
-	Policy                 *Policy
-}
-
-// GetTag returns the tag value associated with a tag key
-func (rd *RuleDefinition) GetTag(tagKey string) (string, bool) {
-	tagValue, ok := rd.Tags[tagKey]
-	if ok {
-		return tagValue, true
-	}
-	return "", false
-}
-
-func applyOverride(rd1, rd2 *RuleDefinition) {
-	// keep track of the combine
-	rd1.Combine = rd2.Combine
-
-	// for backward compatibility, by default only the expression is copied if no options
-	if len(rd2.OverrideOptions.Fields) == 0 {
-		rd1.Expression = rd2.Expression
-	} else if slices.Contains(rd2.OverrideOptions.Fields, OverrideAllFields) {
-		// keep the original policy
-		policy := rd1.Policy
-
-		*rd1 = *rd2
-		rd1.Policy = policy
-	} else {
-		if slices.Contains(rd2.OverrideOptions.Fields, OverrideExpressionField) {
-			rd1.Expression = rd2.Expression
-		}
-		if slices.Contains(rd2.OverrideOptions.Fields, OverrideActionFields) {
-			rd1.Actions = rd2.Actions
-		}
-		if slices.Contains(rd2.OverrideOptions.Fields, OverrideEveryField) {
-			rd1.Every = rd2.Every
-		}
-		if slices.Contains(rd2.OverrideOptions.Fields, OverrideTagsField) {
-			rd1.Tags = rd2.Tags
-		}
-	}
-}
-
-// MergeWith merges rule rd2 into rd
-func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
-	switch rd2.Combine {
-	case OverridePolicy:
-		applyOverride(rd, rd2)
-	default:
-		if !rd2.Disabled {
-			return &ErrRuleLoad{Definition: rd2, Err: ErrDefinitionIDConflict}
-		}
-	}
-	rd.Disabled = rd2.Disabled
-	return nil
-}
-
-// Rule describes a rule of a ruleset
+// Rule presents a rule in a ruleset
 type Rule struct {
+	*PolicyRule
 	*eval.Rule
-	Definition  *RuleDefinition
 	NoDiscarder bool
 }
 
@@ -236,7 +94,7 @@ func (rs *RuleSet) ListMacroIDs() []MacroID {
 }
 
 // AddMacros parses the macros AST and adds them to the list of macros of the ruleset
-func (rs *RuleSet) AddMacros(parsingContext *ast.ParsingContext, macros []*MacroDefinition) *multierror.Error {
+func (rs *RuleSet) AddMacros(parsingContext *ast.ParsingContext, macros []*PolicyMacro) *multierror.Error {
 	var result *multierror.Error
 
 	// Build the list of macros for the ruleset
@@ -250,25 +108,25 @@ func (rs *RuleSet) AddMacros(parsingContext *ast.ParsingContext, macros []*Macro
 }
 
 // AddMacro parses the macro AST and adds it to the list of macros of the ruleset
-func (rs *RuleSet) AddMacro(parsingContext *ast.ParsingContext, macroDef *MacroDefinition) (*eval.Macro, error) {
+func (rs *RuleSet) AddMacro(parsingContext *ast.ParsingContext, pMacro *PolicyMacro) (*eval.Macro, error) {
 	var err error
 
-	if rs.evalOpts.MacroStore.Contains(macroDef.ID) {
-		return nil, &ErrMacroLoad{Definition: macroDef, Err: ErrDefinitionIDConflict}
+	if rs.evalOpts.MacroStore.Contains(pMacro.Def.ID) {
+		return nil, &ErrMacroLoad{Macro: pMacro, Err: ErrDefinitionIDConflict}
 	}
 
 	var macro *eval.Macro
 
 	switch {
-	case macroDef.Expression != "" && len(macroDef.Values) > 0:
-		return nil, &ErrMacroLoad{Definition: macroDef, Err: errors.New("only one of 'expression' and 'values' can be defined")}
-	case macroDef.Expression != "":
-		if macro, err = eval.NewMacro(macroDef.ID, macroDef.Expression, rs.model, parsingContext, rs.evalOpts); err != nil {
-			return nil, &ErrMacroLoad{Definition: macroDef, Err: err}
+	case pMacro.Def.Expression != "" && len(pMacro.Def.Values) > 0:
+		return nil, &ErrMacroLoad{Macro: pMacro, Err: errors.New("only one of 'expression' and 'values' can be defined")}
+	case pMacro.Def.Expression != "":
+		if macro, err = eval.NewMacro(pMacro.Def.ID, pMacro.Def.Expression, rs.model, parsingContext, rs.evalOpts); err != nil {
+			return nil, &ErrMacroLoad{Macro: pMacro, Err: err}
 		}
 	default:
-		if macro, err = eval.NewStringValuesMacro(macroDef.ID, macroDef.Values, rs.evalOpts); err != nil {
-			return nil, &ErrMacroLoad{Definition: macroDef, Err: err}
+		if macro, err = eval.NewStringValuesMacro(pMacro.Def.ID, pMacro.Def.Values, rs.evalOpts); err != nil {
+			return nil, &ErrMacroLoad{Macro: pMacro, Err: err}
 		}
 	}
 
@@ -278,11 +136,11 @@ func (rs *RuleSet) AddMacro(parsingContext *ast.ParsingContext, macroDef *MacroD
 }
 
 // AddRules adds rules to the ruleset and generate their partials
-func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, rules []*RuleDefinition) *multierror.Error {
+func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, pRules []*PolicyRule) *multierror.Error {
 	var result *multierror.Error
 
-	for _, ruleDef := range rules {
-		if _, err := rs.AddRule(parsingContext, ruleDef); err != nil {
+	for _, pRule := range pRules {
+		if _, err := rs.AddRule(parsingContext, pRule); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -290,21 +148,21 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, rules []*RuleDef
 	return result
 }
 
-func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefinition, opts PolicyLoaderOpts) *multierror.Error {
+func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*PolicyRule, opts PolicyLoaderOpts) *multierror.Error {
 	var errs *multierror.Error
 
 	for _, rule := range policyRules {
-		for _, action := range rule.Actions {
-			if err := action.Check(opts); err != nil {
-				errs = multierror.Append(errs, fmt.Errorf("invalid action in rule %s: %w", rule.ID, err))
+		for _, actionDef := range rule.Def.Actions {
+			if err := actionDef.Check(opts); err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("skipping invalid action in rule %s: %w", rule.Def.ID, err))
 				continue
 			}
 
 			switch {
-			case action.Set != nil:
-				varName := action.Set.Name
-				if action.Set.Scope != "" {
-					varName = string(action.Set.Scope) + "." + varName
+			case actionDef.Set != nil:
+				varName := actionDef.Set.Name
+				if actionDef.Set.Scope != "" {
+					varName = string(actionDef.Set.Scope) + "." + varName
 				}
 
 				if _, err := rs.eventCtor().GetFieldValue(varName); err == nil {
@@ -319,34 +177,34 @@ func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefiniti
 
 				var variableValue interface{}
 
-				if action.Set.Value != nil {
-					switch value := action.Set.Value.(type) {
+				if actionDef.Set.Value != nil {
+					switch value := actionDef.Set.Value.(type) {
 					case int:
-						action.Set.Value = []int{value}
+						actionDef.Set.Value = []int{value}
 					case string:
-						action.Set.Value = []string{value}
+						actionDef.Set.Value = []string{value}
 					case []interface{}:
 						if len(value) == 0 {
-							errs = multierror.Append(errs, fmt.Errorf("unable to infer item type for '%s'", action.Set.Name))
+							errs = multierror.Append(errs, fmt.Errorf("unable to infer item type for '%s'", actionDef.Set.Name))
 							continue
 						}
 
 						switch arrayType := value[0].(type) {
 						case int:
-							action.Set.Value = cast.ToIntSlice(value)
+							actionDef.Set.Value = cast.ToIntSlice(value)
 						case string:
-							action.Set.Value = cast.ToStringSlice(value)
+							actionDef.Set.Value = cast.ToStringSlice(value)
 						default:
-							errs = multierror.Append(errs, fmt.Errorf("unsupported item type '%s' for array '%s'", reflect.TypeOf(arrayType), action.Set.Name))
+							errs = multierror.Append(errs, fmt.Errorf("unsupported item type '%s' for array '%s'", reflect.TypeOf(arrayType), actionDef.Set.Name))
 							continue
 						}
 					}
 
-					variableValue = action.Set.Value
-				} else if action.Set.Field != "" {
-					kind, err := rs.eventCtor().GetFieldType(action.Set.Field)
+					variableValue = actionDef.Set.Value
+				} else if actionDef.Set.Field != "" {
+					kind, err := rs.eventCtor().GetFieldType(actionDef.Set.Field)
 					if err != nil {
-						errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", action.Set.Field, err))
+						errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", actionDef.Set.Field, err))
 						continue
 					}
 
@@ -358,7 +216,7 @@ func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefiniti
 					case reflect.Bool:
 						variableValue = false
 					default:
-						errs = multierror.Append(errs, fmt.Errorf("unsupported field type '%s' for variable '%s'", kind, action.Set.Name))
+						errs = multierror.Append(errs, fmt.Errorf("unsupported field type '%s' for variable '%s'", kind, actionDef.Set.Name))
 						continue
 					}
 				}
@@ -366,27 +224,27 @@ func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefiniti
 				var variable eval.VariableValue
 				var variableProvider VariableProvider
 
-				if action.Set.Scope != "" {
-					stateScopeBuilder := rs.opts.StateScopes[action.Set.Scope]
+				if actionDef.Set.Scope != "" {
+					stateScopeBuilder := rs.opts.StateScopes[actionDef.Set.Scope]
 					if stateScopeBuilder == nil {
-						errs = multierror.Append(errs, fmt.Errorf("invalid scope '%s'", action.Set.Scope))
+						errs = multierror.Append(errs, fmt.Errorf("invalid scope '%s'", actionDef.Set.Scope))
 						continue
 					}
 
-					if _, found := rs.scopedVariables[action.Set.Scope]; !found {
-						rs.scopedVariables[action.Set.Scope] = stateScopeBuilder()
+					if _, found := rs.scopedVariables[actionDef.Set.Scope]; !found {
+						rs.scopedVariables[actionDef.Set.Scope] = stateScopeBuilder()
 					}
 
-					variableProvider = rs.scopedVariables[action.Set.Scope]
+					variableProvider = rs.scopedVariables[actionDef.Set.Scope]
 				} else {
 					variableProvider = &rs.globalVariables
 				}
 
-				opts := eval.VariableOpts{TTL: action.Set.TTL, Size: action.Set.Size}
+				opts := eval.VariableOpts{TTL: actionDef.Set.TTL, Size: actionDef.Set.Size}
 
-				variable, err := variableProvider.GetVariable(action.Set.Name, variableValue, opts)
+				variable, err := variableProvider.GetVariable(actionDef.Set.Name, variableValue, opts)
 				if err != nil {
-					errs = multierror.Append(errs, fmt.Errorf("invalid type '%s' for variable '%s': %w", reflect.TypeOf(action.Set.Value), action.Set.Name, err))
+					errs = multierror.Append(errs, fmt.Errorf("invalid type '%s' for variable '%s': %w", reflect.TypeOf(actionDef.Set.Value), actionDef.Set.Name, err))
 					continue
 				}
 
@@ -397,6 +255,10 @@ func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefiniti
 
 				rs.evalOpts.VariableStore.Add(varName, variable)
 			}
+
+			rule.Actions = append(rule.Actions, &Action{
+				Def: actionDef,
+			})
 		}
 	}
 	return errs
@@ -422,74 +284,74 @@ func GetRuleEventType(rule *eval.Rule) (eval.EventType, error) {
 }
 
 // AddRule creates the rule evaluator and adds it to the bucket of its events
-func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, ruleDef *RuleDefinition) (*eval.Rule, error) {
-	if ruleDef.Disabled {
+func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule) (*eval.Rule, error) {
+	if pRule.Def.Disabled {
 		return nil, nil
 	}
 
 	for _, id := range rs.opts.ReservedRuleIDs {
-		if id == ruleDef.ID {
-			return nil, &ErrRuleLoad{Definition: ruleDef, Err: ErrInternalIDConflict}
+		if id == pRule.Def.ID {
+			return nil, &ErrRuleLoad{Rule: pRule, Err: ErrInternalIDConflict}
 		}
 	}
 
-	if _, exists := rs.rules[ruleDef.ID]; exists {
-		return nil, &ErrRuleLoad{Definition: ruleDef, Err: ErrDefinitionIDConflict}
+	if _, exists := rs.rules[pRule.Def.ID]; exists {
+		return nil, &ErrRuleLoad{Rule: pRule, Err: ErrDefinitionIDConflict}
 	}
 
 	var tags []string
-	for k, v := range ruleDef.Tags {
+	for k, v := range pRule.Def.Tags {
 		tags = append(tags, k+":"+v)
 	}
 
 	rule := &Rule{
-		Rule:       eval.NewRule(ruleDef.ID, ruleDef.Expression, rs.evalOpts, tags...),
-		Definition: ruleDef,
+		PolicyRule: pRule,
+		Rule:       eval.NewRule(pRule.Def.ID, pRule.Def.Expression, rs.evalOpts, tags...),
 	}
 
 	if err := rule.Parse(parsingContext); err != nil {
-		return nil, &ErrRuleLoad{Definition: ruleDef, Err: &ErrRuleSyntax{Err: err}}
+		return nil, &ErrRuleLoad{Rule: pRule, Err: &ErrRuleSyntax{Err: err}}
 	}
 
 	if err := rule.GenEvaluator(rs.model, parsingContext); err != nil {
-		return nil, &ErrRuleLoad{Definition: ruleDef, Err: err}
+		return nil, &ErrRuleLoad{Rule: pRule, Err: err}
 	}
 
 	eventType, err := GetRuleEventType(rule.Rule)
 	if err != nil {
-		return nil, &ErrRuleLoad{Definition: ruleDef, Err: err}
+		return nil, &ErrRuleLoad{Rule: pRule, Err: err}
 	}
 
 	// validate event context against event type
 	for _, field := range rule.GetFields() {
 		restrictions := rs.model.GetFieldRestrictions(field)
 		if len(restrictions) > 0 && !slices.Contains(restrictions, eventType) {
-			return nil, &ErrRuleLoad{Definition: ruleDef, Err: &ErrFieldNotAvailable{Field: field, EventType: eventType, RestrictedTo: restrictions}}
+			return nil, &ErrRuleLoad{Rule: pRule, Err: &ErrFieldNotAvailable{Field: field, EventType: eventType, RestrictedTo: restrictions}}
 		}
 	}
 
 	// ignore event types not supported
 	if _, exists := rs.opts.EventTypeEnabled["*"]; !exists {
 		if _, exists := rs.opts.EventTypeEnabled[eventType]; !exists {
-			return nil, &ErrRuleLoad{Definition: ruleDef, Err: ErrEventTypeNotEnabled}
+			return nil, &ErrRuleLoad{Rule: pRule, Err: ErrEventTypeNotEnabled}
 		}
 	}
 
-	for _, action := range rule.Definition.Actions {
+	for _, action := range rule.PolicyRule.Actions {
 		// compile action filter
-		if action.Filter != nil {
+		if action.Def.Filter != nil {
 			if err := action.CompileFilter(parsingContext, rs.model, rs.evalOpts); err != nil {
-				return nil, &ErrRuleLoad{Definition: ruleDef, Err: err}
+				return nil, &ErrRuleLoad{Rule: pRule, Err: err}
 			}
 		}
 
-		if action.Set != nil && action.Set.Field != "" {
-			if _, found := rs.fieldEvaluators[action.Set.Field]; !found {
-				evaluator, err := rs.model.GetEvaluator(action.Set.Field, "")
+		if action.Def.Set != nil && action.Def.Set.Field != "" {
+			if _, found := rs.fieldEvaluators[action.Def.Set.Field]; !found {
+				evaluator, err := rs.model.GetEvaluator(action.Def.Set.Field, "")
 				if err != nil {
 					return nil, err
 				}
-				rs.fieldEvaluators[action.Set.Field] = evaluator
+				rs.fieldEvaluators[action.Def.Set.Field] = evaluator
 			}
 		}
 	}
@@ -507,7 +369,7 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, ruleDef *RuleDefi
 	// Merge the fields of the new rule with the existing list of fields of the ruleset
 	rs.AddFields(rule.GetEvaluator().GetFields())
 
-	rs.rules[ruleDef.ID] = rule
+	rs.rules[pRule.Def.ID] = rule
 
 	return rule.Rule, nil
 }
@@ -641,19 +503,19 @@ func (rs *RuleSet) IsDiscarder(event eval.Event, field eval.Field) (bool, error)
 }
 
 func (rs *RuleSet) runRuleActions(_ eval.Event, ctx *eval.Context, rule *Rule) error {
-	for _, action := range rule.Definition.Actions {
+	for _, action := range rule.PolicyRule.Actions {
 		if !action.IsAccepted(ctx) {
 			continue
 		}
 
 		switch {
 		// action.Kill has to handled by a ruleset listener
-		case action.Set != nil:
-			name := string(action.Set.Scope)
+		case action.Def.Set != nil:
+			name := string(action.Def.Set.Scope)
 			if name != "" {
 				name += "."
 			}
-			name += action.Set.Name
+			name += action.Def.Set.Name
 
 			variable := rs.evalOpts.VariableStore.Get(name)
 			if variable == nil {
@@ -661,14 +523,14 @@ func (rs *RuleSet) runRuleActions(_ eval.Event, ctx *eval.Context, rule *Rule) e
 			}
 
 			if mutable, ok := variable.(eval.MutableVariable); ok {
-				value := action.Set.Value
-				if field := action.Set.Field; field != "" {
+				value := action.Def.Set.Value
+				if field := action.Def.Set.Field; field != "" {
 					if evaluator := rs.fieldEvaluators[field]; evaluator != nil {
 						value = evaluator.Eval(ctx)
 					}
 				}
 
-				if action.Set.Append {
+				if action.Def.Set.Append {
 					if err := mutable.Append(ctx, value); err != nil {
 						return fmt.Errorf("append is not supported for %s", reflect.TypeOf(value))
 					}
@@ -858,10 +720,10 @@ func (rs *RuleSet) StopEventCollector() []CollectedEvent {
 func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *multierror.Error {
 	var (
 		errs       *multierror.Error
-		allRules   []*RuleDefinition
-		allMacros  []*MacroDefinition
-		macroIndex = make(map[string]*MacroDefinition)
-		rulesIndex = make(map[string]*RuleDefinition)
+		allRules   []*PolicyRule
+		allMacros  []*PolicyMacro
+		macroIndex = make(map[string]*PolicyMacro)
+		rulesIndex = make(map[string]*PolicyRule)
 	)
 
 	parsingContext := ast.NewParsingContext()
@@ -873,29 +735,29 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 	rs.policies = policies
 
 	for _, policy := range policies {
-		for _, macro := range policy.Macros {
-			if existingMacro := macroIndex[macro.ID]; existingMacro != nil {
+		for _, macro := range policy.GetAcceptedMacros() {
+			if existingMacro := macroIndex[macro.Def.ID]; existingMacro != nil {
 				if err := existingMacro.MergeWith(macro); err != nil {
 					errs = multierror.Append(errs, err)
 				}
 			} else {
-				macroIndex[macro.ID] = macro
+				macroIndex[macro.Def.ID] = macro
 				allMacros = append(allMacros, macro)
 			}
 		}
 
-		for _, rule := range policy.Rules {
-			if existingRule := rulesIndex[rule.ID]; existingRule != nil {
+		for _, rule := range policy.GetAcceptedRules() {
+			if existingRule := rulesIndex[rule.Def.ID]; existingRule != nil {
 				if err := existingRule.MergeWith(rule); err != nil {
 					errs = multierror.Append(errs, err)
 				}
 			} else {
-				rulesIndex[rule.ID] = rule
+				rulesIndex[rule.Def.ID] = rule
 				allRules = append(allRules, rule)
 			}
 		}
 
-		rs.OnDemandHookPoints = append(rs.OnDemandHookPoints, policy.OnDemandHookPoints...)
+		rs.OnDemandHookPoints = append(rs.OnDemandHookPoints, policy.onDemandHookPoints...)
 	}
 
 	if err := rs.AddMacros(parsingContext, allMacros); err.ErrorOrNil() != nil {
@@ -930,19 +792,6 @@ func (rs *RuleSet) newFakeEvent() eval.Event {
 	}
 
 	return model.NewFakeEvent()
-}
-
-// OnDemandHookPoint represents a hook point definition
-type OnDemandHookPoint struct {
-	Name      string         `yaml:"name"`
-	IsSyscall bool           `yaml:"syscall"`
-	Args      []HookPointArg `yaml:"args"`
-}
-
-// HookPointArg represents the definition of a hook point argument
-type HookPointArg struct {
-	N    int    `yaml:"n"`
-	Kind string `yaml:"kind"`
 }
 
 // NewRuleSet returns a new ruleset for the specified data model

--- a/pkg/security/secl/rules/testutil.go
+++ b/pkg/security/secl/rules/testutil.go
@@ -17,20 +17,22 @@ import (
 func AddTestRuleExpr(t testing.TB, rs *RuleSet, exprs ...string) {
 	t.Helper()
 
-	var ruleDefs []*RuleDefinition
+	var rules []*PolicyRule
 
 	for i, expr := range exprs {
-		ruleDef := &RuleDefinition{
-			ID:         fmt.Sprintf("ID%d", i),
-			Expression: expr,
-			Tags:       make(map[string]string),
+		rule := &PolicyRule{
+			Def: &RuleDefinition{
+				ID:         fmt.Sprintf("ID%d", i),
+				Expression: expr,
+				Tags:       make(map[string]string),
+			},
 		}
-		ruleDefs = append(ruleDefs, ruleDef)
+		rules = append(rules, rule)
 	}
 
 	pc := ast.NewParsingContext()
 
-	if err := rs.AddRules(pc, ruleDefs); err != nil {
+	if err := rs.AddRules(pc, rules); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -47,6 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	rulesmodule "github.com/DataDog/datadog-agent/pkg/security/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -676,7 +677,7 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 
 	if opts.dynamicOpts.disableBundledRules {
 		ruleDefs = append(ruleDefs, &rules.RuleDefinition{
-			ID:       events.NeedRefreshSBOMRuleID,
+			ID:       bundled.NeedRefreshSBOMRuleID,
 			Disabled: true,
 			Combine:  rules.OverridePolicy,
 		})

--- a/pkg/security/tests/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/tests/schemas/ruleset_loaded.schema.json
@@ -18,7 +18,7 @@
         "date"
     ],
     "$defs": {
-        "policy": {
+        "policyinfo": {
             "type": "object",
             "properties": {
                 "source": {
@@ -35,7 +35,18 @@
                 },
                 "version": {
                     "type": "string"
-                },
+                }
+            },
+            "required": [
+                "source",
+                "name",
+                "version"
+            ]
+        },
+        "policy": {
+            "type": "object",
+            "allOf": [{ "$ref": "#/$defs/policyinfo" }],
+            "properties": {
                 "rules": {
                     "type": "array",
                     "items": {
@@ -44,9 +55,6 @@
                 }
             },
             "required": [
-                "source",
-                "name",
-                "version",
                 "rules"
             ]
         },
@@ -74,6 +82,24 @@
                 },
                 "message": {
                     "type": "string"
+                },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "actions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/action"
+                    }
+                },
+                "modified_by": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/policyinfo"
+                    }
                 }
             },
             "required": [
@@ -81,6 +107,72 @@
                 "status",
                 "expression"
             ]
+        },
+        "action": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "type": "string"
+                },
+                "set": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type":["string", "number", "object", "array", "boolean", "null"]
+                        },
+                        "field": {
+                            "type": "string"
+                        },
+                        "append": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": ["process", "container"]
+                        }
+                    }
+                },
+                "kill": {
+                    "type": "object",
+                    "properties": {
+                        "signal": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": ["process", "container"]
+                        }
+                    }
+                },
+                "hash": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "coredump": {
+                    "type": "object",
+                    "properties": {
+                        "process": {
+                            "type": "boolean"
+                        },
+                        "mount": {
+                            "type": "boolean"
+                        },
+                        "dentry": {
+                            "type": "boolean"
+                        },
+                        "no_compression": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- Refactors the rule/policy data model by splitting the type definitions from the internal rule loading logic, making it easier to load a policy from its definition.
- Adds a new `modified_by` field to the rules listed in a `ruleset_loaded` event. This field lists the policies that caused the original rule to be updated.
- Updates the `ruleset_loaded` event schema.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
