### PR TITLE
refactor tagger entity id prefixes to its own type

### DIFF
--- a/comp/core/tagger/common/prefixes.go
+++ b/comp/core/tagger/common/prefixes.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package common provides common constants and methods for the tagger component and implementation
+package common
+
+import "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+
+const (
+	// ContainerID is the prefix `container_id`
+	ContainerID types.EntityIDPrefix = "container_id"
+	// ContainerImageMetadata is the prefix `container_image_metadata`
+	ContainerImageMetadata types.EntityIDPrefix = "container_image_metadata"
+	// ECSTask is the prefix `ecs_task`
+	ECSTask types.EntityIDPrefix = "ecs_task"
+	// Host is the prefix `host`
+	Host types.EntityIDPrefix = "host"
+	// KubernetesDeployment is the prefix `deployment`
+	KubernetesDeployment types.EntityIDPrefix = "deployment"
+	// KubernetesMetadata is the prefix `kubernetes_metadata`
+	KubernetesMetadata types.EntityIDPrefix = "kubernetes_metadata"
+	// KubernetesPodUID is the prefix `kubernetes_pod_uid`
+	KubernetesPodUID types.EntityIDPrefix = "kubernetes_pod_uid"
+	// Process is the prefix `process`
+	Process types.EntityIDPrefix = "process"
+)
+
+// AllPrefixesSet returns a set of all possible entity id prefixes that can be used in the tagger
+func AllPrefixesSet() map[types.EntityIDPrefix]struct{} {
+	return map[types.EntityIDPrefix]struct{}{
+		ContainerID:            {},
+		ContainerImageMetadata: {},
+		ECSTask:                {},
+		Host:                   {},
+		KubernetesDeployment:   {},
+		KubernetesMetadata:     {},
+		KubernetesPodUID:       {},
+		Process:                {},
+	}
+}

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -11,15 +11,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	k8smetadata "github.com/DataDog/datadog-agent/comp/core/tagger/k8s_metadata"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -822,21 +821,21 @@ func (c *WorkloadMetaCollector) addOpenTelemetryStandardTags(container *workload
 func buildTaggerEntityID(entityID workloadmeta.EntityID) string {
 	switch entityID.Kind {
 	case workloadmeta.KindContainer:
-		return containers.BuildTaggerEntityName(entityID.ID)
+		return common.ContainerID.ToUID(entityID.ID)
 	case workloadmeta.KindKubernetesPod:
-		return kubelet.PodUIDToTaggerEntityName(entityID.ID)
+		return common.KubernetesPodUID.ToUID(entityID.ID)
 	case workloadmeta.KindECSTask:
-		return fmt.Sprintf("ecs_task://%s", entityID.ID)
+		return common.ECSTask.ToUID(entityID.ID)
 	case workloadmeta.KindContainerImageMetadata:
-		return fmt.Sprintf("container_image_metadata://%s", entityID.ID)
+		return common.ContainerImageMetadata.ToUID(entityID.ID)
 	case workloadmeta.KindProcess:
-		return fmt.Sprintf("process://%s", entityID.ID)
+		return common.Process.ToUID(entityID.ID)
 	case workloadmeta.KindKubernetesDeployment:
-		return fmt.Sprintf("deployment://%s", entityID.ID)
+		return common.KubernetesDeployment.ToUID(entityID.ID)
 	case workloadmeta.KindHost:
-		return fmt.Sprintf("host://%s", entityID.ID)
+		return common.Host.ToUID(entityID.ID)
 	case workloadmeta.KindKubernetesMetadata:
-		return fmt.Sprintf("kubernetes_metadata://%s", entityID.ID)
+		return common.KubernetesMetadata.ToUID(entityID.ID)
 	default:
 		log.Errorf("can't recognize entity %q with kind %q; trying %s://%s as tagger entity",
 			entityID.ID, entityID.Kind, entityID.ID, entityID.Kind)

--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -164,3 +164,16 @@ type EntityEvent struct {
 	EventType EventType
 	Entity    Entity
 }
+
+// EntityIDPrefix represents the prefix of a TagEntity id
+type EntityIDPrefix string
+
+// ToUID builds a unique id from the passed id
+// if the passed id is empty, an empty string is returned
+// else it returns `{entityPrefix}://{id}`
+func (e EntityIDPrefix) ToUID(id string) string {
+	if id == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s", e, id)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The tagger builds on predefined entity id prefixes to uniquely identify tag entities in the tagstore. 

The available prefixes are fixed and defined [here](https://github.com/DataDog/datadog-agent/tree/main/comp/core/tagger#entity-ids).

This PR refactors the usage of these prefixes so that it is uniform and based on a distinct type.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Unify usage of entity id prefixes.
- Preparatory step for adding subscription filters to the tagger (we should be able to list possible prefixes, include and exclude them) 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

There are other places in the codebase that build the entity id manually. We can refactor them to use the new `EntityIDPrefix` type in a separate PR to homogenise building the tag entity id.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

No need. Handled by unit tests and E2E.