### PR TITLE
Print error instead of exception if `cmd.Start()` fails

### DIFF
--- a/pkg/collector/python/test_util.go
+++ b/pkg/collector/python/test_util.go
@@ -59,7 +59,7 @@ func testGetSubprocessOutputUnknownBin(t *testing.T) {
 	assert.Equal(t, "", C.GoString(cStdout))
 	assert.Equal(t, "", C.GoString(cStderr))
 	assert.Equal(t, C.int(0), cRetCode)
-	assert.NotNil(t, exception)
+	assert.Nil(t, exception)
 }
 
 func testGetSubprocessOutputError(t *testing.T) {

--- a/pkg/collector/python/util.go
+++ b/pkg/collector/python/util.go
@@ -20,6 +20,8 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetSubprocessOutput runs the subprocess and returns the output
@@ -70,8 +72,7 @@ func GetSubprocessOutput(argv **C.char, env **C.char, cStdout **C.char, cStderr 
 
 	err = cmd.Start()
 	if err != nil {
-		*exception = TrackedCString(fmt.Sprintf("internal error starting subprocess: %v", err))
-		return
+		log.Errorf("internal error starting subprocess: %v", err)
 	}
 
 	// Wait for the pipes to be closed *before* waiting for the cmd to exit, as per os.exec docs


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!-- TODO 
Followup to this PR https://github.com/DataDog/datadog-agent/pull/27986
Some integrations were depending on this error not being exposed. it's difficult to determine without testing every integration that uses this function what the impact could be, so to be safe and take more time to investigate, lets revert this 
-->
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
