### PR TITLE
[NETPATH-175] add maxContexts to pathteststore

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -16,7 +16,7 @@ type collectorConfigs struct {
 	workers                      int
 	pathtestInputChanSize        int
 	pathtestProcessingChanSize   int
-	pathtestMaxContexts          int
+	pathtestContextsLimit        int
 	pathtestTTL                  time.Duration
 	pathtestInterval             time.Duration
 	flushInterval                time.Duration
@@ -29,7 +29,7 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		workers:                      agentConfig.GetInt("network_path.collector.workers"),
 		pathtestInputChanSize:        agentConfig.GetInt("network_path.collector.input_chan_size"),
 		pathtestProcessingChanSize:   agentConfig.GetInt("network_path.collector.processing_chan_size"),
-		pathtestMaxContexts:          agentConfig.GetInt("network_path.collector.pathtest_max_contexts"),
+		pathtestContextsLimit:        agentConfig.GetInt("network_path.collector.pathtest_contexts_limit"),
 		pathtestTTL:                  agentConfig.GetDuration("network_path.collector.pathtest_ttl"),
 		pathtestInterval:             agentConfig.GetDuration("network_path.collector.pathtest_interval"),
 		flushInterval:                agentConfig.GetDuration("network_path.collector.flush_interval"),

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -16,6 +16,7 @@ type collectorConfigs struct {
 	workers                      int
 	pathtestInputChanSize        int
 	pathtestProcessingChanSize   int
+	pathtestMaxContexts          int
 	pathtestTTL                  time.Duration
 	pathtestInterval             time.Duration
 	flushInterval                time.Duration
@@ -28,6 +29,7 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		workers:                      agentConfig.GetInt("network_path.collector.workers"),
 		pathtestInputChanSize:        agentConfig.GetInt("network_path.collector.input_chan_size"),
 		pathtestProcessingChanSize:   agentConfig.GetInt("network_path.collector.processing_chan_size"),
+		pathtestMaxContexts:          agentConfig.GetInt("network_path.collector.pathtest_max_contexts"),
 		pathtestTTL:                  agentConfig.GetDuration("network_path.collector.pathtest_ttl"),
 		pathtestInterval:             agentConfig.GetDuration("network_path.collector.pathtest_interval"),
 		flushInterval:                agentConfig.GetDuration("network_path.collector.flush_interval"),

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -75,10 +75,11 @@ func newNoopNpCollectorImpl() *npCollectorImpl {
 }
 
 func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *collectorConfigs, logger log.Component, telemetrycomp telemetryComp.Component) *npCollectorImpl {
-	logger.Infof("New NpCollector (workers=%d input_chan_size=%d processing_chan_size=%d pathtest_ttl=%s pathtest_interval=%s flush_interval=%s)",
+	logger.Infof("New NpCollector (workers=%d input_chan_size=%d processing_chan_size=%d pathtest_max_contexts=%d pathtest_ttl=%s pathtest_interval=%s flush_interval=%s)",
 		collectorConfigs.workers,
 		collectorConfigs.pathtestInputChanSize,
 		collectorConfigs.pathtestProcessingChanSize,
+		collectorConfigs.pathtestMaxContexts,
 		collectorConfigs.pathtestTTL,
 		collectorConfigs.pathtestInterval,
 		collectorConfigs.flushInterval)
@@ -88,7 +89,7 @@ func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *c
 		collectorConfigs: collectorConfigs,
 		logger:           logger,
 
-		pathtestStore:          pathteststore.NewPathtestStore(collectorConfigs.pathtestTTL, collectorConfigs.pathtestInterval, logger),
+		pathtestStore:          pathteststore.NewPathtestStore(collectorConfigs.pathtestTTL, collectorConfigs.pathtestInterval, collectorConfigs.pathtestMaxContexts, logger),
 		pathtestInputChan:      make(chan *common.Pathtest, collectorConfigs.pathtestInputChanSize),
 		pathtestProcessingChan: make(chan *pathteststore.PathtestContext, collectorConfigs.pathtestProcessingChanSize),
 		flushInterval:          collectorConfigs.flushInterval,

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -75,11 +75,11 @@ func newNoopNpCollectorImpl() *npCollectorImpl {
 }
 
 func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *collectorConfigs, logger log.Component, telemetrycomp telemetryComp.Component) *npCollectorImpl {
-	logger.Infof("New NpCollector (workers=%d input_chan_size=%d processing_chan_size=%d pathtest_max_contexts=%d pathtest_ttl=%s pathtest_interval=%s flush_interval=%s)",
+	logger.Infof("New NpCollector (workers=%d input_chan_size=%d processing_chan_size=%d pathtest_contexts_limit=%d pathtest_ttl=%s pathtest_interval=%s flush_interval=%s)",
 		collectorConfigs.workers,
 		collectorConfigs.pathtestInputChanSize,
 		collectorConfigs.pathtestProcessingChanSize,
-		collectorConfigs.pathtestMaxContexts,
+		collectorConfigs.pathtestContextsLimit,
 		collectorConfigs.pathtestTTL,
 		collectorConfigs.pathtestInterval,
 		collectorConfigs.flushInterval)
@@ -89,7 +89,7 @@ func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *c
 		collectorConfigs: collectorConfigs,
 		logger:           logger,
 
-		pathtestStore:          pathteststore.NewPathtestStore(collectorConfigs.pathtestTTL, collectorConfigs.pathtestInterval, collectorConfigs.pathtestMaxContexts, logger),
+		pathtestStore:          pathteststore.NewPathtestStore(collectorConfigs.pathtestTTL, collectorConfigs.pathtestInterval, collectorConfigs.pathtestContextsLimit, logger),
 		pathtestInputChan:      make(chan *common.Pathtest, collectorConfigs.pathtestInputChanSize),
 		pathtestProcessingChan: make(chan *pathteststore.PathtestContext, collectorConfigs.pathtestProcessingChanSize),
 		flushInterval:          collectorConfigs.flushInterval,

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -293,16 +293,18 @@ func Test_newNpCollectorImpl_defaultConfigs(t *testing.T) {
 	assert.Equal(t, 4, npCollector.workers)
 	assert.Equal(t, 1000, cap(npCollector.pathtestInputChan))
 	assert.Equal(t, 1000, cap(npCollector.pathtestProcessingChan))
+	assert.Equal(t, 10000, npCollector.collectorConfigs.pathtestMaxContexts)
 	assert.Equal(t, "default", npCollector.networkDevicesNamespace)
 }
 
 func Test_newNpCollectorImpl_overrideConfigs(t *testing.T) {
 	agentConfigs := map[string]any{
-		"network_path.connections_monitoring.enabled": true,
-		"network_path.collector.workers":              2,
-		"network_path.collector.input_chan_size":      300,
-		"network_path.collector.processing_chan_size": 400,
-		"network_devices.namespace":                   "ns1",
+		"network_path.connections_monitoring.enabled":  true,
+		"network_path.collector.workers":               2,
+		"network_path.collector.input_chan_size":       300,
+		"network_path.collector.processing_chan_size":  400,
+		"network_path.collector.pathtest_max_contexts": 500,
+		"network_devices.namespace":                    "ns1",
 	}
 
 	_, npCollector := newTestNpCollector(t, agentConfigs)
@@ -311,6 +313,7 @@ func Test_newNpCollectorImpl_overrideConfigs(t *testing.T) {
 	assert.Equal(t, 2, npCollector.workers)
 	assert.Equal(t, 300, cap(npCollector.pathtestInputChan))
 	assert.Equal(t, 400, cap(npCollector.pathtestProcessingChan))
+	assert.Equal(t, 500, npCollector.collectorConfigs.pathtestMaxContexts)
 	assert.Equal(t, "ns1", npCollector.networkDevicesNamespace)
 }
 

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -293,18 +293,18 @@ func Test_newNpCollectorImpl_defaultConfigs(t *testing.T) {
 	assert.Equal(t, 4, npCollector.workers)
 	assert.Equal(t, 1000, cap(npCollector.pathtestInputChan))
 	assert.Equal(t, 1000, cap(npCollector.pathtestProcessingChan))
-	assert.Equal(t, 10000, npCollector.collectorConfigs.pathtestMaxContexts)
+	assert.Equal(t, 10000, npCollector.collectorConfigs.pathtestContextsLimit)
 	assert.Equal(t, "default", npCollector.networkDevicesNamespace)
 }
 
 func Test_newNpCollectorImpl_overrideConfigs(t *testing.T) {
 	agentConfigs := map[string]any{
-		"network_path.connections_monitoring.enabled":  true,
-		"network_path.collector.workers":               2,
-		"network_path.collector.input_chan_size":       300,
-		"network_path.collector.processing_chan_size":  400,
-		"network_path.collector.pathtest_max_contexts": 500,
-		"network_devices.namespace":                    "ns1",
+		"network_path.connections_monitoring.enabled":    true,
+		"network_path.collector.workers":                 2,
+		"network_path.collector.input_chan_size":         300,
+		"network_path.collector.processing_chan_size":    400,
+		"network_path.collector.pathtest_contexts_limit": 500,
+		"network_devices.namespace":                      "ns1",
 	}
 
 	_, npCollector := newTestNpCollector(t, agentConfigs)
@@ -313,7 +313,7 @@ func Test_newNpCollectorImpl_overrideConfigs(t *testing.T) {
 	assert.Equal(t, 2, npCollector.workers)
 	assert.Equal(t, 300, cap(npCollector.pathtestInputChan))
 	assert.Equal(t, 400, cap(npCollector.pathtestProcessingChan))
-	assert.Equal(t, 500, npCollector.collectorConfigs.pathtestMaxContexts)
+	assert.Equal(t, 500, npCollector.collectorConfigs.pathtestContextsLimit)
 	assert.Equal(t, "ns1", npCollector.networkDevicesNamespace)
 }
 

--- a/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
@@ -46,6 +46,9 @@ type Store struct {
 	// are called by different routines.
 	contextsMutex sync.Mutex
 
+	// maxContexts is the maximum number of contexts to keep in the store
+	maxContexts int
+
 	// interval defines how frequently pathtests should run
 	interval time.Duration
 
@@ -64,12 +67,13 @@ func newPathtestContext(pt *common.Pathtest, runUntilDuration time.Duration) *Pa
 }
 
 // NewPathtestStore creates a new Store
-func NewPathtestStore(pathtestTTL time.Duration, pathtestInterval time.Duration, logger log.Component) *Store {
+func NewPathtestStore(pathtestTTL time.Duration, pathtestInterval time.Duration, maxContexts int, logger log.Component) *Store {
 	return &Store{
-		contexts: make(map[uint64]*PathtestContext),
-		ttl:      pathtestTTL,
-		interval: pathtestInterval,
-		logger:   logger,
+		contexts:    make(map[uint64]*PathtestContext),
+		ttl:         pathtestTTL,
+		interval:    pathtestInterval,
+		maxContexts: maxContexts,
+		logger:      logger,
 	}
 }
 
@@ -118,6 +122,11 @@ func (f *Store) Add(pathtestToAdd *common.Pathtest) {
 
 	f.contextsMutex.Lock()
 	defer f.contextsMutex.Unlock()
+
+	if len(f.contexts) >= f.maxContexts {
+		f.logger.Warnf("Pathteststore is full, dropping pathtest: %+v, maximum set to: %d", pathtestToAdd, f.maxContexts)
+		return
+	}
 
 	hash := pathtestToAdd.GetHash()
 	pathtestCtx, ok := f.contexts[hash]

--- a/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
@@ -124,7 +124,7 @@ func (f *Store) Add(pathtestToAdd *common.Pathtest) {
 	defer f.contextsMutex.Unlock()
 
 	if len(f.contexts) >= f.maxContexts {
-		f.logger.Warnf("Pathteststore is full, dropping pathtest: %+v, maximum set to: %d", pathtestToAdd, f.maxContexts)
+		f.logger.Warnf("Pathteststore is full, maximum set to: %d, dropping pathtest: %+v", f.maxContexts, pathtestToAdd)
 		return
 	}
 

--- a/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore.go
@@ -46,8 +46,8 @@ type Store struct {
 	// are called by different routines.
 	contextsMutex sync.Mutex
 
-	// maxContexts is the maximum number of contexts to keep in the store
-	maxContexts int
+	// contextsLimit is the maximum number of contexts to keep in the store
+	contextsLimit int
 
 	// interval defines how frequently pathtests should run
 	interval time.Duration
@@ -67,13 +67,13 @@ func newPathtestContext(pt *common.Pathtest, runUntilDuration time.Duration) *Pa
 }
 
 // NewPathtestStore creates a new Store
-func NewPathtestStore(pathtestTTL time.Duration, pathtestInterval time.Duration, maxContexts int, logger log.Component) *Store {
+func NewPathtestStore(pathtestTTL time.Duration, pathtestInterval time.Duration, contextsLimit int, logger log.Component) *Store {
 	return &Store{
-		contexts:    make(map[uint64]*PathtestContext),
-		ttl:         pathtestTTL,
-		interval:    pathtestInterval,
-		maxContexts: maxContexts,
-		logger:      logger,
+		contexts:      make(map[uint64]*PathtestContext),
+		ttl:           pathtestTTL,
+		interval:      pathtestInterval,
+		contextsLimit: contextsLimit,
+		logger:        logger,
 	}
 }
 
@@ -123,8 +123,8 @@ func (f *Store) Add(pathtestToAdd *common.Pathtest) {
 	f.contextsMutex.Lock()
 	defer f.contextsMutex.Unlock()
 
-	if len(f.contexts) >= f.maxContexts {
-		f.logger.Warnf("Pathteststore is full, maximum set to: %d, dropping pathtest: %+v", f.maxContexts, pathtestToAdd)
+	if len(f.contexts) >= f.contextsLimit {
+		f.logger.Warnf("Pathteststore is full, maximum set to: %d, dropping pathtest: %+v", f.contextsLimit, pathtestToAdd)
 		return
 	}
 

--- a/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore_test.go
@@ -33,7 +33,7 @@ func Test_pathtestStore_add(t *testing.T) {
 	logger := logmock.New(t)
 
 	// GIVEN
-	store := NewPathtestStore(10*time.Minute, 1*time.Minute, logger)
+	store := NewPathtestStore(10*time.Minute, 1*time.Minute, 10, logger)
 
 	// WHEN
 	pt1 := &common.Pathtest{Hostname: "host1", Port: 53}
@@ -48,6 +48,31 @@ func Test_pathtestStore_add(t *testing.T) {
 
 	pt1Ctx := store.contexts[pt1.GetHash()]
 	pt2Ctx := store.contexts[pt2.GetHash()]
+	pt3Ctx := store.contexts[pt3.GetHash()]
+	assert.Equal(t, *pt1, *pt1Ctx.Pathtest)
+	assert.Equal(t, *pt2, *pt2Ctx.Pathtest)
+	assert.Equal(t, *pt3, *pt3Ctx.Pathtest)
+}
+
+func Test_pathtestStore_add_when_full(t *testing.T) {
+	logger := logmock.New(t)
+
+	// GIVEN
+	store := NewPathtestStore(10*time.Minute, 1*time.Minute, 2, logger)
+
+	// WHEN
+	pt1 := &common.Pathtest{Hostname: "host1", Port: 53}
+	pt2 := &common.Pathtest{Hostname: "host2", Port: 53}
+	pt3 := &common.Pathtest{Hostname: "host3", Port: 53}
+	store.Add(pt1)
+	store.Add(pt2)
+	store.Add(pt3)
+
+	// THEN
+	assert.Equal(t, 2, len(store.contexts))
+
+	pt1Ctx := store.contexts[pt1.GetHash()]
+	pt2Ctx := store.contexts[pt2.GetHash()]
 	assert.Equal(t, *pt1, *pt1Ctx.Pathtest)
 	assert.Equal(t, *pt2, *pt2Ctx.Pathtest)
 }
@@ -59,7 +84,7 @@ func Test_pathtestStore_flush(t *testing.T) {
 	runInterval := 1 * time.Minute
 
 	// GIVEN
-	store := NewPathtestStore(runDurationFromDisc, runInterval, logger)
+	store := NewPathtestStore(runDurationFromDisc, runInterval, 10, logger)
 
 	// WHEN
 	pt := &common.Pathtest{Hostname: "host1", Port: 53}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -422,6 +422,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("network_path.collector.workers", 4)
 	config.BindEnvAndSetDefault("network_path.collector.input_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 1000)
+	config.BindEnvAndSetDefault("network_path.collector.pathtest_max_contexts", 10000)
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "15m")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "5m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -422,7 +422,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("network_path.collector.workers", 4)
 	config.BindEnvAndSetDefault("network_path.collector.input_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 1000)
-	config.BindEnvAndSetDefault("network_path.collector.pathtest_max_contexts", 10000)
+	config.BindEnvAndSetDefault("network_path.collector.pathtest_contexts_limit", 10000)
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "15m")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "5m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")

--- a/releasenotes/notes/network-path-add-max-path-config-91d70b05b0db086a.yaml
+++ b/releasenotes/notes/network-path-add-max-path-config-91d70b05b0db086a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds a default upper limit of 10000 to the number of Network Traffic
+    paths that will be captured at a single time. This limit can be
+    configured by the user to increase or decrease it as needed.

--- a/releasenotes/notes/network-path-add-max-path-config-91d70b05b0db086a.yaml
+++ b/releasenotes/notes/network-path-add-max-path-config-91d70b05b0db086a.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Adds a default upper limit of 10000 to the number of Network Traffic
-    paths that will be captured at a single time. This limit can be
-    configured by the user to increase or decrease it as needed.
+    Adds a default upper limit of 10000 to the number of network traffic
+    paths that are captured at a single time. The user can increase or 
+    decrease this limit as needed.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds a configurable limit to the number of paths stored to run for Network Path

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Adds an upper bound on number of path tests to hold at a given time to prevent the list from growing endlessly 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
