### PR TITLE
discovery: Get injected environment variables

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/envs.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build linux
+
 package module
 
 import (

--- a/pkg/collector/corechecks/servicediscovery/module/envs.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package module
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+const (
+	// injectorMemFdName is the name the injector (Datadog/auto_inject) uses.
+	injectorMemFdName = "dd_environ"
+	injectorMemFdPath = "/memfd:" + injectorMemFdName + " (deleted)"
+
+	// memFdMaxSize is used to limit the amount of data we read from the memfd.
+	// This is for safety to limit our memory usage in the case of a corrupt
+	// file.
+	memFdMaxSize = 4096
+)
+
+// readEnvsFile reads the env file created by the auto injector.
+func readEnvsFile(path string) ([]string, error) {
+	reader, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(io.LimitReader(reader, memFdMaxSize))
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(data), "\000"), nil
+}
+
+// getInjectedEnvs gets environment variables injected by the auto injector, if
+// present.
+func getInjectedEnvs(proc *process.Process) []string {
+	fdsPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "fd")
+	entries, err := os.ReadDir(fdsPath)
+	if err != nil {
+		return nil
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(fdsPath, entry.Name())
+		name, err := os.Readlink(path)
+		if err != nil {
+			continue
+		}
+
+		if name != injectorMemFdPath {
+			continue
+		}
+
+		envs, _ := readEnvsFile(path)
+		return envs
+	}
+
+	return nil
+}
+
+// envsToMap splits a list of strings containing environment variables of the
+// format NAME=VAL to a map.
+func envsToMap(envs ...string) map[string]string {
+	envMap := make(map[string]string, len(envs))
+	for _, env := range envs {
+		name, val, found := strings.Cut(env, "=")
+		if !found {
+			continue
+		}
+
+		envMap[name] = val
+	}
+
+	return envMap
+}
+
+// getEnvs gets the environment variables for the process, both the initial
+// ones, and if present, the ones injected via the auto injector.
+func getEnvs(proc *process.Process) (map[string]string, error) {
+	envs, err := proc.Environ()
+	if err != nil {
+		return nil, nil
+	}
+
+	envs = append(envs, getInjectedEnvs(proc)...)
+	return envsToMap(envs...), nil
+}

--- a/pkg/collector/corechecks/servicediscovery/module/envs.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs.go
@@ -91,7 +91,7 @@ func envsToMap(envs ...string) map[string]string {
 func getEnvs(proc *process.Process) (map[string]string, error) {
 	envs, err := proc.Environ()
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	envs = append(envs, getInjectedEnvs(proc)...)

--- a/pkg/collector/corechecks/servicediscovery/module/envs_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestInjectedEnvBasic(t *testing.T) {
+	curPid := os.Getpid()
+	proc, err := process.NewProcess(int32(curPid))
+	require.NoError(t, err)
+	envs := getInjectedEnvs(proc)
+	require.Nil(t, envs)
+
+	// Provide an injected replacement for some already-present env variable
+	first := os.Environ()[0]
+	parts := strings.Split(first, "=")
+	key := parts[0]
+
+	expected := []string{"key1=val1", "key2=val2", "key3=val3", fmt.Sprint(key, "=", "new")}
+	createEnvsMemfd(t, expected)
+
+	envMap, err := getEnvs(proc)
+	require.Subset(t, envMap, map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+		key:    "new",
+	})
+}
+
+func TestInjectedEnvLimit(t *testing.T) {
+	env := "A=" + strings.Repeat("A", memFdMaxSize*2)
+	full := []string{env}
+	createEnvsMemfd(t, full)
+
+	expected := []string{full[0][:memFdMaxSize]}
+
+	proc, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+	envs := getInjectedEnvs(proc)
+	require.Equal(t, expected, envs)
+}
+
+// createEnvsMemfd creates an memfd in the current process with the specified
+// environment variables in the same way as Datadog/auto_inject.
+func createEnvsMemfd(t *testing.T, envs []string) {
+	t.Helper()
+
+	var b bytes.Buffer
+	for _, env := range envs {
+		_, err := b.WriteString(env)
+		require.NoError(t, err)
+
+		err = b.WriteByte(0)
+		require.NoError(t, err)
+	}
+
+	memfd, err := memfile(injectorMemFdName, b.Bytes())
+	require.NoError(t, err)
+	t.Cleanup(func() { unix.Close(memfd) })
+}
+
+// memfile takes a file name used, and the byte slice containing data the file
+// should contain.
+//
+// name does not need to be unique, as it's used only for debugging purposes.
+//
+// It is up to the caller to close the returned descriptor.
+func memfile(name string, b []byte) (int, error) {
+	fd, err := unix.MemfdCreate(name, 0)
+	if err != nil {
+		return 0, fmt.Errorf("MemfdCreate: %v", err)
+	}
+
+	err = unix.Ftruncate(fd, int64(len(b)))
+	if err != nil {
+		return 0, fmt.Errorf("Ftruncate: %v", err)
+	}
+
+	data, err := unix.Mmap(fd, 0, len(b), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		return 0, fmt.Errorf("Mmap: %v", err)
+	}
+
+	copy(data, b)
+
+	err = unix.Munmap(data)
+	if err != nil {
+		return 0, fmt.Errorf("Munmap: %v", err)
+	}
+
+	return fd, nil
+}

--- a/pkg/collector/corechecks/servicediscovery/module/envs_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs_test.go
@@ -35,6 +35,7 @@ func TestInjectedEnvBasic(t *testing.T) {
 	createEnvsMemfd(t, expected)
 
 	envMap, err := getEnvs(proc)
+	require.NoError(t, err)
 	require.Subset(t, envMap, map[string]string{
 		"key1": "val1",
 		"key2": "val2",

--- a/pkg/collector/corechecks/servicediscovery/module/envs_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package module
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -199,22 +199,6 @@ type parsingContext struct {
 	netNsInfo map[uint32]*namespaceInfo
 }
 
-// envsToMap splits a list of strings containing environment variables of the
-// format NAME=VAL to a map.
-func envsToMap(envs ...string) map[string]string {
-	envMap := make(map[string]string, len(envs))
-	for _, env := range envs {
-		name, val, found := strings.Cut(env, "=")
-		if !found {
-			continue
-		}
-
-		envMap[name] = val
-	}
-
-	return envMap
-}
-
 // getServiceName gets the service name for a process using the servicedetector
 // module.
 func (s *discovery) getServiceName(proc *process.Process) (string, error) {
@@ -223,12 +207,12 @@ func (s *discovery) getServiceName(proc *process.Process) (string, error) {
 		return "", nil
 	}
 
-	env, err := proc.Environ()
+	envs, err := getEnvs(proc)
 	if err != nil {
 		return "", nil
 	}
 
-	return s.serviceDetector.GetServiceName(cmdline, envsToMap(env...)), nil
+	return s.serviceDetector.GetServiceName(cmdline, envs), nil
 }
 
 // getService gets information for a single service.

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -294,6 +294,25 @@ func TestServiceName(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
+func TestInjectedServiceName(t *testing.T) {
+	url := setupDiscoveryModule(t)
+
+	createEnvsMemfd(t, []string{
+		"OTHER_ENV=test",
+		"DD_SERVICE=injected-service-name",
+		"YET_ANOTHER_ENV=test",
+	})
+
+	listener, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	pid := os.Getpid()
+	portMap := getServicesMap(t, url)
+	require.Contains(t, portMap, pid)
+	require.Equal(t, "injected-service-name", portMap[pid].Name)
+}
+
 // Check that we can get listening processes in other namespaces.
 func TestNamespaces(t *testing.T) {
 	url := setupDiscoveryModule(t)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
   
Get injected environment variables from the auto injector (Datadog/auto_inject) via a memfd which the auto injector creates and makes available with a specific name via /proc/$PID/fds.

This PR is based on https://github.com/DataDog/datadog-agent/pull/28290.

Note that the PR to add the feature to Datadog/auto_inject is not merged yet: https://github.com/DataDog/auto_inject/pull/342

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1156

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
