### PR TITLE
[EBPF] Allow destroying stacks with invalid stack.output files

### DIFF
--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -188,7 +188,7 @@ def build_infrastructure(stack: str, ssh_key_obj: SSHKey | None = None):
         try:
             infra_map: StackOutput = json.load(f)
         except json.decoder.JSONDecodeError as e:
-            raise Exit(f"{stack_output} file is not a valid json file") from e
+            raise RuntimeError(f"{stack_output} file is not a valid json file") from e
 
     infra: dict[KMTArchNameOrLocal, HostInstance] = {}
     for arch in infra_map:

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -24,7 +24,7 @@ from tasks.kernel_matrix_testing.libvirt import (
     resource_in_stack,
     resume_domains,
 )
-from tasks.kernel_matrix_testing.tool import Exit, NoLibvirt, error, info
+from tasks.kernel_matrix_testing.tool import Exit, NoLibvirt, error, info, warn
 from tasks.kernel_matrix_testing.vars import VMCONFIG
 
 if TYPE_CHECKING:
@@ -284,7 +284,14 @@ def destroy_ec2_instances(ctx: Context, stack: str):
     if not os.path.exists(stack_output):
         return
 
-    infra = build_infrastructure(stack)
+    try:
+        infra = build_infrastructure(stack)
+    except RuntimeError:
+        warn(
+            f"[-] Failed to read stack output file {stack_output}, this might be due to stack not being created properly. If you know there are EC2 instances remaining, please use the AWS console to terminate them."
+        )
+        return
+
     ips: list[str] = []
     for arch, instance in infra.items():
         if arch != "local":


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allows running `kmt.destroy-stack` even if the `stack.output` file is invalid.

### Motivation

Allow users to remove stacks that were not created properly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
