### PR TITLE
(fleet) always create the experiment symlink pointing to stable by default

### DIFF
--- a/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
@@ -12,7 +12,7 @@ Type=oneshot
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 ExecStart=/bin/false
 ExecStop=/bin/false

--- a/pkg/fleet/installer/service/embedded/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-process-exp.service
@@ -9,7 +9,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/process-agent --cfgpath=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
@@ -9,7 +9,7 @@ Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/security-agent -c /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
@@ -9,7 +9,7 @@ ConditionPathExists=/etc/datadog-agent/system-probe.yaml
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 Restart=on-failure
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-trace-exp.service
@@ -8,7 +8,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-agent --config /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -118,6 +118,7 @@ func (h *Host) SetupFakeAgentExp() FakeAgent {
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/embedded/bin", vBroken))
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/bin/agent", vBroken))
 
+	h.remote.MustExecute("rm -f /opt/datadog-packages/datadog-agent/experiment") // remove symlink if it exists, next command doesn't overwrite it
 	h.remote.MustExecute(fmt.Sprintf("sudo ln -sf %s /opt/datadog-packages/datadog-agent/experiment", vBroken))
 	f := FakeAgent{
 		h:    h,

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -118,7 +118,7 @@ func (h *Host) SetupFakeAgentExp() FakeAgent {
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/embedded/bin", vBroken))
 	h.remote.MustExecute(fmt.Sprintf("sudo mkdir -p %s/bin/agent", vBroken))
 
-	h.remote.MustExecute("rm -f /opt/datadog-packages/datadog-agent/experiment") // remove symlink if it exists, next command doesn't overwrite it
+	h.remote.MustExecute("sudo rm -f /opt/datadog-packages/datadog-agent/experiment") // remove symlink if it exists, next command doesn't overwrite it
 	h.remote.MustExecute(fmt.Sprintf("sudo ln -sf %s /opt/datadog-packages/datadog-agent/experiment", vBroken))
 	f := FakeAgent{
 		h:    h,

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -6,11 +6,12 @@
 package agenttests
 
 import (
+	"testing"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
+	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
-	"testing"
 )
 
 type testAgentUpgradeSuite struct {
@@ -88,6 +89,5 @@ func (s *testAgentUpgradeSuite) stopExperiment() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.StableAgentVersion().Version())
 		}).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage)).
-		NoDirExists(installerwindows.GetExperimentDirFor(installerwindows.AgentPackage))
+		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage))
 }


### PR DESCRIPTION
This PR makes a small changes to package repos: instead of deleting the experiment symlink when there is no experiment we make it point to stable. This addresses a commmon need to target "experiment if there is one or stable if there is not".