### PR TITLE
Use linux tags in devcontainer config, lint package level

### DIFF
--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -108,7 +108,7 @@ def setup(
         }
     }
     devcontainer["postStartCommand"] = (
-        f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && invoke install-tools && invoke deps"
+        f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && invoke -e install-tools && invoke -e deps"
     )
 
     devcontainer["remoteEnv"] = {"GITLAB_TOKEN": "${localEnv:GITLAB_TOKEN}"}

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -43,7 +43,7 @@ def setup(
         return
 
     build_include = (
-        get_default_build_tags(build=target, flavor=flavor)
+        get_default_build_tags(build=target, flavor=flavor, platform='linux')
         if build_include is None
         else filter_incompatible_tags(build_include.split(","))
     )
@@ -92,7 +92,7 @@ def setup(
                 "go.buildTags": local_build_tags,
                 "go.testTags": local_build_tags,
                 "go.lintTool": "golangci-lint",
-                "go.lintOnSave": "file",
+                "go.lintOnSave": "package",
                 "go.lintFlags": [
                     "--build-tags",
                     local_build_tags,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
1. Fix Go build tags used in devcontainer config to be Linux tags rather than host machine tags
2. Lint packages rather than files
3. Add `-e` flag to invoke start commands

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
1. One of the main reasons to use devcontainer is to work on Linux-specific code from MacOS, so we should use Linux build tags rather than MacOS
2. Linting files doesn't seem to work in Go, it complains about symbols defined in other files of the package  
3. Know what's happening when you start the container, otherwise you can have no output when it runs `inv deps`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
