### PR TITLE
[Backport 7.56.x] Bump modules minimal Go version to 1.22

### DIFF
--- a/cmd/agent/common/path/go.mod
+++ b/cmd/agent/common/path/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/cmd/agent/common/path
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/api/api/def/go.mod
+++ b/comp/api/api/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/api/api/def
 
-go 1.21.0
+go 1.22.0
 
 require go.uber.org/fx v1.18.2
 

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/config
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../cmd/agent/common/path

--- a/comp/core/flare/builder/go.mod
+++ b/comp/core/flare/builder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/builder
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/comp/def => ../../../def
 

--- a/comp/core/flare/types/go.mod
+++ b/comp/core/flare/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/types
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder => ../builder

--- a/comp/core/hostname/hostnameinterface/go.mod
+++ b/comp/core/hostname/hostnameinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../../../comp/def

--- a/comp/core/log/go.mod
+++ b/comp/core/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../cmd/agent/common/path

--- a/comp/core/secrets/go.mod
+++ b/comp/core/secrets/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../api/api/def

--- a/comp/core/status/go.mod
+++ b/comp/core/status/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/status
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/comp/core/telemetry/go.mod
+++ b/comp/core/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/telemetry
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../../comp/def

--- a/comp/def/go.mod
+++ b/comp/def/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/comp/def
 
-go 1.21.0
+go 1.22.0

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../cmd/agent/common/path

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../../cmd/agent/common/path

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/logs/agent/config
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../../cmd/agent/common/path

--- a/comp/otelcol/collector-contrib/def/go.mod
+++ b/comp/otelcol/collector-contrib/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def
 
-go 1.21.0
+go 1.22.0
 
 require go.opentelemetry.io/collector/otelcol v0.104.0
 

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/DataDog/comp/otelcol/collector-contrib
 
-go 1.21.0
+go 1.22.0
 
 toolchain go1.22.4
 

--- a/comp/otelcol/configstore/def/go.mod
+++ b/comp/otelcol/configstore/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/configstore/def
 
-go 1.21.0
+go 1.22.0
 
 require (
 	go.opentelemetry.io/collector/confmap v0.104.0

--- a/comp/otelcol/configstore/impl/go.mod
+++ b/comp/otelcol/configstore/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/configstore/impl
 
-go 1.21.0
+go 1.22.0
 
 require (
 	go.opentelemetry.io/collector/confmap v0.104.0

--- a/comp/otelcol/converter/def/go.mod
+++ b/comp/otelcol/converter/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/converter/def
 
-go 1.21.0
+go 1.22.0
 
 require go.opentelemetry.io/collector/confmap v0.104.0
 

--- a/comp/otelcol/converter/impl/go.mod
+++ b/comp/otelcol/converter/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/converter/impl
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ../def
 

--- a/comp/otelcol/extension/def/go.mod
+++ b/comp/otelcol/extension/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/extension/def
 
-go 1.21.0
+go 1.22.0
 
 require go.opentelemetry.io/collector/extension v0.104.0
 

--- a/comp/otelcol/extension/impl/go.mod
+++ b/comp/otelcol/extension/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/extension/impl
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/otelcol/configstore/def => ../../configstore/def

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../cmd/agent/common/path

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../../cmd/agent/common/path

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/datadogexporter
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../../../../cmd/agent/common/path

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../../../api/api/def

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../../../../cmd/agent/common/path

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/pkg/trace => ../../../../../pkg/trace
 

--- a/comp/otelcol/otlp/components/statsprocessor/go.mod
+++ b/comp/otelcol/otlp/components/statsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient => ../metricsclient

--- a/comp/otelcol/otlp/testutil/go.mod
+++ b/comp/otelcol/otlp/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../../comp/api/api/def

--- a/comp/serializer/compression/go.mod
+++ b/comp/serializer/compression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/serializer/compression
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../../cmd/agent/common/path

--- a/comp/trace/agent/def/go.mod
+++ b/comp/trace/agent/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/agent/def
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/pkg/proto => ../../../../pkg/proto
 

--- a/comp/trace/compression/def/go.mod
+++ b/comp/trace/compression/def/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/def
 
-go 1.21.0
+go 1.22.0

--- a/comp/trace/compression/impl-gzip/go.mod
+++ b/comp/trace/compression/impl-gzip/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../../comp/trace/compression/def/
 

--- a/comp/trace/compression/impl-zstd/go.mod
+++ b/comp/trace/compression/impl-zstd/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../../comp/trace/compression/def/
 

--- a/pkg/aggregator/ckey/go.mod
+++ b/pkg/aggregator/ckey/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/aggregator/ckey
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/tagset => ../../tagset/

--- a/pkg/collector/check/defaults/go.mod
+++ b/pkg/collector/check/defaults/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/pkg/collector/check/defaults
 
-go 1.21.0
+go 1.22.0

--- a/pkg/config/env/go.mod
+++ b/pkg/config/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/env
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/config/model => ../model/

--- a/pkg/config/logs/go.mod
+++ b/pkg/config/logs/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/logs
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/config/model => ../model/

--- a/pkg/config/model/go.mod
+++ b/pkg/config/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/model
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../../util/log/

--- a/pkg/config/setup/go.mod
+++ b/pkg/config/setup/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/setup
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/config/utils/go.mod
+++ b/pkg/config/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/utils
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/auditor/go.mod
+++ b/pkg/logs/auditor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/auditor
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/client/go.mod
+++ b/pkg/logs/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/client
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/diagnostic
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/message
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/metrics/go.mod
+++ b/pkg/logs/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/metrics
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../../comp/core/telemetry

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/pipeline
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/processor
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/sds/go.mod
+++ b/pkg/logs/sds/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sds
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/sender/go.mod
+++ b/pkg/logs/sender/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sender
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sources
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../comp/api/api/def

--- a/pkg/logs/status/statusinterface/go.mod
+++ b/pkg/logs/status/statusinterface/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface
 
-go 1.21.0
+go 1.22.0

--- a/pkg/logs/status/utils/go.mod
+++ b/pkg/logs/status/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/utils
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/util/testutils
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../../comp/api/api/def

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/metrics
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../comp/core/telemetry/

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/obfuscate
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0

--- a/pkg/orchestrator/model/go.mod
+++ b/pkg/orchestrator/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/orchestrator/model
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../../util/log/

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/process/util/api
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../../../comp/core/telemetry/

--- a/pkg/proto/go.mod
+++ b/pkg/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/proto
 
-go 1.21.0
+go 1.22.0
 
 retract v0.46.0-devel
 

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/remoteconfig/state
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/serializer
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/cmd/agent/common/path => ../../cmd/agent/common/path

--- a/pkg/status/health/go.mod
+++ b/pkg/status/health/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/status/health
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/tagger/types/go.mod
+++ b/pkg/tagger/types/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/pkg/tagger/types
 
-go 1.21.0
+go 1.22.0

--- a/pkg/tagset/go.mod
+++ b/pkg/tagset/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/tagset
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/pkg/util/sort => ../util/sort/
 

--- a/pkg/telemetry/go.mod
+++ b/pkg/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/telemetry
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../comp/core/telemetry

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace
 
-go 1.21.0
+go 1.22.0
 
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/stats/oteltest
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.11

--- a/pkg/util/backoff/go.mod
+++ b/pkg/util/backoff/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/backoff
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/buf/go.mod
+++ b/pkg/util/buf/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/buf
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cgroups
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../log

--- a/pkg/util/common/go.mod
+++ b/pkg/util/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/common
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/executable/go.mod
+++ b/pkg/util/executable/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/executable
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/pkg/util/filesystem/go.mod
+++ b/pkg/util/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/filesystem
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../log/

--- a/pkg/util/fxutil/go.mod
+++ b/pkg/util/fxutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/fxutil
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.11

--- a/pkg/util/hostname/validate/go.mod
+++ b/pkg/util/hostname/validate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/hostname/validate
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../../log/

--- a/pkg/util/http/go.mod
+++ b/pkg/util/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/http
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model

--- a/pkg/util/json/go.mod
+++ b/pkg/util/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/json
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log
 
-go 1.21.0
+go 1.22.0
 
 replace github.com/DataDog/datadog-agent/pkg/util/scrubber => ../scrubber
 

--- a/pkg/util/optional/go.mod
+++ b/pkg/util/optional/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/optional
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/pointer/go.mod
+++ b/pkg/util/pointer/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/pkg/util/pointer
 
-go 1.21.0
+go 1.22.0

--- a/pkg/util/scrubber/go.mod
+++ b/pkg/util/scrubber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/scrubber
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/pkg/util/sort/go.mod
+++ b/pkg/util/sort/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/sort
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/startstop/go.mod
+++ b/pkg/util/startstop/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/startstop
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/statstracker/go.mod
+++ b/pkg/util/statstracker/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/statstracker
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 

--- a/pkg/util/system/go.mod
+++ b/pkg/util/system/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/system
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/filesystem => ../filesystem

--- a/pkg/util/system/socket/go.mod
+++ b/pkg/util/system/socket/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/system/socket
 
-go 1.21.0
+go 1.22.0
 
 require github.com/Microsoft/go-winio v0.6.1
 

--- a/pkg/util/testutil/go.mod
+++ b/pkg/util/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/testutil
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/winutil
 
-go 1.21.0
+go 1.22.0
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../log/

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/version
 
-go 1.21.0
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Backport 782ccb5f4e427cbbfb152e9c082c6d33d6e14b88 from #28452.

___

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Now that the OpenTelemetry project has bumped their minimal version to 1.22, do the same.
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34658 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Stay up to date, and fix failing version compatibility test #incident-29728.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
