### PR TITLE
Fix a cluster-agent crash at startup

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -324,7 +324,7 @@ func start(log log.Component,
 		DatadogClient:          dc,
 	}
 
-	if aggErr := controllers.StartControllers(ctx); aggErr != nil {
+	if aggErr := controllers.StartControllers(&ctx); aggErr != nil {
 		for _, err := range aggErr.Errors() {
 			pkglog.Warnf("Error while starting controller: %v", err)
 		}

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -12,10 +12,6 @@ test/new-e2e/tests/containers:
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestECSSuite
-  - TestEKSSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting
-  - TestEKSSuite/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting
-  - TestKindSuite/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting
-  - TestKindSuite/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting
 
 test/new-e2e/tests/installer:
   - TestPackages/upgrade_scenario_ubuntu_22_04_x86_64/TestUpgradeSuccessful

--- a/pkg/util/kubernetes/apiserver/controllers/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers/controllers.go
@@ -33,7 +33,7 @@ const autoscalerNowHandleMsgEvent = "Autoscaler is now handled by the Cluster-Ag
 
 var errIsEmpty = errors.New("entity is empty") //nolint:revive
 
-type startFunc func(ControllerContext, chan error)
+type startFunc func(*ControllerContext, chan error)
 
 type controllerFuncs struct {
 	enabled func() bool
@@ -64,6 +64,7 @@ var controllerCatalog = map[controllerName]controllerFuncs{
 // ControllerContext holds all the attributes needed by the controllers
 type ControllerContext struct {
 	informers              map[apiserver.InformerName]cache.SharedInformer
+	informersMutex         sync.Mutex
 	InformerFactory        informers.SharedInformerFactory
 	DynamicClient          dynamic.Interface
 	DynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
@@ -77,7 +78,7 @@ type ControllerContext struct {
 
 // StartControllers runs the enabled Kubernetes controllers for the Datadog Cluster Agent. This is
 // only called once, when we have confirmed we could correctly connect to the API server.
-func StartControllers(ctx ControllerContext) k8serrors.Aggregate {
+func StartControllers(ctx *ControllerContext) k8serrors.Aggregate {
 	ctx.informers = make(map[apiserver.InformerName]cache.SharedInformer)
 
 	var wg sync.WaitGroup
@@ -126,9 +127,7 @@ func StartControllers(ctx ControllerContext) k8serrors.Aggregate {
 
 // startMetadataController starts the informers needed for metadata collection.
 // The synchronization of the informers is handled by the controller.
-//
-//nolint:revive // TODO(CAPP) Fix revive linter
-func startMetadataController(ctx ControllerContext, c chan error) {
+func startMetadataController(ctx *ControllerContext, _ chan error) {
 	metaController := newMetadataController(
 		ctx.InformerFactory.Core().V1().Endpoints(),
 		ctx.WorkloadMeta,
@@ -138,7 +137,7 @@ func startMetadataController(ctx ControllerContext, c chan error) {
 
 // startAutoscalersController starts the informers needed for autoscaling.
 // The synchronization of the informers is handled by the controller.
-func startAutoscalersController(ctx ControllerContext, c chan error) {
+func startAutoscalersController(ctx *ControllerContext, c chan error) {
 	var err error
 	if ctx.DatadogClient == nil {
 		c <- fmt.Errorf("datadog client is nil")
@@ -166,15 +165,19 @@ func startAutoscalersController(ctx ControllerContext, c chan error) {
 }
 
 // registerServicesInformer registers the services informer.
-//
-//nolint:revive // TODO(CAPP) Fix revive linter
-func registerServicesInformer(ctx ControllerContext, c chan error) {
-	ctx.informers[servicesInformer] = ctx.InformerFactory.Core().V1().Services().Informer()
+func registerServicesInformer(ctx *ControllerContext, _ chan error) {
+	informer := ctx.InformerFactory.Core().V1().Services().Informer()
+
+	ctx.informersMutex.Lock()
+	ctx.informers[servicesInformer] = informer
+	ctx.informersMutex.Unlock()
 }
 
 // registerEndpointsInformer registers the endpoints informer.
-//
-//nolint:revive // TODO(CAPP) Fix revive linter
-func registerEndpointsInformer(ctx ControllerContext, c chan error) {
-	ctx.informers[endpointsInformer] = ctx.InformerFactory.Core().V1().Endpoints().Informer()
+func registerEndpointsInformer(ctx *ControllerContext, _ chan error) {
+	informer := ctx.InformerFactory.Core().V1().Endpoints().Informer()
+
+	ctx.informersMutex.Lock()
+	ctx.informers[endpointsInformer] = informer
+	ctx.informersMutex.Unlock()
 }


### PR DESCRIPTION
### What does this PR do?

Fix `cluster-agent` crash at startup.

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/595831609

```
fatal error: concurrent map writes
        
        goroutine 507 [running]:
        github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers.registerEndpointsInformer({0xc0012ca660, {0x55063d0, 0xc000798930}, {0x5484a00, 0xc000e5e150}, {0x54cc260, 0xc0006efec0}, {0x55178a0, 0xc000bbc680}, 0xc0012b51e0, ...}, ...)
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers/controllers.go:179 +0x7d
        github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers.StartControllers.func1(0x0?)
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers/controllers.go:98 +0x9f
        created by github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers.StartControllers in goroutine 1
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers/controllers.go:96 +0x28b
        
        goroutine 1 [semacquire]:
        sync.runtime_Semacquire(0xc000fcd128?)
        	/usr/local/go/src/runtime/sema.go:62 +0x25
        sync.(*WaitGroup).Wait(0xc00100e198?)
        	/usr/local/go/src/sync/waitgroup.go:116 +0x48
        github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers.StartControllers({0x0, {0x55063d0, 0xc000798930}, {0x5484a00, 0xc000e5e150}, {0x54cc260, 0xc0006efec0}, {0x55178a0, 0xc000bbc680}, 0xc0012b51e0, ...})
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers/controllers.go:102 +0x317
        github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.start({0x54f1cc0, 0xc000841620}, {0x55131b0, 0xc000c801f8}, {0x54fd170, 0xc000cf6900}, {_, _}, {0x54fb488, 0xc000038a80}, ...)
        	/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:327 +0xb58
        reflect.Value.call({0x43b48e0?, 0x4a07678?, 0x10?}, {0x475c4a0, 0x4}, {0xc000b8af00, 0xf, 0xc00100ee90?})
        	/usr/local/go/src/reflect/value.go:596 +0xca6
        reflect.Value.Call({0x43b48e0?, 0x4a07678?, 0x54f12d?}, {0xc000b8af00?, 0x0?, 0x935c80?})
        	/usr/local/go/src/reflect/value.go:380 +0xb9
        github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0xc000eb5860?)
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/args.go:72 +0x8f
        github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot({0x43b48e0?, 0x4a07678?}, {0xc000e98488, 0x21, 0x21})
        	/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/oneshot.go:54 +0x317
        github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.Commands.func1(0xc000ea6f00?, {0x475ca28?, 0x4?, 0x475c47c?})
        	/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:129 +0x1b65
        github.com/spf13/cobra.(*Command).execute(0xc000ea0308, {0x82efc00, 0x0, 0x0})
        	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaca
        github.com/spf13/cobra.(*Command).ExecuteC(0xc000ea0008)
        	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
        github.com/spf13/cobra.(*Command).Execute(0xc000b1fec0?)
        	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x13
        main.main()
        	/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/main.go:30 +0x159
```

### Motivation

Crashing is bad.

### Additional Notes

The `ctx.informers` `map` is concurrently updated by:
https://github.com/DataDog/datadog-agent/blob/8af60b00af87ea238eb0dfb1e7005add4bce325d/pkg/util/kubernetes/apiserver/controllers/controllers.go#L171-L173
and
https://github.com/DataDog/datadog-agent/blob/8af60b00af87ea238eb0dfb1e7005add4bce325d/pkg/util/kubernetes/apiserver/controllers/controllers.go#L178-L180
which are executed concurrently in their own goroutines spawned by:
https://github.com/DataDog/datadog-agent/blob/8af60b00af87ea238eb0dfb1e7005add4bce325d/pkg/util/kubernetes/apiserver/controllers/controllers.go#L85-L100

I hesitated between adding a `sync.Mutex` only where concurrent accesses are susceptible to happen and replacing the type of `"controllers.ControllerContext".informers` from `map[apiserver.InformerName]cache.SharedInformer` to `sync.Map` but the later was impacting more code and code which didn’t need to be synchronized.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The bug this PR addresses has been caught by e2e tests.