### PR TITLE
add retry logic in metadata v4 client

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -53,11 +53,14 @@ type collector struct {
 	// taskCollectionEnabled is a flag to enable detailed task collection
 	// if the flag is enabled, the collector will query the latest metadata endpoint, currently v4, for each task
 	// that is returned from the v1/tasks endpoint
-	taskCollectionEnabled bool
-	taskCollectionParser  util.TaskParser
-	taskCache             *cache.Cache
-	taskRateRPS           int
-	taskRateBurst         int
+	taskCollectionEnabled        bool
+	taskCollectionParser         util.TaskParser
+	taskCache                    *cache.Cache
+	taskRateRPS                  int
+	taskRateBurst                int
+	metadataRetryInitialInterval time.Duration
+	metadataRetryMaxElapsedTime  time.Duration
+	metadataRetryTimeoutFactor   int
 }
 
 type resourceTags struct {
@@ -69,15 +72,18 @@ type resourceTags struct {
 func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
-			id:                    collectorID,
-			resourceTags:          make(map[string]resourceTags),
-			seen:                  make(map[workloadmeta.EntityID]struct{}),
-			catalog:               workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
-			config:                deps.Config,
-			taskCollectionEnabled: util.IsTaskCollectionEnabled(deps.Config),
-			taskCache:             cache.New(deps.Config.GetDuration("ecs_task_cache_ttl"), 30*time.Second),
-			taskRateRPS:           deps.Config.GetInt("ecs_task_collection_rate"),
-			taskRateBurst:         deps.Config.GetInt("ecs_task_collection_burst"),
+			id:                           collectorID,
+			resourceTags:                 make(map[string]resourceTags),
+			seen:                         make(map[workloadmeta.EntityID]struct{}),
+			catalog:                      workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			config:                       deps.Config,
+			taskCollectionEnabled:        util.IsTaskCollectionEnabled(deps.Config),
+			taskCache:                    cache.New(deps.Config.GetDuration("ecs_task_cache_ttl"), 30*time.Second),
+			taskRateRPS:                  deps.Config.GetInt("ecs_task_collection_rate"),
+			taskRateBurst:                deps.Config.GetInt("ecs_task_collection_burst"),
+			metadataRetryInitialInterval: deps.Config.GetDuration("ecs_metadata_retry_initial_interval"),
+			metadataRetryMaxElapsedTime:  deps.Config.GetDuration("ecs_metadata_retry_max_elapsed_time"),
+			metadataRetryTimeoutFactor:   deps.Config.GetInt("ecs_metadata_retry_timeout_factor"),
 		},
 	}, nil
 }

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -80,7 +81,11 @@ func (c *collector) getTaskWithTagsFromV4Endpoint(ctx context.Context, task v1.T
 		return v1TaskToV4Task(task), errors.New(err)
 	}
 
-	taskWithTags, err := c.metaV3or4(metaURI, "v4").GetTaskWithTags(ctx)
+	taskWithTags, err := v3or4.NewClient(metaURI, "v4", v3or4.WithTryOption(
+		c.metadataRetryInitialInterval,
+		c.metadataRetryMaxElapsedTime,
+		func(d time.Duration) time.Duration { return time.Duration(c.metadataRetryTimeoutFactor) * d }),
+	).GetTaskWithTags(ctx)
 	if err != nil {
 		log.Warnf("failed to get task with tags from metadata v4 API: %s", err)
 		return v1TaskToV4Task(task), err

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -522,6 +522,9 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("ecs_collect_resource_tags_ec2", false)
 	config.BindEnvAndSetDefault("ecs_resource_tags_replace_colon", false)
 	config.BindEnvAndSetDefault("ecs_metadata_timeout", 500) // value in milliseconds
+	config.BindEnvAndSetDefault("ecs_metadata_retry_initial_interval", 100*time.Millisecond)
+	config.BindEnvAndSetDefault("ecs_metadata_retry_max_elapsed_time", 3000*time.Millisecond)
+	config.BindEnvAndSetDefault("ecs_metadata_retry_timeout_factor", 3)
 	config.BindEnvAndSetDefault("ecs_task_collection_enabled", false)
 	config.BindEnvAndSetDefault("ecs_task_cache_ttl", 3*time.Minute)
 	config.BindEnvAndSetDefault("ecs_task_collection_rate", 35)

--- a/pkg/util/ecs/metadata/testutil/dummy_ecs.go
+++ b/pkg/util/ecs/metadata/testutil/dummy_ecs.go
@@ -11,14 +11,20 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
+	"time"
 )
 
 // DummyECS allows tests to mock ECS metadata server responses
 type DummyECS struct {
-	mux          *http.ServeMux
-	fileHandlers map[string]string
-	rawHandlers  map[string]string
-	Requests     chan *http.Request
+	sync.Mutex
+	mux               *http.ServeMux
+	fileHandlers      map[string]string
+	fileHandlersDelay map[string]time.Duration
+	rawHandlers       map[string]string
+	rawHandlersDelay  map[string]time.Duration
+	Requests          chan *http.Request
+	RequestCount      int
 }
 
 // Option represents an option used to create a new mock of the ECS metadata
@@ -33,6 +39,13 @@ func FileHandlerOption(pattern, testDataFile string) Option {
 	}
 }
 
+// FileHandlerDelayOption allows returning to requests matching a pattern with a delay.
+func FileHandlerDelayOption(pattern string, delay time.Duration) Option {
+	return func(d *DummyECS) {
+		d.fileHandlersDelay[pattern] = delay
+	}
+}
+
 // RawHandlerOption allows returning the specified string to requests matching a
 // pattern.
 func RawHandlerOption(pattern, rawResponse string) Option {
@@ -41,13 +54,22 @@ func RawHandlerOption(pattern, rawResponse string) Option {
 	}
 }
 
+// RawHandlerDelayOption allows returning to requests matching a pattern with a delay.
+func RawHandlerDelayOption(pattern string, delay time.Duration) Option {
+	return func(d *DummyECS) {
+		d.rawHandlersDelay[pattern] = delay
+	}
+}
+
 // NewDummyECS create a mock of the ECS metadata API.
 func NewDummyECS(ops ...Option) (*DummyECS, error) {
 	d := &DummyECS{
-		mux:          http.NewServeMux(),
-		fileHandlers: make(map[string]string),
-		rawHandlers:  make(map[string]string),
-		Requests:     make(chan *http.Request, 10),
+		mux:               http.NewServeMux(),
+		fileHandlers:      make(map[string]string),
+		fileHandlersDelay: make(map[string]time.Duration),
+		rawHandlers:       make(map[string]string),
+		rawHandlersDelay:  make(map[string]time.Duration),
+		Requests:          make(chan *http.Request, 10),
 	}
 	for _, o := range ops {
 		o(d)
@@ -58,11 +80,17 @@ func NewDummyECS(ops ...Option) (*DummyECS, error) {
 			return nil, fmt.Errorf("failed to register handler for pattern %s: could not read test data file with path %s", pattern, testDataPath)
 		}
 		d.mux.HandleFunc(pattern, func(w http.ResponseWriter, _ *http.Request) {
+			if delay, ok := d.fileHandlersDelay[pattern]; ok {
+				time.Sleep(delay)
+			}
 			w.Write(raw)
 		})
 	}
 	for pattern, rawData := range d.rawHandlers {
 		d.mux.HandleFunc(pattern, func(w http.ResponseWriter, _ *http.Request) {
+			if delay, ok := d.rawHandlersDelay[pattern]; ok {
+				time.Sleep(delay)
+			}
 			w.Write([]byte(rawData))
 		})
 	}
@@ -72,6 +100,9 @@ func NewDummyECS(ops ...Option) (*DummyECS, error) {
 // ServeHTTP is used to handle HTTP requests.
 func (d *DummyECS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("dummyECS received %s on %s\n", r.Method, r.URL.Path)
+	d.Lock()
+	d.RequestCount++
+	d.Unlock()
 	d.Requests <- r
 	d.mux.ServeHTTP(w, r)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

When the agent is deployed on a large EC2 instance running on ECS, such as with 500 tasks running on the same instance, the Datadog agent can encounter timeout errors:
```
2024-08-01 13:24:21 UTC \| CORE \| WARN \| (comp/core/workloadmeta/collectors/internal/ecs/v4parser.go:85 in getTaskWithTagsFromV4Endpoint) \| failed to get task with tags from metadata v4 API: Get "http://169.254.170.2/v4/12345678-44bd-4cc6-9fd9-4f4340c123456/taskWithTags": context deadline exceeded (Client.Timeout exceeded while awaiting headers) |  
```
This is because the default timeout value is not sufficient to wait for responses from the ECS agent.
https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/config.go#L524

Other types of error can occur as well when updating or restarting the ECS agent.

This PR improves metadata client by adding a retry logic to reduce these errors.
1. `ecs_metadata_retry_initial_interval ` is the initial interval between retries
2. `ecs_metadata_retry_max_elapsed_time` is the maximum time to retry before giving up
3. `ecs_metadata_retry_timeout_factor` is a factor used to increases the request timeout on each retry

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

It just adds an extra layer to minimise any temporary errors. We can deploy agent on ECS to see if we can see any regression. 
