### PR TITLE
improve invalid gMSA error message

### DIFF
--- a/releasenotes/notes/msi-invalid-gmsa-error-message-d6943b9dc18a0cd7.yaml
+++ b/releasenotes/notes/msi-invalid-gmsa-error-message-d6943b9dc18a0cd7.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Windows Agent Installer gives a better error message when a gMSA
+    account is provided for ``ddagentuser`` that Windows does not recognize.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -1,3 +1,4 @@
+using Datadog.CustomActions.Interfaces;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -6,7 +7,6 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
-using Datadog.CustomActions.Interfaces;
 
 // ReSharper disable InconsistentNaming
 
@@ -489,7 +489,7 @@ namespace Datadog.CustomActions.Native
         public bool IsServiceAccount(SecurityIdentifier securityIdentifier)
         {
             // NetIsServiceAccount returns true if NetQueryServiceAccount returns MsaInfoInstalled,
-            // this is the same behavior as the Test-ServiceAccount cmdlet in PowerShell.
+            // this is the same behavior as the Test-ADServiceAccount cmdlet in PowerShell.
             NetIsServiceAccount(null, securityIdentifier.Translate(typeof(NTAccount)).Value, out var isServiceAccount);
             isServiceAccount |= securityIdentifier.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
                                 securityIdentifier.IsWellKnown(WellKnownSidType.LocalServiceSid) ||

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -488,6 +488,8 @@ namespace Datadog.CustomActions.Native
 
         public bool IsServiceAccount(SecurityIdentifier securityIdentifier)
         {
+            // NetIsServiceAccount returns true if NetQueryServiceAccount returns MsaInfoInstalled,
+            // this is the same behavior as the Test-ServiceAccount cmdlet in PowerShell.
             NetIsServiceAccount(null, securityIdentifier.Translate(typeof(NTAccount)).Value, out var isServiceAccount);
             isServiceAccount |= securityIdentifier.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
                                 securityIdentifier.IsWellKnown(WellKnownSidType.LocalServiceSid) ||

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -286,11 +286,17 @@ namespace Datadog.CustomActions
                 return;
             }
 
-            // If the account name looks like a gMSA account, but wasn't detected as one
-            if (ddAgentUserName.EndsWith("$") && !isServiceAccount)
+            // If the account name looks like a gMSA account, but wasn't detected as one.
+            // Only look for $ at the end of the account name if it's a domain account, because
+            // normal account names can end with $. In the case of a domain account that ends
+            // in $ that is NOT intended to be a gMSA account, the user must provide a password.
+            if (isDomainController || isDomainAccount)
             {
-                throw new InvalidAgentUserConfigurationException(
-                    $"The provided account '{ddAgentUserName}' ends with '$' but is not recognized as a valid gMSA account. Please ensure the username is correct and this host is a member of PrincipalsAllowedToRetrieveManagedPassword.");
+                if (ddAgentUserName.EndsWith("$") && !isServiceAccount)
+                {
+                    throw new InvalidAgentUserConfigurationException(
+                        $"The provided account '{ddAgentUserName}' ends with '$' but is not recognized as a valid gMSA account. Please ensure the username is correct and this host is a member of PrincipalsAllowedToRetrieveManagedPassword. If the account is a normal account, please provide a password.");
+                }
             }
 
             if (isDomainController)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Improve the error message if a misconfigured gMSA account is provided to the installer.

Example error popup:
![image](https://github.com/user-attachments/assets/881c7b7f-6153-4ad1-bac4-66bd3003e8ab)


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-922

Previously, if a misconfigured gMSA account is provided to the installer, when [NetIsServiceAccount](https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netisserviceaccount) returns `false` the installer treats the account as a regular domain account and throws the error `A password was not provided. Passwords are required for domain accounts.`. This error is misleading when the user intends to provide a gMSA account, which do not require a password.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
E2E tests will validate non-domain and DC installs. but we do not have E2E tests for gMSA accounts.

Create a gMSA test environment (see [wiki](https://datadoghq.atlassian.net/wiki/spaces/AW/pages/3149334109))
1. Create gMSA account that the host does not have access to, the popup should appear and the message should appear in the install log.
2. Create gMSA account that the host does have access to, install should succeed.