### PR TITLE
BARX-500 removes the retries for the install agent 7 and 6

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -2,13 +2,11 @@
   rules: !reference [.on_kitchen_tests] #TODO: Change when migration is complete to another name without 'kitchen'
   variables:
     AGENT_MAJOR_VERSION: 6
-  retry: 1
 
 .new-e2e_agent_a7:
   rules: !reference [.on_kitchen_tests] #TODO: Change when migration is complete to another name without 'kitchen'
   variables:
     AGENT_MAJOR_VERSION: 7
-  retry: 1
 
 .new-e2e_install_script:
   variables:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the retry from the job level for the install e2e tests. 

### Motivation

This goes into the effort of identifying flaky test and tackling it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

We might see more flakes on the install script tests

