### PR TITLE
Add a quality gate for idle experiment memory usage

### DIFF
--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -1,3 +1,6 @@
+# Agent 'out of the box' idle experiment. Represents an agent install with the
+# default configuration and no active workload.
+
 optimization_goal: memory
 erratic: false
 
@@ -25,3 +28,10 @@ target:
     DD_PROFILING_WAIT_PROFILE: true
 
     DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:idle
+
+checks:
+  - name: memory_usage
+    description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
+    bounds:
+      series: total_rss_bytes
+      upper_bound: "424.0 MiB"


### PR DESCRIPTION
### What does this PR do?

Add a total memory bounds check to the `idle` SMP experiment. This will be used as a starting point for [Agent Quality Gates](https://datadoghq.atlassian.net/wiki/spaces/SMP/pages/3853091678/Agent+Quality+Gates).

### Motivation

See the Agent Quality Gates doc.

### Additional Notes

I wrote up a notebook [here](https://app.datadoghq.com/notebook/9360486/starting-point-for-agents-quality-gates) with justification for the selected threshold.

### Describe how to test/QA your changes

This will show up in the Regression Detector PR report in a new 'Bounds Check' section. It will also run nightly and be triaged by the SMP team as part of the Agent Quality Gates project.