### PR TITLE
usm: Refactor monitors to use common uprobe attacher

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -477,6 +477,7 @@ func (ua *UprobeAttacher) Sync(trackCreations, trackDeletions bool) error {
 	var deletionCandidates map[uint32]struct{}
 	if trackDeletions {
 		deletionCandidates = ua.fileRegistry.GetRegisteredProcesses()
+		fmt.Println("deletionCandidates", deletionCandidates)
 	}
 	thisPID, err := kernel.RootNSPID()
 	if err != nil {

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -477,7 +477,6 @@ func (ua *UprobeAttacher) Sync(trackCreations, trackDeletions bool) error {
 	var deletionCandidates map[uint32]struct{}
 	if trackDeletions {
 		deletionCandidates = ua.fileRegistry.GetRegisteredProcesses()
-		fmt.Println("deletionCandidates", deletionCandidates)
 	}
 	thisPID, err := kernel.RootNSPID()
 	if err != nil {

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -151,7 +151,7 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 			return nil, errors.New("goTLS support requires runtime-compilation or CO-RE to be enabled")
 		}
 
-		attacherCfg := &uprobes.AttacherConfig{
+		attacherCfg := uprobes.AttacherConfig{
 			EbpfConfig: &c.Config,
 			Rules: []*uprobes.AttachRule{{
 				Targets: uprobes.AttachToExecutable,

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -166,6 +166,13 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 						},
 					},
 				},
+				ProbeOptionsOverride: map[string]uprobes.ProbeOptions{
+					connReadProbe:     {IsManualReturn: false, Symbol: bininspect.ReadGoTLSFunc},
+					connReadRetProbe:  {IsManualReturn: true, Symbol: bininspect.ReadGoTLSFunc},
+					connWriteProbe:    {IsManualReturn: false, Symbol: bininspect.WriteGoTLSFunc},
+					connWriteRetProbe: {IsManualReturn: true, Symbol: bininspect.WriteGoTLSFunc},
+					connCloseProbe:    {IsManualReturn: false, Symbol: bininspect.CloseGoTLSFunc},
+				},
 			}},
 			ExcludeTargets:     (uprobes.ExcludeSelf | uprobes.ExcludeInternal),
 			PerformInitialScan: true,

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -177,8 +177,12 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 					connCloseProbe:    {IsManualReturn: false, Symbol: bininspect.CloseGoTLSFunc},
 				},
 			}},
-			ExcludeTargets:     (uprobes.ExcludeSelf | uprobes.ExcludeInternal),
+			ExcludeTargets:     uprobes.ExcludeInternal,
 			PerformInitialScan: true,
+		}
+
+		if c.GoTLSExcludeSelf {
+			attacherCfg.ExcludeTargets |= uprobes.ExcludeSelf
 		}
 
 		inspector := &GoTLSBinaryInspector{

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -93,14 +93,6 @@ type goTLSProgram struct {
 
 	// Path to the process/container's procfs
 	procRoot string
-
-	// binAnalysisMetric handles telemetry on the time spent doing binary
-	// analysis
-	binAnalysisMetric *libtelemetry.Counter
-
-	// binNoSymbolsMetric counts Golang binaries without symbols.
-	binNoSymbolsMetric *libtelemetry.Counter
-
 	registry *utils.FileRegistry
 }
 
@@ -190,6 +182,7 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 			structFieldsLookupFunctions: structFieldsLookupFunctions,
 			paramLookupFunctions:        paramLookupFunctions,
 			binAnalysisMetric:           libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
+			binNoSymbolsMetric:          libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
 		}
 
 		attacher, err := uprobes.NewUprobeAttacher(UsmGoTLSAttacherName, attacherCfg, m, nil, inspector)
@@ -198,13 +191,11 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 		}
 
 		return &goTLSProgram{
-			cfg:                c,
-			manager:            m,
-			procRoot:           c.ProcRoot,
-			inspector:          inspector,
-			binAnalysisMetric:  libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
-			binNoSymbolsMetric: libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
-			attacher:           attacher,
+			cfg:       c,
+			manager:   m,
+			procRoot:  c.ProcRoot,
+			inspector: inspector,
+			attacher:  attacher,
 		}, nil
 	}
 }

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -44,6 +44,9 @@ const (
 	connWriteProbe    = "uprobe__crypto_tls_Conn_Write"
 	connWriteRetProbe = "uprobe__crypto_tls_Conn_Write__return"
 	connCloseProbe    = "uprobe__crypto_tls_Conn_Close"
+
+	// UsmGoTLSAttacherName holds the name used for the uprobe attacher of go-tls programs. Used for tests.
+	UsmGoTLSAttacherName = "usm_gotls"
 )
 
 type uprobesInfo struct {
@@ -184,7 +187,7 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 			binAnalysisMetric:           libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
 		}
 
-		attacher, err := uprobes.NewUprobeAttacher("usm_gotls", attacherCfg, m, nil, inspector)
+		attacher, err := uprobes.NewUprobeAttacher(UsmGoTLSAttacherName, attacherCfg, m, nil, inspector)
 		if err != nil {
 			return nil, fmt.Errorf("Cannot create uprobe attacher: %w", err)
 		}

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -177,8 +177,9 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 					connCloseProbe:    {IsManualReturn: false, Symbol: bininspect.CloseGoTLSFunc},
 				},
 			}},
-			ExcludeTargets:     uprobes.ExcludeInternal,
-			PerformInitialScan: true,
+			ExcludeTargets:                 uprobes.ExcludeInternal,
+			PerformInitialScan:             true,
+			EnablePeriodicScanNewProcesses: false,
 		}
 
 		if c.GoTLSExcludeSelf {

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -87,6 +87,7 @@ func (p *GoTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.
 	return inspectionResult.Functions, true, nil
 }
 
+// Cleanup removes the inspection result for the binary at the given path from the map.
 func (p *GoTLSBinaryInspector) Cleanup(fpath utils.FilePath) {
 	p.removeInspectionResultFromMap(fpath.ID)
 }

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -61,9 +61,14 @@ func (p *GoTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.
 
 	functionsConfig := make(map[string]bininspect.FunctionConfiguration, len(requests))
 	for _, req := range requests {
+		lookupFunc, ok := p.paramLookupFunctions[req.Name]
+		if !ok {
+			return nil, false, fmt.Errorf("no parameter lookup function found for function %s", req.Name)
+		}
+
 		functionsConfig[req.Name] = bininspect.FunctionConfiguration{
 			IncludeReturnLocations: req.IncludeReturnLocations,
-			ParamLookupFunction:    p.paramLookupFunctions[req.Name],
+			ParamLookupFunction:    lookupFunc,
 		}
 	}
 

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -446,11 +446,12 @@ func newSSLProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactory 
 				},
 			}
 			attacherConfig := uprobes.AttacherConfig{
-				ProcRoot:           procRoot,
-				Rules:              rules,
-				ExcludeTargets:     uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
-				EbpfConfig:         &c.Config,
-				PerformInitialScan: true,
+				ProcRoot:                       procRoot,
+				Rules:                          rules,
+				ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
+				EbpfConfig:                     &c.Config,
+				PerformInitialScan:             true,
+				EnablePeriodicScanNewProcesses: false,
 			}
 
 			attacher, err = uprobes.NewUprobeAttacher(UsmTLSAttacherName, attacherConfig, m, nil, &uprobes.NativeBinaryInspector{})

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -442,7 +442,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactory 
 					LibraryNameRegex: regexp.MustCompile(`libgnutls.so`),
 				},
 			}
-			attacherConfig := &uprobes.AttacherConfig{
+			attacherConfig := uprobes.AttacherConfig{
 				ProcRoot:           procRoot,
 				Rules:              rules,
 				ExcludeTargets:     uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -55,6 +55,9 @@ const (
 	gnutlsRecordSendRetprobe    = "uretprobe__gnutls_record_send"
 	gnutlsByeProbe              = "uprobe__gnutls_bye"
 	gnutlsDeinitProbe           = "uprobe__gnutls_deinit"
+
+	// UsmTLSAttacherName holds the name used for the uprobe attacher of tls programs. Used for tests.
+	UsmTLSAttacherName = "usm_tls"
 )
 
 var openSSLProbes = []manager.ProbesSelector{
@@ -450,7 +453,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactory 
 				PerformInitialScan: true,
 			}
 
-			attacher, err = uprobes.NewUprobeAttacher("usm_tls", attacherConfig, m, nil, &uprobes.NativeBinaryInspector{})
+			attacher, err = uprobes.NewUprobeAttacher(UsmTLSAttacherName, attacherConfig, m, nil, &uprobes.NativeBinaryInspector{})
 			if err != nil {
 				return nil, fmt.Errorf("error initializing uprobes attacher: %s", err)
 			}

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -483,7 +483,12 @@ func (o *sslProgram) ConfigureOptions(_ *manager.Manager, options *manager.Optio
 
 // PreStart is called before the start of the provided eBPF manager.
 func (o *sslProgram) PreStart(*manager.Manager) error {
-	o.attacher.Start()
+	if o.attacher != nil {
+		err := o.attacher.Start()
+		if err != nil {
+			return err
+		}
+	}
 	o.istioMonitor.Start()
 	o.nodeJSMonitor.Start()
 	return nil
@@ -496,7 +501,9 @@ func (o *sslProgram) PostStart(*manager.Manager) error {
 
 // Stop stops the program.
 func (o *sslProgram) Stop(*manager.Manager) {
-	o.attacher.Stop()
+	if o.attacher != nil {
+		o.attacher.Stop()
+	}
 	o.istioMonitor.Stop()
 	o.nodeJSMonitor.Stop()
 }

--- a/pkg/network/usm/ebpf_ssl_test.go
+++ b/pkg/network/usm/ebpf_ssl_test.go
@@ -13,12 +13,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	fileopener "github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/stretchr/testify/require"
 )
 
 func testArch(t *testing.T, arch string) {
@@ -43,9 +44,9 @@ func testArch(t *testing.T, arch string) {
 	require.NoError(t, err)
 
 	if arch == runtime.GOARCH {
-		utils.WaitForProgramsToBeTraced(t, "shared_libraries", cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
+		utils.WaitForProgramsToBeTraced(t, UsmTLSAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 	} else {
-		utils.WaitForPathToBeBlocked(t, "shared_libraries", lib)
+		utils.WaitForPathToBeBlocked(t, UsmTLSAttacherName, lib)
 	}
 }
 

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -20,6 +20,8 @@ import (
 const (
 	istioSslReadRetprobe  = "istio_uretprobe__SSL_read"
 	istioSslWriteRetprobe = "istio_uretprobe__SSL_write"
+
+	IstioAttacherName = "istio"
 )
 
 var istioProbes = []manager.ProbesSelector{
@@ -101,7 +103,7 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
 	}
 
-	attacher, err := uprobes.NewUprobeAttacher("istio", attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	attacher, err := uprobes.NewUprobeAttacher(IstioAttacherName, attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
 	if err != nil {
 		log.Errorf("Cannot create uprobe attacher: %v", err)
 	}

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -92,7 +91,7 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 	}
 
 	attachCfg := uprobes.AttacherConfig{
-		ProcRoot: kernel.ProcFSRoot(),
+		ProcRoot: c.ProcRoot,
 		Rules: []*uprobes.AttachRule{{
 			Targets:          uprobes.AttachToExecutable,
 			ProbesSelector:   nodeJSProbes,
@@ -117,7 +116,7 @@ func (m *istioMonitor) Start() {
 		return
 	}
 
-	m.attacher.Start()
+	_ = m.attacher.Start()
 	log.Info("Istio monitoring enabled")
 }
 
@@ -132,7 +131,6 @@ func (m *istioMonitor) Stop() {
 
 // isIstioBinary checks whether the given file is an istioBinary, based on the expected envoy
 // command substring (as defined by m.envoyCmd).
-func (m *istioMonitor) isIstioBinary(path string, procInfo *uprobes.ProcInfo) bool {
-	exec, err := procInfo.Exe()
-	return err == nil && strings.Contains(exec, m.envoyCmd)
+func (m *istioMonitor) isIstioBinary(path string, _ *uprobes.ProcInfo) bool {
+	return strings.Contains(path, m.envoyCmd)
 }

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -100,7 +100,7 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 			ExecutableFilter: monitor.isIstioBinary,
 		}},
 		EbpfConfig:                     &c.Config,
-		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
 		EnablePeriodicScanNewProcesses: true,
 	}
 

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -101,7 +101,7 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
 	}
 
-	attacher, err := uprobes.NewUprobeAttacher("istio", &attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	attacher, err := uprobes.NewUprobeAttacher("istio", attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
 	if err != nil {
 		log.Errorf("Cannot create uprobe attacher: %v", err)
 	}

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -8,17 +8,14 @@
 package usm
 
 import (
-	"fmt"
 	"strings"
-	"sync"
-	"time"
 
+	manager "github.com/DataDog/ebpf-manager"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -80,64 +77,38 @@ var istioProbes = []manager.ProbesSelector{
 // because the Envoy binary embedded in the Istio containers have debug symbols
 // whereas the "vanilla" Envoy images are distributed without them.
 type istioMonitor struct {
-	registry *utils.FileRegistry
-	procRoot string
+	attacher *uprobes.UprobeAttacher
 	envoyCmd string
-
-	// `utils.FileRegistry` callbacks
-	registerCB   func(utils.FilePath) error
-	unregisterCB func(utils.FilePath) error
-
-	// Termination
-	wg   sync.WaitGroup
-	done chan struct{}
 }
-
-// Validate that istioMonitor implements the Attacher interface.
-var _ utils.Attacher = &istioMonitor{}
 
 func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 	if !c.EnableIstioMonitoring {
 		return nil
 	}
 
-	procRoot := kernel.ProcFSRoot()
-	return &istioMonitor{
-		registry: utils.NewFileRegistry("istio"),
-		procRoot: procRoot,
+	monitor := &istioMonitor{
 		envoyCmd: c.EnvoyPath,
-		done:     make(chan struct{}),
-
-		// Callbacks
-		registerCB:   addHooks(mgr, procRoot, istioProbes),
-		unregisterCB: removeHooks(mgr, istioProbes),
-	}
-}
-
-// DetachPID detaches a given pid from the eBPF program
-func (m *istioMonitor) DetachPID(pid uint32) error {
-	return m.registry.Unregister(pid)
-}
-
-var (
-	// ErrNoEnvoyPath is returned when no envoy path is found for a given PID
-	ErrNoEnvoyPath = fmt.Errorf("no envoy path found for PID")
-)
-
-// AttachPID attaches a given pid to the eBPF program
-func (m *istioMonitor) AttachPID(pid uint32) error {
-	path := m.getEnvoyPath(pid)
-	if path == "" {
-		return ErrNoEnvoyPath
+		attacher: nil,
 	}
 
-	return m.registry.Register(
-		path,
-		pid,
-		m.registerCB,
-		m.unregisterCB,
-		utils.IgnoreCB,
-	)
+	attachCfg := uprobes.AttacherConfig{
+		ProcRoot: kernel.ProcFSRoot(),
+		Rules: []*uprobes.AttachRule{{
+			Targets:          uprobes.AttachToExecutable,
+			ProbesSelector:   nodeJSProbes,
+			ExecutableFilter: monitor.isIstioBinary,
+		}},
+		EbpfConfig:     &c.Config,
+		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+	}
+
+	attacher, err := uprobes.NewUprobeAttacher("istio", &attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	if err != nil {
+		log.Errorf("Cannot create uprobe attacher: %v", err)
+	}
+
+	monitor.attacher = attacher
+	return monitor
 }
 
 // Start the istioMonitor
@@ -146,48 +117,7 @@ func (m *istioMonitor) Start() {
 		return
 	}
 
-	processMonitor := monitor.GetProcessMonitor()
-
-	// Subscribe to process events
-	doneExec := processMonitor.SubscribeExec(m.handleProcessExec)
-	doneExit := processMonitor.SubscribeExit(m.handleProcessExit)
-
-	// Attach to existing processes
-	m.sync()
-
-	m.wg.Add(1)
-	go func() {
-		// This ticker is responsible for controlling the rate at which
-		// we scrape the whole procFS again in order to ensure that we
-		// terminate any dangling uprobes and register new processes
-		// missed by the process monitor stream
-		processSync := time.NewTicker(scanTerminatedProcessesInterval)
-
-		defer func() {
-			processSync.Stop()
-			// Execute process monitor callback termination functions
-			doneExec()
-			doneExit()
-			// Stopping the process monitor (if we're the last instance)
-			processMonitor.Stop()
-			// Cleaning up all active hooks
-			m.registry.Clear()
-			// marking we're finished.
-			m.wg.Done()
-		}()
-
-		for {
-			select {
-			case <-m.done:
-				return
-			case <-processSync.C:
-				m.sync()
-				m.registry.Log()
-			}
-		}
-	}()
-
-	utils.AddAttacher("istio", m)
+	m.attacher.Start()
 	log.Info("Istio monitoring enabled")
 }
 
@@ -197,62 +127,12 @@ func (m *istioMonitor) Stop() {
 		return
 	}
 
-	close(m.done)
-	m.wg.Wait()
+	m.attacher.Stop()
 }
 
-// sync state of istioMonitor with the current state of procFS
-// the purpose of this method is two-fold:
-// 1) register processes for which we missed exec events (targeted mostly at startup)
-// 2) unregister processes for which we missed exit events
-func (m *istioMonitor) sync() {
-	deletionCandidates := m.registry.GetRegisteredProcesses()
-
-	_ = kernel.WithAllProcs(m.procRoot, func(pid int) error {
-		if _, ok := deletionCandidates[uint32(pid)]; ok {
-			// We have previously hooked into this process and it remains active,
-			// so we remove it from the deletionCandidates list, and move on to the next PID
-			delete(deletionCandidates, uint32(pid))
-			return nil
-		}
-
-		// This is a new PID so we attempt to attach SSL probes to it
-		_ = m.AttachPID(uint32(pid))
-		return nil
-	})
-
-	// At this point all entries from deletionCandidates are no longer alive, so
-	// we should detach our SSL probes from them
-	for pid := range deletionCandidates {
-		m.handleProcessExit(pid)
-	}
-}
-
-func (m *istioMonitor) handleProcessExit(pid uint32) {
-	// We avoid filtering PIDs here because it's cheaper to simply do a registry lookup
-	// instead of fetching a process name in order to determine whether it is an
-	// envoy process or not (which at the very minimum involves syscalls)
-	_ = m.DetachPID(pid)
-}
-
-func (m *istioMonitor) handleProcessExec(pid uint32) {
-	_ = m.AttachPID(pid)
-}
-
-// getEnvoyPath returns the executable path of the envoy binary for a given PID.
-// It constructs the path to the symbolic link for the executable file of the process with the given PID,
-// then resolves this symlink to determine the actual path of the binary.
-//
-// If the resolved path contains the expected envoy command substring (as defined by m.envoyCmd),
-// the function returns this path. If the PID does not correspond to an envoy process or if an error
-// occurs during resolution, it returns an empty string.
-func (m *istioMonitor) getEnvoyPath(pid uint32) string {
-	exePath := fmt.Sprintf("%s/%d/exe", m.procRoot, pid)
-
-	envoyPath, err := utils.ResolveSymlink(exePath)
-	if err != nil || !strings.Contains(envoyPath, m.envoyCmd) {
-		return ""
-	}
-
-	return envoyPath
+// isIstioBinary checks whether the given file is an istioBinary, based on the expected envoy
+// command substring (as defined by m.envoyCmd).
+func (m *istioMonitor) isIstioBinary(path string, procInfo *uprobes.ProcInfo) bool {
+	exec, err := procInfo.Exe()
+	return err == nil && strings.Contains(exec, m.envoyCmd)
 }

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -99,8 +99,9 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) *istioMonitor {
 			ProbesSelector:   nodeJSProbes,
 			ExecutableFilter: monitor.isIstioBinary,
 		}},
-		EbpfConfig:     &c.Config,
-		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		EbpfConfig:                     &c.Config,
+		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		EnablePeriodicScanNewProcesses: true,
 	}
 
 	attacher, err := uprobes.NewUprobeAttacher(IstioAttacherName, attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})

--- a/pkg/network/usm/istio_test.go
+++ b/pkg/network/usm/istio_test.go
@@ -62,7 +62,7 @@ func TestIstioSync(t *testing.T) {
 		mockRegistry.On("Register", defaultEnvoyName, uint32(3), mock.Anything, mock.Anything).Return(nil)
 
 		// Calling sync should detect the two envoy processes
-		monitor.attacher.Sync(true)
+		monitor.attacher.Sync(true, true)
 
 		mockRegistry.AssertExpectations(tt)
 	})
@@ -80,7 +80,7 @@ func TestIstioSync(t *testing.T) {
 		mockRegistry.On("GetRegisteredProcesses").Return(map[uint32]struct{}{})
 		mockRegistry.On("Register", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil) // Tell the mock to just say ok to everything, we'll validate later
 
-		monitor.attacher.Sync(true)
+		monitor.attacher.Sync(true, true)
 
 		mockRegistry.AssertCalled(tt, "Register", defaultEnvoyName, uint32(1), mock.Anything, mock.Anything)
 		mockRegistry.AssertCalled(tt, "Register", defaultEnvoyName, uint32(3), mock.Anything, mock.Anything)
@@ -105,7 +105,7 @@ func TestIstioSync(t *testing.T) {
 
 		// Once we call sync() again, PID 3 termination should be detected
 		// and the unregister callback should be executed
-		monitor.attacher.Sync(true)
+		monitor.attacher.Sync(true, true)
 		mockRegistry.AssertCalled(tt, "Unregister", uint32(3))
 	})
 }

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -538,7 +538,7 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 			})
 			monitor := newKafkaMonitor(t, cfg)
 			if tls && cfg.EnableGoTLSSupport {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 			tt.testBody(t, &tt.context, monitor)
 		})
@@ -1136,7 +1136,7 @@ func testKafkaFetchRaw(t *testing.T, tls bool, apiVersion int) {
 
 	monitor := newKafkaMonitor(t, getDefaultTestConfiguration(tls))
 	if tls {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyPid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyPid, utils.ManualTracingFallbackEnabled)
 	}
 
 	for _, tt := range tests {
@@ -1361,7 +1361,7 @@ func testKafkaProduceRaw(t *testing.T, tls bool, apiVersion int) {
 
 	monitor := newKafkaMonitor(t, getDefaultTestConfiguration(tls))
 	if tls {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyPid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyPid, utils.ManualTracingFallbackEnabled)
 	}
 
 	for _, tt := range tests {

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -181,7 +181,7 @@ func (s *tlsSuite) TestHTTPSViaLibraryIntegration() {
 func testHTTPSLibrary(t *testing.T, cfg *config.Config, fetchCmd, prefetchLibs []string) {
 	usmMonitor := setupUSMTLSMonitor(t, cfg)
 	// not ideal but, short process are hard to catch
-	utils.WaitForProgramsToBeTraced(t, "shared_libraries", prefetchLib(t, prefetchLibs...).Process.Pid, utils.ManualTracingFallbackDisabled)
+	utils.WaitForProgramsToBeTraced(t, UsmTLSAttacherName, prefetchLib(t, prefetchLibs...).Process.Pid, utils.ManualTracingFallbackDisabled)
 
 	// Issue request using fetchCmd (wget, curl, ...)
 	// This is necessary (as opposed to using net/http) because we want to
@@ -196,7 +196,7 @@ func testHTTPSLibrary(t *testing.T, cfg *config.Config, fetchCmd, prefetchLibs [
 	requestCmd.Stderr = requestCmd.Stdout
 	require.NoError(t, requestCmd.Start())
 
-	utils.WaitForProgramsToBeTraced(t, "shared_libraries", requestCmd.Process.Pid, utils.ManualTracingFallbackDisabled)
+	utils.WaitForProgramsToBeTraced(t, UsmTLSAttacherName, requestCmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 
 	if err := requestCmd.Wait(); err != nil {
 		output, err := io.ReadAll(stdout)
@@ -283,7 +283,7 @@ func (s *tlsSuite) TestOpenSSLVersions() {
 		EnableTLS: true,
 	})
 
-	utils.WaitForProgramsToBeTraced(t, "shared_libraries", cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, UsmTLSAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
 
 	client, requestFn := simpleGetRequestsGenerator(t, addressOfHTTPPythonServer)
 	var requests []*nethttp.Request
@@ -350,7 +350,7 @@ func (s *tlsSuite) TestOpenSSLVersionsSlowStart() {
 
 	usmMonitor := setupUSMTLSMonitor(t, cfg)
 	// Giving the tracer time to install the hooks
-	utils.WaitForProgramsToBeTraced(t, "shared_libraries", cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, UsmTLSAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
 
 	// Send a warmup batch of requests to trigger the fallback behavior
 	for i := 0; i < numberOfRequests; i++ {
@@ -650,7 +650,7 @@ func TestOldConnectionRegression(t *testing.T) {
 		usmMonitor := setupUSMTLSMonitor(t, cfg)
 
 		// Ensure this test program is being traced
-		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
 
 		// The HTTPServer used here effectively works as an "echo" servers and
 		// returns back in the response whatever it received in the request
@@ -721,7 +721,7 @@ func TestLimitListenerRegression(t *testing.T) {
 		usmMonitor := setupUSMTLSMonitor(t, cfg)
 
 		// Ensure this test program is being traced
-		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
 
 		// Issue multiple HTTP requests
 		for i := 0; i < 10; i++ {
@@ -781,7 +781,7 @@ func testHTTPGoTLSCaptureNewProcess(t *testing.T, cfg *config.Config, isHTTP2 bo
 
 	// spin-up goTLS client and issue requests after initialization
 	command, runRequests := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences, isHTTP2)
-	utils.WaitForProgramsToBeTraced(t, "go-tls", command.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, command.Process.Pid, utils.ManualTracingFallbackEnabled)
 	runRequests()
 	checkRequests(t, usmMonitor, expectedOccurrences, reqs, isHTTP2)
 }
@@ -818,7 +818,7 @@ func testHTTPGoTLSCaptureAlreadyRunning(t *testing.T, cfg *config.Config, isHTTP
 		reqs[req] = false
 	}
 
-	utils.WaitForProgramsToBeTraced(t, "go-tls", command.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, command.Process.Pid, utils.ManualTracingFallbackEnabled)
 	issueRequestsFn()
 	checkRequests(t, usmMonitor, expectedOccurrences, reqs, isHTTP2)
 }

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -990,7 +990,7 @@ func (s *tlsSuite) TestNodeJSTLS() {
 	cfg.EnableNodeJSMonitoring = true
 
 	usmMonitor := setupUSMTLSMonitor(t, cfg)
-	utils.WaitForProgramsToBeTraced(t, "nodejs", int(nodeJSPID), utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, NodeJsAttacherName, int(nodeJSPID), utils.ManualTracingFallbackEnabled)
 
 	// This maps will keep track of whether the tracer saw this request already or not
 	client, requestFn := simpleGetRequestsGenerator(t, fmt.Sprintf("localhost:%s", serverPort))

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -123,7 +123,7 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) *nodeJSMonitor {
 		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
 	}
 
-	attacher, err := uprobes.NewUprobeAttacher("nodejs-tls", &attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	attacher, err := uprobes.NewUprobeAttacher("nodejs-tls", attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
 	if err != nil {
 		log.Errorf("Cannot create uprobe attacher: %v", err)
 	}

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -8,19 +8,12 @@
 package usm
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -111,35 +104,32 @@ var (
 // nodeJSMonitor essentially scans for Node processes and attaches SSL uprobes
 // to them.
 type nodeJSMonitor struct {
-	registry *utils.FileRegistry
-	procRoot string
-
-	// `utils.FileRegistry` callbacks
-	registerCB   func(utils.FilePath) error
-	unregisterCB func(utils.FilePath) error
-
-	// Termination
-	wg   sync.WaitGroup
-	done chan struct{}
+	attacher *uprobes.UprobeAttacher
 }
-
-// Validate that nodeJSMonitor implements the Attacher interface.
-var _ utils.Attacher = &nodeJSMonitor{}
 
 func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) *nodeJSMonitor {
 	if !c.EnableNodeJSMonitoring {
 		return nil
 	}
 
-	procRoot := kernel.ProcFSRoot()
-	return &nodeJSMonitor{
-		registry: utils.NewFileRegistry("nodejs"),
-		procRoot: procRoot,
-		done:     make(chan struct{}),
+	attachCfg := uprobes.AttacherConfig{
+		ProcRoot: kernel.ProcFSRoot(),
+		Rules: []*uprobes.AttachRule{{
+			Targets:          uprobes.AttachToExecutable,
+			ProbesSelector:   nodeJSProbes,
+			ExecutableFilter: isNodeJSBinary,
+		}},
+		EbpfConfig:     &c.Config,
+		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+	}
 
-		// Callbacks
-		registerCB:   addHooks(mgr, procRoot, nodeJSProbes),
-		unregisterCB: removeHooks(mgr, nodeJSProbes),
+	attacher, err := uprobes.NewUprobeAttacher("nodejs-tls", &attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	if err != nil {
+		log.Errorf("Cannot create uprobe attacher: %v", err)
+	}
+
+	return &nodeJSMonitor{
+		attacher: attacher,
 	}
 }
 
@@ -149,47 +139,7 @@ func (m *nodeJSMonitor) Start() {
 		return
 	}
 
-	processMonitor := monitor.GetProcessMonitor()
-
-	// Subscribe to process events
-	doneExec := processMonitor.SubscribeExec(m.handleProcessExec)
-	doneExit := processMonitor.SubscribeExit(m.handleProcessExit)
-
-	// Attach to existing processes
-	m.sync()
-
-	m.wg.Add(1)
-	go func() {
-		// This ticker is responsible for controlling the rate at which
-		// we scrape the whole procFS again in order to ensure that we
-		// terminate any dangling uprobes and register new processes
-		// missed by the process monitor stream
-		processSync := time.NewTicker(scanTerminatedProcessesInterval)
-
-		defer func() {
-			processSync.Stop()
-			// Execute process monitor callback termination functions
-			doneExec()
-			doneExit()
-			// Stopping the process monitor (if we're the last instance)
-			processMonitor.Stop()
-			// Cleaning up all active hooks
-			m.registry.Clear()
-			// marking we're finished.
-			m.wg.Done()
-		}()
-
-		for {
-			select {
-			case <-m.done:
-				return
-			case <-processSync.C:
-				m.sync()
-				m.registry.Log()
-			}
-		}
-	}()
-	utils.AddAttacher("nodejs-tls", m)
+	m.attacher.Start()
 	log.Info("Node JS TLS monitoring enabled")
 }
 
@@ -199,101 +149,14 @@ func (m *nodeJSMonitor) Stop() {
 		return
 	}
 
-	close(m.done)
-	m.wg.Wait()
+	m.attacher.Stop()
 }
 
-// DetachPID detaches a given pid from the eBPF program
-func (m *nodeJSMonitor) DetachPID(pid uint32) error {
-	// We avoid filtering PIDs here because it's cheaper to simply do a registry lookup
-	// instead of fetching a process name in order to determine whether it is an
-	// envoy process or not (which at the very minimum involves syscalls)
-	return m.registry.Unregister(pid)
-}
-
-var (
-	// ErrNoNodeJSPath is returned when no nodejs path is found for a given PID
-	ErrNoNodeJSPath = errors.New("no nodejs path found for PID")
-)
-
-// AttachPID attaches a given pid to the eBPF program
-func (m *nodeJSMonitor) AttachPID(pid uint32) error {
-	path := m.getNodeJSPath(pid)
-	if path == "" {
-		return ErrNoNodeJSPath
-	}
-
-	return m.registry.Register(
-		path,
-		pid,
-		m.registerCB,
-		m.unregisterCB,
-		utils.IgnoreCB,
-	)
-}
-
-// sync state of nodeJSMonitor with the current state of procFS
-// the purpose of this method is two-fold:
-// 1) register processes for which we missed exec events (targeted mostly at startup)
-// 2) unregister processes for which we missed exit events
-func (m *nodeJSMonitor) sync() {
-	deletionCandidates := m.registry.GetRegisteredProcesses()
-
-	_ = kernel.WithAllProcs(m.procRoot, func(pid int) error {
-		if _, ok := deletionCandidates[uint32(pid)]; ok {
-			// We have previously hooked into this process and it remains active,
-			// so we remove it from the deletionCandidates list, and move on to the next PID
-			delete(deletionCandidates, uint32(pid))
-			return nil
-		}
-
-		// This is a new PID so we attempt to attach SSL probes to it
-		m.handleProcessExec(uint32(pid))
-		return nil
-	})
-
-	// At this point all entries from deletionCandidates are no longer alive, so
-	// we should detach our SSL probes from them
-	for pid := range deletionCandidates {
-		m.handleProcessExit(pid)
-	}
-}
-
-func (m *nodeJSMonitor) handleProcessExit(pid uint32) {
-	_ = m.DetachPID(pid)
-}
-
-func (m *nodeJSMonitor) handleProcessExec(pid uint32) {
-	_ = m.AttachPID(pid)
-}
-
-// getNodeJSPath returns the executable path of the nodejs binary for a given PID.
-// In case the PID doesn't represent a nodejs process, an empty string is returned.
-func (m *nodeJSMonitor) getNodeJSPath(pid uint32) string {
-	pidAsStr := strconv.FormatUint(uint64(pid), 10)
-	exePath := filepath.Join(m.procRoot, pidAsStr, "exe")
-
-	binPath, err := os.Readlink(exePath)
+// getNodeJSPath checks if the given PID is a NodeJS process and returns the path to the binary
+func isNodeJSBinary(path string, procInfo *uprobes.ProcInfo) bool {
+	exe, err := procInfo.Exe()
 	if err != nil {
-		// We receive the Exec event, /proc could be slow to update
-		end := time.Now().Add(10 * time.Millisecond)
-		for end.After(time.Now()) {
-			binPath, err = os.Readlink(exePath)
-			if err == nil {
-				break
-			}
-			time.Sleep(time.Millisecond)
-		}
+		return false
 	}
-	if err != nil {
-		// we can't access to the binary path here (pid probably ended already)
-		// there are not much we can do, and we don't want to flood the logs
-		return ""
-	}
-
-	if strings.Contains(binPath, nodeJSPath) {
-		return binPath
-	}
-
-	return ""
+	return strings.Contains(exe, nodeJSPath)
 }

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -122,7 +122,7 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) *nodeJSMonitor {
 			ExecutableFilter: isNodeJSBinary,
 		}},
 		EbpfConfig:                     &c.Config,
-		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
 		EnablePeriodicScanNewProcesses: true,
 	}
 

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -25,6 +25,8 @@ const (
 	nodejsSslReadExRetprobe  = "nodejs_uretprobe__SSL_read_ex"
 	nodejsSslWriteRetprobe   = "nodejs_uretprobe__SSL_write"
 	nodejsSslWriteExRetprobe = "nodejs_uretprobe__SSL_write_ex"
+
+	NodeJsAttacherName = "nodejs"
 )
 
 var (
@@ -123,7 +125,7 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) *nodeJSMonitor {
 		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
 	}
 
-	attacher, err := uprobes.NewUprobeAttacher("nodejs-tls", attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
+	attacher, err := uprobes.NewUprobeAttacher(NodeJsAttacherName, attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})
 	if err != nil {
 		log.Errorf("Cannot create uprobe attacher: %v", err)
 	}

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -121,8 +121,9 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) *nodeJSMonitor {
 			ProbesSelector:   nodeJSProbes,
 			ExecutableFilter: isNodeJSBinary,
 		}},
-		EbpfConfig:     &c.Config,
-		ExcludeTargets: uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		EbpfConfig:                     &c.Config,
+		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal,
+		EnablePeriodicScanNewProcesses: true,
 	}
 
 	attacher, err := uprobes.NewUprobeAttacher(NodeJsAttacherName, attachCfg, mgr, nil, &uprobes.NativeBinaryInspector{})

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -185,7 +185,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 
 	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
 	if isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
 	}
 
 	tests := []postgresParsingTestAttributes{

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2409,11 +2409,11 @@ func testProtocolClassificationLinux(t *testing.T, tr *tracer.Tracer, clientHost
 // Wraps the call to the Go-TLS attach function and waits for the program to be traced.
 func goTLSAttachPID(t *testing.T, pid int) {
 	t.Helper()
-	if utils.IsProgramTraced("go-tls", pid) {
+	if utils.IsProgramTraced(usm.UsmGoTLSAttacherName, pid) {
 		return
 	}
 	require.NoError(t, usm.GoTLSAttachPID(uint32(pid)))
-	utils.WaitForProgramsToBeTraced(t, "go-tls", pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, usm.UsmGoTLSAttacherName, pid, utils.ManualTracingFallbackEnabled)
 }
 
 // goTLSDetachPID detaches the Go-TLS monitoring from the given PID.
@@ -2422,13 +2422,13 @@ func goTLSDetachPID(t *testing.T, pid int) {
 	t.Helper()
 
 	// The program is not traced; nothing to do.
-	if !utils.IsProgramTraced("go-tls", pid) {
+	if !utils.IsProgramTraced(usm.UsmGoTLSAttacherName, pid) {
 		return
 	}
 
 	require.NoError(t, usm.GoTLSDetachPID(uint32(pid)))
 
 	require.Eventually(t, func() bool {
-		return !utils.IsProgramTraced("go-tls", pid)
+		return !utils.IsProgramTraced(usm.UsmGoTLSAttacherName, pid)
 	}, 5*time.Second, 100*time.Millisecond, "process %v is still traced by Go-TLS after detaching", pid)
 }

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -115,7 +115,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 
 	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 	// c is a stream endpoint
 	// a + b are unary endpoints
@@ -443,7 +443,7 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 
 	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	// Random string generation is an heavy operation, and it's proportional for the length (15MB)

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -145,7 +145,7 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	clients := getHTTP2UnixClientArray(2, unixPath)
@@ -207,7 +207,7 @@ func (s *usmHTTP2Suite) TestSimpleHTTP2() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	tests := []struct {
@@ -395,7 +395,7 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 		t.Run(tt.name, func(t *testing.T) {
 			monitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			tt.runClients(t, 1)
@@ -450,7 +450,7 @@ func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	const (
@@ -516,7 +516,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 	tests := []struct {
 		name              string
@@ -1314,7 +1314,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)
@@ -1400,7 +1400,7 @@ func (s *usmHTTP2Suite) TestRemainderTable() {
 		t.Run(tt.name, func(t *testing.T) {
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)
@@ -1470,7 +1470,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 		t.Run(tt.name, func(t *testing.T) {
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, UsmGoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR applies the new uprobe attacher introduced in #27663 to the existing USM monitors, unifying features and behavior.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Several tests were performed in the load-test environment, using [the manual QA checklist](https://datadoghq.atlassian.net/wiki/spaces/UT/pages/3884417087/USM+Manual+QA+-+7.56) as a reference. The base version was the agent release 7.55. The commit under test for this branch was [d87ae5175511826d94b6f623798ed8a1e33fcc3e](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/d87ae5175511826d94b6f623798ed8a1e33fcc3e), tests will be repeated before merge with the latest available commit of this branch.

<details>
<summary>soak_test - openssl</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gjulian-uprobes-ssl-base&tpl_var_client-service%5B0%5D=python-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=gjulian-uprobes-ssl-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=python-httpbin-tls&tpl_var_tls.library%5B0%5D=openssl&view=spans&from_ts=1723207636034&to_ts=1723208793343&live=false)

#### Accuracy base

![Screenshot 2024-08-09 at 15 08 57](https://github.com/user-attachments/assets/6121e364-72c1-4717-8689-daafe3f55b71)

#### Accuracy of this branch

![Screenshot 2024-08-09 at 15 09 23](https://github.com/user-attachments/assets/f699fdae-e2f7-49f1-ac58-2c74947b6b0e)

</details>

<details>
<summary>soak_test - gotls</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gjulian-uprobes-gotls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=gjulian-uprobes-gotls-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-httpbin-tls&tpl_var_tls.library%5B0%5D=go&view=spans&from_ts=1723213389607&to_ts=1723290099888&live=false)

#### Accuracy base

<img width="1612" alt="Screenshot 2024-08-12 at 10 14 06" src="https://github.com/user-attachments/assets/b7393247-85bb-4609-ac6a-d15599e5ee83">

#### Accuracy of this branch

<img width="1612" alt="Screenshot 2024-08-12 at 10 14 19" src="https://github.com/user-attachments/assets/72fae5cf-5208-4674-ae23-3ea7cea7151e">

</details>


<details>
<summary>soak_test - istio</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gjulian-uprobes-istio-base&tpl_var_client-service%5B0%5D=golang-k6-client-http&tpl_var_compare_agent-env%5B0%5D=gjulian-uprobes-istio-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-httpbin&tpl_var_tls.library%5B0%5D=istio&view=spans&from_ts=1723454512005&to_ts=1723455108000&live=false)

#### Accuracy base

<img width="1612" alt="Screenshot 2024-08-12 at 11 32 07" src="https://github.com/user-attachments/assets/645ae8a2-6f25-4251-ac37-420ee920819c">


#### Accuracy of this branch

<img width="1612" alt="Screenshot 2024-08-12 at 11 32 25" src="https://github.com/user-attachments/assets/92c76b80-65d1-49c9-b9ad-e33ea15aaccd">


</details>

<details>
<summary>soak_test - nodejs</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gjulian-uprobes-node-base&tpl_var_client-service%5B0%5D=node-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=gjulian-uprobes-node-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=node-httpbin-tls&tpl_var_tls.library%5B0%5D=nodejs&view=spans&from_ts=1724245336902&to_ts=1724246705173&live=false)

#### Accuracy base

<img width="1400" alt="Screenshot 2024-08-21 at 15 25 37" src="https://github.com/user-attachments/assets/f9c840aa-23c9-46e8-938b-4e709327b00a">


#### Accuracy of this branch


<img width="1400" alt="Screenshot 2024-08-21 at 15 25 44" src="https://github.com/user-attachments/assets/e0d90e05-4237-45f2-bfbe-5bbd3ad5661f">

</details>

Additionally, tests were performed with the `process-load-test` configuration to better test the performance impact of the changes, which should be more clear with a higher load of processes being created/stopped. The differences in CPU and memory usages were not significant. The profiling comparisons were also checked and the CPU usage was similar in the changed code. Details:

<details><summary>process-test - openssl</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=gj-up-proc-openssl-base&tpl_var_compare_agent-env%5B0%5D=gj-up-proc-openssl-new&tpl_var_kube_cluster_name%5B0%5D=usm1&view=spans&from_ts=1724408674191&to_ts=1724410474191&live=true) and [profiling comparison](https://dddev.datadoghq.com/profiling/comparison?query=agent-env%3Agj-up-proc-openssl-base%20&compare_end_A=1724411099999&compare_query_A=agent-env%3Agj-up-proc-openssl-base%20service%3Asystem-probe&compare_query_B=agent-env%3Agj-up-proc-openssl-new%20service%3Asystem-probe%20&compare_start_A=1724410689280.7134&compare_start_B=1724410697438.5715&compareValuesMode=absolute&my_code=enabled&refresh_mode=paused&viz=flame_graph&from_ts=1724407461167&to_ts=1724411061167&live=false)

![Screenshot 2024-08-23 at 13 13 26](https://github.com/user-attachments/assets/84bc4c8d-5d9b-470e-9cfa-0d79497f8a0e)
</details>

<details><summary>process-test - go-tls</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gj-up-proc-gotls-base&tpl_var_compare_agent-env%5B0%5D=gj-up-proc-gotls-new&tpl_var_kube_cluster_name%5B0%5D=usm1&view=spans&from_ts=1724412171895&to_ts=1724412826000&live=false) and [profiling comparison](https://dddev.datadoghq.com/profiling/comparison?query=agent-env%3Agj-up-proc-openssl-base%20&compare_end_A=1724412787559&compare_end_B=1724412789840&compare_query_A=agent-env%3Agj-up-proc-gotls-base%20service%3Asystem-probe%20&compare_query_B=agent-env%3Agj-up-proc-gotls-new%20service%3Asystem-probe%20&compare_start_A=1724411887559&compare_start_B=1724411889840&compareValuesMode=absolute&my_code=enabled&refresh_mode=paused&viz=flame_graph&from_ts=1724407461167&to_ts=1724411061167&live=false)

![Screenshot 2024-08-23 at 13 34 33](https://github.com/user-attachments/assets/09276187-bcf6-4d2a-8761-22adccd04fe5)

</details>

<details><summary>process-test - nodejs</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gj-up-proc-nodejs-base&tpl_var_compare_agent-env%5B0%5D=gj-up-proc-nodejs-new&tpl_var_kube_cluster_name%5B0%5D=usm1&view=spans&from_ts=1724414713634&to_ts=1724415610000&live=false) and [profiling comparison](https://dddev.datadoghq.com/profiling/comparison?query=agent-env%3Agj-up-proc-openssl-base%20&compare_end_A=1724415727834&compare_end_B=1724415725620&compare_query_A=agent-env%3Agj-up-proc-nodejs-base%20service%3Asystem-probe%20&compare_query_B=agent-env%3Agj-up-proc-nodejs-new%20service%3Asystem-probe%20&compare_start_A=1724415201706.1406&compare_start_B=1724415200803.8472&compareValuesMode=absolute&my_code=enabled&refresh_mode=paused&viz=flame_graph&from_ts=1724407461167&to_ts=1724411061167&live=false)

![Screenshot 2024-08-23 at 14 21 21](https://github.com/user-attachments/assets/9e624213-5673-4014-b794-7e82fe286e4a)

</details>


<details><summary>process-test - istio</summary>

[Dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gj-up-proc-istio-base&tpl_var_compare_agent-env%5B0%5D=gj-up-proc-istio-new&tpl_var_kube_cluster_name%5B0%5D=usm1&view=spans&from_ts=1724416419909&to_ts=1724416719909&live=false) and [profiling comparison](https://dddev.datadoghq.com/profiling/comparison?query=agent-env%3Agj-up-proc-openssl-base%20&compare_end_A=1724415727834&compare_end_B=1724415725620&compare_query_A=agent-env%3Agj-up-proc-nodejs-base%20service%3Asystem-probe%20&compare_query_B=agent-env%3Agj-up-proc-nodejs-new%20service%3Asystem-probe%20&compare_start_A=1724415201706.1406&compare_start_B=1724415200803.8472&compareValuesMode=absolute&my_code=enabled&refresh_mode=paused&viz=flame_graph&from_ts=1724407461167&to_ts=1724411061167&live=false)

![Screenshot 2024-08-23 at 14 40 35](https://github.com/user-attachments/assets/6ec0ddf6-ef63-4119-9ceb-96ef4a07e24e)


</details>


