### PR TITLE
comp/trace/config: update windows agent binary locator code

### DIFF
--- a/comp/trace/config/config_windows.go
+++ b/comp/trace/config/config_windows.go
@@ -18,7 +18,7 @@ import (
 var DefaultLogFilePath = "c:\\programdata\\datadog\\logs\\trace-agent.log"
 
 // defaultDDAgentBin specifies the default path to the main agent executable.
-var defaultDDAgentBin = "c:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe"
+var defaultDDAgentBin = filepath.Join(setup.InstallPath, "bin\\agent.exe")
 
 // defaultReceiverSocket specifies the default Unix Domain Socket to receive traces.
 const defaultReceiverSocket = ""
@@ -28,9 +28,8 @@ func init() {
 	if err == nil {
 		DefaultLogFilePath = filepath.Join(pd, "logs", "trace-agent.log")
 	}
-	_here, err := executable.Folder()
-	if err == nil {
-		defaultDDAgentBin = filepath.Join(_here, "..", "agent.exe")
+	installDir, err := winutil.GetProgramFilesDirForProduct("DataDog Agent")
+	if err != nil {
+		defaultDDAgentBin = path.Join(installDir, "bin", "agent.exe")
 	}
-
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This updates the config logic responsible for locating the core agent binary on Windows to use the install path rather than the current binary location, so it works with all agent binaries, not just the trace agent.

### Motivation

Errors were occurring when non-trace-agent executables were using this variable, since the core agent was resolved relative to the executable's location.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
TODO: e2e test
