### PR TITLE
Skip flaky tests in the Slack notification

### DIFF
--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -13,12 +13,14 @@ from tasks.libs.ciproviders.gitlab_api import (
 from tasks.libs.common.utils import gitlab_section
 from tasks.test_core import ModuleTestResult
 
+FLAKY_TEST_INDICATOR = "flakytest: this is a known flaky test"
+
 
 class TestWasher:
     def __init__(
         self,
         test_output_json_file="module_test_output.json",
-        flaky_test_indicator="flakytest: this is a known flaky test",
+        flaky_test_indicator=FLAKY_TEST_INDICATOR,
         flakes_file_path="flakes.yaml",
     ):
         self.test_output_json_file = test_output_json_file


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Skip flaky tests in the Slack notification 


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The notification currently also print the flakes, example:
<img width="911" alt="Screenshot 2024-08-08 at 17 12 04" src="https://github.com/user-attachments/assets/6092b57b-947d-4eb9-80c5-84e3cfc22784">

This test is in fact flaky and did not make the job fail (the other one did)
https://github.com/DataDog/datadog-agent/blob/0d39c837ce789bdd039632a85e9b0929ede31af6/comp/dogstatsd/server/server_test.go#L82-L85

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Tested with `CI_PIPELINE_ID=41214170 deva notify.send-message -n merge --dry-run`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
