### PR TITLE
[EBPF] Use SSH multiplexing in connections to KMT remotes

### DIFF
--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -25,6 +25,13 @@ SSH_OPTIONS = {
     "UserKnownHostsFile": "/dev/null",
 }
 
+# SSH options to use when we want to use the SSH multiplexer, to avoid reauthentication
+SSH_MULTIPLEX_OPTIONS = {
+    "ControlMaster": "auto",
+    "ControlPersist": "10m",
+    "ControlPath": "/tmp/ssh_mux_%h_%p_%r",
+}
+
 
 def ssh_options_command(extra_opts: dict[str, str] | None = None):
     opts = SSH_OPTIONS.copy()
@@ -104,9 +111,9 @@ class LibvirtDomain:
 
     def run_cmd(self, ctx: Context, cmd: str, allow_fail=False, verbose=False, timeout_sec=None):
         if timeout_sec is not None:
-            extra_opts = {"ConnectTimeout": str(timeout_sec)}
+            extra_opts = {"ConnectTimeout": str(timeout_sec)} | SSH_MULTIPLEX_OPTIONS
         else:
-            extra_opts = None
+            extra_opts = SSH_MULTIPLEX_OPTIONS
 
         run = f"ssh {ssh_options_command(extra_opts)} -o IdentitiesOnly=yes -i {self.ssh_key} root@{self.ip} {{proxy_cmd}} '{cmd}'"
         return self.instance.runner.run_cmd(ctx, self.instance, run, allow_fail, verbose)
@@ -116,7 +123,7 @@ class LibvirtDomain:
         if exclude is not None:
             exclude_arg = f"--exclude '{exclude}'"
 
-        return f"rsync -e \"ssh {ssh_options_command({'IdentitiesOnly': 'yes'})} {{proxy_cmd}} -i {self.ssh_key}\" -p -rt --exclude='.git*' {exclude_arg} --filter=':- .gitignore'"
+        return f"rsync -e \"ssh {ssh_options_command({'IdentitiesOnly': 'yes'} | SSH_MULTIPLEX_OPTIONS)} {{proxy_cmd}} -i {self.ssh_key}\" -p -rt --exclude='.git*' {exclude_arg} --filter=':- .gitignore'"
 
     def copy(
         self,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR enables SSH multiplexing in connections to remote EC2 instances in KMT. Establishing the SSH connections through the tunnel was taking a significant time of each copy operation in tasks such as `kmt.test`. Enabling multiplexing means those connections are reused and the process is much faster.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
