### PR TITLE
[CWS] Fix 2 races and add another guard on finalize()

### DIFF
--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -446,6 +446,10 @@ func (ad *ActivityDump) Finalize(releaseTracedCgroupSpot bool) {
 // finalize (thread unsafe) finalizes an active dump: envs and args are scrubbed, tags, service and container ID are set. If a cgroup
 // spot can be released, the dump will be fully stopped.
 func (ad *ActivityDump) finalize(releaseTracedCgroupSpot bool) {
+	if ad.state == Stopped {
+		return
+	}
+
 	ad.Metadata.End = time.Now()
 	ad.adm.lastStoppedDumpTime = ad.Metadata.End
 

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -143,14 +143,7 @@ func (adm *ActivityDumpManager) cleanup() {
 		} else {
 			adm.emptyDropped.Inc()
 		}
-
-		// remove from the map of ignored dumps
-		adm.Lock()
-		delete(adm.ignoreFromSnapshot, ad.Metadata.ContainerID)
-		adm.Unlock()
 	}
-
-	adm.RemoveStoppedActivityDumps()
 
 	// cleanup cgroup_wait_list map
 	iterator := adm.cgroupWaitList.Iterate()
@@ -166,37 +159,23 @@ func (adm *ActivityDumpManager) cleanup() {
 	}
 }
 
-// RemoveStoppedActivityDumps removes all stopped activity dumps from the active list
-func (adm *ActivityDumpManager) RemoveStoppedActivityDumps() {
-	adm.Lock()
-	defer adm.Unlock()
-
-	newActiveDumps := make([]*ActivityDump, 0, len(adm.activeDumps))
-	for _, ad := range adm.activeDumps {
-		ad.Lock()
-		state := ad.state
-		ad.Unlock()
-
-		if state != Stopped {
-			newActiveDumps = append(newActiveDumps, ad)
-		}
-	}
-	adm.activeDumps = newActiveDumps
-}
-
-// getExpiredDumps returns the list of dumps that have timed out
+// getExpiredDumps returns the list of dumps that have timed out and remove them from the active dumps
 func (adm *ActivityDumpManager) getExpiredDumps() []*ActivityDump {
 	adm.Lock()
 	defer adm.Unlock()
 
-	var dumps []*ActivityDump
+	var expiredDumps []*ActivityDump
+	var newDumps []*ActivityDump
 	for _, ad := range adm.activeDumps {
-		if time.Now().After(ad.Metadata.End) {
-			dumps = append(dumps, ad)
-			adm.ignoreFromSnapshot[ad.Metadata.ContainerID] = true
+		if time.Now().After(ad.Metadata.End) || ad.state == Stopped {
+			expiredDumps = append(expiredDumps, ad)
+			delete(adm.ignoreFromSnapshot, ad.Metadata.ContainerID)
+		} else {
+			newDumps = append(newDumps, ad)
 		}
 	}
-	return dumps
+	adm.activeDumps = newDumps
+	return expiredDumps
 }
 
 func (adm *ActivityDumpManager) resolveTagsPerAd(ad *ActivityDump) {

--- a/pkg/security/security_profile/dump/manager_test.go
+++ b/pkg/security/security_profile/dump/manager_test.go
@@ -204,7 +204,6 @@ func TestActivityDumpManager_getExpiredDumps(t *testing.T) {
 			for _, ad := range expiredDumps {
 				ad.state = Stopped
 			}
-			adm.RemoveStoppedActivityDumps()
 
 			compareListOfDumps(t, expiredDumps, tt.expiredDumps)
 			compareListOfDumps(t, adm.activeDumps, tt.activeDumps)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
The finalize call append some container_id tag so calling it multiple times can append multiple times the same tag.

In some cases we call finalize(true) stopping the dump, but we do not remove the stopped dumps afterwards, allowing a future call to finalize to append (especially in the cleanup phase which will always be the case since the end is always in the past). In the end we arrive to a point where we have a lot of container_id tags.

It also avoid to lock/unlock dump manager during the cleanup, avoiding possible races

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
