### PR TITLE
[NETPATH-277] Ignore intrahost traffic in network path

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/utils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils.go
@@ -17,7 +17,7 @@ func shouldScheduleNetworkPathForConn(conn *model.Connection) bool {
 		return false
 	}
 	remoteIP := net.ParseIP(conn.Raddr.Ip)
-	if remoteIP.IsLoopback() {
+	if remoteIP.IsLoopback() || conn.IntraHost {
 		return false
 	}
 	return conn.Family == model.ConnectionFamily_v4

--- a/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/utils_test.go
@@ -68,6 +68,17 @@ func Test_shouldScheduleNetworkPathForConn(t *testing.T) {
 			},
 			shouldSchedule: false,
 		},
+		{
+			name: "should not schedule for intrahost",
+			conn: &model.Connection{
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
+				Direction: model.ConnectionDirection_outgoing,
+				Family:    model.ConnectionFamily_v4,
+				IntraHost: true,
+			},
+			shouldSchedule: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Ignore intrahost traffic for Network Path

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
### Motivation
Prevent tracing requests between services on the same host which creates noise and non-useful traces.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
