### PR TITLE
Append `_custom` to k8s event source if filtering is enabled and custom filter is used

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -118,6 +118,10 @@ const defaultEventSource = "kubernetes"
 // kubernetesEventSource is the name of the source for kubernetes events
 const kubernetesEventSource = "kubernetes"
 
+// customEventSourceSuffix is the suffix that will be added to the event source type when
+// filtering is enabled and the event does not exist within integrationToCollectedEventTypes.
+const customEventSourceSuffix = "custom"
+
 var integrationToCollectedEventTypes = map[string][]collectedEventType{
 	"kubernetes": {
 		{

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -73,7 +73,16 @@ func (c *unbundledTransformer) Transform(events []*v1.Event) ([]event.Event, []e
 			source,
 		)
 
-		isCollected := (c.filteringEnabled && shouldCollectByDefault(ev)) || c.shouldCollect(ev)
+		collectedByDefault := false
+		if c.filteringEnabled {
+			if !shouldCollectByDefault(ev) {
+				source = fmt.Sprintf("%s_%s", source, customEventSourceSuffix)
+			} else {
+				collectedByDefault = true
+			}
+		}
+
+		isCollected := collectedByDefault || c.shouldCollect(ev)
 		if !isCollected {
 			if c.bundleUnspecifiedEvents {
 				eventsToBundle = append(eventsToBundle, ev)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -567,6 +567,7 @@ func TestUnbundledEventsTransformFiltering(t *testing.T) {
 		name                   string
 		bundleUnspecifedEvents bool
 		filteringEnabled       bool
+		customFilter           []collectedEventType
 		expected               []event.Event
 	}{
 		{
@@ -596,6 +597,68 @@ func TestUnbundledEventsTransformFiltering(t *testing.T) {
 					AlertType:      event.AlertTypeWarning,
 					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
 					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+			},
+		},
+		{
+			name:                   "default filtering enabled with custom filter, bundle unspecified events disabled",
+			bundleUnspecifedEvents: false,
+			filteringEnabled:       true,
+			customFilter: []collectedEventType{
+				{
+					Kind:    "Pod",
+					Source:  "kubelet",
+					Reasons: []string{"Pulled"},
+				},
+			},
+			expected: []event.Event{
+				{
+					Title:    "Pod default/wartortle-8fff95dbb-tsc7v: Failed",
+					Text:     "All containers terminated",
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"event_reason:Failed",
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes",
+					EventType:      "kubernetes_apiserver",
+				},
+				{
+					Title:    "Pod default/wartortle-8fff95dbb-tsc7v: Pulled",
+					Text:     "Successfully pulled image \"pokemon/squirtle:latest\" in 1.263s (1.263s including waiting)",
+					Ts:       ts.Time.Unix(),
+					Priority: event.PriorityNormal,
+					Host:     "test-host-test-cluster",
+					Tags: []string{
+						"event_reason:Pulled",
+						"kube_kind:Pod",
+						"kube_name:wartortle-8fff95dbb-tsc7v",
+						"kube_namespace:default",
+						"kubernetes_kind:Pod",
+						"name:wartortle-8fff95dbb-tsc7v",
+						"namespace:default",
+						"pod_name:wartortle-8fff95dbb-tsc7v",
+						"orchestrator:kubernetes",
+						"reporting_controller:",
+						"source_component:kubelet",
+					},
+					AlertType:      event.AlertTypeWarning,
+					AggregationKey: "kubernetes_apiserver:17f2bab8-d051-4861-bc87-db3ba75dd6f6",
+					SourceTypeName: "kubernetes_custom",
 					EventType:      "kubernetes_apiserver",
 				},
 			},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR will append `_custom` to the source field for emitted kubernetes events when `filtering_enabled` is set to true and the event is defined in a user provided custom filter

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
