### PR TITLE
[CONTP-356] feat(admission server): implement ValidatingAdmissionWebhook

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -199,17 +199,8 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request, webhookName stri
 		}
 
 		// Generate admission response
-		switch webhookType {
-		case admicommon.ValidatingWebhook:
-			validationResponse := webhookFunc(&admissionRequest)
-			admissionReview.Response = validationResponse
-		case admicommon.MutatingWebhook:
-			mutationResponse := webhookFunc(&admissionRequest)
-			admissionReview.Response = mutationResponse
-		default:
-			log.Errorf("Invalid webhook type %v", webhookType)
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		admissionResponse := webhookFunc(&admissionRequest)
+		admissionReview.Response = admissionResponse
 		admissionReview.Response.UID = admissionReviewReq.Request.UID
 		response = admissionReview
 	case admiv1beta1.SchemeGroupVersion.WithKind("AdmissionReview"):
@@ -230,17 +221,8 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request, webhookName stri
 		}
 
 		// Generate admission response
-		switch webhookType {
-		case admicommon.ValidatingWebhook:
-			validationResponse := webhookFunc(&admissionRequest)
-			admissionReview.Response = responseV1ToV1beta1(validationResponse)
-		case admicommon.MutatingWebhook:
-			mutationResponse := webhookFunc(&admissionRequest)
-			admissionReview.Response = responseV1ToV1beta1(mutationResponse)
-		default:
-			log.Errorf("Invalid webhook type %v", webhookType)
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		admissionResponse := webhookFunc(&admissionRequest)
+		admissionReview.Response = responseV1ToV1beta1(admissionResponse)
 		admissionReview.Response.UID = admissionReviewReq.Request.UID
 		response = admissionReview
 	default:

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -18,30 +18,28 @@ import (
 	"net/http"
 	"time"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
-
 	"github.com/cihub/seelog"
+	admiv1 "k8s.io/api/admission/v1"
+	admiv1beta1 "k8s.io/api/admission/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
+	admicommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
-
-	admiv1 "k8s.io/api/admission/v1"
-	admiv1beta1 "k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 const jsonContentType = "application/json"
 
-// MutateRequest contains the information of a mutation request
-type MutateRequest struct {
+// Request contains the information of an admission request
+type Request struct {
 	// Raw is the raw request object
 	Raw []byte
 	// Name is the name of the object
@@ -56,8 +54,9 @@ type MutateRequest struct {
 	APIClient kubernetes.Interface
 }
 
-// MutatingWebhookFunc is the function that runs the mutating webhook logic
-type MutatingWebhookFunc func(request *MutateRequest) ([]byte, error)
+// WebhookFunc is the function that runs the webhook logic.
+// We always return an `admissionv1.AdmissionResponse` as it will be converted to the appropriate version if needed.
+type WebhookFunc func(request *Request) *admiv1.AdmissionResponse
 
 // Server TODO <container-integrations>
 type Server struct {
@@ -94,9 +93,9 @@ func (s *Server) initDecoder() {
 
 // Register adds an admission webhook handler.
 // Register must be called to register the desired webhook handlers before calling Run.
-func (s *Server) Register(uri string, webhookName string, f MutatingWebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
+func (s *Server) Register(uri string, webhookName string, webhookType admicommon.WebhookType, f WebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
 	s.mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		s.mutateHandler(w, r, webhookName, f, dc, apiClient)
+		s.handle(w, r, webhookName, webhookType, f, dc, apiClient)
 	})
 }
 
@@ -136,16 +135,21 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 	return server.Shutdown(shutdownCtx)
 }
 
-// mutateHandler contains the main logic responsible for handling mutation requests.
+// handle contains the main logic responsible for handling admission requests.
 // It supports both v1 and v1beta1 requests.
-func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookName string, mutateFunc MutatingWebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
-	metrics.MutatingWebhooksReceived.Inc(webhookName)
+func (s *Server) handle(w http.ResponseWriter, r *http.Request, webhookName string, webhookType admicommon.WebhookType, webhookFunc WebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
+	// Increment the metrics for the received webhook.
+	// We send the webhook name twice to keep the backward compatibility with `mutation_type` tag.
+	metrics.WebhooksReceived.Inc(webhookName, webhookName, webhookType.String())
 
+	// Measure the time it takes to process the request.
 	start := time.Now()
 	defer func() {
-		metrics.MutatingWebhooksResponseDuration.Observe(time.Since(start).Seconds(), webhookName)
+		// We send the webhook name twice to keep the backward compatibility with `mutation_type` tag.
+		metrics.WebhooksResponseDuration.Observe(time.Since(start).Seconds(), webhookName, webhookName, webhookType.String())
 	}()
 
+	// Validate admission request.
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		log.Warnf("Invalid method %s, only POST requests are allowed", r.Method)
@@ -166,6 +170,7 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 		return
 	}
 
+	// Deserialize admission request.
 	obj, gvk, err := s.decoder.Decode(body, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -173,6 +178,7 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 		return
 	}
 
+	// Handle the request based on `GroupVersionKind`.
 	var response runtime.Object
 	switch *gvk {
 	case admiv1.SchemeGroupVersion.WithKind("AdmissionReview"):
@@ -180,9 +186,10 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 		if !ok {
 			log.Errorf("Expected v1.AdmissionReview, got type %T", obj)
 		}
-		admissionReviewResp := &admiv1.AdmissionReview{}
-		admissionReviewResp.SetGroupVersionKind(*gvk)
-		mutateRequest := MutateRequest{
+
+		admissionReview := &admiv1.AdmissionReview{}
+		admissionReview.SetGroupVersionKind(*gvk)
+		admissionRequest := Request{
 			Raw:           admissionReviewReq.Request.Object.Raw,
 			Name:          admissionReviewReq.Request.Name,
 			Namespace:     admissionReviewReq.Request.Namespace,
@@ -190,18 +197,30 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 			DynamicClient: dc,
 			APIClient:     apiClient,
 		}
-		jsonPatch, err := mutateFunc(&mutateRequest)
-		admissionReviewResp.Response = mutationResponse(jsonPatch, err)
-		admissionReviewResp.Response.UID = admissionReviewReq.Request.UID
-		response = admissionReviewResp
+
+		// Generate admission response
+		switch webhookType {
+		case admicommon.ValidatingWebhook:
+			validationResponse := webhookFunc(&admissionRequest)
+			admissionReview.Response = validationResponse
+		case admicommon.MutatingWebhook:
+			mutationResponse := webhookFunc(&admissionRequest)
+			admissionReview.Response = mutationResponse
+		default:
+			log.Errorf("Invalid webhook type %v", webhookType)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		admissionReview.Response.UID = admissionReviewReq.Request.UID
+		response = admissionReview
 	case admiv1beta1.SchemeGroupVersion.WithKind("AdmissionReview"):
 		admissionReviewReq, ok := obj.(*admiv1beta1.AdmissionReview)
 		if !ok {
 			log.Errorf("Expected v1beta1.AdmissionReview, got type %T", obj)
 		}
-		admissionReviewResp := &admiv1beta1.AdmissionReview{}
-		admissionReviewResp.SetGroupVersionKind(*gvk)
-		mutateRequest := MutateRequest{
+
+		admissionReview := &admiv1beta1.AdmissionReview{}
+		admissionReview.SetGroupVersionKind(*gvk)
+		admissionRequest := Request{
 			Raw:           admissionReviewReq.Request.Object.Raw,
 			Name:          admissionReviewReq.Request.Name,
 			Namespace:     admissionReviewReq.Request.Namespace,
@@ -209,10 +228,21 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 			DynamicClient: dc,
 			APIClient:     apiClient,
 		}
-		jsonPatch, err := mutateFunc(&mutateRequest)
-		admissionReviewResp.Response = responseV1ToV1beta1(mutationResponse(jsonPatch, err))
-		admissionReviewResp.Response.UID = admissionReviewReq.Request.UID
-		response = admissionReviewResp
+
+		// Generate admission response
+		switch webhookType {
+		case admicommon.ValidatingWebhook:
+			validationResponse := webhookFunc(&admissionRequest)
+			admissionReview.Response = responseV1ToV1beta1(validationResponse)
+		case admicommon.MutatingWebhook:
+			mutationResponse := webhookFunc(&admissionRequest)
+			admissionReview.Response = responseV1ToV1beta1(mutationResponse)
+		default:
+			log.Errorf("Invalid webhook type %v", webhookType)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		admissionReview.Response.UID = admissionReviewReq.Request.UID
+		response = admissionReview
 	default:
 		log.Errorf("Group version kind %v is not supported", gvk)
 		w.WriteHeader(http.StatusBadRequest)
@@ -225,29 +255,6 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookNa
 		log.Warnf("Failed to encode the response: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-}
-
-// mutationResponse returns the adequate v1.AdmissionResponse based on the mutation result.
-func mutationResponse(jsonPatch []byte, err error) *admiv1.AdmissionResponse {
-	if err != nil {
-		log.Warnf("Failed to mutate: %v", err)
-
-		return &admiv1.AdmissionResponse{
-			Result: &metav1.Status{
-				Message: err.Error(),
-			},
-			Allowed: true,
-		}
-
-	}
-
-	patchType := admiv1.PatchTypeJSONPatch
-
-	return &admiv1.AdmissionResponse{
-		Patch:     jsonPatch,
-		PatchType: &patchType,
-		Allowed:   true,
 	}
 }
 

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -56,8 +56,8 @@ type MutateRequest struct {
 	APIClient kubernetes.Interface
 }
 
-// WebhookFunc is the function that runs the webhook logic
-type WebhookFunc func(request *MutateRequest) ([]byte, error)
+// MutatingWebhookFunc is the function that runs the mutating webhook logic
+type MutatingWebhookFunc func(request *MutateRequest) ([]byte, error)
 
 // Server TODO <container-integrations>
 type Server struct {
@@ -94,7 +94,7 @@ func (s *Server) initDecoder() {
 
 // Register adds an admission webhook handler.
 // Register must be called to register the desired webhook handlers before calling Run.
-func (s *Server) Register(uri string, webhookName string, f WebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
+func (s *Server) Register(uri string, webhookName string, f MutatingWebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
 	s.mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		s.mutateHandler(w, r, webhookName, f, dc, apiClient)
 	})
@@ -138,12 +138,12 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 
 // mutateHandler contains the main logic responsible for handling mutation requests.
 // It supports both v1 and v1beta1 requests.
-func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookName string, mutateFunc WebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
-	metrics.WebhooksReceived.Inc(webhookName)
+func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, webhookName string, mutateFunc MutatingWebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
+	metrics.MutatingWebhooksReceived.Inc(webhookName)
 
 	start := time.Now()
 	defer func() {
-		metrics.WebhooksResponseDuration.Observe(time.Since(start).Seconds(), webhookName)
+		metrics.MutatingWebhooksResponseDuration.Observe(time.Since(start).Seconds(), webhookName)
 	}()
 
 	if r.Method != http.MethodPost {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -468,16 +468,16 @@ func start(log log.Component,
 			StopCh:              stopCh,
 		}
 
-		mutatingWebhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
+		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
 		if err != nil {
 			pkglog.Errorf("Could not start admission controller: %v", err)
 		} else {
 			// Webhook and secret controllers are started successfully
-			// Setup the k8s admission webhook server
+			// Set up the k8s admission webhook server
 			server := admissioncmd.NewServer()
 
-			for _, webhookConf := range mutatingWebhooks {
-				server.Register(webhookConf.Endpoint(), webhookConf.Name(), webhookConf.MutateFunc(), apiCl.DynamicCl, apiCl.Cl)
+			for _, webhookConf := range webhooks {
+				server.Register(webhookConf.Endpoint(), webhookConf.Name(), webhookConf.WebhookType(), webhookConf.WebhookFunc(), apiCl.DynamicCl, apiCl.Cl)
 			}
 
 			// Start the k8s admission webhook server

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -10,11 +10,11 @@ package start
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -471,7 +471,8 @@ func start(log log.Component,
 
 		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
 		// Ignore the error if it's related to the missing validatingwebhookconfigurations RBACs
-		if err != nil && !strings.HasPrefix(err.Error(), "couldn't sync informer admissionregistration.k8s.io/v1/validatingwebhookconfigurations") {
+		var syncInformerError *apiserver.SyncInformersError
+		if err != nil && !(errors.As(err, &syncInformerError) && syncInformerError.Name == apiserver.ValidatingWebhooksInformer) {
 			pkglog.Errorf("Could not start admission controller: %v", err)
 		} else {
 			if err != nil {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -468,7 +468,7 @@ func start(log log.Component,
 			StopCh:              stopCh,
 		}
 
-		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
+		mutatingWebhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
 		if err != nil {
 			pkglog.Errorf("Could not start admission controller: %v", err)
 		} else {
@@ -476,7 +476,7 @@ func start(log log.Component,
 			// Setup the k8s admission webhook server
 			server := admissioncmd.NewServer()
 
-			for _, webhookConf := range webhooks {
+			for _, webhookConf := range mutatingWebhooks {
 				server.Register(webhookConf.Endpoint(), webhookConf.Name(), webhookConf.MutateFunc(), apiCl.DynamicCl, apiCl.Cl)
 			}
 

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -470,7 +470,7 @@ func start(log log.Component,
 		}
 
 		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
-		// Ignore the error if it's related to the missing validatingwebhookconfigurations RBACs
+		// Ignore the error if it's related to the validatingwebhookconfigurations.
 		var syncInformerError *apiserver.SyncInformersError
 		if err != nil && !(errors.As(err, &syncInformerError) && syncInformerError.Name == apiserver.ValidatingWebhooksInformer) {
 			pkglog.Errorf("Could not start admission controller: %v", err)

--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -8,11 +8,26 @@
 // Package common defines constants and types used by the Admission Controller.
 package common
 
+// WebhookType is the type of the webhook.
+type WebhookType string
+
+// String returns the string representation of the WebhookType.
+func (t WebhookType) String() string {
+	return string(t)
+}
+
+const (
+	// ValidatingWebhook is type for Validating Webhooks.
+	ValidatingWebhook = "validating"
+	// MutatingWebhook is type for Mutating Webhooks.
+	MutatingWebhook = "mutating"
+)
+
 const (
 	// EnabledLabelKey pod label to disable/enable mutations at the pod level.
 	EnabledLabelKey = "admission.datadoghq.com/enabled"
 
-	// InjectionModeLabelKey pod label to chose the config injection at the pod level.
+	// InjectionModeLabelKey pod label to choose the config injection at the pod level.
 	InjectionModeLabelKey = "admission.datadoghq.com/config.mode"
 
 	// LibVersionAnnotKeyFormat is the format of the library version annotation

--- a/pkg/clusteragent/admission/common/global.go
+++ b/pkg/clusteragent/admission/common/global.go
@@ -10,9 +10,54 @@ package common
 import (
 	"strconv"
 	"time"
+
+	admiv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
 	// ClusterAgentStartTime records the Cluster Agent start time
 	ClusterAgentStartTime = strconv.FormatInt(time.Now().Unix(), 10)
 )
+
+// ValidationResponse returns the result of the validation
+func ValidationResponse(validation bool, err error) *admiv1.AdmissionResponse {
+	if err != nil {
+		log.Warnf("Failed to validate: %v", err)
+
+		return &admiv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+			Allowed: false,
+		}
+	}
+
+	return &admiv1.AdmissionResponse{
+		Allowed: validation,
+	}
+}
+
+// MutationResponse returns the result of the mutation
+func MutationResponse(jsonPatch []byte, err error) *admiv1.AdmissionResponse {
+	if err != nil {
+		log.Warnf("Failed to mutate: %v", err)
+
+		return &admiv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+			Allowed: true,
+		}
+	}
+
+	patchType := admiv1.PatchTypeJSONPatch
+
+	return &admiv1.AdmissionResponse{
+		Patch:     jsonPatch,
+		PatchType: &patchType,
+		Allowed:   true,
+	}
+}

--- a/pkg/clusteragent/admission/common/label_selectors.go
+++ b/pkg/clusteragent/admission/common/label_selectors.go
@@ -10,7 +10,6 @@ package common
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
@@ -25,7 +24,7 @@ func DefaultLabelSelectors(useNamespaceSelector bool) (namespaceSelector, object
 		labelSelector = metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      common.EnabledLabelKey,
+					Key:      EnabledLabelKey,
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"false"},
 				},
@@ -35,7 +34,7 @@ func DefaultLabelSelectors(useNamespaceSelector bool) (namespaceSelector, object
 		// Ignore all, accept pods if they're explicitly allowed
 		labelSelector = metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				common.EnabledLabelKey: "true",
+				EnabledLabelKey: "true",
 			},
 		}
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -54,8 +54,8 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 
 func (w *Config) getWebhookName() string        { return w.webhookName }
 func (w *Config) getSecretName() string         { return w.secretName }
-func (w *Config) getValidationEnabled() bool    { return w.validationEnabled }
-func (w *Config) getMutationEnabled() bool      { return w.mutationEnabled }
+func (w *Config) isValidationEnabled() bool     { return w.validationEnabled }
+func (w *Config) isMutationEnabled() bool       { return w.mutationEnabled }
 func (w *Config) getSecretNs() string           { return w.namespace }
 func (w *Config) useAdmissionV1() bool          { return w.admissionV1Enabled }
 func (w *Config) useNamespaceSelector() bool    { return w.namespaceSelectorEnabled }

--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 )
 
 // Config contains config parameters

--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"strings"
 
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // Config contains config parameters
@@ -22,6 +22,8 @@ import (
 type Config struct {
 	webhookName              string
 	secretName               string
+	validationEnabled        bool
+	mutationEnabled          bool
 	namespace                string
 	admissionV1Enabled       bool
 	namespaceSelectorEnabled bool
@@ -37,6 +39,8 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 	return Config{
 		webhookName:              pkgconfigsetup.Datadog().GetString("admission_controller.webhook_name"),
 		secretName:               pkgconfigsetup.Datadog().GetString("admission_controller.certificate.secret_name"),
+		validationEnabled:        pkgconfigsetup.Datadog().GetBool("admission_controller.validation.enabled"),
+		mutationEnabled:          pkgconfigsetup.Datadog().GetBool("admission_controller.mutation.enabled"),
 		namespace:                common.GetResourcesNamespace(),
 		admissionV1Enabled:       admissionV1Enabled,
 		namespaceSelectorEnabled: namespaceSelectorEnabled,
@@ -50,6 +54,8 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 
 func (w *Config) getWebhookName() string        { return w.webhookName }
 func (w *Config) getSecretName() string         { return w.secretName }
+func (w *Config) getValidationEnabled() bool    { return w.validationEnabled }
+func (w *Config) getMutationEnabled() bool      { return w.mutationEnabled }
 func (w *Config) getSecretNs() string           { return w.namespace }
 func (w *Config) useAdmissionV1() bool          { return w.admissionV1Enabled }
 func (w *Config) useNamespaceSelector() bool    { return w.namespaceSelectorEnabled }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -99,6 +99,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 
 	// Add Validating webhooks.
 	if c.config.getValidationEnabled() {
+		// Future validating webhooks can be added here.
 		validatingWebhooks = []Webhook{}
 		webhooks = append(webhooks, validatingWebhooks...)
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -98,14 +98,14 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	var mutatingWebhooks []Webhook
 
 	// Add Validating webhooks.
-	if c.config.getValidationEnabled() {
+	if c.config.isValidationEnabled() {
 		// Future validating webhooks can be added here.
 		validatingWebhooks = []Webhook{}
 		webhooks = append(webhooks, validatingWebhooks...)
 	}
 
 	// Add Mutating webhooks.
-	if c.config.getMutationEnabled() {
+	if c.config.isMutationEnabled() {
 		mutatingWebhooks = []Webhook{
 			configWebhook.NewWebhook(wmeta, injectionFilter),
 			tagsfromlabels.NewWebhook(wmeta, injectionFilter),

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	agentsidecar "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/agent_sidecar"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoscaling"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
+	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -37,7 +38,7 @@ import (
 // Controller is an interface implemented by ControllerV1 and ControllerV1beta1.
 type Controller interface {
 	Run(stopCh <-chan struct{})
-	EnabledMutatingWebhooks() []MutatingWebhook
+	EnabledWebhooks() []Webhook
 }
 
 // NewController returns the adequate implementation of the Controller interface.
@@ -52,16 +53,17 @@ func NewController(
 	pa workload.PodPatcher,
 ) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+		return NewControllerV1(client, secretInformer, admissionInterface.V1().ValidatingWebhookConfigurations(), admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 	}
-
-	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().ValidatingWebhookConfigurations(), admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 }
 
-// MutatingWebhook represents a mutating webhook
-type MutatingWebhook interface {
+// Webhook represents an admission webhook
+type Webhook interface {
 	// Name returns the name of the webhook
 	Name() string
+	// WebhookType Type returns the type of the webhook
+	WebhookType() common.WebhookType
 	// IsEnabled returns whether the webhook is enabled
 	IsEnabled() bool
 	// Endpoint returns the endpoint of the webhook
@@ -75,41 +77,56 @@ type MutatingWebhook interface {
 	// LabelSelectors returns the label selectors that specify when the webhook
 	// should be invoked
 	LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector)
-	// MutateFunc returns the function that mutates the resources
-	MutateFunc() admission.MutatingWebhookFunc
+	// WebhookFunc runs the logic of the webhook and returns the admission response
+	WebhookFunc() admission.WebhookFunc
 }
 
-// mutatingWebhooks returns the list of mutating webhooks. Notice that the order
-// of the webhooks returned is the order in which they will be executed. For
-// now, the only restriction is that the agent sidecar webhook needs to go after
-// the config one. The reason is that the volume mount for the APM socket added
-// by the config webhook doesn't always work on Fargate (one of the envs where
-// we use an agent sidecar), and the agent sidecar webhook needs to remove it.
-func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher) []MutatingWebhook {
+// generateWebhooks returns the list of webhooks. The order of the webhooks returned
+// is the order in which they will be executed. For now, the only restriction is that
+// the agent sidecar webhook needs to go after the configWebhook one.
+// The reason is that the volume mount for the APM socket added by the configWebhook webhook
+// doesn't always work on Fargate (one of the envs where we use an agent sidecar), and
+// the agent sidecar webhook needs to remove it.
+func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher) []Webhook {
 	// Note: the auto_instrumentation pod injection filter is used across
 	// multiple mutating webhooks, so we add it as a hard dependency to each
 	// of the components that use it via the injectionFilter parameter.
 	injectionFilter := autoinstrumentation.GetInjectionFilter()
 
-	webhooks := []MutatingWebhook{
-		config.NewWebhook(wmeta, injectionFilter),
-		tagsfromlabels.NewWebhook(wmeta, injectionFilter),
-		agentsidecar.NewWebhook(),
-		autoscaling.NewWebhook(pa),
+	var webhooks []Webhook
+	var validatingWebhooks []Webhook
+	var mutatingWebhooks []Webhook
+
+	// Add Validating webhooks.
+	if c.config.getValidationEnabled() {
+		validatingWebhooks = []Webhook{}
+		webhooks = append(webhooks, validatingWebhooks...)
 	}
 
-	apm, err := autoinstrumentation.NewWebhook(wmeta, injectionFilter)
-	if err == nil {
-		webhooks = append(webhooks, apm)
-	} else {
-		log.Errorf("failed to register APM Instrumentation webhook: %v", err)
-	}
+	// Add Mutating webhooks.
+	if c.config.getMutationEnabled() {
+		mutatingWebhooks = []Webhook{
+			configWebhook.NewWebhook(wmeta, injectionFilter),
+			tagsfromlabels.NewWebhook(wmeta, injectionFilter),
+			agentsidecar.NewWebhook(),
+			autoscaling.NewWebhook(pa),
+		}
+		webhooks = append(webhooks, mutatingWebhooks...)
 
-	cws, err := cwsinstrumentation.NewCWSInstrumentation(wmeta)
-	if err == nil {
-		webhooks = append(webhooks, cws.WebhookForPods(), cws.WebhookForCommands())
-	} else {
-		log.Errorf("failed to register CWS Instrumentation webhook: %v", err)
+		// APM Instrumentation webhook needs to be registered after the configWebhook webhook.
+		apm, err := autoinstrumentation.NewWebhook(wmeta, injectionFilter)
+		if err == nil {
+			webhooks = append(webhooks, apm)
+		} else {
+			log.Errorf("failed to register APM Instrumentation webhook: %v", err)
+		}
+
+		cws, err := cwsinstrumentation.NewCWSInstrumentation(wmeta)
+		if err == nil {
+			webhooks = append(webhooks, cws.WebhookForPods(), cws.WebhookForCommands())
+		} else {
+			log.Errorf("failed to register CWS Instrumentation webhook: %v", err)
+		}
 	}
 
 	return webhooks
@@ -119,22 +136,23 @@ func mutatingWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher) []Mu
 // It contains the shared fields and provides shared methods.
 // For the nolint:structcheck see https://github.com/golangci/golangci-lint/issues/537
 type controllerBase struct {
-	clientSet              kubernetes.Interface //nolint:structcheck
-	config                 Config
-	secretsLister          corelisters.SecretLister
-	secretsSynced          cache.InformerSynced //nolint:structcheck
-	mutatingWebhooksSynced cache.InformerSynced //nolint:structcheck
-	queue                  workqueue.RateLimitingInterface
-	isLeaderFunc           func() bool
-	isLeaderNotif          <-chan struct{}
-	mutatingWebhooks       []MutatingWebhook
+	clientSet                kubernetes.Interface //nolint:structcheck
+	config                   Config
+	secretsLister            corelisters.SecretLister
+	secretsSynced            cache.InformerSynced //nolint:structcheck
+	validatingWebhooksSynced cache.InformerSynced //nolint:structcheck
+	mutatingWebhooksSynced   cache.InformerSynced //nolint:structcheck
+	queue                    workqueue.RateLimitingInterface
+	isLeaderFunc             func() bool
+	isLeaderNotif            <-chan struct{}
+	webhooks                 []Webhook
 }
 
-// EnabledMutatingWebhooks returns the list of enabled mutating webhooks.
-func (c *controllerBase) EnabledMutatingWebhooks() []MutatingWebhook {
-	var res []MutatingWebhook
+// EnabledWebhooks returns the list of enabled webhooks.
+func (c *controllerBase) EnabledWebhooks() []Webhook {
+	var res []Webhook
 
-	for _, webhook := range c.mutatingWebhooks {
+	for _, webhook := range c.webhooks {
 		if webhook.IsEnabled() {
 			res = append(res, webhook)
 		}
@@ -257,7 +275,7 @@ func (c *controllerBase) processNextWorkItem(reconcile func() error) bool {
 
 	if err := reconcile(); err != nil {
 		c.requeue(key)
-		log.Infof("Couldn't reconcile Webhook %s: %v", c.config.getWebhookName(), err)
+		log.Errorf("Couldn't reconcile webhook %s: %v", c.config.getWebhookName(), err)
 		metrics.ReconcileErrors.Inc(metrics.WebhooksControllerName)
 		return true
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -45,7 +45,8 @@ type Controller interface {
 func NewController(
 	client kubernetes.Interface,
 	secretInformer coreinformers.SecretInformer,
-	admissionInterface admissionregistration.Interface,
+	validatingInformers admissionregistration.Interface,
+	mutatingInformers admissionregistration.Interface,
 	isLeaderFunc func() bool,
 	isLeaderNotif <-chan struct{},
 	config Config,
@@ -53,9 +54,9 @@ func NewController(
 	pa workload.PodPatcher,
 ) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, admissionInterface.V1().ValidatingWebhookConfigurations(), admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 	}
-	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().ValidatingWebhookConfigurations(), admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
 }
 
 // Webhook represents an admission webhook

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -31,6 +31,7 @@ func TestNewController(t *testing.T) {
 		client,
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration(),
+		factory.Admissionregistration(),
 		func() bool { return true },
 		make(chan struct{}),
 		v1Cfg,
@@ -44,6 +45,7 @@ func TestNewController(t *testing.T) {
 	controller = NewController(
 		client,
 		factory.Core().V1().Secrets(),
+		factory.Admissionregistration(),
 		factory.Admissionregistration(),
 		func() bool { return true },
 		make(chan struct{}),

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -195,14 +195,14 @@ func (c *ControllerV1) reconcile() error {
 				log.Infof("Mutating Webhook %s was not found, creating it", c.config.getWebhookName())
 				err := c.createMutatingWebhook(secret)
 				if err != nil {
-					_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+					log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 				}
 			}
 		} else {
 			log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
 			err := c.updateMutatingWebhook(secret, mutatingWebhook)
 			if err != nil {
-				_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+				log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}
@@ -214,14 +214,14 @@ func (c *ControllerV1) reconcile() error {
 				log.Infof("Validating Webhook %s was not found, creating it", c.config.getWebhookName())
 				err := c.createValidatingWebhook(secret)
 				if err != nil {
-					_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+					log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
 				}
 			}
 		} else {
 			log.Debugf("Validating Webhook %s was found, updating it", c.config.getWebhookName())
 			err := c.updateValidatingWebhook(secret, validatingWebhook)
 			if err != nil {
-				_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+				log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -35,15 +36,18 @@ import (
 // It uses the admissionregistration/v1 API.
 type ControllerV1 struct {
 	controllerBase
-	mutatingWebhooksLister   admissionlisters.MutatingWebhookConfigurationLister
-	mutatingWebhookTemplates []admiv1.MutatingWebhook
+	validatingWebhooksLister   admissionlisters.ValidatingWebhookConfigurationLister
+	validatingWebhookTemplates []admiv1.ValidatingWebhook
+	mutatingWebhooksLister     admissionlisters.MutatingWebhookConfigurationLister
+	mutatingWebhookTemplates   []admiv1.MutatingWebhook
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
 func NewControllerV1(
 	client kubernetes.Interface,
 	secretInformer coreinformers.SecretInformer,
-	MutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
+	validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer,
+	mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
 	isLeaderFunc func() bool,
 	isLeaderNotif <-chan struct{},
 	config Config,
@@ -55,12 +59,14 @@ func NewControllerV1(
 	controller.config = config
 	controller.secretsLister = secretInformer.Lister()
 	controller.secretsSynced = secretInformer.Informer().HasSynced
-	controller.mutatingWebhooksLister = MutatingWebhookInformer.Lister()
-	controller.mutatingWebhooksSynced = MutatingWebhookInformer.Informer().HasSynced
+	controller.validatingWebhooksLister = validatingWebhookInformer.Lister()
+	controller.validatingWebhooksSynced = validatingWebhookInformer.Informer().HasSynced
+	controller.mutatingWebhooksLister = mutatingWebhookInformer.Lister()
+	controller.mutatingWebhooksSynced = mutatingWebhookInformer.Informer().HasSynced
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -71,12 +77,20 @@ func NewControllerV1(
 		log.Errorf("cannot add event handler to secret informer: %v", err)
 	}
 
-	if _, err := MutatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := validatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleWebhook,
-		UpdateFunc: controller.handleMutatingWebhookUpdate,
+		UpdateFunc: controller.handleWebhookUpdate,
 		DeleteFunc: controller.handleWebhook,
 	}); err != nil {
-		log.Errorf("cannot add event handler to webhook informer: %v", err)
+		log.Errorf("cannot add event handler to validating webhook informer: %v", err)
+	}
+
+	if _, err := mutatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.handleWebhook,
+		UpdateFunc: controller.handleWebhookUpdate,
+		DeleteFunc: controller.handleWebhook,
+	}); err != nil {
+		log.Errorf("cannot add event handler to mutating webhook informer: %v", err)
 	}
 
 	return controller
@@ -90,7 +104,7 @@ func (c *ControllerV1) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting webhook controller for secret %s/%s and webhook %s - Using admissionregistration/v1", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 	defer log.Infof("Stopping webhook controller for secret %s/%s and webhook %s", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 
-	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.mutatingWebhooksSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.validatingWebhooksSynced, c.mutatingWebhooksSynced); !ok {
 		return
 	}
 
@@ -109,30 +123,42 @@ func (c *ControllerV1) run() {
 	}
 }
 
-// handleMutatingWebhookUpdate handles the new Webhook reported in update events.
+// handleWebhookUpdate handles the new Webhook reported in update events.
 // It can be a callback function for update events.
-func (c *ControllerV1) handleMutatingWebhookUpdate(oldObj, newObj interface{}) {
+func (c *ControllerV1) handleWebhookUpdate(oldObj, newObj interface{}) {
 	if !c.isLeaderFunc() {
 		return
 	}
 
-	newWebhook, ok := newObj.(*admiv1.MutatingWebhookConfiguration)
-	if !ok {
-		log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", newObj)
+	switch newObj.(type) {
+	case *admiv1.ValidatingWebhookConfiguration:
+		newWebhook, _ := newObj.(*admiv1.ValidatingWebhookConfiguration)
+		oldWebhook, ok := oldObj.(*admiv1.ValidatingWebhookConfiguration)
+		if !ok {
+			log.Debugf("Expected ValidatingWebhookConfiguration object, got: %v", oldObj)
+			return
+		}
+
+		if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
+			return
+		}
+		c.handleWebhook(newObj)
+	case *admiv1.MutatingWebhookConfiguration:
+		newWebhook, _ := newObj.(*admiv1.MutatingWebhookConfiguration)
+		oldWebhook, ok := oldObj.(*admiv1.MutatingWebhookConfiguration)
+		if !ok {
+			log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", oldObj)
+			return
+		}
+
+		if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
+			return
+		}
+		c.handleWebhook(newObj)
+	default:
+		log.Debugf("Expected ValidatingWebhookConfiguration or MutatingWebhookConfiguration object, got: %v", newObj)
 		return
 	}
-
-	oldWebhook, ok := oldObj.(*admiv1.MutatingWebhookConfiguration)
-	if !ok {
-		log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", oldObj)
-		return
-	}
-
-	if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
-		return
-	}
-
-	c.handleWebhook(newObj)
 }
 
 // reconcile creates/updates the webhook object on new events.
@@ -142,19 +168,78 @@ func (c *ControllerV1) reconcile() error {
 		return err
 	}
 
+	validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("Validating Webhook %s was not found, creating it", c.config.getWebhookName())
+			err := c.createValidatingWebhook(secret)
+			if err != nil {
+				_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
+	} else {
+		log.Debugf("Validating Webhook %s was found, updating it", c.config.getWebhookName())
+		err := c.updateValidatingWebhook(secret, validatingWebhook)
+		if err != nil {
+			_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+		}
+	}
+
 	mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Infof("Mutating Webhook %s was not found, creating it", c.config.getWebhookName())
-			return c.createMutatingWebhook(secret)
+			err := c.createMutatingWebhook(secret)
+			if err != nil {
+				_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
-
-		return err
+	} else {
+		log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
+		err := c.updateMutatingWebhook(secret, mutatingWebhook)
+		if err != nil {
+			_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+		}
 	}
 
-	log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
+	return err
+}
 
-	return c.updateMutatingWebhook(secret, mutatingWebhook)
+// createValidatingWebhook creates a new ValidatingWebhookConfiguration object.
+func (c *ControllerV1) createValidatingWebhook(secret *corev1.Secret) error {
+	webhook := &admiv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.config.getWebhookName(),
+		},
+		Webhooks: c.newValidatingWebhooks(secret),
+	}
+
+	_, err := c.clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), webhook, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		log.Infof("Validating Webhook %s already exists", webhook.GetName())
+		return nil
+	}
+
+	return err
+}
+
+// updateValidatingWebhook stores a new configuration in the ValidatingWebhookConfiguration object.
+func (c *ControllerV1) updateValidatingWebhook(secret *corev1.Secret, webhook *admiv1.ValidatingWebhookConfiguration) error {
+	webhook = webhook.DeepCopy()
+	webhook.Webhooks = c.newValidatingWebhooks(secret)
+	_, err := c.clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
+	return err
+}
+
+// newValidatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
+func (c *ControllerV1) newValidatingWebhooks(secret *corev1.Secret) []admiv1.ValidatingWebhook {
+	webhooks := []admiv1.ValidatingWebhook{}
+	for _, tpl := range c.validatingWebhookTemplates {
+		tpl.ClientConfig.CABundle = certificate.GetCABundle(secret.Data)
+		webhooks = append(webhooks, tpl)
+	}
+
+	return webhooks
 }
 
 // createMutatingWebhook creates a new MutatingWebhookConfiguration object.
@@ -183,7 +268,7 @@ func (c *ControllerV1) updateMutatingWebhook(secret *corev1.Secret, webhook *adm
 	return err
 }
 
-// newMutatingWebhooks generates MutatingWebhook objects from config templates with updated CABundle from Secret.
+// newMutatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
 func (c *ControllerV1) newMutatingWebhooks(secret *corev1.Secret) []admiv1.MutatingWebhook {
 	webhooks := []admiv1.MutatingWebhook{}
 	for _, tpl := range c.mutatingWebhookTemplates {
@@ -194,18 +279,38 @@ func (c *ControllerV1) newMutatingWebhooks(secret *corev1.Secret) []admiv1.Mutat
 	return webhooks
 }
 
+// generateTemplates generates the webhook templates from the configuration.
 func (c *ControllerV1) generateTemplates() {
-	webhooks := []admiv1.MutatingWebhook{}
-
-	for _, webhook := range c.mutatingWebhooks {
-		if !webhook.IsEnabled() {
+	// Generate validating webhook templates
+	validatingWebhooks := []admiv1.ValidatingWebhook{}
+	for _, webhook := range c.webhooks {
+		if !webhook.IsEnabled() || webhook.WebhookType() != common.ValidatingWebhook {
 			continue
 		}
-
 		nsSelector, objSelector := webhook.LabelSelectors(c.config.useNamespaceSelector())
+		validatingWebhooks = append(
+			validatingWebhooks,
+			c.getValidatingWebhookSkeleton(
+				webhook.Name(),
+				webhook.Endpoint(),
+				webhook.Operations(),
+				webhook.Resources(),
+				nsSelector,
+				objSelector,
+			),
+		)
+	}
+	c.validatingWebhookTemplates = validatingWebhooks
 
-		webhooks = append(
-			webhooks,
+	// Generate mutating webhook templates
+	mutatingWebhooks := []admiv1.MutatingWebhook{}
+	for _, webhook := range c.webhooks {
+		if !webhook.IsEnabled() || webhook.WebhookType() != common.MutatingWebhook {
+			continue
+		}
+		nsSelector, objSelector := webhook.LabelSelectors(c.config.useNamespaceSelector())
+		mutatingWebhooks = append(
+			mutatingWebhooks,
 			c.getMutatingWebhookSkeleton(
 				webhook.Name(),
 				webhook.Endpoint(),
@@ -216,8 +321,46 @@ func (c *ControllerV1) generateTemplates() {
 			),
 		)
 	}
+	c.mutatingWebhookTemplates = mutatingWebhooks
+}
 
-	c.mutatingWebhookTemplates = webhooks
+func (c *ControllerV1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1.ValidatingWebhook {
+	matchPolicy := admiv1.Exact
+	sideEffects := admiv1.SideEffectClassNone
+	port := c.config.getServicePort()
+	timeout := c.config.getTimeout()
+	failurePolicy := c.getFailurePolicy()
+
+	webhook := admiv1.ValidatingWebhook{
+		Name: c.config.configName(nameSuffix),
+		ClientConfig: admiv1.WebhookClientConfig{
+			Service: &admiv1.ServiceReference{
+				Namespace: c.config.getServiceNs(),
+				Name:      c.config.getServiceName(),
+				Port:      &port,
+				Path:      &path,
+			},
+		},
+		Rules: []admiv1.RuleWithOperations{
+			{
+				Operations: operations,
+				Rule: admiv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   resources,
+				},
+			},
+		},
+		FailurePolicy:           &failurePolicy,
+		MatchPolicy:             &matchPolicy,
+		SideEffects:             &sideEffects,
+		TimeoutSeconds:          &timeout,
+		AdmissionReviewVersions: []string{"v1", "v1beta1"},
+		NamespaceSelector:       namespaceSelector,
+		ObjectSelector:          objectSelector,
+	}
+
+	return webhook
 }
 
 func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1.MutatingWebhook {
@@ -225,8 +368,9 @@ func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, opera
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
-	failurePolicy := c.getAdmiV1FailurePolicy()
+	failurePolicy := c.getFailurePolicy()
 	reinvocationPolicy := c.getReinvocationPolicy()
+
 	webhook := admiv1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1.WebhookClientConfig{
@@ -260,7 +404,7 @@ func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, opera
 	return webhook
 }
 
-func (c *ControllerV1) getAdmiV1FailurePolicy() admiv1.FailurePolicyType {
+func (c *ControllerV1) getFailurePolicy() admiv1.FailurePolicyType {
 	policy := strings.ToLower(c.config.getFailurePolicy())
 	switch policy {
 	case "ignore":

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -436,7 +436,7 @@ func (c *ControllerV1) getFailurePolicy() admiv1.FailurePolicyType {
 	case "fail":
 		return admiv1.Fail
 	default:
-		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
+		log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1.Ignore
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -37,6 +37,7 @@ import (
 // It uses the admissionregistration/v1 API.
 type ControllerV1 struct {
 	controllerBase
+	validatingWebhooksInformer cache.SharedIndexInformer
 	validatingWebhooksLister   admissionlisters.ValidatingWebhookConfigurationLister
 	validatingWebhookTemplates []admiv1.ValidatingWebhook
 	mutatingWebhooksLister     admissionlisters.MutatingWebhookConfigurationLister
@@ -60,6 +61,7 @@ func NewControllerV1(
 	controller.config = config
 	controller.secretsLister = secretInformer.Lister()
 	controller.secretsSynced = secretInformer.Informer().HasSynced
+	controller.validatingWebhooksInformer = validatingWebhookInformer.Informer()
 	controller.validatingWebhooksLister = validatingWebhookInformer.Lister()
 	controller.validatingWebhooksSynced = validatingWebhookInformer.Informer().HasSynced
 	controller.mutatingWebhooksLister = mutatingWebhookInformer.Lister()
@@ -76,15 +78,6 @@ func NewControllerV1(
 		DeleteFunc: controller.handleSecret,
 	}); err != nil {
 		log.Errorf("cannot add event handler to secret informer: %v", err)
-	}
-
-	// Check if ValidatingWebhookConfiguration RBACs are enabled.
-	err := apiserver.SyncInformers(map[apiserver.InformerName]cache.SharedInformer{
-		apiserver.ValidatingWebhooksInformer: validatingWebhookInformer.Informer(),
-	}, 0)
-	if err != nil {
-		log.Warnf("Disabling validation webhook controller: %v", err)
-		controller.config.validationEnabled = false
 	}
 
 	if _, err := validatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -113,6 +106,13 @@ func (c *ControllerV1) Run(stopCh <-chan struct{}) {
 
 	log.Infof("Starting webhook controller for secret %s/%s and webhook %s - Using admissionregistration/v1", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 	defer log.Infof("Stopping webhook controller for secret %s/%s and webhook %s", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
+
+	// Check if ValidatingWebhookConfiguration RBACs are enabled.
+	err := apiserver.SyncInformers(map[apiserver.InformerName]cache.SharedInformer{apiserver.ValidatingWebhooksInformer: c.validatingWebhooksInformer}, 0)
+	if err != nil {
+		log.Warnf("Validating Webhook Informer not synced: disabling validation webhook controller")
+		c.config.validationEnabled = false
+	}
 
 	syncedInformer := []cache.InformerSynced{
 		c.secretsSynced,

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -35,15 +35,15 @@ import (
 // It uses the admissionregistration/v1 API.
 type ControllerV1 struct {
 	controllerBase
-	webhooksLister   admissionlisters.MutatingWebhookConfigurationLister
-	webhookTemplates []admiv1.MutatingWebhook
+	mutatingWebhooksLister   admissionlisters.MutatingWebhookConfigurationLister
+	mutatingWebhookTemplates []admiv1.MutatingWebhook
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
 func NewControllerV1(
 	client kubernetes.Interface,
 	secretInformer coreinformers.SecretInformer,
-	webhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
+	MutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
 	isLeaderFunc func() bool,
 	isLeaderNotif <-chan struct{},
 	config Config,
@@ -55,8 +55,8 @@ func NewControllerV1(
 	controller.config = config
 	controller.secretsLister = secretInformer.Lister()
 	controller.secretsSynced = secretInformer.Informer().HasSynced
-	controller.webhooksLister = webhookInformer.Lister()
-	controller.webhooksSynced = webhookInformer.Informer().HasSynced
+	controller.mutatingWebhooksLister = MutatingWebhookInformer.Lister()
+	controller.mutatingWebhooksSynced = MutatingWebhookInformer.Informer().HasSynced
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
@@ -71,9 +71,9 @@ func NewControllerV1(
 		log.Errorf("cannot add event handler to secret informer: %v", err)
 	}
 
-	if _, err := webhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := MutatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleWebhook,
-		UpdateFunc: controller.handleWebhookUpdate,
+		UpdateFunc: controller.handleMutatingWebhookUpdate,
 		DeleteFunc: controller.handleWebhook,
 	}); err != nil {
 		log.Errorf("cannot add event handler to webhook informer: %v", err)
@@ -90,7 +90,7 @@ func (c *ControllerV1) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting webhook controller for secret %s/%s and webhook %s - Using admissionregistration/v1", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 	defer log.Infof("Stopping webhook controller for secret %s/%s and webhook %s", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 
-	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.webhooksSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.mutatingWebhooksSynced); !ok {
 		return
 	}
 
@@ -109,9 +109,9 @@ func (c *ControllerV1) run() {
 	}
 }
 
-// handleWebhookUpdate handles the new Webhook reported in update events.
+// handleMutatingWebhookUpdate handles the new Webhook reported in update events.
 // It can be a callback function for update events.
-func (c *ControllerV1) handleWebhookUpdate(oldObj, newObj interface{}) {
+func (c *ControllerV1) handleMutatingWebhookUpdate(oldObj, newObj interface{}) {
 	if !c.isLeaderFunc() {
 		return
 	}
@@ -142,51 +142,51 @@ func (c *ControllerV1) reconcile() error {
 		return err
 	}
 
-	webhook, err := c.webhooksLister.Get(c.config.getWebhookName())
+	mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
-			return c.createWebhook(secret)
+			log.Infof("Mutating Webhook %s was not found, creating it", c.config.getWebhookName())
+			return c.createMutatingWebhook(secret)
 		}
 
 		return err
 	}
 
-	log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+	log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
 
-	return c.updateWebhook(secret, webhook)
+	return c.updateMutatingWebhook(secret, mutatingWebhook)
 }
 
-// createWebhook creates a new MutatingWebhookConfiguration object.
-func (c *ControllerV1) createWebhook(secret *corev1.Secret) error {
+// createMutatingWebhook creates a new MutatingWebhookConfiguration object.
+func (c *ControllerV1) createMutatingWebhook(secret *corev1.Secret) error {
 	webhook := &admiv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.config.getWebhookName(),
 		},
-		Webhooks: c.newWebhooks(secret),
+		Webhooks: c.newMutatingWebhooks(secret),
 	}
 
 	_, err := c.clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), webhook, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
-		log.Infof("Webhook %s already exists", webhook.GetName())
+		log.Infof("Mutating Webhook %s already exists", webhook.GetName())
 		return nil
 	}
 
 	return err
 }
 
-// updateWebhook stores a new configuration in the MutatingWebhookConfiguration object.
-func (c *ControllerV1) updateWebhook(secret *corev1.Secret, webhook *admiv1.MutatingWebhookConfiguration) error {
+// updateMutatingWebhook stores a new configuration in the MutatingWebhookConfiguration object.
+func (c *ControllerV1) updateMutatingWebhook(secret *corev1.Secret, webhook *admiv1.MutatingWebhookConfiguration) error {
 	webhook = webhook.DeepCopy()
-	webhook.Webhooks = c.newWebhooks(secret)
+	webhook.Webhooks = c.newMutatingWebhooks(secret)
 	_, err := c.clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
 	return err
 }
 
-// newWebhooks generates MutatingWebhook objects from config templates with updated CABundle from Secret.
-func (c *ControllerV1) newWebhooks(secret *corev1.Secret) []admiv1.MutatingWebhook {
+// newMutatingWebhooks generates MutatingWebhook objects from config templates with updated CABundle from Secret.
+func (c *ControllerV1) newMutatingWebhooks(secret *corev1.Secret) []admiv1.MutatingWebhook {
 	webhooks := []admiv1.MutatingWebhook{}
-	for _, tpl := range c.webhookTemplates {
+	for _, tpl := range c.mutatingWebhookTemplates {
 		tpl.ClientConfig.CABundle = certificate.GetCABundle(secret.Data)
 		webhooks = append(webhooks, tpl)
 	}
@@ -206,7 +206,7 @@ func (c *ControllerV1) generateTemplates() {
 
 		webhooks = append(
 			webhooks,
-			c.getWebhookSkeleton(
+			c.getMutatingWebhookSkeleton(
 				webhook.Name(),
 				webhook.Endpoint(),
 				webhook.Operations(),
@@ -217,10 +217,10 @@ func (c *ControllerV1) generateTemplates() {
 		)
 	}
 
-	c.webhookTemplates = webhooks
+	c.mutatingWebhookTemplates = webhooks
 }
 
-func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1.MutatingWebhook {
+func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1.MutatingWebhook {
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -188,37 +188,41 @@ func (c *ControllerV1) reconcile() error {
 		return err
 	}
 
-	validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Infof("Validating Webhook %s was not found, creating it", c.config.getWebhookName())
-			err := c.createValidatingWebhook(secret)
-			if err != nil {
-				_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
-			}
-		}
-	} else {
-		log.Debugf("Validating Webhook %s was found, updating it", c.config.getWebhookName())
-		err := c.updateValidatingWebhook(secret, validatingWebhook)
+	if c.config.mutationEnabled {
+		mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
 		if err != nil {
-			_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			if errors.IsNotFound(err) {
+				log.Infof("Mutating Webhook %s was not found, creating it", c.config.getWebhookName())
+				err := c.createMutatingWebhook(secret)
+				if err != nil {
+					_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+				}
+			}
+		} else {
+			log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
+			err := c.updateMutatingWebhook(secret, mutatingWebhook)
+			if err != nil {
+				_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
 	}
 
-	mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Infof("Mutating Webhook %s was not found, creating it", c.config.getWebhookName())
-			err := c.createMutatingWebhook(secret)
-			if err != nil {
-				_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
-			}
-		}
-	} else {
-		log.Debugf("Mutating Webhook %s was found, updating it", c.config.getWebhookName())
-		err := c.updateMutatingWebhook(secret, mutatingWebhook)
+	if c.config.validationEnabled {
+		validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
 		if err != nil {
-			_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			if errors.IsNotFound(err) {
+				log.Infof("Validating Webhook %s was not found, creating it", c.config.getWebhookName())
+				err := c.createValidatingWebhook(secret)
+				if err != nil {
+					_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+				}
+			}
+		} else {
+			log.Debugf("Validating Webhook %s was found, updating it", c.config.getWebhookName())
+			err := c.updateValidatingWebhook(secret, validatingWebhook)
+			if err != nil {
+				_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
 	}
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -77,6 +77,8 @@ func TestCreateWebhookV1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
+	c.config.validationEnabled = true
+	c.config.mutationEnabled = true
 
 	var validatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
@@ -146,6 +148,8 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
+	c.config.validationEnabled = true
+	c.config.mutationEnabled = true
 
 	var newValidatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -961,7 +961,7 @@ func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 	sideEffects := admiv1.SideEffectClassNone
 	port := int32(443)
 	path := "/bar"
-	defaultTimeout := config.Datadog().GetInt32("admission_controller.timeout_seconds")
+	defaultTimeout := pkgconfigsetup.Datadog().GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
 	namespaceSelector, _ := common.DefaultLabelSelectors(true)
 	_, objectSelector := common.DefaultLabelSelectors(false)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -29,7 +29,7 @@ import (
 	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -78,13 +78,19 @@ func TestCreateWebhookV1(t *testing.T) {
 	defer close(stopCh)
 	c := f.run(stopCh)
 
-	var webhook *admiv1.MutatingWebhookConfiguration
+	var validatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		webhook, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
+		validatingWebhookConfiguration, err = c.validatingWebhooksLister.Get(v1Cfg.getWebhookName())
 		return err == nil
 	}, waitFor, tick)
 
-	if err := validateV1(webhook, secret); err != nil {
+	var mutatingWebhookConfiguration *admiv1.MutatingWebhookConfiguration
+	require.Eventually(t, func() bool {
+		mutatingWebhookConfiguration, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
+		return err == nil
+	}, waitFor, tick)
+
+	if err := validateV1(validatingWebhookConfiguration, mutatingWebhookConfiguration, secret); err != nil {
 		t.Fatalf("Invalid Webhook: %v", err)
 	}
 
@@ -107,7 +113,22 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 	secret := buildSecret(data, v1Cfg)
 	f.populateSecretsCache(secret)
 
-	webhook := &admiv1.MutatingWebhookConfiguration{
+	oldValidatingWebhookConfiguration := &admiv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v1Cfg.getWebhookName(),
+		},
+		Webhooks: []admiv1.ValidatingWebhook{
+			{
+				Name: "webhook-foo",
+			},
+			{
+				Name: "webhook-bar",
+			},
+		},
+	}
+	f.populateValidatingWebhooksCache(oldValidatingWebhookConfiguration)
+
+	oldMutatingWebhookConfiguration := &admiv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: v1Cfg.getWebhookName(),
 		},
@@ -120,20 +141,25 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 			},
 		},
 	}
-
-	f.populateWebhooksCache(webhook)
+	f.populateMutatingWebhooksCache(oldMutatingWebhookConfiguration)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
 
-	var newWebhook *admiv1.MutatingWebhookConfiguration
+	var newValidatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		newWebhook, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
-		return err == nil && !reflect.DeepEqual(webhook, newWebhook)
+		newValidatingWebhookConfiguration, err = c.validatingWebhooksLister.Get(v1Cfg.getWebhookName())
+		return err == nil && !reflect.DeepEqual(oldValidatingWebhookConfiguration, newValidatingWebhookConfiguration)
 	}, waitFor, tick)
 
-	if err := validateV1(newWebhook, secret); err != nil {
+	var newMutatingWebhookConfiguration *admiv1.MutatingWebhookConfiguration
+	require.Eventually(t, func() bool {
+		newMutatingWebhookConfiguration, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
+		return err == nil && !reflect.DeepEqual(oldMutatingWebhookConfiguration, newMutatingWebhookConfiguration)
+	}, waitFor, tick)
+
+	if err := validateV1(newValidatingWebhookConfiguration, newMutatingWebhookConfiguration, secret); err != nil {
 		t.Fatalf("Invalid Webhook: %v", err)
 	}
 
@@ -142,90 +168,44 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 	}, waitFor, tick, "Work queue isn't empty")
 }
 
-func TestAdmissionControllerFailureModeIgnore(t *testing.T) {
-	mockConfig := configmock.New(t)
-	f := newFixtureV1(t)
-	c, _ := f.createController()
-	c.config = NewConfig(true, false)
-
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "Ignore")
-	c.config = NewConfig(true, false)
-
-	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "ignore")
-	c.config = NewConfig(true, false)
-
-	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "BadVal")
-	c.config = NewConfig(true, false)
-
-	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "")
-	c.config = NewConfig(true, false)
-
-	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Ignore, *webhookSkeleton.FailurePolicy)
-}
-
-func TestAdmissionControllerFailureModeFail(t *testing.T) {
+func TestAdmissionControllerFailureModeV1(t *testing.T) {
 	mockConfig := configmock.New(t)
 	f := newFixtureV1(t)
 	c, _ := f.createController()
 
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "Fail")
-	c.config = NewConfig(true, false)
+	for _, value := range []string{"Ignore", "ignore", "BadVal", ""} {
+		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
+		c.config = NewConfig(true, false)
 
-	webhookSkeleton := c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Fail, *webhookSkeleton.FailurePolicy)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
+		assert.Equal(t, admiv1.Ignore, *validatingWebhookSkeleton.FailurePolicy)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
+		assert.Equal(t, admiv1.Ignore, *mutatingWebhookSkeleton.FailurePolicy)
+	}
 
-	mockConfig.SetWithoutSource("admission_controller.failure_policy", "fail")
-	c.config = NewConfig(true, false)
+	for _, value := range []string{"Fail", "fail"} {
+		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
+		c.config = NewConfig(true, false)
 
-	webhookSkeleton = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.Fail, *webhookSkeleton.FailurePolicy)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
+		assert.Equal(t, admiv1.Fail, *validatingWebhookSkeleton.FailurePolicy)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
+		assert.Equal(t, admiv1.Fail, *mutatingWebhookSkeleton.FailurePolicy)
+	}
 }
 
 func TestAdmissionControllerReinvocationPolicyV1(t *testing.T) {
 	mockConfig := configmock.New(t)
 	f := newFixtureV1(t)
 	c, _ := f.createController()
-	c.config = NewConfig(true, false)
 
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "IfNeeded")
-	c.config = NewConfig(true, false)
-	webhook := c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *webhook.ReinvocationPolicy)
+	for _, value := range []string{"IfNeeded", "ifneeded", "Never", "never", "wrong", ""} {
+		mockConfig.SetWithoutSource("admission_controller.reinvocationpolicy", value)
+		c.config = NewConfig(true, false)
 
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "ifneeded")
-	c.config = NewConfig(true, false)
-	webhook = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *webhook.ReinvocationPolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "Never")
-	c.config = NewConfig(true, false)
-	webhook = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "never")
-	c.config = NewConfig(true, false)
-	webhook = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "wrong")
-	c.config = NewConfig(true, false)
-	webhook = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *webhook.ReinvocationPolicy)
-
-	mockConfig.SetWithoutSource("admission_controller.reinvocation_policy", "")
-	c.config = NewConfig(true, false)
-	webhook = c.getWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
-	assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *webhook.ReinvocationPolicy)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nil, nil)
+		assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *mutatingWebhookSkeleton.ReinvocationPolicy)
+	}
 }
 
 func TestGenerateTemplatesV1(t *testing.T) {
@@ -962,7 +942,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()
-			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
+			c.webhooks = c.generateWebhooks(wmeta, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -970,7 +950,110 @@ func TestGenerateTemplatesV1(t *testing.T) {
 	}
 }
 
-func TestGetWebhookSkeletonV1(t *testing.T) {
+func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
+	mockConfig := configmock.New(t)
+	failurePolicy := admiv1.Ignore
+	matchPolicy := admiv1.Exact
+	sideEffects := admiv1.SideEffectClassNone
+	port := int32(443)
+	path := "/bar"
+	defaultTimeout := config.Datadog().GetInt32("admission_controller.timeout_seconds")
+	customTimeout := int32(2)
+	namespaceSelector, _ := common.DefaultLabelSelectors(true)
+	_, objectSelector := common.DefaultLabelSelectors(false)
+	webhook := func(to *int32, objSelector, nsSelector *metav1.LabelSelector) admiv1.ValidatingWebhook {
+		return admiv1.ValidatingWebhook{
+			Name: "datadog.webhook.foo",
+			ClientConfig: admiv1.WebhookClientConfig{
+				Service: &admiv1.ServiceReference{
+					Namespace: "nsfoo",
+					Name:      "datadog-admission-controller",
+					Port:      &port,
+					Path:      &path,
+				},
+			},
+			Rules: []admiv1.RuleWithOperations{
+				{
+					Operations: []admiv1.OperationType{
+						admiv1.Create,
+					},
+					Rule: admiv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				},
+			},
+			FailurePolicy:           &failurePolicy,
+			MatchPolicy:             &matchPolicy,
+			SideEffects:             &sideEffects,
+			TimeoutSeconds:          to,
+			AdmissionReviewVersions: []string{"v1", "v1beta1"},
+			ObjectSelector:          objSelector,
+			NamespaceSelector:       nsSelector,
+		}
+	}
+	type args struct {
+		nameSuffix string
+		path       string
+	}
+	tests := []struct {
+		name              string
+		args              args
+		timeout           *int32
+		namespaceSelector bool
+		want              admiv1.ValidatingWebhook
+	}{
+		{
+			name: "nominal case",
+			args: args{
+				nameSuffix: "foo",
+				path:       "/bar",
+			},
+			namespaceSelector: false,
+			want:              webhook(&defaultTimeout, objectSelector, nil),
+		},
+		{
+			name: "namespace selector",
+			args: args{
+				nameSuffix: "foo",
+				path:       "/bar",
+			},
+			namespaceSelector: true,
+			want:              webhook(&defaultTimeout, nil, namespaceSelector),
+		},
+		{
+			name: "custom timeout",
+			args: args{
+				nameSuffix: "foo",
+				path:       "/bar",
+			},
+			timeout:           &customTimeout,
+			namespaceSelector: false,
+			want:              webhook(&customTimeout, objectSelector, nil),
+		},
+	}
+
+	mockConfig.SetWithoutSource("kube_resources_namespace", "nsfoo")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.timeout != nil {
+				mockConfig.SetWithoutSource("admission_controller.timeout_seconds", *tt.timeout)
+				defer mockConfig.SetDefault("admission_controller.timeout_seconds", defaultTimeout)
+			}
+
+			c := &ControllerV1{}
+			c.config = NewConfig(false, tt.namespaceSelector)
+
+			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
+
+			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nsSelector, objSelector))
+		})
+	}
+}
+
+func TestGetMutatingWebhookSkeletonV1(t *testing.T) {
 	mockConfig := configmock.New(t)
 	defaultReinvocationPolicy := admiv1.IfNeededReinvocationPolicy
 	failurePolicy := admiv1.Ignore
@@ -1070,7 +1153,7 @@ func TestGetWebhookSkeletonV1(t *testing.T) {
 
 			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
 
-			assert.EqualValues(t, tt.want, c.getWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nsSelector, objSelector))
+			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, nsSelector, objSelector))
 		})
 	}
 }
@@ -1092,6 +1175,7 @@ func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerF
 	return NewControllerV1(
 		f.client,
 		factory.Core().V1().Secrets(),
+		factory.Admissionregistration().V1().ValidatingWebhookConfigurations(),
 		factory.Admissionregistration().V1().MutatingWebhookConfigurations(),
 		func() bool { return true },
 		make(chan struct{}),
@@ -1110,22 +1194,37 @@ func (f *fixtureV1) run(stopCh chan struct{}) *ControllerV1 {
 	return c
 }
 
-func (f *fixtureV1) populateWebhooksCache(webhooks ...*admiv1.MutatingWebhookConfiguration) {
+func (f *fixtureV1) populateValidatingWebhooksCache(webhooks ...*admiv1.ValidatingWebhookConfiguration) {
+	for _, w := range webhooks {
+		_, _ = f.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), w, metav1.CreateOptions{})
+	}
+}
+
+func (f *fixtureV1) populateMutatingWebhooksCache(webhooks ...*admiv1.MutatingWebhookConfiguration) {
 	for _, w := range webhooks {
 		_, _ = f.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), w, metav1.CreateOptions{})
 	}
 }
 
-func validateV1(w *admiv1.MutatingWebhookConfiguration, s *corev1.Secret) error {
-	if len(w.Webhooks) != 3 {
-		return fmt.Errorf("Webhooks should contain 3 entries, got %d", len(w.Webhooks))
+func validateV1(validatingWebhooks *admiv1.ValidatingWebhookConfiguration, mutatingWebhooks *admiv1.MutatingWebhookConfiguration, s *corev1.Secret) error {
+	// Validate the number of webhooks.
+	if len(validatingWebhooks.Webhooks) != 0 {
+		return fmt.Errorf("validatingWebhooks should contain 1 entries, got %d", len(validatingWebhooks.Webhooks))
+	}
+	if len(mutatingWebhooks.Webhooks) != 3 {
+		return fmt.Errorf("mutatingWebhooks should contain 3 entries, got %d", len(validatingWebhooks.Webhooks))
 	}
 
-	for i := 0; i < len(w.Webhooks); i++ {
-		if !reflect.DeepEqual(w.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data)) {
-			return fmt.Errorf("The Webhook CABundle doesn't match the Secret: CABundle: %v, Secret: %v", w.Webhooks[i].ClientConfig.CABundle, s)
+	// Validate the CA bundle for webhooks.
+	for i := 0; i < len(validatingWebhooks.Webhooks); i++ {
+		if !reflect.DeepEqual(validatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data)) {
+			return fmt.Errorf("the webhook CA bundle doesn't match the secret. CA bundle: %v, Secret: %v", validatingWebhooks.Webhooks[i].ClientConfig.CABundle, s)
 		}
 	}
-
+	for i := 0; i < len(mutatingWebhooks.Webhooks); i++ {
+		if !reflect.DeepEqual(mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data)) {
+			return fmt.Errorf("the webhook CA bundle doesn't match the secret. CA bundle: %v, Secret: %v", mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, s)
+		}
+	}
 	return nil
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -52,7 +52,7 @@ func TestSecretNotFoundV1(t *testing.T) {
 	defer close(stopCh)
 	c := f.run(stopCh)
 
-	_, err := c.webhooksLister.Get(v1Cfg.getWebhookName())
+	_, err := c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
 	if !errors.IsNotFound(err) {
 		t.Fatal("Webhook shouldn't be created")
 	}
@@ -80,7 +80,7 @@ func TestCreateWebhookV1(t *testing.T) {
 
 	var webhook *admiv1.MutatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		webhook, err = c.webhooksLister.Get(v1Cfg.getWebhookName())
+		webhook, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
 		return err == nil
 	}, waitFor, tick)
 
@@ -129,7 +129,7 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 
 	var newWebhook *admiv1.MutatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		newWebhook, err = c.webhooksLister.Get(v1Cfg.getWebhookName())
+		newWebhook, err = c.mutatingWebhooksLister.Get(v1Cfg.getWebhookName())
 		return err == nil && !reflect.DeepEqual(webhook, newWebhook)
 	}, waitFor, tick)
 
@@ -965,7 +965,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
 			c.generateTemplates()
 
-			assert.EqualValues(t, tt.want(), c.webhookTemplates)
+			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
 		})
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -1218,9 +1218,7 @@ func validateV1(t *testing.T, validatingWebhooks *admiv1.ValidatingWebhookConfig
 		require.Equal(t, validatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data))
 	}
 	for i := 0; i < len(mutatingWebhooks.Webhooks); i++ {
-		if !reflect.DeepEqual(mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data)) {
-			return fmt.Errorf("the webhook CA bundle doesn't match the secret. CA bundle: %v, Secret: %v", mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, s)
-		}
+		require.Equal(t, mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data))
 	}
 	return nil
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -9,7 +9,6 @@ package webhook
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"runtime"
 	"testing"
@@ -1208,9 +1207,7 @@ func (f *fixtureV1) populateMutatingWebhooksCache(webhooks ...*admiv1.MutatingWe
 
 func validateV1(t *testing.T, validatingWebhooks *admiv1.ValidatingWebhookConfiguration, mutatingWebhooks *admiv1.MutatingWebhookConfiguration, s *corev1.Secret) {
 	// Validate the number of webhooks.
-	if len(validatingWebhooks.Webhooks) != 0 {
-		return fmt.Errorf("validatingWebhooks should contain 1 entries, got %d", len(validatingWebhooks.Webhooks))
-	}
+	require.Len(t, validatingWebhooks.Webhooks, 0)
 	require.Len(t, mutatingWebhooks.Webhooks, 3)
 
 	// Validate the CA bundle for webhooks.
@@ -1220,5 +1217,4 @@ func validateV1(t *testing.T, validatingWebhooks *admiv1.ValidatingWebhookConfig
 	for i := 0; i < len(mutatingWebhooks.Webhooks); i++ {
 		require.Equal(t, mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data))
 	}
-	return nil
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -195,14 +195,14 @@ func (c *ControllerV1beta1) reconcile() error {
 				log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
 				err = c.createMutatingWebhook(secret)
 				if err != nil {
-					_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+					log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 				}
 			}
 		} else {
 			log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
 			err = c.updateMutatingWebhook(secret, mutatingWebhook)
 			if err != nil {
-				_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+				log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}
@@ -214,14 +214,14 @@ func (c *ControllerV1beta1) reconcile() error {
 				log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
 				err = c.createValidatingWebhook(secret)
 				if err != nil {
-					_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+					log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
 				}
 			}
 		} else {
 			log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
 			err = c.updateValidatingWebhook(secret, validatingWebhook)
 			if err != nil {
-				_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+				log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -438,7 +438,7 @@ func (c *ControllerV1beta1) getFailurePolicy() admiv1beta1.FailurePolicyType {
 	case "fail":
 		return admiv1beta1.Fail
 	default:
-		_ = log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
+		log.Warnf("Unknown failure policy %s - defaulting to 'Ignore'", policy)
 		return admiv1beta1.Ignore
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -27,6 +27,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -77,6 +78,15 @@ func NewControllerV1beta1(
 		log.Errorf("cannot add event handler to secret informer: %v", err)
 	}
 
+	// Check if ValidatingWebhookConfiguration RBACs are enabled.
+	err := apiserver.SyncInformers(map[apiserver.InformerName]cache.SharedInformer{
+		apiserver.ValidatingWebhooksInformer: validatingWebhookInformer.Informer(),
+	}, 0)
+	if err != nil {
+		log.Warnf("Disabling validation webhook controller: %v", err)
+		controller.config.validationEnabled = false
+	}
+
 	if _, err := validatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleWebhook,
 		UpdateFunc: controller.handleWebhookUpdate,
@@ -104,7 +114,17 @@ func (c *ControllerV1beta1) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting webhook controller for secret %s/%s and webhook %s - Using admissionregistration/v1beta1", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 	defer log.Infof("Stopping webhook controller for secret %s/%s and webhook %s", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 
-	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.validatingWebhooksSynced, c.mutatingWebhooksSynced); !ok {
+	syncedInformer := []cache.InformerSynced{
+		c.secretsSynced,
+	}
+	if c.config.validationEnabled {
+		syncedInformer = append(syncedInformer, c.validatingWebhooksSynced)
+	}
+	if c.config.mutationEnabled {
+		syncedInformer = append(syncedInformer, c.mutatingWebhooksSynced)
+	}
+
+	if ok := cache.WaitForCacheSync(stopCh, syncedInformer...); !ok {
 		return
 	}
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -35,23 +36,37 @@ import (
 // It uses the admissionregistration/v1beta1 API.
 type ControllerV1beta1 struct {
 	controllerBase
-	mutatingWebhooksLister   admissionlisters.MutatingWebhookConfigurationLister
-	mutatingWebhookTemplates []admiv1beta1.MutatingWebhook
+	validatingWebhooksLister   admissionlisters.ValidatingWebhookConfigurationLister
+	validatingWebhookTemplates []admiv1beta1.ValidatingWebhook
+	mutatingWebhooksLister     admissionlisters.MutatingWebhookConfigurationLister
+	mutatingWebhookTemplates   []admiv1beta1.MutatingWebhook
 }
 
 // NewControllerV1beta1 returns a new Webhook Controller using admissionregistration/v1beta1.
-func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config, wmeta workloadmeta.Component, pa workload.PodPatcher) *ControllerV1beta1 {
+func NewControllerV1beta1(
+	client kubernetes.Interface,
+	secretInformer coreinformers.SecretInformer,
+	validatingWebhookInformer admissioninformers.ValidatingWebhookConfigurationInformer,
+	mutatingWebhookInformer admissioninformers.MutatingWebhookConfigurationInformer,
+	isLeaderFunc func() bool,
+	isLeaderNotif <-chan struct{},
+	config Config,
+	wmeta workloadmeta.Component,
+	pa workload.PodPatcher,
+) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
 	controller.config = config
 	controller.secretsLister = secretInformer.Lister()
 	controller.secretsSynced = secretInformer.Informer().HasSynced
-	controller.mutatingWebhooksLister = webhookInformer.Lister()
-	controller.mutatingWebhooksSynced = webhookInformer.Informer().HasSynced
+	controller.validatingWebhooksLister = validatingWebhookInformer.Lister()
+	controller.validatingWebhooksSynced = validatingWebhookInformer.Informer().HasSynced
+	controller.mutatingWebhooksLister = mutatingWebhookInformer.Lister()
+	controller.mutatingWebhooksSynced = mutatingWebhookInformer.Informer().HasSynced
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.mutatingWebhooks = mutatingWebhooks(wmeta, pa)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -62,9 +77,17 @@ func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinform
 		log.Errorf("cannot add event handler to secret informer: %v", err)
 	}
 
-	if _, err := webhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := validatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleWebhook,
-		UpdateFunc: controller.handleMutatingWebhookUpdate,
+		UpdateFunc: controller.handleWebhookUpdate,
+		DeleteFunc: controller.handleWebhook,
+	}); err != nil {
+		log.Errorf("cannot add event handler to webhook informer: %v", err)
+	}
+
+	if _, err := mutatingWebhookInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.handleWebhook,
+		UpdateFunc: controller.handleWebhookUpdate,
 		DeleteFunc: controller.handleWebhook,
 	}); err != nil {
 		log.Errorf("cannot add event handler to webhook informer: %v", err)
@@ -81,7 +104,7 @@ func (c *ControllerV1beta1) Run(stopCh <-chan struct{}) {
 	log.Infof("Starting webhook controller for secret %s/%s and webhook %s - Using admissionregistration/v1beta1", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 	defer log.Infof("Stopping webhook controller for secret %s/%s and webhook %s", c.config.getSecretNs(), c.config.getSecretName(), c.config.getWebhookName())
 
-	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.mutatingWebhooksSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.secretsSynced, c.validatingWebhooksSynced, c.mutatingWebhooksSynced); !ok {
 		return
 	}
 
@@ -100,51 +123,125 @@ func (c *ControllerV1beta1) run() {
 	}
 }
 
-// handleMutatingWebhookUpdate handles the new Webhook reported in update events.
+// handleWebhookUpdate handles the new Webhook reported in update events.
 // It can be a callback function for update events.
-func (c *ControllerV1beta1) handleMutatingWebhookUpdate(oldObj, newObj interface{}) {
+func (c *ControllerV1beta1) handleWebhookUpdate(oldObj, newObj interface{}) {
 	if !c.isLeaderFunc() {
 		return
 	}
 
-	newWebhook, ok := newObj.(*admiv1beta1.MutatingWebhookConfiguration)
-	if !ok {
-		log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", newObj)
+	switch newObj.(type) {
+	case *admiv1beta1.ValidatingWebhookConfiguration:
+		newWebhook, _ := newObj.(*admiv1beta1.ValidatingWebhookConfiguration)
+		oldWebhook, ok := oldObj.(*admiv1beta1.ValidatingWebhookConfiguration)
+		if !ok {
+			log.Debugf("Expected ValidatingWebhookConfiguration object, got: %v", oldObj)
+			return
+		}
+
+		if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
+			return
+		}
+		c.handleWebhook(newObj)
+	case *admiv1beta1.MutatingWebhookConfiguration:
+		newWebhook, _ := newObj.(*admiv1beta1.MutatingWebhookConfiguration)
+		oldWebhook, ok := oldObj.(*admiv1beta1.MutatingWebhookConfiguration)
+		if !ok {
+			log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", oldObj)
+			return
+		}
+
+		if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
+			return
+		}
+		c.handleWebhook(newObj)
+	default:
+		log.Debugf("Expected ValidatingWebhookConfiguration or MutatingWebhookConfiguration object, got: %v", newObj)
 		return
 	}
-
-	oldWebhook, ok := oldObj.(*admiv1beta1.MutatingWebhookConfiguration)
-	if !ok {
-		log.Debugf("Expected MutatingWebhookConfiguration object, got: %v", oldObj)
-		return
-	}
-
-	if newWebhook.ResourceVersion == oldWebhook.ResourceVersion {
-		return
-	}
-
-	c.handleWebhook(newObj)
 }
 
 // reconcile creates/updates the webhook object on new events.
 func (c *ControllerV1beta1) reconcile() error {
+	var err error
+
 	secret, err := c.getSecret()
 	if err != nil {
 		return err
+	}
+
+	validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
+			err = c.createValidatingWebhook(secret)
+			if err != nil {
+				_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
+	} else {
+		log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+		err = c.updateValidatingWebhook(secret, validatingWebhook)
+		if err != nil {
+			_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+		}
 	}
 
 	mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
-			return c.createMutatingWebhook(secret)
+			err = c.createMutatingWebhook(secret)
+			if err != nil {
+				_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
-		return err
+	} else {
+		log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+		err = c.updateMutatingWebhook(secret, mutatingWebhook)
+		if err != nil {
+			_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+		}
 	}
 
-	log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+	return err
+}
 
-	return c.updateMutatingWebhook(secret, mutatingWebhook)
+// createValidatingWebhook creates a new ValidatingWebhookConfiguration object.
+func (c *ControllerV1beta1) createValidatingWebhook(secret *corev1.Secret) error {
+	webhook := &admiv1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.config.getWebhookName(),
+		},
+		Webhooks: c.newValidatingWebhooks(secret),
+	}
+
+	_, err := c.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), webhook, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		log.Infof("Webhook %s already exists", webhook.GetName())
+		return nil
+	}
+
+	return err
+}
+
+// updateValidatingWebhook stores a new configuration in the ValidatingWebhookConfiguration object.
+func (c *ControllerV1beta1) updateValidatingWebhook(secret *corev1.Secret, webhook *admiv1beta1.ValidatingWebhookConfiguration) error {
+	webhook = webhook.DeepCopy()
+	webhook.Webhooks = c.newValidatingWebhooks(secret)
+	_, err := c.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
+	return err
+}
+
+// newValidatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
+func (c *ControllerV1beta1) newValidatingWebhooks(secret *corev1.Secret) []admiv1beta1.ValidatingWebhook {
+	webhooks := []admiv1beta1.ValidatingWebhook{}
+	for _, tpl := range c.validatingWebhookTemplates {
+		tpl.ClientConfig.CABundle = certificate.GetCABundle(secret.Data)
+		webhooks = append(webhooks, tpl)
+	}
+
+	return webhooks
 }
 
 // createMutatingWebhook creates a new MutatingWebhookConfiguration object.
@@ -174,7 +271,7 @@ func (c *ControllerV1beta1) updateMutatingWebhook(secret *corev1.Secret, webhook
 	return err
 }
 
-// newWebhooks generates MutatingWebhook objects from config templates with updated CABundle from Secret.
+// newWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
 func (c *ControllerV1beta1) newMutatingWebhooks(secret *corev1.Secret) []admiv1beta1.MutatingWebhook {
 	webhooks := []admiv1beta1.MutatingWebhook{}
 	for _, tpl := range c.mutatingWebhookTemplates {
@@ -186,18 +283,17 @@ func (c *ControllerV1beta1) newMutatingWebhooks(secret *corev1.Secret) []admiv1b
 }
 
 func (c *ControllerV1beta1) generateTemplates() {
-	webhooks := []admiv1beta1.MutatingWebhook{}
-
-	for _, webhook := range c.mutatingWebhooks {
-		if !webhook.IsEnabled() {
+	validatingWebhooks := []admiv1beta1.ValidatingWebhook{}
+	for _, webhook := range c.webhooks {
+		if !webhook.IsEnabled() || webhook.WebhookType() != common.ValidatingWebhook {
 			continue
 		}
 
 		nsSelector, objSelector := webhook.LabelSelectors(c.config.useNamespaceSelector())
 
-		webhooks = append(
-			webhooks,
-			c.getWebhookSkeleton(
+		validatingWebhooks = append(
+			validatingWebhooks,
+			c.getValidatingWebhookSkeleton(
 				webhook.Name(),
 				webhook.Endpoint(),
 				webhook.Operations(),
@@ -207,17 +303,78 @@ func (c *ControllerV1beta1) generateTemplates() {
 			),
 		)
 	}
+	c.validatingWebhookTemplates = validatingWebhooks
 
-	c.mutatingWebhookTemplates = webhooks
+	mutatingWebhooks := []admiv1beta1.MutatingWebhook{}
+	for _, webhook := range c.webhooks {
+		if !webhook.IsEnabled() || webhook.WebhookType() != common.MutatingWebhook {
+			continue
+		}
+
+		nsSelector, objSelector := webhook.LabelSelectors(c.config.useNamespaceSelector())
+
+		mutatingWebhooks = append(
+			mutatingWebhooks,
+			c.getMutatingWebhookSkeleton(
+				webhook.Name(),
+				webhook.Endpoint(),
+				webhook.Operations(),
+				webhook.Resources(),
+				nsSelector,
+				objSelector,
+			),
+		)
+	}
+	c.mutatingWebhookTemplates = mutatingWebhooks
 }
 
-func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1beta1.MutatingWebhook {
+func (c *ControllerV1beta1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1beta1.ValidatingWebhook {
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := c.config.getServicePort()
 	timeout := c.config.getTimeout()
-	failurePolicy := c.getAdmiV1Beta1FailurePolicy()
+	failurePolicy := c.getFailurePolicy()
+
+	webhook := admiv1beta1.ValidatingWebhook{
+		Name: c.config.configName(nameSuffix),
+		ClientConfig: admiv1beta1.WebhookClientConfig{
+			Service: &admiv1beta1.ServiceReference{
+				Namespace: c.config.getServiceNs(),
+				Name:      c.config.getServiceName(),
+				Port:      &port,
+				Path:      &path,
+			},
+		},
+		Rules: []admiv1beta1.RuleWithOperations{
+			{
+				Operations: operations,
+				Rule: admiv1beta1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   resources,
+				},
+			},
+		},
+		FailurePolicy:           &failurePolicy,
+		MatchPolicy:             &matchPolicy,
+		SideEffects:             &sideEffects,
+		TimeoutSeconds:          &timeout,
+		AdmissionReviewVersions: []string{"v1beta1"},
+		NamespaceSelector:       namespaceSelector,
+		ObjectSelector:          objectSelector,
+	}
+
+	return webhook
+}
+
+func (c *ControllerV1beta1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resources []string, namespaceSelector, objectSelector *metav1.LabelSelector) admiv1beta1.MutatingWebhook {
+	matchPolicy := admiv1beta1.Exact
+	sideEffects := admiv1beta1.SideEffectClassNone
+	port := c.config.getServicePort()
+	timeout := c.config.getTimeout()
+	failurePolicy := c.getFailurePolicy()
 	reinvocationPolicy := c.getReinvocationPolicy()
+
 	webhook := admiv1beta1.MutatingWebhook{
 		Name: c.config.configName(nameSuffix),
 		ClientConfig: admiv1beta1.WebhookClientConfig{
@@ -251,7 +408,7 @@ func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string, operatio
 	return webhook
 }
 
-func (c *ControllerV1beta1) getAdmiV1Beta1FailurePolicy() admiv1beta1.FailurePolicyType {
+func (c *ControllerV1beta1) getFailurePolicy() admiv1beta1.FailurePolicyType {
 	policy := strings.ToLower(c.config.getFailurePolicy())
 	switch policy {
 	case "ignore":

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -183,44 +183,46 @@ func (c *ControllerV1beta1) handleWebhookUpdate(oldObj, newObj interface{}) {
 
 // reconcile creates/updates the webhook object on new events.
 func (c *ControllerV1beta1) reconcile() error {
-	var err error
-
 	secret, err := c.getSecret()
 	if err != nil {
 		return err
 	}
 
-	validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
-			err = c.createValidatingWebhook(secret)
-			if err != nil {
-				_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
-			}
-		}
-	} else {
-		log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
-		err = c.updateValidatingWebhook(secret, validatingWebhook)
+	if c.config.mutationEnabled {
+		mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
 		if err != nil {
-			_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			if errors.IsNotFound(err) {
+				log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
+				err = c.createMutatingWebhook(secret)
+				if err != nil {
+					_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+				}
+			}
+		} else {
+			log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+			err = c.updateMutatingWebhook(secret, mutatingWebhook)
+			if err != nil {
+				_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
 	}
 
-	mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
-			err = c.createMutatingWebhook(secret)
-			if err != nil {
-				_ = log.Errorf("Failed to create Mutating Webhook %s: %v", c.config.getWebhookName(), err)
-			}
-		}
-	} else {
-		log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
-		err = c.updateMutatingWebhook(secret, mutatingWebhook)
+	if c.config.validationEnabled {
+		validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
 		if err != nil {
-			_ = log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			if errors.IsNotFound(err) {
+				log.Infof("Webhook %s was not found, creating it", c.config.getWebhookName())
+				err = c.createValidatingWebhook(secret)
+				if err != nil {
+					_ = log.Errorf("Failed to create Validating Webhook %s: %v", c.config.getWebhookName(), err)
+				}
+			}
+		} else {
+			log.Debugf("The Webhook %s was found, updating it", c.config.getWebhookName())
+			err = c.updateValidatingWebhook(secret, validatingWebhook)
+			if err != nil {
+				_ = log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
 		}
 	}
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -47,7 +47,7 @@ func TestSecretNotFoundV1beta1(t *testing.T) {
 	defer close(stopCh)
 	c := f.run(stopCh)
 
-	_, err := c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
+	_, err := c.mutatingWebhooksLister.Get(v1beta1Cfg.getWebhookName())
 	if !errors.IsNotFound(err) {
 		t.Fatal("Webhook shouldn't be created")
 	}
@@ -75,7 +75,7 @@ func TestCreateWebhookV1beta1(t *testing.T) {
 
 	var webhook *admiv1beta1.MutatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		webhook, err = c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
+		webhook, err = c.mutatingWebhooksLister.Get(v1beta1Cfg.getWebhookName())
 		return err == nil
 	}, waitFor, tick)
 
@@ -124,7 +124,7 @@ func TestUpdateOutdatedWebhookV1beta1(t *testing.T) {
 
 	var newWebhook *admiv1beta1.MutatingWebhookConfiguration
 	require.Eventually(t, func() bool {
-		newWebhook, err = c.webhooksLister.Get(v1beta1Cfg.getWebhookName())
+		newWebhook, err = c.mutatingWebhooksLister.Get(v1beta1Cfg.getWebhookName())
 		return err == nil && !reflect.DeepEqual(webhook, newWebhook)
 	}, waitFor, tick)
 
@@ -958,7 +958,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 			c.mutatingWebhooks = mutatingWebhooks(wmeta, nil)
 			c.generateTemplates()
 
-			assert.EqualValues(t, tt.want(), c.webhookTemplates)
+			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
 		})
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -954,7 +954,7 @@ func TestGetValidatingWebhookSkeletonV1beta1(t *testing.T) {
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := int32(443)
 	path := "/bar"
-	defaultTimeout := config.Datadog().GetInt32("admission_controller.timeout_seconds")
+	defaultTimeout := pkgconfigsetup.Datadog().GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
 	namespaceSelector, _ := common.DefaultLabelSelectors(true)
 	_, objectSelector := common.DefaultLabelSelectors(false)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -72,6 +72,8 @@ func TestCreateWebhookV1beta1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
+	c.config.validationEnabled = true
+	c.config.mutationEnabled = true
 
 	var validatingWebhookConfiguration *admiv1beta1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
@@ -141,6 +143,8 @@ func TestUpdateOutdatedWebhookV1beta1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
+	c.config.validationEnabled = true
+	c.config.mutationEnabled = true
 
 	var newValidatingWebhookConfiguration *admiv1beta1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -9,14 +9,13 @@ package webhook
 
 import (
 	"context"
-	"fmt"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	admiv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -1201,7 +1200,7 @@ func (f *fixtureV1beta1) populateMutatingWebhooksCache(webhooks ...*admiv1beta1.
 
 func validateV1beta1(t *testing.T, validatingWebhooks *admiv1beta1.ValidatingWebhookConfiguration, mutatingWebhooks *admiv1beta1.MutatingWebhookConfiguration, s *corev1.Secret) {
 	// Validate the number of webhooks.
-	require.Empty(t, validatingWebhooks.Webhooks)
+	require.Len(t, validatingWebhooks.Webhooks, 0)
 	require.Len(t, mutatingWebhooks.Webhooks, 3)
 
 	// Validate the CA bundle for webhooks.
@@ -1211,5 +1210,4 @@ func validateV1beta1(t *testing.T, validatingWebhooks *admiv1beta1.ValidatingWeb
 	for i := 0; i < len(mutatingWebhooks.Webhooks); i++ {
 		require.Equal(t, mutatingWebhooks.Webhooks[i].ClientConfig.CABundle, certificate.GetCABundle(s.Data))
 	}
-	return nil
 }

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -44,22 +44,29 @@ var (
 	CertificateDuration = telemetry.NewGaugeWithOpts("admission_webhooks", "certificate_expiry",
 		[]string{}, "Time left before the certificate expires in hours.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	ValidationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "validation_attempts",
+		[]string{"webhook_name", "status", "validated", "error"}, "Number of pod validation attempts by validation type",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
 		[]string{"mutation_type", "status", "injected", "error"}, "Number of pod mutation attempts by mutation type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	MutatingWebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "mutating_webhooks_received",
-		[]string{"mutation_type"}, "Number of webhook requests received.",
-		telemetry.Options{NoDoubleUnderscoreSep: true})
+	WebhooksReceived = telemetry.NewCounterWithOpts(
+		"admission_webhooks",
+		"webhooks_received",
+		[]string{"mutation_type", "webhook_name", "webhook_type"},
+		"Number of webhook requests received.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
 	GetOwnerCacheHit = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_hit",
 		[]string{"resource"}, "Number of cache hits while getting pod's owner object.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	GetOwnerCacheMiss = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_miss",
 		[]string{"resource"}, "Number of cache misses while getting pod's owner object.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	MutatingWebhooksResponseDuration = telemetry.NewHistogramWithOpts(
+	WebhooksResponseDuration = telemetry.NewHistogramWithOpts(
 		"admission_webhooks",
-		"mutating_response_duration",
-		[]string{"mutation_type"},
+		"response_duration",
+		[]string{"mutation_type", "webhook_name", "webhook_type"},
 		"Webhook response duration distribution (in seconds).",
 		prometheus.DefBuckets, // The default prometheus buckets are adapted to measure response time
 		telemetry.Options{NoDoubleUnderscoreSep: true},

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -47,8 +47,8 @@ var (
 	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
 		[]string{"mutation_type", "status", "injected", "error"}, "Number of pod mutation attempts by mutation type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	WebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "webhooks_received",
-		[]string{"mutation_type"}, "Number of mutation webhook requests received.",
+	MutatingWebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "mutating_webhooks_received",
+		[]string{"mutation_type"}, "Number of webhook requests received.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	GetOwnerCacheHit = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_hit",
 		[]string{"resource"}, "Number of cache hits while getting pod's owner object.",
@@ -56,9 +56,9 @@ var (
 	GetOwnerCacheMiss = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_miss",
 		[]string{"resource"}, "Number of cache misses while getting pod's owner object.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	WebhooksResponseDuration = telemetry.NewHistogramWithOpts(
+	MutatingWebhooksResponseDuration = telemetry.NewHistogramWithOpts(
 		"admission_webhooks",
-		"response_duration",
+		"mutating_response_duration",
 		[]string{"mutation_type"},
 		"Webhook response duration distribution (in seconds).",
 		prometheus.DefBuckets, // The default prometheus buckets are adapted to measure response time

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -45,7 +45,6 @@ type Selector struct {
 // Webhook is the webhook that injects a Datadog Agent sidecar
 type Webhook struct {
 	name              string
-	webhookType       common.WebhookType
 	isEnabled         bool
 	endpoint          string
 	resources         []string
@@ -63,7 +62,6 @@ func NewWebhook() *Webhook {
 
 	return &Webhook{
 		name:              webhookName,
-		webhookType:       common.MutatingWebhook,
 		isEnabled:         pkgconfigsetup.Datadog().GetBool("admission_controller.agent_sidecar.enabled"),
 		endpoint:          pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.endpoint"),
 		resources:         []string{"pods"},
@@ -81,7 +79,7 @@ func (w *Webhook) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *Webhook) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -17,15 +17,17 @@ import (
 	"slices"
 	"strconv"
 
-	admiv1 "k8s.io/api/admissionregistration/v1"
+	admiv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
@@ -43,10 +45,11 @@ type Selector struct {
 // Webhook is the webhook that injects a Datadog Agent sidecar
 type Webhook struct {
 	name              string
+	webhookType       common.WebhookType
 	isEnabled         bool
 	endpoint          string
 	resources         []string
-	operations        []admiv1.OperationType
+	operations        []admissionregistrationv1.OperationType
 	namespaceSelector *metav1.LabelSelector
 	objectSelector    *metav1.LabelSelector
 	containerRegistry string
@@ -56,14 +59,15 @@ type Webhook struct {
 func NewWebhook() *Webhook {
 	nsSelector, objSelector := labelSelectors()
 
-	containerRegistry := common.ContainerRegistry("admission_controller.agent_sidecar.container_registry")
+	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.agent_sidecar.container_registry")
 
 	return &Webhook{
 		name:              webhookName,
+		webhookType:       common.MutatingWebhook,
 		isEnabled:         pkgconfigsetup.Datadog().GetBool("admission_controller.agent_sidecar.enabled"),
 		endpoint:          pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.endpoint"),
 		resources:         []string{"pods"},
-		operations:        []admiv1.OperationType{admiv1.Create},
+		operations:        []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		namespaceSelector: nsSelector,
 		objectSelector:    objSelector,
 		containerRegistry: containerRegistry,
@@ -73,6 +77,11 @@ func NewWebhook() *Webhook {
 // Name returns the name of the webhook
 func (w *Webhook) Name() string {
 	return w.name
+}
+
+// WebhookType returns the type of the webhook
+func (w *Webhook) WebhookType() common.WebhookType {
+	return w.webhookType
 }
 
 // IsEnabled returns whether the webhook is enabled
@@ -93,7 +102,7 @@ func (w *Webhook) Resources() []string {
 
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
-func (w *Webhook) Operations() []admiv1.OperationType {
+func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 	return w.operations
 }
 
@@ -103,14 +112,11 @@ func (w *Webhook) LabelSelectors(_ bool) (namespaceSelector *metav1.LabelSelecto
 	return w.namespaceSelector, w.objectSelector
 }
 
-// MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
-	return w.mutate
-}
-
-// mutate handles mutating pod requests for the agentsidecar webhook
-func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, w.Name(), w.injectAgentSidecar, request.DynamicClient)
+// WebhookFunc returns the function that mutates the resources
+func (w *Webhook) WebhookFunc() admission.WebhookFunc {
+	return func(request *admission.Request) *admiv1.AdmissionResponse {
+		return common.MutationResponse(mutatecommon.Mutate(request.Raw, request.Namespace, w.Name(), w.injectAgentSidecar, request.DynamicClient))
+	}
 }
 
 func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -104,7 +104,7 @@ func (w *Webhook) LabelSelectors(_ bool) (namespaceSelector *metav1.LabelSelecto
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.WebhookFunc {
+func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
 	return w.mutate
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -50,7 +50,6 @@ const (
 // Webhook is the auto instrumentation webhook
 type Webhook struct {
 	name                     string
-	webhookType              common.WebhookType
 	isEnabled                bool
 	endpoint                 string
 	resources                []string
@@ -103,7 +102,6 @@ func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilte
 
 	return &Webhook{
 		name:                     webhookName,
-		webhookType:              common.MutatingWebhook,
 		isEnabled:                isEnabled,
 		endpoint:                 pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.endpoint"),
 		resources:                []string{"pods"},
@@ -126,7 +124,7 @@ func (w *Webhook) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *Webhook) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -150,7 +150,7 @@ func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.WebhookFunc {
+func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
 	return w.injectAutoInstrumentation
 }
 

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -9,16 +9,16 @@
 package autoscaling
 
 import (
-	"k8s.io/client-go/dynamic"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admiv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -83,7 +83,7 @@ func (w *Webhook) LabelSelectors(_ bool) (namespaceSelector *metav1.LabelSelecto
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.WebhookFunc {
+func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
 	return w.mutate
 }
 

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -29,25 +29,23 @@ const (
 
 // Webhook implements the MutatingWebhook interface
 type Webhook struct {
-	name        string
-	webhookType common.WebhookType
-	isEnabled   bool
-	endpoint    string
-	resources   []string
-	operations  []admissionregistrationv1.OperationType
-	patcher     workload.PodPatcher
+	name       string
+	isEnabled  bool
+	endpoint   string
+	resources  []string
+	operations []admissionregistrationv1.OperationType
+	patcher    workload.PodPatcher
 }
 
 // NewWebhook returns a new Webhook
 func NewWebhook(patcher workload.PodPatcher) *Webhook {
 	return &Webhook{
-		name:        webhookName,
-		webhookType: common.MutatingWebhook,
-		isEnabled:   pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled"),
-		endpoint:    webhookEndpoint,
-		resources:   []string{"pods"},
-		operations:  []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-		patcher:     patcher,
+		name:       webhookName,
+		isEnabled:  pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled"),
+		endpoint:   webhookEndpoint,
+		resources:  []string{"pods"},
+		operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+		patcher:    patcher,
 	}
 }
 
@@ -58,7 +56,7 @@ func (w *Webhook) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *Webhook) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -9,15 +9,17 @@
 package autoscaling
 
 import (
-	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-
-	admiv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/dynamic"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admiv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
+
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 const (
@@ -27,29 +29,36 @@ const (
 
 // Webhook implements the MutatingWebhook interface
 type Webhook struct {
-	name       string
-	isEnabled  bool
-	endpoint   string
-	resources  []string
-	operations []admiv1.OperationType
-	patcher    workload.PodPatcher
+	name        string
+	webhookType common.WebhookType
+	isEnabled   bool
+	endpoint    string
+	resources   []string
+	operations  []admissionregistrationv1.OperationType
+	patcher     workload.PodPatcher
 }
 
 // NewWebhook returns a new Webhook
 func NewWebhook(patcher workload.PodPatcher) *Webhook {
 	return &Webhook{
-		name:       webhookName,
-		isEnabled:  pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled"),
-		endpoint:   webhookEndpoint,
-		resources:  []string{"pods"},
-		operations: []admiv1.OperationType{admiv1.Create},
-		patcher:    patcher,
+		name:        webhookName,
+		webhookType: common.MutatingWebhook,
+		isEnabled:   pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled"),
+		endpoint:    webhookEndpoint,
+		resources:   []string{"pods"},
+		operations:  []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+		patcher:     patcher,
 	}
 }
 
 // Name returns the name of the webhook
 func (w *Webhook) Name() string {
 	return w.name
+}
+
+// WebhookType returns the type of the webhook
+func (w *Webhook) WebhookType() common.WebhookType {
+	return w.webhookType
 }
 
 // IsEnabled returns whether the webhook is enabled
@@ -70,7 +79,7 @@ func (w *Webhook) Resources() []string {
 
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
-func (w *Webhook) Operations() []admiv1.OperationType {
+func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 	return w.operations
 }
 
@@ -82,18 +91,14 @@ func (w *Webhook) LabelSelectors(_ bool) (namespaceSelector *metav1.LabelSelecto
 	return nil, nil
 }
 
-// MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
-	return w.mutate
+// WebhookFunc returns the function that mutates the resources
+func (w *Webhook) WebhookFunc() admission.WebhookFunc {
+	return func(request *admission.Request) *admiv1.AdmissionResponse {
+		return common.MutationResponse(mutatecommon.Mutate(request.Raw, request.Namespace, w.Name(), w.updateResources, request.DynamicClient))
+	}
 }
 
-// mutate adds the DD_AGENT_HOST and DD_ENTITY_ID env vars to the pod template if they don't exist
-func (w *Webhook) mutate(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, w.Name(), w.updateResources, request.DynamicClient)
-}
-
-// updateResource finds the owner of a pod, calls the recommender to retrieve the recommended CPU and Memory
-// requests
+// updateResources finds the owner of a pod, calls the recommender to retrieve the recommended CPU and Memory requests
 func (w *Webhook) updateResources(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	return w.patcher.ApplyRecommendations(pod)
 }

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -109,7 +109,7 @@ func injectDynamicEnvInContainers(containers []corev1.Container, fn BuildEnvVarF
 	for i := range containers {
 		env, err := fn(&containers[i], init)
 		if err != nil {
-			_ = log.Errorf("Error building env var: %v", err)
+			log.Errorf("Error building env var: %v", err)
 			continue
 		}
 		injected = injectEnvInContainer(&containers[i], env) || injected

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -103,7 +103,6 @@ var (
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod
 type Webhook struct {
 	name            string
-	webhookType     common.WebhookType
 	isEnabled       bool
 	endpoint        string
 	resources       []string
@@ -117,7 +116,6 @@ type Webhook struct {
 func NewWebhook(wmeta workloadmeta.Component, injectionFilter mutatecommon.InjectionFilter) *Webhook {
 	return &Webhook{
 		name:            webhookName,
-		webhookType:     common.MutatingWebhook,
 		isEnabled:       pkgconfigsetup.Datadog().GetBool("admission_controller.inject_config.enabled"),
 		endpoint:        pkgconfigsetup.Datadog().GetString("admission_controller.inject_config.endpoint"),
 		resources:       []string{"pods"},
@@ -135,7 +133,7 @@ func (w *Webhook) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *Webhook) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -159,7 +159,7 @@ func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.WebhookFunc {
+func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
 	return w.mutate
 }
 

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -14,20 +14,20 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/client-go/dynamic"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admiv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -297,7 +297,7 @@ func injectSocketVolumes(pod *corev1.Pod) bool {
 
 		for volumeName, volumePath := range volumes {
 			volume, volumeMount := buildVolume(volumeName, volumePath, corev1.HostPathSocket, true)
-			injectedVol := common.InjectVolume(pod, volume, volumeMount)
+			injectedVol := mutatecommon.InjectVolume(pod, volume, volumeMount)
 			if injectedVol {
 				injectedVolNames = append(injectedVolNames, volumeName)
 			}
@@ -309,14 +309,14 @@ func injectSocketVolumes(pod *corev1.Pod) bool {
 			corev1.HostPathDirectoryOrCreate,
 			true,
 		)
-		injectedVol := common.InjectVolume(pod, volume, volumeMount)
+		injectedVol := mutatecommon.InjectVolume(pod, volume, volumeMount)
 		if injectedVol {
 			injectedVolNames = append(injectedVolNames, DatadogVolumeName)
 		}
 	}
 
 	for _, volName := range injectedVolNames {
-		common.MarkVolumeAsSafeToEvictForAutoscaler(pod, volName)
+		mutatecommon.MarkVolumeAsSafeToEvictForAutoscaler(pod, volName)
 	}
 
 	return len(injectedVolNames) > 0

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	admiv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -506,9 +506,7 @@ func BenchmarkJSONPatch(b *testing.B) {
 		}
 		admissionResponse := webhook.WebhookFunc()(&request)
 		jsonPatch, err := json.Marshal(admissionResponse.Patch)
-		if err != nil {
-			b.Fatal(err)
-		}
+		require.NoError(b, err)
 
 		if len(jsonPatch) < 100 {
 			b.Fatal("Empty JSONPatch")

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -87,7 +87,6 @@ type mutatePodExecFunc func(*corev1.PodExecOptions, string, string, *authenticat
 // WebhookForPods is the webhook that injects CWS pod instrumentation
 type WebhookForPods struct {
 	name          string
-	webhookType   common.WebhookType
 	isEnabled     bool
 	endpoint      string
 	resources     []string
@@ -97,8 +96,7 @@ type WebhookForPods struct {
 
 func newWebhookForPods(admissionFunc admission.WebhookFunc) *WebhookForPods {
 	return &WebhookForPods{
-		name:        webhookForPodsName,
-		webhookType: common.MutatingWebhook,
+		name: webhookForPodsName,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
 			len(pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")) > 0,
 		endpoint:      pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.pod_endpoint"),
@@ -115,7 +113,7 @@ func (w *WebhookForPods) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *WebhookForPods) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled
@@ -154,7 +152,6 @@ func (w *WebhookForPods) WebhookFunc() admission.WebhookFunc {
 // WebhookForCommands is the webhook that injects CWS pods/exec instrumentation
 type WebhookForCommands struct {
 	name          string
-	webhookType   common.WebhookType
 	isEnabled     bool
 	endpoint      string
 	resources     []string
@@ -164,8 +161,7 @@ type WebhookForCommands struct {
 
 func newWebhookForCommands(admissionFunc admission.WebhookFunc) *WebhookForCommands {
 	return &WebhookForCommands{
-		name:        webhookForCommandsName,
-		webhookType: common.MutatingWebhook,
+		name: webhookForCommandsName,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
 			len(pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")) > 0,
 		endpoint:      pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.command_endpoint"),
@@ -182,7 +178,7 @@ func (w *WebhookForCommands) Name() string {
 
 // WebhookType returns the name of the webhook
 func (w *WebhookForCommands) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -17,23 +17,24 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"k8s.io/kubectl/pkg/cmd/util/podcmd"
-	"k8s.io/utils/strings/slices"
-
 	"github.com/wI2L/jsondiff"
-	admiv1 "k8s.io/api/admissionregistration/v1"
+	admiv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/cmd/util/podcmd"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -86,21 +87,23 @@ type mutatePodExecFunc func(*corev1.PodExecOptions, string, string, *authenticat
 // WebhookForPods is the webhook that injects CWS pod instrumentation
 type WebhookForPods struct {
 	name          string
+	webhookType   common.WebhookType
 	isEnabled     bool
 	endpoint      string
 	resources     []string
-	operations    []admiv1.OperationType
-	admissionFunc admission.MutatingWebhookFunc
+	operations    []admissionregistrationv1.OperationType
+	admissionFunc admission.WebhookFunc
 }
 
-func newWebhookForPods(admissionFunc admission.MutatingWebhookFunc) *WebhookForPods {
+func newWebhookForPods(admissionFunc admission.WebhookFunc) *WebhookForPods {
 	return &WebhookForPods{
-		name: webhookForPodsName,
+		name:        webhookForPodsName,
+		webhookType: common.MutatingWebhook,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
 			len(pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")) > 0,
 		endpoint:      pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.pod_endpoint"),
 		resources:     []string{"pods"},
-		operations:    []admiv1.OperationType{admiv1.Create},
+		operations:    []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		admissionFunc: admissionFunc,
 	}
 }
@@ -108,6 +111,11 @@ func newWebhookForPods(admissionFunc admission.MutatingWebhookFunc) *WebhookForP
 // Name returns the name of the webhook
 func (w *WebhookForPods) Name() string {
 	return w.name
+}
+
+// WebhookType returns the type of the webhook
+func (w *WebhookForPods) WebhookType() common.WebhookType {
+	return w.webhookType
 }
 
 // IsEnabled returns whether the webhook is enabled
@@ -128,7 +136,7 @@ func (w *WebhookForPods) Resources() []string {
 
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
-func (w *WebhookForPods) Operations() []admiv1.OperationType {
+func (w *WebhookForPods) Operations() []admissionregistrationv1.OperationType {
 	return w.operations
 }
 
@@ -138,29 +146,31 @@ func (w *WebhookForPods) LabelSelectors(useNamespaceSelector bool) (namespaceSel
 	return labelSelectors(useNamespaceSelector)
 }
 
-// MutateFunc returns the function that mutates the resources
-func (w *WebhookForPods) MutateFunc() admission.MutatingWebhookFunc {
+// WebhookFunc returns the function that mutates the resources
+func (w *WebhookForPods) WebhookFunc() admission.WebhookFunc {
 	return w.admissionFunc
 }
 
 // WebhookForCommands is the webhook that injects CWS pods/exec instrumentation
 type WebhookForCommands struct {
 	name          string
+	webhookType   common.WebhookType
 	isEnabled     bool
 	endpoint      string
 	resources     []string
-	operations    []admiv1.OperationType
-	admissionFunc admission.MutatingWebhookFunc
+	operations    []admissionregistrationv1.OperationType
+	admissionFunc admission.WebhookFunc
 }
 
-func newWebhookForCommands(admissionFunc admission.MutatingWebhookFunc) *WebhookForCommands {
+func newWebhookForCommands(admissionFunc admission.WebhookFunc) *WebhookForCommands {
 	return &WebhookForCommands{
-		name: webhookForCommandsName,
+		name:        webhookForCommandsName,
+		webhookType: common.MutatingWebhook,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
 			len(pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")) > 0,
 		endpoint:      pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.command_endpoint"),
 		resources:     []string{"pods/exec"},
-		operations:    []admiv1.OperationType{admiv1.Connect},
+		operations:    []admissionregistrationv1.OperationType{admissionregistrationv1.Connect},
 		admissionFunc: admissionFunc,
 	}
 }
@@ -168,6 +178,11 @@ func newWebhookForCommands(admissionFunc admission.MutatingWebhookFunc) *Webhook
 // Name returns the name of the webhook
 func (w *WebhookForCommands) Name() string {
 	return w.name
+}
+
+// WebhookType returns the name of the webhook
+func (w *WebhookForCommands) WebhookType() common.WebhookType {
+	return w.webhookType
 }
 
 // IsEnabled returns whether the webhook is enabled
@@ -188,7 +203,7 @@ func (w *WebhookForCommands) Resources() []string {
 
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
-func (w *WebhookForCommands) Operations() []admiv1.OperationType {
+func (w *WebhookForCommands) Operations() []admissionregistrationv1.OperationType {
 	return w.operations
 }
 
@@ -198,8 +213,8 @@ func (w *WebhookForCommands) LabelSelectors(_ bool) (namespaceSelector *metav1.L
 	return nil, nil
 }
 
-// MutateFunc returns the function that mutates the resources
-func (w *WebhookForCommands) MutateFunc() admission.MutatingWebhookFunc {
+// WebhookFunc MutateFunc returns the function that mutates the resources
+func (w *WebhookForCommands) WebhookFunc() admission.WebhookFunc {
 	return w.admissionFunc
 }
 
@@ -302,7 +317,7 @@ func NewCWSInstrumentation(wmeta workloadmeta.Component) (*CWSInstrumentation, e
 	cwsInjectorImageName := pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")
 	cwsInjectorImageTag := pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_tag")
 
-	cwsInjectorContainerRegistry := common.ContainerRegistry("admission_controller.cws_instrumentation.container_registry")
+	cwsInjectorContainerRegistry := mutatecommon.ContainerRegistry("admission_controller.cws_instrumentation.container_registry")
 
 	if len(cwsInjectorImageName) == 0 {
 		return nil, fmt.Errorf("can't initialize CWS Instrumentation without an image_name")
@@ -357,8 +372,8 @@ func (ci *CWSInstrumentation) WebhookForCommands() *WebhookForCommands {
 	return ci.webhookForCommands
 }
 
-func (ci *CWSInstrumentation) injectForCommand(request *admission.MutateRequest) ([]byte, error) {
-	return mutatePodExecOptions(request.Raw, request.Name, request.Namespace, ci.webhookForCommands.Name(), request.UserInfo, ci.injectCWSCommandInstrumentation, request.DynamicClient, request.APIClient)
+func (ci *CWSInstrumentation) injectForCommand(request *admission.Request) *admiv1.AdmissionResponse {
+	return common.MutationResponse(mutatePodExecOptions(request.Raw, request.Name, request.Namespace, ci.webhookForCommands.Name(), request.UserInfo, ci.injectCWSCommandInstrumentation, request.DynamicClient, request.APIClient))
 }
 
 func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kubernetes.Interface) (string, error) {
@@ -476,7 +491,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		// is the pod instrumentation ready ? (i.e. has the CWS Instrumentation init container been added ?)
 		if !isPodCWSInstrumentationReady(pod.Annotations) {
 			// pod isn't instrumented, do not attempt to override the pod exec command
-			log.Debugf("Ignoring exec request into %s, pod not instrumented yet", common.PodString(pod))
+			log.Debugf("Ignoring exec request into %s, pod not instrumented yet", mutatecommon.PodString(pod))
 			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsPodNotInstrumentedReason)
 			return false, nil
 		}
@@ -487,7 +502,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		if ci.mountVolumeForRemoteCopy {
 			if !isPodCWSInstrumentationReady(pod.Annotations) {
 				// pod isn't instrumented, do not attempt to override the pod exec command
-				log.Debugf("Ignoring exec request into %s, pod not instrumented yet", common.PodString(pod))
+				log.Debugf("Ignoring exec request into %s, pod not instrumented yet", mutatecommon.PodString(pod))
 				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsPodNotInstrumentedReason)
 				return false, nil
 			}
@@ -496,7 +511,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			// check if the target pod has a read only filesystem
 			if readOnly := ci.hasReadonlyRootfs(pod, exec.Container); readOnly {
 				// readonly rootfs containers can't be instrumented
-				log.Errorf("Ignoring exec request into %s, container %s has read only rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", common.PodString(pod), exec.Container)
+				log.Errorf("Ignoring exec request into %s, container %s has read only rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), exec.Container)
 				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsReadonlyFilesystemReason)
 				return false, errors.New(metrics.InvalidInput)
 			}
@@ -512,7 +527,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 
 		arch, err := ci.resolveNodeArch(pod.Spec.NodeName, apiClient)
 		if err != nil {
-			log.Errorf("Ignoring exec request into %s: %v", common.PodString(pod), err)
+			log.Errorf("Ignoring exec request into %s: %v", mutatecommon.PodString(pod), err)
 			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsMissingArchReason)
 			return false, errors.New(metrics.InternalError)
 		}
@@ -520,7 +535,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 
 		// check if the pod is ready to be exec-ed into
 		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
-			log.Errorf("Ignoring exec request into %s: cannot exec into a container in a completed pod; current phase is %s", common.PodString(pod), pod.Status.Phase)
+			log.Errorf("Ignoring exec request into %s: cannot exec into a container in a completed pod; current phase is %s", mutatecommon.PodString(pod), pod.Status.Phase)
 			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsCompletedPodReason)
 			return false, errors.New(metrics.InvalidInput)
 		}
@@ -528,19 +543,19 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		// check if the input container exists, or select the default one to which the user will be redirected
 		container, err := podcmd.FindOrDefaultContainerByName(pod, exec.Container, true, nil)
 		if err != nil {
-			log.Errorf("Ignoring exec request into %s, invalid container: %v", common.PodString(pod), err)
+			log.Errorf("Ignoring exec request into %s, invalid container: %v", mutatecommon.PodString(pod), err)
 			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsInvalidInputContainerReason)
 			return false, errors.New(metrics.InvalidInput)
 		}
 
 		// copy CWS instrumentation directly to the target container
 		if err := ci.injectCWSCommandInstrumentationRemoteCopy(pod, container.Name, cwsInstrumentationLocalPath, cwsInstrumentationRemotePath); err != nil {
-			log.Warnf("Ignoring exec request into %s, remote copy failed: %v", common.PodString(pod), err)
+			log.Warnf("Ignoring exec request into %s, remote copy failed: %v", mutatecommon.PodString(pod), err)
 			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsRemoteCopyFailedReason)
 			return false, errors.New(metrics.InternalError)
 		}
 	default:
-		log.Errorf("Ignoring exec request into %s, unknown CWS Instrumentation mode %v", common.PodString(pod), ci.mode)
+		log.Errorf("Ignoring exec request into %s, unknown CWS Instrumentation mode %v", mutatecommon.PodString(pod), ci.mode)
 		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsUnknownModeReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
@@ -548,7 +563,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	// prepare the user session context
 	userSessionCtx, err := usersessions.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
 	if err != nil {
-		log.Debugf("ignoring instrumentation of %s: %v", common.PodString(pod), err)
+		log.Debugf("ignoring instrumentation of %s: %v", mutatecommon.PodString(pod), err)
 		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsCredentialsSerializationErrorReason)
 		return false, errors.New(metrics.InternalError)
 	}
@@ -563,7 +578,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			exec.Command[6] == "--" {
 
 			if exec.Command[5] == string(userSessionCtx) {
-				log.Debugf("Exec request into %s is already instrumented, ignoring", common.PodString(pod))
+				log.Debugf("Exec request into %s is already instrumented, ignoring", mutatecommon.PodString(pod))
 				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsAlreadyInstrumentedReason)
 				return true, nil
 			}
@@ -581,7 +596,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		"--",
 	}, exec.Command...)
 
-	log.Debugf("Pod exec request to %s by %s is now instrumented for CWS", common.PodString(pod), userInfo.Username)
+	log.Debugf("Pod exec request to %s by %s is now instrumented for CWS", mutatecommon.PodString(pod), userInfo.Username)
 	metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "true", "")
 	injected = true
 
@@ -604,8 +619,8 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentationRemoteCopy(pod *cor
 	return health.Run(cwsInstrumentationRemotePath, pod, container)
 }
 
-func (ci *CWSInstrumentation) injectForPod(request *admission.MutateRequest) ([]byte, error) {
-	return common.Mutate(request.Raw, request.Namespace, ci.webhookForPods.Name(), ci.injectCWSPodInstrumentation, request.DynamicClient)
+func (ci *CWSInstrumentation) injectForPod(request *admission.Request) *admiv1.AdmissionResponse {
+	return common.MutationResponse(mutatecommon.Mutate(request.Raw, request.Namespace, ci.webhookForPods.Name(), ci.injectCWSPodInstrumentation, request.DynamicClient))
 }
 
 func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool, error) {
@@ -637,7 +652,7 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 	case RemoteCopy:
 		instrumented = ci.injectCWSPodInstrumentationRemoteCopy(pod)
 	default:
-		log.Errorf("Ignoring Pod %s admission request: unknown CWS Instrumentation mode %v", common.PodString(pod), ci.mode)
+		log.Errorf("Ignoring Pod %s admission request: unknown CWS Instrumentation mode %v", mutatecommon.PodString(pod), ci.mode)
 		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsUnknownModeReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
@@ -648,7 +663,7 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 			pod.Annotations = make(map[string]string)
 		}
 		pod.Annotations[cwsInstrumentationPodAnotationStatus] = cwsInstrumentationPodAnotationReady
-		log.Debugf("Pod %s is now instrumented for CWS", common.PodString(pod))
+		log.Debugf("Pod %s is now instrumented for CWS", mutatecommon.PodString(pod))
 		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "true", "")
 	} else {
 		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsNoInstrumentationNeededReason)

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -90,10 +90,10 @@ type WebhookForPods struct {
 	endpoint      string
 	resources     []string
 	operations    []admiv1.OperationType
-	admissionFunc admission.WebhookFunc
+	admissionFunc admission.MutatingWebhookFunc
 }
 
-func newWebhookForPods(admissionFunc admission.WebhookFunc) *WebhookForPods {
+func newWebhookForPods(admissionFunc admission.MutatingWebhookFunc) *WebhookForPods {
 	return &WebhookForPods{
 		name: webhookForPodsName,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
@@ -139,7 +139,7 @@ func (w *WebhookForPods) LabelSelectors(useNamespaceSelector bool) (namespaceSel
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *WebhookForPods) MutateFunc() admission.WebhookFunc {
+func (w *WebhookForPods) MutateFunc() admission.MutatingWebhookFunc {
 	return w.admissionFunc
 }
 
@@ -150,10 +150,10 @@ type WebhookForCommands struct {
 	endpoint      string
 	resources     []string
 	operations    []admiv1.OperationType
-	admissionFunc admission.WebhookFunc
+	admissionFunc admission.MutatingWebhookFunc
 }
 
-func newWebhookForCommands(admissionFunc admission.WebhookFunc) *WebhookForCommands {
+func newWebhookForCommands(admissionFunc admission.MutatingWebhookFunc) *WebhookForCommands {
 	return &WebhookForCommands{
 		name: webhookForCommandsName,
 		isEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.cws_instrumentation.enabled") &&
@@ -199,7 +199,7 @@ func (w *WebhookForCommands) LabelSelectors(_ bool) (namespaceSelector *metav1.L
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *WebhookForCommands) MutateFunc() admission.WebhookFunc {
+func (w *WebhookForCommands) MutateFunc() admission.MutatingWebhookFunc {
 	return w.admissionFunc
 }
 

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -726,7 +726,7 @@ func injectCWSVolume(pod *corev1.Pod) {
 		VolumeSource: volumeSource,
 	})
 
-	common.MarkVolumeAsSafeToEvictForAutoscaler(pod, cwsVolumeName)
+	mutatecommon.MarkVolumeAsSafeToEvictForAutoscaler(pod, cwsVolumeName)
 }
 
 func injectCWSVolumeMount(container *corev1.Container) {

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -100,7 +100,7 @@ func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *
 }
 
 // MutateFunc returns the function that mutates the resources
-func (w *Webhook) MutateFunc() admission.WebhookFunc {
+func (w *Webhook) MutateFunc() admission.MutatingWebhookFunc {
 	return w.mutate
 }
 

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -45,7 +45,6 @@ const webhookName = "standard_tags"
 // Webhook is the webhook that injects DD_ENV, DD_VERSION, DD_SERVICE env vars
 type Webhook struct {
 	name            string
-	webhookType     common.WebhookType
 	isEnabled       bool
 	endpoint        string
 	resources       []string
@@ -59,7 +58,6 @@ type Webhook struct {
 func NewWebhook(wmeta workloadmeta.Component, injectionFilter mutatecommon.InjectionFilter) *Webhook {
 	return &Webhook{
 		name:            webhookName,
-		webhookType:     common.MutatingWebhook,
 		isEnabled:       pkgconfigsetup.Datadog().GetBool("admission_controller.inject_tags.enabled"),
 		endpoint:        pkgconfigsetup.Datadog().GetString("admission_controller.inject_tags.endpoint"),
 		resources:       []string{"pods"},
@@ -77,7 +75,7 @@ func (w *Webhook) Name() string {
 
 // WebhookType returns the type of the webhook
 func (w *Webhook) WebhookType() common.WebhookType {
-	return w.webhookType
+	return common.MutatingWebhook
 }
 
 // IsEnabled returns whether the webhook is enabled

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -95,11 +95,13 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa wo
 	if v1Enabled {
 		informers[apiserver.ValidatingWebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
 		informers[apiserver.MutatingWebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-		getWebhookStatus = getWebhookStatusV1
+		getValidatingWebhookStatus = getValidatingWebhookStatusV1
+		getMutatingWebhookStatus = getMutatingWebhookStatusV1
 	} else {
 		informers[apiserver.ValidatingWebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations().Informer()
 		informers[apiserver.MutatingWebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1beta1().MutatingWebhookConfigurations().Informer()
-		getWebhookStatus = getWebhookStatusV1beta1
+		getValidatingWebhookStatus = getValidatingWebhookStatusV1beta1
+		getMutatingWebhookStatus = getMutatingWebhookStatusV1beta1
 	}
 
 	webhooks = append(webhooks, webhookController.EnabledWebhooks()...)

--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -40,11 +40,12 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	status["WebhookName"] = webhookName
 	status["SecretName"] = fmt.Sprintf("%s/%s", ns, secretName)
 
-	webhookStatus, err := getWebhookStatus(webhookName, apiCl)
+	validatingWebhookStatus, mutatingWebhookStatus, err := getWebhookStatus(webhookName, apiCl)
 	if err != nil {
 		status["WebhookError"] = err.Error()
 	} else {
-		status["Webhooks"] = webhookStatus
+		status["ValidatingWebhooks"] = validatingWebhookStatus
+		status["MutatingWebhooks"] = mutatingWebhookStatus
 	}
 
 	secretStatus, err := getSecretStatus(ns, secretName, apiCl)
@@ -57,24 +58,27 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	return status
 }
 
-var getWebhookStatus = func(string, kubernetes.Interface) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("admission controller not started")
+var getWebhookStatus = func(string, kubernetes.Interface) (map[string]interface{}, map[string]interface{}, error) {
+	return nil, nil, fmt.Errorf("admission controller not started")
 }
 
-func getWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	webhookStatus := make(map[string]interface{})
-	webhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+func getWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]interface{}, map[string]interface{}, error) {
+	validatingWebhookStatus, mutatingWebhookStatus := make(map[string]interface{}), make(map[string]interface{})
+	validatingWebhook, err := apiCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		return webhookStatus, err
+		return validatingWebhookStatus, mutatingWebhookStatus, err
+	}
+	mutatingWebhook, err := apiCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return validatingWebhookStatus, mutatingWebhookStatus, err
 	}
 
-	webhookStatus["Name"] = webhook.GetName()
-	webhookStatus["CreatedAt"] = webhook.GetCreationTimestamp()
-
-	webhooksConfig := make(map[string]map[string]interface{})
-	webhookStatus["Webhooks"] = webhooksConfig
-	for _, w := range webhook.Webhooks {
-		webhooksConfig[w.Name] = make(map[string]interface{})
+	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
+	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
+	validatingWebhooksConfig := make(map[string]map[string]interface{})
+	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
+	for _, w := range validatingWebhook.Webhooks {
+		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
 		svc := w.ClientConfig.Service
 		if svc != nil {
 			port := "Port: None (default 443)"
@@ -85,33 +89,23 @@ func getWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[strin
 			if svc.Path != nil {
 				path = fmt.Sprintf("Path: %s", *svc.Path)
 			}
-			webhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
 		}
 		if w.ObjectSelector != nil {
-			webhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
 		}
 		for i, r := range w.Rules {
-			webhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
 		}
-		webhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
-	}
-	return webhookStatus, nil
-}
-
-func getWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	webhookStatus := make(map[string]interface{})
-	webhook, err := apiCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return webhookStatus, err
+		validatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
 	}
 
-	webhookStatus["Name"] = webhook.GetName()
-	webhookStatus["CreatedAt"] = webhook.GetCreationTimestamp()
-
-	webhooksConfig := make(map[string]map[string]interface{})
-	webhookStatus["Webhooks"] = webhooksConfig
-	for _, w := range webhook.Webhooks {
-		webhooksConfig[w.Name] = make(map[string]interface{})
+	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
+	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
+	mutatingWebhooksConfig := make(map[string]map[string]interface{})
+	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
+	for _, w := range mutatingWebhook.Webhooks {
+		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
 		svc := w.ClientConfig.Service
 		if svc != nil {
 			port := "Port: None (default 443)"
@@ -122,17 +116,84 @@ func getWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]int
 			if svc.Path != nil {
 				path = fmt.Sprintf("Path: %s", *svc.Path)
 			}
-			webhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
 		}
 		if w.ObjectSelector != nil {
-			webhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
 		}
 		for i, r := range w.Rules {
-			webhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
 		}
-		webhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
+		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
 	}
-	return webhookStatus, nil
+	return validatingWebhookStatus, mutatingWebhookStatus, nil
+}
+
+func getWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[string]interface{}, map[string]interface{}, error) {
+	validatingWebhookStatus, mutatingWebhookStatus := make(map[string]interface{}), make(map[string]interface{})
+	validatingWebhook, err := apiCl.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return validatingWebhookStatus, mutatingWebhookStatus, err
+	}
+	mutatingWebhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return validatingWebhookStatus, mutatingWebhookStatus, err
+	}
+
+	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
+	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
+	validatingWebhooksConfig := make(map[string]map[string]interface{})
+	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
+	for _, w := range validatingWebhook.Webhooks {
+		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = fmt.Sprintf("Path: %s", *svc.Path)
+			}
+			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		validatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
+	}
+
+	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
+	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
+	mutatingWebhooksConfig := make(map[string]map[string]interface{})
+	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
+	for _, w := range mutatingWebhook.Webhooks {
+		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = fmt.Sprintf("Path: %s", *svc.Path)
+			}
+			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
+	}
+	return validatingWebhookStatus, mutatingWebhookStatus, nil
 }
 
 func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {

--- a/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
+++ b/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
@@ -5,16 +5,17 @@
   Disabled: {{ .admissionWebhook.Disabled }}
   {{ else }}
   {{ if .admissionWebhook.WebhookError }}
-  MutatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
+  ValidatingWebhookConfigurations and MutatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
   Error: {{ .admissionWebhook.WebhookError }}
-  {{- end }}
-  {{- if .admissionWebhook.Webhooks }}
+  {{ else }}
     Webhooks info
     -------------
-      MutatingWebhookConfigurations name: {{ .admissionWebhook.Webhooks.Name }}
-      Created at: {{ .admissionWebhook.Webhooks.CreatedAt }}
+  {{- end }}
+  {{if .admissionWebhook.ValidatingWebhooks }}
+      ValidatingWebhookConfigurations name: {{ .admissionWebhook.ValidatingWebhooks.Name }}
+      Created at: {{ .admissionWebhook.ValidatingWebhooks.CreatedAt }}
 
-      {{- range $name, $config := .admissionWebhook.Webhooks.Webhooks }}
+      {{- range $name, $config := .admissionWebhook.ValidatingWebhooks.Webhooks }}
       ---------
         Name: {{ $name }}
         {{- range $k, $v := $config }}
@@ -22,6 +23,18 @@
         {{- end }}
       {{- end }}
   {{- end }}
+  {{if .admissionWebhook.MutatingWebhooks }}
+      MutatingWebhookConfigurations name: {{ .admissionWebhook.MutatingWebhooks.Name }}
+      Created at: {{ .admissionWebhook.MutatingWebhooks.CreatedAt }}
+
+      {{- range $name, $config := .admissionWebhook.MutatingWebhooks.Webhooks }}
+      ---------
+        Name: {{ $name }}
+        {{- range $k, $v := $config }}
+        {{$k}}: {{$v}}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   {{ if .admissionWebhook.SecretError }}
   Secret name: {{ .admissionWebhook.SecretName }}
   Error: {{ .admissionWebhook.SecretError }}

--- a/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
+++ b/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
@@ -4,14 +4,12 @@
   {{- if .admissionWebhook.Disabled }}
   Disabled: {{ .admissionWebhook.Disabled }}
   {{ else }}
-  {{ if .admissionWebhook.WebhookError }}
-  ValidatingWebhookConfigurations and MutatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
-  Error: {{ .admissionWebhook.WebhookError }}
-  {{ else }}
     Webhooks info
     -------------
-  {{- end }}
-  {{if .admissionWebhook.ValidatingWebhooks }}
+    {{ if .admissionWebhook.ValidatingWebhookError }}
+      ValidatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
+      Error: {{ .admissionWebhook.ValidatingWebhookError }}
+    {{else if .admissionWebhook.ValidatingWebhooks }}
       ValidatingWebhookConfigurations name: {{ .admissionWebhook.ValidatingWebhooks.Name }}
       Created at: {{ .admissionWebhook.ValidatingWebhooks.CreatedAt }}
 
@@ -22,8 +20,11 @@
         {{$k}}: {{$v}}
         {{- end }}
       {{- end }}
-  {{- end }}
-  {{if .admissionWebhook.MutatingWebhooks }}
+    {{- end }}
+    {{ if .admissionWebhook.MutatingWebhookError }}
+      MutatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
+      Error: {{ .admissionWebhook.MutatingWebhookError }}
+    {{else if .admissionWebhook.MutatingWebhooks }}
       MutatingWebhookConfigurations name: {{ .admissionWebhook.MutatingWebhooks.Name }}
       Created at: {{ .admissionWebhook.MutatingWebhooks.CreatedAt }}
 

--- a/pkg/clusteragent/admission/validate/common/common.go
+++ b/pkg/clusteragent/admission/validate/common/common.go
@@ -27,13 +27,13 @@ type ValidationFunc func(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool
 func Validate(rawPod []byte, ns string, webhookName string, v ValidationFunc, dc dynamic.Interface) (bool, error) {
 	var pod corev1.Pod
 	if err := json.Unmarshal(rawPod, &pod); err != nil {
-		return false, fmt.Errorf("failed to decode raw object: %v", err)
+		return false, fmt.Errorf("failed to decode raw object: %w", err)
 	}
 
 	validated, err := v(&pod, ns, dc)
 	if err != nil {
 		metrics.ValidationAttempts.Inc(webhookName, metrics.StatusError, strconv.FormatBool(false), err.Error())
-		return false, fmt.Errorf("failed to validate pod: %v", err)
+		return false, fmt.Errorf("failed to validate pod: %w", err)
 	}
 
 	metrics.ValidationAttempts.Inc(webhookName, metrics.StatusSuccess, strconv.FormatBool(validated), "")

--- a/pkg/clusteragent/admission/validate/common/common.go
+++ b/pkg/clusteragent/admission/validate/common/common.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package common provides functions used by several mutating webhooks
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
+)
+
+// ValidationFunc is a function that validates a pod
+type ValidationFunc func(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error)
+
+// Validate handles validating pods and encoding and decoding admission
+// requests and responses for the public validate functions
+func Validate(rawPod []byte, ns string, webhookName string, v ValidationFunc, dc dynamic.Interface) (bool, error) {
+	var pod corev1.Pod
+	if err := json.Unmarshal(rawPod, &pod); err != nil {
+		return false, fmt.Errorf("failed to decode raw object: %v", err)
+	}
+
+	validated, err := v(&pod, ns, dc)
+	if err != nil {
+		metrics.ValidationAttempts.Inc(webhookName, metrics.StatusError, strconv.FormatBool(false), err.Error())
+		return false, fmt.Errorf("failed to validate pod: %v", err)
+	}
+
+	metrics.ValidationAttempts.Inc(webhookName, metrics.StatusSuccess, strconv.FormatBool(validated), "")
+	return validated, nil
+}

--- a/pkg/clusteragent/admission/validate/doc.go
+++ b/pkg/clusteragent/admission/validate/doc.go
@@ -5,27 +5,24 @@
 
 //go:build kubeapiserver
 
-// Package mutate contains mutating webhooks registered in the admission
+// Package validate contains validating webhooks registered in the admission
 // controller.
 //
-// The general idea of mutating webhooks is to intercept requests to the
-// Kubernetes API server and modify the Kubernetes objects before the operation
-// specified in the request is applied. For example, a mutating webhook can be
-// configured to receive all the requests about creating or updating a pod, and
-// modify the pod to enforce some defaults. A typical example is to intercept
-// requests to create a pod and add some environment variables or volumes to the
-// pod to enable some functionality automatically. This saves the user from
-// having to add environment variables or volumes manually on each pod in their
-// cluster.
-// To learn more about mutating webhooks, see the official Kubernetes documentation:
+// The general idea of validating webhooks is to intercept requests to the
+// Kubernetes API server and either admit or refuse the Kubernetes request before the operation
+// specified in the request is applied. For example, a validating webhook can be
+// configured to receive all the requests about creating or updating a pod, and refuse pod creation
+// if they don't respect specific rules. Validating webhooks can be used to
+// enforce security policies, best practices, etc.
+// To learn more about validating webhooks, see the official Kubernetes documentation:
 // https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 //
-// In general, each mutating webhook should be implemented in its own Go
+// In general, each validating webhook should be implemented in its own Go
 // package. If there are some related webhooks that share some code, they can be
 // grouped in the same package. For example, the CWS webhooks are all in the
 // same package.
 //
-// Each mutating webhook needs to implement the "Webhook" interface.
+// Each validating webhook needs to implement the "Webhook" interface.
 // Here's a brief description of each function and what they are used for:
 // - Name: it's the name of the webhook. It's used to identify it. The name
 // appears in some telemetry tags.
@@ -48,9 +45,9 @@
 // in the "common" package.
 // - WebhookFunc: the function that runs the logic of the webhook and returns the admission response.
 //
-// As any other feature, mutating webhooks can be configured using the Datadog
+// As any other feature, validating webhooks can be configured using the Datadog
 // configuration. When adding new configuration parameters, please try to follow
-// the convention of the other mutating webhooks. The configuration parameters
+// the convention of the other validating webhooks. The configuration parameters
 // for a webhook should be under the "admission_controller.name_of_the_webhook"
 // key.
 //
@@ -62,12 +59,12 @@
 // webhooks are executed is the order in which they are returned by the
 // "generateWebhooks" function in the "webhook" package.
 //
-// Mutating webhooks emit telemetry metrics. Each webhook can define its own
-// metrics as needed but some metrics like "mutation_attempts" or
+// Validating webhooks emit telemetry metrics. Each webhook can define its own
+// metrics as needed but some metrics like "validation_attempts" or
 // "webhooks_received" are common to all webhooks and defined in common code, so
 // new webhooks can use them without having to define them again.
 //
 // When implementing a new webhook keep performance in mind. For instance, if
 // the webhook reacts upon the creation of a new pod, it could slow down the pod
 // creation process.
-package mutate
+package validate

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1736,7 +1736,7 @@ api_key:
   #  enabled: false
 {{- if (eq .OS "linux")}}
 
- 
+
   # container_image:
   #   enabled: false
 {{ end -}}
@@ -2911,6 +2911,28 @@ api_key:
   ## Set to true to enable the admission controller in the cluster-agent.
   #
   # enabled: false
+
+  ## @param validation - custom object - optional
+  ## The admission controller's validation configuration.
+  #
+  # validation:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_ADMISSION_CONTROLLER_VALIDATION_ENABLED - boolean - optional - default: true
+    ## Set to true to enable validation webhooks controller in the cluster-agent.
+    #
+    # enabled: true
+
+  ## @param mutation - custom object - optional
+  ## The admission controller's mutation configuration.
+  #
+  # mutation:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_ADMISSION_CONTROLLER_MUTATION_ENABLED - boolean - optional - default: true
+    ## Set to true to enable mutation webhooks controller in the cluster-agent.
+    #
+    # enabled: true
 
   ## @param mutate_unlabelled - boolean - optional - default: false
   ## @env DD_ADMISSION_CONTROLLER_MUTATE_ENABLED - boolean - optional - default: false

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -705,6 +705,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
+	config.BindEnvAndSetDefault("admission_controller.validation.enabled", true)
+	config.BindEnvAndSetDefault("admission_controller.mutation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
 	config.BindEnvAndSetDefault("admission_controller.container_registry", "gcr.io/datadoghq")

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -13,6 +13,6 @@ type InformerName string
 const (
 	// SecretsInformer holds the name of the informer
 	SecretsInformer InformerName = "v1/secrets"
-	// WebhooksInformer holds the name of the informer
-	WebhooksInformer InformerName = "admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
+	// MutatingWebhooksInformer holds the name of the mutating webhook informer
+	MutatingWebhooksInformer InformerName = "admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
 )

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -13,6 +13,8 @@ type InformerName string
 const (
 	// SecretsInformer holds the name of the informer
 	SecretsInformer InformerName = "v1/secrets"
+	// ValidatingWebhooksInformer holds the name of the validating webhook informer
+	ValidatingWebhooksInformer InformerName = "admissionregistration.k8s.io/v1/validatingwebhookconfigurations"
 	// MutatingWebhooksInformer holds the name of the mutating webhook informer
 	MutatingWebhooksInformer InformerName = "admissionregistration.k8s.io/v1/mutatingwebhookconfigurations"
 )

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -23,6 +23,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// SyncInformersError represents an Informer synchronization error.
+type SyncInformersError struct {
+	Name InformerName
+}
+
+// Error returns the error message.
+func (e *SyncInformersError) Error() string {
+	return fmt.Sprintf("couldn't sync informer %s", e.Name)
+}
+
 // SyncInformers should be called after the instantiation of new informers.
 // It's blocking until the informers are synced or the timeout exceeded.
 // An extra timeout duration can be provided depending on the informer
@@ -42,7 +52,7 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 				end := time.Now()
 				cacheSyncTimeouts.Inc()
 				log.Warnf("couldn't sync informer %s in %v (kube_cache_sync_timeout_seconds: %v)", name, end.Sub(start), timeoutConfig)
-				return fmt.Errorf("couldn't sync informer %s in %v", name, end.Sub(start))
+				return &SyncInformersError{name}
 			}
 			log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Since(start), informers[name].LastSyncResourceVersion())
 			return nil

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -35,7 +35,7 @@ func (e *SyncInformersError) Error() string {
 
 // SyncInformers should be called after the instantiation of new informers.
 // It's blocking until the informers are synced or the timeout exceeded.
-// An extra timeout duration can be provided depending on the informer
+// An extra timeout duration can be provided depending on the informer.
 func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) error {
 	var g errgroup.Group
 	timeoutConfig := pkgconfigsetup.Datadog().GetDuration("kube_cache_sync_timeout_seconds") * time.Second


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR implements [ValidatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) in the Cluster Agent.

### Motivation

Support for `ValidatingAdmissionWebhook` is needed for future Cluster Agent features.

### Additional Notes

This PR also refactors heavily the Admission Controller to avoid code duplication between `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook`.

### Describe how to test/QA your changes

QA was done by using a custom version of this PR that contains a basic Validation Webhook called `alwaysadmit` that works the same way as this [default webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwaysadmit). Note that I've sometime modified this webhook to actually also be an `alwaysdeny` webhook for testing purposes. It will not be a part of the Datadog Agent.

I also used this [custom branch of the Operator](https://github.com/DataDog/datadog-operator/tree/CONTP-378/wassim.dhif/implement-validating-admission-webhook) that give the Cluster Agent the correct RBACs to be able to create, edit and delete the Validation Admission Webhooks. This will be merged and done for the Datadog Helm Charts too.

#### Without the correct RBACs for `ValidatingWebhookConfigurations`

```
➜ k exec -it deployments/datadog-cluster-agent -- agent status
[...]
====================
Admission Controller
====================

    Webhooks info
    -------------

      ValidatingWebhookConfigurations name: datadog-webhook
      Error: validatingwebhookconfigurations.admissionregistration.k8s.io "datadog-webhook" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "validatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope


      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-09-02 09:28:31 +0000 UTC
      ---------
        Name: datadog.webhook.agent.config
        CA bundle digest: 3d87ba8d81bd3bac
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-admission-controller - Port: 443 - Path: /injectconfig
      ---------
        Name: datadog.webhook.lib.injection
        CA bundle digest: 3d87ba8d81bd3bac
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-admission-controller - Port: 443 - Path: /injectlib
      ---------
        Name: datadog.webhook.standard.tags
        CA bundle digest: 3d87ba8d81bd3bac
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-admission-controller - Port: 443 - Path: /injecttags
```
The MutatingAdmissionWebhook still works as expected but the ValidatingAdmissionWebhook are disabled.
```
➜ k logs deployments/datadog-cluster-agent | grep "couldn't sync informer"
2024-09-02 09:28:31 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:44 in func1) | couldn't sync informer admissionregistration.k8s.io/v1/validatingwebhookconfigurations in 5.001327878s (kube_cache_sync_timeout_seconds: 5s)
2024-09-02 09:28:31 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/controllers/webhook/controller_v1.go:86 in NewControllerV1) | Disabling validation webhook controller: couldn't sync informer admissionregistration.k8s.io/v1/validatingwebhookconfigurations in 5.001327878s
2024-09-02 09:28:36 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:44 in func1) | couldn't sync informer admissionregistration.k8s.io/v1/validatingwebhookconfigurations in 5.001771294s (kube_cache_sync_timeout_seconds: 5s)
2024-09-02 09:28:36 UTC | CLUSTER | WARN | (subcommands/start/command.go:483 in start) | Admission controller started with errors: couldn't sync informer admissionregistration.k8s.io/v1/validatingwebhookconfigurations in 5.001771294s
```

#### With the correct RBACs for `ValidatingWebhookConfigurations`

With both ValidatingAdmissionWebhook and MutatingAdmissionWebhook disabled.
```
    Webhooks info
    -------------

      ValidatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-08-27 09:03:49 +0000 UTC

      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-08-27 09:03:49 +0000 UTC
```

By default or with it enabled:
```
      ValidatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-08-27 09:03:49 +0000 UTC
      ---------
        Name: datadog.webhook.always.admit
[...]
      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-08-27 09:03:49 +0000 UTC
      ---------
        Name: datadog.webhook.agent.config
[...]
      ---------
        Name: datadog.webhook.lib.injection
[...]
      ---------
        Name: datadog.webhook.standard.tags
[...]
```
```
➜ k describe validatingwebhookconfigurations.admissionregistration.k8s.io datadog-webhook | grep datadog.webhook.
  Name:            datadog.webhook.always.admit
➜ k describe mutatingwebhookconfigurations.admissionregistration.k8s.io datadog-webhook | grep datadog.webhook.
  Name:            datadog.webhook.agent.config
  Name:            datadog.webhook.standard.tags
  Name:            datadog.webhook.lib.injection
```

When `alwaysadmit` returns `true` and log a specific message:
```
➜ k apply -f workloads/nginx.yaml
deployment.apps/nginx created
➜ k get pod | grep nginx
nginx-794d7f6dd5-wx9q6                           1/1     Running   0          66s
➜ k logs deployments/datadog-cluster-agent | grep "Pod validation webhook"
2024-08-27 15:36:03 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always admitting pods
```

When modifying the Cluster Agent with an `alwaysadmit` webhook that returns `false` and log a specific message, and re-deploying the Agent:
```
➜ k describe replicasets/nginx-794d7f6dd5 | grep -A 3 Events
Events:
  Type     Reason        Age                 From                   Message
  ----     ------        ----                ----                   -------
  Warning  FailedCreate  12s (x14 over 53s)  replicaset-controller  Error creating: admission webhook "datadog.webhook.always.admit" denied the request without explanation
➜ k logs deployments/datadog-cluster-agent | grep "Pod validation webhook"
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:05 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:06 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:06 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:08 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:10 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:15 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:26 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:45:46 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
2024-08-27 15:46:27 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always refusing pods
```

When keeping the same behaviour but changing the endpoint of the `alwaysadmit` webhook to validate webhook updates.
Before
```
➜ k describe validatingwebhookconfigurations.admissionregistration.k8s.io datadog-webhook
Name:         datadog-webhook
[...]
API Version:  admissionregistration.k8s.io/v1
Kind:         ValidatingWebhookConfiguration
Metadata:
  Creation Timestamp:  2024-08-27T15:27:43Z
  Generation:          1
  Resource Version:    1763
  UID:                 fd7e11e6-7bb1-4391-8059-8ce4a71bac60
[...]
    Service:
      Name:        datadog-admission-controller
      Namespace:   system
      Path:        /always-admit
      Port:        443
  Failure Policy:  Ignore
  Match Policy:    Exact
  Name:            datadog.webhook.always.admit
```
After
```
➜  datadog-dev git:(main) ✗ k describe validatingwebhookconfigurations.admissionregistration.k8s.io datadog-webhook
Name:         datadog-webhook
[...]
API Version:  admissionregistration.k8s.io/v1
Kind:         ValidatingWebhookConfiguration
Metadata:
  Creation Timestamp:  2024-08-27T15:27:43Z
  Generation:          2
  Resource Version:    4519
  UID:                 fd7e11e6-7bb1-4391-8059-8ce4a71bac60
[...]
    Service:
      Name:        datadog-admission-controller
      Namespace:   system
      Path:        /always-deny
      Port:        443
  Failure Policy:  Ignore
  Match Policy:    Exact
  Name:            datadog.webhook.always.admit
```

Webhook still works as expected, in this case, by always denying.
```
➜ k logs deployments/datadog-cluster-agent | grep "Pod validation webhook"
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:40 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:41 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:41 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:43 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
2024-08-27 16:00:45 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/validate/alwaysadmit/alwaysadmit.go:94 in 1) | Pod validation webhook always_admit is always denies pods
```