### PR TITLE
[apm] add ECS task metadata endpoint to allowed IPs for quantization

### DIFF
--- a/pkg/obfuscate/ip_address.go
+++ b/pkg/obfuscate/ip_address.go
@@ -39,6 +39,8 @@ var allowedIPAddresses = map[string]bool{
 	// link-local cloud provider metadata server addresses
 	"169.254.169.254": true,
 	"fd00:ec2::254":   true,
+	// ECS task metadata
+	"169.254.170.2": true,
 }
 
 func splitPrefix(raw string) (prefix, after string) {

--- a/pkg/obfuscate/ip_address_test.go
+++ b/pkg/obfuscate/ip_address_test.go
@@ -23,6 +23,7 @@ func TestQuantizePeerIpAddresses(t *testing.T) {
 		// - link-local IP address, aka "metadata server" for various cloud providers
 		{"169.254.169.254", "169.254.169.254"},
 		{"fd00:ec2::254", "fd00:ec2::254"},
+		{"169.254.170.2", "169.254.170.2"},
 		// blocking cases
 		{"", ""},
 		{"foo.dog", "foo.dog"},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Follow-up to https://github.com/DataDog/datadog-agent/pull/28229, add the [ECS Task Metadata](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html) IP address to the set of allowed IPs which bypass quantization.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Enable differentiating client-side traffic sent to the ECS Task Metadata endpoint. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
