### PR TITLE
[ASCII-2120] Add timeout to providers in flare `Create` function

### DIFF
--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -163,7 +163,7 @@ func (f *flare) Create(pdata ProfileData, ipcError error) (string, error) {
 	if fb.IsLocal() {
 		// If we have a ipcError we failed to reach the agent process, else the user requested a local flare
 		// from the CLI.
-		msg := []byte("local flare was requested")
+		msg := []byte(fmt.Sprintf("local flare was requested\nFlare creation time: %s", time.Now().Format(time.RFC3339)))
 		if ipcError != nil {
 			msg = []byte(fmt.Sprintf("unable to contact the agent to retrieve flare: %s", ipcError))
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR add a timeout of 15 second to every providers for the creation of flares
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/ASCII-1882
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Profiles are created before the call of `Create` flare function, it should not impact timeouts
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
