### PR TITLE
[EBPF-553] Fix TestGetSourceMap tests

### DIFF
--- a/pkg/ebpf/verifier/elf_test.go
+++ b/pkg/ebpf/verifier/elf_test.go
@@ -21,6 +21,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +53,7 @@ func TestGetSourceMap(t *testing.T) {
 
 	for name, path := range objectFiles {
 		t.Run(name, func(tt *testing.T) {
+			log.Debugf("Processing %s", path)
 			spec, err := ebpf.LoadCollectionSpec(path)
 			require.NoError(tt, err)
 			sourceMap, funcsPerSection, err := getSourceMap(path, spec)

--- a/pkg/ebpf/verifier/elf_test.go
+++ b/pkg/ebpf/verifier/elf_test.go
@@ -41,8 +41,13 @@ func TestGetSourceMap(t *testing.T) {
 			return nil
 		}
 
-		if _, ok := objectFiles[d.Name()]; !ok {
-			objectFiles[d.Name()] = path
+		objName := d.Name()
+		if strings.Contains(path, "/co-re/") {
+			objName = "co-re/" + objName
+		}
+
+		if _, ok := objectFiles[objName]; !ok {
+			objectFiles[objName] = path
 		}
 		return nil
 	})

--- a/pkg/ebpf/verifier/elf_test.go
+++ b/pkg/ebpf/verifier/elf_test.go
@@ -117,6 +117,14 @@ func TestGetSourceMap(t *testing.T) {
 					require.GreaterOrEqual(tt, line, 0, "invalid line %d, ins %d", line, ins)
 					require.LessOrEqual(tt, line, len(fileCache[sourceFile]), "line %d not found in %s, ins %d", line, sourceFile, ins)
 					expectedLine := fileCache[sourceFile][line-1]
+
+					if expectedLine == "{" && expectedLine != sl.Line && line > 1 {
+						// We have problems with the initial instructions sometimes, as one
+						// source can assign them to the opening brace and another to the function declaration
+						// if they're in different lines. Try with the previous line in that case.
+						expectedLine = fileCache[sourceFile][line-2]
+					}
+
 					require.Equal(tt, expectedLine, sl.Line, "mismatch at instruction %d, lineinfo=%s, prog %s", ins, sl.LineInfo, prog)
 				}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix the `TestGetSourceMap` test for Clang 18 builds: 

* Ensure paths are always absolute (clang 18 seems to output relative paths in DWARF information)
* Deal with differences in what is considered the first instruction of a function, when the function declaration and the opening brace are in separate lines.

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-553

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
