### PR TITLE
rpmsigning: Gracefully interrupt RPM operations

### DIFF
--- a/comp/metadata/packagesigning/packagesigningimpl/rpmsigning.go
+++ b/comp/metadata/packagesigning/packagesigningimpl/rpmsigning.go
@@ -89,7 +89,7 @@ func updateWithRepoFiles(cacheKeys map[string]signingKey, pkgManager string, cli
 
 func updateWithRPMDB(cacheKeys map[string]signingKey) error {
 	// It seems not possible to get the expiration date from rpmdb, so we extract the list of keys and call gpg
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "/usr/bin/rpm", "-qa", "gpg-pubkey*")
 	cmd.Cancel = func() error {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR attempts to interrupt RPM operations in a more gracefull way, by using SIGINT instead of the SIGKILL defaults.
It also increase the timeout before interrupting the RPM commands, as 2s might be a bit too short in some high load conditions.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Let RPM cleanup behind it and leave its database in an uncorrupted state

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
