### PR TITLE
[CWS] make sure we close the fd from the eRPC client

### DIFF
--- a/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
+++ b/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
@@ -96,6 +96,7 @@ func injectUserSession(params *InjectCliParams) error {
 	if err != nil {
 		return fmt.Errorf("couldn't create eRPC client: %w", err)
 	}
+	defer client.Close()
 
 	// generate random ID for this session
 	id := (uint64(rand.Uint32()) << 32) + uint64(time.Now().Unix())

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -82,6 +82,7 @@ func (k *ERPC) Request(req *Request) error {
 	return nil
 }
 
+// Close closes the ERPC client
 func (k *ERPC) Close() error {
 	return syscall.Close(k.fd)
 }

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -82,6 +82,10 @@ func (k *ERPC) Request(req *Request) error {
 	return nil
 }
 
+func (k *ERPC) Close() error {
+	return syscall.Close(k.fd)
+}
+
 // NewERPC returns a new ERPC object
 func NewERPC() (*ERPC, error) {
 	fd, err := syscall.Dup(syscall.Stdout)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1408,6 +1408,10 @@ func (p *EBPFProbe) Close() error {
 		return err
 	}
 
+	if err := p.Erpc.Close(); err != nil {
+		return err
+	}
+
 	// when we reach this point, we do not generate nor consume events anymore, we can close the resolvers
 	return p.Resolvers.Close()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR makes sure the fd associated with the eRPC client is correctly closed.  This is not a big deal for the regular CWS in system probe part, but can be when used in cws-instrumentation. And it's also just basic hygiene.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
