### PR TITLE
[ASCII-2075] Wait for providers to stop in metadata runner stop

### DIFF
--- a/comp/metadata/runner/runnerimpl/runner_test.go
+++ b/comp/metadata/runner/runnerimpl/runner_test.go
@@ -12,14 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
-	"go.uber.org/fx/fxtest"
 )
 
 func TestHandleProvider(t *testing.T) {
@@ -44,6 +47,85 @@ func TestHandleProvider(t *testing.T) {
 	// either the provider call wg.Done() or the test will fail as a timeout
 	wg.Wait()
 	assert.NoError(t, r.stop())
+}
+
+func TestHandleProviderShortTimeout(t *testing.T) {
+	// runChan is used to signal when the provider is running
+	runChan := make(chan struct{})
+	provider := func(context.Context) time.Duration {
+		close(runChan)
+		time.Sleep(1 * time.Minute) // Long timeout to block
+		return 1 * time.Minute
+	}
+
+	r := createRunner(
+		fxutil.Test[dependencies](
+			t,
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			config.MockModule(),
+			fx.Supply(NewProvider(provider)),
+		))
+
+	r.config.Set("metadata_provider_stop_timeout", time.Duration(0), model.SourceFile)
+	require.NoError(t, r.start())
+
+	// wait for the provider to run
+	<-runChan
+
+	cerr := make(chan error)
+	go func() {
+		cerr <- r.stop()
+	}()
+
+	select {
+	case err := <-cerr:
+		require.NoError(t, err)
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "timeout waiting for stop")
+	}
+}
+
+func TestHandleProviderLongTimeout(t *testing.T) {
+	// c is used to signal when the provider is running
+	runChan := make(chan struct{})
+	// blockChan is used to block the provider
+	blockChan := make(chan struct{})
+	provider := func(context.Context) time.Duration {
+		close(runChan)
+		<-blockChan
+		return 1 * time.Minute
+	}
+
+	r := createRunner(
+		fxutil.Test[dependencies](
+			t,
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			config.MockModule(),
+			fx.Supply(NewProvider(provider)),
+		))
+
+	r.config.Set("metadata_provider1_stop_timeout", 1*time.Minute, model.SourceFile)
+	require.NoError(t, r.start())
+
+	// wait for the provider to run
+	<-runChan
+
+	cerr := make(chan error)
+	go func() {
+		cerr <- r.stop()
+	}()
+
+	time.AfterFunc(100*time.Millisecond, func() {
+		// unblock the provider
+		close(blockChan)
+	})
+
+	select {
+	case err := <-cerr:
+		require.NoError(t, err)
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "timeout waiting for stop")
+	}
 }
 
 func TestRunnerCreation(t *testing.T) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1012,6 +1012,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("enable_signing_metadata_collection", true)
+	config.BindEnvAndSetDefault("metadata_provider_stop_timeout", 30*time.Second)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("check_cancel_timeout", 500*time.Millisecond)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Improve stopping mechanism of the metadata runner component.

The metadata runner currently stops running providers asynchronously to avoid blocking the agent stop.
This PR changes that to wait at most 30 seconds for providers to stop.
That way we can both limit risks of interrupting a provider, and avoid blocking the agent stop indefinitely.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Trying to fix https://github.com/DataDog/datadog-agent/issues/24171.
We suspect some metadata providers could be interrupted when the agent stops, while they are still running, causing a corruption. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Providers should check the context so that they stop as early as possible when it's canceled, but most don't.
Follow-up work will improve that. 

This PR also fixes an issue with the use of the `WaitGroup` where it was incremented in the routine instead of before starting it, so when starting and stopping quickly in tests it could not wait for routines.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Could make the agent longer to stop, but stop is cleaner.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Added unit tests to ensure each case works as expected when we try to stop the runner while providers are running:
- runner stop timeout is shorter than provider duration: stop returns after timeout
- runner stop timeout is longer than provider duration: stop returns when provider ends 