### PR TITLE
[AMLII-1957] Fix integrations launcher filesource field creation and logs filepath

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -13,7 +13,7 @@ import (
 	ddLog "github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	"github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	pkgConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -154,7 +154,7 @@ func (s *Launcher) createFile(source *sources.LogSource) (string, error) {
 
 // integrationLogFilePath returns a directory and file to use for an integration log file
 func (s *Launcher) integrationLogFilePath(source sources.LogSource) (string, string) {
-	fileName := source.Name + ".log"
+	fileName := source.Config.Name + ".log"
 	directoryComponents := []string{s.runPath, "integrations", source.Config.Service}
 	directory := strings.Join(directoryComponents, "/")
 	filepath := strings.Join([]string{directory, fileName}, "/")

--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -125,8 +125,8 @@ func (s *Launcher) makeFileSource(source *sources.LogSource, filepath string) *s
 		Type:        config.FileType,
 		TailingMode: source.Config.TailingMode,
 		Path:        filepath,
-		Name:        "integrations",
-		Source:      "integrations source",
+		Name:        source.Config.Name,
+		Source:      source.Config.Source,
 		Tags:        source.Config.Tags,
 	})
 
@@ -157,7 +157,7 @@ func (s *Launcher) integrationLogFilePath(source sources.LogSource) (string, str
 	fileName := source.Name + ".log"
 	directoryComponents := []string{s.runPath, "integrations", source.Config.Service}
 	directory := strings.Join(directoryComponents, "/")
-	filepath := strings.Join([]string{directory, fileName}, "")
+	filepath := strings.Join([]string{directory, fileName}, "/")
 
 	return directory, filepath
 }

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -8,6 +8,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,26 @@ func (suite *LauncherTestSuite) TestWriteLogToFile() {
 
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), logText, string(fileContents))
+}
+
+// TestIntegrationLogFilePath ensures the filepath for the logs files are correct
+func (suite *LauncherTestSuite) TestIntegrationLogFilePath() {
+	logSource := sources.NewLogSource("testLogsSource", &config.LogsConfig{
+		Type:    config.IntegrationType,
+		Name:    "test_name",
+		Service: "test_service",
+		Path:    suite.testPath,
+	})
+
+	actualDirectory, actualFilePath := suite.s.integrationLogFilePath(*logSource)
+
+	expectedDirectoryComponents := []string{suite.s.runPath, "integrations", logSource.Config.Service}
+	expectedDirectory := strings.Join(expectedDirectoryComponents, "/")
+
+	expectedFilePath := strings.Join([]string{expectedDirectory, logSource.Config.Name + ".log"}, "/")
+
+	assert.Equal(suite.T(), expectedDirectory, actualDirectory)
+	assert.Equal(suite.T(), expectedFilePath, actualFilePath)
 }
 
 func TestLauncherTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Two small fixes for integrations launcher:
1. Removes the hardcoded name and source for the `fileSource`
2. Corrects the directory for integrations logs files

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing broken behavior.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

N/A

This isn't in use in production yet, so no changes should be expected.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Write a custom integration file like so:

``` yaml
logs:
  - type: integration
    service: integration_service
    source: integration_source
    name: integration_name
```

Check the datadog run directory for the file it creates (in `/opt/datadog/run/integrations/`) on nix machines, and make sure the log file is there. The final path should be `/opt/datadog/run/integrations/integration_service/integration_name.log`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
