### PR TITLE
[E2E] default to ErrorActionPreference=Stop

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -489,6 +489,23 @@ func buildCommandFactory(osFamily oscomp.Family) buildCommandFn {
 
 func buildCommandOnWindows(h *Host, command string, envVar EnvVar) string {
 	cmd := ""
+
+	// Set $ErrorActionPreference to 'Stop' to cause PowerShell to stop on an erorr instead
+	// of the default 'Continue' behavior.
+	// This also ensures that Execute() will return an error when the command fails.
+	//
+	// For example, if the command is (Get-Service -Name ddnpm).Status and the service does not exist,
+	// then by default the command will print an error but the exit code will be 0 and Execute() will not return an error.
+	// By setting $ErrorActionPreference to 'Stop', Execute() will return an error as one would expect.
+	//
+	// Thus, we default to 'Stop' to make sure that an error is raised when the command fails instead of failing silently.
+	// Commands that this causes issues for will be immediately noticed and can be adjusted as needed, instead of
+	// silent errors going unnoticed and affecting test results.
+	//
+	// To ignore errors, prefix command with $ErrorActionPreference='Continue' or use -ErrorAction Continue
+	// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#erroractionpreference
+	cmd += "$ErrorActionPreference='Stop'; "
+
 	envVarSave := map[string]string{}
 	for envName, envValue := range envVar {
 		previousEnvVar, err := h.executeAndReconnectOnError(fmt.Sprintf("$env:%s", envName))

--- a/test/new-e2e/tests/windows/common/acl.go
+++ b/test/new-e2e/tests/windows/common/acl.go
@@ -337,7 +337,7 @@ func GetSecurityInfoForPath(host *components.RemoteHost, path string) (ObjectSec
 	}
 
 	// Get the ACL information
-	cmd := fmt.Sprintf(`$ErrorActionPreference = 'Stop'; . %s; Get-Acl -Audit -Path '%s' | ConvertTo-ACLDTO`, aclHelpersPath, path)
+	cmd := fmt.Sprintf(`. %s; Get-Acl -Audit -Path '%s' | ConvertTo-ACLDTO`, aclHelpersPath, path)
 	output, err := host.Execute(cmd)
 	if err != nil {
 		return s, err
@@ -361,7 +361,7 @@ func GetServiceSecurityInfo(host *components.RemoteHost, serviceName string) (Ob
 	}
 
 	// Get the ACL information
-	cmd := fmt.Sprintf(`$ErrorActionPreference = 'Stop'; . %s; GetServiceSDDL('%s') | ConvertTo-ServiceSecurityDTO`, aclHelpersPath, serviceName)
+	cmd := fmt.Sprintf(`. %s; GetServiceSDDL('%s') | ConvertTo-ServiceSecurityDTO`, aclHelpersPath, serviceName)
 	output, err := host.Execute(cmd)
 	if err != nil {
 		return s, err

--- a/test/new-e2e/tests/windows/common/crashdump.go
+++ b/test/new-e2e/tests/windows/common/crashdump.go
@@ -40,7 +40,6 @@ type WERDumpFile struct {
 func EnableWERGlobalDumps(host *components.RemoteHost, dumpFolder string) error {
 
 	cmd := fmt.Sprintf(`
-		$ErrorActionPreference='stop'
 		mkdir '%s' -Force
 		icacls.exe '%s' /grant 'Everyone:(OI)(CI)F'
 		New-Item -Path '%s' -Force

--- a/test/new-e2e/tests/windows/common/powershell/command_builder.go
+++ b/test/new-e2e/tests/windows/common/powershell/command_builder.go
@@ -21,6 +21,8 @@ type powerShellCommandBuilder struct {
 //nolint:revive
 func PsHost() *powerShellCommandBuilder {
 	return &powerShellCommandBuilder{
+		// Although host.Execute() will also add `$ErrorActionPreference = "Stop"` to the command,
+		// we set it here, too, as PsHost is used in pulumi commands.
 		cmds: []string{
 			"$ErrorActionPreference = \"Stop\"",
 		},

--- a/test/new-e2e/tests/windows/common/service.go
+++ b/test/new-e2e/tests/windows/common/service.go
@@ -97,7 +97,7 @@ func (s *ServiceConfig) FetchUserSID(host *components.RemoteHost) error {
 
 // GetServiceStatus returns the status of the service
 func GetServiceStatus(host *components.RemoteHost, service string) (string, error) {
-	cmd := fmt.Sprintf("$ErrorActionPreference='Stop'; (Get-Service -Name '%s').Status", service)
+	cmd := fmt.Sprintf("(Get-Service -Name '%s').Status", service)
 	out, err := host.Execute(cmd)
 	return strings.TrimSpace(out), err
 }

--- a/test/new-e2e/tests/windows/common/utils.go
+++ b/test/new-e2e/tests/windows/common/utils.go
@@ -50,7 +50,6 @@ func MeasureCommand(host *components.RemoteHost, command string) (time.Duration,
 	// *>&1 redirects all streams
 	// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_redirection
 	powershellCommand := fmt.Sprintf(`
-		$ErrorActionPreference = "Stop"
 		$taken = Measure-Command { $cmdout = $( %s ) *>&1 | Out-String }
 		@{
 			TotalMilliseconds=$taken.TotalMilliseconds


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add `$ErrorActionPreference='stop'` for every command run with E2E on Windows hosts.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-902

Global version of https://github.com/DataDog/datadog-agent/pull/28289

Prevent silent failures of commands by default.
See code comment for more details.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
