### PR TITLE
discovery: Add system-probe module to CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@ component/system-probe:
 - changed-files:
   - any-glob-to-any-file:
     - pkg/collector/corechecks/ebpf/** #ebpf-platform (oomkill and tcp_queue_length)
+    - pkg/collector/corechecks/servicediscovery/module/** # usm
     - pkg/ebpf/** # ebpf-platform (ebpf_manager)
     - pkg/eventmonitor/** # cws (new event monitor component)
     - pkg/network/** # npm and usm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -736,6 +736,7 @@ workflow:
 
 .system_probe_change_paths: &system_probe_change_paths
   - pkg/collector/corechecks/ebpf/**/*
+  - pkg/collector/corechecks/servicediscovery/module/*
   - pkg/ebpf/**/*
   - pkg/network/**/*
   - pkg/process/monitor/*


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The `pkg/collector/corechecks/servicediscovery/module/` path is part of system-probe so add the path to the relevant CI files.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
