### PR TITLE
usm: classification: tls: Do not classify a classified connection in a socket filter

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -167,7 +167,6 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
 
     const char *buffer = &(usm_ctx->buffer.data[0]);
 
-    // If application-layer is known we don't bother to check for HTTP protocols and skip to the next layers
     protocol_t app_layer_proto = get_protocol_from_stack(protocol_stack, LAYER_APPLICATION);
 
     if ((app_layer_proto == PROTOCOL_UNKNOWN || app_layer_proto == PROTOCOL_POSTGRES) && is_tls(buffer, usm_ctx->buffer.size, skb_info.data_end)) {

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -166,16 +166,18 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
     init_routing_cache(usm_ctx, protocol_stack);
 
     const char *buffer = &(usm_ctx->buffer.data[0]);
-    // TLS classification
-    if (is_tls(buffer, usm_ctx->buffer.size, skb_info.data_end)) {
+
+    // If application-layer is known we don't bother to check for HTTP protocols and skip to the next layers
+    protocol_t app_layer_proto = get_protocol_from_stack(protocol_stack, LAYER_APPLICATION);
+
+    if ((app_layer_proto == PROTOCOL_UNKNOWN || app_layer_proto == PROTOCOL_POSTGRES) && is_tls(buffer, usm_ctx->buffer.size, skb_info.data_end)) {
+        // TLS classification
         update_protocol_information(usm_ctx, protocol_stack, PROTOCOL_TLS);
         // The connection is TLS encrypted, thus we cannot classify the protocol
         // using the socket filter and therefore we can bail out;
         return;
     }
 
-    // If application-layer is known we don't bother to check for HTTP protocols and skip to the next layers
-    protocol_t app_layer_proto = get_protocol_from_stack(protocol_stack, LAYER_APPLICATION);
     if (app_layer_proto != PROTOCOL_UNKNOWN && app_layer_proto != PROTOCOL_HTTP2) {
         goto next_program;
     }

--- a/pkg/network/usm/monitor_testutil.go
+++ b/pkg/network/usm/monitor_testutil.go
@@ -10,12 +10,16 @@ package usm
 import (
 	"io"
 	"testing"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/require"
 
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 )
@@ -101,4 +105,13 @@ func patchProtocolMock(t *testing.T, spec protocolMockSpec) {
 	}
 
 	knownProtocols[0] = p
+}
+
+// SetConnectionProtocol sets the connection protocol for the given connection tuple.
+func (m *Monitor) SetConnectionProtocol(t *testing.T, p netebpf.ProtocolStackWrapper, tup netebpf.ConnTuple) {
+	t.Helper()
+
+	connProtocolMap, _, err := m.ebpfProgram.GetMap(probes.ConnectionProtocolMap)
+	require.NoError(t, err)
+	require.NoError(t, connProtocolMap.Update(unsafe.Pointer(&tup), unsafe.Pointer(&p), ebpf.UpdateAny))
 }

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net"
 	nethttp "net/http"
+	"net/netip"
 	"os"
 	"os/exec"
 	"strconv"
@@ -39,6 +40,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	netlink "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/amqp"
@@ -58,6 +60,7 @@ import (
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/testutil/grpc"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	grpc2 "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -289,6 +292,148 @@ func getFreePort() (port uint16, err error) {
 		}
 	}
 	return
+}
+
+func (s *USMSuite) TestIgnoreTLSClassificationIfApplicationProtocolWasDetected() {
+	t := s.T()
+	cfg := tracertestutil.Config()
+	cfg.ServiceMonitoringEnabled = true
+	// USM cannot be enabled without a protocol.
+	cfg.EnableHTTPMonitoring = true
+	cfg.ProtocolClassificationEnabled = true
+	cfg.CollectTCPv4Conns = true
+	cfg.CollectTCPv6Conns = true
+
+	if !classificationSupported(cfg) {
+		t.Skip("TLS classification platform not supported")
+	}
+
+	const srvPort = 9111
+	srvAddress := fmt.Sprintf("localhost:%d", srvPort)
+
+	srv := testutil.NewTLSServerWithSpecificVersion(srvAddress, func(conn net.Conn) {
+		defer conn.Close()
+		// Echo back whatever is received
+		_, err := io.Copy(conn, conn)
+		if err != nil {
+			fmt.Printf("Failed to echo data: %v\n", err)
+			return
+		}
+	}, tls.VersionTLS12)
+	done := make(chan struct{})
+	require.NoError(t, srv.Run(done))
+	t.Cleanup(func() { close(done) })
+
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
+
+	tr := setupTracer(t, cfg)
+
+	localhostAddress, err := netip.ParseAddr("127.0.0.1")
+	require.NoError(t, err)
+	addrLow, addrHigh := util.ToLowHighIP(localhostAddress)
+
+	tests := []struct {
+		name          string
+		protocolValue uint8
+		shouldBeTLS   bool
+	}{
+		{
+			name:          "UNKNOWN",
+			protocolValue: 0,
+			shouldBeTLS:   true,
+		},
+		{
+			name:          "HTTP",
+			protocolValue: 1,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "HTTP2",
+			protocolValue: 2,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "KAFKA",
+			protocolValue: 3,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "MONGO",
+			protocolValue: 4,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "POSTGRES",
+			protocolValue: 5,
+			shouldBeTLS:   true,
+		},
+		{
+			name:          "AMQP",
+			protocolValue: 6,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "REDIS",
+			protocolValue: 7,
+			shouldBeTLS:   false,
+		},
+		{
+			name:          "MYSQL",
+			protocolValue: 8,
+			shouldBeTLS:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientPort, err := getFreePort()
+			require.NoError(t, err)
+			dialer := &net.Dialer{
+				LocalAddr: &net.TCPAddr{
+					IP:   net.ParseIP("localhost"),
+					Port: int(clientPort),
+				},
+			}
+			conn, err := dialer.Dial("tcp", srvAddress)
+			require.NoError(t, err)
+			defer conn.Close()
+			tlsConn := tls.Client(conn, tlsConfig)
+
+			connTupleKey := netebpf.ConnTuple{
+				Saddr_h:  addrHigh,
+				Saddr_l:  addrLow,
+				Daddr_h:  addrHigh,
+				Daddr_l:  addrLow,
+				Sport:    clientPort,
+				Dport:    srvPort,
+				Metadata: uint32(netebpf.TCP),
+			}
+			protocolValue := netebpf.ProtocolStackWrapper{
+				Stack: netebpf.ProtocolStack{
+					Application: tt.protocolValue,
+				},
+			}
+			tr.USMMonitor().SetConnectionProtocol(t, protocolValue, connTupleKey)
+			connTupleKey.Sport, connTupleKey.Dport = connTupleKey.Dport, connTupleKey.Sport
+			tr.USMMonitor().SetConnectionProtocol(t, protocolValue, connTupleKey)
+
+			// Perform the TLS handshake
+			require.NoError(t, tlsConn.Handshake())
+
+			require.Eventually(t, func() bool {
+				payload := getConnections(t, tr)
+				for _, c := range payload.Conns {
+					if c.DPort == srvPort || c.SPort == srvPort {
+						return c.ProtocolStack.Contains(protocols.TLS) == tt.shouldBeTLS
+					}
+				}
+				return false
+			}, 10*time.Second, 100*time.Millisecond)
+		})
+	}
 }
 
 // TLS classification tests


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

In the context of a socket filter, is a connection is classified with an application level protocol (HTTP, HTTP2, etc.) it cannot suddenly become a TLS connection. The only exception is postgres, which starts as a plaintext postgres and then migrates to TLS.

In the case above, we don't attempt to classify a connection as TLS.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reducing the possibility for false positives.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
