### PR TITLE
[APM] Fix potential integer overflow on conversion

### DIFF
--- a/pkg/trace/filters/replacer.go
+++ b/pkg/trace/filters/replacer.go
@@ -86,7 +86,7 @@ func (f Replacer) ReplaceStatsGroup(b *pb.ClientGroupedStats) {
 			b.Resource = re.ReplaceAllString(b.Resource, str)
 			fallthrough
 		case "http.status_code":
-			strcode := re.ReplaceAllString(strconv.Itoa(int(b.HTTPStatusCode)), str)
+			strcode := re.ReplaceAllString(strconv.FormatUint(uint64(b.HTTPStatusCode), 10), str)
 			if code, err := strconv.ParseUint(strcode, 10, 32); err == nil {
 				b.HTTPStatusCode = uint32(code)
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This is a fix for https://datadoghq.atlassian.net/browse/VULN-7917

Use `strconv.ParseUint` instead of `Itoa` for integer to string conversion, ensuring the integer is not overflown in the `int` casting.

### Motivation

https://datadoghq.atlassian.net/browse/VULN-7917

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
