### PR TITLE
fix(trace-agent): Add fleetcfgpath flag

### DIFF
--- a/cmd/trace-agent/command/command.go
+++ b/cmd/trace-agent/command/command.go
@@ -37,9 +37,10 @@ func MakeRootCommand() *cobra.Command {
 func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 	globalConfGetter := func() *subcommands.GlobalParams {
 		return &subcommands.GlobalParams{
-			ConfPath:   globalParams.ConfPath,
-			ConfigName: globalParams.ConfigName,
-			LoggerName: LoggerName,
+			ConfPath:             globalParams.ConfPath,
+			ConfigName:           globalParams.ConfigName,
+			LoggerName:           LoggerName,
+			FleetPoliciesDirPath: globalParams.FleetPoliciesDirPath,
 		}
 	}
 	commands := []*cobra.Command{
@@ -60,6 +61,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 	}
 
 	traceAgentCmd.PersistentFlags().StringVarP(&globalParams.ConfPath, "config", "c", defaultConfigPath, "path to directory containing datadog.yaml")
+	traceAgentCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
 
 	return &traceAgentCmd
 }


### PR DESCRIPTION
### What does this PR do?
Follow-up of https://github.com/DataDog/datadog-agent/pull/28067, there was a parameter missing for the trace agent run command.

### Motivation
Same as https://github.com/DataDog/datadog-agent/pull/28067/s

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
