### PR TITLE
fix: get lambda runtime API endpoint dynamically

### DIFF
--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -45,16 +45,16 @@ func NewWithShutdown(demux aggregator.Demultiplexer) (lp *httpsec.ProxyLifecycle
 		return nil, nil, nil // appsec disabled
 	}
 
-	lambdaRuntimeApi := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API")
-	if lambdaRuntimeApi == "" {
-		lambdaRuntimeApi = "127.0.0.1:9001"
+	lambdaRuntimeAPI := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API")
+	if lambdaRuntimeAPI == "" {
+		lambdaRuntimeAPI = "127.0.0.1:9001"
 	}
 
 	// AppSec monitors the invocations by acting as a proxy of the AWS Lambda Runtime API.
 	lp = httpsec.NewProxyLifecycleProcessor(appsecInstance, demux)
 	shutdownProxy := proxy.Start(
 		"127.0.0.1:9000",
-		lambdaRuntimeApi,
+		lambdaRuntimeAPI,
 		lp,
 	)
 	log.Debug("appsec: started successfully using the runtime api proxy monitoring mode")

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -45,7 +45,7 @@ func NewWithShutdown(demux aggregator.Demultiplexer) (lp *httpsec.ProxyLifecycle
 		return nil, nil, nil // appsec disabled
 	}
 
-	lambdaRuntimeAPI := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API")
+	lambdaRuntimeAPI := os.Getenv("AWS_LAMBDA_RUNTIME_API")
 	if lambdaRuntimeAPI == "" {
 		lambdaRuntimeAPI = "127.0.0.1:9001"
 	}

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"os"
 	"time"
 
 	appsecLog "github.com/DataDog/appsec-internal-go/log"
@@ -44,11 +45,16 @@ func NewWithShutdown(demux aggregator.Demultiplexer) (lp *httpsec.ProxyLifecycle
 		return nil, nil, nil // appsec disabled
 	}
 
+	lambdaRuntimeApi := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API")
+	if lambdaRuntimeApi == "" {
+		lambdaRuntimeApi = "127.0.0.1:9001"
+	}
+
 	// AppSec monitors the invocations by acting as a proxy of the AWS Lambda Runtime API.
 	lp = httpsec.NewProxyLifecycleProcessor(appsecInstance, demux)
 	shutdownProxy := proxy.Start(
 		"127.0.0.1:9000",
-		"127.0.0.1:9001",
+		lambdaRuntimeApi,
 		lp,
 	)
 	log.Debug("appsec: started successfully using the runtime api proxy monitoring mode")

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -8,6 +8,7 @@ package trace
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
@@ -60,8 +61,8 @@ const tcpRemotePortMetaKey = "tcp.remote.port"
 // dnsAddressMetaKey is the key of the span meta containing the DNS address
 const dnsAddressMetaKey = "dns.address"
 
-// lambdaRuntimeUrlPrefix is the first part of a URL for a call to the Lambda runtime API
-const lambdaRuntimeURLPrefix = "http://127.0.0.1:9001"
+// lambdaRuntimeUrlPrefix is the first part of a URL for a call to the Lambda runtime API. The value may be replaced if `DD_AWS_LAMBDA_RUNTIME_API` is set.
+var lambdaRuntimeURLPrefix = "http://127.0.0.1:9001"
 
 // lambdaExtensionURLPrefix is the first part of a URL for a call from the Datadog Lambda Library to the Lambda Extension
 const lambdaExtensionURLPrefix = "http://127.0.0.1:8124"
@@ -257,3 +258,9 @@ func (t noopTraceAgent) SetTags(map[string]string)           {}
 func (t noopTraceAgent) SetTargetTPS(float64)                {}
 func (t noopTraceAgent) SetSpanModifier(agent.SpanModifier)  {}
 func (t noopTraceAgent) GetSpanModifier() agent.SpanModifier { return nil }
+
+func init() {
+	if lambdaRuntime := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API"); lambdaRuntime != "" {
+		lambdaRuntimeURLPrefix = fmt.Sprintf("http://%s", lambdaRuntime)
+	}
+}

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -61,7 +61,7 @@ const tcpRemotePortMetaKey = "tcp.remote.port"
 // dnsAddressMetaKey is the key of the span meta containing the DNS address
 const dnsAddressMetaKey = "dns.address"
 
-// lambdaRuntimeUrlPrefix is the first part of a URL for a call to the Lambda runtime API. The value may be replaced if `DD_AWS_LAMBDA_RUNTIME_API` is set.
+// lambdaRuntimeUrlPrefix is the first part of a URL for a call to the Lambda runtime API. The value may be replaced if `AWS_LAMBDA_RUNTIME_API` is set.
 var lambdaRuntimeURLPrefix = "http://127.0.0.1:9001"
 
 // lambdaExtensionURLPrefix is the first part of a URL for a call from the Datadog Lambda Library to the Lambda Extension
@@ -260,7 +260,7 @@ func (t noopTraceAgent) SetSpanModifier(agent.SpanModifier)  {}
 func (t noopTraceAgent) GetSpanModifier() agent.SpanModifier { return nil }
 
 func init() {
-	if lambdaRuntime := os.Getenv("DD_AWS_LAMBDA_RUNTIME_API"); lambdaRuntime != "" {
+	if lambdaRuntime := os.Getenv("AWS_LAMBDA_RUNTIME_API"); lambdaRuntime != "" {
 		lambdaRuntimeURLPrefix = fmt.Sprintf("http://%s", lambdaRuntime)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Use an `DD_AWS_LAMBDA_RUNTIME_API` environment variable to obtain the real value of `AWS_LAMBDA_RUNTIME`, so the runtime API endpoint does not need to be hardcoded.

### Motivation


This is necessary with new runtimes that don't necessarily use the usual `127.0.0.1:9001` endpoint.


### Additional Notes

The extension wrapper script fowards the original `AWS_LAMBDA_RUNTIME` to `DD_AWS_LAMBDA_RUNTIME_API` before overwriting it.
