### PR TITLE
[notify] Fix consecutive / cumulative job alert URLs

### DIFF
--- a/tasks/libs/notify/alerts.py
+++ b/tasks/libs/notify/alerts.py
@@ -14,7 +14,6 @@ from tasks.libs.notify.utils import (
     AWS_S3_CP_CMD,
     CHANNEL_BROADCAST,
     PROJECT_NAME,
-    PROJECT_TITLE,
     get_ci_visibility_job_url,
 )
 from tasks.libs.pipeline.data import get_failed_jobs
@@ -132,7 +131,7 @@ class ConsecutiveJobAlert:
         # Find initial PR
         initial_pr_sha = next(iter(self.failures.values()))[0].commit
         initial_pr_title = ctx.run(f'git show -s --format=%s {initial_pr_sha}', hide=True).stdout.strip()
-        initial_pr_info = get_pr_from_commit(initial_pr_title, PROJECT_TITLE)
+        initial_pr_info = get_pr_from_commit(initial_pr_title, PROJECT_NAME)
         if initial_pr_info:
             pr_id, pr_url = initial_pr_info
             initial_pr = f'<{pr_url}|#{pr_id}>'

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -4,7 +4,6 @@ import re
 from urllib.parse import quote
 
 PROJECT_NAME = "DataDog/datadog-agent"
-PROJECT_TITLE = PROJECT_NAME.removeprefix("DataDog/")
 CI_VISIBILITY_JOB_URL = 'https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A{name}{extra_flags}&agg_m=count'
 NOTIFICATION_DISCLAIMER = "If there is something wrong with the notification please contact #agent-devx-help"
 CHANNEL_BROADCAST = '#agent-devx-ops'

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -112,14 +112,22 @@ def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNE
     return owners_to_notify
 
 
-def get_pr_from_commit(commit_title, project_title) -> tuple[str, str] | None:
+def get_pr_from_commit(commit_title: str, project_name: str) -> tuple[str, str] | None:
+    """
+    Tries to find a GitHub PR id within a commit title (eg: "Fix PR (#27584)"),
+    and returns the corresponding PR URL.
+
+    commit_title: the commit title to parse
+    project_name: the GitHub project from which the PR originates, in the "org/repo" format
+    """
+
     parsed_pr_id_found = re.search(r'.*\(#([0-9]*)\)$', commit_title)
     if not parsed_pr_id_found:
         return None
 
     parsed_pr_id = parsed_pr_id_found.group(1)
 
-    return parsed_pr_id, f"{GITHUB_BASE_URL}/{project_title}/pull/{parsed_pr_id}"
+    return parsed_pr_id, f"{GITHUB_BASE_URL}/{project_name}/pull/{parsed_pr_id}"
 
 
 def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCommit, header: str, state: str):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes the use of `get_pr_from_commit` in job alerts logic, which was missing the organization name.
Adds documentation to `get_pr_from_commit`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix PR links in job alerts.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run unit tests. Check that the `notify.send-message` task is not affected by this change.