### PR TITLE
auto-instrumentation: adding /etc/ld.so.preload mount

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -246,6 +246,9 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			require.Equal(t, volumeName, tt.pod.Spec.Volumes[0].Name,
 				"expected datadog volume to be injected")
 
+			require.Equal(t, etcVolume.Name, tt.pod.Spec.Volumes[1].Name,
+				"expected datadog-etc volume to be injected")
+
 			require.Equal(t, len(tt.libInfo.libs)+1, len(tt.pod.Spec.InitContainers),
 				"expected there to be one more than the number of libs to inject for init containers")
 
@@ -253,7 +256,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 
 				var injectorMountPath string
 
-				if i == 0 { // check init container
+				if i == 0 { // check inject container
 					require.Equal(t, "datadog-init-apm-inject", c.Name,
 						"expected the first init container to be apm-inject")
 					require.Equal(t, tt.expectedInjectorImage, c.Image,
@@ -273,18 +276,22 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 
 				// each of the init containers writes a timestamp to their given volume mount path
 				require.Equal(t, 1, len(c.Args), "expected container args")
-				_, suffix, found := strings.Cut(c.Args[0], "&&")
-				require.True(t, found, "expected container args separated by &&")
-				echoDate, toFile, found := strings.Cut(suffix, ">>")
-				require.True(t, found, "expected container args with piping redirection")
-				require.Equal(t, "echo $(date +%s)", strings.TrimSpace(echoDate), "expected container args with date")
-				require.Equal(t, injectorMountPath+"/c-init-time."+c.Name, strings.TrimSpace(toFile),
-					"expected to write to file based on the container name")
+				// the last part of each of the init container's command should be writing
+				// a timestamp based on the name of the container.
+				expectedTimestampPath := injectorMountPath + "/c-init-time." + c.Name
+				cmdTail := "&& echo $(date +%s) >> " + expectedTimestampPath
+				require.Contains(t, c.Args[0], cmdTail, "expected args to contain %s", cmdTail)
+				prefix, found := strings.CutSuffix(c.Args[0], cmdTail)
+				require.True(t, found, "expected args to end with %s ", cmdTail)
+
+				if i == 0 { // inject container
+					require.Contains(t, prefix, "&& echo /opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so > /datadog-etc/ld.so.preload")
+				}
 			}
 
-			// two volume mounts
+			// three volume mounts
 			mounts := tt.pod.Spec.Containers[0].VolumeMounts
-			require.Equal(t, 2, len(mounts), "expected 2 volume mounts in the application container")
+			require.Equal(t, 3, len(mounts), "expected 3 volume mounts in the application container")
 			require.Equal(t, corev1.VolumeMount{
 				Name:      volumeName,
 				MountPath: "/opt/datadog-packages/datadog-apm-inject",
@@ -292,10 +299,16 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				ReadOnly:  true,
 			}, mounts[0], "expected first container volume mount to be the injector")
 			require.Equal(t, corev1.VolumeMount{
+				Name:      etcVolume.Name,
+				MountPath: "/etc/ld.so.preload",
+				SubPath:   "ld.so.preload",
+				ReadOnly:  true,
+			}, mounts[1], "expected first container volume mount to be the injector")
+			require.Equal(t, corev1.VolumeMount{
 				Name:      volumeName,
 				MountPath: "/opt/datadog/apm/library",
 				SubPath:   "opt/datadog/apm/library",
-			}, mounts[1], "expected the second container volume mount to be the language libraries")
+			}, mounts[2], "expected the second container volume mount to be the language libraries")
 
 			requireEnv(t, "LD_PRELOAD", true, "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so")
 			requireEnv(t, "DD_INJECT_SENDER_TYPE", true, "k8s")

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
@@ -15,6 +15,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	injectPackageDir   = "opt/datadog-packages/datadog-apm-inject"
+	libraryPackagesDir = "opt/datadog/apm/library"
+)
+
+func asAbs(path string) string {
+	return "/" + path
+}
+
+func injectorFilePath(name string) string {
+	return injectPackageDir + "/stable/inject/" + name
+}
+
 var sourceVolume = volume{
 	Volume: corev1.Volume{
 		Name: volumeName,
@@ -29,13 +42,32 @@ var v1VolumeMount = sourceVolume.mount(corev1.VolumeMount{
 })
 
 var v2VolumeMountInjector = sourceVolume.mount(corev1.VolumeMount{
-	MountPath: "/opt/datadog-packages/datadog-apm-inject",
-	SubPath:   "opt/datadog-packages/datadog-apm-inject",
+	MountPath: asAbs(injectPackageDir),
+	SubPath:   injectPackageDir,
 })
 
 var v2VolumeMountLibrary = sourceVolume.mount(corev1.VolumeMount{
-	MountPath: "/opt/datadog/apm/library",
-	SubPath:   "opt/datadog/apm/library",
+	MountPath: asAbs(libraryPackagesDir),
+	SubPath:   libraryPackagesDir,
+})
+
+var etcVolume = volume{
+	Volume: corev1.Volume{
+		Name: "datadog-auto-instrumentation-etc",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
+}
+
+var volumeMountETCDPreloadInitContainer = etcVolume.mount(corev1.VolumeMount{
+	MountPath: "/datadog-etc",
+})
+
+var volumeMountETCDPreloadAppContainer = etcVolume.mount(corev1.VolumeMount{
+	MountPath: "/etc/ld.so.preload",
+	SubPath:   "ld.so.preload",
+	ReadOnly:  true,
 })
 
 type injector struct {
@@ -62,12 +94,20 @@ func (i *injector) initContainer() initContainer {
 			Image:   i.image,
 			Command: []string{"/bin/sh", "-c", "--"},
 			Args: []string{
+				// TODO: We should probably move this into either a script that's in the container _or_
+				//       something we can do with a go template because this is not great.
 				fmt.Sprintf(
-					`cp -r /%s/* %s && echo $(date +%%s) >> %s`,
-					mount.SubPath, mount.MountPath, tsFilePath,
+					`cp -r /%s/* %s && echo %s > /datadog-etc/ld.so.preload && echo $(date +%%s) >> %s`,
+					mount.SubPath,
+					mount.MountPath,
+					asAbs(injectorFilePath("launcher.preload.so")),
+					tsFilePath,
 				),
 			},
-			VolumeMounts: []corev1.VolumeMount{mount},
+			VolumeMounts: []corev1.VolumeMount{
+				mount,
+				volumeMountETCDPreloadInitContainer.VolumeMount,
+			},
 		},
 	}
 }
@@ -75,20 +115,22 @@ func (i *injector) initContainer() initContainer {
 func (i *injector) requirements() libRequirement {
 	return libRequirement{
 		initContainers: []initContainer{i.initContainer()},
-		volumes:        []volume{sourceVolume},
-		volumeMounts:   []volumeMount{v2VolumeMountInjector.readOnly().prepended()},
+		volumes: []volume{
+			sourceVolume,
+			etcVolume,
+		},
+		volumeMounts: []volumeMount{
+			volumeMountETCDPreloadAppContainer.prepended(),
+			v2VolumeMountInjector.readOnly().prepended(),
+		},
 		envVars: []envVar{
 			{
-				key: "LD_PRELOAD",
-				valFunc: identityValFunc(
-					"/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
-				),
+				key:     "LD_PRELOAD",
+				valFunc: identityValFunc(asAbs(injectorFilePath("launcher.preload.so"))),
 			},
 			{
-				key: "DD_INJECT_SENDER_TYPE",
-				valFunc: identityValFunc(
-					"k8s",
-				),
+				key:     "DD_INJECT_SENDER_TYPE",
+				valFunc: identityValFunc("k8s"),
 			},
 			{
 				key:     "DD_INJECT_START_TIME",


### PR DESCRIPTION
### What does this PR do?

Updated the apm-injector mutator to also set mount the `ld.so.preload` to `/etc/ld.so.preload` to be consistent with what we do on other platforms.

[APMON-1361](https://datadoghq.atlassian.net/browse/APMON-1361)

### Motivation

Follow up to feedback on #27811, this ensures consistency between injection approaches on k8s, host, and docker.

### Additional Notes

- [x] We need to add `ld.so.preload` to the inject package first.


<img width="863" alt="Screenshot 2024-08-14 at 12 09 06 PM" src="https://github.com/user-attachments/assets/ad0cc53a-5c00-4a69-a5c3-50b98f63c87b">

### Possible Drawbacks / Trade-offs

Not doing this means that we would have different behavior across platforms that would involve more forking documentation, and would make things harder to debug for our users.

### Describe how to test/QA your changes

Testing is covered via updates to unit tests and also going through manual QA with https://github.com/DataDog/k8s-ssi-v2-testing

#### Manual testing steps 

- [x] Validate that `ld.so.preload` is mounted to the application container
- [x] exec into the container, unset the `LD_PRELOAD` environment variable and try to run the application again-- injection should still work.
- [x] Validate that the wehbook sets the path correctly :) 

Results:
<img width="755" alt="Screenshot 2024-08-14 at 5 21 07 PM" src="https://github.com/user-attachments/assets/aa7d23d0-0a1a-4800-a75a-04e512f95c15">

<img width="878" alt="Screenshot 2024-08-14 at 5 22 25 PM" src="https://github.com/user-attachments/assets/f241e00e-b9e1-45b2-b3f9-0bc085cb4141">


[APMON-1361]: https://datadoghq.atlassian.net/browse/APMON-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ