### PR TITLE
Increase security for Datadog application folder

### DIFF
--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -39,7 +39,7 @@ func (s *testInstallSuite) TestInstall() {
 	// initialize test helper
 	t := s.newTester(vm)
 
-	// create a dummy auth-token with known value to see if it gets replaced
+	// create a dummy auth-token with known value to be replaced
 	vm.MkdirAll(windowsAgent.DefaultConfigRoot)
 	vm.WriteFile(filepath.Join(windowsAgent.DefaultConfigRoot, "auth_token"), []byte("F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0"))
 

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -246,10 +246,6 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	// don't need to check registry key permissions because the key is removed
 
 	tt.Run("file permissions", func(tt *testing.T) {
-		if strings.HasPrefix(tt.Name(), "TestInstallFail/") {
-			// TODO WINA-852: install rollback leaves different permissions behind
-			// tt.Skip("WINA-852: skipping known failure, install rollback leaves different permissions behind")
-		}
 		t.testUninstalledFilePermissions(tt)
 	})
 }

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -248,7 +248,7 @@ func (t *Tester) TestUninstallExpectations(tt *testing.T) {
 	tt.Run("file permissions", func(tt *testing.T) {
 		if strings.HasPrefix(tt.Name(), "TestInstallFail/") {
 			// TODO WINA-852: install rollback leaves different permissions behind
-			tt.Skip("WINA-852: skipping known failure, install rollback leaves different permissions behind")
+			// tt.Skip("WINA-852: skipping known failure, install rollback leaves different permissions behind")
 		}
 		t.testUninstalledFilePermissions(tt)
 	})

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -425,7 +425,7 @@ namespace Datadog.CustomActions
         }
 
         private static ActionResult DDCreateFolders(ISession session)
-        { 
+        {
             var path = session.Property("APPLICATIONDATADIRECTORY");
 
             // This section is copied from RollbackDataStore.cs
@@ -448,7 +448,6 @@ namespace Datadog.CustomActions
             if (Directory.Exists(path)) // If the Datadog directory already exists, we need ensure it is locked down
             {
                 session.Log($"{path} already exists. Verifying permissions");
-                
                 var directoryInfo = new DirectoryInfo(path);
                 var _fileSystemServices = new FileSystemServices();
                 var _fileSystemSecurity = _fileSystemServices.GetAccessControl(path, AccessControlSections.All);

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -9,6 +9,9 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Text;
 using Datadog.CustomActions.Interfaces;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Datadog.CustomActions.Native;
 
 namespace Datadog.CustomActions
 {
@@ -377,6 +380,14 @@ namespace Datadog.CustomActions
                                 })
                             }
                         });
+
+                var auth = Path.Combine(configFolder, "auth_token");
+                if (File.Exists(auth)) // Delete pre-existing auth token
+                {
+                    File.Delete(auth);
+                    session.Log($"Deleting old {auth}");
+                }
+
                 foreach (var c in configFiles)
                 {
                     var configPath = Path.Combine(configFolder, c.Path);
@@ -411,6 +422,69 @@ namespace Datadog.CustomActions
         public static ActionResult WriteConfig(Session session)
         {
             return WriteConfig(new SessionWrapper(session));
+        }
+
+        private static ActionResult DDCreateFolders(ISession session)
+        { 
+            var path = session.Property("APPLICATIONDATADIRECTORY");
+
+            // This section is copied from RollbackDataStore.cs
+            // Create DACL for only SYSTEM and Administrators, disable inheritance
+            FileSystemSecurity security = new DirectorySecurity();
+            security.SetAccessRuleProtection(true, false);
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl,
+                InheritanceFlags.ObjectInherit | InheritanceFlags.ContainerInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl,
+                InheritanceFlags.ObjectInherit | InheritanceFlags.ContainerInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow));
+
+            if (Directory.Exists(path)) // If the Datadog directory already exists, we need ensure it is locked down
+            {
+                session.Log($"{path} already exists. Verifying permissions");
+                
+                var directoryInfo = new DirectoryInfo(path);
+                var _fileSystemServices = new FileSystemServices();
+                var _fileSystemSecurity = _fileSystemServices.GetAccessControl(path, AccessControlSections.All);
+
+                // Getting and removing old owner
+                var owner = (SecurityIdentifier)_fileSystemSecurity.GetOwner(typeof(SecurityIdentifier));
+                var group = (SecurityIdentifier)_fileSystemSecurity.GetGroup(typeof(SecurityIdentifier));
+                session.Log($"{path} has owner: {owner}. Setting owner to SYSTEM");
+
+                _fileSystemSecurity.SetOwner(new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null));
+                _fileSystemSecurity.SetGroup(new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null));
+
+                // Apply the modified security back to the directory
+                directoryInfo.SetAccessControl((DirectorySecurity)_fileSystemSecurity);
+
+                // Verifying
+                owner = (SecurityIdentifier)_fileSystemSecurity.GetOwner(typeof(SecurityIdentifier));
+                session.Log($"{path} has new owner: {owner}");
+
+                // Set the modified ACL to the directory
+                directoryInfo.SetAccessControl((DirectorySecurity)security);
+                session.Log($"Permissions for {path} validated successfully.");
+            }
+            else
+            {
+                // Create the directory with the DACL
+                session.Log($"Creating {path}");
+                Directory.CreateDirectory(path, (DirectorySecurity)security);
+            }
+            return ActionResult.Success;
+        }
+
+        [CustomAction]
+        public static ActionResult DDCreateFolders(Session session)
+        {
+            return DDCreateFolders(new SessionWrapper(session));
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -178,6 +178,10 @@ namespace Datadog.CustomActions
                 InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
                 PropagationFlags.None,
                 AccessControlType.Allow));
+            fileSystemSecurity.SetOwner(new SecurityIdentifier(
+                WellKnownSidType.LocalSystemSid, null));
+            fileSystemSecurity.SetGroup(new SecurityIdentifier(
+                WellKnownSidType.LocalSystemSid, null));
             UpdateAndLogAccessControl(_session.Property("APPLICATIONDATADIRECTORY"), fileSystemSecurity);
         }
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -555,6 +555,10 @@ namespace WixSetup.Datadog_Agent
                     Return.check,
                     When.Before,
                     Step.CreateFolders,
+                    // Run only on FirstInstall.
+                    // In Upgrade/Repair the directory has already been
+                    // created and configured, and this action could leave the directory
+                    // without access for ddagentuser if the installer rolls back.
                     Conditions.FirstInstall
                     )
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using Datadog.CustomActions;
 using Datadog.CustomActions.Interfaces;
 using Datadog.CustomActions.Rollback;
@@ -71,6 +74,8 @@ namespace WixSetup.Datadog_Agent
         public ManagedAction StartDDServicesRollback { get; }
 
         public ManagedAction RestoreDaclRollback { get; }
+
+        public ManagedAction DDCreateFolders { get; }
 
         /// <summary>
         /// Registers and sequences our custom actions
@@ -544,6 +549,19 @@ namespace WixSetup.Datadog_Agent
                 Impersonate = false
             }.SetProperties("PROJECTLOCATION=[PROJECTLOCATION]");
 
+            DDCreateFolders = new CustomAction<ConfigCustomActions>(
+                    new Id(nameof(DDCreateFolders)),
+                    ConfigCustomActions.DDCreateFolders,
+
+                    Return.check,
+                    When.Before,
+                    Step.CreateFolders,
+                    Conditions.FirstInstall | Conditions.Upgrading
+                    )
+            {
+                Execute = Execute.deferred,
+                Impersonate = false
+            }.SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -552,11 +552,10 @@ namespace WixSetup.Datadog_Agent
             DDCreateFolders = new CustomAction<ConfigCustomActions>(
                     new Id(nameof(DDCreateFolders)),
                     ConfigCustomActions.DDCreateFolders,
-
                     Return.check,
                     When.Before,
                     Step.CreateFolders,
-                    Conditions.FirstInstall | Conditions.Upgrading
+                    Conditions.FirstInstall
                     )
             {
                 Execute = Execute.deferred,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Create the Datadog config folder with restricted permissions before writing any other files on install.

Remove any old `auth_token` file that may be left from previous installs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/WINA-852
https://datadoghq.atlassian.net/browse/WINA-874
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Created new e2e test `testAuthTokenReplacement` and removed the `Skip` from the existing file permissions test.