### PR TITLE
Adding some extra asserts to debug falky tests in dogstatsd server_test

### DIFF
--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -172,8 +172,6 @@ func TestStopServer(t *testing.T) {
 // properly protected from multiple accesses by `cachedTlmLock`.
 // The main purpose of this test is to detect early if a future code change is
 // introducing a data race.
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func TestNoRaceOriginTagMaps(t *testing.T) {
 	const N = 100
 	cfg := make(map[string]interface{})
@@ -215,7 +213,9 @@ func TestNoRaceOriginTagMaps(t *testing.T) {
 
 func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMock) {
 	// Test metric
-	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err := conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
+
 	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -227,7 +227,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	assert.ElementsMatch(t, sample.Tags, []string{"sometag1:somevalue1", "sometag2:somevalue2"})
 	demux.Reset()
 
-	conn.Write([]byte("daemon:666|c|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon:666|c|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -239,7 +240,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	assert.Equal(t, 0.5, sample.SampleRate)
 	demux.Reset()
 
-	conn.Write([]byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -251,7 +253,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	assert.Equal(t, 0.5, sample.SampleRate)
 	demux.Reset()
 
-	conn.Write([]byte("daemon:666|ms|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon:666|ms|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -263,7 +266,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	assert.Equal(t, 0.5, sample.SampleRate)
 	demux.Reset()
 
-	conn.Write([]byte("daemon_set:abc|s|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon_set:abc|s|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -275,7 +279,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// multi-metric packet
-	conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
+	_, err = conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second*2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
@@ -292,7 +297,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// multi-value packet
-	conn.Write([]byte("daemon1:666:123|c\ndaemon2:1000|c"))
+	_, err = conn.Write([]byte("daemon1:666:123|c\ndaemon2:1000|c"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second*2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
@@ -314,7 +320,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// multi-value packet with skip empty
-	conn.Write([]byte("daemon1::666::123::::|c\ndaemon2:1000|c"))
+	_, err = conn.Write([]byte("daemon1::666::123::::|c\ndaemon2:1000|c"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second*2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
@@ -336,7 +343,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	//	// slightly malformed multi-metric packet, should still be parsed in whole
-	conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
+	_, err = conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second*2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
@@ -353,7 +361,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// Test erroneous metric
-	conn.Write([]byte("daemon1:666a|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon1:666a|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -363,7 +372,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// Test empty metric
-	conn.Write([]byte("daemon1:|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2\ndaemon3: :1:|g"))
+	_, err = conn.Write([]byte("daemon1:|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2\ndaemon3: :1:|g"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 0)
@@ -373,7 +383,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// Late gauge
-	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
+	_, err = conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 0)
 	require.Len(t, timedSamples, 1)
@@ -385,7 +396,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// Late count
-	conn.Write([]byte("daemon:666|c|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
+	_, err = conn.Write([]byte("daemon:666|c|#sometag1:somevalue1,sometag2:somevalue2|T1658328888"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Len(t, samples, 0)
 	require.Len(t, timedSamples, 1)
@@ -397,7 +409,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	demux.Reset()
 
 	// Late metric and a normal one
-	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888\ndaemon2:666|c"))
+	_, err = conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888\ndaemon2:666|c"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForNumberOfSamples(1, 1, time.Second*2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 1)
@@ -416,7 +429,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 
 	eventOut, serviceOut := demux.GetEventsAndServiceChecksChannels()
 
-	conn.Write([]byte("_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	select {
 	case res := <-serviceOut:
 		assert.NotNil(t, res)
@@ -425,7 +439,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	}
 
 	// Test erroneous Service Check
-	conn.Write([]byte("_sc|agen.down\n_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("_sc|agen.down\n_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	select {
 	case res := <-serviceOut:
 		assert.Equal(t, 1, len(res))
@@ -439,7 +454,8 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	// Test Event
 	// ----------
 
-	conn.Write([]byte("_e{10,10}:test title|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	_, err = conn.Write([]byte("_e{10,10}:test title|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	select {
 	case res := <-eventOut:
 		event := res[0]
@@ -450,13 +466,14 @@ func testReceive(t *testing.T, conn net.Conn, demux demultiplexer.FakeSamplerMoc
 	}
 
 	// Test erroneous Events
-	conn.Write(
+	_, err = conn.Write(
 		[]byte("_e{0,9}:|test text\n" +
 			"_e{-5,2}:abc\n" +
 			"_e{11,10}:test title2|test\\ntext|" +
 			"t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test",
 		),
 	)
+	require.NoError(t, err, "cannot write to DSD socket")
 	select {
 	case res := <-eventOut:
 		assert.Equal(t, 1, len(res))
@@ -514,9 +531,10 @@ func TestUDPForward(t *testing.T) {
 	// Check if message is forwarded
 	message := []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
-	conn.Write(message)
+	_, err = conn.Write(message)
+	require.NoError(t, err, "cannot write to DSD socket")
 
-	pc.SetReadDeadline(time.Now().Add(4 * time.Second))
+	_ = pc.SetReadDeadline(time.Now().Add(4 * time.Second))
 
 	buffer := make([]byte, len(message))
 	_, _, err = pc.ReadFrom(buffer)
@@ -542,8 +560,8 @@ func TestHistToDist(t *testing.T) {
 	defer conn.Close()
 
 	// Test metric
-	conn.Write([]byte("daemon:666|h|#sometag1:somevalue1,sometag2:somevalue2"))
-	time.Sleep(time.Millisecond * 200) // give some time to the socket write/read
+	_, err = conn.Write([]byte("daemon:666|h|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 2, len(samples))
 	require.Equal(t, 0, len(timedSamples))
@@ -646,7 +664,8 @@ func TestE2EParsing(t *testing.T) {
 	defer conn.Close()
 
 	// Test metric expecting an EOL
-	conn.Write([]byte("daemon:666|g|#foo:bar\ndaemon:666|g|#foo:bar"))
+	_, err = conn.Write([]byte("daemon:666|g|#foo:bar\ndaemon:666|g|#foo:bar"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 1, len(samples))
 	assert.Equal(t, 0, len(timedSamples))
@@ -668,7 +687,8 @@ func TestExtraTags(t *testing.T) {
 	defer conn.Close()
 
 	// Test metric
-	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	_, err = conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	require.NoError(t, err, "cannot write to DSD socket")
 	samples, timedSamples := demux.WaitForSamples(time.Second * 2)
 	require.Equal(t, 1, len(samples))
 	require.Equal(t, 0, len(timedSamples))
@@ -757,7 +777,7 @@ func TestParseMetricMessageTelemetry(t *testing.T) {
 
 	assert.Nil(t, s.mapper)
 
-	samples := []metrics.MetricSample{}
+	var samples []metrics.MetricSample
 
 	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
 
@@ -1187,5 +1207,5 @@ func TestOrigin(t *testing.T) {
 
 func requireStart(t *testing.T, s Component) {
 	assert.NotNil(t, s)
-	assert.True(t, s.IsRunning())
+	assert.True(t, s.IsRunning(), "server was not running")
 }

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -10,7 +10,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"net"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -76,6 +78,11 @@ func fulfillDeps(t testing.TB) serverDeps {
 }
 
 func fulfillDepsWithConfigOverrideAndFeatures(t testing.TB, overrides map[string]interface{}, features []config.Feature) serverDeps {
+
+	// TODO: https://datadoghq.atlassian.net/browse/AMLII-1948
+	if runtime.GOOS == "darwin" {
+		flake.Mark(t)
+	}
 	return fxutil.Test[serverDeps](t, fx.Options(
 		core.MockBundle(),
 		serverdebugimpl.MockModule(),


### PR DESCRIPTION
### What does this PR do?

This marks tests in `comp/dogstatsd/server/server_test.go` as flaky when run on macOS.

### Motivation

Since 25/07 these tests on macOS have started failing randomly without any code changes. There also has been no change the macOS runner that may have also caused this to fail.

### Additional Notes

Have raised a new JIRA ticket to look into rewriting these tests so that they test the business logic rather than spin up and test things using UDP.

### Possible Drawbacks / Trade-offs

This might mean we catch regressions on macOS. I've not disabled the tests on other OS so if the code changes and breaks anything here we will know about it.

### Describe how to test/QA your changes

None.