### PR TITLE
[workloadmeta/remote] Delete unused param from StreamEntities()

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -40,7 +40,7 @@ var errWorkloadmetaStreamNotStarted = errors.New("workloadmeta stream not starte
 // GrpcClient interface that represents a gRPC client for the remote workloadmeta.
 type GrpcClient interface {
 	// StreamEntities establishes the stream between the client and the remote gRPC server.
-	StreamEntities(ctx context.Context, opts ...grpc.CallOption) (Stream, error)
+	StreamEntities(ctx context.Context) (Stream, error)
 }
 
 // Stream is an interface that represents a gRPC stream.

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
@@ -48,7 +48,7 @@ type client struct {
 	parentCollector *streamHandler
 }
 
-func (c *client) StreamEntities(ctx context.Context, _ ...grpc.CallOption) (remote.Stream, error) {
+func (c *client) StreamEntities(ctx context.Context) (remote.Stream, error) {
 	log.Debug("starting a new stream")
 	streamcl, err := c.cl.StreamEntities(
 		ctx,

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -59,7 +59,7 @@ type client struct {
 	filter *workloadmeta.Filter
 }
 
-func (c *client) StreamEntities(ctx context.Context, _ ...grpc.CallOption) (remote.Stream, error) {
+func (c *client) StreamEntities(ctx context.Context) (remote.Stream, error) {
 	protoFilter, err := proto.ProtobufFilterFromWorkloadmetaFilter(c.filter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

Deletes an unused parameter in the remote collector of workloadmeta.

### Describe how to test/QA your changes

Skip.
