### PR TITLE
fix(e2e-test):  k8s auto-instrumentation v2

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1015,7 +1015,6 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 				"/opt/datadog-packages/datadog-apm-inject",
 				"/opt/datadog/apm/library",
 			}, volumeMounts["datadog-auto-instrumentation"])
-			suite.Equal("/datadog-lib", volumeMounts["datadog-auto-instrumentation"])
 		}
 	}
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -987,9 +987,9 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 		suite.Equal("/var/run/datadog", hostPathVolumes["datadog"].Path)
 	}
 
-	volumeMounts := make(map[string]string)
+	volumeMounts := make(map[string][]string)
 	for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
-		volumeMounts[volumeMount.Name] = volumeMount.MountPath
+		volumeMounts[volumeMount.Name] = append(volumeMounts[volumeMount.Name], volumeMount.MountPath)
 	}
 
 	if suite.Contains(volumeMounts, "datadog") {
@@ -1011,6 +1011,10 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 		}
 		suite.Contains(emptyDirVolumes, "datadog-auto-instrumentation")
 		if suite.Contains(volumeMounts, "datadog-auto-instrumentation") {
+			suite.Equal([]string{
+				"/opt/datadog-packages/datadog-apm-inject",
+				"/opt/datadog/apm/library",
+			}, volumeMounts["datadog-auto-instrumentation"])
 			suite.Equal("/datadog-lib", volumeMounts["datadog-auto-instrumentation"])
 		}
 	}

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -993,7 +993,7 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 	}
 
 	if suite.Contains(volumeMounts, "datadog") {
-		suite.Equal("/var/run/datadog", volumeMounts["datadog"])
+		suite.ElementsMatch([]string{"/var/run/datadog"}, volumeMounts["datadog"])
 	}
 
 	switch language {
@@ -1011,7 +1011,7 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 		}
 		suite.Contains(emptyDirVolumes, "datadog-auto-instrumentation")
 		if suite.Contains(volumeMounts, "datadog-auto-instrumentation") {
-			suite.Equal([]string{
+			suite.ElementsMatch([]string{
 				"/opt/datadog-packages/datadog-apm-inject",
 				"/opt/datadog/apm/library",
 			}, volumeMounts["datadog-auto-instrumentation"])

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1006,9 +1006,6 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 			}
 		}
 
-		if suite.Contains(env, "PYTHONPATH") {
-			suite.Equal("/datadog-lib/", env["PYTHONPATH"])
-		}
 		suite.Contains(emptyDirVolumes, "datadog-auto-instrumentation")
 		if suite.Contains(volumeMounts, "datadog-auto-instrumentation") {
 			suite.ElementsMatch([]string{


### PR DESCRIPTION
### What does this PR do?

This PR fixes an end to end test, we changed what volumes we are mounting in the container for
auto-instrumentation.

### Motivation

Missed in https://github.com/DataDog/datadog-agent/pull/27811

### Additional Notes

#incident-29616


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

