### PR TITLE
fix(installer): Don't install the PHP tracer by default

### DIFF
--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -88,16 +88,18 @@ func apmInjectEnabled(_ Package, e *env.Env) bool {
 	return false
 }
 
+// apmLanguageEnabled returns true if the package should be installed
+// Note: the PHP tracer is in beta and isn't included in the "all" or default languages
 func apmLanguageEnabled(p Package, e *env.Env) bool {
 	if _, ok := e.ApmLibraries[packageToLanguage(p.Name)]; ok {
 		return true
 	}
-	if _, ok := e.ApmLibraries["all"]; ok {
+	if _, ok := e.ApmLibraries["all"]; ok && p.Name != "datadog-apm-library-php" {
 		return true
 	}
 	// If the ApmLibraries env is left empty but apm injection is
 	// enabled, we install all languages
-	if len(e.ApmLibraries) == 0 && apmInjectEnabled(p, e) {
+	if len(e.ApmLibraries) == 0 && apmInjectEnabled(p, e) && p.Name != "datadog-apm-library-php" {
 		return true
 	}
 	return false

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -36,7 +36,6 @@ func TestDefaultPackagesAPMInjectEnabled(t *testing.T) {
 		"oci://gcr.io/datadoghq/apm-library-js-package:5",
 		"oci://gcr.io/datadoghq/apm-library-dotnet-package:2",
 		"oci://gcr.io/datadoghq/apm-library-python-package:2",
-		"oci://gcr.io/datadoghq/apm-library-php-package:1",
 	}, packages)
 }
 
@@ -200,6 +199,7 @@ func TestDefaultPackages(t *testing.T) {
 				DefaultPackagesInstallOverride: map[string]bool{
 					"datadog-apm-library-java": true,
 					"datadog-apm-library-ruby": true,
+					"datadog-apm-library-php":  true,
 				},
 			},
 			expected: []pkg{
@@ -252,15 +252,18 @@ func TestDefaultPackages(t *testing.T) {
 			packages: []Package{
 				{Name: "datadog-apm-library-java", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 				{Name: "datadog-apm-library-ruby", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
+				{Name: "datadog-apm-library-php", version: apmLanguageVersion, released: true, condition: apmLanguageEnabled},
 			},
 			env: &env.Env{
 				ApmLibraries: map[env.ApmLibLanguage]env.ApmLibVersion{
 					"java": "1.2.3",
+					"php":  "1",
 				},
 				InstallScript: env.InstallScriptEnv{},
 			},
 			expected: []pkg{
 				{n: "datadog-apm-library-java", v: "1.2.3-1"},
+				{n: "datadog-apm-library-php", v: "1"},
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Prevents installation of the PHP tracer when specifying "all" languages or nothing for the env var.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
