### PR TITLE
[CWS] add a approver mode to bypass discarders

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command_test.go
+++ b/cmd/security-agent/subcommands/runtime/command_test.go
@@ -133,19 +133,22 @@ func Test_checkPoliciesLoaded(t *testing.T) {
 					{
 						"Field": "open.file.path",
 						"Value": "/etc/gshadow",
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode": 0
 					},
 					{
 						"Field": "open.file.path",
 						"Value": "/etc/shadow",
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode": 0
 					}
 				],
 				"open.flags": [
 					{
 						"Field": "open.flags",
 						"Value": 64,
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode": 0
 					}
 				]
 			}

--- a/cmd/system-probe/subcommands/runtime/command_test.go
+++ b/cmd/system-probe/subcommands/runtime/command_test.go
@@ -134,7 +134,7 @@ func Test_checkPoliciesLoaded(t *testing.T) {
 						"Field": "open.file.path",
 						"Value": "/etc/gshadow",
 						"Type": "scalar",
-						"Mode:" 0
+						"Mode": 0
 					},
 					{
 						"Field": "open.file.path",

--- a/cmd/system-probe/subcommands/runtime/command_test.go
+++ b/cmd/system-probe/subcommands/runtime/command_test.go
@@ -133,19 +133,22 @@ func Test_checkPoliciesLoaded(t *testing.T) {
 					{
 						"Field": "open.file.path",
 						"Value": "/etc/gshadow",
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode:" 0
 					},
 					{
 						"Field": "open.file.path",
 						"Value": "/etc/shadow",
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode": 0
 					}
 				],
 				"open.flags": [
 					{
 						"Field": "open.flags",
 						"Value": 64,
-						"Type": "scalar"
+						"Type": "scalar",
+						"Mode": 0
 					}
 				]
 			}

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -332,8 +332,11 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 			return false, false, err
 		}
 
-		if isDiscarder, _ := rules.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
-			return false, true, nil
+		if len(basenameRules) > 0 {
+			if isDiscarder, err := rules.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
+				fmt.Printf("COM: %v %v\n", isDiscarder, err)
+				return false, true, nil
+			}
 		}
 
 		return true, true, nil

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -333,8 +333,7 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 		}
 
 		if len(basenameRules) > 0 {
-			if isDiscarder, err := rules.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
-				fmt.Printf("COM: %v %v\n", isDiscarder, err)
+			if isDiscarder, _ := rules.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
 				return false, true, nil
 			}
 		}

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -30,6 +30,8 @@ type ApplyRuleSetReport struct {
 func NewApplyRuleSetReport(config *config.Config, rs *rules.RuleSet) (*ApplyRuleSetReport, error) {
 	policies := make(map[eval.EventType]*PolicyReport)
 
+	// We need to call the approver detection even when approvers aren't enabled as it may have impact on some rule flags and
+	// the discarder mechanism, see ruleset.go
 	approvers, err := rs.GetApprovers(GetCapababilities())
 	if err != nil {
 		return nil, err

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -75,9 +75,12 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 
 	// for each rule we should at least find one approver otherwise we will return no approver for the field
 	for _, rule := range rules {
-		var bestFilterField eval.Field
-		var bestFilterValues FilterValues
-		var bestFilterWeight int
+		var (
+			bestFilterField  eval.Field
+			bestFilterValues FilterValues
+			bestFilterWeight int
+			bestFilterMode   FilterMode
+		)
 
 	LOOP:
 		for _, fieldCap := range fieldCaps {
@@ -95,7 +98,7 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 					}
 
 					if isAnApprover {
-						filterValues = filterValues.Merge(FilterValue{Field: field, Value: value.Value, Type: value.Type})
+						filterValues = filterValues.Merge(FilterValue{Field: field, Value: value.Value, Type: value.Type, Mode: fieldCap.FilterMode})
 					} else if fieldCap.TypeBitmask&eval.BitmaskValueType == 0 {
 						// if not a bitmask we need to have all the value as approvers
 						// basically a list of values ex: in ["test123", "test456"]
@@ -125,12 +128,22 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 				bestFilterField = field
 				bestFilterValues = filterValues
 				bestFilterWeight = fieldCap.FilterWeight
+				bestFilterMode = fieldCap.FilterMode
 			}
 		}
 
 		// no filter value for a rule thus no approver for the event type
 		if bestFilterValues == nil {
 			return nil, nil
+		}
+
+		// this rule as an approver in ApproverOnly mode. Disable to rule from being used by the discarder mechanism.
+		// the goal is to have approver that are good enough to filter properly the events used by rule that would break the
+		// discarder discovery.
+		// ex: open.file.name != "" && process.auid == 1000 # this rule avoid open.file.path discarder discovery, but with a ApproverOnly on process.auid the problem disappear
+		//     open.file.filename == "/etc/passwd"
+		if bestFilterMode == ApproverOnly {
+			rule.NoDiscarder = true
 		}
 
 		approvers[bestFilterField] = append(approvers[bestFilterField], bestFilterValues...)

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -142,7 +142,7 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 		// discarder discovery.
 		// ex: open.file.name != "" && process.auid == 1000 # this rule avoid open.file.path discarder discovery, but with a ApproverOnly on process.auid the problem disappear
 		//     open.file.filename == "/etc/passwd"
-		if bestFilterMode == ApproverOnly {
+		if bestFilterMode == ApproverOnlyMode {
 			rule.NoDiscarder = true
 		}
 

--- a/pkg/security/secl/rules/capabilities.go
+++ b/pkg/security/secl/rules/capabilities.go
@@ -10,6 +10,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+// FilterMode defines a filter mode
+type FilterMode int
+
+const (
+	// NormalMode enabled approver and discarder
+	Normal FilterMode = iota
+	// ApproverOnly not used to generate a discarder
+	ApproverOnly
+)
+
 // FieldCapabilities holds a list of field capabilities
 type FieldCapabilities []FieldCapability
 
@@ -19,6 +29,7 @@ type FieldCapability struct {
 	TypeBitmask  eval.FieldValueType
 	ValidateFnc  func(FilterValue) bool
 	FilterWeight int
+	FilterMode   FilterMode
 }
 
 // GetFields returns all the fields of FieldCapabilities

--- a/pkg/security/secl/rules/capabilities.go
+++ b/pkg/security/secl/rules/capabilities.go
@@ -15,9 +15,9 @@ type FilterMode int
 
 const (
 	// NormalMode enabled approver and discarder
-	Normal FilterMode = iota
-	// ApproverOnly not used to generate a discarder
-	ApproverOnly
+	NormalMode FilterMode = iota
+	// ApproverOnlyMode not used to generate a discarder
+	ApproverOnlyMode
 )
 
 // FieldCapabilities holds a list of field capabilities

--- a/pkg/security/secl/rules/filter_values.go
+++ b/pkg/security/secl/rules/filter_values.go
@@ -17,6 +17,7 @@ type FilterValue struct {
 	Field eval.Field
 	Value interface{}
 	Type  eval.FieldValueType
+	Mode  FilterMode
 }
 
 // Merge merges to FilterValues ensuring there is no duplicate value

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -169,7 +169,8 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 // Rule describes a rule of a ruleset
 type Rule struct {
 	*eval.Rule
-	Definition *RuleDefinition
+	Definition  *RuleDefinition
+	NoDiscarder bool
 }
 
 // RuleSetListener describes the methods implemented by an object used to be
@@ -603,13 +604,22 @@ func (rs *RuleSet) GetFieldValues(field eval.Field) []eval.FieldValue {
 
 // IsDiscarder partially evaluates an Event against a field
 func IsDiscarder(ctx *eval.Context, field eval.Field, rules []*Rule) (bool, error) {
+	var isDiscarder bool
+
 	for _, rule := range rules {
+		// ignore rule that can't generate discarders
+		if rule.NoDiscarder {
+			continue
+		}
+
 		isTrue, err := rule.PartialEval(ctx, field)
 		if err != nil || isTrue {
 			return false, err
 		}
+
+		isDiscarder = true
 	}
-	return true, nil
+	return isDiscarder, nil
 }
 
 // IsDiscarder partially evaluates an Event against a field

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -581,12 +581,12 @@ func TestRuleSetApprovers16(t *testing.T) {
 	caps := FieldCapabilities{
 		{
 			Field:        "open.file.path",
-			Types:        eval.ScalarValueType | eval.PatternValueType,
+			TypeBitmask:  eval.ScalarValueType | eval.PatternValueType,
 			FilterWeight: 3,
 		},
 	}
 
-	approvers, _ := rs.GetEventApprovers("open", caps)
+	approvers, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver")
 	}
@@ -594,16 +594,16 @@ func TestRuleSetApprovers16(t *testing.T) {
 	caps = FieldCapabilities{
 		{
 			Field:        "open.file.oath",
-			Types:        eval.ScalarValueType | eval.PatternValueType,
+			TypeBitmask:  eval.ScalarValueType | eval.PatternValueType,
 			FilterWeight: 3,
 		},
 		{
-			Field: "process.auid",
-			Types: eval.ScalarValueType,
+			Field:       "process.auid",
+			TypeBitmask: eval.ScalarValueType,
 		},
 	}
 
-	approvers, _ = rs.GetEventApprovers("open", caps)
+	approvers, _ = rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver")
 	}
@@ -625,17 +625,17 @@ func TestRuleSetApprovers16(t *testing.T) {
 	caps = FieldCapabilities{
 		{
 			Field:        "open.file.path",
-			Types:        eval.ScalarValueType | eval.PatternValueType,
+			TypeBitmask:  eval.ScalarValueType | eval.PatternValueType,
 			FilterWeight: 3,
 		},
 		{
-			Field:      "process.auid",
-			Types:      eval.ScalarValueType,
-			FilterMode: ApproverOnly,
+			Field:       "process.auid",
+			TypeBitmask: eval.ScalarValueType,
+			FilterMode:  ApproverOnly,
 		},
 	}
 
-	approvers, _ = rs.GetEventApprovers("open", caps)
+	approvers, _ = rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 2 || len(approvers["open.file.path"]) != 1 || len(approvers["process.auid"]) != 1 {
 		t.Fatalf("should get an approver`: %v", approvers)
 	}

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -631,7 +631,7 @@ func TestRuleSetApprovers16(t *testing.T) {
 		{
 			Field:       "process.auid",
 			TypeBitmask: eval.ScalarValueType,
-			FilterMode:  ApproverOnly,
+			FilterMode:  ApproverOnlyMode,
 		},
 	}
 

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -19,17 +19,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
-type testFieldValues map[string][]interface{}
+type testFieldValues map[eval.Field][]interface{}
 
 type testHandler struct {
-	filters map[string]testFieldValues
+	filters map[eval.EventType]testFieldValues
+}
+
+func (f *testHandler) Reset() {
+	f.filters = make(map[eval.EventType]testFieldValues)
 }
 
 func (f *testHandler) RuleMatch(_ *Rule, _ eval.Event) bool {
 	return true
 }
 
-func (f *testHandler) EventDiscarderFound(_ *RuleSet, event eval.Event, field string, _ eval.EventType) {
+func (f *testHandler) EventDiscarderFound(_ *RuleSet, event eval.Event, field eval.Field, _ eval.EventType) {
 	values, ok := f.filters[event.GetType()]
 	if !ok {
 		values = make(testFieldValues)
@@ -533,7 +537,7 @@ func TestRuleSetApprovers14(t *testing.T) {
 
 	approvers, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.path"]) != 2 {
-		t.Fatalf("shouldn't get an approver for `open.file.path`: %v", approvers)
+		t.Fatalf("should get an approver for `open.file.path`: %v", approvers)
 	}
 }
 
@@ -555,7 +559,93 @@ func TestRuleSetApprovers15(t *testing.T) {
 
 	approvers, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.name"]) != 1 {
-		t.Fatalf("shouldn't get an approver for `open.file.name`: %v", approvers)
+		t.Fatalf("should get an approver for `open.file.name`: %v", approvers)
+	}
+}
+
+func TestRuleSetApprovers16(t *testing.T) {
+	exprs := []string{
+		`open.file.path == "/etc/httpd.conf"`,
+		`open.file.path != "" && open.retval == -1 && process.auid == 1000`,
+	}
+
+	handler := &testHandler{
+		filters: make(map[string]testFieldValues),
+	}
+
+	rs := newRuleSet()
+	rs.AddListener(handler)
+
+	AddTestRuleExpr(t, rs, exprs...)
+
+	caps := FieldCapabilities{
+		{
+			Field:        "open.file.path",
+			Types:        eval.ScalarValueType | eval.PatternValueType,
+			FilterWeight: 3,
+		},
+	}
+
+	approvers, _ := rs.GetEventApprovers("open", caps)
+	if len(approvers) != 0 {
+		t.Fatal("shouldn't get an approver")
+	}
+
+	caps = FieldCapabilities{
+		{
+			Field:        "open.file.oath",
+			Types:        eval.ScalarValueType | eval.PatternValueType,
+			FilterWeight: 3,
+		},
+		{
+			Field: "process.auid",
+			Types: eval.ScalarValueType,
+		},
+	}
+
+	approvers, _ = rs.GetEventApprovers("open", caps)
+	if len(approvers) != 0 {
+		t.Fatal("shouldn't get an approver")
+	}
+
+	// shouldn't generate a discarder
+	ev := model.NewFakeEvent()
+	ev.Type = uint32(model.FileOpenEventType)
+	ev.SetFieldValue("open.file.path", "/usr/local/bin/rootkit")
+
+	if !rs.Evaluate(ev) {
+		rs.EvaluateDiscarders(ev)
+	}
+
+	if _, ok := handler.filters["open.file.path"]; ok {
+		t.Fatalf("shouldn't have a discarder for `open.file.path`")
+	}
+
+	// change the approver mode, now should have an approver + a discader
+	caps = FieldCapabilities{
+		{
+			Field:        "open.file.path",
+			Types:        eval.ScalarValueType | eval.PatternValueType,
+			FilterWeight: 3,
+		},
+		{
+			Field:      "process.auid",
+			Types:      eval.ScalarValueType,
+			FilterMode: ApproverOnly,
+		},
+	}
+
+	approvers, _ = rs.GetEventApprovers("open", caps)
+	if len(approvers) != 2 || len(approvers["open.file.path"]) != 1 || len(approvers["process.auid"]) != 1 {
+		t.Fatalf("should get an approver`: %v", approvers)
+	}
+
+	if !rs.Evaluate(ev) {
+		rs.EvaluateDiscarders(ev)
+	}
+
+	if _, ok := handler.filters["open"]; !ok {
+		t.Fatalf("should have a discarder for `open.file.path`: %v", handler.filters)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add an Approver mode which can be used in capabilities declaration in order to remove the rule having an approver with this mode from the set of rule used to generate discarders. The goal is to be able to write approver only rules which have in-kernel filters but which would avoid the discarder detection.

ex: 

```
open.file.path ~= "/etc/*" # parent discarder
open.file.name != "" && process.auid == 1000 # no more `open.file.path` discarder except if we set `process.auid` as "approver only" 
```

This PR is part of a series which aims to improve the approver mechanism. There is no functional impact, it is only add unit tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
