### PR TITLE
[PROCS-4228] Add E2E tests in K8s for running the process checks in the core agent

### DIFF
--- a/test/new-e2e/tests/process/config/helm-template.tmpl
+++ b/test/new-e2e/tests/process/config/helm-template.tmpl
@@ -1,7 +1,19 @@
 datadog:
   processAgent:
-    enabled: {{.ProcessAgentEnabled}}
     processCollection: {{.ProcessCollection}}
     processDiscovery: {{.ProcessDiscoveryCollection}}
+    containerCollection: {{.ContainerCollection}}
+    runInCoreAgent: false
   networkMonitoring:
-    enabled: false
+    enabled: {{.NetworkPerformanceMonitoring}}
+
+agents: 
+  containers:
+    agent:
+      env:
+        - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+          value: {{.RunInCoreAgent}}
+    processAgent:
+      env:
+        - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+          value: {{.RunInCoreAgent}}

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -226,6 +226,26 @@ func assertContainersCollected(t *testing.T, payloads []*aggregator.ProcessPaylo
 	}
 }
 
+// assertContainersNotCollected asserts that the given containers are not collected
+func assertContainersNotCollected(t *testing.T, payloads []*aggregator.ProcessPayload, containers []string) {
+	defer func() {
+		if t.Failed() {
+			t.Logf("Payloads:\n%+v\n", payloads)
+		}
+	}()
+
+	for _, container := range containers {
+		var found bool
+		for _, payload := range payloads {
+			if findContainer(container, payload.Containers) {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, "%s container found", container)
+	}
+}
+
 // findContainer returns whether the container with the given name exists in the given list of
 // containers and whether it has the expected data populated
 func findContainer(name string, containers []*agentmodel.Container) bool {

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -228,17 +228,12 @@ func assertContainersCollected(t *testing.T, payloads []*aggregator.ProcessPaylo
 
 // assertContainersNotCollected asserts that the given containers are not collected
 func assertContainersNotCollected(t *testing.T, payloads []*aggregator.ProcessPayload, containers []string) {
-	defer func() {
-		if t.Failed() {
-			t.Logf("Payloads:\n%+v\n", payloads)
-		}
-	}()
-
 	for _, container := range containers {
 		var found bool
 		for _, payload := range payloads {
 			if findContainer(container, payload.Containers) {
 				found = true
+				t.Logf("Payload:\n%+v\n", payload)
 				break
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Add e2e tests in K8s for running the process checks in the core agent. This also enables the process discovery test as the mentioned [issue](https://github.com/DataDog/datadog-agent/blob/0d57ed23b8e139b89675ea8c9e0ead595427b658/test/new-e2e/tests/process/k8s_test.go#L107) was fixed.

### Motivation

PROCS-4228

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

E2E test passes 😃 