### PR TITLE
[AGENT-11735] Fix Nil Pointer Dereference in Tailer DidRotate Functions

### DIFF
--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -22,12 +22,9 @@ import (
 // - removed and recreated
 // - truncated
 func (t *Tailer) DidRotate() (bool, error) {
-	if t.osFile == nil {
-		return false, fmt.Errorf("osFile is nil")
-	}
-	f, err := filesystem.OpenShared(t.osFile.Name())
+	f, err := filesystem.OpenShared(t.fullpath)
 	if err != nil {
-		return false, fmt.Errorf("open %q: %w", t.osFile.Name(), err)
+		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}
 	defer f.Close()
 	lastReadOffset := t.lastReadOffset.Load()

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -22,6 +22,9 @@ import (
 // - removed and recreated
 // - truncated
 func (t *Tailer) DidRotate() (bool, error) {
+	if t.osFile == nil {
+		return false, fmt.Errorf("osFile is nil")
+	}
 	f, err := filesystem.OpenShared(t.osFile.Name())
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.osFile.Name(), err)

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -19,12 +19,9 @@ import (
 // On Windows, log rotation is identified by the file size being smaller
 // than the last offset read.
 func (t *Tailer) DidRotate() (bool, error) {
-	if t.osFile == nil {
-		return false, fmt.Errorf("osFile is nil")
-	}
 	f, err := filesystem.OpenShared(t.fullpath)
 	if err != nil {
-		return false, fmt.Errorf("open %q: %w", t.osFile.Name(), err)
+		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}
 	defer f.Close()
 	offset := t.lastReadOffset.Load()

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -19,6 +19,9 @@ import (
 // On Windows, log rotation is identified by the file size being smaller
 // than the last offset read.
 func (t *Tailer) DidRotate() (bool, error) {
+	if t.osFile == nil {
+		return false, fmt.Errorf("osFile is nil")
+	}
 	f, err := filesystem.OpenShared(t.fullpath)
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.osFile.Name(), err)


### PR DESCRIPTION
### What does this PR do?
Starting in agent v7.55.3 we found a bug where the agent randomly get terminated due to nil pointer dereference in 2 separate functions. 

### Motivation
This PR helps making sure the agent does not panic and terminate itself

### Additional Notes
Example of the crash stack:
```
(dlv) frame 10
Stopped at: 0x7ffb1aab973e
=>   1: no source available
Frame 10: c:/go/1.21.12/go/src/os/file.go:56 (PC: 7ff652341a0b)
(dlv) args -v
Sending output to pager...
t = ("*github.com/DataDog/datadog-agent/pkg/logs/tailers/file.Tailer")(0xc00675c750)
*github.com/DataDog/datadog-agent/pkg/logs/tailers/file.Tailer {
        lastReadOffset: *go.uber.org/atomic.Int64 {
                _: go.uber.org/atomic.nocmp [],
                v: 172813,},
        decodedOffset: *go.uber.org/atomic.Int64 {
                _: go.uber.org/atomic.nocmp [],
                v: 172813,},
        file: *github.com/DataDog/datadog-agent/pkg/logs/tailers/file.File {
                Path: "D:\\Logs\\Siemens\\tcserver4T\\tcserver.exe5968a583.syslog",
                IsWildcardPath: true,
                Source: *(*"github.com/DataDog/datadog-agent/pkg/logs/sources.ReplaceableSource")(0xc0008038e0),},
        fullpath: "D:\\Logs\\Siemens\\tcserver4T\\tcserver.exe5968a583.syslog",
        osFile: *os.File nil,
        tags: []string len: 2, cap: 2, [
                "filename:tcserver.exe5968a583.syslog",
                "dirname:D:\\Logs\\Siemens\\tcserver4T",

```
