### PR TITLE
[NDM][Cisco SD-WAN] Enable sending BGP neighbor metrics

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -283,6 +283,19 @@ func (ms *SDWanSender) SendCloudApplicationMetrics(cloudApplications []client.Cl
 	ms.updateTimestamps(newTimestamps)
 }
 
+// SendBGPNeighborMetrics sends hardware metrics
+func (ms *SDWanSender) SendBGPNeighborMetrics(bgpNeighbors []client.BGPNeighbor) {
+	for _, entry := range bgpNeighbors {
+		as := fmt.Sprintf("%d", int(entry.AS))
+		vpnID := fmt.Sprintf("%d", int(entry.VpnID))
+
+		tags := ms.getDeviceTags(entry.VmanageSystemIP)
+		tags = append(tags, "peer_state:"+entry.State, "remote_as:"+as, "neighbor:"+entry.PeerAddr, "vpn_id:"+vpnID, "afi:"+entry.Afi)
+
+		ms.sender.Gauge(ciscoSDWANMetricPrefix+"bgp.neighbor", float64(1), "", tags)
+	}
+}
+
 // Commit commits to the sender
 func (ms *SDWanSender) Commit() {
 	ms.sender.Commit()

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -53,6 +53,7 @@ type checkCfg struct {
 	CollectBFDSessionStatus         *bool  `yaml:"collect_bfd_session_status"`
 	CollectHardwareStatus           *bool  `yaml:"collect_hardware_status"`
 	CollectCloudApplicationsMetrics *bool  `yaml:"collect_cloud_applications_metrics"`
+	CollectBGPNeighborStates        *bool  `yaml:"collect_bgp_neighbor_states"`
 }
 
 // CiscoSdwanCheck contains the field for the CiscoSdwanCheck
@@ -178,6 +179,15 @@ func (c *CiscoSdwanCheck) Run() error {
 		c.metricsSender.SendCloudApplicationMetrics(cloudApplications)
 	}
 
+	// Disabled  by default
+	if *c.config.CollectBGPNeighborStates {
+		bgpNeighbors, err := client.GetBGPNeighbors()
+		if err != nil {
+			log.Warnf("Error getting BGP neighbors from Cisco SD-WAN API: %s", err)
+		}
+		c.metricsSender.SendBGPNeighborMetrics(bgpNeighbors)
+	}
+
 	if *c.config.SendNDMMetadata {
 		c.metricsSender.SendMetadata(devicesMetadata, interfacesMetadata, ipAddressesMetadata)
 	}
@@ -217,6 +227,7 @@ func (c *CiscoSdwanCheck) Configure(senderManager sender.SenderManager, integrat
 	instanceConfig.CollectBFDSessionStatus = boolPointer(false)
 	instanceConfig.CollectHardwareStatus = boolPointer(false)
 	instanceConfig.CollectCloudApplicationsMetrics = boolPointer(false)
+	instanceConfig.CollectBGPNeighborStates = boolPointer(false)
 
 	err = yaml.Unmarshal(rawInstance, &instanceConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -71,6 +71,7 @@ min_collection_interval: 180
 collect_bfd_session_status: true
 collect_hardware_status: true
 collect_cloud_applications_metrics: true
+collect_bgp_neighbor_states: true
 `)
 
 	// Use ID to ensure the mock sender gets registered
@@ -190,6 +191,9 @@ collect_cloud_applications_metrics: true
 	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.latency", 404, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.loss", 0, "", tags, ts)
 	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.application.qoe", 5, "", tags, ts)
+
+	// Assert BGP neighbor metrics
+	sender.AssertMetric(t, "Gauge", "cisco_sdwan.bgp.neighbor", 1, "", []string{"system_ip:10.10.1.11", "peer_state:established", "remote_as:2024", "neighbor:10.60.1.1", "vpn_id:1", "afi:ipv4-unicast"})
 
 	// Assert metadata
 	// language=json
@@ -423,6 +427,9 @@ collect_cloud_applications_metrics: false
 	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.latency", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.loss", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertNotCalled(t, "GaugeWithTimestamp", "cisco_sdwan.application.qoe", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+	// Assert BGP peer metrics
+	sender.AssertNotCalled(t, "Gauge", "cisco_sdwan.bgp.neighbor", mock.Anything, mock.Anything, mock.Anything)
 
 	sender.AssertNotCalled(t, "EventPlatformEvent", mock.Anything, mock.Anything)
 }

--- a/releasenotes/notes/cisco-sdwan-bgp-neighbor-metrics-1bbf0a7161d3028a.yaml
+++ b/releasenotes/notes/cisco-sdwan-bgp-neighbor-metrics-1bbf0a7161d3028a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [NDM] Add option to collect BGP neighbors metrics from Cisco SD-WAN.

--- a/releasenotes/notes/cisco-sdwan-bgp-neighbor-metrics-1bbf0a7161d3028a.yaml
+++ b/releasenotes/notes/cisco-sdwan-bgp-neighbor-metrics-1bbf0a7161d3028a.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [NDM] Add option to collect BGP neighbors metrics from Cisco SD-WAN.
+    [NDM] Adds the option to collect BGP neighbors metrics from Cisco SD-WAN.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Enable sending BGP neighbor metrics using `collect_bgp_neighbor_states: true`
NDMII-2980

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
