### PR TITLE
[CWS] exclude binaries from kill action

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -131,4 +131,5 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// CWS enforcement capabilities
 	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.raw_syscall.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.exclude_binaries", []string{})
 }

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -235,6 +235,7 @@ type RuntimeSecurityConfig struct {
 	// Enforcement capabilities
 	EnforcementEnabled           bool
 	EnforcementRawSyscallEnabled bool
+	EnforcementBinaryExcluded    []string
 
 	//WindowsFilenameCacheSize is the max number of filenames to cache
 	WindowsFilenameCacheSize int
@@ -415,6 +416,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 		// enforcement
 		EnforcementEnabled:           coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.enabled"),
+		EnforcementBinaryExcluded:    coreconfig.SystemProbe().GetStringSlice("runtime_security_config.enforcement.exclude_binaries"),
 		EnforcementRawSyscallEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.raw_syscall.enabled"),
 
 		// User Sessions

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1661,7 +1661,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, wmeta optional
 		ctx:                  ctx,
 		cancelFnc:            cancelFnc,
 		newTCNetDevices:      make(chan model.NetDevice, 16),
-		processKiller:        NewProcessKiller(),
+		processKiller:        NewProcessKiller(config),
 		onDemandRateLimiter:  rate.NewLimiter(onDemandRate, 1),
 	}
 

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -646,7 +646,7 @@ func NewEBPFLessProbe(probe *Probe, config *config.Config, opts Opts, telemetry 
 		ctx:               ctx,
 		cancelFnc:         cancelFnc,
 		clients:           make(map[net.Conn]*client),
-		processKiller:     NewProcessKiller(),
+		processKiller:     NewProcessKiller(config),
 		containerContexts: make(map[string]*ebpfless.ContainerContext),
 	}
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1189,7 +1189,7 @@ func initializeWindowsProbe(config *config.Config, opts Opts) (*WindowsProbe, er
 
 		volumeMap: make(map[string]string),
 
-		processKiller: NewProcessKiller(),
+		processKiller: NewProcessKiller(config),
 
 		blockonchannelsend: bocs,
 

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -79,6 +79,19 @@ func (p *ProcessKiller) HandleProcessExited(event *model.Event) {
 	})
 }
 
+func isKillAllowed(pids []uint32, paths []string) bool {
+	for i, pid := range pids {
+		if pid <= 1 || pid == utils.Getpid() {
+			return false
+		}
+
+		if slices.Contains(protectedBinaries, paths[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // KillAndReport kill and report
 func (p *ProcessKiller) KillAndReport(scope string, signal string, rule *rules.Rule, ev *model.Event, killFnc func(pid uint32, sig uint32) error) {
 	entry, exists := ev.ResolveProcessCacheEntry()
@@ -92,9 +105,15 @@ func (p *ProcessKiller) KillAndReport(scope string, signal string, rule *rules.R
 		scope = "process"
 	}
 
-	pids, err := p.getPids(scope, ev, entry)
+	pids, paths, err := p.getProcesses(scope, ev, entry)
 	if err != nil {
 		log.Errorf("unable to kill: %s", err)
+		return
+	}
+
+	// if one pids is not allowed don't kill anything
+	if !isKillAllowed(pids, paths) {
+		log.Warnf("unable to kill, some processes are protected: %v, %v", pids, paths)
 		return
 	}
 
@@ -102,10 +121,6 @@ func (p *ProcessKiller) KillAndReport(scope string, signal string, rule *rules.R
 
 	killedAt := time.Now()
 	for _, pid := range pids {
-		if pid <= 1 || pid == utils.Getpid() {
-			continue
-		}
-
 		log.Debugf("requesting signal %s to be sent to %d", signal, pid)
 
 		if err := killFnc(uint32(pid), uint32(sig)); err != nil {

--- a/pkg/security/probe/process_killer_linux.go
+++ b/pkg/security/probe/process_killer_linux.go
@@ -22,12 +22,13 @@ const (
 
 var (
 	// list of binaries that can't be killed
-	protectedBinaries = []string{
+	binariesExcluded = []string{
 		"/opt/datadog-agent/bin/agent/agent",
 		"/opt/datadog-agent/embedded/bin/trace-agent",
 		"/opt/datadog-agent/embedded/bin/security-agent",
 		"/opt/datadog-agent/embedded/bin/process-agent",
 		"/opt/datadog-agent/embedded/bin/system-probe",
+		"/opt/datadog-agent/embedded/bin/cws-instrumentation",
 		"/opt/datadog-agent/bin/datadog-cluster-agent",
 	}
 )

--- a/pkg/security/probe/process_killer_linux.go
+++ b/pkg/security/probe/process_killer_linux.go
@@ -20,6 +20,18 @@ const (
 	userSpaceKillWithinMillis = 2000
 )
 
+var (
+	// list of binaries that can't be killed
+	protectedBinaries = []string{
+		"/opt/datadog-agent/bin/agent/agent",
+		"/opt/datadog-agent/embedded/bin/trace-agent",
+		"/opt/datadog-agent/embedded/bin/security-agent",
+		"/opt/datadog-agent/embedded/bin/process-agent",
+		"/opt/datadog-agent/embedded/bin/system-probe",
+		"/opt/datadog-agent/bin/datadog-cluster-agent",
+	}
+)
+
 // KillFromUserspace tries to kill from userspace
 func (p *ProcessKiller) KillFromUserspace(pid uint32, sig uint32, ev *model.Event) error {
 	proc, err := psutil.NewProcess(int32(pid))
@@ -47,13 +59,17 @@ func (p *ProcessKiller) KillFromUserspace(pid uint32, sig uint32, ev *model.Even
 	return syscall.Kill(int(pid), syscall.Signal(sig))
 }
 
-func (p *ProcessKiller) getPids(scope string, ev *model.Event, entry *model.ProcessCacheEntry) ([]uint32, error) {
-	var pids []uint32
+func (p *ProcessKiller) getProcesses(scope string, ev *model.Event, entry *model.ProcessCacheEntry) ([]uint32, []string, error) {
+	var (
+		pids  []uint32
+		paths []string
+	)
 
 	if entry.ContainerID != "" && scope == "container" {
-		pids = entry.GetContainerPIDs()
+		pids, paths = entry.GetContainerPIDs()
 	} else {
 		pids = []uint32{ev.ProcessContext.Pid}
+		paths = []string{ev.ProcessContext.FileEvent.PathnameStr}
 	}
-	return pids, nil
+	return pids, paths, nil
 }

--- a/pkg/security/probe/process_killer_windows.go
+++ b/pkg/security/probe/process_killer_windows.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// list of binaries that can't be killed
-	protectedBinaries = []string{}
+	binariesExcluded = []string{}
 )
 
 // KillFromUserspace tries to kill from userspace

--- a/pkg/security/probe/process_killer_windows.go
+++ b/pkg/security/probe/process_killer_windows.go
@@ -13,6 +13,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
+var (
+	// list of binaries that can't be killed
+	protectedBinaries = []string{}
+)
+
 // KillFromUserspace tries to kill from userspace
 func (p *ProcessKiller) KillFromUserspace(pid uint32, sig uint32, _ *model.Event) error {
 	if sig != model.SIGKILL {
@@ -21,9 +26,9 @@ func (p *ProcessKiller) KillFromUserspace(pid uint32, sig uint32, _ *model.Event
 	return winutil.KillProcess(int(pid), 0)
 }
 
-func (p *ProcessKiller) getPids(scope string, ev *model.Event, _ *model.ProcessCacheEntry) ([]uint32, error) {
+func (p *ProcessKiller) getProcesses(scope string, ev *model.Event, _ *model.ProcessCacheEntry) ([]uint32, []string, error) {
 	if scope == "container" {
-		return nil, errors.New("container scope not supported")
+		return nil, nil, errors.New("container scope not supported")
 	}
-	return []uint32{ev.ProcessContext.Pid}, nil
+	return []uint32{ev.ProcessContext.Pid}, []string{ev.ProcessContext.FileEvent.PathnameStr}, nil
 }

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -106,19 +106,23 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 }
 
 // GetContainerPIDs return the pids
-func (pc *ProcessCacheEntry) GetContainerPIDs() []uint32 {
-	var pids []uint32
+func (pc *ProcessCacheEntry) GetContainerPIDs() ([]uint32, []string) {
+	var (
+		pids  []uint32
+		paths []string
+	)
 
 	for pc != nil {
 		if pc.ContainerID == "" {
 			break
 		}
 		pids = append(pids, pc.Pid)
+		paths = append(paths, pc.FileEvent.PathnameStr)
 
 		pc = pc.Ancestor
 	}
 
-	return pids
+	return pids, paths
 }
 
 // SetParentOfForkChild set the parent of a fork child

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/oliveagle/jsonpath"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -187,6 +188,64 @@ func TestActionKill(t *testing.T) {
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
 		assert.NoError(t, err)
 	})
+}
+
+func TestActionKillExcludeBinary(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if !ebpfLessEnabled {
+		checkKernelCompatibility(t, "bpf_send_signal is not supported on this kernel and agent is running in container mode", func(kv *kernel.Version) bool {
+			return !kv.SupportBPFSendSignal() && config.IsContainerized()
+		})
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "kill_action_kill_exclude",
+			Expression: `exec.file.name == "sleep" && exec.argv in ["1234567"]`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Kill: &rules.KillDefinition{
+						Signal: "SIGKILL",
+					},
+				},
+			},
+		},
+	}
+
+	executable := which(t, "sleep")
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enforcementExcludeBinary: executable}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	killed := atomic.NewBool(false)
+
+	err = test.GetEventSent(t, func() error {
+		go func() {
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			cmd := exec.CommandContext(timeoutCtx, "sleep", "1234567")
+			_ = cmd.Run()
+
+			killed.Store(true)
+		}()
+
+		return nil
+	}, func(rule *rules.Rule, event *model.Event) bool {
+		return true
+	}, time.Second*5, "kill_action_kill_exclude")
+
+	if err != nil {
+		t.Error("should get an event")
+	}
+
+	if killed.Load() {
+		t.Error("shouldn't be killed")
+	}
 }
 
 func TestActionKillRuleSpecific(t *testing.T) {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -774,6 +774,7 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		"FIMEnabled":                                 opts.enableFIM, // should only be enabled/disabled on windows
 		"NetworkIngressEnabled":                      opts.networkIngressEnabled,
 		"OnDemandRateLimiterEnabled":                 !opts.disableOnDemandRateLimiter,
+		"EnforcementExcludeBinary":                   opts.enforcementExcludeBinary,
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -117,6 +117,9 @@ runtime_security_config:
     enabled: {{ .SBOMEnabled }}
     host:
       enabled: {{ .HostSBOMEnabled }}
+  enforcement:
+    exclude_binaries:
+      - {{ .EnforcementExcludeBinary }}
   activity_dump:
     enabled: {{ .EnableActivityDump }}
     syscall_monitor:

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -63,6 +63,7 @@ type testOpts struct {
 	disableOnDemandRateLimiter                 bool
 	ebpfLessEnabled                            bool
 	dontWaitEBPFLessClient                     bool
+	enforcementExcludeBinary                   string
 }
 
 type dynamicTestOpts struct {
@@ -137,5 +138,6 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.preStartCallback == nil && opts.preStartCallback == nil &&
 		to.networkIngressEnabled == opts.networkIngressEnabled &&
 		to.disableOnDemandRateLimiter == opts.disableOnDemandRateLimiter &&
-		to.ebpfLessEnabled == opts.ebpfLessEnabled
+		to.ebpfLessEnabled == opts.ebpfLessEnabled &&
+		to.enforcementExcludeBinary == opts.enforcementExcludeBinary
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR exclude specific binaries from the kill action : 

* statically defined binaries, currently agent binaries
* from the configuration file

An more accurate list of default binary path will be provided in a follow-up PR

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Don't kill essential binaries, like to core agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Write a rule with a kill action targeting the security-agent for example and check that the rule matches and the agent is not killed.
Add a binary in the exclusion config parameter and check that the binary is not killed.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
