### PR TITLE
fix(fleet): Hide `fleetcfgpath` beta flag

### DIFF
--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -87,6 +87,7 @@ monitoring and performance data.`,
 	agentCmd.PersistentFlags().StringArrayVarP(&globalParams.ExtraConfFilePath, "extracfgpath", "E", []string{}, "specify additional configuration files to be loaded sequentially after the main datadog.yaml")
 	agentCmd.PersistentFlags().StringVarP(&globalParams.SysProbeConfFilePath, "sysprobecfgpath", "", "", "path to directory containing system-probe.yaml")
 	agentCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
+	_ = agentCmd.PersistentFlags().MarkHidden("fleetcfgpath")
 
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -88,6 +88,7 @@ func MakeCommand(subcommandFactories []SubcommandFactory, winParams bool, rootCm
 
 	rootCmd.PersistentFlags().StringVar(&globalParams.ConfFilePath, flags.CfgPath, flags.DefaultConfPath, "Path to datadog.yaml config")
 	rootCmd.PersistentFlags().StringVar(&globalParams.FleetPoliciesDirPath, flags.FleetCfgPath, "", "Path to the directory containing fleet policies")
+	_ = rootCmd.PersistentFlags().MarkHidden(flags.FleetCfgPath)
 
 	if flags.DefaultSysProbeConfPath != "" {
 		rootCmd.PersistentFlags().StringVar(&globalParams.SysProbeConfFilePath, flags.SysProbeConfig, flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")

--- a/cmd/security-agent/command/command.go
+++ b/cmd/security-agent/command/command.go
@@ -70,6 +70,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	SecurityAgentCmd.PersistentFlags().StringVar(&globalParams.SysProbeConfFilePath, "sysprobe-config", defaultSysProbeConfPath, "path to system-probe.yaml config")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&globalParams.NoColor, "no-color", "n", false, "disable color output")
 	SecurityAgentCmd.PersistentFlags().StringVar(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "path to the directory containing fleet policies")
+	_ = SecurityAgentCmd.PersistentFlags().MarkHidden("fleetcfgpath")
 
 	for _, factory := range subcommandFactories {
 		for _, subcmd := range factory(&globalParams) {

--- a/cmd/system-probe/command/command.go
+++ b/cmd/system-probe/command/command.go
@@ -48,6 +48,7 @@ Runtime Security Monitoring, Universal Service Monitoring, and others.`,
 
 	sysprobeCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to directory containing system-probe.yaml")
 	sysprobeCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
+	_ = sysprobeCmd.PersistentFlags().MarkHidden("fleetcfgpath")
 
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when

--- a/cmd/trace-agent/command/command.go
+++ b/cmd/trace-agent/command/command.go
@@ -62,6 +62,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 
 	traceAgentCmd.PersistentFlags().StringVarP(&globalParams.ConfPath, "config", "c", defaultConfigPath, "path to directory containing datadog.yaml")
 	traceAgentCmd.PersistentFlags().StringVarP(&globalParams.FleetPoliciesDirPath, "fleetcfgpath", "", "", "path to the directory containing fleet policies")
+	_ = traceAgentCmd.PersistentFlags().MarkHidden("fleetcfgpath")
 
 	return &traceAgentCmd
 }


### PR DESCRIPTION
### What does this PR do?
Hides the newly added `fleetcfgpath` flag. 

Fleet policies are a WIP feature, we need to have some flexibility regarding how it is implemented. Fleet policies won't be implemented in time for the next agent release, let's not display a partially-working feature to customers yet.

### Motivation
Fleet Policies safe development


### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Run `datadog-agent help` (or any agent binary) & check that fleetcfgpath isn't shown
