### PR TITLE
Mark AWS errors as internal errors when retrieving values in SSM

### DIFF
--- a/test/new-e2e/pkg/runner/parameters/store_aws.go
+++ b/test/new-e2e/pkg/runner/parameters/store_aws.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -50,7 +51,7 @@ func (s awsStore) get(key StoreKey) (string, error) {
 			return "", ParameterNotFoundError{key: key}
 		}
 
-		return "", fmt.Errorf("failed to get SSM parameter '%s', err: %w", awsKey, err)
+		return "", common.InternalError{Err: fmt.Errorf("failed to get SSM parameter '%s', err: %w", awsKey, err)}
 	}
 
 	return *output.Parameter.Value, nil

--- a/test/new-e2e/pkg/utils/common/internal_error.go
+++ b/test/new-e2e/pkg/utils/common/internal_error.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package common implements utilities shared across the e2e tests
+package common
+
+import "fmt"
+
+// InternalError is an error type used to wrap internal errors
+type InternalError struct {
+	Err error
+}
+
+// Error returns a printable InternalError
+func (i InternalError) Error() string {
+	return fmt.Sprintf("E2E INTERNAL ERROR: %v", i.Err)
+}
+
+// Is returns true if the target error is an InternalError
+func (i InternalError) Is(target error) bool {
+	_, ok := target.(InternalError)
+	return ok
+}

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"io"
 	"os"
 	"runtime"
@@ -50,19 +51,6 @@ var (
 	stackManager     *StackManager
 	initStackManager sync.Once
 )
-
-type internalError struct {
-	err error
-}
-
-func (i internalError) Error() string {
-	return fmt.Sprintf("E2E INTERNAL ERROR: %v", i.err)
-}
-
-func (i internalError) Is(target error) bool {
-	_, ok := target.(internalError)
-	return ok
-}
 
 // StackManager handles
 type StackManager struct {
@@ -129,7 +117,7 @@ func newStackManager() (*StackManager, error) {
 func (sm *StackManager) GetStack(ctx context.Context, name string, config runner.ConfigMap, deployFunc pulumi.RunFunc, failOnMissing bool) (_ *auto.Stack, _ auto.UpResult, err error) {
 	defer func() {
 		if err != nil {
-			err = internalError{err}
+			err = common.InternalError{Err: err}
 		}
 	}()
 
@@ -216,7 +204,7 @@ func WithCancelTimeout(cancelTimeout time.Duration) GetStackOption {
 func (sm *StackManager) GetStackNoDeleteOnFailure(ctx context.Context, name string, deployFunc pulumi.RunFunc, options ...GetStackOption) (_ *auto.Stack, _ auto.UpResult, err error) {
 	defer func() {
 		if err != nil {
-			err = internalError{err}
+			err = common.InternalError{Err: err}
 		}
 	}()
 
@@ -227,7 +215,7 @@ func (sm *StackManager) GetStackNoDeleteOnFailure(ctx context.Context, name stri
 func (sm *StackManager) DeleteStack(ctx context.Context, name string, logWriter io.Writer) (err error) {
 	defer func() {
 		if err != nil {
-			err = internalError{err}
+			err = common.InternalError{Err: err}
 		}
 	}()
 
@@ -257,7 +245,7 @@ func (sm *StackManager) DeleteStack(ctx context.Context, name string, logWriter 
 func (sm *StackManager) ForceRemoveStackConfiguration(ctx context.Context, name string) (err error) {
 	defer func() {
 		if err != nil {
-			err = internalError{err}
+			err = common.InternalError{Err: err}
 		}
 	}()
 
@@ -278,7 +266,7 @@ func (sm *StackManager) Cleanup(ctx context.Context) []error {
 	sm.stacks.Range(func(stackID string, stack *auto.Stack) {
 		err := sm.deleteStack(ctx, stackID, stack, nil, nil)
 		if err != nil {
-			errors = append(errors, internalError{err})
+			errors = append(errors, common.InternalError{Err: err})
 		}
 	})
 
@@ -573,7 +561,7 @@ func sendEventToDatadog(sender datadogEventSender, title string, message string,
 func (sm *StackManager) GetPulumiStackName(name string) (_ string, err error) {
 	defer func() {
 		if err != nil {
-			err = internalError{err}
+			err = common.InternalError{Err: err}
 		}
 	}()
 

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -9,6 +9,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"io"
 	"strings"
 	"testing"
@@ -149,7 +150,7 @@ func TestStackManager(t *testing.T) {
 			WithDatadogEventSender(mockDatadogEventSender),
 		)
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, internalError{}, "should be an internal error")
+		assert.ErrorIs(t, err, common.InternalError{}, "should be an internal error")
 		require.NotNil(t, stack)
 		defer func() {
 			err := stackManager.DeleteStack(ctx, stackName, mockWriter)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Mark AWS errors as internal errors when retrieving values in SSM

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We got some errors here: 
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/598354063
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/598354059
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/598354043

Where these errors were not marked as infra issues. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I'm still a noob when it comes to the e2e framework, any suggestions will be appreciated regarding the structure or whatever comes to your mind.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
