### PR TITLE
Fix `*/TestCLI/agent_CLI/agent_check_-r_container` e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -300,7 +300,10 @@ func (suite *k8sSuite) testAgentCLI() {
 			if !assert.NoError(c, err) {
 				return
 			}
-			assert.Contains(c, stdout, "container.memory.usage        gauge")
+			matched, err := regexp.MatchString(`container\.memory\.usage\s+gauge\s+\d+\s+\d+`, stdout)
+			if assert.NoError(c, err) {
+				assert.Truef(c, matched, "Output of `agent check -r container` doesn’t contain the expected metric")
+			}
 		}, 2*time.Minute, 1*time.Second)
 	})
 


### PR DESCRIPTION
### What does this PR do?

Fix the parsing of the output of `agent check` in the `*/TestCLI/agent_CLI/agent_check_-r_container` e2e test.

### Motivation

Whereas [this test is currently passing on `kind`, it is flaky of `EKS`](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3ATest%2ASuite%2FTestCLI%2Fagent_CLI%2Fagent_check_-r_container&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=true&index=citest&mode=sliding&saved-view-id=2236559&start=1721908378747&end=1722513178747&paused=false).

### Additional Notes

Depending on the environment, the `container` check can report different metrics.
As the `--table` output format is aligning the fields, the number of spaces between fields can vary.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that `*/TestCLI/agent_CLI/agent_check_-r_container` e2e test is less flaky.