### PR TITLE
Stop using the deprecated `linters.errcheck.ignore` in the golangci-lint configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -605,7 +605,6 @@ linters-settings:
 
   errcheck:
     exclude-functions:
-      - fmt.Sscanf
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFile
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileFromFunc
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileWithoutScrubbing
@@ -614,29 +613,47 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyDirToWithoutScrubbing
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyFile
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyFileTo
-      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
-      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).ChangeLogLevel
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Critical
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Error
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Errorf
-      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).ChangeLogLevel
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
+      - (net/http.ResponseWriter).Write
+      - fmt.Sscanf
+      - github.com/cihub/seelog.Warnf
       - github.com/DataDog/datadog-agent/pkg/collector/corechecks.Warnf
+      - github.com/DataDog/datadog-agent/pkg/util/log.ChangeLogLevel
+      - github.com/DataDog/datadog-agent/pkg/util/log.Critical
+      - github.com/DataDog/datadog-agent/pkg/util/log.Criticalc
+      - github.com/DataDog/datadog-agent/pkg/util/log.Criticalf
+      - github.com/DataDog/datadog-agent/pkg/util/log.CriticalStackDepth
       - github.com/DataDog/datadog-agent/pkg/util/log.Error
       - github.com/DataDog/datadog-agent/pkg/util/log.Errorc
       - github.com/DataDog/datadog-agent/pkg/util/log.Errorf
-      - github.com/DataDog/datadog-agent/pkg/util/log.Critical
+      - github.com/DataDog/datadog-agent/pkg/util/log.ErrorStackDepth
+      - github.com/DataDog/datadog-agent/pkg/util/log.JMXError
+      - github.com/DataDog/datadog-agent/pkg/util/log.logContextWithError
+      - github.com/DataDog/datadog-agent/pkg/util/log.logFormatWithError
       - github.com/DataDog/datadog-agent/pkg/util/log.Warn
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnc
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
-      - github.com/DataDog/datadog-agent/pkg/util/log.ChangeLogLevel
       - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth
-      - github.com/DataDog/datadog-agent/pkg/util/log.CriticalStackDepth
-      - github.com/DataDog/datadog-agent/pkg/util/log.logFormatWithError
-      - github.com/DataDog/datadog-agent/pkg/util/log.logContextWithError
-      - github.com/DataDog/datadog-agent/pkg/util/log.Criticalc
-      - github.com/DataDog/datadog-agent/pkg/util/log.ErrorStackDepth
-      - github.com/DataDog/datadog-agent/pkg/util/log.JMXError
-      - (net/http.ResponseWriter).Write
+      - github.com/lxn/walk:Dispose
+      - golang.org/x/sys/windows.CloseHandle
+      - golang.org/x/sys/windows.FreeLibrary
+      - golang.org/x/sys/windows.FreeSid
+      - golang.org/x/sys/windows.RegCloseKey
+      - golang.org/x/sys/windows/registry.Close
+      - golang.org/x/sys/windows/svc/debug.Close
+      - golang.org/x/sys/windows/svc/debug.Error
+      - golang.org/x/sys/windows/svc/debug.Info
+      - golang.org/x/sys/windows/svc/debug.Warning
+      - golang.org/x/sys/windows/svc/mgr:Disconnect
+      - golang.org/x/sys/windows:LocalFree
+      - golang.org/x/sys/windows:SetEvent
       - pkg/util/log.JMXError
+      - syscall:CloseHandle
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -499,7 +499,7 @@ issues:
     - path: comp/core/autodiscovery/providers/prometheus_services_nop.go
       linters:
         - pkgconfigusage
-    - path: comp/core/autodiscovery/providers/zookeeper_nop.go	
+    - path: comp/core/autodiscovery/providers/zookeeper_nop.go
       linters:
         - pkgconfigusage
     - path: comp/otelcol/otlp/no_otlp.go
@@ -606,7 +606,22 @@ linters-settings:
   errcheck:
     # Disable warnings for `fmt`, `log` and `seelog` packages. Also ignore `Write` functions from `net/http` package.
     # Disable warnings for select Windows functions
-    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log/def:.*,github.com/DataDog/datadog-agent/comp/core/log/mock:.*,github.com/cihub/seelog:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent|LocalFree),syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect,golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning),github.com/lxn/walk:Dispose,github.com/DataDog/datadog-agent/comp/core/flare/types:(AddFile.*|CopyDir.*|CopyFile.*),github.com/DataDog/datadog-agent/comp/core/flare/builder:(AddFile.*|CopyDir.*|CopyFile.*),golang.org/x/sys/windows/registry:Close
+    exclude-functions:
+      - fmt:.*
+      - github.com/cihub/seelog:.*
+      - github.com/DataDog/datadog-agent/comp/core/flare/builder:(AddFile.*|CopyDir.*|CopyFile.*)
+      - github.com/DataDog/datadog-agent/comp/core/flare/types:(AddFile.*|CopyDir.*|CopyFile.*)
+      - github.com/DataDog/datadog-agent/comp/core/log/def:.*
+      - github.com/DataDog/datadog-agent/comp/core/log/mock:.*
+      - github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?
+      - github.com/DataDog/datadog-agent/pkg/trace/metrics:.*
+      - github.com/DataDog/datadog-agent/pkg/util/log:.*
+      - github.com/lxn/walk:Dispose
+      - golang.org/x/sys/windows/registry:Close
+      - golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning)
+      - golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent|LocalFree)
+      - net/http:Write
+      - syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -621,10 +621,14 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
       - (github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/systen/memory.Check).Warnf
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/systen/memory.Check).Warn
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/orchestrator/ecs.Check).Warnf
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/orchestrator/ecs.Check).Warn
       - (net/http.ResponseWriter).Write
       - fmt.Sscanf
       - github.com/cihub/seelog.Warnf
-      - github.com/DataDog/datadog-agent/pkg/collector/corechecks.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.ChangeLogLevel
       - github.com/DataDog/datadog-agent/pkg/util/log.Critical
       - github.com/DataDog/datadog-agent/pkg/util/log.Criticalc
@@ -653,7 +657,7 @@ linters-settings:
       - golang.org/x/sys/windows/svc/debug.Error
       - golang.org/x/sys/windows/svc/debug.Info
       - golang.org/x/sys/windows/svc/debug.Warning
-      - golang.org/x/sys/windows/svc/mgr.Disconnect
+      - (golang.org/x/sys/windows/svc/mgr.Mgr).Disconnect
       - pkg/util/log.JMXError
       - syscall.CloseHandle
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -620,12 +620,8 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Errorf
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/systen/memory.Check).Warnf
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/systen/memory.Check).Warn
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/orchestrator/ecs.Check).Warnf
-      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks/orchestrator/ecs.Check).Warn
+      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
+      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
       - (net/http.ResponseWriter).Write
       - fmt.Sscanf
       - github.com/cihub/seelog.Warnf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -639,7 +639,7 @@ linters-settings:
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnc
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth
-      - github.com/lxn/walk:Dispose
+      - github.com/lxn/walk.Dispose
       - golang.org/x/sys/windows.CloseHandle
       - golang.org/x/sys/windows.FreeLibrary
       - golang.org/x/sys/windows.FreeSid

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -615,10 +615,12 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyFileTo
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).ChangeLogLevel
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Critical
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Criticalf
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Error
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Errorf
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
+      - (github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
       - (net/http.ResponseWriter).Write
       - fmt.Sscanf
       - github.com/cihub/seelog.Warnf
@@ -643,15 +645,15 @@ linters-settings:
       - golang.org/x/sys/windows.CloseHandle
       - golang.org/x/sys/windows.FreeLibrary
       - golang.org/x/sys/windows.FreeSid
+      - golang.org/x/sys/windows.LocalFree
       - golang.org/x/sys/windows.RegCloseKey
+      - golang.org/x/sys/windows.SetEvent
       - golang.org/x/sys/windows/registry.Close
       - golang.org/x/sys/windows/svc/debug.Close
       - golang.org/x/sys/windows/svc/debug.Error
       - golang.org/x/sys/windows/svc/debug.Info
       - golang.org/x/sys/windows/svc/debug.Warning
       - golang.org/x/sys/windows/svc/mgr.Disconnect
-      - golang.org/x/sys/windows.LocalFree
-      - golang.org/x/sys/windows.SetEvent
       - pkg/util/log.JMXError
       - syscall.CloseHandle
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -605,6 +605,7 @@ linters-settings:
 
   errcheck:
     exclude-functions:
+      - fmt.Sscanf
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFile
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileFromFunc
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileWithoutScrubbing
@@ -620,8 +621,11 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).ChangeLogLevel
       - github.com/DataDog/datadog-agent/pkg/collector/corechecks.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.Error
+      - github.com/DataDog/datadog-agent/pkg/util/log.Errorc
       - github.com/DataDog/datadog-agent/pkg/util/log.Errorf
+      - github.com/DataDog/datadog-agent/pkg/util/log.Critical
       - github.com/DataDog/datadog-agent/pkg/util/log.Warn
+      - github.com/DataDog/datadog-agent/pkg/util/log.Warnc
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.ChangeLogLevel
       - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -632,6 +632,7 @@ linters-settings:
       - github.com/DataDog/datadog-agent/pkg/util/log.ErrorStackDepth
       - github.com/DataDog/datadog-agent/pkg/util/log.JMXError
       - (net/http.ResponseWriter).Write
+      - pkg/util/log.JMXError
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -605,6 +605,9 @@ linters-settings:
 
   errcheck:
     exclude-functions:
+      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
+      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
+      - (*golang.org/x/sys/windows/svc/mgr.Mgr).Disconnect
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFile
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileFromFunc
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileWithoutScrubbing
@@ -620,8 +623,6 @@ linters-settings:
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Errorf
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
       - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
-      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
-      - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
       - (net/http.ResponseWriter).Write
       - fmt.Sscanf
       - github.com/cihub/seelog.Warnf
@@ -653,7 +654,6 @@ linters-settings:
       - golang.org/x/sys/windows/svc/debug.Error
       - golang.org/x/sys/windows/svc/debug.Info
       - golang.org/x/sys/windows/svc/debug.Warning
-      - (golang.org/x/sys/windows/svc/mgr.Mgr).Disconnect
       - pkg/util/log.JMXError
       - syscall.CloseHandle
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -629,6 +629,7 @@ linters-settings:
       - github.com/DataDog/datadog-agent/pkg/util/log.logFormatWithError
       - github.com/DataDog/datadog-agent/pkg/util/log.logContextWithError
       - github.com/DataDog/datadog-agent/pkg/util/log.Criticalc
+      - github.com/DataDog/datadog-agent/pkg/util/log.ErrorStackDepth
       - github.com/DataDog/datadog-agent/pkg/util/log.JMXError
       - (net/http.ResponseWriter).Write
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -649,11 +649,11 @@ linters-settings:
       - golang.org/x/sys/windows/svc/debug.Error
       - golang.org/x/sys/windows/svc/debug.Info
       - golang.org/x/sys/windows/svc/debug.Warning
-      - golang.org/x/sys/windows/svc/mgr:Disconnect
-      - golang.org/x/sys/windows:LocalFree
-      - golang.org/x/sys/windows:SetEvent
+      - golang.org/x/sys/windows/svc/mgr.Disconnect
+      - golang.org/x/sys/windows.LocalFree
+      - golang.org/x/sys/windows.SetEvent
       - pkg/util/log.JMXError
-      - syscall:CloseHandle
+      - syscall.CloseHandle
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -604,24 +604,33 @@ linters-settings:
             desc: "Not really forbidden to use, but it is usually imported by mistake instead of github.com/stretchr/testify/assert, and confusing since it actually has the behavior of github.com/stretchr/testify/require"
 
   errcheck:
-    # Disable warnings for `fmt`, `log` and `seelog` packages. Also ignore `Write` functions from `net/http` package.
-    # Disable warnings for select Windows functions
     exclude-functions:
-      - fmt:.*
-      - github.com/cihub/seelog:.*
-      - github.com/DataDog/datadog-agent/comp/core/flare/builder:(AddFile.*|CopyDir.*|CopyFile.*)
-      - github.com/DataDog/datadog-agent/comp/core/flare/types:(AddFile.*|CopyDir.*|CopyFile.*)
-      - github.com/DataDog/datadog-agent/comp/core/log/def:.*
-      - github.com/DataDog/datadog-agent/comp/core/log/mock:.*
-      - github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?
-      - github.com/DataDog/datadog-agent/pkg/trace/metrics:.*
-      - github.com/DataDog/datadog-agent/pkg/util/log:.*
-      - github.com/lxn/walk:Dispose
-      - golang.org/x/sys/windows/registry:Close
-      - golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning)
-      - golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent|LocalFree)
-      - net/http:Write
-      - syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFile
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileFromFunc
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileWithoutScrubbing
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyDir
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyDirTo
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyDirToWithoutScrubbing
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyFile
+      - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).CopyFileTo
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warn
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Warnf
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Error
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).Errorf
+      - (github.com/DataDog/datadog-agent/comp/core/log/def.Component).ChangeLogLevel
+      - github.com/DataDog/datadog-agent/pkg/collector/corechecks.Warnf
+      - github.com/DataDog/datadog-agent/pkg/util/log.Error
+      - github.com/DataDog/datadog-agent/pkg/util/log.Errorf
+      - github.com/DataDog/datadog-agent/pkg/util/log.Warn
+      - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
+      - github.com/DataDog/datadog-agent/pkg/util/log.ChangeLogLevel
+      - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth
+      - github.com/DataDog/datadog-agent/pkg/util/log.CriticalStackDepth
+      - github.com/DataDog/datadog-agent/pkg/util/log.logFormatWithError
+      - github.com/DataDog/datadog-agent/pkg/util/log.logContextWithError
+      - github.com/DataDog/datadog-agent/pkg/util/log.Criticalc
+      - github.com/DataDog/datadog-agent/pkg/util/log.JMXError
+      - (net/http.ResponseWriter).Write
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -607,6 +607,7 @@ linters-settings:
     exclude-functions:
       - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warn
       - (*github.com/DataDog/datadog-agent/pkg/collector/corechecks.CheckBase).Warnf
+      - (*github.com/lxn/walk.NotifyIcon).Dispose
       - (*golang.org/x/sys/windows/svc/mgr.Mgr).Disconnect
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFile
       - (github.com/DataDog/datadog-agent/comp/core/flare/builder.FlareBuilder).AddFileFromFunc
@@ -642,7 +643,6 @@ linters-settings:
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnc
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth
-      - github.com/lxn/walk.Dispose
       - golang.org/x/sys/windows.CloseHandle
       - golang.org/x/sys/windows.FreeLibrary
       - golang.org/x/sys/windows.FreeSid

--- a/pkg/util/log/klog_redirect.go
+++ b/pkg/util/log/klog_redirect.go
@@ -46,11 +46,11 @@ func (l KlogRedirectLogger) Write(b []byte) (int, error) {
 	case 'I':
 		InfoStackDepth(l.stackDepth, msg)
 	case 'W':
-		WarnStackDepth(l.stackDepth, msg)
+		_ = WarnStackDepth(l.stackDepth, msg)
 	case 'E':
-		ErrorStackDepth(l.stackDepth, msg)
+		_ = ErrorStackDepth(l.stackDepth, msg)
 	case 'F':
-		CriticalStackDepth(l.stackDepth, msg)
+		_ = CriticalStackDepth(l.stackDepth, msg)
 	default:
 		InfoStackDepth(l.stackDepth, msg)
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -878,25 +878,25 @@ func InfoFunc(logFunc func() string) {
 
 // Warn logs at the warn level and returns an error containing the formated log message
 func Warn(v ...interface{}) error {
-	return logWithError(seelog.WarnLvl, func() { Warn(v...) }, logger.warn, false, v...)
+	return logWithError(seelog.WarnLvl, func() { _ = Warn(v...) }, logger.warn, false, v...)
 }
 
 // Warnf logs with format at the warn level and returns an error containing the formated log message
 func Warnf(format string, params ...interface{}) error {
-	return logFormatWithError(seelog.WarnLvl, func() { Warnf(format, params...) }, logger.warnf, format, false, params...)
+	return logFormatWithError(seelog.WarnLvl, func() { _ = Warnf(format, params...) }, logger.warnf, format, false, params...)
 }
 
 // WarnfStackDepth logs with format at the warn level and the current stack depth plus the given depth
 func WarnfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(seelog.WarnLvl, func() { WarnStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(seelog.WarnLvl, func() { _ = WarnStackDepth(depth, msg) }, func(s string) error {
 		return logger.warnStackDepth(s, depth)
 	}, false, msg)
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func WarncStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(seelog.WarnLvl, func() { Warnc(message, context...) }, logger.warn, message, false, depth, context...)
+	return logContextWithError(seelog.WarnLvl, func() { _ = Warnc(message, context...) }, logger.warn, message, false, depth, context...)
 }
 
 // Warnc logs at the warn level with context and returns an error containing the formated log message
@@ -908,31 +908,31 @@ func Warnc(message string, context ...interface{}) error {
 func WarnFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.WarnLvl {
-		WarnStackDepth(2, logFunc())
+		_ = WarnStackDepth(2, logFunc())
 	}
 }
 
 // Error logs at the error level and returns an error containing the formated log message
 func Error(v ...interface{}) error {
-	return logWithError(seelog.ErrorLvl, func() { Error(v...) }, logger.error, true, v...)
+	return logWithError(seelog.ErrorLvl, func() { _ = Error(v...) }, logger.error, true, v...)
 }
 
 // Errorf logs with format at the error level and returns an error containing the formated log message
 func Errorf(format string, params ...interface{}) error {
-	return logFormatWithError(seelog.ErrorLvl, func() { Errorf(format, params...) }, logger.errorf, format, true, params...)
+	return logFormatWithError(seelog.ErrorLvl, func() { _ = Errorf(format, params...) }, logger.errorf, format, true, params...)
 }
 
 // ErrorfStackDepth logs with format at the error level and the current stack depth plus the given depth
 func ErrorfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(seelog.ErrorLvl, func() { ErrorStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(seelog.ErrorLvl, func() { _ = ErrorStackDepth(depth, msg) }, func(s string) error {
 		return logger.errorStackDepth(s, depth)
 	}, true, msg)
 }
 
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorcStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(seelog.ErrorLvl, func() { Errorc(message, context...) }, logger.error, message, true, depth, context...)
+	return logContextWithError(seelog.ErrorLvl, func() { _ = Errorc(message, context...) }, logger.error, message, true, depth, context...)
 }
 
 // Errorc logs at the error level with context and returns an error containing the formated log message
@@ -944,31 +944,31 @@ func Errorc(message string, context ...interface{}) error {
 func ErrorFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.ErrorLvl {
-		ErrorStackDepth(2, logFunc())
+		_ = ErrorStackDepth(2, logFunc())
 	}
 }
 
 // Critical logs at the critical level and returns an error containing the formated log message
 func Critical(v ...interface{}) error {
-	return logWithError(seelog.CriticalLvl, func() { Critical(v...) }, logger.critical, true, v...)
+	return logWithError(seelog.CriticalLvl, func() { _ = Critical(v...) }, logger.critical, true, v...)
 }
 
 // Criticalf logs with format at the critical level and returns an error containing the formated log message
 func Criticalf(format string, params ...interface{}) error {
-	return logFormatWithError(seelog.CriticalLvl, func() { Criticalf(format, params...) }, logger.criticalf, format, true, params...)
+	return logFormatWithError(seelog.CriticalLvl, func() { _ = Criticalf(format, params...) }, logger.criticalf, format, true, params...)
 }
 
 // CriticalfStackDepth logs with format at the critical level and the current stack depth plus the given depth
 func CriticalfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(seelog.CriticalLvl, func() { CriticalStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(seelog.CriticalLvl, func() { _ = CriticalStackDepth(depth, msg) }, func(s string) error {
 		return logger.criticalStackDepth(s, depth)
 	}, false, msg)
 }
 
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func CriticalcStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(seelog.CriticalLvl, func() { Criticalc(message, context...) }, logger.critical, message, true, depth, context...)
+	return logContextWithError(seelog.CriticalLvl, func() { _ = Criticalc(message, context...) }, logger.critical, message, true, depth, context...)
 }
 
 // Criticalc logs at the critical level with context and returns an error containing the formated log message
@@ -980,7 +980,7 @@ func Criticalc(message string, context ...interface{}) error {
 func CriticalFunc(logFunc func() string) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.CriticalLvl {
-		CriticalStackDepth(2, logFunc())
+		_ = CriticalStackDepth(2, logFunc())
 	}
 }
 
@@ -993,7 +993,7 @@ func InfoStackDepth(depth int, v ...interface{}) {
 
 // WarnStackDepth logs at the warn level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func WarnStackDepth(depth int, v ...interface{}) error {
-	return logWithError(seelog.WarnLvl, func() { WarnStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(seelog.WarnLvl, func() { _ = WarnStackDepth(depth, v...) }, func(s string) error {
 		return logger.warnStackDepth(s, depth)
 	}, false, v...)
 }
@@ -1014,14 +1014,14 @@ func TraceStackDepth(depth int, v ...interface{}) {
 
 // ErrorStackDepth logs at the error level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorStackDepth(depth int, v ...interface{}) error {
-	return logWithError(seelog.ErrorLvl, func() { ErrorStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(seelog.ErrorLvl, func() { _ = ErrorStackDepth(depth, v...) }, func(s string) error {
 		return logger.errorStackDepth(s, depth)
 	}, true, v...)
 }
 
 // CriticalStackDepth logs at the critical level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func CriticalStackDepth(depth int, v ...interface{}) error {
-	return logWithError(seelog.CriticalLvl, func() { CriticalStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(seelog.CriticalLvl, func() { _ = CriticalStackDepth(depth, v...) }, func(s string) error {
 		return logger.criticalStackDepth(s, depth)
 	}, true, v...)
 }
@@ -1032,7 +1032,7 @@ func CriticalStackDepth(depth int, v ...interface{}) error {
 
 // JMXError Logs for JMX check
 func JMXError(v ...interface{}) error {
-	return logWithError(seelog.ErrorLvl, func() { JMXError(v...) }, jmxLogger.error, true, v...)
+	return logWithError(seelog.ErrorLvl, func() { _ = JMXError(v...) }, jmxLogger.error, true, v...)
 }
 
 // JMXInfo Logs


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Stop using the deprecated `linters.errcheck.ignore` in the golangci-lint configuration file

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/613303294#L822

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- This new option does not support regex, at least yet. @pgimalac opened an issue about it https://github.com/kisielk/errcheck/issues/250
- It seems there's a bug for functions that are called from the same package. I fixed it in the code using `_ = myFunction()` since there was only a handful of them located in the same package. I opened an issue for this https://github.com/kisielk/errcheck/issues/251

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
