### PR TITLE
[USM] add Postgres message counters to the eBPF module, extract these…

### DIFF
--- a/pkg/network/ebpf/c/protocols/postgres/decoding-maps.h
+++ b/pkg/network/ebpf/c/protocols/postgres/decoding-maps.h
@@ -12,4 +12,11 @@ BPF_HASH_MAP(postgres_in_flight, conn_tuple_t, postgres_transaction_t, 0)
 // Acts as a scratch buffer for Postgres events, for preparing events before they are sent to userspace.
 BPF_PERCPU_ARRAY_MAP(postgres_scratch_buffer, postgres_event_t, 1)
 
+/* Postgres telemetry maps in kernel space help to find empirical statistics about
+ * the number of Postgres messages in each TCP packet.
+ * use only key 0, value is postgres telemetry object.
+ */
+BPF_ARRAY_MAP(postgres_plain_msg_count, postgres_kernel_msg_count_t, 1)
+BPF_ARRAY_MAP(postgres_tls_msg_count, postgres_kernel_msg_count_t, 1)
+
 #endif

--- a/pkg/network/ebpf/c/protocols/postgres/decoding.h
+++ b/pkg/network/ebpf/c/protocols/postgres/decoding.h
@@ -173,7 +173,7 @@ static __always_inline void postgres_entrypoint(pktbuf_t pkt, conn_tuple_t *conn
     if (pg_msg_counts == NULL) {
         return;
     }
-    bucket_idx = (bucket_idx > (PG_KERNEL_MSG_COUNT_NUM_BUCKETS - 1)) ? PG_KERNEL_MSG_COUNT_NUM_BUCKETS - 1: bucket_idx - 1;
+    bucket_idx = (bucket_idx > PG_KERNEL_MSG_COUNT_NUM_BUCKETS) ? PG_KERNEL_MSG_COUNT_NUM_BUCKETS: bucket_idx - 1;
     __sync_fetch_and_add(&pg_msg_counts->pg_messages_count_buckets[bucket_idx], 1);
 }
 

--- a/pkg/network/ebpf/c/protocols/postgres/types.h
+++ b/pkg/network/ebpf/c/protocols/postgres/types.h
@@ -43,7 +43,7 @@ typedef struct {
 
 // postgres_kernel_msg_count_t This structure stores statistics about the number of Postgres messages in a TCP packet.
 typedef struct {
-    __u64 pg_messages_count_buckets[PG_KERNEL_MSG_COUNT_NUM_BUCKETS];
+    __u64 pg_messages_count_buckets[PG_KERNEL_MSG_COUNT_NUM_BUCKETS + 1];
 } postgres_kernel_msg_count_t;
 
 #endif

--- a/pkg/network/ebpf/c/protocols/postgres/types.h
+++ b/pkg/network/ebpf/c/protocols/postgres/types.h
@@ -10,7 +10,7 @@
 #define POSTGRES_BUFFER_SIZE 160
 
 // Maximum number of Postgres messages we can parse for a single packet.
-#define POSTGRES_MAX_MESSAGES 64
+#define POSTGRES_MAX_MESSAGES 72
 
 // Postgres transaction information we store in the kernel.
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/postgres/types.h
+++ b/pkg/network/ebpf/c/protocols/postgres/types.h
@@ -10,7 +10,7 @@
 #define POSTGRES_BUFFER_SIZE 160
 
 // Maximum number of Postgres messages we can parse for a single packet.
-#define POSTGRES_MAX_MESSAGES 40
+#define POSTGRES_MAX_MESSAGES 64
 
 // Postgres transaction information we store in the kernel.
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/postgres/types.h
+++ b/pkg/network/ebpf/c/protocols/postgres/types.h
@@ -10,7 +10,7 @@
 #define POSTGRES_BUFFER_SIZE 160
 
 // Maximum number of Postgres messages we can parse for a single packet.
-#define POSTGRES_MAX_MESSAGES 72
+#define POSTGRES_MAX_MESSAGES 70
 
 // Postgres transaction information we store in the kernel.
 typedef struct {
@@ -33,17 +33,15 @@ typedef struct {
 // Each TCP packet can include multiple postgres messages.
 // Postgres telemetry helps to find empirical statistics about the number of messages in each packet,
 // these statistics allow to optimize monitoring code.
-// It is expected that there can be from 1 to PG_KERNEL_MSG_COUNT_MAX messages in a packet.
 // Collect counters for each subsequent bucket:
 // 0 to (BUCKET_SIZE-1), BUCKET_SIZE to (BUCKET_SIZE*2-1), (BUCKET_SIZE*2) to (BUCKET_SIZE*3-1), ...
-#define PG_KERNEL_MSG_COUNT_NUM_BUCKETS 8
-#define PG_KERNEL_MSG_COUNT_BUCKET_SIZE (POSTGRES_MAX_MESSAGES / PG_KERNEL_MSG_COUNT_NUM_BUCKETS)
-#define PG_KERNEL_MSG_COUNT_MAX (PG_KERNEL_MSG_COUNT_NUM_BUCKETS * PG_KERNEL_MSG_COUNT_BUCKET_SIZE)
+#define PG_KERNEL_MSG_COUNT_BUCKET_SIZE 10
+#define PG_KERNEL_MSG_COUNT_NUM_BUCKETS (POSTGRES_MAX_MESSAGES / PG_KERNEL_MSG_COUNT_BUCKET_SIZE)
 #define PG_KERNEL_MSG_COUNT_BUCKET_INDEX(count) (count / PG_KERNEL_MSG_COUNT_BUCKET_SIZE)
 
 // postgres_kernel_msg_count_t This structure stores statistics about the number of Postgres messages in a TCP packet.
 typedef struct {
-    __u64 pg_messages_count_buckets[PG_KERNEL_MSG_COUNT_NUM_BUCKETS + 1];
+    __u64 pg_messages_count_buckets[PG_KERNEL_MSG_COUNT_NUM_BUCKETS];
 } postgres_kernel_msg_count_t;
 
 #endif

--- a/pkg/network/protocols/postgres/ebpf/types.go
+++ b/pkg/network/protocols/postgres/ebpf/types.go
@@ -25,5 +25,5 @@ type PostgresKernelMsgCount C.postgres_kernel_msg_count_t
 const (
 	BufferSize            = C.POSTGRES_BUFFER_SIZE
 	KerMsgCountBucketSize = C.PG_KERNEL_MSG_COUNT_BUCKET_SIZE
-	KerMsgCountNumBuckets = C.PG_KERNEL_MSG_COUNT_NUM_BUCKETS + 1
+	KerMsgCountNumBuckets = C.PG_KERNEL_MSG_COUNT_NUM_BUCKETS
 )

--- a/pkg/network/protocols/postgres/ebpf/types.go
+++ b/pkg/network/protocols/postgres/ebpf/types.go
@@ -25,5 +25,5 @@ type PostgresKernelMsgCount C.postgres_kernel_msg_count_t
 const (
 	BufferSize            = C.POSTGRES_BUFFER_SIZE
 	KerMsgCountBucketSize = C.PG_KERNEL_MSG_COUNT_BUCKET_SIZE
-	KerMsgCountNumBuckets = C.PG_KERNEL_MSG_COUNT_NUM_BUCKETS
+	KerMsgCountNumBuckets = C.PG_KERNEL_MSG_COUNT_NUM_BUCKETS + 1
 )

--- a/pkg/network/protocols/postgres/ebpf/types.go
+++ b/pkg/network/protocols/postgres/ebpf/types.go
@@ -9,6 +9,7 @@ package ebpf
 
 /*
 #include "../../ebpf/c/protocols/postgres/types.h"
+#include "../../ebpf/c/protocols/postgres/defs.h"
 #include "../../ebpf/c/protocols/classification/defs.h"
 */
 import "C"
@@ -19,7 +20,10 @@ type ConnTuple = C.conn_tuple_t
 
 type EbpfEvent C.postgres_event_t
 type EbpfTx C.postgres_transaction_t
+type PostgresKernelMsgCount C.postgres_kernel_msg_count_t
 
 const (
-	BufferSize = C.POSTGRES_BUFFER_SIZE
+	BufferSize            = C.POSTGRES_BUFFER_SIZE
+	KerMsgCountBucketSize = C.PG_KERNEL_MSG_COUNT_BUCKET_SIZE
+	KerMsgCountNumBuckets = C.PG_KERNEL_MSG_COUNT_NUM_BUCKETS
 )

--- a/pkg/network/protocols/postgres/ebpf/types_linux.go
+++ b/pkg/network/protocols/postgres/ebpf/types_linux.go
@@ -28,11 +28,11 @@ type EbpfTx struct {
 	Pad_cgo_0           [3]byte
 }
 type PostgresKernelMsgCount struct {
-	Messages_count_buckets [9]uint64
+	Messages_count_buckets [7]uint64
 }
 
 const (
 	BufferSize            = 0xa0
-	KerMsgCountBucketSize = 0x9
-	KerMsgCountNumBuckets = 0x8 + 1
+	KerMsgCountBucketSize = 0xa
+	KerMsgCountNumBuckets = 0x7
 )

--- a/pkg/network/protocols/postgres/ebpf/types_linux.go
+++ b/pkg/network/protocols/postgres/ebpf/types_linux.go
@@ -33,6 +33,6 @@ type PostgresKernelMsgCount struct {
 
 const (
 	BufferSize            = 0xa0
-	KerMsgCountBucketSize = 0x5
+	KerMsgCountBucketSize = 0x8
 	KerMsgCountNumBuckets = 0x8
 )

--- a/pkg/network/protocols/postgres/ebpf/types_linux.go
+++ b/pkg/network/protocols/postgres/ebpf/types_linux.go
@@ -27,7 +27,12 @@ type EbpfTx struct {
 	Tags                uint8
 	Pad_cgo_0           [3]byte
 }
+type PostgresKernelMsgCount struct {
+	Messages_count_buckets [8]uint64
+}
 
 const (
-	BufferSize = 0xa0
+	BufferSize            = 0xa0
+	KerMsgCountBucketSize = 0x5
+	KerMsgCountNumBuckets = 0x8
 )

--- a/pkg/network/protocols/postgres/ebpf/types_linux.go
+++ b/pkg/network/protocols/postgres/ebpf/types_linux.go
@@ -28,11 +28,11 @@ type EbpfTx struct {
 	Pad_cgo_0           [3]byte
 }
 type PostgresKernelMsgCount struct {
-	Messages_count_buckets [8]uint64
+	Messages_count_buckets [9]uint64
 }
 
 const (
 	BufferSize            = 0xa0
 	KerMsgCountBucketSize = 0x9
-	KerMsgCountNumBuckets = 0x8
+	KerMsgCountNumBuckets = 0x8 + 1
 )

--- a/pkg/network/protocols/postgres/ebpf/types_linux.go
+++ b/pkg/network/protocols/postgres/ebpf/types_linux.go
@@ -33,6 +33,6 @@ type PostgresKernelMsgCount struct {
 
 const (
 	BufferSize            = 0xa0
-	KerMsgCountBucketSize = 0x8
+	KerMsgCountBucketSize = 0x9
 	KerMsgCountNumBuckets = 0x8
 )

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -257,13 +257,13 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 func (p *protocol) updatePgKernelTelemetry(mgr *manager.Manager) {
 	mapPlain, err := protocols.GetMap(mgr, KernelTelemetryMapPlain)
 	if err != nil {
-		log.Warn(err)
+		log.Errorf("Couldnt find kernel telemetry map: %s, error: %v", KernelTelemetryMapPlain, err)
 		return
 	}
 
 	mapTLS, err := protocols.GetMap(mgr, KernelTelemetryMapTLS)
 	if err != nil {
-		log.Warn(err)
+		log.Errorf("Couldnt find kernel telemetry map: %s, error: %v", KernelTelemetryMapTLS, err)
 		return
 	}
 
@@ -278,13 +278,13 @@ func (p *protocol) updatePgKernelTelemetry(mgr *manager.Manager) {
 			select {
 			case <-ticker.C:
 				if err := mapPlain.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(pgKernelMsgCount)); err != nil {
-					_ = log.Errorf("unable to lookup %q map: %s", KernelTelemetryMapPlain, err)
+					log.Errorf("unable to lookup %q map: %s", KernelTelemetryMapPlain, err)
 					return
 				}
 				p.pgKernelTelemetry.update(pgKernelMsgCount, false)
 
 				if err := mapTLS.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(pgKernelMsgCount)); err != nil {
-					_ = log.Errorf("unable to lookup %q map: %s", KernelTelemetryMapTLS, err)
+					log.Errorf("unable to lookup %q map: %s", KernelTelemetryMapTLS, err)
 					return
 				}
 				p.pgKernelTelemetry.update(pgKernelMsgCount, true)

--- a/pkg/network/protocols/postgres/telemetry.go
+++ b/pkg/network/protocols/postgres/telemetry.go
@@ -9,10 +9,12 @@ package postgres
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres/ebpf"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -107,4 +109,136 @@ func (t *Telemetry) Count(tx *ebpf.EbpfEvent, eventWrapper *EventWrapper, option
 // Log logs the postgres stats summary
 func (t *Telemetry) Log() {
 	log.Debugf("postgres stats summary: %s", t.metricGroup.Summary())
+}
+
+// tlsAwareCounter has a plain counter and a counter for TLS.
+// It enables the use of a single metric that increments based on the encryption, avoiding the need for separate metrics for each use-case.
+type tlsAwareCounter struct {
+	counterPlain *libtelemetry.Counter
+	counterTLS   *libtelemetry.Counter
+}
+
+// NewTLSAwareCounter creates and returns a new instance of the struct
+func newTLSAwareCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *tlsAwareCounter {
+	return &tlsAwareCounter{
+		counterPlain: metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),
+		counterTLS:   metricGroup.NewCounter(metricName, append(tags, "encrypted:true")...),
+	}
+}
+
+// Add adds the given delta to the counter based on the encryption.
+func (c *tlsAwareCounter) add(delta int64, isTLS bool) {
+	if isTLS {
+		c.counterTLS.Add(delta)
+		return
+	}
+	c.counterPlain.Add(delta)
+}
+
+// Get returns the counter value based on the encryption.
+func (c *tlsAwareCounter) get(isTLS bool) int64 {
+	if isTLS {
+		return c.counterTLS.Get()
+	}
+	return c.counterPlain.Get()
+}
+
+// PGKernelTelemetry	provides empirical kernel statistics about the number of messages in each TCP packet
+type PGKernelTelemetry struct {
+	// metricGroup is used here mostly for building the log message below
+	metricGroup *libtelemetry.MetricGroup
+	// pgMessagesCountBuckets		count Postgres messages and divide the count into buckets
+	pgMessagesCountBuckets [ebpf.KerMsgCountNumBuckets]*tlsAwareCounter
+	// pgKernelMsgCountPlainPrev	save the last counters observed from the kernel, plain messages
+	pgKernelMsgCountPlainPrev ebpf.PostgresKernelMsgCount
+	// pgKernelMsgCountPrev			save the last counters observed from the kernel, TLS messages
+	pgKernelMsgCountTlsPrev ebpf.PostgresKernelMsgCount
+}
+
+// newPGKernelTelemetry this is the Postgres message counter store.
+func newPGKernelTelemetry() *PGKernelTelemetry {
+	metricGroup := libtelemetry.NewMetricGroup("usm.postgres", libtelemetry.OptStatsd)
+	pgKernelTel := &PGKernelTelemetry{
+		metricGroup: metricGroup,
+	}
+	pgKernelTel.createMessagesCountBuckets(metricGroup)
+
+	return pgKernelTel
+}
+
+func (t *PGKernelTelemetry) createMessagesCountBuckets(metricGroup *libtelemetry.MetricGroup) {
+	for bucketIndex := range t.pgMessagesCountBuckets {
+		t.pgMessagesCountBuckets[bucketIndex] = newTLSAwareCounter(metricGroup,
+			"messages_count_bucket_"+(strconv.Itoa(bucketIndex+1)))
+	}
+}
+
+// update the Postgres message counter store with new counters from the kernel.
+// return if nothing to add, in this case also metric group summary ignores unmodified metrics.
+func (t *PGKernelTelemetry) update(kernMsgCounts *ebpf.PostgresKernelMsgCount, isTLS bool) {
+	if kernMsgCounts == nil {
+		return
+	}
+	if isEmptyCounts(kernMsgCounts) {
+		log.Debugf("postgres kernel telemetry empty.")
+		return
+	}
+	delta := t.getDiff(kernMsgCounts, isTLS)
+	if isEmptyCounts(delta) {
+		log.Debugf("postgres kernel telemetry, no difference with previous counters.")
+		return
+	}
+	for bucketIndex := range t.pgMessagesCountBuckets {
+		t.pgMessagesCountBuckets[bucketIndex].add(int64(delta.Messages_count_buckets[bucketIndex]), isTLS)
+	}
+	if isTLS {
+		t.pgKernelMsgCountTlsPrev = *kernMsgCounts
+	} else {
+		t.pgKernelMsgCountPlainPrev = *kernMsgCounts
+	}
+	s := t.metricGroup.Summary()
+	log.Debugf("postgres kernel telemetry, isTLS=%t, summary: %s", isTLS, s)
+}
+
+func (t *PGKernelTelemetry) getDiff(kernMsgCounts *ebpf.PostgresKernelMsgCount, isTLS bool) *ebpf.PostgresKernelMsgCount {
+	if isTLS {
+		return subtractCounts(kernMsgCounts, &t.pgKernelMsgCountTlsPrev)
+	}
+	return subtractCounts(kernMsgCounts, &t.pgKernelMsgCountPlainPrev)
+}
+
+// subtractCounts create a new PostgresKernelMsgCount by subtracting the counts of 'b' from 'a'.
+func subtractCounts(a *ebpf.PostgresKernelMsgCount, b *ebpf.PostgresKernelMsgCount) *ebpf.PostgresKernelMsgCount {
+	res := &ebpf.PostgresKernelMsgCount{}
+	res.Messages_count_buckets = subtractArrays(a.Messages_count_buckets, b.Messages_count_buckets)
+	return res
+}
+
+// subtractArrays returns new array[] = a[] - b[]
+// note that if b > a then the result is negative, although it is stored as an unsigned value giving a very large result.
+func subtractArrays(a, b [ebpf.KerMsgCountNumBuckets]uint64) [ebpf.KerMsgCountNumBuckets]uint64 {
+	var result [ebpf.KerMsgCountNumBuckets]uint64
+	for i := 0; i < ebpf.KerMsgCountNumBuckets; i++ {
+		result[i] = a[i] - b[i]
+		if b[i] > a[i] {
+			log.Debugf("postgres kernel telemetry, unexpected result(%u) = a(%u) - b(%u)", result[i], a[i], b[i])
+		}
+	}
+	return result
+}
+
+func isEmptyCounts(p *ebpf.PostgresKernelMsgCount) bool {
+	if !arrayIsEmpty(p.Messages_count_buckets) {
+		return false
+	}
+	return true
+}
+
+func arrayIsEmpty(arr [ebpf.KerMsgCountNumBuckets]uint64) bool {
+	for i := 0; i < ebpf.KerMsgCountNumBuckets; i++ {
+		if arr[i] > 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/network/protocols/postgres/telemetry.go
+++ b/pkg/network/protocols/postgres/telemetry.go
@@ -11,10 +11,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres/ebpf"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -38,6 +38,11 @@ func (c *Counter) Add(v int64) {
 	c.value.Add(v)
 }
 
+// Set value atomically
+func (c *Counter) Set(v int64) {
+	c.value.Store(v)
+}
+
 func (c *Counter) base() *metricBase {
 	return c.metricBase
 }
@@ -118,6 +123,15 @@ func NewTLSAwareCounter(metricGroup *MetricGroup, metricName string, tags ...str
 		counterPlain: metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),
 		counterTLS:   metricGroup.NewCounter(metricName, append(tags, "encrypted:true")...),
 	}
+}
+
+// Set Sets the given value to the counter based on the encryption.
+func (c *TLSAwareCounter) Set(v int64, isTLS bool) {
+	if isTLS {
+		c.counterTLS.Set(v)
+		return
+	}
+	c.counterPlain.Set(v)
 }
 
 // Add adds the given delta to the counter based on the encryption.

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -777,10 +777,10 @@ func testKernelMessagesCount(t *testing.T, isTLS bool) {
 	var pgClient *postgres.PGXClient
 
 	expectedMsgCounts := &pgebpf.PostgresKernelMsgCount{
-		Messages_count_buckets: [8]uint64{0, 0, 0, 0, 0, 0, 0, 0},
+		Messages_count_buckets: [pgebpf.KerMsgCountNumBuckets]uint64{},
 	}
 
-	for i := 0; i < pgebpf.KerMsgCountNumBuckets; i++ {
+	for i := 0; i < pgebpf.KerMsgCountNumBuckets-1; i++ {
 		testName := fmt.Sprintf("kernel messages count bucket[%d]", i)
 		t.Run(testName, func(t *testing.T) {
 			t.Cleanup(func() {
@@ -843,7 +843,7 @@ func compareMessagesCount(a *pgebpf.PostgresKernelMsgCount, b *pgebpf.PostgresKe
 // For example return true if a[43, 21, 22, 0, 0, 0, 0, 0] and b[1, 1, 1, 0, 0, 0, 0, 0]
 // the first array represents the retrieved counters, while the second array represents
 // the buckets that are expected to be non-empty.
-func compareBucketsFilling(a [8]uint64, b [8]uint64) bool {
+func compareBucketsFilling(a [pgebpf.KerMsgCountNumBuckets]uint64, b [pgebpf.KerMsgCountNumBuckets]uint64) bool {
 	for i := range a {
 		if a[i] != b[i] && (a[i]*b[i] == 0) {
 			return false

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -781,8 +781,8 @@ func testKernelMessagesCount(t *testing.T, isTLS bool) {
 	}
 
 	for i := 0; i < pgebpf.KerMsgCountNumBuckets; i++ {
-		test_name := fmt.Sprintf("kernel messages count bucket[%d]", i)
-		t.Run(test_name, func(t *testing.T) {
+		testName := fmt.Sprintf("kernel messages count bucket[%d]", i)
+		t.Run(testName, func(t *testing.T) {
 			t.Cleanup(func() {
 				if pgClient != nil {
 					_ = pgClient.RunQuery(dropTableQuery)
@@ -792,8 +792,7 @@ func testKernelMessagesCount(t *testing.T, isTLS bool) {
 					}
 				}
 			})
-			pgClient = setupPgClient(t, serverAddress, isTLS)
-			require.NoError(t, pgClient.Ping())
+			pgClient = setupPGClient(t, serverAddress, isTLS)
 
 			// 'sqlInsertCount' is the heuristic number of values to construct the long query
 			sqlInsertCount := i*pgebpf.KerMsgCountBucketSize + 1
@@ -811,7 +810,7 @@ func runQueryForBucket(t *testing.T, pg *postgres.PGXClient, insertCount int) {
 	require.NoError(t, pg.RunQuery(selectAllQuery))
 }
 
-func setupPgClient(t *testing.T, serverAddress string, isTLS bool) *postgres.PGXClient {
+func setupPGClient(t *testing.T, serverAddress string, isTLS bool) *postgres.PGXClient {
 	pg, err := postgres.NewPGXClient(postgres.ConnectionOptions{
 		ServerAddress: serverAddress,
 		EnableTLS:     isTLS,

--- a/releasenotes/notes/usm-postgres-metrics-messages-count-54cd26ca83cc77d7.yaml
+++ b/releasenotes/notes/usm-postgres-metrics-messages-count-54cd26ca83cc77d7.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Added metrics about the distribution of the number of Postgres messages in each TCP packet.

--- a/releasenotes/notes/usm-postgres-metrics-messages-count-54cd26ca83cc77d7.yaml
+++ b/releasenotes/notes/usm-postgres-metrics-messages-count-54cd26ca83cc77d7.yaml
@@ -1,3 +1,0 @@
-enhancements:
-  - |
-    Added metrics about the distribution of the number of Postgres messages in each TCP packet.


### PR DESCRIPTION
### What does this PR do?

Adds Postgres message counters to the eBPF module of the system-probe

### Motivation

Postgres uses a message protocol for communication between client and server. These messages are sent over TCP, each TCP packet may include a different number of Postgres messages. This code collects statistics about the number of Postgres messages in each TCP packet in the Linux kernel. This statistics/telemetry allows to optimize eBPF buffer sizes when processing Postgres messages in the agent and system-probe process.

### Additional Notes

This code also includes golang tests for the new eBPF maps.

### Possible Drawbacks / Trade-offs

The complexity of an eBPF program will increase and may reach program size limits on some platforms.


### Describe how to test/QA your changes


New TestKernelTelemetry() verifies Postgres kernel telemetry 

