### PR TITLE
Fix flaky OTel e2e tests

### DIFF
--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -21,7 +21,7 @@ qa_agent_ot:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    - !reference [.on_container_or_e2e_changes]
+    - !reference [.on_otel_or_e2e_changes]
   needs:
     - docker_build_ot_agent7
     - docker_build_ot_agent7_arm64

--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -22,6 +22,7 @@ qa_agent_ot:
   stage: dev_container_deploy
   rules:
     - !reference [.on_otel_or_e2e_changes]
+    - !reference [.manual]
   needs:
     - docker_build_ot_agent7
     - docker_build_ot_agent7_arm64

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -414,6 +414,7 @@ new-e2e-otel:
     - !reference [.needs_new_e2e_template]
     - qa_dca
     - qa_agent
+    - qa_agent_ot
   variables:
     TARGETS: ./tests/otel
     TEAM: otel

--- a/test/new-e2e/tests/otel/collector.yml
+++ b/test/new-e2e/tests/otel/collector.yml
@@ -14,9 +14,6 @@ exporters:
       key: ${DD_API_KEY}
 processors:
   batch:
-  # using the sampler
-  probabilistic_sampler:
-    sampling_percentage: 30
 connectors:
   # Use datadog connector to compute stats for pre-sampled traces
   datadog/connector:
@@ -26,14 +23,10 @@ connectors:
       peer_tags_aggregation: true
 service:
   pipelines:
-    traces: # this pipeline computes APM stats
+    traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [datadog/connector]
-    traces/sampling: # this pipeline uses sampling and sends traces
-      receivers: [otlp]
-      processors: [probabilistic_sampler,batch]
-      exporters: [datadog]
+      exporters: [datadog/connector, datadog]
     metrics:
       receivers: [otlp, datadog/connector]
       processors: [batch]

--- a/test/new-e2e/tests/otel/collector.yml
+++ b/test/new-e2e/tests/otel/collector.yml
@@ -26,7 +26,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [datadog/connector, datadog]
+      exporters: [datadog/connector]
+    traces/send:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]
     metrics:
       receivers: [otlp, datadog/connector]
       processors: [batch]

--- a/test/new-e2e/tests/otel/otel_test.go
+++ b/test/new-e2e/tests/otel/otel_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,23 +55,27 @@ func (s *linuxTestSuite) TestOTLPTraces() {
 	s.T().Log("Starting telemetrygen")
 	s.createTelemetrygenJob(ctx, "traces", []string{"--service", service, "--traces", fmt.Sprint(numTraces)})
 
+	var traces []*aggregator.TracePayload
+	var err error
 	s.T().Log("Waiting for traces")
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		traces, err := s.Env().FakeIntake.Client().GetTraces()
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		traces, err = s.Env().FakeIntake.Client().GetTraces()
 		assert.NoError(c, err)
 		assert.NotEmpty(c, traces)
-		trace := traces[0]
-		assert.Equal(c, "none", trace.Env)
-		assert.NotEmpty(c, trace.TracerPayloads)
-		tp := trace.TracerPayloads[0]
-		assert.NotEmpty(c, tp.Chunks)
-		assert.NotEmpty(c, tp.Chunks[0].Spans)
-		spans := tp.Chunks[0].Spans
-		for _, sp := range spans {
-			assert.Equal(c, service, sp.Service)
-			assert.Equal(c, "telemetrygen", sp.Meta["otel.library.name"])
-		}
 	}, 2*time.Minute, 10*time.Second)
+
+	require.NotEmpty(s.T(), traces)
+	trace := traces[0]
+	assert.Equal(s.T(), "none", trace.Env)
+	require.NotEmpty(s.T(), trace.TracerPayloads)
+	tp := trace.TracerPayloads[0]
+	require.NotEmpty(s.T(), tp.Chunks)
+	require.NotEmpty(s.T(), tp.Chunks[0].Spans)
+	spans := tp.Chunks[0].Spans
+	for _, sp := range spans {
+		assert.Equal(s.T(), service, sp.Service)
+		assert.Equal(s.T(), "telemetrygen", sp.Meta["otel.library.name"])
+	}
 }
 
 func (s *linuxTestSuite) TestOTLPMetrics() {
@@ -84,7 +89,7 @@ func (s *linuxTestSuite) TestOTLPMetrics() {
 	s.createTelemetrygenJob(ctx, "metrics", []string{"--metrics", fmt.Sprint(numMetrics), "--otlp-attributes", serviceAttribute})
 
 	s.T().Log("Waiting for metrics")
-	s.EventuallyWithT(func(c *assert.CollectT) {
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		serviceTag := "service:" + service
 		metrics, err := s.Env().FakeIntake.Client().FilterMetrics("gen", fakeintake.WithTags[*aggregator.MetricSeries]([]string{serviceTag}))
 		assert.NoError(c, err)
@@ -103,15 +108,19 @@ func (s *linuxTestSuite) TestOTLPLogs() {
 	s.T().Log("Starting telemetrygen")
 	s.createTelemetrygenJob(ctx, "logs", []string{"--logs", fmt.Sprint(numLogs), "--otlp-attributes", serviceAttribute, "--body", logBody})
 
+	var logs []*aggregator.Log
+	var err error
 	s.T().Log("Waiting for logs")
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		logs, err := s.Env().FakeIntake.Client().FilterLogs(service)
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		logs, err = s.Env().FakeIntake.Client().FilterLogs(service)
 		assert.NoError(c, err)
 		assert.NotEmpty(c, logs)
-		for _, log := range logs {
-			assert.Contains(c, log.Message, logBody)
-		}
 	}, 2*time.Minute, 10*time.Second)
+
+	require.NotEmpty(s.T(), logs)
+	for _, log := range logs {
+		assert.Contains(s.T(), log.Message, logBody)
+	}
 }
 
 func (s *linuxTestSuite) TestOTelFlare() {
@@ -120,13 +129,13 @@ func (s *linuxTestSuite) TestOTelFlare() {
 	s.T().Log("Starting flare")
 	agent := s.getAgentPod()
 	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "agent", []string{"agent", "flare", "--email", "e2e@test.com", "--send"})
-	assert.NoError(s.T(), err, "Failed to execute flare")
-	assert.Empty(s.T(), stderr)
-	assert.NotNil(s.T(), stdout)
+	require.NoError(s.T(), err, "Failed to execute flare")
+	require.Empty(s.T(), stderr)
+	require.NotNil(s.T(), stdout)
 
 	s.T().Log("Getting latest flare")
 	flare, err := s.Env().FakeIntake.Client().GetLatestFlare()
-	assert.NoError(s.T(), err, "Failed to get latest flare")
+	require.NoError(s.T(), err, "Failed to get latest flare")
 	otelFolder, otelFlareFolder := false, false
 	var otelResponse string
 	for _, filename := range flare.GetFilenames() {
@@ -143,7 +152,7 @@ func (s *linuxTestSuite) TestOTelFlare() {
 	assert.True(s.T(), otelFolder)
 	assert.True(s.T(), otelFlareFolder)
 	otelResponseContent, err := flare.GetFileContent(otelResponse)
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 	expectedContents := []string{"otel-agent", "datadog/dd-autoconfigured:", "health_check/dd-autoconfigured:", "pprof/dd-autoconfigured:", "zpages/dd-autoconfigured:", "infraattributes/dd-autoconfigured:", "prometheus/dd-autoconfigured:", "key: '[REDACTED]'"}
 	for _, expected := range expectedContents {
 		assert.Contains(s.T(), otelResponseContent, expected)
@@ -154,8 +163,8 @@ func (s *linuxTestSuite) getAgentPod() corev1.Pod {
 	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
 	})
-	assert.NoError(s.T(), err)
-	assert.NotEmpty(s.T(), res.Items)
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), res.Items)
 	return res.Items[0]
 }
 
@@ -188,5 +197,5 @@ func (s *linuxTestSuite) createTelemetrygenJob(ctx context.Context, telemetry st
 	}
 
 	_, err := s.Env().KubernetesCluster.Client().BatchV1().Jobs("datadog").Create(ctx, jobSpec, metav1.CreateOptions{})
-	assert.NoError(s.T(), err, "Could not properly start job")
+	require.NoError(s.T(), err, "Could not properly start job")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes flaky OTel e2e tests by removing sampling from the traces pipeline and updating the gitlab job requirements. Also uses `require` instead of `assert` where applicable, and changes the scope of `EventuallyWithT` to only include sections that could contain network errors.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The test was previously sampling traces at a rate of 30%, which resulted in no traces being received by fakeintake in rare occasions. The gitlab job also occasionally ran without the required images being built, so this should be resolved too.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
