### PR TITLE
Store K8S container "ready" state for container health in WLM (used in process payload)

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
@@ -262,7 +263,6 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 
 	switch ev.Action {
 	case events.ActionStart, events.ActionRename, events.ActionHealthStatusRunning, events.ActionHealthStatusHealthy, events.ActionHealthStatusUnhealthy, events.ActionHealthStatus:
-
 		container, err := c.dockerUtil.InspectNoCache(ctx, ev.ContainerID, false)
 		if err != nil {
 			return event, fmt.Errorf("could not inspect container %q: %s", ev.ContainerID, err)
@@ -310,7 +310,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 			State: workloadmeta.ContainerState{
 				Running:    container.State.Running,
 				Status:     extractStatus(container.State),
-				Health:     extractHealth(container.State.Health),
+				Health:     extractHealth(container.Config.Labels, container.State.Health),
 				StartedAt:  startedAt,
 				FinishedAt: finishedAt,
 				CreatedAt:  createdAt,
@@ -509,7 +509,12 @@ func extractStatus(containerState *types.ContainerState) workloadmeta.ContainerS
 	return workloadmeta.ContainerStatusUnknown
 }
 
-func extractHealth(containerHealth *types.Health) workloadmeta.ContainerHealth {
+func extractHealth(containerLabels map[string]string, containerHealth *types.Health) workloadmeta.ContainerHealth {
+	// When we're running in Kubernetes, do not report health from Docker but from Kubelet readiness
+	if _, ok := containerLabels[kubernetes.CriContainerNamespaceLabel]; ok {
+		return ""
+	}
+
 	if containerHealth == nil {
 		return workloadmeta.ContainerHealthUnknown
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -275,6 +275,13 @@ func (c *collector) parsePodContainers(
 			containerState.FinishedAt = st.FinishedAt
 		}
 
+		// Kubelet considers containers without probe to be ready
+		if container.Ready {
+			containerState.Health = workloadmeta.ContainerHealthHealthy
+		} else {
+			containerState.Health = workloadmeta.ContainerHealthUnhealthy
+		}
+
 		podContainers = append(podContainers, podContainer)
 		events = append(events, workloadmeta.CollectorEvent{
 			Source: workloadmeta.SourceNodeOrchestrator,

--- a/comp/core/workloadmeta/def/merge_test.go
+++ b/comp/core/workloadmeta/def/merge_test.go
@@ -46,6 +46,7 @@ func container1(testTime time.Time) Container {
 			CreatedAt:  testTime,
 			StartedAt:  testTime,
 			FinishedAt: time.Time{},
+			Health:     ContainerHealthUnknown,
 		},
 		CollectorTags: []string{"tag1", "tag2"},
 	}
@@ -87,6 +88,7 @@ func container2() Container {
 			StartedAt:  time.Time{},
 			FinishedAt: time.Time{},
 			ExitCode:   pointer.Ptr(int64(100)),
+			Health:     ContainerHealthHealthy,
 		},
 		CollectorTags: []string{"tag3"},
 	}
@@ -110,6 +112,7 @@ func TestMerge(t *testing.T) {
 			StartedAt:  testTime,
 			FinishedAt: time.Time{},
 			ExitCode:   pointer.Ptr(int64(100)),
+			Health:     ContainerHealthHealthy,
 		},
 	}
 

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -124,7 +124,7 @@ func (w *workloadmeta) Subscribe(name string, priority wmdef.SubscriberPriority,
 	w.storeMut.RLock()
 	defer w.storeMut.RUnlock()
 
-	if filter == nil || (filter != nil && filter.EventType() != wmdef.EventTypeUnset) {
+	if filter == nil || filter.EventType() != wmdef.EventTypeUnset {
 		for kind, entitiesOfKind := range w.store {
 			if !sub.filter.MatchKind(kind) {
 				continue


### PR DESCRIPTION
### What does this PR do?

When a container is running in Kubernetes, reflect container readiness in process container payload using the health field (currently only fed when running Docker containers AND when an healthcheck is defined).

### Motivation

Additional data for Autoscaling.

### Additional Notes

The Health column of container running Docker+Kubernetes+Docker healthcheck will show Kubernetes health instead of Docker health.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy Kubernetes PODs with readiness probe, observe the `ready` status being reflected per container in the `process-agent` by running `process-agent check container --json` and checking the `Health` field