### PR TITLE
ProvideComponentConstructor gives a reasonable error message for an unexported field 

### DIFF
--- a/pkg/util/fxutil/provide_comp.go
+++ b/pkg/util/fxutil/provide_comp.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"unicode"
+	"unicode/utf8"
 
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"go.uber.org/fx"
@@ -224,6 +226,10 @@ func ensureFieldsNotAllowed(typ reflect.Type, badEmbeds []reflect.Type) error {
 		field := typ.Field(n)
 		if slices.Contains(badEmbeds, field.Type) {
 			return fmt.Errorf("invalid embedded field: %v", field.Type)
+		}
+		firstRune, _ := utf8.DecodeRuneInString(field.Name)
+		if unicode.IsLower(firstRune) {
+			return fmt.Errorf("field is not exported: %v", field.Name)
 		}
 	}
 	return nil

--- a/pkg/util/fxutil/provide_comp_test.go
+++ b/pkg/util/fxutil/provide_comp_test.go
@@ -680,6 +680,7 @@ type provides5 struct {
 
 type providesPrivate struct {
 	compdef.Out
+	//nolint:unused
 	private FirstComp
 }
 

--- a/pkg/util/fxutil/provide_comp_test.go
+++ b/pkg/util/fxutil/provide_comp_test.go
@@ -300,6 +300,14 @@ func TestConstructFxAwareStructWithLifecycle(t *testing.T) {
 	require.Equal(t, typ.Field(1).Type, reflect.TypeOf((*compdef.Lifecycle)(nil)).Elem())
 }
 
+func TestInvalidPrivateOutput(t *testing.T) {
+	prv := providesPrivate{}
+	typ := reflect.TypeOf(prv)
+	err := ensureFieldsNotAllowed(typ, nil)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "field is not exported: private")
+}
+
 // test that fx App is able to use constructor with no reqs
 func TestFxNoRequirements(t *testing.T) {
 	// plain component constructor, no fx
@@ -666,6 +674,13 @@ type FruitProvider struct {
 type provides5 struct {
 	compdef.Out
 	First FirstComp
+}
+
+// providesPrivate has an unexported field
+
+type providesPrivate struct {
+	compdef.Out
+	private FirstComp
 }
 
 // requires1 requires 1 component using a composite struct


### PR DESCRIPTION
### What does this PR do?

If an unexported field in a `Provides` struct or `Depends` struct is used with `ProvideComponentConstructor`, the error message is better.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Behavior change covered by tests.