### PR TITLE
Submit metric directly from autoscaling controller to notify availability

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -347,22 +347,25 @@ func start(log log.Component,
 	var rcClient *rcclient.Client
 	rcserv, isSet := rcService.Get()
 	if pkgconfig.IsRemoteConfigEnabled(config) && isSet {
-		// TODO: Is APM Tracing always required? I am not sure
-		products := []string{state.ProductAPMTracing}
-
+		var products []string
+		if config.GetBool("admission_controller.auto_instrumentation.patcher.enabled") {
+			products = append(products, state.ProductAPMTracing)
+		}
 		if config.GetBool("autoscaling.workload.enabled") {
 			products = append(products, state.ProductContainerAutoscalingSettings, state.ProductContainerAutoscalingValues)
 		}
 
-		var err error
-		rcClient, err = initializeRemoteConfigClient(rcserv, config, clusterName, clusterID, products...)
-		if err != nil {
-			log.Errorf("Failed to start remote-configuration: %v", err)
-		} else {
-			rcClient.Start()
-			defer func() {
-				rcClient.Close()
-			}()
+		if len(products) > 0 {
+			var err error
+			rcClient, err = initializeRemoteConfigClient(rcserv, config, clusterName, clusterID, products...)
+			if err != nil {
+				log.Errorf("Failed to start remote-configuration: %v", err)
+			} else {
+				rcClient.Start()
+				defer func() {
+					rcClient.Close()
+				}()
+			}
 		}
 	}
 
@@ -421,7 +424,7 @@ func start(log log.Component,
 			log.Error("Admission controller is disabled, vertical autoscaling requires the admission controller to be enabled. Vertical scaling will be disabled.")
 		}
 
-		if adapter, err := workload.StartWorkloadAutoscaling(mainCtx, apiCl, rcClient, wmeta); err != nil {
+		if adapter, err := workload.StartWorkloadAutoscaling(mainCtx, clusterID, apiCl, rcClient, wmeta, demultiplexer); err != nil {
 			pkglog.Errorf("Error while starting workload autoscaling: %v", err)
 		} else {
 			pa = adapter

--- a/pkg/clusteragent/autoscaling/controller.go
+++ b/pkg/clusteragent/autoscaling/controller.go
@@ -91,10 +91,16 @@ func (c *Controller) Run(ctx context.Context) {
 		log.Errorf("Failed to wait for caches to sync for controller id: %s", c.ID)
 		return
 	}
+	log.Infof("Started controller: %s (cache sync finished)", c.ID)
 
+	if preStart, ok := c.processor.(ProcessorPreStart); ok {
+		preStart.PreStart(c.context)
+		log.Debugf("PreStart done for controller id: %s", c.ID)
+	}
+
+	log.Debugf("Starting workers for controller id: %s", c.ID)
 	go wait.Until(c.worker, time.Second, ctx.Done())
 
-	log.Infof("Started controller: %s (cache sync finished)", c.ID)
 	<-ctx.Done()
 	log.Infof("Stopping controller id: %s", c.ID)
 }

--- a/pkg/clusteragent/autoscaling/processor.go
+++ b/pkg/clusteragent/autoscaling/processor.go
@@ -61,3 +61,9 @@ type Processor interface {
 	// Process is called by the controller to process an object
 	Process(ctx context.Context, key, ns, name string) ProcessResult
 }
+
+// ProcessorPreStart is an interface that can be implemented by the Processor to perform some initialization after informers are synced and before the controller starts
+type ProcessorPreStart interface {
+	// PreStart is called by the controller before starting workers
+	PreStart(ctx context.Context)
+}

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -22,6 +22,7 @@ import (
 
 	datadoghq "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -48,18 +49,22 @@ type store = autoscaling.Store[model.PodAutoscalerInternal]
 type Controller struct {
 	*autoscaling.Controller
 
-	eventRecorder record.EventRecorder
+	clusterID string
+	clock     clock.Clock
 
-	clock clock.Clock
-	store *store
+	eventRecorder record.EventRecorder
+	store         *store
 
 	podWatcher           podWatcher
 	horizontalController *horizontalController
 	verticalController   *verticalController
+
+	localSender sender.Sender
 }
 
 // newController returns a new workload autoscaling controller
 func newController(
+	clusterID string,
 	eventRecorder record.EventRecorder,
 	restMapper apimeta.RESTMapper,
 	scaleClient scaleclient.ScalesGetter,
@@ -68,10 +73,13 @@ func newController(
 	isLeader func() bool,
 	store *store,
 	podWatcher podWatcher,
+	localSender sender.Sender,
 ) (*Controller, error) {
 	c := &Controller{
-		eventRecorder: eventRecorder,
+		clusterID:     clusterID,
 		clock:         clock.RealClock{},
+		eventRecorder: eventRecorder,
+		localSender:   localSender,
 	}
 
 	baseController, err := autoscaling.NewController(controllerID, c, dynamicClient, dynamicInformer, podAutoscalerGVR, isLeader, store)
@@ -88,6 +96,11 @@ func newController(
 	c.verticalController = newVerticalController(c.clock, eventRecorder, dynamicClient, c.podWatcher)
 
 	return c, nil
+}
+
+// PreStart is called before the controller starts
+func (c *Controller) PreStart(ctx context.Context) {
+	startLocalTelemetry(ctx, c.localSender, []string{"kube_cluster_id:" + c.clusterID})
 }
 
 // Process implements the Processor interface (so required to be public)

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -44,7 +44,7 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 		ControllerFixture: autoscaling.NewFixture(
 			t, podAutoscalerGVR,
 			func(fakeClient *fake.FakeDynamicClient, informer dynamicinformer.DynamicSharedInformerFactory, isLeader func() bool) (*autoscaling.Controller, error) {
-				c, err := newController(recorder, nil, nil, fakeClient, informer, isLeader, store, nil)
+				c, err := newController("cluster-id1", recorder, nil, nil, fakeClient, informer, isLeader, store, nil, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/clusteragent/autoscaling/workload/telemetry.go
+++ b/pkg/clusteragent/autoscaling/workload/telemetry.go
@@ -8,11 +8,16 @@
 package workload
 
 import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
 const (
-	subsystem = "workload_autoscaling"
+	subsystem              = "workload_autoscaling"
+	aliveTelemetryInterval = 5 * time.Minute
 )
 
 var commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
@@ -25,3 +30,26 @@ var rolloutTriggered = telemetry.NewCounterWithOpts(
 	"Tracks the number of patch requests sent by the patcher to the kubernetes api server",
 	commonOpts,
 )
+
+func startLocalTelemetry(ctx context.Context, sender sender.Sender, tags []string) {
+	submit := func() {
+		sender.Gauge("datadog.cluster_agent.autoscaling.workload.running", 1, "", tags)
+		sender.Commit()
+	}
+
+	go func() {
+		ticker := time.NewTicker(aliveTelemetryInterval)
+		defer ticker.Stop()
+
+		// Submit once immediately and then every ticker
+		submit()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				submit()
+			}
+		}
+	}()
+}


### PR DESCRIPTION
### What does this PR do?

Submit metric directly from autoscaling controller to notify availability

### Motivation

Required for autoscaling feature.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Change already QA-ed as part of autoscaling. Verifying is easy: `datadog.cluster_agent.autoscaling.workload.running` metric should be emitted with a value 1 when Autoscaling is enabled.
