### PR TITLE
[APM] Normalize X-Datadog-Container-Tags header

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -853,3 +853,9 @@ func getMediaType(req *http.Request) string {
 	}
 	return mt
 }
+
+// normalizeHTTPHeader takes a raw string and normalizes the value to be compatible
+// with an HTTP header value.
+func normalizeHTTPHeader(val string) string {
+	return strings.ReplaceAll(val, "\n", "_")
+}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -857,5 +857,8 @@ func getMediaType(req *http.Request) string {
 // normalizeHTTPHeader takes a raw string and normalizes the value to be compatible
 // with an HTTP header value.
 func normalizeHTTPHeader(val string) string {
-	return strings.ReplaceAll(val, "\n", "_")
+	val = strings.ReplaceAll(val, "\r\n", "_")
+	val = strings.ReplaceAll(val, "\r", "_")
+	val = strings.ReplaceAll(val, "\n", "_")
+	return val
 }

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1063,23 +1063,39 @@ func TestNormalizeHTTPHeader(t *testing.T) {
 		expected string
 	}{
 		{
-			input:    "tag value\nAnother tag value",
-			expected: "tag value_Another tag value",
+			input:    "Header: value\nAnother header: value",
+			expected: "Header: value_Another header: value",
+		},
+		{
+			input:    "Header: value\rAnother header: value",
+			expected: "Header: value_Another header: value",
+		},
+		{
+			input:    "Header: value\r\nAnother header: value",
+			expected: "Header: value_Another header: value",
 		},
 		{
 			input:    "SingleLineHeader: value",
 			expected: "SingleLineHeader: value",
 		},
 		{
+			input:    "\rLeading carriage return",
+			expected: "_Leading carriage return",
+		},
+		{
 			input:    "\nLeading line break",
 			expected: "_Leading line break",
+		},
+		{
+			input:    "Trailing carriage return\r",
+			expected: "Trailing carriage return_",
 		},
 		{
 			input:    "Trailing line break\n",
 			expected: "Trailing line break_",
 		},
 		{
-			input:    "Multiple\nline\nbreaks",
+			input:    "Multiple\r\nline\r\nbreaks",
 			expected: "Multiple_line_breaks",
 		},
 		{

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1057,6 +1057,45 @@ func TestExpvar(t *testing.T) {
 	})
 }
 
+func TestNormalizeHTTPHeader(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "tag value\nAnother tag value",
+			expected: "tag value_Another tag value",
+		},
+		{
+			input:    "SingleLineHeader: value",
+			expected: "SingleLineHeader: value",
+		},
+		{
+			input:    "\nLeading line break",
+			expected: "_Leading line break",
+		},
+		{
+			input:    "Trailing line break\n",
+			expected: "Trailing line break_",
+		},
+		{
+			input:    "Multiple\nline\nbreaks",
+			expected: "Multiple_line_breaks",
+		},
+		{
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		result := normalizeHTTPHeader(test.input)
+		if result != test.expected {
+			t.Errorf("normalizeHTTPHeader(%q) = %q; expected %q", test.input, result, test.expected)
+		}
+	}
+}
+
 func msgpTraces(t *testing.T, traces pb.Traces) []byte {
 	bts, err := traces.MarshalMsg(nil)
 	if err != nil {

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -164,8 +164,9 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	if containerID != "" {
 		req.Header.Set(header.ContainerID, containerID)
 		if ctags := getContainerTags(t.conf.ContainerTags, containerID); ctags != "" {
-			req.Header.Set("X-Datadog-Container-Tags", ctags)
-			log.Debugf("Setting header X-Datadog-Container-Tags=%s for evp proxy", ctags)
+			ctagsHeader := normalizeHTTPHeader(ctags)
+			req.Header.Set("X-Datadog-Container-Tags", ctagsHeader)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for evp proxy", ctagsHeader)
 		}
 	}
 	req.Header.Set("X-Datadog-Hostname", t.conf.Hostname)

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -82,8 +82,9 @@ func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []
 		}
 		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
 		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
-			req.Header.Set("X-Datadog-Container-Tags", ctags)
-			log.Debugf("Setting header X-Datadog-Container-Tags=%s for pipeline stats proxy", ctags)
+			ctagsHeader := normalizeHTTPHeader(ctags)
+			req.Header.Set("X-Datadog-Container-Tags", ctagsHeader)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for pipeline stats proxy", ctagsHeader)
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
 		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for pipeline stats proxy", tags)

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -116,8 +116,9 @@ func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string
 		}
 		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
 		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
-			req.Header.Set("X-Datadog-Container-Tags", ctags)
-			log.Debugf("Setting header X-Datadog-Container-Tags=%s for profiles proxy", ctags)
+			ctagsHeader := normalizeHTTPHeader(ctags)
+			req.Header.Set("X-Datadog-Container-Tags", ctagsHeader)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for profiles proxy", ctagsHeader)
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
 		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for profiles proxy", tags)


### PR DESCRIPTION
HTTP header values cannot contain line breaks. This PR ensures that if Container Tags contain line breaks, the value is sanitized to replace those line breaks with underscores. It would otherwise result in an invalid header/request.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This is a fix for https://datadoghq.atlassian.net/browse/APMS-13035

HTTP header values cannot contain line breaks. This PR ensures that if Container Tags contain line breaks, the value is sanitized to replace those line breaks with underscores. It would otherwise result in an invalid header/request.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/APMS-13035

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
