### PR TITLE
[CONTP-62] Add external_metrics_provider.api_key and app_key to secret allowlistpath

### DIFF
--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -369,7 +369,7 @@ func (r *secretResolver) Resolve(data []byte, origin string) ([]byte, error) {
 // allowlistPaths restricts what config settings may be updated
 // tests can override this to exercise functionality: by setting this to nil, allow all settings
 // NOTE: Related feature to `authorizedConfigPathsCore` in `comp/api/api/apiimpl/internal/config/endpoint.go`
-var allowlistPaths = map[string]struct{}{"api_key": {}, "app_key": {}}
+var allowlistPaths = map[string]struct{}{"api_key": {}, "app_key": {}, "external_metrics_provider/api_key": {}, "external_metrics_provider/app_key": {}}
 
 // matchesAllowlist returns whether the handle is allowed, by matching all setting paths that
 // handle appears at against the allowlist


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
[CONTP-62](https://datadoghq.atlassian.net/browse/CONTP-62) 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://github.com/DataDog/datadog-agent/blob/3490564d40f82a062a1f03c6e50979ac1a3642e6/pkg/config/setup/config.go#L637-L638
These configs override default api_key and app_key in external_metrics_provider endpoints. And we would like to support secret refresh from these configs. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[CONTP-62]: https://datadoghq.atlassian.net/browse/CONTP-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ