### PR TITLE
Deprecation of SetEnvVarTransformer in favor of typed helpers

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -110,7 +110,15 @@ type Setup interface {
 	SetEnvPrefix(in string)
 	BindEnv(input ...string)
 	SetEnvKeyReplacer(r *strings.Replacer)
+
+	// SetEnvKeyTransformer is deprecated in favor of ParseEnvAs* functions
 	SetEnvKeyTransformer(key string, fn func(string) interface{})
+	// The following helpers allow a type to be enforce when parsing environment variables. Most of them exists to
+	// support historic behavior. Refrain from adding more as it's most likely a sign of poorly design configuration
+	// layout.
+	ParseEnvAsStringSlice(key string, fx func(string) []string)
+	ParseEnvAsMapStringInterface(key string, fx func(string) map[string]interface{})
+	ParseEnvAsSliceMapString(key string, fx func(string) []map[string]string)
 
 	// SetKnown adds a key to the set of known valid config keys
 	SetKnown(key string)

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -238,10 +238,34 @@ func (c *safeConfig) GetKnownKeysLowercased() map[string]interface{} {
 
 // SetEnvKeyTransformer allows defining a transformer function which decides
 // how an environment variables value gets assigned to key.
+//
+// [DEPRECATED] This function will soon be remove. Use one of the ParseEnvAs* helpers instead.
 func (c *safeConfig) SetEnvKeyTransformer(key string, fn func(string) interface{}) {
 	c.Lock()
 	defer c.Unlock()
 	c.Viper.SetEnvKeyTransformer(key, fn)
+}
+
+// ParseEnvAsStringSlice registers a transformer function to parse an an environment variables as a []string.
+func (c *safeConfig) ParseEnvAsStringSlice(key string, fn func(string) []string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetEnvKeyTransformer(key, func(data string) interface{} { return fn(data) })
+}
+
+// ParseEnvAsMapStringInterface registers a transformer function to parse an an environment variables as a
+// map[string]interface{}.
+func (c *safeConfig) ParseEnvAsMapStringInterface(key string, fn func(string) map[string]interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetEnvKeyTransformer(key, func(data string) interface{} { return fn(data) })
+}
+
+// ParseEnvAsSliceMapString registers a transformer function to parse an an environment variables as a []map[string]string.
+func (c *safeConfig) ParseEnvAsSliceMapString(key string, fn func(string) []map[string]string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetEnvKeyTransformer(key, func(data string) interface{} { return fn(data) })
 }
 
 // SetFs wraps Viper for concurrent access

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -418,3 +418,34 @@ func TestMergeFleetPolicy(t *testing.T) {
 	assert.Equal(t, "baz", config.Get("foo"))
 	assert.Equal(t, SourceFleetPolicies, config.GetSource("foo"))
 }
+
+func TestParseEnvAsStringSlice(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	config.BindEnv("slice_of_string")
+	config.ParseEnvAsStringSlice("slice_of_string", func(string) []string { return []string{"a", "b", "c"} })
+
+	t.Setenv("DD_SLICE_OF_STRING", "__some_data__")
+	assert.Equal(t, []string{"a", "b", "c"}, config.Get("slice_of_string"))
+}
+
+func TestParseEnvAsMapStringInterface(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	config.BindEnv("map_of_float")
+	config.ParseEnvAsMapStringInterface("map_of_float", func(string) map[string]interface{} { return map[string]interface{}{"a": 1.0, "b": 2.0, "c": 3.0} })
+
+	t.Setenv("DD_MAP_OF_FLOAT", "__some_data__")
+	assert.Equal(t, map[string]interface{}{"a": 1.0, "b": 2.0, "c": 3.0}, config.Get("map_of_float"))
+	assert.Equal(t, map[string]interface{}{"a": 1.0, "b": 2.0, "c": 3.0}, config.GetStringMap("map_of_float"))
+}
+
+func TestParseEnvAsSliceMapString(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	config.BindEnv("map")
+	config.ParseEnvAsSliceMapString("map", func(string) []map[string]string { return []map[string]string{{"a": "a", "b": "b", "c": "c"}} })
+
+	t.Setenv("DD_MAP", "__some_data__")
+	assert.Equal(t, []map[string]string{{"a": "a", "b": "b", "c": "c"}}, config.Get("map"))
+}


### PR DESCRIPTION
### What does this PR do?

This paves the way to a fully typed configuration. We need each settings to have predictable types not mattern the source (env, yaml files, ...).

This PR only remove the usage from SetEnvVarTransformer from the trace-agent.