### PR TITLE
remove unneeded Address functions

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Convert []int8 to []byte in multiple generated fields from the kernel, to simplify
 	// conversion to string; see golang.org/issue/20753
-	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Victim_comm|Trigger_comm)(\s+)\[(\d+)\]u?int8`)
+	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Victim_comm|Trigger_comm|LocalAddress|RemoteAddress)(\s+)\[(\d+)\]u?int8`)
 	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
 	b, err = format.Source(b)

--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -11,6 +11,7 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"math/rand"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -329,7 +330,7 @@ func randomAddressGen() func() util.Address {
 				continue
 			}
 
-			return util.V4AddressFromBytes(b)
+			return util.Address{Addr: netip.AddrFrom4([4]byte(b))}
 		}
 	}
 }

--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -114,8 +114,8 @@ type PerFlowData struct {
 	AddressFamily            uint16
 	Protocol                 uint16
 	Flags                    uint32
-	LocalAddress             [16]uint8
-	RemoteAddress            [16]uint8
+	LocalAddress             [16]byte
+	RemoteAddress            [16]byte
 	PacketsOut               uint64
 	MonotonicSentBytes       uint64
 	TransportBytesOut        uint64

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -8,7 +8,7 @@
 package network
 
 import (
-	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
@@ -59,12 +59,12 @@ func isTCPFlowEstablished(flow *driver.PerFlowData) bool {
 
 func convertV4Addr(addr [16]uint8) util.Address {
 	// We only read the first 4 bytes for v4 address
-	return util.V4AddressFromBytes(addr[:net.IPv4len])
+	return util.Address{Addr: netip.AddrFrom4([4]byte(addr))}
 }
 
 func convertV6Addr(addr [16]uint8) util.Address {
 	// We read all 16 bytes for v6 address
-	return util.V6AddressFromBytes(addr[:net.IPv6len])
+	return util.Address{Addr: netip.AddrFrom16(addr)}
 }
 
 // Monotonic values include retransmits and headers, while transport does not. We default to using transport

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -57,12 +57,12 @@ func isTCPFlowEstablished(flow *driver.PerFlowData) bool {
 	return false
 }
 
-func convertV4Addr(addr [16]uint8) util.Address {
+func convertV4Addr(addr [16]byte) util.Address {
 	// We only read the first 4 bytes for v4 address
-	return util.Address{Addr: netip.AddrFrom4([4]byte(addr))}
+	return util.Address{Addr: netip.AddrFrom4([4]byte(addr[:]))}
 }
 
-func convertV6Addr(addr [16]uint8) util.Address {
+func convertV6Addr(addr [16]byte) util.Address {
 	// We read all 16 bytes for v6 address
 	return util.Address{Addr: netip.AddrFrom16(addr)}
 }

--- a/pkg/network/gateway_lookup_linux.go
+++ b/pkg/network/gateway_lookup_linux.go
@@ -131,7 +131,7 @@ func (g *gatewayLookup) LookupWithIPs(source util.Address, dest util.Address, ne
 
 	// if there is no gateway, we don't need to add subnet info
 	// for gateway resolution in the backend
-	if r.Gateway.IsZero() || r.Gateway.IsUnspecified() {
+	if !r.Gateway.IsValid() || r.Gateway.IsUnspecified() {
 		return nil
 	}
 

--- a/pkg/network/nat.go
+++ b/pkg/network/nat.go
@@ -14,7 +14,7 @@ func GetNATLocalAddress(c ConnectionStats) (util.Address, uint16) {
 	localIP := c.Source
 	localPort := c.SPort
 
-	if c.IPTranslation != nil && !c.IPTranslation.ReplDstIP.IsZero() {
+	if c.IPTranslation != nil && c.IPTranslation.ReplDstIP.IsValid() {
 		// Fields are flipped
 		localIP = c.IPTranslation.ReplDstIP
 		localPort = c.IPTranslation.ReplDstPort
@@ -27,7 +27,7 @@ func GetNATRemoteAddress(c ConnectionStats) (util.Address, uint16) {
 	remoteIP := c.Dest
 	remotePort := c.DPort
 
-	if c.IPTranslation != nil && !c.IPTranslation.ReplSrcIP.IsZero() {
+	if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP.IsValid() {
 		// Fields are flipped
 		remoteIP = c.IPTranslation.ReplSrcIP
 		remotePort = c.IPTranslation.ReplSrcPort

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -201,12 +201,12 @@ func ipv4(b []byte) (netip.Addr, error) {
 	if len(b) != 4 {
 		return netip.Addr{}, fmt.Errorf("invalid IPv4 size")
 	}
-	return netip.AddrFrom4(*(*[4]byte)(b)), nil
+	return netip.AddrFrom4([4]byte(b)), nil
 }
 
 func ipv6(b []byte) (netip.Addr, error) {
 	if len(b) != 16 {
 		return netip.Addr{}, fmt.Errorf("invalid IPv6 size")
 	}
-	return netip.AddrFrom16(*(*[16]byte)(b)), nil
+	return netip.AddrFrom16([16]byte(b)), nil
 }

--- a/pkg/network/protocols/http/etw_http_service.go
+++ b/pkg/network/protocols/http/etw_http_service.go
@@ -1472,7 +1472,7 @@ func ipAndPortFromTup(tup driver.ConnTupleType, local bool) ([16]uint8, uint16) 
 }
 
 func ip4format(ip [16]uint8) string {
-	ipObj := netip.AddrFrom4(*(*[4]byte)(ip[:4]))
+	ipObj := netip.AddrFrom4([4]byte(ip))
 	return ipObj.String()
 }
 

--- a/pkg/network/protocols/http/etw_http_service.go
+++ b/pkg/network/protocols/http/etw_http_service.go
@@ -1472,7 +1472,7 @@ func ipAndPortFromTup(tup driver.ConnTupleType, local bool) ([16]uint8, uint16) 
 }
 
 func ip4format(ip [16]uint8) string {
-	ipObj := netip.AddrFrom4([4]byte(ip))
+	ipObj := netip.AddrFrom4([4]byte(ip[:]))
 	return ipObj.String()
 }
 

--- a/pkg/network/protocols/http/model_linux.go
+++ b/pkg/network/protocols/http/model_linux.go
@@ -110,7 +110,7 @@ func (e *EbpfEvent) String() string {
 
 func requestFragment(fragment []byte) [BufferSize]byte {
 	if len(fragment) >= BufferSize {
-		return *(*[BufferSize]byte)(fragment)
+		return [BufferSize]byte(fragment)
 	}
 	var b [BufferSize]byte
 	copy(b[:], fragment)

--- a/pkg/network/protocols/http/statkeeper_test_linux.go
+++ b/pkg/network/protocols/http/statkeeper_test_linux.go
@@ -25,9 +25,9 @@ func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourceP
 	event.Http.Response_last_seen = event.Http.Request_started + latencyNS
 	event.Http.Response_status_code = uint16(code)
 	event.Http.Request_fragment = requestFragment([]byte(reqFragment))
-	event.Tuple.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Bytes()))
+	event.Tuple.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Unmap().AsSlice()))
 	event.Tuple.Sport = uint16(sourcePort)
-	event.Tuple.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Bytes()))
+	event.Tuple.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Unmap().AsSlice()))
 	event.Tuple.Dport = uint16(destPort)
 	event.Tuple.Metadata = 1
 

--- a/pkg/network/protocols/http/statkeeper_test_windows.go
+++ b/pkg/network/protocols/http/statkeeper_test_windows.go
@@ -25,11 +25,10 @@ func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourceP
 	tx.Txn.ResponseStatusCode = uint16(code)
 	tx.RequestFragment = []byte(reqFragment)
 
-	source.WriteTo(tx.Txn.Tup.RemoteAddr[:])
-
+	copy(tx.Txn.Tup.RemoteAddr[:], source.AsSlice())
 	tx.Txn.Tup.RemotePort = uint16(sourcePort)
 
-	dest.WriteTo(tx.Txn.Tup.LocalAddr[:])
+	copy(tx.Txn.Tup.LocalAddr[:], dest.AsSlice())
 	tx.Txn.Tup.LocalPort = uint16(destPort)
 
 	return &tx

--- a/pkg/network/protocols/kafka/statkeeper_test.go
+++ b/pkg/network/protocols/kafka/statkeeper_test.go
@@ -135,9 +135,9 @@ func generateKafkaTransaction(source util.Address, dest util.Address, sourcePort
 	event.Transaction.Records_count = recordsCount
 	event.Transaction.Topic_name_size = uint8(len(topicName))
 	event.Transaction.Topic_name = topicNameFromString([]byte(topicName))
-	event.Tup.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Bytes()))
+	event.Tup.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Unmap().AsSlice()))
 	event.Tup.Sport = uint16(sourcePort)
-	event.Tup.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Bytes()))
+	event.Tup.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Unmap().AsSlice()))
 	event.Tup.Dport = uint16(destPort)
 	event.Tup.Metadata = 1
 

--- a/pkg/network/protocols/postgres/model_linux_test.go
+++ b/pkg/network/protocols/postgres/model_linux_test.go
@@ -77,7 +77,7 @@ func BenchmarkExtractTableName(b *testing.B) {
 
 func requestFragment(fragment []byte) [ebpf.BufferSize]byte {
 	if len(fragment) >= ebpf.BufferSize {
-		return *(*[ebpf.BufferSize]byte)(fragment)
+		return [ebpf.BufferSize]byte(fragment)
 	}
 	var b [ebpf.BufferSize]byte
 	copy(b[:], fragment)

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -169,10 +169,10 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 func newRouteKey(source, dest util.Address, netns uint32) routeKey {
 	k := routeKey{netns: netns, source: source, dest: dest}
 
-	switch dest.Len() {
-	case 4:
+	switch {
+	case dest.Is4():
 		k.connFamily = AFINET
-	case 16:
+	case dest.Is6():
 		k.connFamily = AFINET6
 	}
 	return k

--- a/pkg/network/tracer/cached_conntrack.go
+++ b/pkg/network/tracer/cached_conntrack.go
@@ -10,7 +10,6 @@ package tracer
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 	"sync"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/netlink"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -65,13 +63,6 @@ func (cache *cachedConntrack) Exists(c *network.ConnectionStats) (bool, error) {
 	return cache.exists(c, c.NetNS, int(c.Pid))
 }
 
-func ipFromAddr(a util.Address) netip.Addr {
-	if a.Len() == net.IPv6len {
-		return netip.AddrFrom16(*(*[16]byte)(a.Bytes()))
-	}
-	return netip.AddrFrom4(*(*[4]byte)(a.Bytes()))
-}
-
 func (cache *cachedConntrack) exists(c *network.ConnectionStats, netns uint32, pid int) (bool, error) {
 	ctrk, err := cache.ensureConntrack(uint64(netns), pid)
 	if err != nil {
@@ -89,8 +80,8 @@ func (cache *cachedConntrack) exists(c *network.ConnectionStats, netns uint32, p
 
 	conn := netlink.Con{
 		Origin: netlink.ConTuple{
-			Src:   netip.AddrPortFrom(ipFromAddr(c.Source), c.SPort),
-			Dst:   netip.AddrPortFrom(ipFromAddr(c.Dest), c.DPort),
+			Src:   netip.AddrPortFrom(c.Source.Unmap(), c.SPort),
+			Dst:   netip.AddrPortFrom(c.Dest.Unmap(), c.DPort),
 			Proto: protoNumber,
 		},
 	}

--- a/pkg/network/tracer/connection/util/conn_tracer.go
+++ b/pkg/network/tracer/connection/util/conn_tracer.go
@@ -163,10 +163,10 @@ func ConnStatsToTuple(c *network.ConnectionStats, tup *netebpf.ConnTuple) {
 	} else {
 		tup.SetType(netebpf.UDP)
 	}
-	if !c.Source.IsZero() {
+	if c.Source.IsValid() {
 		tup.Saddr_l, tup.Saddr_h = util.ToLowHigh(c.Source)
 	}
-	if !c.Dest.IsZero() {
+	if c.Dest.IsValid() {
 		tup.Daddr_l, tup.Daddr_h = util.ToLowHigh(c.Dest)
 	}
 }

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -20,41 +20,6 @@ type Address struct {
 	netip.Addr
 }
 
-// WriteTo writes the address byte representation into the supplied buffer
-func (a Address) WriteTo(b []byte) int {
-	if a.Is4() {
-		v := a.As4()
-		return copy(b, v[:])
-	}
-
-	v := a.As16()
-	return copy(b, v[:])
-
-}
-
-// Bytes returns a byte slice representing the Address.
-// You may want to consider using `WriteTo` instead to avoid allocations
-func (a Address) Bytes() []byte {
-	// Note: this implicitly converts IPv4-in-6 to IPv4
-	if a.Is4() || a.Is4In6() {
-		v := a.As4()
-		return v[:]
-	}
-
-	v := a.As16()
-	return v[:]
-}
-
-// Len returns the number of bytes required to represent this IP
-func (a Address) Len() int {
-	return int(a.BitLen()) / 8
-}
-
-// IsZero reports whether a is its zero value
-func (a Address) IsZero() bool {
-	return a.Addr == netip.Addr{}
-}
-
 // AddressFromNetIP returns an Address from a provided net.IP
 func AddressFromNetIP(ip net.IP) Address {
 	addr, _ := netipx.FromStdIP(ip)
@@ -71,7 +36,7 @@ func AddressFromString(s string) Address {
 // Warning: the returned `net.IP` will share the same underlying
 // memory as the given `buf` argument.
 func NetIPFromAddress(addr Address, buf []byte) net.IP {
-	n := addr.WriteTo(buf)
+	n := copy(buf, addr.AsSlice())
 	return net.IP(buf[:n])
 }
 
@@ -115,22 +80,12 @@ func V4Address(ip uint32) Address {
 	}
 }
 
-// V4AddressFromBytes creates an Address using the byte representation of an v4 IP
-func V4AddressFromBytes(buf []byte) Address {
-	return Address{netip.AddrFrom4(*(*[4]byte)(buf))}
-}
-
 // V6Address creates an Address using the uint128 representation of an v6 IP
 func V6Address(low, high uint64) Address {
 	var a [16]byte
 	binary.LittleEndian.PutUint64(a[:8], high)
 	binary.LittleEndian.PutUint64(a[8:], low)
 	return Address{netip.AddrFrom16(a)}
-}
-
-// V6AddressFromBytes creates an Address using the byte representation of an v6 IP
-func V6AddressFromBytes(buf []byte) Address {
-	return Address{netip.AddrFrom16(*(*[16]byte)(buf))}
 }
 
 // IPBufferPool is meant to be used in conjunction with `NetIPFromAddress`

--- a/pkg/process/util/address_test.go
+++ b/pkg/process/util/address_test.go
@@ -88,22 +88,16 @@ func TestAddressUsageInMaps(t *testing.T) {
 func TestAddressV4(t *testing.T) {
 	addr := V4Address(889192575)
 
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("127.0.0.53"))
 	assert.Equal(t, "127.0.0.53", addr.String())
 
 	addr = V4Address(0)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("0.0.0.0"))
 	assert.Equal(t, "0.0.0.0", addr.String())
 
 	addr = V4Address(16820416)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("192.168.0.1"))
 	assert.Equal(t, "192.168.0.1", addr.String())
@@ -111,31 +105,23 @@ func TestAddressV4(t *testing.T) {
 
 func TestAddressV6(t *testing.T) {
 	addr := V6Address(889192575, 0)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("::7f00:35:0:0"))
 	assert.Equal(t, "::7f00:35:0:0", addr.String())
 	assert.False(t, addr.IsLoopback())
 
 	addr = V6Address(0, 0)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("::"))
 	assert.Equal(t, "::", addr.String())
 
 	addr = V6Address(72057594037927936, 0)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("::1"))
 	assert.Equal(t, "::1", addr.String())
 	assert.True(t, addr.IsLoopback())
 
 	addr = V6Address(72059793061183488, 3087860000)
-	// Should be able to recreate addr from bytes alone
-	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("2001:db8::2:1"))
 	assert.Equal(t, "2001:db8::2:1", addr.String())
@@ -174,35 +160,6 @@ func BenchmarkV6Address(b *testing.B) {
 		addr = V6Address(889192575, 0)
 	}
 	runtime.KeepAlive(addr)
-}
-
-func BenchmarkBytes(b *testing.B) {
-	var (
-		addr  = AddressFromString("8.8.8.8")
-		bytes []byte
-	)
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		// this allocates a slice descriptor that escapes to the heap
-		bytes = addr.Bytes()
-	}
-	runtime.KeepAlive(bytes)
-}
-
-func BenchmarkWriteTo(b *testing.B) {
-	addr := AddressFromString("8.8.8.8")
-	bytes := make([]byte, 4)
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		// this method shouldn't allocate
-		_ = addr.WriteTo(bytes)
-		bytes = bytes[:0]
-	}
-	runtime.KeepAlive(bytes)
 }
 
 func BenchmarkToLowHigh(b *testing.B) {

--- a/pkg/util/winutil/iphelper/routes.go
+++ b/pkg/util/winutil/iphelper/routes.go
@@ -198,20 +198,3 @@ func GetIFTable() (table map[uint32]windows.MibIfRow, err error) {
 	return table, nil
 
 }
-
-// Ntohs converts a network byte order 16 bit int to host byte order
-func Ntohs(i uint16) uint16 {
-	return binary.BigEndian.Uint16((*(*[2]byte)(unsafe.Pointer(&i)))[:])
-}
-
-// Ntohl converts a network byte order 32 bit int to host byte order
-func Ntohl(i uint32) uint32 {
-	return binary.BigEndian.Uint32((*(*[4]byte)(unsafe.Pointer(&i)))[:])
-}
-
-// Htonl converts a host byte order 32 bit int to network byte order
-func Htonl(i uint32) uint32 {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b, i)
-	return *(*uint32)(unsafe.Pointer(&b[0]))
-}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Removes functions from `util.Address` that can be easily replaced with `net/netip.Addr` functions.

### Motivation

Reduce surface area of `util.Address` abstraction for eventual replacement with `net/netip.Addr` directly.

### Additional Notes

> Go 1.17 added [conversions from slice to an array pointer](https://go.dev/ref/spec#Conversions_from_slice_to_array_or_array_pointer). Go 1.20 extends this to allow conversions from a slice to an array: given a slice `x`, `[4]byte(x)` can now be written instead of `*(*[4]byte)(x)`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
