### PR TITLE
[Invoke] Allow multiple versions in the `check_tools_version` function

### DIFF
--- a/tasks/libs/common/check_tools_version.py
+++ b/tasks/libs/common/check_tools_version.py
@@ -59,10 +59,10 @@ def check_tools_version(ctx: Context, tools_list: list[str]) -> bool:
     """
     is_expected_versions = True
     tools_versions = {
-        'go': {'current_v': current_go_v(ctx), 'expected_v': expected_go_repo_v()},
+        'go': {'current_v': current_go_v(ctx), 'expected_vs': [expected_go_repo_v()]},
         'golangci-lint': {
             'current_v': current_golangci_lint_v(ctx),
-            'expected_v': custom_golangci_v(expected_golangci_lint_repo_v(ctx)),
+            'expected_vs': [expected_golangci_lint_repo_v(ctx), custom_golangci_v(expected_golangci_lint_repo_v(ctx))],
         },
     }
     for tool in tools_list:
@@ -72,11 +72,11 @@ def check_tools_version(ctx: Context, tools_list: list[str]) -> bool:
                 file=sys.stderr,
             )
         else:
-            current_v, expected_v = tools_versions[tool]['current_v'], tools_versions[tool]['expected_v']
-            if current_v != expected_v:
+            current_v, expected_vs = tools_versions[tool]['current_v'], tools_versions[tool]['expected_vs']
+            if current_v not in expected_vs:
                 is_expected_versions = False
                 print(
-                    f"Warning: Expecting {tool} '{expected_v}' but you have {tool} '{current_v}'. Please fix this as you might encounter issues using the tooling.",
+                    f"Warning: You are using {tool} '{current_v}'. Expected {tool} version in {expected_vs}' . Please fix this as you might encounter issues using the tooling.",
                     file=sys.stderr,
                 )
     return is_expected_versions


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR allows multiple versions in the `check_tools_version` function.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In the current state you can't use the upstream version of golangci-lint in the CI:
```
inv -e install-tools --no-custom-golangci-lint
inv -e linter.go
> Warning: Expecting golangci-lint 'v1.59.1-custom-gcl' but you have golangci-lint 'v1.59.1'. Please fix this as you might encounter issues using the tooling.
Error: The golanci-lint version you are using is not the correct one. Please run inv -e install-tools to install the correct version.
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
