### PR TITLE
Remove 'ResetSystemProbeConfig' function in favor of the config mocks

### DIFF
--- a/cmd/system-probe/config/adjust_npm_test.go
+++ b/cmd/system-probe/config/adjust_npm_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -28,8 +28,7 @@ func TestAdjustConnectionRollup(t *testing.T) {
 
 	for _, te := range tests {
 		t.Run(fmt.Sprintf("npm_enabled_%t_usm_enabled_%t", te.npmEnabled, te.usmEnabled), func(t *testing.T) {
-			config.ResetSystemProbeConfig(t)
-			cfg := config.SystemProbe()
+			cfg := mock.NewSystemProbe(t)
 			cfg.Set(netNS("enable_connection_rollup"), te.npmEnabled, model.SourceUnknown)
 			cfg.Set(smNS("enable_connection_rollup"), te.usmEnabled, model.SourceUnknown)
 			Adjust(cfg)

--- a/cmd/system-probe/config/config_linux_test.go
+++ b/cmd/system-probe/config/config_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestNetworkProcessEventMonitoring(t *testing.T) {
@@ -60,9 +61,8 @@ func TestDynamicInstrumentation(t *testing.T) {
 }
 
 func TestEventStreamEnabledForSupportedKernelsLinux(t *testing.T) {
-	config.ResetSystemProbeConfig(t)
 	t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-	cfg := config.SystemProbe()
+	cfg := mock.NewSystemProbe(t)
 	Adjust(cfg)
 
 	if ProcessEventDataStreamSupported() {

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -9,7 +9,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"strconv"
 	"testing"
@@ -18,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestEventMonitor(t *testing.T) {
@@ -65,9 +65,8 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 		if runtime.GOOS != "windows" {
 			t.Skip("This is only for windows")
 		}
-		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-		cfg := config.SystemProbe()
+		cfg := mock.NewSystemProbe(t)
 		Adjust(cfg)
 
 		require.False(t, cfg.GetBool("event_monitoring_config.network_process.enabled"))
@@ -76,9 +75,8 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 		if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
 			t.Skip("This is only for unsupported")
 		}
-		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(true))
-		cfg := config.SystemProbe()
+		cfg := mock.NewSystemProbe(t)
 		Adjust(cfg)
 
 		require.False(t, cfg.GetBool("event_monitoring_config.network_process.enabled"))
@@ -87,37 +85,19 @@ func TestEventStreamEnabledForSupportedKernelsWindowsUnsupported(t *testing.T) {
 
 func TestEnableDiscovery(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		config.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-discovery:
-  enabled: true
-`)
+		cfg := mock.NewSystemProbe(t)
+		cfg.SetWithoutSource("discovery.enabled", true)
 		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		config.ResetSystemProbeConfig(t)
 		t.Setenv("DD_DISCOVERY_ENABLED", "true")
-		assert.True(t, config.SystemProbe().GetBool(discoveryNS("enabled")))
+		cfg := mock.NewSystemProbe(t)
+		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
 	})
 
 	t.Run("default", func(t *testing.T) {
-		config.ResetSystemProbeConfig(t)
-		assert.False(t, config.SystemProbe().GetBool(discoveryNS("enabled")))
+		cfg := mock.NewSystemProbe(t)
+		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
 	})
-}
-
-func configurationFromYAML(t *testing.T, yaml string) config.Config {
-	f, err := os.CreateTemp(t.TempDir(), "system-probe.*.yaml")
-	require.NoError(t, err)
-	defer f.Close()
-
-	b := []byte(yaml)
-	n, err := f.Write(b)
-	require.NoError(t, err)
-	require.Equal(t, len(b), n)
-	f.Sync()
-
-	_, _ = New(f.Name(), "")
-	return config.SystemProbe()
 }

--- a/pkg/config/test_helpers.go
+++ b/pkg/config/test_helpers.go
@@ -8,9 +8,6 @@
 package config
 
 import (
-	"strings"
-	"testing"
-
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -21,19 +18,6 @@ var (
 	// SetFeaturesNoCleanup is alias from env
 	SetFeaturesNoCleanup = env.SetFeaturesNoCleanup
 
-	// SetupConf generates and returns a new configuration
-	SetupConf = pkgconfigsetup.Conf
-
 	// SetupConfFromYAML generates a configuration from the given yaml config
 	SetupConfFromYAML = pkgconfigsetup.ConfFromYAML
 )
-
-// ResetSystemProbeConfig resets the configuration.
-func ResetSystemProbeConfig(t *testing.T) {
-	originalConfig := pkgconfigsetup.SystemProbe()
-	t.Cleanup(func() {
-		pkgconfigsetup.SetSystemProbe(originalConfig)
-	})
-	pkgconfigsetup.SetSystemProbe(NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")))
-	pkgconfigsetup.InitSystemProbeConfig(pkgconfigsetup.SystemProbe())
-}

--- a/pkg/network/config/config_linux_test.go
+++ b/pkg/network/config/config_linux_test.go
@@ -9,15 +9,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netns"
-
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestDisableRootNetNamespace(t *testing.T) {
-	aconfig.ResetSystemProbeConfig(t)
 	t.Setenv("DD_NETWORK_CONFIG_ENABLE_ROOT_NETNS", "false")
+	mock.NewSystemProbe(t)
 
 	cfg := New()
 	require.False(t, cfg.EnableConntrackAllNamespaces)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -20,8 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 // variables for testing config options
@@ -33,27 +32,23 @@ const (
 	invalidHTTPRequestFragment         = 600
 )
 
-func makeYamlConfigString(section, entry string, val int) string {
-	return fmt.Sprintf("\n%s:\n  %s: %d", section, entry, val)
-}
 func TestDisablingDNSInspection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-    enabled: true
-    disable_dns_inspection: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.disable_dns_inspection", true)
+		cfg := New()
 
 		assert.False(t, cfg.DNSInspection)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_DISABLE_DNS_INSPECTION", "true")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.DNSInspection)
 	})
@@ -61,21 +56,19 @@ system_probe_config:
 
 func TestDisablingProtocolClassification(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-    enable_protocol_classification: false
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.enable_protocol_classification", false)
+		cfg := New()
 
 		assert.False(t, cfg.ProtocolClassificationEnabled)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_ENABLE_PROTOCOL_CLASSIFICATION", "false")
+		cfg := New()
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.ProtocolClassificationEnabled)
 	})
@@ -83,21 +76,19 @@ network_config:
 
 func TestEnableHTTPStatsByStatusCode(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_http_stats_by_status_code: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_http_stats_by_status_code", true)
+		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPStatsByStatusCode)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_STATS_BY_STATUS_CODE", "true")
+		cfg := New()
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPStatsByStatusCode)
 	})
@@ -105,107 +96,98 @@ service_monitoring_config:
 
 func TestEnableHTTPMonitoring(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  enable_http_monitoring: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.enable_http_monitoring", true)
+		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
+		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_http_monitoring: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_http_monitoring", true)
+		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
+		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "false")
+		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "false")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
+		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
+		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
-
 		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 }
 
 func TestEnableJavaTLSSupport(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    java:
-      enabled: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.java.enabled", true)
+		cfg := New()
+
 		require.True(t, cfg.EnableJavaTLSSupport)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_JAVA_ENABLED", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableJavaTLSSupport)
@@ -215,21 +197,20 @@ service_monitoring_config:
 
 func TestEnableHTTP2Monitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_http2_monitoring: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_http2_monitoring", true)
+		cfg := New()
 
 		assert.True(t, cfg.EnableHTTP2Monitoring)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING", "true")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableHTTP2Monitoring)
 	})
@@ -237,21 +218,20 @@ service_monitoring_config:
 
 func TestEnableKafkaMonitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_kafka_monitoring: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_kafka_monitoring", true)
+		cfg := New()
 
 		assert.True(t, cfg.EnableKafkaMonitoring)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_KAFKA_MONITORING", "true")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableKafkaMonitoring)
 	})
@@ -259,27 +239,26 @@ service_monitoring_config:
 
 func TestEnablePostgresMonitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_postgres_monitoring: true
-`)
-
-		assert.True(t, cfg.EnablePostgresMonitoring)
-	})
-
-	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_POSTGRES_MONITORING", "true")
-		_, err := sysconfig.New("", "")
-		require.NoError(t, err)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_postgres_monitoring", true)
 		cfg := New()
 
 		assert.True(t, cfg.EnablePostgresMonitoring)
 	})
 
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_POSTGRES_MONITORING", "true")
+		cfg := New()
+
+		_, err := sysconfig.New("", "")
+		require.NoError(t, err)
+
+		assert.True(t, cfg.EnablePostgresMonitoring)
+	})
+
 	t.Run("default", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
 
 		assert.False(t, cfg.EnablePostgresMonitoring)
@@ -288,27 +267,26 @@ service_monitoring_config:
 
 func TestEnableRedisMonitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_redis_monitoring: true
-`)
-
-		assert.True(t, cfg.EnableRedisMonitoring)
-	})
-
-	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_REDIS_MONITORING", "true")
-		_, err := sysconfig.New("", "")
-		require.NoError(t, err)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_redis_monitoring", true)
 		cfg := New()
 
 		assert.True(t, cfg.EnableRedisMonitoring)
 	})
 
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_REDIS_MONITORING", "true")
+		cfg := New()
+
+		_, err := sysconfig.New("", "")
+		require.NoError(t, err)
+
+		assert.True(t, cfg.EnableRedisMonitoring)
+	})
+
 	t.Run("default", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
 
 		assert.False(t, cfg.EnableRedisMonitoring)
@@ -316,50 +294,47 @@ service_monitoring_config:
 }
 
 func TestDefaultDisabledJavaTLSSupport(t *testing.T) {
-	aconfig.ResetSystemProbeConfig(t)
+	mock.NewSystemProbe(t)
+	cfg := New()
 
 	_, err := sysconfig.New("", "")
 	require.NoError(t, err)
-	cfg := New()
 
 	assert.False(t, cfg.EnableJavaTLSSupport)
 }
 
 func TestDefaultDisabledHTTP2Support(t *testing.T) {
-	aconfig.ResetSystemProbeConfig(t)
+	mock.NewSystemProbe(t)
+	cfg := New()
 
 	_, err := sysconfig.New("", "")
 	require.NoError(t, err)
-	cfg := New()
 
 	assert.False(t, cfg.EnableHTTP2Monitoring)
 }
 
 func TestDisableGatewayLookup(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		cfg := New()
 		// default config
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.True(t, cfg.EnableGatewayLookup)
 
-		aconfig.ResetSystemProbeConfig(t)
-		cfg = configurationFromYAML(t, `
-network_config:
-  enable_gateway_lookup: false
-`)
+		mockSystemProbe.SetWithoutSource("network_config.enable_gateway_lookup", false)
+		cfg = New()
 
 		assert.False(t, cfg.EnableGatewayLookup)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "false")
+		cfg := New()
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.EnableGatewayLookup)
 	})
@@ -367,21 +342,20 @@ network_config:
 
 func TestIgnoreConntrackInitFailure(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  ignore_conntrack_init_failure: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.ignore_conntrack_init_failure", true)
+		cfg := New()
 
 		assert.True(t, cfg.IgnoreConntrackInitFailure)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE", "true")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.Nil(t, err)
 		assert.True(t, cfg.IgnoreConntrackInitFailure)
@@ -390,56 +364,53 @@ network_config:
 
 func TestEnablingDNSStatsCollection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-  collect_dns_stats: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.collect_dns_stats", true)
+		cfg := New()
 
 		assert.True(t, cfg.CollectDNSStats)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_COLLECT_DNS_STATS", "false")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.CollectDNSStats)
 
-		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_COLLECT_DNS_STATS", "true")
 		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg = New()
-
 		assert.True(t, cfg.CollectDNSStats)
 	})
 }
 
 func TestDisablingDNSDomainCollection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-  collect_dns_domains: false
-  max_dns_stats: 100
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		cfg := New()
+
+		mockSystemProbe.SetWithoutSource("system_probe_config.max_dns_stats", 100)
 
 		assert.False(t, cfg.CollectDNSDomains)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_COLLECT_DNS_DOMAINS", "false")
+		cfg := New()
+
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.False(t, cfg.CollectDNSDomains)
 
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_COLLECT_DNS_DOMAINS", "true")
 		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
@@ -451,26 +422,23 @@ system_probe_config:
 
 func TestSettingMaxDNSStats(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-  collect_dns_domains: false
-  max_dns_stats: 100
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.collect_dns_domains", false)
+		mockSystemProbe.SetWithoutSource("system_probe_config.max_dns_stats", 100)
+		cfg := New()
 
 		assert.Equal(t, 100, cfg.MaxDNSStats)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
+		cfg := New()
 		os.Unsetenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS")
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
-		cfg := New()
 
 		assert.Equal(t, 20000, cfg.MaxDNSStats) // default value
 
-		aconfig.ResetSystemProbeConfig(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS", "10000")
 		_, err = sysconfig.New("", "")
 		require.NoError(t, err)
@@ -512,19 +480,16 @@ func TestHTTPReplaceRules(t *testing.T) {
             "pattern": "payment_id"
           }
         ]
-        `
+	`
 
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  http_replace_rules:
-    - pattern: "/users/(.*)"
-      repl: "/users/?"
-    - pattern: "foo"
-      repl: "bar"
-    - pattern: "payment_id"
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_replace_rules", []map[string]string{
+			{"pattern": "/users/(.*)", "repl": "/users/?"},
+			{"pattern": "foo", "repl": "bar"},
+			{"pattern": "payment_id"},
+		})
+		cfg := New()
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
 		for i, r := range expected {
@@ -533,9 +498,8 @@ network_config:
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES", envContent)
-
 		cfg := New()
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
@@ -545,16 +509,14 @@ network_config:
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  http_replace_rules:
-    - pattern: "/users/(.*)"
-      repl: "/users/?"
-    - pattern: "foo"
-      repl: "bar"
-    - pattern: "payment_id"
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_replace_rules", []map[string]string{
+			{"pattern": "/users/(.*)", "repl": "/users/?"},
+			{"pattern": "foo", "repl": "bar"},
+			{"pattern": "payment_id"},
+		})
+		cfg := New()
+
 		require.Len(t, cfg.HTTPReplaceRules, 3)
 		for i, r := range expected {
 			assert.Equal(t, r, cfg.HTTPReplaceRules[i])
@@ -562,9 +524,8 @@ service_monitoring_config:
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_REPLACE_RULES", envContent)
-
 		cfg := New()
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
@@ -574,9 +535,8 @@ service_monitoring_config:
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES", envContent)
-
 		cfg := New()
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
@@ -586,9 +546,8 @@ service_monitoring_config:
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_REPLACE_RULES", envContent)
-
 		cfg := New()
 
 		require.Len(t, cfg.HTTPReplaceRules, 3)
@@ -598,8 +557,10 @@ service_monitoring_config:
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_REPLACE_RULES", envContent)
+		cfg := New()
+
 		// Setting a different value for the old value, as we should override.
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES", `
         [
@@ -609,8 +570,6 @@ service_monitoring_config:
         ]
         `)
 
-		cfg := New()
-
 		require.Len(t, cfg.HTTPReplaceRules, 3)
 		for i, r := range expected {
 			assert.Equal(t, r, cfg.HTTPReplaceRules[i])
@@ -618,7 +577,7 @@ service_monitoring_config:
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
 
 		assert.Empty(t, cfg.HTTPReplaceRules)
@@ -627,75 +586,66 @@ service_monitoring_config:
 
 func TestMaxTrackedHTTPConnections(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  max_tracked_http_connections: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.max_tracked_http_connections", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_tracked_http_connections: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_tracked_http_connections", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1026")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_TRACKED_HTTP_CONNECTIONS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1025))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.MaxTrackedHTTPConnections, int64(1024))
 	})
@@ -703,27 +653,25 @@ service_monitoring_config:
 
 func TestHTTP2DynamicTableMapCleanerInterval(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  http2_dynamic_table_map_cleaner_interval_seconds: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http2_dynamic_table_map_cleaner_interval_seconds", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTP2DynamicTableMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP2_DYNAMIC_TABLE_MAP_CLEANER_INTERVAL_SECONDS", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTP2DynamicTableMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTP2DynamicTableMapCleanerInterval, 30*time.Second)
 	})
@@ -731,75 +679,66 @@ service_monitoring_config:
 
 func TestHTTPMapCleanerInterval(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-  http_map_cleaner_interval_in_s: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.http_map_cleaner_interval_in_s", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  http_map_cleaner_interval_in_s: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_map_cleaner_interval_in_s", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1026")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAP_CLEANER_INTERVAL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 1025*time.Second)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPMapCleanerInterval, 300*time.Second)
 	})
@@ -807,74 +746,66 @@ service_monitoring_config:
 
 func TestHTTPIdleConnectionTTL(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-system_probe_config:
-  http_idle_connection_ttl_in_s: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.http_idle_connection_ttl_in_s", 1025)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  http_idle_connection_ttl_in_s: 1025
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_idle_connection_ttl_in_s", 1025)
+		cfg := New()
+
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1026")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_IDLE_CONNECTION_TTL_IN_S", "1025")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 1025*time.Second)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPIdleConnectionTTL, 30*time.Second)
 	})
@@ -882,67 +813,64 @@ service_monitoring_config:
 
 func TestHTTPNotificationThreshold(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_notification_threshold", validNotificationThreshold))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_notification_threshold", validNotificationThreshold)
+		cfg := New()
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_notification_threshold", validNotificationThreshold))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_notification_threshold", validNotificationThreshold)
+		cfg := New()
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value.
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold+1))
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(validNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
@@ -951,69 +879,66 @@ func TestHTTPNotificationThreshold(t *testing.T) {
 // Testing we're not exceeding the limit for http_notification_threshold.
 func TestHTTPNotificationThresholdOverLimit(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_notification_threshold", invalidNotificationThreshold))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_notification_threshold", invalidNotificationThreshold)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_notification_threshold", invalidNotificationThreshold))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_notification_threshold", invalidNotificationThreshold)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold+1))
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_NOTIFICATION_THRESHOLD", strconv.Itoa(invalidNotificationThreshold))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
@@ -1021,73 +946,66 @@ func TestHTTPNotificationThresholdOverLimit(t *testing.T) {
 
 func TestHTTPMaxRequestFragment(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  http_max_request_fragment: 155
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_max_request_fragment", 155)
+		cfg := New()
+
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "155")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  http_max_request_fragment: 155
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_max_request_fragment", 155)
+		cfg := New()
+
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "155")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "155")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "155")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "151")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "155")
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(155))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
@@ -1096,69 +1014,66 @@ service_monitoring_config:
 // Testing we're not exceeding the hard coded limit of http_max_request_fragment.
 func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_max_request_fragment", invalidHTTPRequestFragment))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.http_max_request_fragment", invalidHTTPRequestFragment)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_max_request_fragment", invalidHTTPRequestFragment))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.http_max_request_fragment", invalidHTTPRequestFragment)
+		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment+1))
-
 		cfg := New()
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
@@ -1168,15 +1083,17 @@ func TestMaxClosedConnectionsBuffered(t *testing.T) {
 	maxTrackedConnections := New().MaxTrackedConnections
 
 	t.Run("value set", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_CLOSED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
 		cfg := New()
+
 		require.Equal(t, maxTrackedConnections-1, cfg.MaxClosedConnectionsBuffered)
 	})
 
 	t.Run("value not set", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		require.Equal(t, cfg.MaxTrackedConnections, cfg.MaxClosedConnectionsBuffered)
 	})
 }
@@ -1185,89 +1102,83 @@ func TestMaxFailedConnectionsBuffered(t *testing.T) {
 	maxTrackedConnections := New().MaxTrackedConnections
 
 	t.Run("value set", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_NETWORK_CONFIG_MAX_FAILED_CONNECTIONS_BUFFERED", fmt.Sprintf("%d", maxTrackedConnections-1))
 		cfg := New()
+
 		require.Equal(t, maxTrackedConnections-1, cfg.MaxFailedConnectionsBuffered)
 	})
 
 	t.Run("value not set", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		require.Equal(t, cfg.MaxTrackedConnections, cfg.MaxFailedConnectionsBuffered)
 	})
 }
 
 func TestMaxHTTPStatsBuffered(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  max_http_stats_buffered: 513
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.max_http_stats_buffered", 513)
+		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED", "513")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_http_stats_buffered: 513
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_http_stats_buffered", 513)
+		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_HTTP_STATS_BUFFERED", "513")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED", "513")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_HTTP_STATS_BUFFERED", "513")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED", "514")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_HTTP_STATS_BUFFERED", "513")
-
 		cfg := New()
 
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 513)
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.Equal(t, cfg.MaxHTTPStatsBuffered, 100000)
 	})
@@ -1275,19 +1186,17 @@ service_monitoring_config:
 
 func TestMaxKafkaStatsBuffered(t *testing.T) {
 	t.Run("value set through env var", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_KAFKA_STATS_BUFFERED", "50000")
-
 		cfg := New()
+
 		assert.Equal(t, 50000, cfg.MaxKafkaStatsBuffered)
 	})
 
 	t.Run("value set through yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_kafka_stats_buffered: 30000
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_kafka_stats_buffered", 30000)
+		cfg := New()
 
 		assert.Equal(t, 30000, cfg.MaxKafkaStatsBuffered)
 	})
@@ -1295,7 +1204,7 @@ service_monitoring_config:
 
 func TestMaxPostgresTelemetryBuffered(t *testing.T) {
 	t.Run("value set through env var", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_POSTGRES_TELEMETRY_BUFFER", "50000")
 
 		cfg := New()
@@ -1303,66 +1212,60 @@ func TestMaxPostgresTelemetryBuffered(t *testing.T) {
 	})
 
 	t.Run("value set through yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_postgres_telemetry_buffer: 30000
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_postgres_telemetry_buffer", 30000)
 
+		cfg := New()
 		assert.Equal(t, 30000, cfg.MaxPostgresTelemetryBuffer)
 	})
 }
 
 func TestMaxPostgresStatsBuffered(t *testing.T) {
 	t.Run("value set through env var", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_POSTGRES_STATS_BUFFERED", "50000")
-
 		cfg := New()
+
 		assert.Equal(t, 50000, cfg.MaxPostgresStatsBuffered)
 	})
 
 	t.Run("value set through yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_postgres_stats_buffered: 30000
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_postgres_stats_buffered", 30000)
+		cfg := New()
 
 		assert.Equal(t, 30000, cfg.MaxPostgresStatsBuffered)
 	})
 
 	t.Run("default", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.Equal(t, 100000, cfg.MaxPostgresStatsBuffered)
 	})
 }
 
 func TestMaxRedisStatsBuffered(t *testing.T) {
 	t.Run("value set through env var", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_REDIS_STATS_BUFFERED", "50000")
-
 		cfg := New()
+
 		assert.Equal(t, 50000, cfg.MaxRedisStatsBuffered)
 	})
 
 	t.Run("value set through yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_redis_stats_buffered: 30000
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_redis_stats_buffered", 30000)
+		cfg := New()
 
 		assert.Equal(t, 30000, cfg.MaxRedisStatsBuffered)
 	})
 
 	t.Run("default", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.Equal(t, 100000, cfg.MaxRedisStatsBuffered)
 	})
 }
@@ -1399,10 +1302,11 @@ func TestNetworkConfigEnabled(t *testing.T) {
 				t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", strconv.FormatBool(*tc.usmIn))
 			}
 
-			aconfig.ResetSystemProbeConfig(t)
+			mock.NewSystemProbe(t)
+			cfg := New()
 			_, err = sysconfig.New(f.Name(), "")
 			require.NoError(t, err)
-			cfg := New()
+
 			assert.Equal(t, tc.npmEnabled, cfg.NPMEnabled, "npm state")
 			assert.Equal(t, tc.usmEnabled, cfg.ServiceMonitoringEnabled, "usm state")
 		})
@@ -1411,200 +1315,184 @@ func TestNetworkConfigEnabled(t *testing.T) {
 
 func TestIstioMonitoring(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.False(t, cfg.EnableIstioMonitoring)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    istio:
-      enabled: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.istio.enabled", true)
+		cfg := New()
+
 		assert.True(t, cfg.EnableIstioMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED", "true")
-
 		cfg := New()
+
 		assert.True(t, cfg.EnableIstioMonitoring)
 	})
 }
 
 func TestEnvoyPathConfig(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.EqualValues(t, cfg.EnvoyPath, "/bin/envoy")
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    istio:
-      envoy_path: "/test/envoy"
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.istio.envoy_path", "/test/envoy")
+		cfg := New()
+
 		assert.EqualValues(t, "/test/envoy", cfg.EnvoyPath)
 	})
 
 	t.Run("value set through env var", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENVOY_PATH", "/test/envoy")
-
 		cfg := New()
+
 		assert.EqualValues(t, "/test/envoy", cfg.EnvoyPath)
 	})
 }
 
 func TestNodeJSMonitoring(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.False(t, cfg.EnableNodeJSMonitoring)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    nodejs:
-      enabled: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.nodejs.enabled", true)
+		cfg := New()
+
 		assert.True(t, cfg.EnableNodeJSMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_NODEJS_ENABLED", "true")
-
 		cfg := New()
+
 		assert.True(t, cfg.EnableNodeJSMonitoring)
 	})
 }
 
 func TestUSMEventStream(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		assert.False(t, cfg.EnableUSMEventStream)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_event_stream: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_event_stream", true)
+		cfg := New()
+
 		assert.True(t, cfg.EnableUSMEventStream)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_EVENT_STREAM", "true")
-
 		cfg := New()
+
 		assert.True(t, cfg.EnableUSMEventStream)
 	})
 }
 
 func TestMaxUSMConcurrentRequests(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Assert that if not explicitly set this param defaults to `MaxTrackedConnections`
 		// Note this behavior should be deprecated on 7.50
 		assert.Equal(t, cfg.MaxTrackedConnections, cfg.MaxUSMConcurrentRequests)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  max_concurrent_requests: 1000
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_concurrent_requests", 1000)
+		cfg := New()
+
 		assert.Equal(t, uint32(1000), cfg.MaxUSMConcurrentRequests)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_CONCURRENT_REQUESTS", "3000")
-
 		cfg := New()
+
 		assert.Equal(t, uint32(3000), cfg.MaxUSMConcurrentRequests)
 	})
 }
 
 func TestUSMTLSNativeEnabled(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-network_config:
-  enable_https_monitoring: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.enable_https_monitoring", true)
+		cfg := New()
 
 		require.True(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    native:
-      enabled: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.native.enabled", true)
+		cfg := New()
+
 		require.True(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_NATIVE_ENABLED", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_NATIVE_ENABLED", "false")
-
 		cfg := New()
 
 		require.False(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING", "false")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_NATIVE_ENABLED", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableNativeTLSMonitoring)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_NATIVE_ENABLED", "true")
 		cfg := New()
@@ -1613,8 +1501,9 @@ service_monitoring_config:
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.False(t, cfg.EnableNativeTLSMonitoring)
 	})
@@ -1622,67 +1511,57 @@ service_monitoring_config:
 
 func TestUSMTLSGoEnabled(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  enable_go_tls_support: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_go_tls_support", true)
+		cfg := New()
 
 		require.True(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    go:
-      enabled: true
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.go.enabled", true)
+		cfg := New()
+
 		require.True(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "false")
-
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
 		cfg := New()
 
 		require.False(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "false")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
-
 		cfg := New()
 
 		require.True(t, cfg.EnableGoTLSSupport)
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
 		cfg := New()
@@ -1691,8 +1570,9 @@ service_monitoring_config:
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.False(t, cfg.EnableGoTLSSupport)
 	})
@@ -1700,28 +1580,25 @@ service_monitoring_config:
 
 func TestUSMTLSGoExcludeSelf(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, `
-service_monitoring_config:
-  tls:
-    go:
-      exclude_self: false
-`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.go.exclude_self", false)
+		cfg := New()
+
 		require.False(t, cfg.GoTLSExcludeSelf)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_EXCLUDE_SELF", "false")
-
 		cfg := New()
 
 		require.False(t, cfg.GoTLSExcludeSelf)
 	})
 
 	t.Run("Not disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mock.NewSystemProbe(t)
 		cfg := New()
+
 		// Default value.
 		require.True(t, cfg.GoTLSExcludeSelf)
 	})
@@ -1729,103 +1606,83 @@ service_monitoring_config:
 
 func TestProcessServiceInference(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    enabled: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.enabled", true)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
 		t.Setenv("DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED", "true")
-		cfg := aconfig.SystemProbe()
-		sysconfig.Adjust(cfg)
+		New()
+		sysconfig.Adjust(mockSystemProbe)
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-network_config:
-  enabled: true
-system_probe_config:
-  process_service_inference:
-    enabled: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.enabled", true)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.enabled", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.enabled", false)
+		New()
 
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    enabled: true
-system_probe_config:
-  process_service_inference:
-    enabled: false`)
-
-		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.False(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.enabled", false)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.enabled", true)
 
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    enabled: false
-system_probe_config:
-  process_service_inference:
-    enabled: true`)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    enabled: true
-system_probe_config:
-  process_service_inference:
-    enabled: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.enabled", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.enabled", true)
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		New()
+
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, ``)
-		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		New()
+		require.False(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("Enabled without net, dsm, sm enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-system_probe_config:
-  process_service_inference:
-    enabled: true`)
-		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.enabled", true)
+		New()
+		require.False(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 
 	t.Run("test platform specific defaults", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
 		// usm or npm must be enabled for the process_service_inference to be enabled
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true`)
-		sysconfig.Adjust(cfg)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		New()
+		sysconfig.Adjust(mockSystemProbe)
 
 		var expected bool
 		if runtime.GOOS == "windows" {
@@ -1834,130 +1691,72 @@ service_monitoring_config:
 			expected = false
 		}
 
-		require.Equal(t, expected, cfg.GetBool("system_probe_config.process_service_inference.enabled"))
+		require.Equal(t, expected, mockSystemProbe.GetBool("system_probe_config.process_service_inference.enabled"))
 	})
 }
 
 func TestProcessServiceInferenceWindows(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    use_windows_service_name: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", true)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
 		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true")
 		t.Setenv("DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_USE_WINDOWS_SERVICE_NAME", "true")
-		cfg := aconfig.SystemProbe()
-		sysconfig.Adjust(cfg)
+		sysconfig.Adjust(mockSystemProbe)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-network_config:
-  enabled: true
-system_probe_config:
-  process_service_inference:
-    use_windows_service_name: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", true)
+		New()
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
 
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    use_windows_service_name: true
-system_probe_config:
-  process_service_inference:
-    use_windows_service_name: false`)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.use_windows_service_name", false)
+		New()
 
-		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.False(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", false)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.use_windows_service_name", true)
+		New()
 
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    use_windows_service_name: false
-system_probe_config:
-  process_service_inference:
-    use_windows_service_name: true`)
-
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		// Setting a different value
-		cfg := modelCfgFromYAML(t, `
-service_monitoring_config:
-  enabled: true
-  process_service_inference:
-    use_windows_service_name: true
-system_probe_config:
-  process_service_inference:
-    use_windows_service_name: true`)
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", true)
+		mockSystemProbe.SetWithoutSource("system_probe_config.process_service_inference.use_windows_service_name", true)
 
-		require.True(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		require.True(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		cfg := modelCfgFromYAML(t, `
-system_probe_config:
-  process_service_inference:
-    use_windows_service_name: false`)
-		require.False(t, cfg.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.process_service_inference.use_windows_service_name", false)
+
+		require.False(t, mockSystemProbe.GetBool("system_probe_config.process_service_inference.use_windows_service_name"))
 	})
-}
-
-func configurationFromYAML(t *testing.T, yaml string) *Config {
-	f, err := os.CreateTemp("", "system-probe.*.yaml")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-
-	b := []byte(yaml)
-	n, err := f.Write(b)
-	require.NoError(t, err)
-	require.Equal(t, len(b), n)
-	f.Sync()
-
-	_, err = sysconfig.New(f.Name(), "")
-	require.NoError(t, err)
-	return New()
-}
-
-func modelCfgFromYAML(t *testing.T, yaml string) model.Config {
-	f, err := os.CreateTemp("", "system-probe.*.yaml")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-
-	b := []byte(yaml)
-	n, err := f.Write(b)
-	require.NoError(t, err)
-	require.Equal(t, len(b), n)
-	f.Sync()
-
-	_, err = sysconfig.New(f.Name(), "")
-
-	require.NoError(t, err)
-	cfg := aconfig.SystemProbe()
-	sysconfig.Adjust(cfg)
-
-	return cfg
 }


### PR DESCRIPTION
### What does this PR do?

Having multiple ways to create a mock of the config makes the code base difficult to maintain and is error prone.

Having a single way to create a mock also ease the transition to components.

### Describe how to test/QA your changes

This only impacts the tests, CI should be enough