### PR TITLE
[ASCII-2215] Revert "Update e2e test as IMDSv1 is disabled by default (#28060)"

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
@@ -6,7 +6,6 @@
 package hostname
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -23,6 +22,7 @@ type linuxHostnameSuite struct {
 }
 
 func TestLinuxHostnameSuite(t *testing.T) {
+	t.Skip("Skipping due to a bug on the latest ubuntu AMI #incident-29343")
 	t.Parallel()
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault))
 	e2e.Run(t, &linuxHostnameSuite{baseHostnameSuite: baseHostnameSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
@@ -47,11 +47,13 @@ func (v *linuxHostnameSuite) TestAgentConfigPreferImdsv2() {
 }
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/util/hostname/README.md#the-current-logic
-func (v *linuxHostnameSuite) TestAgentDefaultHostnameIMDSv1() {
-	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(v.GetOs(), awshost.WithAgentOptions(agentparams.WithAgentConfig("ec2_prefer_imdsv2: false"))))
+func (v *linuxHostnameSuite) TestAgentHostnameDefaultsToResourceId() {
+	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(v.GetOs(), awshost.WithAgentOptions(agentparams.WithAgentConfig(""))))
 
+	metadata := client.NewEC2Metadata(v.T(), v.Env().RemoteHost.Host, v.Env().RemoteHost.OSFamily)
 	hostname := v.Env().Agent.Client.Hostname()
-	osHostname := v.Env().RemoteHost.Host.MustExecute("hostname")
-	osHostname = strings.TrimSpace(osHostname)
-	assert.Equal(v.T(), osHostname, hostname)
+
+	// Default configuration of hostname for EC2 instances is the resource-id
+	resourceID := metadata.Get("instance-id")
+	assert.Equal(v.T(), resourceID, hostname)
 }

--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_nix_test.go
@@ -22,7 +22,6 @@ type linuxHostnameSuite struct {
 }
 
 func TestLinuxHostnameSuite(t *testing.T) {
-	t.Skip("Skipping due to a bug on the latest ubuntu AMI #incident-29343")
 	t.Parallel()
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault))
 	e2e.Run(t, &linuxHostnameSuite{baseHostnameSuite: baseHostnameSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -21,9 +21,9 @@ type linuxStatusSuite struct {
 }
 
 func TestLinuxStatusSuite(t *testing.T) {
-	enableImdsv2 := awshost.WithAgentOptions(agentparams.WithAgentConfig("ec2_prefer_imdsv2: true"))
+	t.Skip("Skipping due to a bug on the latest ubuntu AMI #incident-29343")
 	t.Parallel()
-	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(enableImdsv2)))
+	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 
 func (v *linuxStatusSuite) TestStatusHostname() {

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -21,7 +21,6 @@ type linuxStatusSuite struct {
 }
 
 func TestLinuxStatusSuite(t *testing.T) {
-	t.Skip("Skipping due to a bug on the latest ubuntu AMI #incident-29343")
 	t.Parallel()
 	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Revert https://github.com/DataDog/datadog-agent/pull/28060 and https://github.com/DataDog/datadog-agent/pull/28049.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
IMDSv1 was enabled back on Ubuntu images, as per https://bugs.launchpad.net/cloud-images/+bug/2075385.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
#incident-29908

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
