### PR TITLE
Fix integration filepath and add service config

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -127,6 +127,7 @@ func (s *Launcher) makeFileSource(source *sources.LogSource, filepath string) *s
 		Path:        filepath,
 		Name:        source.Config.Name,
 		Source:      source.Config.Source,
+		Service:     source.Config.Service,
 		Tags:        source.Config.Tags,
 	})
 
@@ -155,8 +156,8 @@ func (s *Launcher) createFile(source *sources.LogSource) (string, error) {
 
 // integrationLogFilePath returns a directory and file to use for an integration log file
 func (s *Launcher) integrationLogFilePath(source sources.LogSource) (string, string) {
-	fileName := source.Config.Name + ".log"
-	directoryComponents := []string{s.runPath, "integrations", source.Config.Service}
+	fileName := source.Name + ".log"
+	directoryComponents := []string{s.runPath, "integrations"}
 	directory := strings.Join(directoryComponents, "/")
 	filepath := strings.Join([]string{directory, fileName}, "/")
 

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -123,10 +123,10 @@ func (suite *LauncherTestSuite) TestIntegrationLogFilePath() {
 
 	actualDirectory, actualFilePath := suite.s.integrationLogFilePath(*logSource)
 
-	expectedDirectoryComponents := []string{suite.s.runPath, "integrations", logSource.Config.Service}
+	expectedDirectoryComponents := []string{suite.s.runPath, "integrations"}
 	expectedDirectory := strings.Join(expectedDirectoryComponents, "/")
 
-	expectedFilePath := strings.Join([]string{expectedDirectory, logSource.Config.Name + ".log"}, "/")
+	expectedFilePath := strings.Join([]string{expectedDirectory, logSource.Name + ".log"}, "/")
 
 	assert.Equal(suite.T(), expectedDirectory, actualDirectory)
 	assert.Equal(suite.T(), expectedFilePath, actualFilePath)

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -7,6 +7,7 @@ package integration
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"strings"
 	"testing"
@@ -118,15 +119,22 @@ func (suite *LauncherTestSuite) TestIntegrationLogFilePath() {
 		Type:    config.IntegrationType,
 		Name:    "test_name",
 		Service: "test_service",
+		Source:  "test_service",
 		Path:    suite.testPath,
 	})
 
-	actualDirectory, actualFilePath := suite.s.integrationLogFilePath(*logSource)
+	actualDirectory, actualFilePath := suite.s.integrationLogFilePath(logSource)
+
+	sourceToHash := logSource.Config.Service + logSource.Config.Source
+	h := fnv.New64a()
+	h.Write([]byte(sourceToHash))
+	hashValue := h.Sum64()
+	filename := fmt.Sprintf("%x", hashValue) + ".log"
 
 	expectedDirectoryComponents := []string{suite.s.runPath, "integrations"}
 	expectedDirectory := strings.Join(expectedDirectoryComponents, "/")
 
-	expectedFilePath := strings.Join([]string{expectedDirectory, logSource.Name + ".log"}, "/")
+	expectedFilePath := strings.Join([]string{expectedDirectory, filename}, "/")
 
 	assert.Equal(suite.T(), expectedDirectory, actualDirectory)
 	assert.Equal(suite.T(), expectedFilePath, actualFilePath)

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -199,7 +199,7 @@ func (s *Scheduler) createSources(config integration.Config) ([]*sourcesPkg.LogS
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType) {
+			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType || cfg.Type == logsConfig.IntegrationType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType) {
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes a bug in the integration launcher where integration log filepaths were decided by user input fields in the integration yaml config, meaning users could set a field to `../` which would allow accidental path traversal in the creation of the log file. This PR changes this behavior so log filepaths are no longer dependent on user input fields in the yaml config, but instead use the `source.Name` field which is derived from the check filepath, and therefore must be a valid filepath. Tests were updated to reflect this change as well.

It also adds the `source.Config.Service` to `fileSource` to ensure that the service name shows up in the logs backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bug caught in QA, this change is needed to ensure that the logs from integrations feature doesn't change cause any unintended behavior.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

N/A

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

In the check configuration directory (`/etc/agent/conf.d/` on unix machines) create a new custom integration with a name of your choice (so the final path is `/etc/agent/conf.d/{integration_name}.d/integration.yaml`) with the following settings:

``` yaml
logs:
  - type: integration
    service: integration_service
    source: integration_source
```

Build and run the agent , then check the datadog run directory to make sure the file it creates to write logs to is in the correct place, it should be `/opt/datadog-agent/run/integrations/{integration_name}.log`.

Also send a log to the backend using the below command, and make sure the log that appears in the logs backend has the correct `service` applied (`integration_service` in this instance).

``` shell
cd /opt/datadog-agent/run/integrations/
echo '{"message":"foobar"}' >> {integration_name}.log
```

