### PR TITLE
add `remotewmonly` build tag to include only remote collectors

### DIFF
--- a/comp/core/workloadmeta/collectors/all_options.go
+++ b/comp/core/workloadmeta/collectors/all_options.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !remotewmonly
+
+// Package collectors is a wrapper that loads the available workloadmeta
+// collectors. It exists as a shorthand for importing all packages manually in
+// all of the agents.
+package collectors
+
+import (
+	"go.uber.org/fx"
+
+	cfcontainer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/container"
+	cfvm "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/containerd"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecsfargate"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/host"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
+	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
+)
+
+func getCollectorOptions() []fx.Option {
+	return []fx.Option{
+		cfcontainer.GetFxOptions(),
+		cfvm.GetFxOptions(),
+		containerd.GetFxOptions(),
+		docker.GetFxOptions(),
+		ecs.GetFxOptions(),
+		ecsfargate.GetFxOptions(),
+		kubeapiserver.GetFxOptions(),
+		kubelet.GetFxOptions(),
+		kubemetadata.GetFxOptions(),
+		podman.GetFxOptions(),
+		remoteworkloadmeta.GetFxOptions(),
+		remoteWorkloadmetaParams(),
+		processcollector.GetFxOptions(),
+		host.GetFxOptions(),
+	}
+}

--- a/comp/core/workloadmeta/collectors/collectors.go
+++ b/comp/core/workloadmeta/collectors/collectors.go
@@ -11,18 +11,6 @@ package collectors
 import (
 	"go.uber.org/fx"
 
-	cfcontainer "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/container"
-	cfvm "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/containerd"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecsfargate"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/host"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -30,22 +18,7 @@ import (
 
 // GetCatalog returns the set of FX options to populate the catalog
 func GetCatalog() fx.Option {
-	options := []fx.Option{
-		cfcontainer.GetFxOptions(),
-		cfvm.GetFxOptions(),
-		containerd.GetFxOptions(),
-		docker.GetFxOptions(),
-		ecs.GetFxOptions(),
-		ecsfargate.GetFxOptions(),
-		kubeapiserver.GetFxOptions(),
-		kubelet.GetFxOptions(),
-		kubemetadata.GetFxOptions(),
-		podman.GetFxOptions(),
-		remoteworkloadmeta.GetFxOptions(),
-		remoteWorkloadmetaParams(),
-		processcollector.GetFxOptions(),
-		host.GetFxOptions(),
-	}
+	options := getCollectorOptions()
 
 	// remove nil options
 	opts := make([]fx.Option, 0, len(options))

--- a/comp/core/workloadmeta/collectors/remote_options.go
+++ b/comp/core/workloadmeta/collectors/remote_options.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build remotewmonly
+
+// Package collectors is a wrapper that loads the available workloadmeta
+// collectors. It exists as a shorthand for importing all packages manually in
+// all of the agents.
+package collectors
+
+import (
+	"go.uber.org/fx"
+
+	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
+)
+
+func getCollectorOptions() []fx.Option {
+	return []fx.Option{
+		remoteworkloadmeta.GetFxOptions(),
+		remoteWorkloadmetaParams(),
+	}
+}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -40,6 +40,7 @@ ALL_TAGS = {
     "podman",
     "process",
     "python",
+    "remotewmonly",  # used when you want to use only the remote workloadmeta store without importing all dependencies of local collectors
     "sds",
     "serverless",
     "systemd",


### PR DESCRIPTION
### What does this PR do?

By default to use the workloadmeta store, even in remote mode, you need to import the whole list of collectors, including the one that are only used when running a local store. This means importing a lot of unneeded packages that can increase the binary size (~8MiB during my testing with system-probe).

To improve this situation this PR adds a new buildtag `remotewmonly` that only includes the collectors interesting for the remote mode. This reduces the increase of using it to less than 1MiB.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
