### PR TITLE
fix(installer): Allow --deploy-installer to run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,6 +384,7 @@ workflow:
         GO_TEST_SKIP_FLAKE: "false"
     - <<: *if_release_branch
     - <<: *if_deploy
+    - <<: *if_deploy_installer
     - if: $CI_COMMIT_TAG == null
 
 #


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/datadog-agent/pull/27740 forgot to add the `if_deploy_installer` rule to the workflow rules, preventing deploy when using `--deploy-installer`. This PR fixes it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
