### PR TITLE
[apm] fix broken compute_stats_by_span_kind

### DIFF
--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -106,7 +106,7 @@ type SpanConcentrator struct {
 // NewSpanConcentrator builds a new SpanConcentrator object
 func NewSpanConcentrator(cfg *SpanConcentratorConfig, now time.Time) *SpanConcentrator {
 	sc := &SpanConcentrator{
-		computeStatsBySpanKind: false,
+		computeStatsBySpanKind: cfg.ComputeStatsBySpanKind,
 		bsize:                  cfg.BucketInterval,
 		oldestTs:               alignTs(now.UnixNano(), cfg.BucketInterval),
 		bufferLen:              defaultBufferLen,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->

Fixes a bug introduced in https://github.com/DataDog/datadog-agent/pull/28107 where the `apm_config.compute_stats_by_span_kind` config setting was not being propagated all the way to the new `SpanConcentrator`.

The reason this wasn't caught by the unit tests is that all of the tests were marking the tests spans as `_dd.measured:1` which meant that stats would be calculated regardless of `span.kind`.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Enable both `apm_config.peer_service_aggregation` and `apm_config.compute_stats_by_span_kind`.
- Send `span.kind=span.kind` spans to the trace agent with `dns.hostname:foo.com` set in the meta.
- Validate that the `peer.hostname:foo.com` tag is available on the client metrics

### QA Results

Confirmed via local testing that client/consumer/producer stats are flowing again. 