### PR TITLE
[E2e] Get unlimited logs of restarted containers

### DIFF
--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -322,7 +322,7 @@ func dumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, o
 				logs, err := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 					Container: containerStatus.Name,
 					Previous:  true,
-					TailLines: pointer.Ptr(int64(100)),
+					// TailLines: pointer.Ptr(int64(100)),
 				}).Stream(ctx)
 				if err != nil {
 					fmt.Fprintf(out, "Failed to get logs: %v\n", err)


### PR DESCRIPTION
### What does this PR do?

Do not restrict the amount of logs e2e tests are collecting from restarted containers anymore.

### Motivation

I’ve been chasing a crash of the `cluster-agent` at startup for a while.
It happens only from time to time in the CI.
Unfortunately, the panic stacktraces are still truncated.
See: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/593685237

### Additional Notes

### Possible Drawbacks / Trade-offs

If any container is OOM killed after having produced verbose debug logs during a given amount of time, the log spamming on the GitLab job output can become uncontrolled.

### Describe how to test/QA your changes

Wait for [`TestKindSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting` e2e test to fail](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.status%3Afail%20%40test.name%3ATestKindSuite%2FTest00UpAndRunning%2Fagent_pods_are_ready_and_not_restarting&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&start=1722247583244&end=1722852383244&paused=false) again and check the logs of the crashed `cluster-agent`. We should hopefully get the full panic stacktraces.