### PR TITLE
V2 Auto Multiline Detection - Pattern Table Heuristic

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1489,8 +1489,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// maximum time that the windows tailer will hold a log file open, while waiting for
 	// the downstream logs pipeline to be ready to accept more data
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
-	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
-	config.SetKnown("logs_config.auto_multi_line_detection_custom_samples")
+
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_extra_patterns", []string{})
 	// The following auto_multi_line settings are experimental and may change
@@ -1498,8 +1497,14 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", 0.48)
 
+	// Experimental auto multiline detection settings (these are subject to change until the feature is no longer experimental)
+	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
+	config.SetKnown("logs_config.auto_multi_line_detection_custom_samples")
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.timestamp_detector_match_threshold", 0.5)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_max_size", 20)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_match_threshold", 0.75)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.dont_aggregate_unmatched_top_format", true)
 
 	// If true, the agent looks for container logs in the location used by podman, rather
 	// than docker.  This is a temporary configuration parameter to support podman logs until

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1504,7 +1504,6 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_max_size", 20)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_match_threshold", 0.75)
-	config.BindEnvAndSetDefault("logs_config.auto_multi_line.dont_aggregate_unmatched_top_format", true)
 
 	// If true, the agent looks for container logs in the location used by podman, rather
 	// than docker.  This is a temporary configuration parameter to support podman logs until

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -18,9 +18,9 @@ func NewJSONDetector() *JSONDetector {
 	return &JSONDetector{}
 }
 
-// Process checks if a message is a JSON message.
+// ProcessAndContinue checks if a message is a JSON message.
 // This implements the Herustic interface - so we should stop processing if we detect a JSON message by returning false.
-func (j *JSONDetector) Process(context *messageContext) bool {
+func (j *JSONDetector) ProcessAndContinue(context *messageContext) bool {
 	if jsonRegexp.Match(context.rawMessage) {
 		context.label = noAggregate
 		return false

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
@@ -43,7 +43,7 @@ func TestJsonDetector(t *testing.T) {
 				rawMessage: []byte(tc.rawMessage),
 				label:      aggregate,
 			}
-			assert.Equal(t, tc.expectedResult, jsonDetector.Process(messageContext))
+			assert.Equal(t, tc.expectedResult, jsonDetector.ProcessAndContinue(messageContext))
 			assert.Equal(t, tc.expectedLabel, messageContext.label)
 		})
 	}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -28,9 +28,9 @@ type messageContext struct {
 
 // Heuristic is an interface representing a strategy to label log messages.
 type Heuristic interface {
-	// Process processes a log message and annotates the context with a label. It returns false if the message should be done processing.
+	// ProcessAndContinue processes a log message and annotates the context with a label. It returns false if the message should be done processing.
 	// Heuristic implementations may mutate the message context but must do so synchronously.
-	Process(*messageContext) bool
+	ProcessAndContinue(*messageContext) bool
 }
 
 // Labeler labels log messages based on a set of heuristics.
@@ -55,7 +55,7 @@ func (l *Labeler) Label(rawMessage []byte) Label {
 		label:      aggregate,
 	}
 	for _, h := range l.heuristics {
-		if !h.Process(context) {
+		if !h.ProcessAndContinue(context) {
 			return context.label
 		}
 	}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -61,3 +61,16 @@ func (l *Labeler) Label(rawMessage []byte) Label {
 	}
 	return context.label
 }
+
+func labelToString(label Label) string {
+	switch label {
+	case startGroup:
+		return "start_group"
+	case noAggregate:
+		return "no_aggregate"
+	case aggregate:
+		return "aggregate"
+	default:
+		return ""
+	}
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
@@ -16,7 +16,7 @@ type mockHeuristic struct {
 	processFunc func(*messageContext) bool
 }
 
-func (m *mockHeuristic) Process(context *messageContext) bool {
+func (m *mockHeuristic) ProcessAndContinue(context *messageContext) bool {
 	return m.processFunc(context)
 }
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
@@ -119,7 +119,7 @@ func (p *PatternTable) DumpTable() []DiagnosticRow {
 }
 
 // ProcessAndContinue adds a pattern to the table and updates its label based on it's frequency.
-// This implements the Herustic interfce - so we should stop processing if the label was changed
+// This implements the Herustic interface - so we should stop processing if the label was changed
 // due to pattern detection.
 func (p *PatternTable) ProcessAndContinue(context *messageContext) bool {
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection/tokens"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type row struct {
+	tokens    []tokens.Token
+	label     Label
+	count     int64
+	lastIndex int64
+}
+
+// DiagnosticRow is a struct that represents a diagnostic view of a row in the PatternTable.
+type DiagnosticRow struct {
+	TokenString string
+	LabelString string
+	Count       int64
+	LastIndex   int64
+}
+
+// PatternTable is a table of patterns that occur over time from a log source.
+// This heuristic is used to prevent certain classes of false positives in multiline detection
+// as well as collect diagnostic data for fine tuning and debugging.
+// The patternt table is always sorted by the frequency of the patterns. When the table
+// becomes full, the least recently updated pattern is evicted.
+type PatternTable struct {
+	table                           []*row
+	index                           int64
+	maxTableSize                    int
+	matchThreshold                  float64
+	dontAggregateUnmatchedTopFormat bool
+}
+
+// NewPatternTable returns a new PatternTable heuristic.
+func NewPatternTable(maxTableSize int, matchThreshold float64, dontAggregateUnmatchedTopFormat bool) *PatternTable {
+	return &PatternTable{
+		table:                           make([]*row, 0, maxTableSize),
+		index:                           0,
+		maxTableSize:                    maxTableSize,
+		matchThreshold:                  matchThreshold,
+		dontAggregateUnmatchedTopFormat: dontAggregateUnmatchedTopFormat,
+	}
+}
+
+func (p *PatternTable) insert(tokens []tokens.Token, label Label) int {
+	p.index++
+	foundIdx := -1
+	for i, r := range p.table {
+		if isMatch(r.tokens, tokens, p.matchThreshold) {
+			r.count++
+			r.label = label
+			r.lastIndex = p.index
+			foundIdx = i
+			break
+		}
+	}
+
+	if foundIdx == 0 {
+		return foundIdx
+	}
+
+	if foundIdx > 0 {
+		return p.siftUp(foundIdx)
+	}
+
+	// If the table is full, make room for a new entry
+	if len(p.table) >= p.maxTableSize {
+		p.evictLRU()
+	}
+
+	p.table = append(p.table, &row{
+		tokens:    tokens,
+		label:     label,
+		count:     1,
+		lastIndex: p.index,
+	})
+	return len(p.table) - 1
+
+}
+
+// siftUp moves the row at the given index up the table until it is in the correct position.
+func (p *PatternTable) siftUp(idx int) int {
+	for idx != 0 && p.table[idx].count > p.table[idx-1].count {
+		p.table[idx], p.table[idx-1] = p.table[idx-1], p.table[idx]
+		idx--
+	}
+	return idx
+}
+
+// evictLRU removes the least recently updated row from the table.
+func (p *PatternTable) evictLRU() {
+	mini := 0
+	minIndex := p.index
+	for i, r := range p.table {
+		if r.lastIndex < minIndex {
+			minIndex = r.lastIndex
+			mini = i
+		}
+	}
+	p.table = append(p.table[:mini], p.table[mini+1:]...)
+}
+
+// DumpTable returns a slice of DiagnosticRow structs that represent the current state of the table.
+func (p *PatternTable) DumpTable() []DiagnosticRow {
+	debug := make([]DiagnosticRow, 0, len(p.table))
+	for _, r := range p.table {
+		debug = append(debug, DiagnosticRow{
+			TokenString: tokensToString(r.tokens),
+			LabelString: labelToString(r.label),
+			Count:       r.count,
+			LastIndex:   r.lastIndex})
+	}
+	return debug
+}
+
+// Process adds a pattern to the table and updates its label based on it's frequency.
+// This implements the Herustic interface - so we should stop processing if the label was changed
+// due to pattern detection.
+func (p *PatternTable) Process(context *messageContext) bool {
+
+	if context.tokens == nil {
+		log.Error("Tokens are required to process patterns")
+		return true
+	}
+
+	idx := p.insert(context.tokens, context.label)
+
+	// If the log has an aggregate (default) label, but is the most popular,
+	// we shouldn't aggreaget it. This is a common false positive case where
+	// a log file with multiple formats can sometimes have log lines that are detected
+	// to have a timestamp but are not actually the start of a multiline message.
+	if p.dontAggregateUnmatchedTopFormat && idx == 0 && context.label == aggregate {
+		context.label = noAggregate
+		return false
+	}
+
+	return true
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
@@ -118,10 +118,10 @@ func (p *PatternTable) DumpTable() []DiagnosticRow {
 	return debug
 }
 
-// Process adds a pattern to the table and updates its label based on it's frequency.
+// ProcessAndContinue adds a pattern to the table and updates its label based on it's frequency.
 // This implements the Herustic interfce - so we should stop processing if the label was changed
 // due to pattern detection.
-func (p *PatternTable) Process(context *messageContext) bool {
+func (p *PatternTable) ProcessAndContinue(context *messageContext) bool {
 
 	if context.tokens == nil {
 		log.Error("Tokens are required to process patterns")

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
@@ -21,7 +21,7 @@ func justTokens(tokens []tokens.Token, _ []int) []tokens.Token {
 func TestPatternTable(t *testing.T) {
 
 	tokenizer := NewTokenizer(0)
-	pt := NewPatternTable(5, 1, true)
+	pt := NewPatternTable(5, 1)
 
 	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
 	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 @"))), aggregate)
@@ -94,32 +94,4 @@ func TestPatternTable(t *testing.T) {
 	assert.Equal(t, "no_aggregate", dump[2].LabelString)
 	assert.Equal(t, "aggregate", dump[3].LabelString)
 	assert.Equal(t, "start_group", dump[4].LabelString)
-}
-
-func TestPatternTableProcess(t *testing.T) {
-
-	tokenizer := NewTokenizer(60)
-	pt := NewPatternTable(5, 1, true)
-
-	process := func(input string, label Label, continueProcessing bool) *messageContext {
-		context := &messageContext{
-			rawMessage: []byte(input),
-			label:      label,
-		}
-
-		assert.True(t, tokenizer.Process(context))
-		assert.Equal(t, continueProcessing, pt.Process(context))
-		return context
-	}
-
-	for i := 0; i < 10; i++ {
-		assert.Equal(t, startGroup, process("start group", startGroup, true).label)
-	}
-
-	for i := 0; i < 10; i++ {
-		assert.Equal(t, aggregate, process("aggregate", aggregate, true).label)
-	}
-
-	// One more aggregate puts it at the top, which will trigger the heuristic to change the label to noAggregate
-	assert.Equal(t, noAggregate, process("aggregate", aggregate, false).label)
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package automultilinedetection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection/tokens"
+)
+
+func justTokens(tokens []tokens.Token, _ []int) []tokens.Token {
+	return tokens
+}
+
+func TestPatternTable(t *testing.T) {
+
+	tokenizer := NewTokenizer(0)
+	pt := NewPatternTable(5, 1, true)
+
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 @"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 $"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 %"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 ^"))), aggregate)
+
+	assert.Equal(t, 5, len(pt.table))
+
+	// Add more of the same pattern - should remain at the top and get it's count updated
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
+
+	assert.Equal(t, 5, len(pt.table))
+	assert.Equal(t, int64(3), pt.table[0].count)
+
+	// At this point `abc 123 @` was the last updated, so it will be evicted first
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 *"))), aggregate)
+
+	assert.Equal(t, 5, len(pt.table), "Table should not grow past limit")
+	dump := pt.DumpTable()
+
+	assert.Equal(t, 5, len(dump))
+	assert.Equal(t, "CCC DDD !", dump[0].TokenString)
+	assert.Equal(t, "CCC DDD $", dump[1].TokenString)
+	assert.Equal(t, "CCC DDD %", dump[2].TokenString)
+	assert.Equal(t, "CCC DDD ^", dump[3].TokenString)
+	assert.Equal(t, "CCC DDD *", dump[4].TokenString)
+
+	// Should sift up to position #2
+	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 *"))), aggregate)
+
+	dump = pt.DumpTable()
+
+	assert.Equal(t, 5, len(dump))
+	assert.Equal(t, "CCC DDD !", dump[0].TokenString)
+	assert.Equal(t, "CCC DDD *", dump[1].TokenString)
+	assert.Equal(t, "CCC DDD $", dump[2].TokenString)
+	assert.Equal(t, "CCC DDD %", dump[3].TokenString)
+	assert.Equal(t, "CCC DDD ^", dump[4].TokenString)
+
+	assert.Equal(t, int64(3), dump[0].Count)
+	assert.Equal(t, int64(2), dump[1].Count)
+	assert.Equal(t, int64(1), dump[2].Count)
+	assert.Equal(t, int64(1), dump[3].Count)
+	assert.Equal(t, int64(1), dump[4].Count)
+
+	// Lets pretend the whole log format totally changes for some reason, and evict the whole table.
+	pt.insert(justTokens(tokenizer.tokenize([]byte("! acb 123"))), startGroup)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("@ acb 123"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("# acb 123"))), noAggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("$ acb 123"))), aggregate)
+	pt.insert(justTokens(tokenizer.tokenize([]byte("% acb 123"))), startGroup)
+
+	dump = pt.DumpTable()
+
+	assert.Equal(t, 5, len(dump))
+	assert.Equal(t, "! CCC DDD", dump[0].TokenString)
+	assert.Equal(t, "@ CCC DDD", dump[1].TokenString)
+	assert.Equal(t, "# CCC DDD", dump[2].TokenString)
+	assert.Equal(t, "$ CCC DDD", dump[3].TokenString)
+	assert.Equal(t, "% CCC DDD", dump[4].TokenString)
+	assert.Equal(t, int64(1), dump[0].Count)
+	assert.Equal(t, int64(1), dump[1].Count)
+	assert.Equal(t, int64(1), dump[2].Count)
+	assert.Equal(t, int64(1), dump[3].Count)
+	assert.Equal(t, int64(1), dump[4].Count)
+	assert.Equal(t, "start_group", dump[0].LabelString)
+	assert.Equal(t, "aggregate", dump[1].LabelString)
+	assert.Equal(t, "no_aggregate", dump[2].LabelString)
+	assert.Equal(t, "aggregate", dump[3].LabelString)
+	assert.Equal(t, "start_group", dump[4].LabelString)
+}
+
+func TestPatternTableProcess(t *testing.T) {
+
+	tokenizer := NewTokenizer(60)
+	pt := NewPatternTable(5, 1, true)
+
+	process := func(input string, label Label, continueProcessing bool) *messageContext {
+		context := &messageContext{
+			rawMessage: []byte(input),
+			label:      label,
+		}
+
+		assert.True(t, tokenizer.Process(context))
+		assert.Equal(t, continueProcessing, pt.Process(context))
+		return context
+	}
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, startGroup, process("start group", startGroup, true).label)
+	}
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, aggregate, process("aggregate", aggregate, true).label)
+	}
+
+	// One more aggregate puts it at the top, which will trigger the heuristic to change the label to noAggregate
+	assert.Equal(t, noAggregate, process("aggregate", aggregate, false).label)
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
@@ -108,8 +108,8 @@ func NewTimestampDetector(matchThreshold float64) *TimestampDetector {
 	}
 }
 
-// Process checks if a message is likely to be a timestamp.
-func (t *TimestampDetector) Process(context *messageContext) bool {
+// ProcessAndContinue checks if a message is likely to be a timestamp.
+func (t *TimestampDetector) ProcessAndContinue(context *messageContext) bool {
 	if context.tokens == nil {
 		log.Error("Tokens are required to detect timestamps")
 		return true

--- a/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector_test.go
@@ -81,8 +81,8 @@ func TestCorrectLabelIsAssigned(t *testing.T) {
 			label:      aggregate,
 		}
 
-		assert.True(t, tokenizer.Process(context))
-		assert.True(t, timestampDetector.Process(context))
+		assert.True(t, tokenizer.ProcessAndContinue(context))
+		assert.True(t, timestampDetector.ProcessAndContinue(context))
 		match := timestampDetector.tokenGraph.MatchProbability(context.tokens)
 		assert.Equal(t, testInput.label, context.label, fmt.Sprintf("input: %s had the wrong label with probability: %f", testInput.input, match.probability))
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
@@ -8,6 +8,7 @@ package automultilinedetection
 
 import (
 	"bytes"
+	"math"
 	"strings"
 	"unicode"
 
@@ -318,20 +319,31 @@ func tokensToString(tokens []tokens.Token) string {
 	return str
 }
 
-// isMatch compares two sequences of tokens and returns true if they match.
-// if the token strings are different lengths, the shortest string is used for comparison.
+// isMatch compares two sequences of tokens and returns true if they match within the
+// given threshold. if the token strings are different lengths, the shortest string is
+// used for comparison. This function is optimized to exit early if the match is impossible
+// without having to compare all of the tokens.
 func isMatch(seqA []tokens.Token, seqB []tokens.Token, thresh float64) bool {
 	count := len(seqA)
 	if len(seqB) < count {
 		count = len(seqB)
 	}
 
+	if count == 0 {
+		return len(seqA) == len(seqB)
+	}
+
+	requiredMatches := int(math.Round(thresh * float64(count)))
 	match := 0
+
 	for i := 0; i < count; i++ {
 		if seqA[i] == seqB[i] {
 			match++
 		}
+		if match+(count-i-1) < requiredMatches {
+			return false
+		}
 	}
 
-	return float64(match)/float64(count) >= thresh
+	return match >= requiredMatches
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
@@ -37,9 +37,9 @@ func NewTokenizer(maxEvalBytes int) *Tokenizer {
 	}
 }
 
-// Process enriches the message context with tokens.
+// ProcessAndContinue enriches the message context with tokens.
 // This implements the Herustic interface - this heuristic does not stop processing.
-func (t *Tokenizer) Process(context *messageContext) bool {
+func (t *Tokenizer) ProcessAndContinue(context *messageContext) bool {
 	maxBytes := len(context.rawMessage)
 	if maxBytes > t.maxEvalBytes {
 		maxBytes = t.maxEvalBytes

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
@@ -345,5 +345,5 @@ func isMatch(seqA []tokens.Token, seqB []tokens.Token, thresh float64) bool {
 		}
 	}
 
-	return match >= requiredMatches
+	return true
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_benchamrk_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_benchamrk_test.go
@@ -23,3 +23,36 @@ func BenchmarkTokenizerShort(b *testing.B) {
 		tokenizer.tokenize([]byte("abc123"))
 	}
 }
+
+func BenchmarkTokenizerIsMatchNoMatchStart(b *testing.B) {
+	tokenizer := NewTokenizer(0)
+	ta, _ := tokenizer.tokenize([]byte("Sun Mar 2PM EST JAN FEB MAR !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST T!Z(T)Z#AM 123-abc-[foo] (bar) 12-12-12T12:12:12.12T12:12Z123"))
+	tb, _ := tokenizer.tokenize([]byte("$ abc foo bar thie beginning is different !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST T!Z(T)Z#AM 123-abc-[foo] (bar) 12-12-12T12:12:12.12T12:12Z123"))
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		isMatch(ta, tb, 0.75)
+	}
+}
+
+func BenchmarkTokenizerIsMatchNoMatchEnd(b *testing.B) {
+	tokenizer := NewTokenizer(0)
+	ta, _ := tokenizer.tokenize([]byte("Sun Mar 2PM EST JAN FEB MAR !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST T!Z(T)Z#AM 123-abc-[foo] (bar) 12-12-12T12:12:12.12T12:12Z123"))
+	tb, _ := tokenizer.tokenize([]byte("Sun Mar 2PM EST JAN FEB MAR !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST But this one is different near the end of the sequence"))
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		isMatch(ta, tb, 0.75)
+	}
+}
+
+func BenchmarkTokenizerIsMatchFullMatch(b *testing.B) {
+	tokenizer := NewTokenizer(0)
+	ta, _ := tokenizer.tokenize([]byte("Sun Mar 2PM EST JAN FEB MAR !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST T!Z(T)Z#AM 123-abc-[foo] (bar) 12-12-12T12:12:12.12T12:12Z123"))
+	tb, _ := tokenizer.tokenize([]byte("Sun Mar 2PM EST JAN FEB MAR !@#$%^&*()_+[]:-/\\.,\\'{}\"`~ 0123456789 NZST ACDT aaaaaaaaaaaaaaaa CHST T!Z(T)Z#AM 123-abc-[foo] (bar) 12-12-12T12:12:12.12T12:12Z123"))
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		isMatch(ta, tb, 0.75)
+	}
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_test.go
@@ -78,26 +78,26 @@ func TestAllSymbolsAreHandled(t *testing.T) {
 func TestTokenizerHeuristic(t *testing.T) {
 	tokenizer := NewTokenizer(10)
 	msg := &messageContext{rawMessage: []byte("1234567890abcdefg")}
-	assert.True(t, tokenizer.Process(msg))
+	assert.True(t, tokenizer.ProcessAndContinue(msg))
 	assert.Equal(t, "DDDDDDDDDD", tokensToString(msg.tokens), "Tokens should be limited to 10 digits")
 
 	msg = &messageContext{rawMessage: []byte("12-12-12T12:12:12.12T12:12Z123")}
-	assert.True(t, tokenizer.Process(msg))
+	assert.True(t, tokenizer.ProcessAndContinue(msg))
 	assert.Equal(t, "DD-DD-DDTD", tokensToString(msg.tokens), "Tokens should be limited to the first 10 bytes")
 	assert.Equal(t, []int{0, 2, 3, 5, 6, 8, 9}, msg.tokenIndicies)
 
 	msg = &messageContext{rawMessage: []byte("abc 123")}
-	assert.True(t, tokenizer.Process(msg))
+	assert.True(t, tokenizer.ProcessAndContinue(msg))
 	assert.Equal(t, "CCC DDD", tokensToString(msg.tokens))
 	assert.Equal(t, []int{0, 3, 4}, msg.tokenIndicies)
 
 	msg = &messageContext{rawMessage: []byte("Jan 123")}
-	assert.True(t, tokenizer.Process(msg))
+	assert.True(t, tokenizer.ProcessAndContinue(msg))
 	assert.Equal(t, "MTH DDD", tokensToString(msg.tokens))
 	assert.Equal(t, []int{0, 3, 4}, msg.tokenIndicies)
 
 	msg = &messageContext{rawMessage: []byte("123Z")}
-	assert.True(t, tokenizer.Process(msg))
+	assert.True(t, tokenizer.ProcessAndContinue(msg))
 	assert.Equal(t, "DDDZONE", tokensToString(msg.tokens))
 	assert.Equal(t, []int{0, 3}, msg.tokenIndicies)
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer_test.go
@@ -101,3 +101,37 @@ func TestTokenizerHeuristic(t *testing.T) {
 	assert.Equal(t, "DDDZONE", tokensToString(msg.tokens))
 	assert.Equal(t, []int{0, 3}, msg.tokenIndicies)
 }
+
+func TestIsMatch(t *testing.T) {
+	tokenizer := NewTokenizer(0)
+	// A string of 10 tokens to make math easier.
+	ta, _ := tokenizer.tokenize([]byte("! @ # $ %"))
+	tb, _ := tokenizer.tokenize([]byte("! @ # $ %"))
+
+	assert.True(t, isMatch(ta, tb, 1))
+
+	ta, _ = tokenizer.tokenize([]byte("! @ # $ % "))
+	tb, _ = tokenizer.tokenize([]byte("! @ #1a1a1"))
+
+	assert.True(t, isMatch(ta, tb, 0.5))
+	assert.False(t, isMatch(ta, tb, 0.55))
+
+	ta, _ = tokenizer.tokenize([]byte("! @ # $ % "))
+	tb, _ = tokenizer.tokenize([]byte("#1a1a1$ $ "))
+
+	assert.False(t, isMatch(ta, tb, 0.5))
+	assert.True(t, isMatch(ta, tb, 0.3))
+
+	ta, _ = tokenizer.tokenize([]byte("! @ # $ % "))
+	tb, _ = tokenizer.tokenize([]byte(""))
+
+	assert.False(t, isMatch(ta, tb, 0.5))
+	assert.False(t, isMatch(ta, tb, 0))
+	assert.False(t, isMatch(ta, tb, 1))
+
+	ta, _ = tokenizer.tokenize([]byte("! @ # $ % "))
+	tb, _ = tokenizer.tokenize([]byte("!"))
+
+	assert.True(t, isMatch(ta, tb, 1))
+	assert.True(t, isMatch(ta, tb, 0.01))
+}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -91,9 +91,9 @@ func NewUserSamples(config config.Reader) *UserSamples {
 	}
 }
 
-// Process applies a user sample to a log message. If it matches, a label is assigned.
+// ProcessAndContinue applies a user sample to a log message. If it matches, a label is assigned.
 // This implements the Herustic interface - so we should stop processing if we detect a user pattern by returning false.
-func (j *UserSamples) Process(context *messageContext) bool {
+func (j *UserSamples) ProcessAndContinue(context *messageContext) bool {
 	if context.tokens == nil {
 		log.Error("Tokens are required to process user samples")
 		return true

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples_test.go
@@ -136,8 +136,8 @@ logs_config:
 			label:      aggregate,
 		}
 
-		assert.True(t, tokenizer.Process(context))
-		assert.Equal(t, test.shouldStop, samples.Process(context), "Expected stop %v, got %v", test.shouldStop, samples.Process(context))
+		assert.True(t, tokenizer.ProcessAndContinue(context))
+		assert.Equal(t, test.shouldStop, samples.ProcessAndContinue(context), "Expected stop %v, got %v", test.shouldStop, samples.ProcessAndContinue(context))
 		assert.Equal(t, test.expectedLabel, context.label, "Expected label %v, got %v", test.expectedLabel, context.label)
 	}
 }
@@ -175,8 +175,8 @@ logs_config:
 			label:      aggregate,
 		}
 
-		assert.True(t, tokenizer.Process(context))
-		assert.Equal(t, test.shouldStop, samples.Process(context), "Expected stop %v, got %v", test.shouldStop, samples.Process(context))
+		assert.True(t, tokenizer.ProcessAndContinue(context))
+		assert.Equal(t, test.shouldStop, samples.ProcessAndContinue(context), "Expected stop %v, got %v", test.shouldStop, samples.ProcessAndContinue(context))
 		assert.Equal(t, test.expectedLabel, context.label, "Expected label %v, got %v", test.expectedLabel, context.label)
 	}
 }

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -31,7 +31,6 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 		automultilinedetection.NewPatternTable(
 			config.Datadog().GetInt("logs_config.auto_multi_line.pattern_table_max_size"),
 			config.Datadog().GetFloat64("logs_config.auto_multi_line.pattern_table_match_threshold"),
-			config.Datadog().GetBool("logs_config.auto_multi_line.dont_aggregate_unmatched_top_format"),
 		),
 	}
 

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -28,6 +28,11 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 		automultilinedetection.NewTokenizer(config.Datadog().GetInt("logs_config.auto_multi_line.tokenizer_max_input_bytes")),
 		automultilinedetection.NewUserSamples(config.Datadog()),
 		automultilinedetection.NewTimestampDetector(config.Datadog().GetFloat64("logs_config.auto_multi_line.timestamp_detector_match_threshold")),
+		automultilinedetection.NewPatternTable(
+			config.Datadog().GetInt("logs_config.auto_multi_line.pattern_table_max_size"),
+			config.Datadog().GetFloat64("logs_config.auto_multi_line.pattern_table_match_threshold"),
+			config.Datadog().GetBool("logs_config.auto_multi_line.dont_aggregate_unmatched_top_format"),
+		),
 	}
 
 	return &AutoMultilineHandler{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR introduces the pattern table heuristic for Auto Multiline Detection and aggregation. 
This is the last heuristic defined in the RFC for the initial version of this feature. 

The pattern table exists to assist in diagnostics and reporting telemetry. Telemetry and diagnostic reporting will come in the next PR. One of the pieces of diagnostics we want to see is the distribution of patterns in a log source which the pattern table stores for us. The pattern table may also be used in the future to apply labels for certain distribution of log patterns

### Implementation details

The pattern table makes the assumption that most log formats are rather consistent and have few unique prefix formats. However there is nothing stopping someone from tailing `/dev/urandom` which would produce consistently unique "formats". As a result, we have to ensure the table doesn't grow forever. 

Since we only care about the most popular formats, we can solve this by: 
- keeping the size limited
- keeping it sorted by frequency 
- evicting patterns we haven't seen in a while if the table becomes full

The eviction strategy is a simple LRU where  the index of the message is stored and if the table becomes full, the pattern with the least recently updated index is evicted. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR also optimizes the tokenizer `isMatch` function to exit early when a match is not met which improves performance in non matching cases, but retains the same impact in matching cases. 

```
before
BenchmarkTokenizerIsMatch-10    	  	 1000000	      1212 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokenizerIsMatchNoMatchEnd-10    	 1296780	      1018 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokenizerIsMatchFullMatch-10    	  998858	      1238 ns/op	       0 B/op	       0 allocs/op
after
BenchmarkTokenizerIsMatchNoMatch-10    	  	 3885801	      295.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokenizerIsMatchNoMatchEnd-10    	 1000000	      1014 ns/op	       0 B/op	       0 allocs/op
BenchmarkTokenizerIsMatchFullMatch-10    	  859585	      1227 ns/op	       0 B/op	       0 allocs/op

```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Here is an example of the kind of data the pattern table can report - something like this will be available on the status page in the future

```
445      start_group     *CCCCC'CCCCCCCCCC'-DDDD-DD-DD DD:DD:DD
102      aggregate       CC:'C'DDDCDDDDDDDDDDCDDDDDDDDCDCDCCDDDDDDDDDD'
74       aggregate       CCCCCC CCCCCCCCCC CCC CCCCCCCC :'CCCCCCCCCC
74       aggregate       CCC CC CC CCCCCCCCCC CCC CCCCCCCC :'CCCCCCCCCC
73       aggregate       CCCCCC CC CCCCCCCCC(CC:CC.CC):CCCCCCCC 'D:DD.DDDDDD' CCCCCC 
72       aggregate       CC:'C'DDDCDDDDDDDDDDCDDDDDDDCCCDDCCDDDDDDDDDD'
43       aggregate       CC:'C'DDDCDDDDDDDDDDCDDCDDDDCDCDDCCDDDDDDDDDD'
38       aggregate        CCCCCC CCCCCCC 
37       aggregate       CCCCCCCC CC CCCCC 
37       aggregate       CCCCCC CC CCCCCCCCC CCC CCCCC(CC:CC.CC): CCCCCCCC 'D:DD.DDD
6        aggregate       CC:'C'DDDCDDDDDDDDDDCCDDDDDDDDDDCCDDDDDDDDDD'
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No Functional change
