### PR TITLE
Rename and add a `check-state` parameter to the unfreeze command

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -568,10 +568,11 @@ def create_and_update_release_branch(ctx, repo, release_branch, base_directory="
             )
 
 
-@task(help={'upstream': "Remote repository name (default 'origin')"})
-def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"):
+# TODO: unfreeze is the former name of this task, kept for backward compatibility. Remove in a few weeks.
+@task(help={'upstream': "Remote repository name (default 'origin')"}, aliases=["unfreeze"])
+def create_release_branches(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin", check_state=True):
     """
-    Performs set of tasks required for the main branch unfreeze during the agent release cycle.
+    Create and push release branches in Agent repositories and update them.
     That includes:
     - creates a release branch in datadog-agent, datadog-agent-macos, omnibus-ruby and omnibus-software repositories,
     - updates release.json on new datadog-agent branch to point to newly created release branches in nightly section
@@ -596,12 +597,12 @@ def unfreeze(ctx, base_directory="~/dd", major_versions="6,7", upstream="origin"
     release_branch = current.branch()
 
     # Step 0: checks
-
-    print(color_message("Checking repository state", "bold"))
     ctx.run("git fetch")
 
-    github = GithubAPI(repository=GITHUB_REPO_NAME)
-    check_clean_branch_state(ctx, github, release_branch)
+    if check_state:
+        print(color_message("Checking repository state", "bold"))
+        github = GithubAPI(repository=GITHUB_REPO_NAME)
+        check_clean_branch_state(ctx, github, release_branch)
 
     if not yes_no_question(
         f"This task will create new branches with the name '{release_branch}' in repositories: {', '.join(UNFREEZE_REPOS)}. Is this OK?",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Rename the unfreeze command
- Add a `check-state` parameter that defaults to `True`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- This command does not unfreeze anything
- We changed the process and we now create the release branches at the beginning of the freeze
- A parameter to avoid having to comment sections of the code is more user-friendly

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
