### PR TITLE
[Documentation] Fix links to current install page in-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 [![Go Report Card](https://goreportcard.com/badge/github.com/DataDog/datadog-agent)](https://goreportcard.com/report/github.com/DataDog/datadog-agent)
 
-The present repository contains the source code of the Datadog Agent version 7 and version 6. Please refer to the [Agent user documentation](docs/agent) for information about differences between Agent v5, Agent v6 and Agent v7. Additionally, we provide a list of prepackaged binaries for an easy install process [here](https://app.datadoghq.com/account/settings#agent)
+The present repository contains the source code of the Datadog Agent version 7 and version 6. Please refer to the [Agent user documentation](docs/agent) for information about differences between Agent v5, Agent v6 and Agent v7. Additionally, we provide a list of prepackaged binaries for an easy install process [here](https://app.datadoghq.com/account/settings/agent/latest?platform=overview)
 
 **Note:** the source code of Datadog Agent v5 is located in the
 [dd-agent](https://github.com/DataDog/dd-agent) repository.

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -357,7 +357,7 @@ DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || gre
 if [ "$DISTRIBUTION" = "Darwin" ]; then
     printf "\033[31mThis script does not support installing on the Mac.
 
-Please use the 1-step script available at https://app.datadoghq.com/account/settings#agent/mac.\033[0m\n"
+Please use the 1-step script available at https://app.datadoghq.com/account/settings/agent/latest?platform=macos.\033[0m\n"
     exit 1;
 
 elif [ -f /etc/debian_version ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
@@ -689,7 +689,7 @@ else
     printf "\033[31mYour OS or distribution are not supported by this install script.
 Please follow the instructions on the Agent setup page:
 
-    https://app.datadoghq.com/account/settings#agent\033[0m\n"
+    https://app.datadoghq.com/account/settings/agent/latest?platform=overview\033[0m\n"
     exit;
 fi
 


### PR DESCRIPTION
### What does this PR do?

* Fixes hyperlinks to current installation page as old one is broken : 
    * old/deprecated : https://app.datadoghq.com/account/settings#agent/
    * current : https://app.datadoghq.com/account/settings/agent/latest?platform=overview

### Motivation

* Slack report

### Additional Notes

* There are still broken links https://github.com/DataDog/datadog-agent/blob/2393b39f24969f504938e696103ec09e3f379852/google-marketplace/chart/datadog-mp/templates/manifests.yaml#L611, I think they're auto generated, so would be changed in a subsequent PR

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
