### PR TITLE
[comp/otelcol/extension] Fix extension check

### DIFF
--- a/comp/otelcol/extension/impl/extension.go
+++ b/comp/otelcol/extension/impl/extension.go
@@ -88,7 +88,6 @@ func (ext *ddExtension) Start(_ context.Context, host component.Host) error {
 		}
 
 		uri, crawl, err := extractor(exconf)
-		fmt.Println("ERROR IS: ========== ", err)
 		if err != nil {
 			ext.telemetry.Logger.Info("Unavailable debug extension for", zap.String("extension", extension.String()))
 		} else {

--- a/comp/otelcol/extension/impl/extension.go
+++ b/comp/otelcol/extension/impl/extension.go
@@ -64,7 +64,7 @@ func (ext *ddExtension) Start(_ context.Context, host component.Host) error {
 
 	// List configured Extensions
 	configstore := ext.cfg.ConfigStore
-	c, err := configstore.GetProvidedConf()
+	c, err := configstore.GetEnhancedConf()
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (ext *ddExtension) Start(_ context.Context, host component.Host) error {
 
 	extensions := host.GetExtensions()
 	for extension := range extensions {
-		extractor, ok := supportedDebugExtensions[extension.String()]
+		extractor, ok := supportedDebugExtensions[extension.Type().String()]
 		if !ok {
 			continue
 		}
@@ -88,6 +88,7 @@ func (ext *ddExtension) Start(_ context.Context, host component.Host) error {
 		}
 
 		uri, crawl, err := extractor(exconf)
+		fmt.Println("ERROR IS: ========== ", err)
 		if err != nil {
 			ext.telemetry.Logger.Info("Unavailable debug extension for", zap.String("extension", extension.String()))
 		} else {

--- a/comp/otelcol/extension/impl/extension_test.go
+++ b/comp/otelcol/extension/impl/extension_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
+	"go.uber.org/zap"
 )
 
 var cpSettings = otelcol.ConfigProviderSettings{
@@ -86,6 +88,15 @@ func TestExtensionHTTPHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	ddExt := ext.(*ddExtension)
+	ddExt.telemetry.Logger = zap.New(zap.NewNop().Core())
+
+	host := newHostWithExtensions(
+		map[component.ID]component.Component{
+			component.MustNewIDWithName("pprof", "custom"): nil,
+		},
+	)
+
+	ddExt.Start(context.TODO(), host)
 
 	// Call the handler's ServeHTTP method
 	ddExt.ServeHTTP(rr, req)
@@ -105,6 +116,7 @@ func TestExtensionHTTPHandler(t *testing.T) {
 		"runtime_override_configuration",
 		"environment_variable_configuration",
 		"environment",
+		"sources",
 	}
 	var response map[string]interface{}
 	json.Unmarshal(rr.Body.Bytes(), &response)
@@ -113,9 +125,20 @@ func TestExtensionHTTPHandler(t *testing.T) {
 		_, ok := response[key]
 		assert.True(t, ok)
 	}
+}
 
-	// There will be no sources configured and thus, that key
-	// should not be present
-	_, ok := response["sources"]
-	assert.False(t, ok)
+type hostWithExtensions struct {
+	component.Host
+	exts map[component.ID]component.Component
+}
+
+func newHostWithExtensions(exts map[component.ID]component.Component) component.Host {
+	return &hostWithExtensions{
+		Host: componenttest.NewNopHost(),
+		exts: exts,
+	}
+}
+
+func (h *hostWithExtensions) GetExtensions() map[component.ID]component.Component {
+	return h.exts
 }

--- a/comp/otelcol/extension/impl/testdata/config.yaml
+++ b/comp/otelcol/extension/impl/testdata/config.yaml
@@ -5,7 +5,10 @@ receivers:
       http:
 exporters:
   otlp:
+extensions:
+  pprof/custom:
 service:
+  extensions: [pprof/custom]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR addresses 2 issues in the extension check logic:
- It now checks for extensions against the enhanced config, instead of the provided config. In fact, the converter logic can add extensions, so some extensions will be present in the enhanced config but not provided config.
- It checks map `supportedDebugExtensions` against `extension.Type().String()` instead of `extension.String()`. Checking for Type will strip the custom `/<anything>`.

This PR also adds a test that fails without the fix.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run converged agent with pprof, health_check and zpages extensions with a suffix in name (e.g. pprof/custom) and ensure that you see log "Found debug extension at" for all three extensions.

also `curl -k https://localhost:7777` and ensure that there is a sources block, e.g.
```
  "sources": {
    "health_check/dd-autoconfigured": {
      "url": "localhost:13133",
      "crawl": false
    },
    "pprof/dd-autoconfigured": {
      "url": "localhost:1777",
      "crawl": false
    },
    "zpages/dd-autoconfigured": {
      "url": "localhost:55679",
      "crawl": true
    }
  },

```
