### PR TITLE
use slice for NPM connection tags

### DIFF
--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -296,7 +296,7 @@ func formatTags(c network.ConnectionStats, tagsSet *network.TagsSet, connDynamic
 	}
 
 	// other tags, e.g., from process env vars like DD_ENV, etc.
-	for tag := range c.Tags {
+	for _, tag := range c.Tags {
 		t := tag.Get().(string)
 		checksum ^= murmur3.StringSum32(t)
 		tagsIdx = append(tagsIdx, tagsSet.Add(t))

--- a/pkg/network/encoding/marshal/format_test.go
+++ b/pkg/network/encoding/marshal/format_test.go
@@ -95,10 +95,10 @@ func BenchmarkConnectionReset(b *testing.B) {
 func BenchmarkFormatTags(b *testing.B) {
 	tagSet := network.NewTagsSet()
 	var c network.ConnectionStats
-	c.Tags = map[*intern.Value]struct{}{
-		intern.GetByString("env:env"):         {},
-		intern.GetByString("version:version"): {},
-		intern.GetByString("service:service"): {},
+	c.Tags = []*intern.Value{
+		intern.GetByString("env:env"),
+		intern.GetByString("version:version"),
+		intern.GetByString("service:service"),
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -257,7 +257,7 @@ type ConnectionStats struct {
 	Direction        ConnectionDirection
 	SPortIsEphemeral EphemeralPortType
 	StaticTags       uint64
-	Tags             map[*intern.Value]struct{}
+	Tags             []*intern.Value
 
 	IntraHost bool
 	IsAssured bool

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
+	"go4.org/intern"
 
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -340,7 +341,8 @@ func (t *Tracer) addProcessInfo(c *network.ConnectionStats) {
 	}
 
 	if len(p.Tags) > 0 {
-		c.Tags = p.Tags
+		c.Tags = make([]*intern.Value, len(p.Tags))
+		copy(c.Tags, p.Tags)
 	}
 
 	if p.ContainerID != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
-	"go4.org/intern"
 
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -341,8 +340,7 @@ func (t *Tracer) addProcessInfo(c *network.ConnectionStats) {
 	}
 
 	if len(p.Tags) > 0 {
-		c.Tags = make([]*intern.Value, len(p.Tags))
-		copy(c.Tags, p.Tags)
+		c.Tags = p.Tags
 	}
 
 	if p.ContainerID != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -341,10 +341,8 @@ func (t *Tracer) addProcessInfo(c *network.ConnectionStats) {
 	}
 
 	if len(p.Tags) > 0 {
-		c.Tags = make(map[*intern.Value]struct{}, len(p.Tags))
-		for _, t := range p.Tags {
-			c.Tags[t] = struct{}{}
-		}
+		c.Tags = make([]*intern.Value, len(p.Tags))
+		copy(c.Tags, p.Tags)
 	}
 
 	if p.ContainerID != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Use a slice for connection tags instead of a map

### Motivation

reduce memory usage because tags are already unique.

### Additional Notes

before:
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/tracer BenchmarkAddProcessInfo
BenchmarkAddProcessInfo-4   	 4172557	       281.4 ns/op	     128 B/op	       2 allocs/op
```

after:
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/tracer BenchmarkAddProcessInfo
BenchmarkAddProcessInfo-4   	 5192451	       224.6 ns/op	      24 B/op	       1 allocs/op
```

Reduces live heap size during TCP load test by ~16MiB

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
