### PR TITLE
[NPM] Optimize memory allocation in TCP Failures path

### DIFF
--- a/cmd/system-probe/config/adjust_npm.go
+++ b/cmd/system-probe/config/adjust_npm.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
@@ -50,7 +51,7 @@ func adjustNetwork(cfg config.Config) {
 
 	validateInt64(cfg, spNS("max_tracked_connections"), defaultMaxTrackedConnections, func(v int64) error {
 		if v <= 0 {
-			return fmt.Errorf("must be a positive value")
+			return errors.New("must be a positive value")
 		}
 		return nil
 	})
@@ -60,19 +61,19 @@ func adjustNetwork(cfg config.Config) {
 	// closed connections in environments with mostly short-lived connections
 	validateInt64(cfg, spNS("max_closed_connections_buffered"), cfg.GetInt64(spNS("max_tracked_connections")), func(v int64) error {
 		if v <= 0 {
-			return fmt.Errorf("must be a positive value")
+			return errors.New("must be a positive value")
 		}
 		return nil
 	})
 	limitMaxInt64(cfg, spNS("max_closed_connections_buffered"), math.MaxUint32)
 	// also ensure that max_failed_connections_buffered is equal to max_tracked_connections if the former is not set
-	validateInt64(cfg, spNS("max_failed_connections_buffered"), cfg.GetInt64(spNS("max_tracked_connections")), func(v int64) error {
+	validateInt64(cfg, netNS("max_failed_connections_buffered"), cfg.GetInt64(spNS("max_tracked_connections")), func(v int64) error {
 		if v <= 0 {
-			return fmt.Errorf("must be a positive value")
+			return errors.New("must be a positive value")
 		}
 		return nil
 	})
-	limitMaxInt64(cfg, spNS("max_failed_connections_buffered"), math.MaxUint32)
+	limitMaxInt64(cfg, netNS("max_failed_connections_buffered"), math.MaxUint32)
 
 	limitMaxInt(cfg, spNS("offset_guess_threshold"), maxOffsetThreshold)
 

--- a/cmd/system-probe/config/adjust_npm.go
+++ b/cmd/system-probe/config/adjust_npm.go
@@ -65,6 +65,14 @@ func adjustNetwork(cfg config.Config) {
 		return nil
 	})
 	limitMaxInt64(cfg, spNS("max_closed_connections_buffered"), math.MaxUint32)
+	// also ensure that max_failed_connections_buffered is equal to max_tracked_connections if the former is not set
+	validateInt64(cfg, spNS("max_failed_connections_buffered"), cfg.GetInt64(spNS("max_tracked_connections")), func(v int64) error {
+		if v <= 0 {
+			return fmt.Errorf("must be a positive value")
+		}
+		return nil
+	})
+	limitMaxInt64(cfg, spNS("max_failed_connections_buffered"), math.MaxUint32)
 
 	limitMaxInt(cfg, spNS("offset_guess_threshold"), maxOffsetThreshold)
 

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -181,6 +181,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
 	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))
+	cfg.BindEnv(join(spNS, "max_failed_connections_buffered"))
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_connection_flush_threshold"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_channel_size"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -181,7 +181,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
 	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))
-	cfg.BindEnv(join(spNS, "max_failed_connections_buffered"))
+	cfg.BindEnv(join(netNS, "max_failed_connections_buffered"))
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_connection_flush_threshold"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_channel_size"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -165,6 +165,10 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxClosedConnectionsBuffered uint32
 
+	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
+	// get flushed on every client request (default 30s check interval)
+	MaxFailedConnectionsBuffered uint32
+
 	// ClosedConnectionFlushThreshold represents the number of closed connections stored before signalling
 	// the agent to flush the connections.  This value only valid on Windows
 	ClosedConnectionFlushThreshold int
@@ -340,6 +344,7 @@ func New() *Config {
 		TCPFailedConnectionsEnabled:    cfg.GetBool(join(netNS, "enable_tcp_failed_connections")),
 		MaxTrackedConnections:          uint32(cfg.GetInt64(join(spNS, "max_tracked_connections"))),
 		MaxClosedConnectionsBuffered:   uint32(cfg.GetInt64(join(spNS, "max_closed_connections_buffered"))),
+		MaxFailedConnectionsBuffered:   uint32(cfg.GetInt64(join(spNS, "max_failed_connections_buffered"))),
 		ClosedConnectionFlushThreshold: cfg.GetInt(join(spNS, "closed_connection_flush_threshold")),
 		ClosedChannelSize:              cfg.GetInt(join(spNS, "closed_channel_size")),
 		MaxConnectionsStateBuffered:    cfg.GetInt(join(spNS, "max_connection_state_buffered")),

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -344,7 +344,7 @@ func New() *Config {
 		TCPFailedConnectionsEnabled:    cfg.GetBool(join(netNS, "enable_tcp_failed_connections")),
 		MaxTrackedConnections:          uint32(cfg.GetInt64(join(spNS, "max_tracked_connections"))),
 		MaxClosedConnectionsBuffered:   uint32(cfg.GetInt64(join(spNS, "max_closed_connections_buffered"))),
-		MaxFailedConnectionsBuffered:   uint32(cfg.GetInt64(join(spNS, "max_failed_connections_buffered"))),
+		MaxFailedConnectionsBuffered:   uint32(cfg.GetInt64(join(netNS, "max_failed_connections_buffered"))),
 		ClosedConnectionFlushThreshold: cfg.GetInt(join(spNS, "closed_connection_flush_threshold")),
 		ClosedChannelSize:              cfg.GetInt(join(spNS, "closed_channel_size")),
 		MaxConnectionsStateBuffered:    cfg.GetInt(join(spNS, "max_connection_state_buffered")),

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -165,8 +165,8 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxClosedConnectionsBuffered uint32
 
-	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
-	// get flushed on every client request (default 30s check interval)
+	// MaxFailedConnectionsBuffered represents the maximum number of failed connections we'll buffer in memory. These connections will be
+	// removed from memory as they are matched to closed connections
 	MaxFailedConnectionsBuffered uint32
 
 	// ClosedConnectionFlushThreshold represents the number of closed connections stored before signalling

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1181,6 +1181,23 @@ func TestMaxClosedConnectionsBuffered(t *testing.T) {
 	})
 }
 
+func TestMaxFailedConnectionsBuffered(t *testing.T) {
+	maxTrackedConnections := New().MaxTrackedConnections
+
+	t.Run("value set", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_FAILED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
+		cfg := New()
+		require.Equal(t, maxTrackedConnections-1, cfg.MaxFailedConnectionsBuffered)
+	})
+
+	t.Run("value not set", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := New()
+		require.Equal(t, cfg.MaxTrackedConnections, cfg.MaxFailedConnectionsBuffered)
+	})
+}
+
 func TestMaxHTTPStatsBuffered(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1186,7 +1186,7 @@ func TestMaxFailedConnectionsBuffered(t *testing.T) {
 
 	t.Run("value set", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_FAILED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
+		t.Setenv("DD_NETWORK_CONFIG_MAX_FAILED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
 		cfg := New()
 		require.Equal(t, maxTrackedConnections-1, cfg.MaxFailedConnectionsBuffered)
 	})

--- a/pkg/network/tracer/connection/failure/failed_conn_consumer.go
+++ b/pkg/network/tracer/connection/failure/failed_conn_consumer.go
@@ -40,11 +40,11 @@ type TCPFailedConnConsumer struct {
 }
 
 // NewFailedConnConsumer creates a new TCPFailedConnConsumer
-func NewFailedConnConsumer(eventHandler ddebpf.EventHandler, m *manager.Manager) *TCPFailedConnConsumer {
+func NewFailedConnConsumer(eventHandler ddebpf.EventHandler, m *manager.Manager, maxFailedConnsBuffered uint32) *TCPFailedConnConsumer {
 	return &TCPFailedConnConsumer{
 		eventHandler: eventHandler,
 		closed:       make(chan struct{}),
-		FailedConns:  NewFailedConns(m),
+		FailedConns:  NewFailedConns(m, maxFailedConnsBuffered),
 	}
 }
 

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -46,12 +46,6 @@ type FailedConnStats struct {
 	Expiry         int64
 }
 
-func (t FailedConnStats) reset() {
-	for k := range t.CountByErrCode {
-		delete(t.CountByErrCode, k)
-	}
-}
-
 // String returns a string representation of the failedConnStats
 func (t FailedConnStats) String() string {
 	return fmt.Sprintf(

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -105,16 +105,12 @@ func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
 
 // MatchFailedConn increments the failed connection counters for a given connection based on the failed connection map
 func (fc *FailedConns) MatchFailedConn(conn *network.ConnectionStats) {
-	if fc == nil {
+	if fc == nil || conn.Type != network.TCP {
 		return
 	}
 
 	fc.Lock()
 	defer fc.Unlock()
-
-	if conn.Type != network.TCP {
-		return
-	}
 
 	util.ConnStatsToTuple(conn, fc.failureTuple)
 

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -134,8 +134,8 @@ func (fc *FailedConns) MatchFailedConn(conn *network.ConnectionStats) {
 	var failedConn *FailedConnStats
 
 	if failedConn, ok := fc.FailedConnMap[*fc.failureTuple]; ok {
-		foundMatch = true
 		// found matching failed connection
+		foundMatch = true
 		conn.TCPFailures = make(map[uint32]uint32)
 
 		for errCode, count := range failedConn.CountByErrCode {

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -26,12 +26,6 @@ import (
 )
 
 var (
-	allowListErrs = map[uint32]struct{}{
-		ebpf.TCPFailureConnReset:   {}, // Connection reset by peer
-		ebpf.TCPFailureConnTimeout: {}, // Connection timed out
-		ebpf.TCPFailureConnRefused: {}, // Connection refused
-	}
-
 	telemetryModuleName = "network_tracer__tcp_failure"
 	mapTTL              = 10 * time.Millisecond.Nanoseconds()
 )
@@ -96,9 +90,6 @@ func NewFailedConns(m *manager.Manager, maxFailedConnsBuffered uint32) *FailedCo
 
 // upsertConn adds or updates the failed connection in the failed connection map
 func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
-	if _, exists := allowListErrs[failedConn.Reason]; !exists {
-		return
-	}
 	if len(fc.FailedConnMap) >= int(fc.maxFailuresBuffered) {
 		failureTelemetry.failedConnsDropped.Inc()
 		return

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -120,6 +120,7 @@ func (fc *FailedConns) MatchFailedConn(conn *network.ConnectionStats) {
 		for errCode := range failedConn.CountByErrCode {
 			failureTelemetry.failedConnMatches.Add(1, unix.ErrnoName(syscall.Errno(errCode)))
 		}
+		failedConn.CountByErrCode = nil
 	}
 	fc.RUnlock()
 	if foundMatch {

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -78,6 +78,10 @@ func NewFailedConns(m *manager.Manager, maxFailedConnsBuffered uint32) *FailedCo
 
 // upsertConn adds or updates the failed connection in the failed connection map
 func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
+	if fc == nil {
+		return
+	}
+
 	fc.Lock()
 	defer fc.Unlock()
 
@@ -101,10 +105,14 @@ func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
 
 // MatchFailedConn increments the failed connection counters for a given connection based on the failed connection map
 func (fc *FailedConns) MatchFailedConn(conn *network.ConnectionStats) {
+	if fc == nil {
+		return
+	}
+
 	fc.Lock()
 	defer fc.Unlock()
 
-	if fc == nil || conn.Type != network.TCP {
+	if conn.Type != network.TCP {
 		return
 	}
 

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -291,7 +291,7 @@ func NewTracer(config *config.Config, _ telemetryComponent.Component) (Tracer, e
 		config.TCPFailedConnectionsEnabled = false
 	}
 	if config.FailedConnectionsSupported() {
-		failedConnConsumer = failure.NewFailedConnConsumer(failedConnsHandler, m)
+		failedConnConsumer = failure.NewFailedConnConsumer(failedConnsHandler, m, config.MaxFailedConnectionsBuffered)
 	}
 
 	tr := &tracer{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

There were a few issues with the existing impl:
- the size of the failures map was uncapped
- failures matched to incoming closed connections were not being immediately removed from the map
- we had an unoptimized allocation pattern for failure stats objects

This PR solves these three issues which should help to resolve increased memory usage on a small number of hosts that were likely seeing large spikes in TCP failures

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

in the tcp load test we see significantly fewer items on heap for the methods in question:

link: https://dddev.datadoghq.com/profiling/comparison?compare_end_A=1722484004715&compare_end_B=1722484002521&compare_query_A=service%3Asystem-probe%20agent-env%3Aadamk-loadtest-base%20&compare_query_B=service%3Asystem-probe%20agent-env%3Aadamk-loadtest-new%20&compare_start_A=1722483104715&compare_start_B=1722483102521&compareValuesMode=absolute&comparisonViz=table&group_by=directory&my_code=enabled&profile_type=heap-live-samples

<img width="1229" alt="Screenshot 2024-07-31 at 11 52 45 PM" src="https://github.com/user-attachments/assets/cf67e1f1-5fff-44bf-a576-89f81ef7b265">


It also significantly reduced the incidence of orphaned failed connections as expected:
<img width="436" alt="Screenshot 2024-08-01 at 9 44 43 AM" src="https://github.com/user-attachments/assets/b967b81c-d809-41f7-bd5d-01ac0846faba">
<img width="439" alt="Screenshot 2024-08-01 at 9 51 46 AM" src="https://github.com/user-attachments/assets/09448788-ee15-42c2-9896-ba17dc695cd0">





<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
