### PR TITLE
[CWS] make sure we define a few VM constants even on darwin

### DIFF
--- a/pkg/security/secl/model/consts_darwin.go
+++ b/pkg/security/secl/model/consts_darwin.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux && !windows
-
 package model
+
+import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
 var (
 	errorConstants = map[string]int{}
@@ -16,7 +16,22 @@ var (
 	addressFamilyConstants = map[string]uint16{}
 )
 
-func initVMConstants()               {}
+var (
+	// vmConstants on darwin are used by some dd-go tests, so we need them on darwin as well
+	vmConstants = map[string]uint64{
+		"VM_NONE":  0x0,
+		"VM_READ":  0x1,
+		"VM_WRITE": 0x2,
+		"VM_EXEC":  0x4,
+	}
+)
+
+func initVMConstants() {
+	for k, v := range vmConstants {
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
+	}
+}
+
 func initBPFCmdConstants()           {}
 func initBPFHelperFuncConstants()    {}
 func initBPFMapTypeConstants()       {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Some downstream tests are run on macOS and needs those constants to be defined to have a good dev experience. This PR makes sure the classical VM_* constants are defined on macOS as well.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
