### PR TITLE
Revert "Handle multiple releases in the `create_rc_pr` workflow"

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -6,14 +6,14 @@ on:
     - cron: '0 14 * * 1,3,5' # Run on Monday, Wednesday, and Friday at 14:00 UTC
     - cron: '0 8 * * 1,3,5' # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
 
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-    find_release_branches:
+    create_rc_pr:
         runs-on: ubuntu-latest
-        outputs:
-          branches: ${{ steps.branches.outputs.value }}
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -33,40 +33,19 @@ jobs:
                 pip install -r tasks/libs/requirements-github.txt
                 pip install -r tasks/requirements_release_tasks.txt
 
-            - name: Determine the release active branches
-              id: branches
+            - name: Determine the release active branch
               run: |
-                echo "value=$(inv release.get-unreleased-release-branches)" >> $GITHUB_OUTPUT
+                echo "RELEASE_BRANCH=$(inv -e release.get-active-release-branch)" >> $GITHUB_ENV
 
             - name: Set the warning option
               if: github.event.schedule == '0 8 * * 1,3,5'
               run: echo "WARNING='-w'" >> $GITHUB_ENV
 
-    create_rc_pr:
-      runs-on: ubuntu-latest
-      needs: find_release_branches
-      strategy:
-        matrix:
-          value: ${{fromJSON(needs.find_release_branches.outputs.branches)}}
-      steps:
             - name: Checkout release branch
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
               with:
-                ref: ${{ matrix.value }}
+                ref: ${{ env.RELEASE_BRANCH }}
                 fetch-depth: 0
-
-            - name: Install python
-              uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
-              with:
-                python-version: 3.11
-                cache: "pip"
-
-            - name: Install Python dependencies
-              run: |
-                python -m pip install --upgrade pip
-                pip install -r requirements.txt
-                pip install -r tasks/libs/requirements-github.txt
-                pip install -r tasks/requirements_release_tasks.txt
 
             - name: Check for changes since last RC
               id: check_for_changes
@@ -74,7 +53,7 @@ jobs:
                 ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
                 ATLASSIAN_PASSWORD: ${{ secrets.ATLASSIAN_PASSWORD }}
               run: |
-                echo "CHANGES=$(inv -e release.check-for-changes -r ${{ matrix.value }} ${{ env.WARNING }})" >> $GITHUB_OUTPUT
+                echo "CHANGES=$(inv -e release.check-for-changes -r ${{ env.RELEASE_BRANCH }} ${{ env.WARNING }})" >> $GITHUB_OUTPUT
 
             - name: Create RC PR
               if: ${{ steps.check_for_changes.outputs.CHANGES == 'true'}}

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -4,10 +4,8 @@ import base64
 import json
 import os
 import platform
-import re
 import subprocess
 from collections.abc import Iterable
-from distutils.version import StrictVersion
 from functools import lru_cache
 
 import requests
@@ -25,8 +23,6 @@ except ImportError:
 from invoke.exceptions import Exit
 
 __all__ = ["GithubAPI"]
-
-RELEASE_BRANCH_PATTERN = re.compile(r"\d+\.\d+\.x")
 
 
 class GithubAPI:
@@ -201,25 +197,6 @@ class GithubAPI:
     def latest_release(self) -> str:
         release = self._repository.get_latest_release()
         return release.title
-
-    def latest_unreleased_release_branches(self):
-        """
-        Get all the release branches that are newer than the latest release.
-        """
-        release = self._repository.get_latest_release()
-        released_version = StrictVersion(release.title)
-
-        for branch in self.release_branches():
-            if StrictVersion(branch.name.removesuffix(".x")) > released_version:
-                yield branch
-
-    def release_branches(self):
-        """
-        Yield all the branches that match the release branch pattern (A.B.x).
-        """
-        for branch in self._repository.get_branches():
-            if RELEASE_BRANCH_PATTERN.match(branch.name):
-                yield branch
 
     def get_rate_limit_info(self):
         """

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -2,7 +2,6 @@
 Release helper tasks
 """
 
-import json
 import os
 import re
 import sys
@@ -880,15 +879,6 @@ def get_active_release_branch(_):
         print(f"{release_branch.name}")
     else:
         print("main")
-
-
-@task
-def get_unreleased_release_branches(_):
-    """
-    Determine what are the current active release branches for the Agent.
-    """
-    gh = GithubAPI()
-    print(json.dumps([branch.name for branch in gh.latest_unreleased_release_branches()]))
 
 
 def get_next_version(gh):


### PR DESCRIPTION
Reverts DataDog/datadog-agent#28539. This broke on macOS runners because they use Python 3.12, which has removed `distutils`.

#incident-29883