### PR TITLE
fix(build-rc): Use correct semantic version ordering

### DIFF
--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -421,10 +421,20 @@ def get_matching_pattern(ctx, major_version, release=False):
     """
     We need to used specific patterns (official release tags) for nightly builds as they are used to install agent versions.
     """
+    from functools import cmp_to_key
+
+    import semver
+
     pattern = rf"{major_version}\.*"
     if release or os.getenv("BUCKET_BRANCH") in ALLOWED_REPO_NIGHTLY_BRANCHES:
-        pattern = ctx.run(
-            rf"git tag --list --merged {get_current_branch(ctx)} | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1",
-            hide=True,
-        ).stdout.strip()
+        tags = (
+            ctx.run(
+                rf"git tag --list --merged {get_current_branch(ctx)} | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$'",
+                hide=True,
+            )
+            .stdout.strip()
+            .split("\n")
+        )
+        semver_tags = sorted(tags, key=cmp_to_key(semver.compare))
+        pattern = semver_tags[-1]
     return pattern

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -435,6 +435,5 @@ def get_matching_pattern(ctx, major_version, release=False):
             .stdout.strip()
             .split("\n")
         )
-        semver_tags = sorted(tags, key=cmp_to_key(semver.compare))
-        pattern = semver_tags[-1]
+        pattern = max(tags, key=cmp_to_key(semver.compare))
     return pattern

--- a/tasks/unit_tests/version_tests.py
+++ b/tasks/unit_tests/version_tests.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from invoke import MockContext, Result
 
-from tasks.libs.releasing.version import query_version
+from tasks.libs.releasing.version import get_matching_pattern, query_version
 from tasks.libs.types.version import Version
 
 
@@ -233,7 +233,7 @@ class TestQueryVersion(unittest.TestCase):
         c = MockContext(
             run={
                 "git rev-parse --abbrev-ref HEAD": Result("main"),
-                rf"git tag --list --merged main | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
+                rf"git tag --list --merged main | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$'": Result(
                     "7.55.0-devel"
                 ),
                 'git describe --tags --candidates=50 --match "7.55.0-devel" --abbrev=7': Result(
@@ -252,7 +252,7 @@ class TestQueryVersion(unittest.TestCase):
         c = MockContext(
             run={
                 "git rev-parse --abbrev-ref HEAD": Result("7.55.x"),
-                rf"git tag --list --merged 7.55.x | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$' | sort -rV | head -1": Result(
+                rf"git tag --list --merged 7.55.x | grep -E '^{major_version}\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$'": Result(
                     "7.55.0-devel"
                 ),
                 'git describe --tags --candidates=50 --match "7.55.0-devel" --abbrev=7': Result(
@@ -265,3 +265,31 @@ class TestQueryVersion(unittest.TestCase):
         self.assertEqual(p, "devel")
         self.assertEqual(c, 543)
         self.assertEqual(g, "315e3a2")
+
+
+class TestGetMatchingPattern(unittest.TestCase):
+    def test_on_patch_release(self):
+        c = MockContext(
+            run={
+                "git rev-parse --abbrev-ref HEAD": Result("7.55.x"),
+                r"git tag --list --merged 7.55.x | grep -E '^7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$'": Result(
+                    '7.15.0-devel\n7.15.0-rc.2\n7.15.0-rc.4\n7.15.0-rc.5\n7.15.0-rc.6\n7.15.0-rc.7\n7.15.0-rc.8\n7.15.0-rc.9\n7.16.0\n7.16.0-rc.1\n7.16.0-rc.2\n7.16.0-rc.3\n7.16.0-rc.4\n7.16.0-rc.5\n7.16.0-rc.6\n7.16.0-rc.7\n7.16.0-rc.8\n7.16.0-rc.9\n7.17.0-devel\n7.17.0-rc.1\n7.17.0-rc.2\n7.17.0-rc.3\n7.17.0-rc.4\n7.18.0-devel\n7.18.0-rc.1\n7.18.0-rc.2\n7.18.0-rc.3\n7.18.0-rc.4\n7.18.0-rc.5\n7.18.0-rc.6\n7.19.0-devel\n7.19.0-rc.1\n7.19.0-rc.2\n7.19.0-rc.3\n7.19.0-rc.4\n7.19.0-rc.5\n7.20.0-devel\n7.20.0-rc.1\n7.20.0-rc.2\n7.20.0-rc.3\n7.20.0-rc.4\n7.20.0-rc.5\n7.20.0-rc.6\n7.20.0-rc.7\n7.21.0-devel\n7.21.0-rc.1\n7.21.0-rc.2\n7.21.0-rc.3\n7.22.0-devel\n7.22.0-rc.1\n7.22.0-rc.2\n7.22.0-rc.3\n7.22.0-rc.4\n7.22.0-rc.5\n7.22.0-rc.6\n7.23.0-devel\n7.23.0-rc.1\n7.23.0-rc.2\n7.23.0-rc.3\n7.24.0-devel\n7.24.0-rc.1\n7.24.0-rc.2\n7.24.0-rc.3\n7.24.0-rc.4\n7.24.0-rc.5\n7.25.0-devel\n7.25.0-rc.1\n7.25.0-rc.2\n7.25.0-rc.3\n7.25.0-rc.4\n7.25.0-rc.5\n7.25.0-rc.6\n7.26.0-devel\n7.26.0-rc.1\n7.26.0-rc.2\n7.26.0-rc.3\n7.27.0-devel\n7.27.0-rc.1\n7.27.0-rc.2\n7.27.0-rc.3\n7.27.0-rc.4\n7.27.0-rc.5\n7.27.0-rc.6\n7.28.0-devel\n7.28.0-rc.1\n7.28.0-rc.2\n7.28.0-rc.3\n7.29.0-devel\n7.29.0-rc.1\n7.29.0-rc.2\n7.29.0-rc.3\n7.29.0-rc.4\n7.29.0-rc.5\n7.29.0-rc.6\n7.30.0-devel\n7.30.0-rc.1\n7.30.0-rc.2\n7.30.0-rc.3\n7.30.0-rc.4\n7.30.0-rc.5\n7.30.0-rc.6\n7.30.0-rc.7\n7.31.0-devel\n7.31.0-rc.1\n7.31.0-rc.2\n7.31.0-rc.3\n7.31.0-rc.4\n7.31.0-rc.5\n7.31.0-rc.6\n7.31.0-rc.7\n7.31.0-rc.8\n7.32.0-devel\n7.32.0-rc.1\n7.32.0-rc.2\n7.32.0-rc.3\n7.32.0-rc.4\n7.32.0-rc.5\n7.32.0-rc.6\n7.33.0-devel\n7.33.0-rc.1\n7.33.0-rc.2\n7.33.0-rc.3\n7.33.0-rc.4\n7.33.0-rc.4-dbm-beta-0.1\n7.34.0-devel\n7.34.0-rc.1\n7.34.0-rc.2\n7.34.0-rc.3\n7.34.0-rc.4\n7.35.0-devel\n7.35.0-rc.1\n7.35.0-rc.2\n7.35.0-rc.3\n7.35.0-rc.4\n7.36.0-devel\n7.36.0-rc.1\n7.36.0-rc.2\n7.36.0-rc.3\n7.36.0-rc.4\n7.37.0-devel\n7.37.0-rc.1\n7.37.0-rc.2\n7.37.0-rc.3\n7.38.0-devel\n7.38.0-rc.1\n7.38.0-rc.2\n7.38.0-rc.3\n7.39.0-devel\n7.39.0-rc.1\n7.39.0-rc.2\n7.39.0-rc.3\n7.40.0-devel\n7.40.0-rc.1\n7.40.0-rc.2\n7.41.0-devel\n7.41.0-rc.1\n7.41.0-rc.2\n7.41.0-rc.3\n7.42.0-devel\n7.42.0-rc.1\n7.42.0-rc.2\n7.42.0-rc.3\n7.43.0-devel\n7.43.0-rc.1\n7.43.0-rc.2\n7.43.0-rc.3\n7.44.0-devel\n7.44.0-rc.1\n7.44.0-rc.2\n7.44.0-rc.3\n7.44.0-rc.4\n7.45.0-devel\n7.45.0-rc.1\n7.45.0-rc.2\n7.45.0-rc.3\n7.46.0-devel\n7.46.0-rc.1\n7.46.0-rc.2\n7.47.0-devel\n7.47.0-rc.1\n7.47.0-rc.2\n7.47.0-rc.3\n7.48.0-devel\n7.48.0-rc.0\n7.48.0-rc.1\n7.48.0-rc.2\n7.49.0-devel\n7.49.0-rc.1\n7.49.0-rc.2\n7.50.0-devel\n7.50.0-rc.1\n7.50.0-rc.2\n7.50.0-rc.3\n7.50.0-rc.4\n7.51.0-devel\n7.51.0-rc.1\n7.51.0-rc.2\n7.52.0-devel\n7.52.0-rc.1\n7.52.0-rc.2\n7.52.0-rc.3\n7.53.0-devel\n7.53.0-rc.1\n7.53.0-rc.2\n7.54.0-devel\n7.54.0-rc.1\n7.54.0-rc.2\n7.55.0\n7.55.0-devel\n7.55.0-rc.1\n7.55.0-rc.10\n7.55.0-rc.11\n7.55.0-rc.2\n7.55.0-rc.3\n7.55.0-rc.4\n7.55.0-rc.5\n7.55.0-rc.6\n7.55.0-rc.7\n7.55.0-rc.8\n7.55.0-rc.9'
+                ),
+            }
+        )
+        self.assertEqual(get_matching_pattern(c, major_version="7", release=True), "7.55.0")
+
+    def test_on_release(self):
+        c = MockContext(
+            run={
+                "git rev-parse --abbrev-ref HEAD": Result("7.55.x"),
+                r"git tag --list --merged 7.55.x | grep -E '^7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$'": Result(
+                    '7.15.0-devel\n7.15.0-rc.2\n7.15.0-rc.4\n7.15.0-rc.5\n7.15.0-rc.6\n7.15.0-rc.7\n7.15.0-rc.8\n7.15.0-rc.9\n7.16.0\n7.16.0-rc.1\n7.16.0-rc.2\n7.16.0-rc.3\n7.16.0-rc.4\n7.16.0-rc.5\n7.16.0-rc.6\n7.16.0-rc.7\n7.16.0-rc.8\n7.16.0-rc.9\n7.17.0-devel\n7.17.0-rc.1\n7.17.0-rc.2\n7.17.0-rc.3\n7.17.0-rc.4\n7.18.0-devel\n7.18.0-rc.1\n7.18.0-rc.2\n7.18.0-rc.3\n7.18.0-rc.4\n7.18.0-rc.5\n7.18.0-rc.6\n7.19.0-devel\n7.19.0-rc.1\n7.19.0-rc.2\n7.19.0-rc.3\n7.19.0-rc.4\n7.19.0-rc.5\n7.20.0-devel\n7.20.0-rc.1\n7.20.0-rc.2\n7.20.0-rc.3\n7.20.0-rc.4\n7.20.0-rc.5\n7.20.0-rc.6\n7.20.0-rc.7\n7.21.0-devel\n7.21.0-rc.1\n7.21.0-rc.2\n7.21.0-rc.3\n7.22.0-devel\n7.22.0-rc.1\n7.22.0-rc.2\n7.22.0-rc.3\n7.22.0-rc.4\n7.22.0-rc.5\n7.22.0-rc.6\n7.23.0-devel\n7.23.0-rc.1\n7.23.0-rc.2\n7.23.0-rc.3\n7.24.0-devel\n7.24.0-rc.1\n7.24.0-rc.2\n7.24.0-rc.3\n7.24.0-rc.4\n7.24.0-rc.5\n7.25.0-devel\n7.25.0-rc.1\n7.25.0-rc.2\n7.25.0-rc.3\n7.25.0-rc.4\n7.25.0-rc.5\n7.25.0-rc.6\n7.26.0-devel\n7.26.0-rc.1\n7.26.0-rc.2\n7.26.0-rc.3\n7.27.0-devel\n7.27.0-rc.1\n7.27.0-rc.2\n7.27.0-rc.3\n7.27.0-rc.4\n7.27.0-rc.5\n7.27.0-rc.6\n7.28.0-devel\n7.28.0-rc.1\n7.28.0-rc.2\n7.28.0-rc.3\n7.29.0-devel\n7.29.0-rc.1\n7.29.0-rc.2\n7.29.0-rc.3\n7.29.0-rc.4\n7.29.0-rc.5\n7.29.0-rc.6\n7.30.0-devel\n7.30.0-rc.1\n7.30.0-rc.2\n7.30.0-rc.3\n7.30.0-rc.4\n7.30.0-rc.5\n7.30.0-rc.6\n7.30.0-rc.7\n7.31.0-devel\n7.31.0-rc.1\n7.31.0-rc.2\n7.31.0-rc.3\n7.31.0-rc.4\n7.31.0-rc.5\n7.31.0-rc.6\n7.31.0-rc.7\n7.31.0-rc.8\n7.32.0-devel\n7.32.0-rc.1\n7.32.0-rc.2\n7.32.0-rc.3\n7.32.0-rc.4\n7.32.0-rc.5\n7.32.0-rc.6\n7.33.0-devel\n7.33.0-rc.1\n7.33.0-rc.2\n7.33.0-rc.3\n7.33.0-rc.4\n7.33.0-rc.4-dbm-beta-0.1\n7.34.0-devel\n7.34.0-rc.1\n7.34.0-rc.2\n7.34.0-rc.3\n7.34.0-rc.4\n7.35.0-devel\n7.35.0-rc.1\n7.35.0-rc.2\n7.35.0-rc.3\n7.35.0-rc.4\n7.36.0-devel\n7.36.0-rc.1\n7.36.0-rc.2\n7.36.0-rc.3\n7.36.0-rc.4\n7.37.0-devel\n7.37.0-rc.1\n7.37.0-rc.2\n7.37.0-rc.3\n7.38.0-devel\n7.38.0-rc.1\n7.38.0-rc.2\n7.38.0-rc.3\n7.39.0-devel\n7.39.0-rc.1\n7.39.0-rc.2\n7.39.0-rc.3\n7.40.0-devel\n7.40.0-rc.1\n7.40.0-rc.2\n7.41.0-devel\n7.41.0-rc.1\n7.41.0-rc.2\n7.41.0-rc.3\n7.42.0-devel\n7.42.0-rc.1\n7.42.0-rc.2\n7.42.0-rc.3\n7.43.0-devel\n7.43.0-rc.1\n7.43.0-rc.2\n7.43.0-rc.3\n7.44.0-devel\n7.44.0-rc.1\n7.44.0-rc.2\n7.44.0-rc.3\n7.44.0-rc.4\n7.45.0-devel\n7.45.0-rc.1\n7.45.0-rc.2\n7.45.0-rc.3\n7.46.0-devel\n7.46.0-rc.1\n7.46.0-rc.2\n7.47.0-devel\n7.47.0-rc.1\n7.47.0-rc.2\n7.47.0-rc.3\n7.48.0-devel\n7.48.0-rc.0\n7.48.0-rc.1\n7.48.0-rc.2\n7.49.0-devel\n7.49.0-rc.1\n7.49.0-rc.2\n7.50.0-devel\n7.50.0-rc.1\n7.50.0-rc.2\n7.50.0-rc.3\n7.50.0-rc.4\n7.51.0-devel\n7.51.0-rc.1\n7.51.0-rc.2\n7.52.0-devel\n7.52.0-rc.1\n7.52.0-rc.2\n7.52.0-rc.3\n7.53.0-devel\n7.53.0-rc.1\n7.53.0-rc.2\n7.54.0-devel\n7.54.0-rc.1\n7.54.0-rc.2\n7.55.0-devel\n7.55.0-rc.1\n7.55.0-rc.10\n7.55.0-rc.11\n7.55.0-rc.2\n7.55.0-rc.3\n7.55.0-rc.4\n7.55.0-rc.5\n7.55.0-rc.6\n7.55.0-rc.7\n7.55.0-rc.8\n7.55.0-rc.9'
+                ),
+            }
+        )
+        self.assertEqual(get_matching_pattern(c, major_version="7", release=True), "7.55.0-rc.11")
+
+    def test_on_branch(self):
+        c = MockContext()
+        self.assertEqual(get_matching_pattern(c, major_version="42", release=False), r"42\.*")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Use proper semantic versioning order when looking for the latest tag in release context.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Since merge #26144, there was a new management to retrieve the tags. But the sort used was not semver-valid leading to issue when calling `inv release.build-rc -k -p` (wanted to do a new release candidate and not a patch)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
[Jira issue](https://datadoghq.atlassian.net/browse/ACIX-396?atlOrigin=eyJpIjoiMTdmYjE0NjY3YTIxNDMwZmE3ZTFiYzQzYmU0NDJlMjEiLCJwIjoiaiJ9)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Tested on branch `7.55.x` with a cherry-pick of the change:
Before
```
 inv -e release.build-rc -k -p
Checking repository state
git --no-pager log --no-color -1 --oneline
75c8ca6433 [Backport 7.55.x] [FA] Mark apm inject as flaky (#27703)
This task will create tags for 6/7.55.3-rc.2 on the current commit: 75c8ca6433 [Backport 7.55.x] [FA] Mark apm inject as flaky (#27703). Is this OK? [y/N] ^C%
```
After
```
 inv -e release.build-rc -k -p
Checking repository state
git --no-pager log --no-color -1 --oneline
75c8ca6433 [Backport 7.55.x] [FA] Mark apm inject as flaky (#27703)
This task will create tags for 6/7.55.4-rc.1 on the current commit: 75c8ca6433 [Backport 7.55.x] [FA] Mark apm inject as flaky (#27703). Is this OK? [y/N]
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
