### PR TITLE
auto-instrumentation: propagate detected langs to injector

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -201,7 +201,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			requireEnv := func(t *testing.T, key string, ok bool, value string) {
 				t.Helper()
 				val, exists := envsByName[key]
-				require.Equal(t, ok, exists, "expected env %v to be %v", key, ok)
+				require.Equal(t, ok, exists, "expected env %v exists to = %v", key, ok)
 				require.Equal(t, value, val.Value, "expected env %v = %v", key, val)
 			}
 
@@ -276,10 +276,10 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 
 			if tt.expectedLangsDetected != "" {
 				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGES_DETECTED", true, tt.expectedLangsDetected)
-				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGE_DETECTION_ENABLED", true, "false")
+				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGE_DETECTION_INJECTION_ENABLED", true, "false")
 			} else {
 				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGES_DETECTED", false, "")
-				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGE_DETECTION_ENABLED", false, "")
+				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGE_DETECTION_INJECTION_ENABLED", false, "")
 			}
 		})
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -631,18 +631,17 @@ func TestExtractLibInfo(t *testing.T) {
 			containerRegistry:   "registry",
 			expectedPodEligible: pointer.Ptr(true),
 			expectedLibsToInject: []libInfo{
-				{
-					lang:  "python",
-					image: "registry/dd-lib-python-init:v1",
-				},
+				python.libInfo("", "registry/dd-lib-python-init:v1"),
 			},
 		},
 		{
-			name:                 "python with unlabelled injection off",
-			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/python-lib.version", "v1"),
-			containerRegistry:    "registry",
-			expectedPodEligible:  pointer.Ptr(false),
-			expectedLibsToInject: []libInfo{},
+			name:                "python with unlabelled injection off",
+			pod:                 common.FakePodWithAnnotation("admission.datadoghq.com/python-lib.version", "v1"),
+			containerRegistry:   "registry",
+			expectedPodEligible: pointer.Ptr(false),
+			expectedLibsToInject: []libInfo{
+				python.libInfo("", "registry/dd-lib-python-init:v1"),
+			},
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -652,10 +651,7 @@ func TestExtractLibInfo(t *testing.T) {
 			pod:               common.FakePodWithAnnotation("admission.datadoghq.com/java-lib.custom-image", "custom/image"),
 			containerRegistry: "registry",
 			expectedLibsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "custom/image",
-				},
+				java.libInfo("", "custom/image"),
 			},
 		},
 		{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util.go
@@ -50,6 +50,12 @@ func getLibListFromDeploymentAnnotations(store workloadmeta.Component, deploymen
 	var libList []libInfo
 	for container, languages := range deployment.InjectableLanguages {
 		for lang := range languages {
+			// There's a mismatch between language detection and auto-instrumentation.
+			// The Node language is a js lib.
+			if lang == "node" {
+				lang = "js"
+			}
+
 			l := language(lang)
 			libList = append(libList, l.defaultLibInfo(registry, container.Name))
 		}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_util_test.go
@@ -71,7 +71,6 @@ func TestGetOwnerNameAndKind(t *testing.T) {
 			require.Equal(t, found, tt.wantFound)
 			require.Equal(t, name, tt.expectedName)
 			require.Equal(t, kind, tt.expectedKind)
-
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
@@ -60,18 +60,6 @@ const (
 	localLibraryInstrumentationInstallType = "k8s_lib_injection"
 )
 
-var (
-	singleStepInstrumentationInstallTypeEnvVar = corev1.EnvVar{
-		Name:  instrumentationInstallTypeEnvVarName,
-		Value: singleStepInstrumentationInstallType,
-	}
-
-	localLibraryInstrumentationInstallTypeEnvVar = corev1.EnvVar{
-		Name:  instrumentationInstallTypeEnvVarName,
-		Value: localLibraryInstrumentationInstallType,
-	}
-)
-
 type envVar struct {
 	key                string
 	valFunc            envValFunc

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -134,7 +134,7 @@ type libInfo struct {
 	image   string
 }
 
-func (i libInfo) podMutator(v version, ics []containerMutator, ms []podMutator) podMutator {
+func (i libInfo) podMutator(v version, opts libRequirementOptions) podMutator {
 	return podMutatorFunc(func(pod *corev1.Pod) error {
 		reqs, ok := i.libRequirement(v)
 		if !ok {
@@ -144,17 +144,10 @@ func (i libInfo) podMutator(v version, ics []containerMutator, ms []podMutator) 
 			)
 		}
 
-		// set the initContainerMutators on the requirements
-		reqs.initContainerMutators = ics
+		reqs.libRequirementOptions = opts
 
 		if err := reqs.injectPod(pod, i.ctrName); err != nil {
 			return err
-		}
-
-		for _, m := range ms {
-			if err := m.mutatePod(pod); err != nil {
-				return err
-			}
 		}
 
 		return nil

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -19,6 +19,26 @@ type containerMutator interface {
 	mutateContainer(*corev1.Container) error
 }
 
+// containerMutatorFunc is a containerMutator as a function.
+type containerMutatorFunc func(*corev1.Container) error
+
+// mutateContainer implements containerMutator for containerMutatorFunc.
+func (f containerMutatorFunc) mutateContainer(c *corev1.Container) error {
+	return f(c)
+}
+
+type containerMutators []containerMutator
+
+func (mutators containerMutators) mutateContainer(c *corev1.Container) error {
+	for _, m := range mutators {
+		if err := m.mutateContainer(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // podMutator describes something that can mutate a pod.
 type podMutator interface {
 	mutatePod(*corev1.Pod) error
@@ -40,7 +60,7 @@ func (f podMutatorFunc) mutatePod(pod *corev1.Pod) error {
 type initContainer struct {
 	corev1.Container
 	Prepend  bool
-	Mutators []containerMutator
+	Mutators containerMutators
 }
 
 var _ podMutator = (*initContainer)(nil)
@@ -48,10 +68,9 @@ var _ podMutator = (*initContainer)(nil)
 // mutatePod implements podMutator for initContainer.
 func (i initContainer) mutatePod(pod *corev1.Pod) error {
 	container := i.Container
-	for _, m := range i.Mutators {
-		if err := m.mutateContainer(&container); err != nil {
-			return err
-		}
+
+	if err := i.Mutators.mutateContainer(&container); err != nil {
+		return err
 	}
 
 	for idx, c := range pod.Spec.InitContainers {


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/APMON-1364

There is a possible mismatch between _injector_ language detection and _process agent_ language detection. This PR propagates the languages detected (while not changing container/injection behavior) through to the application container in environment variables.

- `DD_INSTRUMENTATION_LANGUAGES_DETECTED`
- `DD_INSTRUMENTATION_LANGUAGE_DETECTION_INJECTION_ENABLED`



<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Pod-startup time is something we are trying to control with the auto-instrumentation, and `language_detection` (which we have yet to enable for the controller), is one method of making this better. The risk of turning on language detection lies with us having having potentially inconsistent results. So we're passing the environment variables to the injector so it can deal with that on its own/directly.

### Additional Notes

1. We send back the detected languages _alongwith_ the ones we will use.
2. extract out `libInfoSource` which has `autodetected() bool` and `injectionType() string`. This also removes redundant logic for setting up `DD_INSTRUMENTATION_INSTALL_TYPE`, which was set twice (first one taking precedence) and added tests for this to be set.
3. `libInfoSource` is a `podMutator`
4. `detectedLanguages` is a mutator
5. `extractLibInfo` returns a struct instead of multiple returns so it's easeir to test, function and pass around

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Change is covered with unit tests and testing using https://github.com/DataDog/k8s-ssi-v2-testing/

<img width="462" alt="Screenshot 2024-08-13 at 7 17 50 PM" src="https://github.com/user-attachments/assets/ba8a8ce8-eb00-4cb6-a20e-000f930fb65b">

