### PR TITLE
Enable LimitRange and StorageClass collection in the orchestrator check

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/limitrange.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/limitrange.go
@@ -40,7 +40,7 @@ func NewLimitRangeCollector() *LimitRangeCollector {
 	return &LimitRangeCollector{
 		metadata: &collectors.CollectorMetadata{
 			IsDefaultVersion:          true,
-			IsStable:                  false,
+			IsStable:                  true,
 			IsMetadataProducer:        true,
 			IsManifestProducer:        true,
 			SupportsManifestBuffering: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/storageclass.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/storageclass.go
@@ -40,7 +40,7 @@ func NewStorageClassCollector() *StorageClassCollector {
 	return &StorageClassCollector{
 		metadata: &collectors.CollectorMetadata{
 			IsDefaultVersion:          true,
-			IsStable:                  false,
+			IsStable:                  true,
 			IsMetadataProducer:        true,
 			IsManifestProducer:        true,
 			SupportsManifestBuffering: true,

--- a/releasenotes-dca/notes/limitrange-storageclass-collection-565db81f99f34c57.yaml
+++ b/releasenotes-dca/notes/limitrange-storageclass-collection-565db81f99f34c57.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LimitRange and StorageClass resources are now collected by the orchestrator check

--- a/releasenotes-dca/notes/limitrange-storageclass-collection-565db81f99f34c57.yaml
+++ b/releasenotes-dca/notes/limitrange-storageclass-collection-565db81f99f34c57.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    LimitRange and StorageClass resources are now collected by the orchestrator check
+    ``LimitRange`` and ``StorageClass`` resources are now collected by the orchestrator check.


### PR DESCRIPTION
### What does this PR do?

Enable LimitRange and StorageClass collection in the orchestrator check

### Additional Notes

Chart change https://github.com/DataDog/helm-charts/pull/1387
