### PR TITLE
[e2e] handle remove within stack destroy

### DIFF
--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -10,13 +10,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"io"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -343,7 +344,7 @@ func (sm *StackManager) deleteStack(ctx context.Context, stackID string, stack *
 	for {
 		downCount++
 		destroyContext, cancel := context.WithTimeout(ctx, defaultStackDestroyTimeout)
-		_, destroyErr = stack.Destroy(destroyContext, progressStreamsDestroyOption, optdestroy.DebugLogging(loggingOptions))
+		_, destroyErr = stack.Destroy(destroyContext, progressStreamsDestroyOption, optdestroy.DebugLogging(loggingOptions), optdestroy.Remove())
 		cancel()
 		if destroyErr == nil {
 			sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : success on Pulumi stack destroy", stackID), "", []string{"operation:destroy", "result:ok", fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", downCount)})
@@ -371,10 +372,7 @@ func (sm *StackManager) deleteStack(ctx context.Context, stackID string, stack *
 		fmt.Printf("Retrying stack on error during stack destroy: %v\n", destroyErr)
 	}
 
-	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)
-	defer cancel()
-	err = stack.Workspace().RemoveStack(deleteContext, stack.Name())
-	return err
+	return nil
 }
 
 func (sm *StackManager) getStack(ctx context.Context, name string, deployFunc pulumi.RunFunc, options ...GetStackOption) (*auto.Stack, auto.UpResult, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add `Remove` option to stack destroy call

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Handle stack removal within the destroy retry loop

Should fix [ADXT-516](https://datadoghq.atlassian.net/browse/ADXT-516),[ADXT-506](https://datadoghq.atlassian.net/browse/ADXT-506), [ADXT-517](https://datadoghq.atlassian.net/browse/ADXT-517) and [ADXT-518](https://datadoghq.atlassian.net/browse/ADXT-518)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We recently saw an increase of test failures at destroy time, with no clear error but `signal: killed`, meaning the pulumi subprocess is killed by the timeout we have in the context passed to the call to remove. This PR should retry on remove errors.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[ADXT-516]: https://datadoghq.atlassian.net/browse/ADXT-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ