### PR TITLE
Set `$ErrorActionPreference` to ensure errors are forwarded

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1123,7 +1123,8 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
-        - test/new-e2e/tests/windows/powershell-module-test/*
+        - powershell-module/**/*
+        - test/new-e2e/tests/windows/powershell-module-test/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true

--- a/test/new-e2e/tests/windows/powershell-module-test/install_test.go
+++ b/test/new-e2e/tests/windows/powershell-module-test/install_test.go
@@ -186,12 +186,12 @@ func (v *vmSuite) setupTestHost() {
 	vm := v.Env().RemoteHost
 
 	// Install powershell-yaml
-	vm.MustExecute("Install-PackageProvider NuGet -Force")
-	vm.MustExecute("Set-PSRepository PSGallery -InstallationPolicy Trusted")
-	vm.MustExecute("Install-Module powershell-yaml -Repository PSGallery")
+	vm.MustExecute("$ErrorActionPreference='stop'; Install-PackageProvider NuGet -Force")
+	vm.MustExecute("$ErrorActionPreference='stop'; Set-PSRepository PSGallery -InstallationPolicy Trusted")
+	vm.MustExecute("$ErrorActionPreference='stop'; Install-Module powershell-yaml -Repository PSGallery")
 }
 
 func (v *vmSuite) getConfiguredValue(applicationDataDirectory, keyName string) (string, error) {
 	vm := v.Env().RemoteHost
-	return vm.Execute(fmt.Sprintf("$(Get-Content -path '%s\\datadog.yaml' | ConvertFrom-Yaml).%s", applicationDataDirectory, keyName))
+	return vm.Execute(fmt.Sprintf("$ErrorActionPreference='stop'; $(Get-Content -path '%s\\datadog.yaml' | ConvertFrom-Yaml).%s", applicationDataDirectory, keyName))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Set's `$ErrorActionPreference='stop'` in some commands in the PowerShell module E2E test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-902

The test occasionally flakes. it seems it's failing to install the `powershell-yaml` module, but `vm.MustExecute` isn't catching it because `Install-Module` errors aren't being forwarded through SSH.

example
```
$ ssh Administrator@192.168.61.10 'install-module powershell-yaml-noexist -repository psgallery'
PackageManagement\Install-Package : No match was found for the specified search criteria and
module name 'powershell-yaml-noexist'. Try Get-PSRepository to see all available registered module
repositories.
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1:1809 char:21
+ ...          $null = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPackage:InstallPackage) [
   Install-Package], Exception
    + FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdle
   ts.InstallPackage

$ echo $?
0
```

example with `$ErrorActionPreference='stop'`
```
$ ssh Administrator@192.168.61.10 '$erroractionpreference="stop"; install-module powershell-yaml-noexist -repository psgallery'
PackageManagement\Install-Package : No match was found for the specified search criteria and
module name 'powershell-yaml-noexist'. Try Get-PSRepository to see all available registered module
repositories.
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1:1809 char:21
+ ...          $null = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPackage:InstallPackage) [
   Install-Package], Exception
    + FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdle
   ts.InstallPackage

$ echo $?
1
```
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
going to look into adding this globally for our E2E tests, this isn't the first time it's been an issue.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
