### PR TITLE
Revert "[CONTP-312] duplicate pod and deployment metadata with address aliasing (#27506)"

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -9,18 +9,15 @@ package kubeapiserver
 
 import (
 	"context"
-	"testing"
-
 	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 )
@@ -30,68 +27,44 @@ func TestDeploymentParser_Parse(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		expected   []workloadmeta.Entity
+		expected   *workloadmeta.KubernetesDeployment
 		deployment *appsv1.Deployment
 	}{
 		{
 			name: "everything",
-			expected: []workloadmeta.Entity{
-				&workloadmeta.KubernetesDeployment{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesDeployment,
-						ID:   "test-namespace/test-deployment",
+			expected: &workloadmeta.KubernetesDeployment{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesDeployment,
+					ID:   "test-namespace/test-deployment",
+				},
+				Env:     "env",
+				Service: "service",
+				Version: "version",
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"test-label":                 "test-value",
+						"tags.datadoghq.com/env":     "env",
+						"tags.datadoghq.com/service": "service",
+						"tags.datadoghq.com/version": "version",
 					},
-					Env:     "env",
-					Service: "service",
-					Version: "version",
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label":                 "test-value",
-							"tags.datadoghq.com/env":     "env",
-							"tags.datadoghq.com/service": "service",
-							"tags.datadoghq.com/version": "version",
-						},
-						Annotations: map[string]string{
-							"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
-							"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
-						},
-					},
-					InjectableLanguages: langUtil.ContainersLanguages{
-						*langUtil.NewInitContainer("nginx-cont"): {
-							langUtil.Language(languagemodels.Go):     {},
-							langUtil.Language(languagemodels.Java):   {},
-							langUtil.Language(languagemodels.Python): {},
-						},
-						*langUtil.NewContainer("nginx-cont"): {
-							langUtil.Language(languagemodels.Go):     {},
-							langUtil.Language(languagemodels.Java):   {},
-							langUtil.Language(languagemodels.Python): {},
-						},
+					Annotations: map[string]string{
+						"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
-
-				&workloadmeta.KubernetesMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesMetadata,
-						ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment")),
+				InjectableLanguages: langUtil.ContainersLanguages{
+					*langUtil.NewInitContainer("nginx-cont"): {
+						langUtil.Language(languagemodels.Go):     {},
+						langUtil.Language(languagemodels.Java):   {},
+						langUtil.Language(languagemodels.Python): {},
 					},
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label":                 "test-value",
-							"tags.datadoghq.com/env":     "env",
-							"tags.datadoghq.com/service": "service",
-							"tags.datadoghq.com/version": "version",
-						},
-						Annotations: map[string]string{
-							"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
-							"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
-						},
+					*langUtil.NewContainer("nginx-cont"): {
+						langUtil.Language(languagemodels.Go):     {},
+						langUtil.Language(languagemodels.Java):   {},
+						langUtil.Language(languagemodels.Python): {},
 					},
-					GVR: &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 				},
 			},
 
@@ -119,46 +92,26 @@ func TestDeploymentParser_Parse(t *testing.T) {
 		},
 		{
 			name: "only usm",
-			expected: []workloadmeta.Entity{
-				&workloadmeta.KubernetesDeployment{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesDeployment,
-						ID:   "test-namespace/test-deployment",
-					},
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label":                 "test-value",
-							"tags.datadoghq.com/env":     "env",
-							"tags.datadoghq.com/service": "service",
-							"tags.datadoghq.com/version": "version",
-						},
-						Annotations: map[string]string{},
-					},
-					Env:                 "env",
-					Service:             "service",
-					Version:             "version",
-					InjectableLanguages: make(langUtil.ContainersLanguages),
+			expected: &workloadmeta.KubernetesDeployment{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesDeployment,
+					ID:   "test-namespace/test-deployment",
 				},
-				&workloadmeta.KubernetesMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesMetadata,
-						ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment")),
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"test-label":                 "test-value",
+						"tags.datadoghq.com/env":     "env",
+						"tags.datadoghq.com/service": "service",
+						"tags.datadoghq.com/version": "version",
 					},
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label":                 "test-value",
-							"tags.datadoghq.com/env":     "env",
-							"tags.datadoghq.com/service": "service",
-							"tags.datadoghq.com/version": "version",
-						},
-						Annotations: map[string]string{},
-					},
-					GVR: &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Annotations: map[string]string{},
 				},
+				Env:                 "env",
+				Service:             "service",
+				Version:             "version",
+				InjectableLanguages: make(langUtil.ContainersLanguages),
 			},
 			deployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
@@ -183,53 +136,33 @@ func TestDeploymentParser_Parse(t *testing.T) {
 
 		{
 			name: "only languages",
-			expected: []workloadmeta.Entity{
-				&workloadmeta.KubernetesDeployment{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesDeployment,
-						ID:   "test-namespace/test-deployment",
+			expected: &workloadmeta.KubernetesDeployment{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesDeployment,
+					ID:   "test-namespace/test-deployment",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"test-label": "test-value",
 					},
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label": "test-value",
-						},
-						Annotations: map[string]string{
-							"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
-							"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
-						},
-					},
-					InjectableLanguages: langUtil.ContainersLanguages{
-						*langUtil.NewInitContainer("nginx-cont"): {
-							langUtil.Language(languagemodels.Go):     {},
-							langUtil.Language(languagemodels.Java):   {},
-							langUtil.Language(languagemodels.Python): {},
-						},
-						*langUtil.NewContainer("nginx-cont"): {
-							langUtil.Language(languagemodels.Go):     {},
-							langUtil.Language(languagemodels.Java):   {},
-							langUtil.Language(languagemodels.Python): {},
-						},
+					Annotations: map[string]string{
+						"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
+						"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
 					},
 				},
-				&workloadmeta.KubernetesMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesMetadata,
-						ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment")),
+				InjectableLanguages: langUtil.ContainersLanguages{
+					*langUtil.NewInitContainer("nginx-cont"): {
+						langUtil.Language(languagemodels.Go):     {},
+						langUtil.Language(languagemodels.Java):   {},
+						langUtil.Language(languagemodels.Python): {},
 					},
-					EntityMeta: workloadmeta.EntityMeta{
-						Name:      "test-deployment",
-						Namespace: "test-namespace",
-						Labels: map[string]string{
-							"test-label": "test-value",
-						},
-						Annotations: map[string]string{
-							"internal.dd.datadoghq.com/nginx-cont.detected_langs":      "go,java,  python  ",
-							"internal.dd.datadoghq.com/init.nginx-cont.detected_langs": "go,java,  python  ",
-						},
+					*langUtil.NewContainer("nginx-cont"): {
+						langUtil.Language(languagemodels.Go):     {},
+						langUtil.Language(languagemodels.Java):   {},
+						langUtil.Language(languagemodels.Python): {},
 					},
-					GVR: &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 				},
 			},
 			deployment: &appsv1.Deployment{
@@ -257,20 +190,10 @@ func TestDeploymentParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser, err := newdeploymentParser(excludeAnnotations)
 			require.NoError(t, err)
-			parsedEntities := parser.Parse(tt.deployment)
-
-			// Assert that entities are correctly generated
-			assert.ElementsMatch(t, tt.expected, parsedEntities)
-
-			// Assert that Annotations and Labels of all entities refer to the same address in memory
-			deploymentEntity, ok := parsedEntities[0].(*workloadmeta.KubernetesDeployment)
+			entity := parser.Parse(tt.deployment)
+			storedDeployment, ok := entity.(*workloadmeta.KubernetesDeployment)
 			require.True(t, ok)
-
-			metadataEntity, ok := parsedEntities[1].(*workloadmeta.KubernetesMetadata)
-			require.True(t, ok)
-
-			assert.Truef(t, sameInMemory(deploymentEntity.Annotations, metadataEntity.Annotations), "parsed annotations are duplicated in memory")
-			assert.True(t, sameInMemory(deploymentEntity.Labels, metadataEntity.Labels), "parsed labels are duplicated in memory")
+			assert.Equal(t, tt.expected, storedDeployment)
 		})
 	}
 }
@@ -317,21 +240,6 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 							},
 							Env:                 "env",
 							InjectableLanguages: make(langUtil.ContainersLanguages),
-						},
-					},
-					{
-						Type: workloadmeta.EventTypeSet,
-						Entity: &workloadmeta.KubernetesMetadata{
-							EntityID: workloadmeta.EntityID{
-								ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment")),
-								Kind: workloadmeta.KindKubernetesMetadata,
-							},
-							EntityMeta: workloadmeta.EntityMeta{
-								Name:      "test-deployment",
-								Namespace: "test-namespace",
-								Labels:    map[string]string{"test-label": "test-value", "tags.datadoghq.com/env": "env"},
-							},
-							GVR: &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 						},
 					},
 				},
@@ -386,24 +294,6 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 									langUtil.Language(languagemodels.Python): {},
 								},
 							},
-						},
-					},
-					{
-						Type: workloadmeta.EventTypeSet,
-						Entity: &workloadmeta.KubernetesMetadata{
-							EntityID: workloadmeta.EntityID{
-								ID:   string(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment")),
-								Kind: workloadmeta.KindKubernetesMetadata,
-							},
-							EntityMeta: workloadmeta.EntityMeta{
-								Name:      "test-deployment",
-								Namespace: "test-namespace",
-								Annotations: map[string]string{"test-label": "test-value",
-									"internal.dd.datadoghq.com/nginx.detected_langs":      "go,java",
-									"internal.dd.datadoghq.com/init.redis.detected_langs": "go,python",
-								},
-							},
-							GVR: &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 						},
 					},
 				},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata.go
@@ -43,8 +43,9 @@ func newMetadataStore(ctx context.Context, wlmetaStore workloadmeta.Component, c
 
 	metadataStore := &reflectorStore{
 		wlmetaStore: wlmetaStore,
-		seen:        make(map[string][]workloadmeta.EntityID),
+		seen:        make(map[string]workloadmeta.EntityID),
 		parser:      parser,
+		filter:      nil,
 	}
 	metadataReflector := cache.NewNamedReflector(
 		componentName,
@@ -70,11 +71,11 @@ func newMetadataParser(gvr schema.GroupVersionResource, annotationsExclude []str
 	return metadataParser{gvr: &gvr, annotationsFilter: filters}, nil
 }
 
-func (p metadataParser) Parse(obj interface{}) []workloadmeta.Entity {
+func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 	partialObjectMetadata := obj.(*metav1.PartialObjectMetadata)
 	id := util.GenerateKubeMetadataEntityID(p.gvr.Group, p.gvr.Resource, partialObjectMetadata.Namespace, partialObjectMetadata.Name)
 
-	return []workloadmeta.Entity{&workloadmeta.KubernetesMetadata{
+	return &workloadmeta.KubernetesMetadata{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesMetadata,
 			ID:   string(id),
@@ -86,5 +87,5 @@ func (p metadataParser) Parse(obj interface{}) []workloadmeta.Entity {
 			Annotations: filterMapStringKey(partialObjectMetadata.Annotations, p.annotationsFilter),
 		},
 		GVR: p.gvr,
-	}}
+	}
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/metadata_test.go
@@ -180,12 +180,10 @@ func TestParse_ParsePartialObjectMetadata(t *testing.T) {
 				require.Errorf(tt, err, "should have failed to create parser")
 			} else {
 				require.NoErrorf(tt, err, "should have not failed to create parser")
-				parsedEntities := parser.Parse(test.partialObjectMetadata)
-				for _, entity := range parsedEntities {
-					storedMetadata, ok := entity.(*workloadmeta.KubernetesMetadata)
-					require.True(t, ok)
-					assert.Equal(t, test.expected, storedMetadata)
-				}
+				entity := parser.Parse(test.partialObjectMetadata)
+				storedMetadata, ok := entity.(*workloadmeta.KubernetesMetadata)
+				require.True(t, ok)
+				assert.Equal(t, test.expected, storedMetadata)
 			}
 		})
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -14,13 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -57,14 +55,13 @@ func newPodReflectorStore(wlmetaStore workloadmeta.Component, config config.Read
 
 	return &reflectorStore{
 		wlmetaStore: wlmetaStore,
-		seen:        make(map[string][]workloadmeta.EntityID),
+		seen:        make(map[string]workloadmeta.EntityID),
 		parser:      parser,
 	}
 }
 
 type podParser struct {
 	annotationsFilter []*regexp.Regexp
-	gvr               *schema.GroupVersionResource
 }
 
 func newPodParser(annotationsExclude []string) (objectParser, error) {
@@ -73,16 +70,10 @@ func newPodParser(annotationsExclude []string) (objectParser, error) {
 		return nil, err
 	}
 
-	return podParser{
-		annotationsFilter: filters,
-		gvr: &schema.GroupVersionResource{
-			Version:  "v1",
-			Resource: "pods",
-		},
-	}, nil
+	return podParser{annotationsFilter: filters}, nil
 }
 
-func (p podParser) Parse(obj interface{}) []workloadmeta.Entity {
+func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 	pod := obj.(*corev1.Pod)
 	owners := make([]workloadmeta.KubernetesPodOwner, 0, len(pod.OwnerReferences))
 	for _, o := range pod.OwnerReferences {
@@ -115,9 +106,7 @@ func (p podParser) Parse(obj interface{}) []workloadmeta.Entity {
 		rtcName = *pod.Spec.RuntimeClassName
 	}
 
-	entities := make([]workloadmeta.Entity, 0, 2)
-
-	podEntity := &workloadmeta.KubernetesPod{
+	return &workloadmeta.KubernetesPod{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesPod,
 			ID:   string(pod.UID),
@@ -143,18 +132,4 @@ func (p podParser) Parse(obj interface{}) []workloadmeta.Entity {
 		// containers can be quite significant
 		// Containers:                 []workloadmeta.OrchestratorContainer{},
 	}
-
-	entities = append(entities, podEntity, &workloadmeta.KubernetesMetadata{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("", "pods", pod.Namespace, pod.Name)),
-		},
-		EntityMeta: workloadmeta.EntityMeta{
-			Labels:      podEntity.Labels,
-			Annotations: podEntity.Annotations,
-		},
-		GVR: p.gvr,
-	})
-
-	return entities
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -21,51 +21,58 @@ import (
 
 // objectParser is an interface allowing to plug any object
 type objectParser interface {
-	Parse(obj interface{}) []workloadmeta.Entity
+	Parse(obj interface{}) workloadmeta.Entity
 }
 
-// entityUID glue together a WLM Entity slice and a Kube UID
-type entitiesUID struct {
-	entities []workloadmeta.Entity
-	uid      types.UID
+// entityUID glue together a WLM Entity and a Kube UID
+type entityUID struct {
+	entity workloadmeta.Entity
+	uid    types.UID
 }
 
 type reflectorStore struct {
 	wlmetaStore workloadmeta.Component
 
 	mu     sync.Mutex
-	seen   map[string][]workloadmeta.EntityID // needs to be updated only if the object is added
+	seen   map[string]workloadmeta.EntityID // needs to be updated only if the object is added
 	parser objectParser
 	// hasSynced logic is based on the logic see in FIFO queue (client-go/tools/cache/fifo.go)
 	// Normally `Replace` is called first and then `Add/Update/Delete`.
 	// If `Add/Update/Delete` is called first, triggers hasSynced
 	hasSynced bool
+
+	// filter to keep only resources that the Cluster-Agent needs
+	filter reflectorStoreFilter
+}
+
+// The filter is called in Replace/Add/Delete functions before the obj is parsed
+type reflectorStoreFilter interface {
+	filteredOut(workloadmeta.Entity) bool
 }
 
 // Add notifies the workloadmeta store with  an EventTypeSet for the given
 // object.
 func (r *reflectorStore) Add(obj interface{}) error {
 	metaObj := obj.(metav1.Object)
-	producedEntities := r.parser.Parse(obj)
+	entity := r.parser.Parse(obj)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.hasSynced = true
-
-	objUID := string(metaObj.GetUID())
-	r.seen[objUID] = make([]workloadmeta.EntityID, 0, len(producedEntities))
-
-	for _, entity := range producedEntities {
-		r.seen[objUID] = append(r.seen[objUID], entity.GetID())
-		r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
-			{
-				Type:   workloadmeta.EventTypeSet,
-				Source: collectorID,
-				Entity: entity,
-			},
-		})
+	if r.filter != nil && r.filter.filteredOut(entity) {
+		// Don't store the object in memory if it is filtered out
+		return nil
 	}
+
+	r.seen[string(metaObj.GetUID())] = entity.GetID()
+	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeSet,
+			Source: collectorID,
+			Entity: entity,
+		},
+	})
 
 	return nil
 }
@@ -79,11 +86,14 @@ func (r *reflectorStore) Update(obj interface{}) error {
 // Replace diffs the given list with the contents of the workloadmeta store
 // (through r.seen), and updates and deletes the necessary objects.
 func (r *reflectorStore) Replace(list []interface{}, _ string) error {
-	entitiesuids := make([]entitiesUID, 0, len(list))
+	entities := make([]entityUID, 0, len(list))
 
 	for _, obj := range list {
-		parsedEntites := r.parser.Parse(obj)
-		entitiesuids = append(entitiesuids, entitiesUID{parsedEntites, obj.(metav1.Object).GetUID()})
+		entity := r.parser.Parse(obj)
+		if r.filter != nil && r.filter.filteredOut(entity) {
+			continue
+		}
+		entities = append(entities, entityUID{entity, obj.(metav1.Object).GetUID()})
 	}
 
 	r.mu.Lock()
@@ -91,42 +101,35 @@ func (r *reflectorStore) Replace(list []interface{}, _ string) error {
 
 	var events []workloadmeta.CollectorEvent
 
-	seenNow := make(map[string][]workloadmeta.EntityID)
+	seenNow := make(map[string]workloadmeta.EntityID)
 	seenBefore := r.seen
 
-	for _, entitiesuid := range entitiesuids {
-		producedEntities := entitiesuid.entities
-		uid := string(entitiesuid.uid)
+	for _, entityuid := range entities {
+		entity := entityuid.entity
+		uid := string(entityuid.uid)
 
-		seenNow[uid] = make([]workloadmeta.EntityID, 0, len(producedEntities))
-
-		for _, producedEntity := range producedEntities {
-			events = append(events, workloadmeta.CollectorEvent{
-				Type:   workloadmeta.EventTypeSet,
-				Source: collectorID,
-				Entity: producedEntity,
-			})
-
-			seenNow[uid] = append(seenNow[uid], producedEntity.GetID())
-		}
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeSet,
+			Source: collectorID,
+			Entity: entity,
+		})
 
 		delete(seenBefore, uid)
+
+		seenNow[uid] = entity.GetID()
 	}
 
-	for _, entityIDs := range seenBefore {
-
-		for _, entityID := range entityIDs {
-			entity, err := entityFromEntityID(entityID)
-			if err != nil {
-				return err
-			}
-
-			events = append(events, workloadmeta.CollectorEvent{
-				Type:   workloadmeta.EventTypeUnset,
-				Source: collectorID,
-				Entity: entity,
-			})
+	for _, entityID := range seenBefore {
+		entity, err := entityFromEntityID(entityID)
+		if err != nil {
+			return err
 		}
+
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeUnset,
+			Source: collectorID,
+			Entity: entity,
+		})
 	}
 
 	r.wlmetaStore.Notify(events)
@@ -143,6 +146,7 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	defer r.mu.Unlock()
 
 	var uid types.UID
+	var entity workloadmeta.Entity
 	switch v := obj.(type) {
 	// All the supported objects need to be in this switch statement to be able
 	// to be deleted.
@@ -159,18 +163,19 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	r.hasSynced = true
 	delete(r.seen, string(uid))
 
-	producedEntities := r.parser.Parse(obj)
+	entity = r.parser.Parse(obj)
 
-	for _, entity := range producedEntities {
-
-		r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
-			{
-				Type:   workloadmeta.EventTypeUnset,
-				Source: collectorID,
-				Entity: entity,
-			},
-		})
+	if r.filter != nil && r.filter.filteredOut(entity) {
+		return nil
 	}
+
+	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeUnset,
+			Source: collectorID,
+			Entity: entity,
+		},
+	})
 
 	return nil
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -37,9 +37,6 @@ func Test_AddDelete_Deployment(t *testing.T) {
 	deploymentStore := newDeploymentReflectorStore(workloadmetaComponent, workloadmetaComponent.GetConfig())
 
 	deployment := appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deployment",
 			Namespace: "test-namespace",
@@ -54,32 +51,17 @@ func Test_AddDelete_Deployment(t *testing.T) {
 
 	err := deploymentStore.Add(&deployment)
 	require.NoError(t, err)
-
-	// require deployment entity in store
 	require.Eventually(t, func() bool {
 		_, err = workloadmetaComponent.GetKubernetesDeployment("test-namespace/test-deployment")
-		return err == nil
-	}, timeout, interval)
-
-	// require metadata entity in store
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment"))
 		return err == nil
 	}, timeout, interval)
 
 	err = deploymentStore.Delete(&deployment)
 	require.NoError(t, err)
-
 	require.Eventually(t, func() bool {
 		_, err = workloadmetaComponent.GetKubernetesDeployment("test-namespace/test-deployment")
 		return err != nil
 	}, timeout, interval)
-
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("apps", "deployments", "test-namespace", "test-deployment"))
-		return err != nil
-	}, timeout, interval)
-
 }
 
 func Test_AddDelete_Pod(t *testing.T) {
@@ -88,9 +70,6 @@ func Test_AddDelete_Pod(t *testing.T) {
 	podStore := newPodReflectorStore(workloadmetaComponent, workloadmetaComponent.GetConfig())
 
 	pod := corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "test-namespace",
@@ -106,32 +85,17 @@ func Test_AddDelete_Pod(t *testing.T) {
 
 	err := podStore.Add(&pod)
 	require.NoError(t, err)
-
-	// require pod entity in store
 	require.Eventually(t, func() bool {
 		_, err = workloadmetaComponent.GetKubernetesPod(string(pod.UID))
 		return err == nil
 	}, timeout, interval)
 
-	// require metadata entity in store
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("", "pods", "test-namespace", "test-pod"))
-		return err == nil
-	}, timeout, interval)
-
 	err = podStore.Delete(&pod)
 	require.NoError(t, err)
-
 	require.Eventually(t, func() bool {
 		_, err = workloadmetaComponent.GetKubernetesDeployment(string(pod.UID))
 		return err != nil
 	}, timeout, interval)
-
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("", "pods", "test-namespace", "test-pod"))
-		return err != nil
-	}, timeout, interval)
-
 }
 
 func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
@@ -147,7 +111,7 @@ func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
 
 	metadataStore := &reflectorStore{
 		wlmetaStore: workloadmetaComponent,
-		seen:        make(map[string][]workloadmeta.EntityID),
+		seen:        make(map[string]workloadmeta.EntityID),
 		parser:      parser,
 	}
 
@@ -265,7 +229,7 @@ func TestReplace(t *testing.T) {
 
 	metadataStore := &reflectorStore{
 		wlmetaStore: workloadmetaComponent,
-		seen:        make(map[string][]workloadmeta.EntityID),
+		seen:        make(map[string]workloadmeta.EntityID),
 		parser:      parser,
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -10,7 +10,6 @@ package kubeapiserver
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -166,9 +165,4 @@ func testCollectMetadataEvent(t *testing.T, createObjects func() []runtime.Objec
 	assert.Equal(t, expected, actual)
 	close(stopStore)
 	wlm.Unsubscribe(ch)
-}
-
-// sameInMemory returns true if the two variables refer to the same data in memory
-func sameInMemory(x, y interface{}) bool {
-	return reflect.ValueOf(x).Pointer() == reflect.ValueOf(y).Pointer()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This reverts commit e1ae6d8e4c5c68cc66946426ebd3fed11953770d.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We noticed significant memory increase on nightlies. 

Reverting before the freeze to have more time to investigate. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- This PR is only reverting duplicating pod and deployment metadata into kubernetes_metadata entities in workloadmeta. 
- Other changes done in the reverted PR are preserved. Examples:
   - Storing deployments annotations in deployments entities
   - Storing GVR by reference 


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Reverting has no impact on any other component in the agent.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Sanity Check and E2E should be enough.
