### PR TITLE
[EBPF] Fix crash when missing register state in annotate_complexity

### DIFF
--- a/pkg/ebpf/verifier/types.go
+++ b/pkg/ebpf/verifier/types.go
@@ -51,6 +51,7 @@ type InstructionInfo struct {
 	Code             string                 `json:"code"`
 	RegisterState    map[int]*RegisterState `json:"register_state"` // Register state after execution of the instruction
 	RegisterStateRaw string                 `json:"register_state_raw"`
+	IsDoubleWidth    bool                   `json:"is_double_width"`
 }
 
 // SourceLineStats holds the aggregate verifier statistics for a given C source line

--- a/pkg/ebpf/verifier/verifier_log_parser.go
+++ b/pkg/ebpf/verifier/verifier_log_parser.go
@@ -6,6 +6,7 @@
 package verifier
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -18,6 +19,7 @@ var (
 	regStateRegex       = regexp.MustCompile(`^([0-9]+): (R[0-9]+.*)`)
 	singleRegStateRegex = regexp.MustCompile(`R([0-9]+)(_[^=]+)?=([^ ]+)`)
 	regInfoRegex        = regexp.MustCompile(`^(P)?([a-z_]+)?(P)?(-?[0-9]+|\((.*)\))`)
+	doubleWidthInsRegex = regexp.MustCompile(`r[0-9] = 0x[0-9a-f]{16}$`)
 )
 
 // verifierLogParser is a struct that maintains the state necessary to parse the verifier log
@@ -72,6 +74,8 @@ func (vlp *verifierLogParser) parseVerifierLog(log string) (*ComplexityInfo, err
 	return &vlp.complexity, nil
 }
 
+var errNotFound = errors.New("instruction not found")
+
 func (vlp *verifierLogParser) tryAttachRegisterState(regData string, insIdx int) error {
 	insinfo, ok := vlp.complexity.InsnMap[insIdx]
 	if !ok {
@@ -79,7 +83,7 @@ func (vlp *verifierLogParser) tryAttachRegisterState(regData string, insIdx int)
 		// the verifier outputs register state. For example, in some versions it will generate
 		// the state *before* each instruction, but we want the state *after* the instruction, and
 		// as such the first state we find (state before instruction 1) will have no match, for example.
-		return nil
+		return errNotFound
 	}
 
 	// For ease of parsing, replace certain patterns that introduce spaces and make parsing harder
@@ -111,7 +115,14 @@ func (vlp *verifierLogParser) parseLine(line string) error {
 
 		// Try attach the register state to the previous instruction
 		err = vlp.tryAttachRegisterState(match[2], regInsnIdx-1)
-		if err != nil {
+		if errors.Is(err, errNotFound) {
+			// The previous instruction was not found. Check if the previous one is double width, and try to attach to the one before that
+			// We need to do this because the instruction index jumps one when we have a double width instruction
+			if insinfo, ok := vlp.complexity.InsnMap[regInsnIdx-2]; ok && insinfo.IsDoubleWidth {
+				err = vlp.tryAttachRegisterState(match[2], regInsnIdx-2)
+			}
+		}
+		if err != nil && !errors.Is(err, errNotFound) {
 			return fmt.Errorf("failed to attach register state (line is '%s'): %w", line, err)
 		}
 		return nil
@@ -134,12 +145,13 @@ func (vlp *verifierLogParser) parseLine(line string) error {
 	if vlp.progSourceMap != nil {
 		insinfo.Source = vlp.progSourceMap[insIdx]
 	}
+	insinfo.IsDoubleWidth = doubleWidthInsRegex.MatchString(insinfo.Code)
 
 	// In some kernel versions (6.5 at least), the register state for the next instruction might be printed after this instruction
 	if len(match) >= 4 && match[3] != "" {
 		regData := match[3][2:] // Remove the leading "; "
 		err = vlp.tryAttachRegisterState(regData, insIdx)
-		if err != nil {
+		if err != nil && !errors.Is(err, errNotFound) {
 			return fmt.Errorf("Cannot attach register state to instruction %d: %w", insIdx, err)
 		}
 	}

--- a/pkg/ebpf/verifier/verifier_log_parser_test.go
+++ b/pkg/ebpf/verifier/verifier_log_parser_test.go
@@ -235,6 +235,53 @@ func TestLogParsingWith(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "DoubleWidthInstruction",
+			input: "1803: R0=0\n1803: (18) r1 = 0xffff0001f3b06000\n1805: R1=1\n",
+			progSourceMap: map[int]*SourceLine{
+				1803: {
+					LineInfo: "file.c:5",
+					Line:     "int a = 2",
+				},
+				1805: {
+					LineInfo: "file.c:5",
+					Line:     "int a = 2",
+				},
+			},
+			expected: ComplexityInfo{
+				InsnMap: map[int]*InstructionInfo{
+					1803: {
+						Index:          1803,
+						TimesProcessed: 1,
+						Source: &SourceLine{
+							LineInfo: "file.c:5",
+							Line:     "int a = 2",
+						},
+						Code: "r1 = 0xffff0001f3b06000",
+						RegisterState: map[int]*RegisterState{
+							1: {
+								Register: 1,
+								Live:     "",
+								Type:     "scalar",
+								Value:    "1",
+								Precise:  false,
+							},
+						},
+						RegisterStateRaw: "R1=1",
+						IsDoubleWidth:    true,
+					},
+				},
+				SourceMap: map[string]*SourceLineStats{
+					"file.c:5": {
+						NumInstructions:            1,
+						MaxPasses:                  1,
+						MinPasses:                  1,
+						TotalInstructionsProcessed: 1,
+						AssemblyInsns:              []int{1803},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -479,12 +479,11 @@ def annotate_complexity(
                                 )
                             )
 
-                            if show_register_state:
+                            # This is the register state after the statement is executed
+                            reg_state = asm_line.get("register_state")
+                            if show_register_state and reg_state is not None:
                                 # Get all the registers that were used in this instruction
                                 registers = re.findall(r"r\d+", asm_code)
-
-                                # This is the register state after the statement is executed
-                                reg_state = asm_line["register_state"]
 
                                 if show_raw_register_state:
                                     total_indent = 4 + 3 + get_total_complexity_stats_len(compinfo_widths)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fixes a crash when there is missing register state in the `ebpf.annotate_complexity` task, in two ways:

- Check the register state existence before printing the data
- Fix the underlying issue, which was double width instructions (which count as two for the instruction counter) messing with the register state attachment.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
