### PR TITLE
Retry the go cache jobs twice instead of once

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -15,7 +15,13 @@
   - mkdir -p $GOPATH/pkg/mod && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod
   - rm -f modcache_e2e.tar.xz
 
-.cache_policy:
+.cache:
+  stage: deps_fetch
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["setup_agent_version"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 16
   rules:
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     variables:
@@ -23,15 +29,11 @@
   - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
     variables:
       POLICY: pull
+  retry: 2
 
 go_deps:
-  stage: deps_fetch
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["setup_agent_version"]
-  extends: .cache_policy
+  extends: .cache
   variables:
-    KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
   script:
@@ -53,16 +55,9 @@ go_deps:
         prefix: "go_deps"
       paths:
         - modcache.tar.xz
-  retry: 1
 
 go_tools_deps:
-  stage: deps_fetch
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["setup_agent_version"]
-  extends: .cache_policy
-  variables:
-    KUBERNETES_CPU_REQUEST: 16
+  extends: .cache
   script:
     - if [ -f modcache_tools.tar.xz  ]; then exit 0; fi
     - source /root/.bashrc
@@ -79,16 +74,9 @@ go_tools_deps:
         prefix: "go_tools_deps"
       paths:
         - modcache_tools.tar.xz
-  retry: 1
 
 go_e2e_deps:
-  stage: deps_fetch
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["setup_agent_version"]
-  extends: .cache_policy
-  variables:
-    KUBERNETES_CPU_REQUEST: 16
+  extends: .cache
   script:
     - if [ -f modcache_e2e.tar.xz  ]; then exit 0; fi
     - source /root/.bashrc
@@ -105,4 +93,3 @@ go_e2e_deps:
         prefix: "go_e2e_deps"
       paths:
         - modcache_e2e.tar.xz
-  retry: 1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Retry the go cache jobs twice instead of once
- Refactor a bit the job, let me know if that's not ok

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

It failed once [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/595973783) and it's unfortunate because this job is here to prevent this kind of failures, but we need to download the deps at least once. Retrying one more time could help, even though I did not find an easy way to wait a bit between the retries

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
