### PR TITLE
[apm] add ip address peer tag quantization

### DIFF
--- a/pkg/obfuscate/ip_address.go
+++ b/pkg/obfuscate/ip_address.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package obfuscate
+
+import (
+	"net"
+	"net/netip"
+	"regexp"
+	"strings"
+)
+
+// QuantizePeerIPAddresses quantizes a comma separated list of hosts. Each entry which is an IP address is replaced using quantizeIP.
+// Duplicate entries post-quantization or collapsed into a single unique value.
+// Entries which are not IP addresses are left unchanged.
+// Comma-separated host lists are common for peer tags like peer.cassandra.contact.points, peer.couchbase.seed.nodes, peer.kafka.bootstrap.servers
+func QuantizePeerIPAddresses(raw string) string {
+	values := strings.Split(raw, ",")
+	uniq := values[:0]
+	uniqSet := make(map[string]bool)
+	for _, v := range values {
+		q := quantizeIP(v)
+		if !uniqSet[q] {
+			uniqSet[q] = true
+			uniq = append(uniq, q)
+		}
+	}
+	return strings.Join(uniq, ",")
+}
+
+var protocolRegex = regexp.MustCompile(`((?:dnspoll|ftp|file|http|https):/{2,3}).*`)
+
+var allowedIPAddresses = map[string]bool{
+	// localhost
+	"127.0.0.1": true,
+	"::1":       true,
+	// link-local cloud provider metadata server addresses
+	"169.254.169.254": true,
+	"fd00:ec2::254":   true,
+}
+
+func splitPrefix(raw string) (prefix, after string) {
+	if after, ok := strings.CutPrefix(raw, "ip-"); ok { // AWS EC2 hostnames e.g. ip-10-123-4-567.ec2.internal
+		return "ip-", after
+	}
+	subMatches := protocolRegex.FindStringSubmatch(raw)
+	if len(subMatches) >= 2 {
+		prefix = subMatches[1]
+	}
+	return prefix, raw[len(prefix):]
+}
+
+// quantizeIP quantizes the ip address in the provided string, only if it exactly matches an ip with an optional port
+// if the string is not an ip then empty string is returned
+func quantizeIP(raw string) string {
+	prefix, raw := splitPrefix(raw)
+	host, port, suffix := parseIPAndPort(raw)
+	if host == "" {
+		// not an ip address
+		return raw
+	}
+	if allowedIPAddresses[host] {
+		return raw
+	}
+	replacement := prefix + "blocked-ip-address"
+	if port != "" {
+		// we're keeping the original port as part of the key because ports are much lower cardinality
+		// than ip addresses, and they also tend to correspond more closely to a protocol (i.e. 443 is HTTPS)
+		// so it's likely safe and probably also useful to leave them in
+		replacement = replacement + ":" + port
+	}
+	return replacement + suffix
+}
+
+// parseIPAndPort returns (host, port) if the host is a valid ip address with an optional port, else returns empty strings.
+func parseIPAndPort(input string) (host, port, suffix string) {
+	host, port, err := net.SplitHostPort(input)
+	if err != nil {
+		host = input
+	}
+	if ok, i := isParseableIP(host); ok {
+		return host[:i], port, host[i:]
+	}
+	return "", "", ""
+}
+
+func isParseableIP(s string) (parsed bool, lastIndex int) {
+	if len(s) == 0 {
+		return false, -1
+	}
+	// Must start with a hex digit, or IPv6 can have a preceding ':'
+	switch s[0] {
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+		'a', 'b', 'c', 'd', 'e', 'f',
+		'A', 'B', 'C', 'D', 'E', 'F',
+		':':
+	default:
+		return false, -1
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.', '_', '-':
+			return parseIPv4(s, s[i])
+		case ':':
+			// IPv6
+			if _, err := netip.ParseAddr(s); err == nil {
+				return true, len(s)
+			}
+			return false, -1
+		case '%':
+			// Assume that this was trying to be an IPv6 address with
+			// a zone specifier, but the address is missing.
+			return false, -1
+		}
+	}
+	return false, -1
+}
+
+// parseIsIPv4 parses s as an IPv4 address and returns whether it is an IP address
+// modified from netip to accept alternate separators besides '.'
+// also modified to return true if s is an IPv4 address with trailing characters
+func parseIPv4(s string, sep byte) (parsed bool, lastIndex int) {
+	var fields [4]uint8
+	var val, pos int
+	var digLen int // number of digits in current octet
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			if digLen == 1 && val == 0 {
+				return false, -1
+			}
+			val = val*10 + int(s[i]) - '0'
+			digLen++
+			if val > 255 {
+				return false, -1
+			}
+		} else if s[i] == sep {
+			// .1.2.3
+			// 1.2.3.
+			// 1..2.3
+			if i == 0 || i == len(s)-1 || s[i-1] == sep {
+				return false, -1
+			}
+			// 1.2.3.4.5
+			if pos == 3 {
+				return true, i
+			}
+			fields[pos] = uint8(val)
+			pos++
+			val = 0
+			digLen = 0
+		} else {
+			if pos == 3 {
+				fields[3] = uint8(val)
+				return true, i
+			}
+			return false, -1
+		}
+	}
+	if pos < 3 {
+		return false, -1
+	}
+	fields[3] = uint8(val)
+	return true, len(s)
+}

--- a/pkg/obfuscate/ip_address_test.go
+++ b/pkg/obfuscate/ip_address_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package obfuscate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuantizePeerIpAddresses(t *testing.T) {
+	testCases := []struct {
+		original  string
+		quantized string
+	}{
+		// special cases
+		// - localhost
+		{"127.0.0.1", "127.0.0.1"},
+		{"::1", "::1"},
+		// - link-local IP address, aka "metadata server" for various cloud providers
+		{"169.254.169.254", "169.254.169.254"},
+		{"fd00:ec2::254", "fd00:ec2::254"},
+		// blocking cases
+		{"", ""},
+		{"foo.dog", "foo.dog"},
+		{"192.168.1.1", "blocked-ip-address"},
+		{"192.168.1.1.foo", "blocked-ip-address.foo"},
+		{"192.168.1.1.2.3.4.5", "blocked-ip-address.2.3.4.5"},
+		{"192_168_1_1", "blocked-ip-address"},
+		{"192-168-1-1", "blocked-ip-address"},
+		{"192-168-1-1.foo", "blocked-ip-address.foo"},
+		{"192-168-1-1-foo", "blocked-ip-address-foo"},
+		{"2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF", "blocked-ip-address"},
+		{"2001:db8:3c4d:15::1a2f:1a2b", "blocked-ip-address"},
+		{"[fe80::1ff:fe23:4567:890a]:8080", "blocked-ip-address:8080"},
+		{"192.168.1.1:1234", "blocked-ip-address:1234"},
+		{"dnspoll:///10.21.120.145:6400", "dnspoll:///blocked-ip-address:6400"},
+		{"http://10.21.120.145:6400", "http://blocked-ip-address:6400"},
+		{"https://10.21.120.145:6400", "https://blocked-ip-address:6400"},
+		{"192.168.1.1:1234,10.23.1.1:53,10.23.1.1,fe80::1ff:fe23:4567:890a,foo.dog", "blocked-ip-address:1234,blocked-ip-address:53,blocked-ip-address,foo.dog"},
+		{"http://172.24.160.151:8091,172.24.163.33:8091,172.24.164.111:8091,172.24.165.203:8091,172.24.168.235:8091,172.24.170.130:8091", "http://blocked-ip-address:8091,blocked-ip-address:8091"},
+		{"10-60-160-172.my-service.namespace.svc.abc.cluster.local", "blocked-ip-address.my-service.namespace.svc.abc.cluster.local"},
+		{"ip-10-152-4-129.ec2.internal", "ip-blocked-ip-address.ec2.internal"},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tc.quantized, QuantizePeerIPAddresses(tc.original))
+		})
+	}
+}

--- a/releasenotes/notes/apm-quantize-ip-addresses-on-peer-tags-f409b4e789a47875.yaml
+++ b/releasenotes/notes/apm-quantize-ip-addresses-on-peer-tags-f409b4e789a47875.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    IP address quantization on all peer tags is done the backend during ingestion. This change updates the Agent to apply the same IP address quantization. This reduces unnecessary aggregation that is currently done on raw IP addresses. And therefore, improves the aggregation performance of stats on peer tags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

For the [Inferred Service dependencies beta](https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=java) we already apply this same IP address quantization to the stats as they are being ingested.

This ensures the agent applies the same quantization prior to stats aggregation, improving the performance of stats aggregation on peer tags by reducing unnecessary work.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve the performance of the agent by reducing unnecessary aggregations. This also makes it safer to include span attributes which are known to have a high likelihood of containing raw IP addresses in them (like `out.host`). 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Enable both `apm_config.peer_service_aggregation` and `apm_config.compute_stats_by_span_kind`.
- Send `span.kind=span.kind` spans to the trace agent with `server.address:{some IP address}` set in the meta.
- Validate that the `peer.hostname` tag is represented as `blocked-ip-address`. 

### QA Results

I set up a local test against an agent built off of this branch. 

Confirmed that `peer.hostname:blocked-ip-address` when querying the stats. 

<img width="825" alt="image" src="https://github.com/user-attachments/assets/457d1cab-8be0-42fc-aabd-5edc43b60014">

Since the backend also applies the same IP address quantization, this isn't sufficient to confirm that the quantization was done by the agent, sso I added a temporary log line to verify that the agent was doing it correctly. 

We can see that `server.address:192.168.1.1` was correctly converted to `server.address:blocked-ip-address`. 

```
2024-08-06 11:59:10 EDT | TRACE | INFO | (pkg/trace/stats/aggregation.go:112 in NewAggregationFromSpan) | NewAggregationFromSpan originalMeta=map[env:local-dev language:go runtime-id:93c4a74f-b793-4d24-95c6-ed77fa9c8420 server.address:192.168.1.1 span.kind:client] peerTags=[server.address:blocked-ip-address]
```
