### PR TITLE
[ASCII-2210] Ensure we set the workloadmeta params correctly for the agent JMX subcommands

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -48,6 +48,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/defaults"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
@@ -57,7 +58,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/cli/standalone"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -134,9 +134,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			}),
 			// workloadmeta setup
 			wmcatalog.GetCatalog(),
-			fx.Supply(workloadmeta.Params{
-				InitHelper: common.GetWorkloadmetaInit(),
-			}),
+			fx.Provide(defaults.DefaultParams),
 			workloadmetafx.Module(),
 			apiimpl.Module(),
 			authtokenimpl.Module(),
@@ -304,7 +302,7 @@ func runJmxCommandConsole(config config.Component,
 	// This prevents log-spam from "comp/core/workloadmeta/collectors/internal/remote/process_collector/process_collector.go"
 	// It appears that this collector creates some contention in AD.
 	// Disabling it is both more efficient and gets rid of this log spam
-	pkgconfig.Datadog().Set("language_detection.enabled", "false", model.SourceAgentRuntime)
+	config.Set("language_detection.enabled", "false", model.SourceAgentRuntime)
 
 	senderManager, err := diagnoseSendermanager.LazyGetSenderManager()
 	if err != nil {

--- a/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
+++ b/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix `agent jmx [command]` subcommands for k8s deployments with annotations-based configs.
+    Fix `agent jmx [command]` subcommands for container environments with annotations-based configs.

--- a/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
+++ b/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix `agent jmx [command]` subcommands for k8s deployments with annotations-based configs.

--- a/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
+++ b/releasenotes/notes/fix-agent-jmx-subcommand-b7338c53cc835660.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix `agent jmx [command]` subcommands for container environments with annotations-based configs.
+    Fix ``agent jmx [command]`` subcommands for container environments with annotations-based configs.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Since `7.51.0` the `jmx` subcommands have not work properly for for k8s pods with annotations-based configs.

The PR fixes the problem.

The issue was that the workloadmeta was not being initialized properly. 

### The fix:

Use the default params for workloadmeta  `fx.Provide(defaults.DefaultParams)`

### Why did it brake for not using the default params? 

The workloadmeta component iterates over the different collectors when initializing, and only add them if the  params AgentType is set. [`if (c.GetTargetCatalog() & deps.Params.AgentType) > 0 {`](https://github.com/DataDog/datadog-agent/blob/f190956ba0e0c58b97b1b4ac3b716feedf915d74/comp/core/workloadmeta/impl/workloadmeta.go#L71-L75)

The `jmx` subcommands was not setting the `AgentType`. That lead to workloadmeta not using any collector from the catalog. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Agent with jmx support running in a containerized environment and a Java appplication running should:
  - `agent status` should display jmx check and its status, jmxfetch should be running
  - `agent jmx list everything` should produce a list of attributes

You can use this deployment file for the Java application

```yml
apiVersion: v1
kind: Pod
metadata:
    name: tomcat-test-http
    annotations:
        ad.datadoghq.com/tomcat.check_names: '["http_check", "tomcat"]'
        ad.datadoghq.com/tomcat.init_configs: '[{}, {"is_jmx": true, "collect_default_metrics": true}]'
        ad.datadoghq.com/tomcat.instances: '[{"name":"tomcat-test", "url":"http://%%host%%:8080"}, {"host":"%%host%%", "port":"9012", "tags": ["pod_name:%%kube_pod_name%%"]}]'
        ad.datadoghq.com/tomcat.logs: '[{"source":"tomcat","service":"tomcat"}]'
spec:
    containers:
        - name: tomcat
          image: tomcat:9.0.27-jdk12-adoptopenjdk-hotspot
          imagePullPolicy: Always
          ports:
              - name: jmx-port
                containerPort: 9012
              - name: http-port
                containerPort: 8080
          env:
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: JAVA_OPTS
              value: >-
                -Xms256m -Xmx6144m
                -Dcom.sun.management.jmxremote
                -Dcom.sun.management.jmxremote.authenticate=false
                -Dcom.sun.management.jmxremote.ssl=false
                -Dcom.sun.management.jmxremote.local.only=false
                -Dcom.sun.management.jmxremote.port=9012
```

Testing using [kind](https://kind.sigs.k8s.io/) and helm 

1. Install kind
2. Install [Helm](https://helm.sh/docs/intro/install/) 
3. Install the Datadog helm charts `helm repo add datadog`
4. Create Kind cluster `kind create cluster --name <YOUR CLUSTER NAME>`
5. Deploy the tomcat application `kubectl apply -f tomcat.yml`
6. Install the Agent RC version 
```
helm install datadog-agent --set datadog.kubelet.tlsVerify=false --set datadog.apiKey=<YOUR_API_KEY> --set datadog.appKey=<YOUR_APP_KEY> --set  datadog.site=<YOUR_SITE> --set datadog.clusterName=kind-<YOUR CLUSTER NAME> set agents.image.tag=<AGENT_RC_VERSION> datadog/datadog
```
7. Check old pods are running `kubectl get pods`
8. Check agent jmx list everything works `kubectl exec -it <AGENT POD> -c agent agent jmx list everything`
9. Check agent status shows JMX infomration `kubectl exec -it <AGENT POD> -c agent agent status`
