### PR TITLE
[CWS] fix unmarshalling of k8s user session payload

### DIFF
--- a/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
+++ b/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
@@ -9,6 +9,7 @@
 package injectcmd
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"os"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
-	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
 
 const (
@@ -106,7 +106,7 @@ func injectUserSession(params *InjectCliParams) error {
 	for cursor < len(params.Data) || (len(params.Data) == 0 && cursor == 0) {
 		req := erpc.NewERPCRequest(erpc.UserSessionContextOp)
 
-		native.Endian.PutUint64(req.Data[0:8], id)
+		binary.NativeEndian.PutUint64(req.Data[0:8], id)
 		req.Data[8] = segmentCursor
 		// padding
 		req.Data[16] = uint8(sessionType)

--- a/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
+++ b/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
@@ -102,7 +102,6 @@ func injectUserSession(params *InjectCliParams) error {
 
 	// send the user session to the CWS agent
 	cursor := 0
-	var segmentSize int
 	segmentCursor := uint8(1)
 	for cursor < len(params.Data) || (len(params.Data) == 0 && cursor == 0) {
 		req := erpc.NewERPCRequest(erpc.UserSessionContextOp)
@@ -112,11 +111,11 @@ func injectUserSession(params *InjectCliParams) error {
 		// padding
 		req.Data[16] = uint8(sessionType)
 
-		if erpc.ERPCDefaultDataSize-17 < len(params.Data)-cursor {
+		segmentSize := len(params.Data) - cursor
+		if erpc.ERPCDefaultDataSize-17 < segmentSize {
 			segmentSize = erpc.ERPCDefaultDataSize - 17
-		} else {
-			segmentSize = len(params.Data) - cursor
 		}
+
 		copy(req.Data[17:], params.Data[cursor:cursor+segmentSize])
 
 		// issue eRPC calls

--- a/pkg/security/ebpf/c/include/helpers/erpc.h
+++ b/pkg/security/ebpf/c/include/helpers/erpc.h
@@ -118,9 +118,6 @@ int __attribute__((always_inline)) handle_erpc_request(ctx_t *ctx) {
         return handle_discard_inode(data);
     case DISCARD_PID_OP:
         return handle_discard_pid(data);
-    }
-
-    switch (op) {
     case RESOLVE_PATH_OP:
         return handle_dr_request(ctx, data, DR_ERPC_KEY);
     case USER_SESSION_CONTEXT_OP:

--- a/pkg/security/ebpf/c/include/structs/user_sessions.h
+++ b/pkg/security/ebpf/c/include/structs/user_sessions.h
@@ -1,10 +1,12 @@
 #ifndef _STRUCTS_USER_SESSIONS_H_
 #define _STRUCTS_USER_SESSIONS_H_
 
+// 16 bytes of key + 1 byte of session_type + 239 bytes of data = 256 bytes, the size of the eRPC payload
+
 struct user_session_t {
     u8 session_type;
-    char data[246];
-    u8 padding[9];
+    char data[239];
+    u8 padding[16];
 };
 
 struct user_session_key_t {

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -10,6 +10,7 @@ package erpc
 
 import (
 	"errors"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -78,6 +79,8 @@ func (k *ERPC) Request(req *Request) error {
 			return errno
 		}
 	}
+
+	runtime.KeepAlive(req)
 
 	return nil
 }

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -44,7 +44,7 @@ func (e *UserSessionData) UnmarshalBinary(data []byte) error {
 	}
 
 	e.SessionType = usersession.Type(data[0])
-	e.RawData += model.NullTerminatedString(data[1:])
+	e.RawData += model.NullTerminatedString(data[1:240])
 	return nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The payload is 239 bytes at a maximum, so the unmarshalling code needs to take this into account. This PR fixes this issue in the unmarshalling code, does a few code cleanup, fix a potential issue with the eRPC req being garbage collected before we are done with it, and switches the k8s session monitoring code to use `binary.NativeEndian` (for some reason this is what made me discover this issue).
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
