### PR TITLE
Deprecation of SetEnvVarTransformer in favor of typed helpers

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -111,7 +111,11 @@ type Setup interface {
 	SetEnvPrefix(in string)
 	BindEnv(input ...string)
 	SetEnvKeyReplacer(r *strings.Replacer)
+
+	// SetEnvKeyTransformer is deprecated in favor of LoadEnv* functions
 	SetEnvKeyTransformer(key string, fn func(string) interface{})
+	LoadEnvAsJSON(key string)
+	LoadEnvAsStringList(key string)
 
 	// SetKnown adds a key to the set of known valid config keys
 	SetKnown(key string)


### PR DESCRIPTION
### What does this PR do?

This paves the way to a fully typed configuration. We need each settings to have predictable types not mattern the source (env, yaml files, ...).
### Describe how to test/QA your changes

Helpers aren't used anywhere yet.