### PR TITLE
[CSPM] Remove service field from LogReporter

### DIFF
--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -50,9 +50,8 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 	logSource := sources.NewLogSource(
 		sourceName,
 		&config.LogsConfig{
-			Type:    sourceType,
-			Service: sourceName,
-			Source:  sourceName,
+			Type:   sourceType,
+			Source: sourceName,
 		},
 	)
 	logChan := pipelineProvider.NextPipelineChan()


### PR DESCRIPTION
### What does this PR do?

A `service:compliance-agent` tag was present on findings reported by the Compliance Agent.

This changes removes the service field from LogReporter, so the service tag is not present anymore on findings.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
