### PR TITLE
[revive] allow unused variables starting with underscore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,12 @@ issues:
 
   # Do not limit the number of times a same issue is reported.
   max-same-issues: 0
-  
+
   exclude-files:
     - pkg/util/cloudproviders/cloudfoundry/bbscache_test.go # implements interface from imported package whose method names fail linting
     - pkg/util/intern/string.go # TODO: fix govet 'unsafeptr' error
     - pkg/serverless/trace/inferredspan/constants.go # TODO: fox revive exported const error
-    
+
   exclude-dirs:
     - pkg/proto/patches
     - tasks/unit_tests/testdata/components_src
@@ -149,6 +149,8 @@ linters-settings:
       - name: unexported-return
       - name: unreachable-code
       - name: unused-parameter
+        arguments:
+          - allowRegex: "^_"
       - name: var-declaration
       - name: var-naming
       # non-default rules:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Allow using variables starting with underscore without `revive` complaining it's unused.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
`_` is not explicit on what the variable is, and it can be useful to make it clear even when the variable is unused.
In that case, allowing using `_somename` is useful.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Feature added in https://github.com/mgechev/revive/pull/858.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
I tested manually that it worked as expected.
