### PR TITLE
[workloadmeta/remote] Make private funcs that don't need to be exposed

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
@@ -74,8 +74,8 @@ type streamHandler struct {
 	config.Reader
 }
 
-// WorkloadmetaEventFromProcessEventSet converts the given ProcessEventSet into a workloadmeta.Event
-func WorkloadmetaEventFromProcessEventSet(protoEvent *pbgo.ProcessEventSet) (workloadmeta.Event, error) {
+// workloadmetaEventFromProcessEventSet converts the given ProcessEventSet into a workloadmeta.Event
+func workloadmetaEventFromProcessEventSet(protoEvent *pbgo.ProcessEventSet) (workloadmeta.Event, error) {
 	if protoEvent == nil {
 		return workloadmeta.Event{}, nil
 	}
@@ -95,8 +95,8 @@ func WorkloadmetaEventFromProcessEventSet(protoEvent *pbgo.ProcessEventSet) (wor
 	}, nil
 }
 
-// WorkloadmetaEventFromProcessEventUnset converts the given ProcessEventSet into a workloadmeta.Event
-func WorkloadmetaEventFromProcessEventUnset(protoEvent *pbgo.ProcessEventUnset) (workloadmeta.Event, error) {
+// workloadmetaEventFromProcessEventUnset converts the given ProcessEventSet into a workloadmeta.Event
+func workloadmetaEventFromProcessEventUnset(protoEvent *pbgo.ProcessEventUnset) (workloadmeta.Event, error) {
 	if protoEvent == nil {
 		return workloadmeta.Event{}, nil
 	}
@@ -163,8 +163,8 @@ func (s *streamHandler) HandleResponse(store workloadmeta.Component, resp interf
 	}
 
 	collectorEvents := make([]workloadmeta.CollectorEvent, 0, len(response.SetEvents)+len(response.UnsetEvents))
-	collectorEvents = handleEvents(collectorEvents, response.UnsetEvents, WorkloadmetaEventFromProcessEventUnset)
-	collectorEvents = handleEvents(collectorEvents, response.SetEvents, WorkloadmetaEventFromProcessEventSet)
+	collectorEvents = handleEvents(collectorEvents, response.UnsetEvents, workloadmetaEventFromProcessEventUnset)
+	collectorEvents = handleEvents(collectorEvents, response.SetEvents, workloadmetaEventFromProcessEventSet)
 	s.populateMissingContainerID(collectorEvents, store)
 	log.Tracef("collected [%d] events", len(collectorEvents))
 	return collectorEvents, nil


### PR DESCRIPTION
### What does this PR do?

This PR makes private a couple of functions in the remote collector of workloadmeta, because they don't need to be exposed.


### Describe how to test/QA your changes

Skip.