### PR TITLE
Fix the k8s cluster state dump in e2e tests

### DIFF
--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -166,11 +166,18 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string) {
 		auth = append(auth, ssh.PublicKeys(signer))
 	}
 
-	sshClient, err := ssh.Dial("tcp", *instanceIP+":22", &ssh.ClientConfig{
-		User:            "ec2-user",
-		Auth:            auth,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	})
+	var sshClient *ssh.Client
+	err = nil
+	for _, user := range []string{"ec2-user", "ubuntu"} {
+		sshClient, err = ssh.Dial("tcp", *instanceIP+":22", &ssh.ClientConfig{
+			User:            user,
+			Auth:            auth,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		})
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		fmt.Fprintf(&out, "Failed to dial SSH server %s: %v\n", *instanceIP, err)
 		return


### PR DESCRIPTION
### What does this PR do?

Fix the Kubernetes cluster state dump that is done in e2e tests.

### Motivation

Whereas it works by default, it fails when the OS of the kind VM is explicitly set to Ubuntu.

Ex. from a `main` pipeline:
* [`new-e2e-containers: [--run TestKindSuite -c ddinfra:kubernetesVersion=1.29]`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/591402811) `kubectl get all,nodes` output is visible.
* [`new-e2e-containers: [--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:22.04]`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/591402815), we have this error: `kindvm_test.go:91: Failed to dial SSH server 10.255.117.54: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain`.

### Additional Notes

The user to use for ssh should be in the pulumi stack output.
Unfortunately, the pulumi stack output can be empty when the pulumi stack creation failed.
And that’s the cases where this debug output would be the more valuable.
That’s why we try several possible users instead of relying on the pulumi stack output.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that the output of `kubectl get all,nodes` is available in all the GitLab CI jobs, including the ones for kind on Ubuntu.