### PR TITLE
fix(junit): Add the line separator in job_env repack

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -370,7 +370,7 @@ def repack_macos_junit_tar(workflow_conclusion, infile, outfile):
 
         # write the proper job url and job name
         with open(os.path.join(tempd, JOB_ENV_FILE_NAME), "w") as fp:
-            fp.write(f'CI_JOB_URL={os.environ.get("CI_JOB_URL", "")}')
+            fp.write(f'CI_JOB_URL={os.environ.get("CI_JOB_URL", "")}\n')
             fp.write(f'CI_JOB_NAME={os.environ.get("CI_JOB_NAME", "")}')
 
         # pack all files to a new tarball


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add a missing line separator (which is [unfortunately](https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/common/junit_upload_core.py#L349) present in the original file) when we repack macos data.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Prevent broadcasting incorrect links like this one
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/595101348CI_JOB_NAME=tests_macos

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
