### PR TITLE
get-failed-jobs: Fixed infra / non infra failure filtering

### DIFF
--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -32,9 +32,10 @@ def get_failed_jobs(pipeline: ProjectPipeline) -> FailedJobs:
         # We truncate the job name to increase readability
         job_name = truncate_job_name(job_name)
         job = jobs[-1]
+        is_standard_job = not isinstance(job, ProjectPipelineBridge)
         # Check the final job in the list: it contains the current status of the job
         # This excludes jobs that were retried and succeeded
-        trace = str(repo.jobs.get(job.id, lazy=True).trace(), 'utf-8') if hasattr(job, 'id') else ""
+        trace = str(repo.jobs.get(job.id, lazy=True).trace(), 'utf-8') if is_standard_job else ""
         failure_type, failure_reason = get_job_failure_context(job, trace)
         final_status = ProjectJob(
             repo.manager,
@@ -43,7 +44,7 @@ def get_failed_jobs(pipeline: ProjectPipeline) -> FailedJobs:
                 "id": job.id,
                 "stage": job.stage,
                 "status": job.status,
-                "tag_list": job.tag_list if isinstance(job, ProjectJob) else [],
+                "tag_list": job.tag_list if is_standard_job else [],
                 "allow_failure": job.allow_failure,
                 "web_url": job.web_url,
                 "retry_summary": [ijob.status for ijob in jobs],

--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -34,7 +34,7 @@ def get_failed_jobs(pipeline: ProjectPipeline) -> FailedJobs:
         job = jobs[-1]
         # Check the final job in the list: it contains the current status of the job
         # This excludes jobs that were retried and succeeded
-        trace = str(repo.jobs.get(job.id, lazy=True).trace(), 'utf-8') if isinstance(job, ProjectJob) else ""
+        trace = str(repo.jobs.get(job.id, lazy=True).trace(), 'utf-8') if hasattr(job, 'id') else ""
         failure_type, failure_reason = get_job_failure_context(job, trace)
         final_status = ProjectJob(
             repo.manager,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

After #28132 and #27972, the jobs were all filtered as infra failures as their types were `ProjectPipelineJob` instead of `ProjectJob`.
Now the type is checked only on `ProjectPipelineBridge`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Tested on pipeline `38410297` for bridge jobs and pipeline `40856854` for standard jobs.
