### PR TITLE
[OTEL-1726] Respect span.type attr in otel_util

### DIFF
--- a/pkg/trace/traceutil/otel_util.go
+++ b/pkg/trace/traceutil/otel_util.go
@@ -125,7 +125,10 @@ func GetOTelAttrValInResAndSpanAttrs(span ptrace.Span, res pcommon.Resource, nor
 
 // GetOTelSpanType returns the DD span type based on OTel span kind and attributes.
 func GetOTelSpanType(span ptrace.Span, res pcommon.Resource) string {
-	var typ string
+	typ := GetOTelAttrValInResAndSpanAttrs(span, res, false, "span.type")
+	if typ != "" {
+		return typ
+	}
 	switch span.Kind() {
 	case ptrace.SpanKindServer:
 		typ = "web"

--- a/pkg/trace/traceutil/otel_util_test.go
+++ b/pkg/trace/traceutil/otel_util_test.go
@@ -162,6 +162,12 @@ func TestGetOTelSpanType(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "override with span.type attr",
+			spanKind: ptrace.SpanKindInternal,
+			rattrs:   map[string]string{"span.type": "my-type"},
+			expected: "my-type",
+		},
+		{
 			name:     "web span",
 			spanKind: ptrace.SpanKindServer,
 			expected: "web",


### PR DESCRIPTION
This corresponds to https://github.com/DataDog/datadog-agent/blob/7424b2490cb74f6fe2aa428a35d663455a04fb84/pkg/trace/api/otlp.go#L486-L487
