### PR TITLE
Adding a check to make sure Fake Intake didn't lie to us about logs existing for a service

### DIFF
--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/k8s-logs/file_tailing_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,8 @@ func TestK8sSuite(t *testing.T) {
 }
 
 func (v *k8sSuite) TestSingleLogAndMetadata() {
-	v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	err := v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(v.T(), err, "Could not reset the Fake Intake")
 	var backOffLimit int32 = 4
 	testLogMessage := "Test log message"
 
@@ -58,7 +60,7 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 		},
 	}
 
-	_, err := v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
+	_, err = v.Env().KubernetesCluster.Client().BatchV1().Jobs("default").Create(context.TODO(), jobSpcec, metav1.CreateOptions{})
 	assert.NoError(v.T(), err, "Could not properly start job")
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
@@ -68,19 +70,22 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
 			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
 			assert.NoError(c, err, "Error filtering logs")
-			assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
+			if assert.NotEmpty(v.T(), filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
 
-			// Check container metatdata
-			assert.Equal(c, filteredLogs[0].Service, "ubuntu", "Could not find service")
-			assert.NotNil(c, filteredLogs[0].HostName, "Hostname not found")
-			assert.NotNil(c, filteredLogs[0].Tags, "Log tags not found")
+				// Check container metatdata
+				assert.Equal(c, filteredLogs[0].Service, "ubuntu", "Could not find service")
+				assert.NotNil(c, filteredLogs[0].HostName, "Hostname not found")
+				assert.NotNil(c, filteredLogs[0].Tags, "Log tags not found")
+			}
 		}
 
 	}, 1*time.Minute, 10*time.Second)
 }
 
 func (v *k8sSuite) TestLongLogLine() {
-	v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	err := v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(v.T(), err, "Could not reset the FakeIntake")
 	var backOffLimit int32 = 4
 	file, err := os.ReadFile("long_line_log.txt")
 	assert.NoError(v.T(), err, "Could not open long line file.")
@@ -117,14 +122,17 @@ func (v *k8sSuite) TestLongLogLine() {
 		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
 			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
 			assert.NoError(c, err, "Error filtering logs")
-			assert.Equal(c, string(file), fmt.Sprintf("%s%s", filteredLogs[0].Message, "\n"), "Test log doesn't match")
+			if assert.NotEmpty(v.T(), filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+				assert.Equal(c, string(file), fmt.Sprintf("%s%s", filteredLogs[0].Message, "\n"), "Test log doesn't match")
+			}
 		}
 
 	}, 1*time.Minute, 10*time.Second)
 }
 
 func (v *k8sSuite) TestContainerExclude() {
-	v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	err := v.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(v.T(), err, "Could not reset the Fake Intake")
 
 	// We're testing exclusion via namespace, so we have to create a new namespace
 	namespaceName := "exclude-namespace"
@@ -133,7 +141,7 @@ func (v *k8sSuite) TestContainerExclude() {
 			Name: namespaceName,
 		},
 	}
-	_, err := v.Env().KubernetesCluster.Client().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	_, err = v.Env().KubernetesCluster.Client().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
 	assert.NoError(v.T(), err, "Could not create namespace")
 
 	var backOffLimit int32 = 4


### PR DESCRIPTION
### What does this PR do?

Added a check to make sure logs returned by the Fake Intake are not empty.

### Motivation

Some of our K8s e2e tests are failing as the Fake Intake returned no logs even though it said logs existed for the given service.

### Possible Drawbacks / Trade-offs

Our K8s e2e tests may fail more frequently due to Fake Intake sending us bad data.

