### PR TITLE
fix linter execution time wrong section

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -192,12 +192,11 @@ def go(
 
     with gitlab_section('Linter execution time'):
         print(color_message('Execution time summary:', 'bold'))
+        for e in execution_times:
+            print(f'- {e.name}: {e.duration:.1f}s')
 
     with gitlab_section('Linter failures'):
         success = process_module_results(flavor=flavor, module_results=lint_results)
-
-        for e in execution_times:
-            print(f'- {e.name}: {e.duration:.1f}s')
 
     if success:
         if not headless_mode:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The current status is:
```
> Linter execution time...
Execution time summary:
> Linter failures...
Linters for module /go/src/github.com/DataDog/datadog-agent failed (base flavor)
Linter failures:
comp/core/workloadmeta/collectors/all_options.go:12:1: package-comments: should have a package comment (revive)
package collectors
^
- pkg: 83.5s
- cmd: 28.1s
- comp: 38.5s
...
```

which is very strange,
This PR fixes this by including the time summary in the time summary section and putting the failures (which is what we really care about) at the end.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
