### PR TITLE
fix(fleet): Add known env var DD_FLEET_POLICIES_DIR

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1844,6 +1844,8 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		"DD_TESTS_RUNTIME_COMPILED": {},
 		// this variable is used by the Kubernetes leader election mechanism
 		"DD_POD_NAME": {},
+		// used for fleet policies
+		"DD_FLEET_POLICIES_DIR": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}


### PR DESCRIPTION
### What does this PR do?
Adds `DD_FLEET_POLICIES_DIR` (added in https://github.com/DataDog/datadog-agent/pull/28349) to the known env var to avoid the warning message at the start of agent components.

Not much customer impact for now as it's only scoped to Fleet Automation Upgrades private beta.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
