### PR TITLE
APMON-1234: write server-provided name overrides from remote config to local disk

### DIFF
--- a/comp/remote-config/rcclient/rcclientimpl/apm_tracing_linux.go
+++ b/comp/remote-config/rcclient/rcclientimpl/apm_tracing_linux.go
@@ -34,7 +34,7 @@ const FileWriteFailure = "FILE_WRITE_FAILURE"
 const DuplicateHostConfig = "DUPLICATE_HOST_CONFIG"
 
 type serviceEnvConfig struct {
-	ProvidedService string `yaml:"provided_service"`
+	ProvidedService string `yaml:"provided_service,omitempty"`
 	Service         string `yaml:"service"`
 	Env             string `yaml:"env"`
 	TracingEnabled  bool   `yaml:"tracing_enabled"`
@@ -57,7 +57,7 @@ type tracingConfigUpdate struct {
 		TracingEnabled bool   `json:"tracing_enabled"`
 	} `json:"lib_config"`
 	ServiceTarget *struct {
-		ProvidedService string `json:"provided_service"`
+		ProvidedService string `json:"provided_service,omitempty"`
 		Service         string `json:"service"`
 		Env             string `json:"env"`
 	} `json:"service_target"`

--- a/comp/remote-config/rcclient/rcclientimpl/apm_tracing_linux_test.go
+++ b/comp/remote-config/rcclient/rcclientimpl/apm_tracing_linux_test.go
@@ -22,12 +22,18 @@ import (
 func TestOnAPMTracingUpdate(t *testing.T) {
 	mkTemp := func(t *testing.T) func() {
 		oldPath := apmTracingFilePath
+		oldPath2 := apmServiceNameFilePath
 		f, err := os.CreateTemp("", "test")
 		require.NoError(t, err)
 		f.Close() // This is required for windows unit tests as windows will not allow this file to be deleted while we have this handle.
 		apmTracingFilePath = f.Name()
+		f2, err := os.CreateTemp("", "test2")
+		require.NoError(t, err)
+		f2.Close() // This is required for windows unit tests as windows will not allow this file to be deleted while we have this handle.
+		apmServiceNameFilePath = f2.Name()
 		return func() {
 			apmTracingFilePath = oldPath
+			apmServiceNameFilePath = oldPath2
 		}
 	}
 
@@ -160,7 +166,7 @@ func TestServiceNameConfig(t *testing.T) {
 
 			// write the file
 			tec := tracingEnabledConfig{
-				ServiceEnvConfigs: nil,
+				ServiceEnvConfigs: d.cfg,
 			}
 			err := writeServiceNameConfig(tec)
 			if err != nil {
@@ -200,6 +206,7 @@ func TestServiceNameConfig(t *testing.T) {
 		t.Cleanup(func() {
 			apmServiceNameFilePath = origName
 		})
+
 
 		// write the file
 		tec := tracingEnabledConfig{


### PR DESCRIPTION
### What does this PR do?

This PR builds a map of generated service names to customer-provided service names and saves it to disk as a YAML file. This file will be read by the single step instrumentation injector code. 

Each APM Tracing configuration sent to the agent is checked to see if it contains a new field, `provided_service`. If it does, the mapping from `service` to `provided_service` is added to a map. This map is serialized to disk as YAML.

https://datadoghq.atlassian.net/browse/APMON-1234

### Motivation

This PR is part of the service discovery project. Allowing customers to override the generated name is a go-to-market requirement.

### Additional Notes

We need a way to allow customers to override the automatically generated service names for discovered services before the services are first instrumented. The customer will provide the name in the UI and the value will be used by single step instrumentation.

### Possible Drawbacks / Trade-offs

This code should have no side-effects. 

There is supporting work that still needs to be completed.

- The Remote Config for APM Tracing has not been updated with the new field (provided_service)
- The UI for updating Remote Config is still not created.
- The automatic injector for single step needs to be updated to use this file. It is being updated in a PR in the auto_inject repo (https://github.com/DataDog/auto_inject/pull/379)

### Describe how to test/QA your changes

- For now, make sure there is no impact
- Once Remote Config has been updated, issue an update to the remote config for a service to include a provided_service name. 
- Check to see if the file /opt/datadog-agent/run/service_name_config.yaml is created
- Check to see if the contents of the file are the original name mapped to the newly provided name
