### PR TITLE
[OTEL-1955] convert comp/core/tagger/types to go module

### DIFF
--- a/comp/core/tagger/types/doc.go
+++ b/comp/core/tagger/types/doc.go
@@ -1,0 +1,5 @@
+    // Unless explicitly stated otherwise all files in this repository are licensed
+    // under the Apache License Version 2.0.
+    // This product includes software developed at Datadog (https://www.datadoghq.com/).
+    // Copyright 2016-present Datadog, Inc.
+    package types

--- a/comp/core/tagger/types/doc.go
+++ b/comp/core/tagger/types/doc.go
@@ -2,4 +2,6 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
+// Package types defines types used by the Tagger component.
 package types

--- a/comp/core/tagger/types/doc.go
+++ b/comp/core/tagger/types/doc.go
@@ -1,5 +1,5 @@
-    // Unless explicitly stated otherwise all files in this repository are licensed
-    // under the Apache License Version 2.0.
-    // This product includes software developed at Datadog (https://www.datadoghq.com/).
-    // Copyright 2016-present Datadog, Inc.
-    package types
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package types

--- a/comp/core/tagger/types/go.mod
+++ b/comp/core/tagger/types/go.mod
@@ -1,0 +1,7 @@
+module github.com/DataDog/datadog-agent/comp/core/tagger/types
+
+go 1.21.0
+
+replace github.com/DataDog/datadog-agent/comp/core/tagger/utils => ../utils
+
+require github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.0.0-00010101000000-000000000000

--- a/comp/core/tagger/types/go.sum
+++ b/comp/core/tagger/types/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/secrets => ./comp/core/secrets
 	github.com/DataDog/datadog-agent/comp/core/status => ./comp/core/status
 	github.com/DataDog/datadog-agent/comp/core/status/statusimpl => ./comp/core/status/statusimpl
+	github.com/DataDog/datadog-agent/comp/core/tagger/types => ./comp/core/tagger/types
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils => ./comp/core/tagger/utils
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ./comp/core/telemetry/
 	github.com/DataDog/datadog-agent/comp/def => ./comp/def/
@@ -593,6 +594,7 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.0.0-00010101000000-000000000000
 	github.com/lorenzosaino/go-sysctl v0.3.1
 )

--- a/pkg/proto/pbgo/trace/span_gen.go
+++ b/pkg/proto/pbgo/trace/span_gen.go
@@ -273,7 +273,7 @@ func (z *Span) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Metrics")
 				return
 			}
-			if z.Metrics == nil && zb0003 > 0{
+			if z.Metrics == nil && zb0003 > 0 {
 				z.Metrics = make(map[string]float64, zb0003)
 			} else if len(z.Metrics) > 0 {
 				for key := range z.Metrics {

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -147,6 +147,7 @@ DEFAULT_MODULES = {
     "comp/core/secrets": GoModule("comp/core/secrets", independent=True, used_by_otel=True),
     "comp/core/status": GoModule("comp/core/status", independent=True, used_by_otel=True),
     "comp/core/status/statusimpl": GoModule("comp/core/status/statusimpl", independent=True),
+    "comp/core/tagger/types": GoModule("comp/core/tagger/types", independent=True, used_by_otel=True),
     "comp/core/tagger/utils": GoModule("comp/core/tagger/utils", independent=True, used_by_otel=True),
     "comp/core/telemetry": GoModule("comp/core/telemetry", independent=True, used_by_otel=True),
     "comp/def": GoModule("comp/def", independent=True, used_by_otel=True),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
converts comp/core/tagger/types to go module 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
module is a dependency to converting comp/otelcol/otlp/components/processor/infraattributesprocessor to a go module
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
also updated one file due to running `go fmt -s -w .` on `datadog-agent` dir: `pkg/proto/pbgo/trace/span_gen.go`
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
run unit/integration tests using go test or invoke test
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
