### PR TITLE
fix(fleet): Properly ignore the run dir

### DIFF
--- a/pkg/fleet/installer/repository/repositories.go
+++ b/pkg/fleet/installer/repository/repositories.go
@@ -52,8 +52,8 @@ func (r *Repositories) loadRepositories() (map[string]*Repository, error) {
 			// Temporary dir created by Repositories.MkdirTemp, ignore
 			continue
 		}
-		if filepath.Join(r.rootPath, d.Name()) == r.locksPath {
-			// Locks dir, ignore
+		if d.Name() == "run" {
+			// run dir, ignore
 			continue
 		}
 		repo := r.newRepository(d.Name())


### PR DESCRIPTION
### What does this PR do?
`r.locksPath` pointed to /run/locks so it wasn't properly ignored

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
