### PR TITLE
[OTEL-2047] Fix flaky APM stats bucket test

### DIFF
--- a/comp/otelcol/otlp/components/statsprocessor/agent_test.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent_test.go
@@ -91,7 +91,7 @@ func TestTraceAgent(t *testing.T) {
 				require.Len(t, stats.Stats, 1)
 				cspayload := stats.Stats[0]
 				// stats can be in one or multiple buckets
-				assert.Greater(t, cspayload.Stats, 0)
+				assert.Greater(t, len(cspayload.Stats), 0)
 				for _, bucket := range cspayload.Stats {
 					assert.Greater(t, len(bucket.Stats), 0)
 					actual = append(actual, bucket.Stats...)

--- a/comp/otelcol/otlp/components/statsprocessor/agent_test.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent_test.go
@@ -89,9 +89,13 @@ func TestTraceAgent(t *testing.T) {
 		case stats = <-out:
 			if len(stats.Stats) != 0 {
 				require.Len(t, stats.Stats, 1)
-				require.Len(t, stats.Stats[0].Stats, 1)
-				assert.Greater(t, len(stats.Stats[0].Stats[0].Stats), 0)
-				actual = append(actual, stats.Stats[0].Stats[0].Stats...)
+				cspayload := stats.Stats[0]
+				// stats can be in one or multiple buckets
+				assert.Greater(t, cspayload.Stats, 0)
+				for _, bucket := range cspayload.Stats {
+					assert.Greater(t, len(bucket.Stats), 0)
+					actual = append(actual, bucket.Stats...)
+				}
 			}
 		case <-timeout:
 			t.Fatal("timed out")


### PR DESCRIPTION
### What does this PR do?

Fix flaky APM stats bucket test `TestTraceAgent`

### Motivation

Stats in test can be in one or multiple buckets. Cannot assume there is exactly one bucket
