### PR TITLE
[Invoke] Remove the `--custom-golangci-lint` flag from the `install-tools` task

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build DataDog agent
         run: |
-          invoke install-tools --no-custom-golangci-lint
+          invoke install-tools
           invoke deps
           invoke agent.build --build-exclude=systemd
 

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -46,7 +46,7 @@ def download_tools(ctx):
 
 
 @task
-def install_tools(ctx: Context, max_retry: int = 3, custom_golangci_lint=True):
+def install_tools(ctx: Context, max_retry: int = 3):
     """Install all Go tools for testing."""
     with gitlab_section("Installing Go tools", collapsed=True):
         with environ({'GO111MODULE': 'on'}):
@@ -54,8 +54,8 @@ def install_tools(ctx: Context, max_retry: int = 3, custom_golangci_lint=True):
                 with ctx.cd(path):
                     for tool in tools:
                         run_command_with_retry(ctx, f"go install {tool}", max_retry=max_retry)
-        if custom_golangci_lint:
-            install_custom_golanci_lint(ctx)
+        # Always install the custom golangci-lint not to fail on custom linters run (e.g pkgconfigusage)
+        install_custom_golanci_lint(ctx)
 
 
 def install_custom_golanci_lint(ctx):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR removes the `--custom-golangci-lint` flag from the `install-tools` invoke task.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Using the flag would make it impossible later on to run other invoke task for example `inv linter.go` since the `.golangci.yml` config file contains our custom linters (e.g `pkgconfigusage`).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
