### PR TITLE
APM: Update gomaxprocs value BEFORE we use it in creating the trace-agent

### DIFF
--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 	"strconv"
 	"sync"
@@ -29,8 +30,10 @@ import (
 	traceagent "github.com/DataDog/datadog-agent/comp/trace/agent/def"
 	compression "github.com/DataDog/datadog-agent/comp/trace/compression/def"
 	"github.com/DataDog/datadog-agent/comp/trace/config"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	agentrt "github.com/DataDog/datadog-agent/pkg/runtime"
 	pkgagent "github.com/DataDog/datadog-agent/pkg/trace/agent"
 	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
@@ -118,6 +121,9 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		return nil, err
 	}
 	setupShutdown(ctx, deps.Shutdowner, statsdCl)
+
+	prepGoRuntime(tracecfg)
+
 	c.Agent = pkgagent.NewAgent(
 		ctx,
 		c.config.Object(),
@@ -133,6 +139,49 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		OnStop:  func(_ context.Context) error { return stop(c) },
 	})
 	return c, nil
+}
+
+func prepGoRuntime(tracecfg *tracecfg.AgentConfig) {
+	cgsetprocs := agentrt.SetMaxProcs()
+	if !cgsetprocs {
+		if mp, ok := os.LookupEnv("GOMAXPROCS"); ok {
+			log.Infof("GOMAXPROCS manually set to %v", mp)
+		} else if tracecfg.MaxCPU > 0 {
+			allowedCores := int(tracecfg.MaxCPU / 100)
+			if allowedCores < 1 {
+				allowedCores = 1
+			}
+			if allowedCores < runtime.GOMAXPROCS(0) {
+				log.Infof("apm_config.max_cpu is less than current GOMAXPROCS. Setting GOMAXPROCS to (%v) %d\n", allowedCores, allowedCores)
+				runtime.GOMAXPROCS(int(allowedCores))
+			}
+		} else {
+			log.Infof("apm_config.max_cpu is disabled. leaving GOMAXPROCS at current value.")
+		}
+	}
+	log.Infof("Trace Agent final GOMAXPROCS: %v", runtime.GOMAXPROCS(0))
+
+	cgmem, err := agentrt.SetGoMemLimit(coreconfig.IsContainerized())
+	if err != nil {
+		log.Infof("Couldn't set Go memory limit from cgroup: %s", err)
+	}
+	if cgmem == 0 {
+		// memory limit not set from cgroups
+		if lim, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+			log.Infof("GOMEMLIMIT manually set to: %v", lim)
+		} else if tracecfg.MaxMemory > 0 {
+			// We have apm_config.max_memory, and no cgroup memory limit is in place.
+			// log.Infof("apm_config.max_memory: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024))
+			finalmem := int64(tracecfg.MaxMemory * 0.9)
+			debug.SetMemoryLimit(finalmem)
+			log.Infof("apm_config.max_memory set to: %vMiB. Setting GOMEMLIMIT to 90%% of max: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024), finalmem/(1024*1024))
+		} else {
+			// There are no memory constraints
+			log.Infof("GOMEMLIMIT unconstrained.")
+		}
+	} else {
+		log.Infof("Memory constrained by cgroup. GOMEMLIMIT is: %vMiB", cgmem/(1024*1024))
+	}
 }
 
 func start(ag component) error {

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -9,9 +9,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"os"
-	"runtime"
-	"runtime/debug"
 	"time"
 
 	remotecfg "github.com/DataDog/datadog-agent/cmd/trace-agent/config/remote"
@@ -20,7 +17,6 @@ import (
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	rc "github.com/DataDog/datadog-agent/pkg/config/remote/client"
-	agentrt "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
@@ -81,49 +77,6 @@ func runAgentSidekicks(ag component) error {
 			return ag.config.SetHandler()
 		},
 	})
-
-	// prepare go runtime
-	cgsetprocs := agentrt.SetMaxProcs()
-	if !cgsetprocs {
-		if mp, ok := os.LookupEnv("GOMAXPROCS"); ok {
-			log.Infof("GOMAXPROCS manually set to %v", mp)
-		} else if tracecfg.MaxCPU > 0 {
-			allowedCores := int(tracecfg.MaxCPU / 100)
-			if allowedCores < 1 {
-				allowedCores = 1
-			}
-			if allowedCores < runtime.GOMAXPROCS(0) {
-				log.Infof("apm_config.max_cpu is less than current GOMAXPROCS. Setting GOMAXPROCS to (%v) %d\n", allowedCores, (allowedCores))
-				runtime.GOMAXPROCS(int(allowedCores))
-			}
-		} else {
-			log.Infof("apm_config.max_cpu is disabled. leaving GOMAXPROCS at current value.")
-		}
-	}
-	log.Infof("Trace Agent final GOMAXPROCS: %v", runtime.GOMAXPROCS(0))
-
-	// prepare go runtime
-	cgmem, err := agentrt.SetGoMemLimit(coreconfig.IsContainerized())
-	if err != nil {
-		log.Infof("Couldn't set Go memory limit from cgroup: %s", err)
-	}
-	if cgmem == 0 {
-		// memory limit not set from cgroups
-		if lim, ok := os.LookupEnv("GOMEMLIMIT"); ok {
-			log.Infof("GOMEMLIMIT manually set to: %v", lim)
-		} else if tracecfg.MaxMemory > 0 {
-			// We have apm_config.max_memory, and no cgroup memory limit is in place.
-			// log.Infof("apm_config.max_memory: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024))
-			finalmem := int64(tracecfg.MaxMemory * 0.9)
-			debug.SetMemoryLimit(finalmem)
-			log.Infof("apm_config.max_memory set to: %vMiB. Setting GOMEMLIMIT to 90%% of max: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024), finalmem/(1024*1024))
-		} else {
-			// There are no memory constraints
-			log.Infof("GOMEMLIMIT unconstrained.")
-		}
-	} else {
-		log.Infof("Memory constrained by cgroup. GOMEMLIMIT is: %vMiB", cgmem/(1024*1024))
-	}
 
 	log.Infof("Trace agent running on host %s", tracecfg.Hostname)
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {

--- a/releasenotes/notes/trace-agent-gomaxprocs-9d8660446a7473b5.yaml
+++ b/releasenotes/notes/trace-agent-gomaxprocs-9d8660446a7473b5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixes issue where the number of HTTP Decoders was incorrectly set if setting GOMAXPROCS to milli-cpu values.

--- a/releasenotes/notes/trace-agent-gomaxprocs-9d8660446a7473b5.yaml
+++ b/releasenotes/notes/trace-agent-gomaxprocs-9d8660446a7473b5.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fixes issue where the number of HTTP Decoders was incorrectly set if setting GOMAXPROCS to milli-cpu values.
+    APM: Fixes issue where the number of HTTP decoders was incorrectly set if setting GOMAXPROCS to milli-cpu values.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Fixes a bug where the number of HTTP decoders was incorrectly set to the default GOMAXPROCS value instead of the updated value. Note that this bug ONLY affects trace-agents where GOMAXPROCS was set to a milli-core value (e.g. `2000m`), given this is a non-standard and not supported by go out of the box very few customers should see any effect from this change. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Limiting the number of decoders based on the available CPUs is important to avoid OOM-ing the trace-agent. OOMs are bad because it means ALL payloads in memory are lost and we get no metrics from that time period.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Where OOMs were occurring before the number of rejected payloads may increase, indicating an overwhelming amount of trace traffic for the provided CPU/MEM.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Tests cover a good part here, I also deployed this change internally (DM me for details) and verified that the correct number of decoders are now created and payloads are still processed correctly.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
