### PR TITLE
Make converter optional

### DIFF
--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -129,8 +129,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	}
 	addFactories(reqs, factories)
 
-	converterEnabled := reqs.Config.Get("otelcollector.converter.enabled").(bool)
-
+	converterEnabled := reqs.Config.GetBool("otelcollector.converter.enabled")
 	err = reqs.ConfigStore.AddConfigs(newConfigProviderSettings(reqs, false), newConfigProviderSettings(reqs, converterEnabled), factories)
 	if err != nil {
 		return Provides{}, err

--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -59,6 +60,7 @@ type Requires struct {
 	Log                 log.Component
 	Provider            confmap.Converter
 	ConfigStore         configstore.Component
+	Config              config.Component
 	CollectorContrib    collectorcontrib.Component
 	Serializer          serializer.MetricSerializer
 	TraceAgent          traceagent.Component
@@ -127,7 +129,9 @@ func NewComponent(reqs Requires) (Provides, error) {
 	}
 	addFactories(reqs, factories)
 
-	err = reqs.ConfigStore.AddConfigs(newConfigProviderSettings(reqs, false), newConfigProviderSettings(reqs, true), factories)
+	converterEnabled := reqs.Config.Get("otelcollector.converter.enabled").(bool)
+
+	err = reqs.ConfigStore.AddConfigs(newConfigProviderSettings(reqs, false), newConfigProviderSettings(reqs, converterEnabled), factories)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -148,7 +152,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		Factories: func() (otelcol.Factories, error) {
 			return factories, nil
 		},
-		ConfigProviderSettings: newConfigProviderSettings(reqs, true),
+		ConfigProviderSettings: newConfigProviderSettings(reqs, converterEnabled),
 	}
 	col, err := otelcol.NewCollector(set)
 	if err != nil {

--- a/comp/otelcol/collector/impl/collector_test.go
+++ b/comp/otelcol/collector/impl/collector_test.go
@@ -17,7 +17,7 @@ import (
 	collectorcontribimpl "github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl"
 	configstore "github.com/DataDog/datadog-agent/comp/otelcol/configstore/impl"
 	converter "github.com/DataDog/datadog-agent/comp/otelcol/converter/impl"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"gopkg.in/yaml.v3"
@@ -121,9 +121,9 @@ func TestGetConfDumpConverterDisabled(t *testing.T) {
 	provider, err := converter.NewConverter()
 	assert.NoError(t, err)
 
-	conf := config.Datadog()
+	conf := setup.Datadog()
 	conf.SetWithoutSource("otelcollector.converter.enabled", false)
-	
+
 	reqs := Requires{
 		CollectorContrib: collectorcontribimpl.NewComponent(),
 		Config:           conf,

--- a/comp/otelcol/collector/impl/collector_test.go
+++ b/comp/otelcol/collector/impl/collector_test.go
@@ -47,8 +47,11 @@ func TestGetConfDump(t *testing.T) {
 	provider, err := converter.NewConverter()
 	assert.NoError(t, err)
 
+	conf := setup.Datadog()
+
 	reqs := Requires{
 		CollectorContrib: collectorcontribimpl.NewComponent(),
+		Config: conf,
 		URIs:             uriFromFile("simple-dd/config.yaml"),
 		ConfigStore:      configstore,
 		Lc:               &lifecycle{},

--- a/comp/otelcol/collector/impl/collector_test.go
+++ b/comp/otelcol/collector/impl/collector_test.go
@@ -51,7 +51,7 @@ func TestGetConfDump(t *testing.T) {
 
 	reqs := Requires{
 		CollectorContrib: collectorcontribimpl.NewComponent(),
-		Config: conf,
+		Config:           conf,
 		URIs:             uriFromFile("simple-dd/config.yaml"),
 		ConfigStore:      configstore,
 		Lc:               &lifecycle{},

--- a/comp/otelcol/collector/impl/collector_test.go
+++ b/comp/otelcol/collector/impl/collector_test.go
@@ -17,6 +17,7 @@ import (
 	collectorcontribimpl "github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl"
 	configstore "github.com/DataDog/datadog-agent/comp/otelcol/configstore/impl"
 	converter "github.com/DataDog/datadog-agent/comp/otelcol/converter/impl"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"gopkg.in/yaml.v3"
@@ -106,6 +107,84 @@ func TestGetConfDump(t *testing.T) {
 		assert.NoError(t, err)
 
 		expectedMap, err := confmaptest.LoadConf("testdata/simple-dd/config-enhanced-result.yaml")
+		expectedStringMap := expectedMap.ToStringMap()
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedStringMap, actualStringMap)
+	})
+}
+
+func TestGetConfDumpConverterDisabled(t *testing.T) {
+	configstore, err := configstore.NewConfigStore()
+	assert.NoError(t, err)
+
+	provider, err := converter.NewConverter()
+	assert.NoError(t, err)
+
+	conf := config.Datadog()
+	conf.SetWithoutSource("otelcollector.converter.enabled", false)
+	
+	reqs := Requires{
+		CollectorContrib: collectorcontribimpl.NewComponent(),
+		Config:           conf,
+		URIs:             uriFromFile("simple-dd/config.yaml"),
+		ConfigStore:      configstore,
+		Lc:               &lifecycle{},
+		Provider:         provider,
+	}
+	_, err = NewComponent(reqs)
+	assert.NoError(t, err)
+
+	t.Run("provided-string", func(t *testing.T) {
+		actualString, _ := configstore.GetProvidedConfAsString()
+		actualStringMap, err := yamlBytesToMap([]byte(actualString))
+		assert.NoError(t, err)
+
+		expectedBytes, err := os.ReadFile(filepath.Join("testdata", "simple-dd", "config-provided-result.yaml"))
+		assert.NoError(t, err)
+		expectedMap, err := yamlBytesToMap(expectedBytes)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedMap, actualStringMap)
+	})
+
+	t.Run("provided-confmap", func(t *testing.T) {
+		actualConfmap, _ := configstore.GetProvidedConf()
+		// marshal to yaml and then to map to drop the types for comparison
+		bytesConf, err := yaml.Marshal(actualConfmap.ToStringMap())
+		assert.NoError(t, err)
+		actualStringMap, err := yamlBytesToMap(bytesConf)
+		assert.NoError(t, err)
+
+		expectedMap, err := confmaptest.LoadConf("testdata/simple-dd/config-provided-result.yaml")
+		expectedStringMap := expectedMap.ToStringMap()
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedStringMap, actualStringMap)
+	})
+
+	t.Run("enhanced-string", func(t *testing.T) {
+		actualString, _ := configstore.GetEnhancedConfAsString()
+		actualStringMap, err := yamlBytesToMap([]byte(actualString))
+		assert.NoError(t, err)
+
+		expectedBytes, err := os.ReadFile(filepath.Join("testdata", "simple-dd", "config-provided-result.yaml"))
+		assert.NoError(t, err)
+		expectedMap, err := yamlBytesToMap(expectedBytes)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedMap, actualStringMap)
+	})
+
+	t.Run("enhance-confmap", func(t *testing.T) {
+		actualConfmap, _ := configstore.GetEnhancedConf()
+		// marshal to yaml and then to map to drop the types for comparison
+		bytesConf, err := yaml.Marshal(actualConfmap.ToStringMap())
+		assert.NoError(t, err)
+		actualStringMap, err := yamlBytesToMap(bytesConf)
+		assert.NoError(t, err)
+
+		expectedMap, err := confmaptest.LoadConf("testdata/simple-dd/config-provided-result.yaml")
 		expectedStringMap := expectedMap.ToStringMap()
 		assert.NoError(t, err)
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -837,6 +837,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("otelcollector.extension_url", "https://localhost:7777")
 	config.BindEnvAndSetDefault("otelcollector.extension_timeout", 0)         // in seconds, 0 for default value
 	config.BindEnvAndSetDefault("otelcollector.submit_dummy_metadata", false) // dev flag - to be removed
+	config.BindEnvAndSetDefault("otelcollector.converter.enabled", true)
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR makes the converter optional in OTel agent. It is enabled by default, but users now have an option to disable it in agent config.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent with the `otelcollector.converter.enabled` set to false (or via env `DD_OTELCOLLECTOR_CONVERTER_ENABLED=false` and ensure the collector config does not get enhanced)