### PR TITLE
fix(installer): Retry layer extracts on upstream internal errors

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -8,12 +8,14 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -24,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/net/http2"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
@@ -55,7 +58,8 @@ const (
 )
 
 const (
-	layerMaxSize = 3 << 30 // 3GiB
+	layerMaxSize        = 3 << 30 // 3GiB
+	extractLayerRetries = 3
 )
 
 // DownloadedPackage is the downloaded package.
@@ -237,14 +241,30 @@ func (d *DownloadedPackage) ExtractLayers(mediaType types.MediaType, dir string)
 			return fmt.Errorf("could not get layer media type: %w", err)
 		}
 		if layerMediaType == mediaType {
-			uncompressedLayer, err := layer.Uncompressed()
-			if err != nil {
-				return fmt.Errorf("could not uncompress layer: %w", err)
-			}
-			defer uncompressedLayer.Close()
-			err = tar.Extract(uncompressedLayer, dir, layerMaxSize)
-			if err != nil {
-				return fmt.Errorf("could not extract layer: %w", err)
+			// Retry stream reset errors
+			for i := 0; i < extractLayerRetries; i++ {
+				if i > 0 {
+					time.Sleep(time.Second)
+				}
+				uncompressedLayer, err := layer.Uncompressed()
+				if err != nil {
+					return fmt.Errorf("could not uncompress layer: %w", err)
+				}
+				err = tar.Extract(uncompressedLayer, dir, layerMaxSize)
+				uncompressedLayer.Close()
+				if err != nil {
+					if !isStreamResetError(err) {
+						return fmt.Errorf("could not extract layer: %w", err)
+					}
+					log.Warnf("stream error while extracting layer, retrying")
+					// Clean up the directory before retrying to avoid partial extraction
+					err = tar.Clean(dir)
+					if err != nil {
+						return fmt.Errorf("could not clean directory: %w", err)
+					}
+				} else {
+					break
+				}
 			}
 		}
 	}
@@ -272,4 +292,20 @@ func PackageURL(env *env.Env, pkg string, version string) string {
 	default:
 		return fmt.Sprintf("oci://gcr.io/datadoghq/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	}
+}
+
+// isStreamResetError returns true if the given error is a stream reset error.
+// Sometimes, in GCR, the tar extract fails with "stream error: stream ID x; INTERNAL_ERROR; received from peer".
+// This happens because the uncompressed layer reader is a http/2 response body under the hood. That body is
+// streamed and receives a "reset stream frame", with the code 0x2 (INTERNAL_ERROR). This is an error from the server
+// that we need to retry.
+func isStreamResetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	serr := http2.StreamError{}
+	if !errors.As(err, &serr) {
+		return false
+	}
+	return serr.Code == http2.ErrCodeInternal
 }

--- a/pkg/fleet/internal/oci/download_test.go
+++ b/pkg/fleet/internal/oci/download_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/http2"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/fixtures"
@@ -209,6 +210,40 @@ func TestPackageURL(t *testing.T) {
 			if actual != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, actual)
 			}
+		})
+	}
+}
+
+func TestIsStreamResetError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non stream reset error",
+			err:      assert.AnError,
+			expected: false,
+		},
+		{
+			name:     "stream error - other error",
+			err:      http2.StreamError{Code: http2.ErrCodeStreamClosed},
+			expected: false,
+		},
+		{
+			name:     "stream error - internal error",
+			err:      http2.StreamError{Code: http2.ErrCodeInternal},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isStreamResetError(tc.err))
 		})
 	}
 }

--- a/pkg/fleet/internal/tar/tar.go
+++ b/pkg/fleet/internal/tar/tar.go
@@ -93,3 +93,18 @@ func extractFile(targetPath string, reader io.Reader, mode fs.FileMode) error {
 	}
 	return nil
 }
+
+// Clean remove all files and directories in the destination path but not the destination path itself
+func Clean(destinationPath string) error {
+	files, err := os.ReadDir(destinationPath)
+	if err != nil {
+		return fmt.Errorf("could not list files in %s: %w", destinationPath, err)
+	}
+	for _, file := range files {
+		err := os.RemoveAll(filepath.Join(destinationPath, file.Name()))
+		if err != nil {
+			return fmt.Errorf("could not remove %s: %w", file.Name(), err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
Retries call to `tar.Extract` in case of stream errors. 
Sometimes, in GCR, the tar extract fails with `stream error: stream ID x; INTERNAL_ERROR; received from peer`. This happens because the uncompressed layer reader is a http/2 response body under the hood. That body is streamed and receives a reset stream frame, with the code `0x2` (`INTERNAL_ERROR`). This is an error from the remote server. While it's not clear why this error happens, it seems to be out of our control and we need to retry when we hit it.

### Motivation
Fix flaky tests & customers that may experience this

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
Slower time to download packages

### Describe how to test/QA your changes
N/A
