### PR TITLE
[Backport 7.56.x][NPM] Optimize memory allocation in TCP Failures path (#28108)

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -178,6 +178,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
 	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))
+	cfg.BindEnv(join(netNS, "max_failed_connections_buffered"))
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_connection_flush_threshold"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_channel_size"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -162,6 +162,10 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxClosedConnectionsBuffered uint32
 
+	// MaxFailedConnectionsBuffered represents the maximum number of failed connections we'll buffer in memory. These connections will be
+	// removed from memory as they are matched to closed connections
+	MaxFailedConnectionsBuffered uint32
+
 	// ClosedConnectionFlushThreshold represents the number of closed connections stored before signalling
 	// the agent to flush the connections.  This value only valid on Windows
 	ClosedConnectionFlushThreshold int
@@ -333,6 +337,7 @@ func New() *Config {
 		TCPFailedConnectionsEnabled:    cfg.GetBool(join(netNS, "enable_tcp_failed_connections")),
 		MaxTrackedConnections:          uint32(cfg.GetInt64(join(spNS, "max_tracked_connections"))),
 		MaxClosedConnectionsBuffered:   uint32(cfg.GetInt64(join(spNS, "max_closed_connections_buffered"))),
+		MaxFailedConnectionsBuffered:   uint32(cfg.GetInt64(join(netNS, "max_failed_connections_buffered"))),
 		ClosedConnectionFlushThreshold: cfg.GetInt(join(spNS, "closed_connection_flush_threshold")),
 		ClosedChannelSize:              cfg.GetInt(join(spNS, "closed_channel_size")),
 		MaxConnectionsStateBuffered:    cfg.GetInt(join(spNS, "max_connection_state_buffered")),

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1151,6 +1151,23 @@ func TestMaxClosedConnectionsBuffered(t *testing.T) {
 	})
 }
 
+func TestMaxFailedConnectionsBuffered(t *testing.T) {
+	maxTrackedConnections := New().MaxTrackedConnections
+
+	t.Run("value set", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_NETWORK_CONFIG_MAX_FAILED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
+		cfg := New()
+		require.Equal(t, maxTrackedConnections-1, cfg.MaxFailedConnectionsBuffered)
+	})
+
+	t.Run("value not set", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := New()
+		require.Equal(t, cfg.MaxTrackedConnections, cfg.MaxFailedConnectionsBuffered)
+	})
+}
+
 func TestMaxHTTPStatsBuffered(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)

--- a/pkg/network/tracer/connection/failure/failed_conn_consumer.go
+++ b/pkg/network/tracer/connection/failure/failed_conn_consumer.go
@@ -40,11 +40,11 @@ type TCPFailedConnConsumer struct {
 }
 
 // NewFailedConnConsumer creates a new TCPFailedConnConsumer
-func NewFailedConnConsumer(eventHandler ddebpf.EventHandler, m *manager.Manager) *TCPFailedConnConsumer {
+func NewFailedConnConsumer(eventHandler ddebpf.EventHandler, m *manager.Manager, maxFailedConnsBuffered uint32) *TCPFailedConnConsumer {
 	return &TCPFailedConnConsumer{
 		eventHandler: eventHandler,
 		closed:       make(chan struct{}),
-		FailedConns:  NewFailedConns(m),
+		FailedConns:  NewFailedConns(m, maxFailedConnsBuffered),
 	}
 }
 

--- a/pkg/network/tracer/connection/failure/matching.go
+++ b/pkg/network/tracer/connection/failure/matching.go
@@ -9,11 +9,12 @@ package failure
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -25,22 +26,18 @@ import (
 )
 
 var (
-	allowListErrs = map[uint32]struct{}{
-		ebpf.TCPFailureConnReset:   {}, // Connection reset by peer
-		ebpf.TCPFailureConnTimeout: {}, // Connection timed out
-		ebpf.TCPFailureConnRefused: {}, // Connection refused
-	}
-
 	telemetryModuleName = "network_tracer__tcp_failure"
 	mapTTL              = 10 * time.Millisecond.Nanoseconds()
 )
 
 var failureTelemetry = struct {
-	failedConnOrphans telemetry.Counter
-	failedConnMatches telemetry.Counter
+	failedConnMatches  telemetry.Counter
+	failedConnOrphans  telemetry.Counter
+	failedConnsDropped telemetry.Counter
 }{
-	telemetry.NewCounter(telemetryModuleName, "orphans", []string{}, "Counter measuring the number of orphans after associating failed connections with a closed connection"),
 	telemetry.NewCounter(telemetryModuleName, "matches", []string{"type"}, "Counter measuring the number of successful matches of failed connections with closed connections"),
+	telemetry.NewCounter(telemetryModuleName, "orphans", []string{}, "Counter measuring the number of orphans after associating failed connections with a closed connection"),
+	telemetry.NewCounter(telemetryModuleName, "dropped", []string{}, "Counter measuring the number of dropped failed connections"),
 }
 
 // FailedConnStats is a wrapper to help document the purpose of the underlying map
@@ -61,17 +58,19 @@ type FailedConnMap map[ebpf.ConnTuple]*FailedConnStats
 
 // FailedConns is a struct to hold failed connections
 type FailedConns struct {
-	FailedConnMap map[ebpf.ConnTuple]*FailedConnStats
-	failureTuple  *ebpf.ConnTuple
-	mapCleaner    *ddebpf.MapCleaner[ebpf.ConnTuple, int64]
-	sync.RWMutex
+	FailedConnMap       map[ebpf.ConnTuple]*FailedConnStats
+	maxFailuresBuffered uint32
+	failureTuple        *ebpf.ConnTuple
+	mapCleaner          *ddebpf.MapCleaner[ebpf.ConnTuple, int64]
+	sync.Mutex
 }
 
 // NewFailedConns returns a new FailedConns struct
-func NewFailedConns(m *manager.Manager) *FailedConns {
+func NewFailedConns(m *manager.Manager, maxFailedConnsBuffered uint32) *FailedConns {
 	fc := &FailedConns{
-		FailedConnMap: make(map[ebpf.ConnTuple]*FailedConnStats),
-		failureTuple:  &ebpf.ConnTuple{},
+		FailedConnMap:       make(map[ebpf.ConnTuple]*FailedConnStats),
+		maxFailuresBuffered: maxFailedConnsBuffered,
+		failureTuple:        &ebpf.ConnTuple{},
 	}
 	fc.setupMapCleaner(m)
 	return fc
@@ -79,13 +78,18 @@ func NewFailedConns(m *manager.Manager) *FailedConns {
 
 // upsertConn adds or updates the failed connection in the failed connection map
 func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
-	if _, exists := allowListErrs[failedConn.Reason]; !exists {
+	if fc == nil {
 		return
 	}
-	connTuple := failedConn.Tup
 
 	fc.Lock()
 	defer fc.Unlock()
+
+	if len(fc.FailedConnMap) >= int(fc.maxFailuresBuffered) {
+		failureTelemetry.failedConnsDropped.Inc()
+		return
+	}
+	connTuple := failedConn.Tup
 
 	stats, ok := fc.FailedConnMap[connTuple]
 	if !ok {
@@ -101,25 +105,23 @@ func (fc *FailedConns) upsertConn(failedConn *ebpf.FailedConn) {
 
 // MatchFailedConn increments the failed connection counters for a given connection based on the failed connection map
 func (fc *FailedConns) MatchFailedConn(conn *network.ConnectionStats) {
-	if fc == nil {
+	if fc == nil || conn.Type != network.TCP {
 		return
 	}
-	if conn.Type != network.TCP {
-		return
-	}
-	util.ConnStatsToTuple(conn, fc.failureTuple)
 
-	fc.RLock()
-	defer fc.RUnlock()
+	fc.Lock()
+	defer fc.Unlock()
+
+	util.ConnStatsToTuple(conn, fc.failureTuple)
 
 	if failedConn, ok := fc.FailedConnMap[*fc.failureTuple]; ok {
 		// found matching failed connection
-		conn.TCPFailures = make(map[uint32]uint32)
+		conn.TCPFailures = failedConn.CountByErrCode
 
-		for errCode, count := range failedConn.CountByErrCode {
-			failureTelemetry.failedConnMatches.Add(1, strconv.Itoa(int(errCode)))
-			conn.TCPFailures[errCode] += count
+		for errCode := range failedConn.CountByErrCode {
+			failureTelemetry.failedConnMatches.Add(1, unix.ErrnoName(syscall.Errno(errCode)))
 		}
+		delete(fc.FailedConnMap, *fc.failureTuple)
 	}
 }
 

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -296,7 +296,7 @@ func NewTracer(config *config.Config, _ telemetryComponent.Component) (Tracer, e
 		config.TCPFailedConnectionsEnabled = false
 	}
 	if config.FailedConnectionsSupported() {
-		failedConnConsumer = failure.NewFailedConnConsumer(failedConnsHandler, m)
+		failedConnConsumer = failure.NewFailedConnConsumer(failedConnsHandler, m, config.MaxFailedConnectionsBuffered)
 	}
 
 	tr := &tracer{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/commit/5463135e73a37ed00bfaeeed27c67b5350bcff3e from https://github.com/DataDog/datadog-agent/pull/28108.

There were a few issues with the existing impl:

- the size of the failures map was uncapped
- failures matched to incoming closed connections were not being immediately removed from the map
- we had an unoptimized allocation pattern for failure stats objects

This PR solves these three issues which should help to resolve increased memory usage on a small number of hosts that were likely seeing large spikes in TCP failures

Bug introduced in https://github.com/DataDog/datadog-agent/pull/25517 (**7.56**) 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
