### PR TITLE
[workflow] Fix get_last_tag function to correctly sort versions

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -169,7 +169,7 @@ def get_last_tag(ctx, repo, pattern):
     import semver
 
     tags = ctx.run(
-        rf'git ls-remote -t https://github.com/DataDog/{repo} "{pattern}"',
+        rf'git ls-remote --sort=creatordate -t https://github.com/DataDog/{repo} "{pattern}"',
         hide=True,
     ).stdout.strip()
     if not tags:
@@ -181,7 +181,7 @@ def get_last_tag(ctx, repo, pattern):
             code=1,
         )
 
-    tags_without_suffix = [line for line in tags.splitlines() if not line.endswith("^{}")]
+    tags_without_suffix = [line for line in tags.splitlines() if not line.endswith("^{}")][-5:]
     last_tag = max(tags_without_suffix, key=lambda x: cmp_to_key(semver.compare)(x.split('/')[-1]))
     last_tag_commit, last_tag_name = last_tag.split()
     tags_with_suffix = [line for line in tags.splitlines() if line.endswith("^{}")]

--- a/tasks/unit_tests/libs/common/git_tests.py
+++ b/tasks/unit_tests/libs/common/git_tests.py
@@ -116,7 +116,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_ordered(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/woof "7.56.*"': Result(
                     "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
                 )
             }
@@ -127,7 +127,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_non_ordered(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/woof "7.56.*"': Result(
                     "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.11\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
                 )
             }
@@ -138,7 +138,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_lower(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/woof "7.56.*"': Result(
                     "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
                 )
             }
@@ -149,7 +149,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_equal(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/woof "7.56.*"': Result(
                     "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.3^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
                 )
             }
@@ -160,7 +160,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_greater(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/woof "7.56.*"': Result(
                     "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.4^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
                 )
             }

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -712,31 +712,31 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t0        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
                     "4n0th3rc0mm1t1        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
                     "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
                     "4n0th3rc0mm1t2        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
                     "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
                     "4n0th3rc0mm1t4        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
                     "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
                 ),
             },
@@ -769,7 +769,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
@@ -779,7 +779,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
                     "4n0th3rc0mm1t1        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
                     "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
@@ -789,7 +789,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
                     "4n0th3rc0mm1t2        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
                     "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
@@ -799,13 +799,13 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
                     "4n0th3rc0mm1t4        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
                     "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
                 ),
                 'git tag 7.55.0-rc.2': Result(""),
@@ -846,17 +846,17 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
-                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
+                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
                     ""
                 ),
                 'rm -rf omnibus-software': Result(""),
                 'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
                     "4n0th3rc0mm1t8        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
                     "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
@@ -866,7 +866,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
                     "4n0th3rc0mm1t7        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
                     "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
@@ -876,13 +876,13 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t6        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
                     "4n0th3rc0mm1t5        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
                     "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
                 ),
                 'git tag 7.55.0-rc.2': Result(""),
@@ -928,31 +928,31 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t0        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/main"': Result(
                     "4n0th3rc0mm1t1        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
                     "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/main"': Result(
                     "4n0th3rc0mm1t2        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
                     "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.2^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/main"': Result(
                     "4n0th3rc0mm1t4        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
                     "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
                 ),
             },
@@ -994,7 +994,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t0        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
@@ -1004,7 +1004,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/omnibus-ruby "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-ruby "7.55.0*"': Result(
                     "this1s4c0mmit1        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t1        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-ruby omnibus-ruby': Result(
@@ -1014,7 +1014,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/datadog-agent-macos-build "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t2        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent-macos-build "7.55.0*"': Result(
                     "this1s4c0mmit2        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t2        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git clone -b 7.55.x --filter=blob:none --no-checkout https://github.com/DataDog/datadog-agent-macos-build datadog-agent-macos-build': Result(
@@ -1024,13 +1024,13 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
                 'git ls-remote -h https://github.com/DataDog/datadog-agent "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t4        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/datadog-agent "7.55.0*"': Result(
                     "this1s4c0mmit4        refs/tags/7.55.0-devel\n4n0th3rc0mm1t4        refs/tags/7.55.0-devel^{}"
                 ),
                 'git tag 7.55.0-rc.2': Result(""),
@@ -1067,7 +1067,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
             },
@@ -1097,7 +1097,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
             },
@@ -1127,7 +1127,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
             },
@@ -1162,7 +1162,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
-                'git ls-remote -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
+                'git ls-remote --sort=creatordate -t https://github.com/DataDog/integrations-core "7.55.0*"': Result(
                     "this1s4c0mmit3        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t3        refs/tags/7.55.0-rc.1^{}"
                 ),
             },

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -849,7 +849,7 @@ class TestCheckForChanges(unittest.TestCase):
                 'git ls-remote --sort=creatordate -t https://github.com/DataDog/omnibus-software "7.55.0*"': Result(
                     "this1s4c0mmit0        refs/tags/7.55.0-rc.1\n4n0th3rc0mm1t0        refs/tags/7.55.0-rc.1^{}"
                 ),
-                 'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
+                'git clone -b main --filter=blob:none --no-checkout https://github.com/DataDog/omnibus-software omnibus-software': Result(
                     ""
                 ),
                 'rm -rf omnibus-software': Result(""),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Mitigate the `get_last_tag` function which doesn't work and prevent the `7.56.0-rc.11` to build

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Only a temporary solution would need to get properly fixed for main

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
