### PR TITLE
discovery: Use system-probe config for check

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -163,7 +163,7 @@ func cmpEvents(a, b *event) bool {
 func Test_linuxImpl(t *testing.T) {
 	host := "test-host"
 	cfgYaml := `ignore_processes: ["ignore-1", "ignore-2"]`
-	t.Setenv("DD_SERVICE_DISCOVERY_ENABLED", "true")
+	t.Setenv("DD_DISCOVERY_ENABLED", "true")
 
 	type checkRun struct {
 		aliveProcs   []testProc
@@ -575,7 +575,7 @@ func (errorProcFS) AllProcs() ([]proc, error) {
 }
 
 func Test_linuxImpl_errors(t *testing.T) {
-	t.Setenv("DD_SERVICE_DISCOVERY_ENABLED", "true")
+	t.Setenv("DD_DISCOVERY_ENABLED", "true")
 
 	// bad procFS
 	{

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -116,7 +116,7 @@ func newCheck() check.Check {
 
 // Configure parses the check configuration and initializes the check
 func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, instanceConfig, initConfig integration.Data, source string) error {
-	if !pkgconfig.Datadog().GetBool("service_discovery.enabled") {
+	if !pkgconfig.SystemProbe.GetBool("discovery.enabled") {
 		return errors.New("service discovery is disabled")
 	}
 	if newOSImpl == nil {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -804,7 +804,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("sbom.host.analyzers", []string{"os"})
 
 	// Service discovery configuration
-	config.BindEnvAndSetDefault("service_discovery.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "service_discovery.forwarder.")
 
 	// Orchestrator Explorer - process agent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Currently, there are two different configs for the service discovery agent check.

One is in the agent config, service_discovery.enabled.  But the check will not work without the system-probe component, which has a different configuration in the system-probe config, discovery.enabled.

Unify these configs by having the agent check use the system-probe config.

Note that apart from this config, the agent check config file still needs to be created in conf.d/service_discovery.d/ like for all other agent checks.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
