### PR TITLE
Fix incorrect kube metadata tagger IDs

### DIFF
--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -82,6 +82,7 @@ github.com/DataDog/datadog-agent/comp/core/tagger/types
 github.com/DataDog/datadog-agent/comp/core/tagger/utils
 github.com/DataDog/datadog-agent/comp/core/telemetry
 github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl
+github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util
 github.com/DataDog/datadog-agent/comp/core/workloadmeta/def
 github.com/DataDog/datadog-agent/comp/def
 github.com/DataDog/datadog-agent/comp/dogstatsd/constants

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -82,6 +82,7 @@ github.com/DataDog/datadog-agent/comp/core/tagger/types
 github.com/DataDog/datadog-agent/comp/core/tagger/utils
 github.com/DataDog/datadog-agent/comp/core/telemetry
 github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl
+github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util
 github.com/DataDog/datadog-agent/comp/core/workloadmeta/def
 github.com/DataDog/datadog-agent/comp/def
 github.com/DataDog/datadog-agent/comp/dogstatsd/constants

--- a/comp/core/tagger/README.md
+++ b/comp/core/tagger/README.md
@@ -48,16 +48,16 @@ cache. Cache invalidation is triggered by the collectors (or source) by either:
 Tagger entities are identified by a string-typed ID, with one of the following forms:
 
 <!-- NOTE: a similar table appears in comp/core/autodiscovery/README.md; please keep both in sync -->
-| *Entity*                                | *ID*                                                                                                         |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| workloadmeta.KindContainer              | `container_id://<sha>`                                                                                       |
-| workloadmeta.KindContainerImageMetadata | `container_image_metadata://<sha>`                                                                           |
-| workloadmeta.KindECSTask                | `ecs_task://<task-id>`                                                                                       |
-| workloadmeta.KindHost                   | `host`                                                                                                       |
-| workloadmeta.KindKubernetesDeployment   | `deployment://<namespace>/<name>`                                                                            |
-| workloadmeta.KindKubernetesMetadata     | `kubernetes_metadata://<resourceType>/<namespace>/<name>` (`<namespace>` is empty in cluster-scoped objects) |
-| workloadmeta.KindKubernetesPod          | `kubernetes_pod_uid://<uid>`                                                                                 |
-| workloadmeta.KindProcess                | `process://<pid>`                                                                                            |
+| *Entity*                                | *ID*                                                                                                                 |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| workloadmeta.KindContainer              | `container_id://<sha>`                                                                                               |
+| workloadmeta.KindContainerImageMetadata | `container_image_metadata://<sha>`                                                                                   |
+| workloadmeta.KindECSTask                | `ecs_task://<task-id>`                                                                                               |
+| workloadmeta.KindHost                   | `host`                                                                                                               |
+| workloadmeta.KindKubernetesDeployment   | `deployment://<namespace>/<name>`                                                                                    |
+| workloadmeta.KindKubernetesMetadata     | `kubernetes_metadata://<group>/<resourceType>/<namespace>/<name>` (`<namespace>` is empty in cluster-scoped objects) |
+| workloadmeta.KindKubernetesPod          | `kubernetes_pod_uid://<uid>`                                                                                         |
+| workloadmeta.KindProcess                | `process://<pid>`                                                                                                    |
 
 ## Tagger
 

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -61,10 +62,10 @@ func entityIDsFromAttributes(attrs pcommon.Map) []string {
 		}
 	}
 	if namespace, ok := attrs.Get(conventions.AttributeK8SNamespaceName); ok {
-		entityIDs = append(entityIDs, fmt.Sprintf("kubernetes_metadata://namespaces//%v", namespace.AsString()))
+		entityIDs = append(entityIDs, fmt.Sprintf("kubernetes_metadata://%s", string(util.GenerateKubeMetadataEntityID("", "namespaces", "", namespace.AsString()))))
 	}
 	if nodeName, ok := attrs.Get(conventions.AttributeK8SNodeName); ok {
-		entityIDs = append(entityIDs, fmt.Sprintf("kubernetes_metadata://nodes//%v", nodeName.AsString()))
+		entityIDs = append(entityIDs, fmt.Sprintf("kubernetes_metadata://%s", string(util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName.AsString()))))
 	}
 	if podUID, ok := attrs.Get(conventions.AttributeK8SPodUID); ok {
 		entityIDs = append(entityIDs, fmt.Sprintf("kubernetes_pod_uid://%v", podUID.AsString()))

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
@@ -228,7 +228,7 @@ func TestEntityIDsFromAttributes(t *testing.T) {
 				})
 				return attributes
 			}(),
-			entityIDs: []string{"deployment://k8s_namespace_goes_here/k8s_deployment_name_goes_here", "kubernetes_metadata://namespaces//k8s_namespace_goes_here"},
+			entityIDs: []string{"deployment://k8s_namespace_goes_here/k8s_deployment_name_goes_here", "kubernetes_metadata:///namespaces//k8s_namespace_goes_here"},
 		},
 		{
 			name: "only namespace name",
@@ -239,7 +239,7 @@ func TestEntityIDsFromAttributes(t *testing.T) {
 				})
 				return attributes
 			}(),
-			entityIDs: []string{"kubernetes_metadata://namespaces//k8s_namespace_goes_here"},
+			entityIDs: []string{"kubernetes_metadata:///namespaces//k8s_namespace_goes_here"},
 		},
 		{
 			name: "only node UID",
@@ -250,7 +250,7 @@ func TestEntityIDsFromAttributes(t *testing.T) {
 				})
 				return attributes
 			}(),
-			entityIDs: []string{"kubernetes_metadata://nodes//k8s_node_name_goes_here"},
+			entityIDs: []string{"kubernetes_metadata:///nodes//k8s_node_name_goes_here"},
 		},
 		{
 			name: "only process pid",

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/kubetags"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	ddConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -259,7 +260,7 @@ func getInvolvedObjectTags(involvedObject v1.ObjectReference, taggerInstance tag
 			fmt.Sprintf("namespace:%s", involvedObject.Namespace),
 		)
 
-		namespaceEntityID := fmt.Sprintf("kubernetes_metadata://namespaces//%s", involvedObject.Namespace)
+		namespaceEntityID := fmt.Sprintf("kubernetes_metadata://%s", string(util.GenerateKubeMetadataEntityID("", "namespaces", "", involvedObject.Namespace)))
 		namespaceEntity, err := taggerInstance.GetEntity(namespaceEntityID)
 		if err == nil {
 			tagList = append(tagList, namespaceEntity.GetTags(types.HighCardinality)...)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -58,7 +58,7 @@ func Test_getInvolvedObjectTags(t *testing.T) {
 	telemetryComponent := fxutil.Test[coretelemetry.Component](t, telemetryimpl.MockModule())
 	telemetryStore := telemetry.NewStore(telemetryComponent)
 	taggerInstance := local.NewFakeTagger(telemetryStore)
-	taggerInstance.SetTags("kubernetes_metadata://namespaces//default", "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
+	taggerInstance.SetTags("kubernetes_metadata:///namespaces//default", "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
 	tests := []struct {
 		name           string
 		involvedObject v1.ObjectReference


### PR DESCRIPTION
### What does this PR do?

Fixes a couple of use cases (kubernetes events and otel) that were using incorrect tagger IDs to fetch kubernetes metadata objects.

This was broken because https://github.com/DataDog/datadog-agent/pull/27358 changed the kubernetes metadata objects ID to also include a group, but those 2 callers were not adapted and were still using the old ID format.


### Describe how to test/QA your changes

This was backported to 7.56 and 7.57, so no need to test for 7.58.


We need to check that the tags in "namespace annotations as tags" and "namespace annotations as tags" are attached to Kubernetes events.

- Create a namespace with some labels and annotations. For example:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test
  labels:
    testlabel: "1"
    anotherlabel: "2"
  annotations:
    testannotation: "3"
    anotherannotation: "4"
```

- Deploy the agent with "namespace annotations as tags" and "namespace annotations as tags". For example:
```yaml
datadog:
  kubelet:
    tlsVerify: false
  clusterTagger:
    collectKubernetesTags: true
  namespaceLabelsAsTags:
    testlabel: testtagfromlabel
agents:
  containers:
    agent:
      env:
        - name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
          value: '{"testannotation":"testtagfromannotation"}'
clusterAgent:
  env:
    - name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
      value: '{"testannotation":"testtagfromannotation"}'
```

- Deploy some pod in the namespace created and make sure that the event shown in the event explorer of the web app includes the tags defined in the config. With the example above, it should include `testtagfromlabel:1` and `testtagfromannotation:3`.


For the otel use case, can the opentelemetry team provide the instructions? Not sure how to test this (but there are unit tests for it).