### PR TITLE
Merge mocks for the config from comp and pkg into a single one

### DIFF
--- a/cmd/security-agent/subcommands/workloadlist/command_test.go
+++ b/cmd/security-agent/subcommands/workloadlist/command_test.go
@@ -25,10 +25,7 @@ func TestWorkloadListCommand(t *testing.T) {
 }
 
 func TestWorkloadURL(t *testing.T) {
-	cfg := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-		// fx.Replace(config.MockParams{Overrides: overrides}),
-	))
+	cfg := config.NewMock(t)
 
 	expected := "https://localhost:5010/agent/workload-list?verbose=true"
 	got, err := workloadURL(cfg, true)

--- a/comp/autoscaling/datadogclient/impl/client_test.go
+++ b/comp/autoscaling/datadogclient/impl/client_test.go
@@ -16,13 +16,12 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 func TestNewSingleClient(t *testing.T) {
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	logger := logmock.New(t)
 	cfg.Set("api_key", "apikey123", pkgconfigmodel.SourceLocalConfigProcess)
 	cfg.Set("app_key", "appkey456", pkgconfigmodel.SourceLocalConfigProcess)
@@ -34,7 +33,7 @@ func TestNewSingleClient(t *testing.T) {
 }
 
 func TestNewFallbackClient(t *testing.T) {
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	logger := logmock.New(t)
 	cfg.Set("api_key", "apikey123", pkgconfigmodel.SourceLocalConfigProcess)
 	cfg.Set("app_key", "appkey456", pkgconfigmodel.SourceLocalConfigProcess)
@@ -66,7 +65,7 @@ func TestExternalMetricsProviderEndpointAndRefresh(t *testing.T) {
 		w.Write([]byte("{\"status\": \"ok\"}"))
 	}))
 	defer ts.Close()
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	logger := logmock.New(t)
 	cfg.Set("api_key", "apikey123", pkgconfigmodel.SourceLocalConfigProcess)
 	cfg.Set("app_key", "appkey456", pkgconfigmodel.SourceLocalConfigProcess)

--- a/comp/core/config/component_mock.go
+++ b/comp/core/config/component_mock.go
@@ -30,7 +30,9 @@ type Mock interface {
 	Component
 }
 
-// MockModule defines the fx options for the mock component.
+// MockModule - deprecated - defines the fx options for the mock component.
+//
+// This is a legacy helper to get a config mock using Fx, use config.NewMock or config.NewMockFromYAML instead.
 func MockModule() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newMock),

--- a/comp/core/config/config_mock.go
+++ b/comp/core/config/config_mock.go
@@ -9,14 +9,14 @@
 package config
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	"github.com/DataDog/datadog-agent/pkg/config/env"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	setup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 type mockDependencies struct {
@@ -37,41 +37,34 @@ func (m mockDependencies) getSecretResolver() (secrets.Component, bool) {
 // newMock exported mock builder to allow modifying mocks that might be
 // supplied in tests and used for dep injection.
 func newMock(deps mockDependencies, t testing.TB) (Component, error) {
-	backupConfig := pkgconfigmodel.NewConfig("", "", strings.NewReplacer())
-	backupConfig.CopyConfig(pkgconfigsetup.Datadog())
+	var mockConf model.Config
 
-	pkgconfigsetup.Datadog().CopyConfig(pkgconfigmodel.NewConfig("mock", "XXXX", strings.NewReplacer()))
-
-	env.SetFeatures(t, deps.Params.Features...)
-
-	// call InitConfig to set defaults.
-	pkgconfigsetup.InitConfig(pkgconfigsetup.Datadog())
-	c := &cfg{
-		Config: pkgconfigsetup.Datadog(),
-	}
-
-	if !deps.Params.SetupConfig {
-		if deps.Params.ConfFilePath != "" {
-			pkgconfigsetup.Datadog().SetConfigType("yaml")
-			err := pkgconfigsetup.Datadog().ReadConfig(strings.NewReader(deps.Params.ConfFilePath))
-			if err != nil {
-				// The YAML was invalid, fail initialization of the mock config.
-				return nil, err
-			}
-		}
+	if deps.Params.ConfFilePath != "" {
+		mockConf = mock.NewFromFile(deps.Params.ConfFilePath)
 	} else {
-		warnings, _ := setupConfig(pkgconfigsetup.Datadog(), deps)
-		c.warnings = warnings
+		mockConf = mock.New(t)
 	}
 
-	// Overrides are explicit and will take precedence over any other
-	// setting
+	// Overrides are explicit and will take precedence over any other setting
 	for k, v := range deps.Params.Overrides {
-		pkgconfigsetup.Datadog().SetWithoutSource(k, v)
+		mockConf.SetWithoutSource(k, v)
 	}
 
-	// swap the existing config back at the end of the test.
-	t.Cleanup(func() { pkgconfigsetup.Datadog().CopyConfig(backupConfig) })
+	setup.LoadProxyFromEnv(mockConf)
+	return &cfg{Config: mockConf}, nil
+}
 
-	return c, nil
+// NewMock returns a mock for the config component
+func NewMock(t testing.TB) Component {
+	return &cfg{Config: mock.New(t)}
+}
+
+// NewMockFromYAML returns a mock for the config component with the given YAML content loaded into it.
+func NewMockFromYAML(t testing.TB, yaml string) Component {
+	return &cfg{Config: mock.NewFromYAML(t, yaml)}
+}
+
+// NewMockFromYAMLFile returns a mock for the config component with the given YAML file loaded into it.
+func NewMockFromYAMLFile(t testing.TB, yamlFilePath string) Component {
+	return &cfg{Config: mock.NewFromFile(t, yamlFilePath)}
 }

--- a/comp/core/config/config_mock.go
+++ b/comp/core/config/config_mock.go
@@ -40,7 +40,7 @@ func newMock(deps mockDependencies, t testing.TB) (Component, error) {
 	var mockConf model.Config
 
 	if deps.Params.ConfFilePath != "" {
-		mockConf = mock.NewFromFile(deps.Params.ConfFilePath)
+		mockConf = mock.NewFromFile(t, deps.Params.ConfFilePath)
 	} else {
 		mockConf = mock.New(t)
 	}

--- a/comp/core/config/config_test.go
+++ b/comp/core/config/config_test.go
@@ -45,7 +45,7 @@ func TestRealConfig(t *testing.T) {
 }
 
 func TestMockConfig(t *testing.T) {
-	t.Setenv("XXXX_APP_KEY", "abc1234")
+	t.Setenv("DD_APP_KEY", "abc1234")
 	t.Setenv("DD_URL", "https://example.com")
 
 	config := fxutil.Test[Component](t, fx.Options(

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -12,6 +12,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../def
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../pkg/config/model/
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/telemetry => ../../../pkg/telemetry
@@ -34,7 +35,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3
@@ -50,6 +51,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.56.0-rc.3 // indirect

--- a/comp/core/config/params_mock.go
+++ b/comp/core/config/params_mock.go
@@ -8,10 +8,6 @@
 
 package config
 
-import (
-	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
-)
-
 // MockParams defines the parameter for the mock config.
 // It is designed to be used with `fx.Replace` which replaces the default
 // empty value of `MockParams`.
@@ -22,10 +18,4 @@ type MockParams struct {
 
 	// Overrides is a parameter used to override values of the config
 	Overrides map[string]interface{}
-
-	// Features is a parameter to set features for the mock config
-	Features []pkgconfigenv.Feature
-
-	// SetupConfig sets up the config as if it weren't a mock; essentially a full init
-	SetupConfig bool
 }

--- a/comp/core/flare/helpers/send_flare_test.go
+++ b/comp/core/flare/helpers/send_flare_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -30,10 +29,7 @@ func TestMkURL(t *testing.T) {
 func TestFlareHasRightForm(t *testing.T) {
 	var lastRequest *http.Request
 
-	cfg := fxutil.Test[config.Component](
-		t,
-		config.MockModule(),
-	)
+	cfg := config.NewMock(t)
 
 	testCases := []struct {
 		name        string

--- a/comp/core/gui/guiimpl/agent_test.go
+++ b/comp/core/gui/guiimpl/agent_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func Test_makeFlare(t *testing.T) {
@@ -94,9 +93,7 @@ func Test_getConfigSetting(t *testing.T) {
 
 	fakeGuiStartTimestamp := time.Now().Unix()
 
-	c := fxutil.Test[config.Component](t,
-		config.MockModule(),
-	)
+	c := config.NewMock(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/comp/core/log/impl-trace/go.mod
+++ b/comp/core/log/impl-trace/go.mod
@@ -51,7 +51,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/config/mock v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.0.0-00010101000000-000000000000
 )
 

--- a/comp/core/log/impl/go.mod
+++ b/comp/core/log/impl/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/config/mock v0.0.0-20240726104123-0f372a5f7b15
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0

--- a/comp/core/settings/settingsimpl/settingsimpl_test.go
+++ b/comp/core/settings/settingsimpl/settingsimpl_test.go
@@ -312,7 +312,7 @@ func TestRuntimeSettings(t *testing.T) {
 				fx.Provide(func() log.Component { return logmock.New(t) }),
 				fx.Supply(
 					settings.Params{
-						Config: fxutil.Test[config.Component](t, config.MockModule()),
+						Config: config.NewMock(t),
 						Settings: map[string]settings.RuntimeSetting{
 							"foo": &runtimeTestSetting{
 								hidden:      false,

--- a/comp/core/status/statusimpl/common_header_provider_test.go
+++ b/comp/core/status/statusimpl/common_header_provider_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCommonHeaderProviderIndex(t *testing.T) {
-	config := fxutil.Test[config.Component](t, config.MockModule())
+	config := config.NewMock(t)
 
 	provider := newCommonHeaderProvider(agentParams, config)
 
@@ -43,7 +43,7 @@ func TestCommonHeaderProviderJSON(t *testing.T) {
 		os.Setenv("TZ", originalTZ)
 	}()
 
-	config := fxutil.Test[config.Component](t, config.MockModule())
+	config := config.NewMock(t)
 
 	provider := newCommonHeaderProvider(agentParams, config)
 	stats := map[string]interface{}{}
@@ -73,7 +73,7 @@ func TestCommonHeaderProviderText(t *testing.T) {
 		startTimeProvider = pkgconfigsetup.StartTime
 	}()
 
-	config := fxutil.Test[config.Component](t, config.MockModule())
+	config := config.NewMock(t)
 
 	provider := newCommonHeaderProvider(agentParams, config)
 
@@ -112,7 +112,7 @@ func TestCommonHeaderProviderTime(t *testing.T) {
 	}
 	defer func() { nowFunc = time.Now }()
 
-	config := fxutil.Test[config.Component](t, config.MockModule())
+	config := config.NewMock(t)
 
 	provider := newCommonHeaderProvider(agentParams, config)
 
@@ -193,7 +193,7 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
 		os.Setenv("TZ", originalTZ)
 	}()
 
-	config := fxutil.Test[config.Component](t, config.MockModule())
+	config := config.NewMock(t)
 
 	provider := newCommonHeaderProvider(agentParams, config)
 

--- a/comp/core/status/statusimpl/go.mod
+++ b/comp/core/status/statusimpl/go.mod
@@ -16,6 +16,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../../def
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/telemetry => ../../../../pkg/telemetry
@@ -59,6 +60,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.0-rc.3 // indirect

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -539,7 +539,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(_ *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			cfg := fxutil.Test[config.Component](t, fx.Options(
 				config.MockModule(),
 				fx.Replace(config.MockParams{Overrides: test.cfg}),

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/utils_test.go
@@ -11,10 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func Test_filterMapStringKey(t *testing.T) {
@@ -30,9 +27,7 @@ func Test_filterMapStringKey(t *testing.T) {
 		"ad.datadoghq.com/tags":             `["bar","foo"]`,
 	}
 
-	conf := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	conf := config.NewMock(t)
 	defaultExclude := conf.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	extraExclude := append(defaultExclude, "foo")
 

--- a/comp/dogstatsd/mapper/mapper_test.go
+++ b/comp/dogstatsd/mapper/mapper_test.go
@@ -14,11 +14,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
 
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestMappings(t *testing.T) {
@@ -520,12 +518,7 @@ dogstatsd_mapper_profiles:
 func getMapper(t *testing.T, configString string) (*MetricMapper, error) {
 	var profiles []config.MappingProfile
 
-	cfg := fxutil.Test[configComponent.Component](t, fx.Options(
-		configComponent.MockModule(),
-		fx.Replace(configComponent.MockParams{
-			Params: configComponent.Params{ConfFilePath: configString},
-		}),
-	))
+	cfg := configComponent.NewMockFromYAML(t, configString)
 
 	err := cfg.UnmarshalKey("dogstatsd_mapper_profiles", &profiles)
 	if err != nil {

--- a/comp/dogstatsd/replay/impl/writer_test.go
+++ b/comp/dogstatsd/replay/impl/writer_test.go
@@ -36,7 +36,7 @@ func writerTest(t *testing.T, z bool) {
 	file, path, err := OpenFile(fs, "foo/bar", "")
 	require.NoError(t, err)
 
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 
 	writer := NewTrafficCaptureWriter(1)
 

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 
 	"github.com/stretchr/testify/assert"
@@ -28,8 +27,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
@@ -41,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -79,8 +82,7 @@ func fulfillDeps(t testing.TB) serverDeps {
 	return fulfillDepsWithConfigOverride(t, map[string]interface{}{})
 }
 
-func fulfillDepsWithConfigOverrideAndFeatures(t testing.TB, overrides map[string]interface{}, features []env.Feature) serverDeps {
-
+func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{}) serverDeps {
 	// TODO: https://datadoghq.atlassian.net/browse/AMLII-1948
 	if runtime.GOOS == "darwin" {
 		flake.Mark(t)
@@ -90,7 +92,6 @@ func fulfillDepsWithConfigOverrideAndFeatures(t testing.TB, overrides map[string
 		serverdebugimpl.MockModule(),
 		fx.Replace(configComponent.MockParams{
 			Overrides: overrides,
-			Features:  features,
 		}),
 		fx.Supply(Params{Serverless: false}),
 		replaymock.MockModule(),
@@ -102,17 +103,13 @@ func fulfillDepsWithConfigOverrideAndFeatures(t testing.TB, overrides map[string
 	))
 }
 
-func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{}) serverDeps {
-	return fulfillDepsWithConfigOverrideAndFeatures(t, overrides, nil)
-}
-
 func fulfillDepsWithConfigYaml(t testing.TB, yaml string) serverDeps {
 	return fxutil.Test[serverDeps](t, fx.Options(
-		core.MockBundle(),
+		fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
+		fx.Provide(func(t testing.TB) configComponent.Component { return configComponent.NewMockFromYAML(t, yaml) }),
+		telemetryimpl.MockModule(),
+		hostnameimpl.MockModule(),
 		serverdebugimpl.MockModule(),
-		fx.Replace(configComponent.MockParams{
-			Params: configComponent.Params{ConfFilePath: yaml},
-		}),
 		fx.Supply(Params{Serverless: false}),
 		replaymock.MockModule(),
 		compressionimpl.MockModule(),
@@ -682,7 +679,8 @@ func TestExtraTags(t *testing.T) {
 	cfg["dogstatsd_port"] = listeners.RandomPortName
 	cfg["dogstatsd_tags"] = []string{"sometag3:somevalue3"}
 
-	deps := fulfillDepsWithConfigOverrideAndFeatures(t, cfg, []env.Feature{env.EKSFargate})
+	env.SetFeatures(t, env.EKSFargate)
+	deps := fulfillDepsWithConfigOverride(t, cfg)
 
 	demux := deps.Demultiplexer
 	requireStart(t, deps.Server)
@@ -711,7 +709,8 @@ func TestStaticTags(t *testing.T) {
 	cfg["dogstatsd_tags"] = []string{"sometag3:somevalue3"}
 	cfg["tags"] = []string{"from:dd_tags"}
 
-	deps := fulfillDepsWithConfigOverrideAndFeatures(t, cfg, []env.Feature{env.EKSFargate})
+	env.SetFeatures(t, env.EKSFargate)
+	deps := fulfillDepsWithConfigOverride(t, cfg)
 
 	demux := deps.Demultiplexer
 	requireStart(t, deps.Server)

--- a/comp/forwarder/defaultforwarder/default_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder_test.go
@@ -12,10 +12,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
 )
 
 // domainAPIKeyMap used by tests to get API keys from each domain resolver
@@ -28,9 +26,7 @@ func (f *DefaultForwarder) domainAPIKeyMap() map[string][]string {
 }
 
 func TestDefaultForwarderUpdateAPIKey(t *testing.T) {
-	mockConfig := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	mockConfig := config.NewMock(t)
 	mockConfig.Set("api_key", "api_key1", pkgconfigmodel.SourceAgentRuntime)
 	log := logmock.New(t)
 

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestCheckValidAPIKey(t *testing.T) {
@@ -38,7 +37,7 @@ func TestCheckValidAPIKey(t *testing.T) {
 		ts2.URL: {"key3"},
 	}
 	log := logmock.New(t)
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	fh := forwarderHealth{log: log, config: cfg, domainResolvers: resolver.NewSingleDomainResolvers(keysPerDomains)}
 	fh.init()
 	assert.True(t, fh.checkValidAPIKey())
@@ -119,7 +118,7 @@ func TestCheckValidAPIKeyErrors(t *testing.T) {
 		ts3.URL: {"key4"},
 	}
 	log := logmock.New(t)
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	fh := forwarderHealth{log: log, config: cfg}
 	fh.init()
 	fh.keysPerAPIEndpoint = keysPerAPIEndpoint
@@ -166,7 +165,7 @@ func TestUpdateAPIKey(t *testing.T) {
 	}
 
 	log := logmock.New(t)
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 
 	fh := forwarderHealth{log: log, config: cfg, domainResolvers: resolver.NewSingleDomainResolvers(keysPerDomains)}
 	fh.init()

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -17,6 +17,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/serializer/compression => ../../../comp/serializer/compression/
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../pkg/config/utils
@@ -81,6 +82,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3 // indirect

--- a/comp/forwarder/defaultforwarder/status_test.go
+++ b/comp/forwarder/defaultforwarder/status_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 func TestJSON(t *testing.T) {
-	config := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	config := config.NewMock(t)
 
 	provider := statusProvider{
 		config: config,
@@ -63,9 +61,7 @@ func TestJSONWith_forwarder_storage_max_size_in_bytes(t *testing.T) {
 }
 
 func TestText(t *testing.T) {
-	config := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	config := config.NewMock(t)
 
 	provider := statusProvider{
 		config: config,
@@ -78,9 +74,7 @@ func TestText(t *testing.T) {
 }
 
 func TestHTML(t *testing.T) {
-	config := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	config := config.NewMock(t)
 
 	provider := statusProvider{
 		config: config,

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -18,6 +18,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../pkg/config/utils
@@ -71,6 +72,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect

--- a/comp/logs/agent/agentimpl/agent_core_init_test.go
+++ b/comp/logs/agent/agentimpl/agent_core_init_test.go
@@ -11,15 +11,11 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 )
 
 func TestBuildEndpoints(t *testing.T) {
-	config := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	config := config.NewMock(t)
 
 	endpoints, err := buildEndpoints(config)
 	assert.Nil(t, err)

--- a/comp/logs/agent/agentimpl/agent_serverless_init_test.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init_test.go
@@ -12,16 +12,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestBuildServerlessEndpoints(t *testing.T) {
-	config := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	))
+	config := config.NewMock(t)
 
 	endpoints, err := buildEndpoints()
 	assert.Nil(t, err)

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -12,21 +12,17 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/fx"
 )
 
 type ConfigTestSuite struct {
 	suite.Suite
-	config config.Mock
+	config config.Component
 }
 
 func (suite *ConfigTestSuite) SetupTest() {
-	suite.config = fxutil.Test[config.Component](suite.T(), fx.Options(
-		config.MockModule(),
-	)).(config.Mock)
+	suite.config = config.NewMock(suite.T())
 }
 
 func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -10,23 +10,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 type EndpointsTestSuite struct {
 	suite.Suite
-	config config.Mock
+	config config.Component
 }
 
 func (suite *EndpointsTestSuite) SetupTest() {
-	suite.config = fxutil.Test[config.Component](suite.T(), fx.Options(
-		config.MockModule(),
-	)).(config.Mock)
+	suite.config = config.NewMock(suite.T())
 }
 
 func (suite *EndpointsTestSuite) TestLogsEndpointConfig() {

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../../def
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../pkg/config/env/
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../pkg/config/model/
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../pkg/config/utils
@@ -52,6 +53,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.56.0-rc.3 // indirect

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -12,10 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestValidateShouldSucceedWithValidConfigs(t *testing.T) {
@@ -55,17 +53,13 @@ func TestValidateShouldFailWithInvalidConfigs(t *testing.T) {
 }
 
 func TestAutoMultilineEnabled(t *testing.T) {
-
-	mockConfig := fxutil.Test[config.Component](t, fx.Options(
-		config.MockModule(),
-	)).(config.Mock)
-
 	decode := func(cfg string) *LogsConfig {
 		lc := LogsConfig{}
 		json.Unmarshal([]byte(cfg), &lc)
 		return &lc
 	}
 
+	mockConfig := config.NewMock(t)
 	mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection", false)
 	assert.False(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled(mockConfig))
 

--- a/comp/metadata/host/hostimpl/utils/meta_test.go
+++ b/comp/metadata/host/hostimpl/utils/meta_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMeta(t *testing.T) {
 	ctx := context.Background()
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 
 	meta := GetMeta(ctx, cfg)
 	assert.NotEmpty(t, meta.SocketHostname)
@@ -27,7 +26,7 @@ func TestGetMeta(t *testing.T) {
 
 func TestGetMetaFromCache(t *testing.T) {
 	ctx := context.Background()
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 
 	cache.Cache.Set(metaCacheKey, &Meta{
 		SocketHostname: "socket_test",

--- a/comp/metadata/securityagent/impl/security_agent_test.go
+++ b/comp/metadata/securityagent/impl/security_agent_test.go
@@ -53,7 +53,7 @@ func setupFetcher(t *testing.T) {
 func getSecurityAgentComp(t *testing.T, enableConfig bool) *secagent {
 	l := logmock.New(t)
 
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	cfg.Set("inventories_configuration_enabled", enableConfig, model.SourceUnknown)
 
 	r := Requires{

--- a/comp/metadata/systemprobe/impl/system_probe_test.go
+++ b/comp/metadata/systemprobe/impl/system_probe_test.go
@@ -56,7 +56,7 @@ func setupFetcher(t *testing.T) {
 func getSystemProbeComp(t *testing.T, enableConfig bool) *systemprobe {
 	l := logmock.New(t)
 
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	cfg.Set("inventories_configuration_enabled", enableConfig, model.SourceUnknown)
 
 	r := Requires{

--- a/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
+++ b/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
@@ -21,13 +21,11 @@ import (
 	"text/template"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func createFakeOTelExtensionHTTPServer() (string, func()) {
@@ -123,11 +121,7 @@ func TestOTelExtFlareBuilder(t *testing.T) {
 	overrideConfigResponse = b.String()
 	defer func() { overrideConfigResponse = "" }()
 
-	cfg := fxutil.Test[config.Component](t,
-		fx.Options(
-			config.MockModule(),
-		),
-	)
+	cfg := config.NewMock(t)
 	cfg.Set("otelcollector.enabled", true, pkgconfigmodel.SourceAgentRuntime)
 	cfg.Set("otelcollector.extension_url", 7777, pkgconfigmodel.SourceAgentRuntime)
 

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -17,6 +17,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../pkg/config/utils

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -18,6 +18,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline => ../../logsagentpipeline
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../pkg/config/utils
@@ -92,6 +93,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/processor v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sds v0.56.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -31,6 +31,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../../../pkg/config/utils
@@ -138,6 +139,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil => ../../../../../../comp/otelcol/otlp/testutil
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../../../pkg/config/utils

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -20,6 +20,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../../../pkg/config/utils
@@ -101,6 +102,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect

--- a/comp/process/agent/status_test.go
+++ b/comp/process/agent/status_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +43,7 @@ func TestStatus(t *testing.T) {
 	server := fakeStatusServer(t, 200, jsonBytes)
 	defer server.Close()
 
-	configComponent := fxutil.Test[config.Component](t, config.MockModule())
+	configComponent := config.NewMock(t)
 
 	headerProvider := StatusProvider{
 		testServerURL: server.URL,
@@ -97,7 +96,7 @@ func TestStatusError(t *testing.T) {
 	errorResponse, err := fixturesTemplates.ReadFile("fixtures/text_error_response.tmpl")
 	assert.NoError(t, err)
 
-	configComponent := fxutil.Test[config.Component](t, config.MockModule())
+	configComponent := config.NewMock(t)
 
 	headerProvider := StatusProvider{
 		testServerURL: server.URL,

--- a/comp/process/status/statusimpl/status_test.go
+++ b/comp/process/status/statusimpl/status_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +43,7 @@ func TestStatus(t *testing.T) {
 	server := fakeStatusServer(t, 200, jsonBytes)
 	defer server.Close()
 
-	configComponent := fxutil.Test[config.Component](t, config.MockModule())
+	configComponent := config.NewMock(t)
 
 	headerProvider := statusProvider{
 		testServerURL: server.URL,
@@ -98,7 +97,7 @@ func TestStatusError(t *testing.T) {
 	errorResponse, err := fixturesTemplates.ReadFile("fixtures/text_error_response.tmpl")
 	assert.NoError(t, err)
 
-	configComponent := fxutil.Test[config.Component](t, config.MockModule())
+	configComponent := config.NewMock(t)
 
 	headerProvider := statusProvider{
 		testServerURL: server.URL,

--- a/comp/serializer/compression/go.mod
+++ b/comp/serializer/compression/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../def
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/telemetry => ../../../pkg/telemetry
@@ -45,6 +46,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect

--- a/comp/trace/config/config_otlp_test.go
+++ b/comp/trace/config/config_otlp_test.go
@@ -25,8 +25,7 @@ func TestFullYamlConfigWithOTLP(t *testing.T) {
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 		}),
 		MockModule(),
 	))

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/cihub/seelog"
@@ -145,13 +145,11 @@ func TestSplitTagRegex(t *testing.T) {
 }
 
 func TestTelemetryEndpointsConfig(t *testing.T) {
-
 	t.Run("default", func(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -161,7 +159,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 	})
 
 	t.Run("dd_url", func(t *testing.T) {
-
 		overrides := map[string]interface{}{
 			"apm_config.telemetry.dd_url": "http://example.com/",
 		}
@@ -171,7 +168,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -181,7 +177,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 	})
 
 	t.Run("dd_url-malformed", func(t *testing.T) {
-
 		overrides := map[string]interface{}{
 			"apm_config.telemetry.dd_url": "111://abc.com",
 		}
@@ -192,7 +187,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 			MockModule(),
 		))
 
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -202,7 +196,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 	})
 
 	t.Run("site", func(t *testing.T) {
-
 		overrides := map[string]interface{}{
 			"site": "new_site.example.com",
 		}
@@ -212,7 +205,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -222,7 +214,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 	})
 
 	t.Run("additional-hosts", func(t *testing.T) {
-
 		additionalEndpoints := map[string]string{
 			"http://test_backend_2.example.com": "test_apikey_2",
 			"http://test_backend_3.example.com": "test_apikey_3",
@@ -236,7 +227,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -251,7 +241,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 	})
 
 	t.Run("keep-malformed", func(t *testing.T) {
-
 		additionalEndpoints := map[string]string{
 			"11://test_backend_2.example.com":   "test_apikey_2",
 			"http://test_backend_3.example.com": "test_apikey_3",
@@ -265,7 +254,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -281,7 +269,6 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 }
 
 func TestConfigHostname(t *testing.T) {
-
 	t.Run("fail", func(t *testing.T) {
 		overrides := map[string]interface{}{
 			"apm_config.dd_agent_bin": "/not/exist",
@@ -298,13 +285,11 @@ func TestConfigHostname(t *testing.T) {
 		fxutil.TestStart(t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
-				SetupConfig: true,
-				Overrides:   overrides,
+				Params:    corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
+				Overrides: overrides,
 			}),
 			MockModule(),
 		), func(t testing.TB, app *fx.App) {
-
 			require.NotNil(t, app)
 
 			ctx := context.Background()
@@ -333,9 +318,8 @@ func TestConfigHostname(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
-				SetupConfig: true,
-				Overrides:   overrides,
+				Params:    corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
+				Overrides: overrides,
 			}),
 			MockModule(),
 		))
@@ -346,12 +330,10 @@ func TestConfigHostname(t *testing.T) {
 	})
 
 	t.Run("file", func(t *testing.T) {
-
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -363,13 +345,12 @@ func TestConfigHostname(t *testing.T) {
 	})
 
 	t.Run("env", func(t *testing.T) {
-		t.Setenv("XXXX_HOSTNAME", "onlyenv")
+		t.Setenv("DD_HOSTNAME", "onlyenv")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/site_override.yaml"},
 			}),
 			MockModule(),
 		))
@@ -380,13 +361,12 @@ func TestConfigHostname(t *testing.T) {
 	})
 
 	t.Run("file+env", func(t *testing.T) {
-		t.Setenv("XXXX_HOSTNAME", "envoverride")
+		t.Setenv("DD_HOSTNAME", "envoverride")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -404,9 +384,8 @@ func TestConfigHostname(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/site_default.yaml"},
-				SetupConfig: true,
-				Overrides:   overrides,
+				Params:    corecomp.Params{ConfFilePath: "./testdata/site_default.yaml"},
+				Overrides: overrides,
 			}),
 			MockModule(),
 		))
@@ -456,7 +435,6 @@ func TestConfigHostname(t *testing.T) {
 		fallbackHostnameFunc = func() (string, error) { return "fallback.host", nil }
 
 		t.Run("good", func(t *testing.T) {
-
 			bin := makeProgram("host.name", 0)
 			defer os.Remove(bin)
 
@@ -464,7 +442,6 @@ func TestConfigHostname(t *testing.T) {
 				corecomp.MockModule(),
 				MockModule(),
 			))
-			// underlying config
 			cfg := config.Object()
 			require.NotNil(t, cfg)
 
@@ -482,7 +459,6 @@ func TestConfigHostname(t *testing.T) {
 				corecomp.MockModule(),
 				MockModule(),
 			))
-			// underlying config
 			cfg := config.Object()
 			require.NotNil(t, cfg)
 
@@ -500,7 +476,6 @@ func TestConfigHostname(t *testing.T) {
 				MockModule(),
 			))
 
-			// underlying config
 			cfg := config.Object()
 			require.NotNil(t, cfg)
 
@@ -518,7 +493,6 @@ func TestConfigHostname(t *testing.T) {
 				corecomp.MockModule(),
 				MockModule(),
 			))
-			// underlying config
 			cfg := config.Object()
 			require.NotNil(t, cfg)
 
@@ -535,7 +509,6 @@ func TestConfigHostname(t *testing.T) {
 				corecomp.MockModule(),
 				MockModule(),
 			))
-			// underlying config
 			cfg := config.Object()
 			require.NotNil(t, cfg)
 
@@ -558,12 +531,10 @@ func TestSite(t *testing.T) {
 		"vector":   {"./testdata/observability_pipelines_worker_override.yaml", "https://observability_pipelines_worker.domain.tld:8443"},
 	} {
 		t.Run(name, func(t *testing.T) {
-
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: tt.file},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: tt.file},
 				}),
 				MockModule(),
 			))
@@ -576,7 +547,6 @@ func TestSite(t *testing.T) {
 }
 
 func TestDefaultConfig(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		MockModule(),
@@ -601,12 +571,10 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestNoAPMConfig(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
 		}),
 		MockModule(),
 	))
@@ -621,12 +589,10 @@ func TestNoAPMConfig(t *testing.T) {
 }
 
 func TestDisableLoggingConfig(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/disable_file_logging.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/disable_file_logging.yaml"},
 		}),
 		MockModule(),
 	))
@@ -638,12 +604,10 @@ func TestDisableLoggingConfig(t *testing.T) {
 }
 
 func TestFullYamlConfig(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 		}),
 		MockModule(),
 	))
@@ -745,12 +709,10 @@ func TestFullYamlConfig(t *testing.T) {
 }
 
 func TestFileLoggingDisabled(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/disable_file_logging.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/disable_file_logging.yaml"},
 		}),
 		MockModule(),
 	))
@@ -761,12 +723,10 @@ func TestFileLoggingDisabled(t *testing.T) {
 }
 
 func TestUndocumentedYamlConfig(t *testing.T) {
-
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
 		}),
 		MockModule(),
 	))
@@ -817,20 +777,18 @@ func TestAcquireHostnameFallback(t *testing.T) {
 }
 
 func TestNormalizeEnvFromDDEnv(t *testing.T) {
-
 	for in, out := range map[string]string{
 		"staging":   "staging",
 		"stAging":   "staging",
 		"staging 1": "staging_1",
 	} {
 		t.Run("", func(t *testing.T) {
-			t.Setenv("XXXX_ENV", in)
+			t.Setenv("DD_ENV", in)
 
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
 				}),
 				MockModule(),
 			))
@@ -844,7 +802,6 @@ func TestNormalizeEnvFromDDEnv(t *testing.T) {
 }
 
 func TestNormalizeEnvFromDDTags(t *testing.T) {
-
 	for in, out := range map[string]string{
 		"env:staging": "staging",
 		"env:stAging": "staging",
@@ -852,13 +809,12 @@ func TestNormalizeEnvFromDDTags(t *testing.T) {
 		"tag:value env:STAGING tag2:value2": "staging",
 	} {
 		t.Run("", func(t *testing.T) {
-			t.Setenv("XXXX_TAGS", in)
+			t.Setenv("DD_TAGS", in)
 
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
 				}),
 				MockModule(),
 			))
@@ -872,7 +828,6 @@ func TestNormalizeEnvFromDDTags(t *testing.T) {
 }
 
 func TestNormalizeEnvFromConfig(t *testing.T) {
-
 	for _, cfgFile := range []string{
 		"./testdata/ok_env_apm_config.yaml",
 		"./testdata/ok_env_top_level.yaml",
@@ -882,12 +837,10 @@ func TestNormalizeEnvFromConfig(t *testing.T) {
 		"./testdata/non-normalized_env_host_tag.yaml",
 	} {
 		t.Run("", func(t *testing.T) {
-
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: cfgFile},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: cfgFile},
 				}),
 				MockModule(),
 			))
@@ -920,8 +873,7 @@ func TestLoadEnv(t *testing.T) {
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -937,15 +889,14 @@ func TestLoadEnv(t *testing.T) {
 		}
 	})
 
-	env := "XXXX_API_KEY"
+	env := "DD_API_KEY"
 	t.Run(env, func(t *testing.T) {
 		t.Setenv(env, "123")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -955,16 +906,14 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal(t, "123", cfg.Endpoints[0].APIKey)
 	})
 
-	env = "XXXX_SITE"
+	env = "DD_SITE"
 	t.Run(env, func(t *testing.T) {
-		os.Setenv(env, "my-site.com")
-		defer os.Unsetenv(env)
+		t.Setenv(env, "my-site.com")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/site_default.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/site_default.yaml"},
 			}),
 			MockModule(),
 		))
@@ -980,8 +929,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -997,8 +945,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1014,8 +961,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1031,8 +977,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1042,14 +987,13 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal(t, "my-proxy.url", cfg.ProxyURL.String())
 	})
 
-	env = "XXXX_HOSTNAME"
+	env = "DD_HOSTNAME"
 	t.Run(env, func(t *testing.T) {
 		t.Setenv(env, "local.host")
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1059,14 +1003,13 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal(t, "local.host", cfg.Hostname)
 	})
 
-	env = "XXXX_BIND_HOST"
+	env = "DD_BIND_HOST"
 	t.Run(env, func(t *testing.T) {
 		t.Setenv(env, "bindhost.com")
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1086,8 +1029,7 @@ func TestLoadEnv(t *testing.T) {
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1098,15 +1040,14 @@ func TestLoadEnv(t *testing.T) {
 		})
 	}
 
-	env = "XXXX_DOGSTATSD_PORT"
+	env = "DD_DOGSTATSD_PORT"
 	t.Run(env, func(t *testing.T) {
 		t.Setenv(env, "4321")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1123,8 +1064,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1141,8 +1081,7 @@ func TestLoadEnv(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/undocumented.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1162,8 +1101,7 @@ func TestLoadEnv(t *testing.T) {
 			config := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1176,14 +1114,12 @@ func TestLoadEnv(t *testing.T) {
 
 	env = "DD_APM_ANALYZED_SPANS"
 	t.Run(env, func(t *testing.T) {
-
 		t.Setenv(env, "web|http.request=1,db|sql.query=0.5")
 
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1204,8 +1140,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1236,8 +1171,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1255,8 +1189,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1274,8 +1207,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1293,8 +1225,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1313,8 +1244,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1331,8 +1261,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1349,8 +1278,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1370,8 +1298,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1387,8 +1314,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1409,8 +1335,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1433,8 +1358,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/deprecated-max-tps-apm.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/deprecated-max-tps-apm.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1452,8 +1376,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1478,8 +1401,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1499,8 +1421,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1520,8 +1441,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -1539,8 +1459,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1557,8 +1476,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1578,8 +1496,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1597,8 +1514,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1616,8 +1532,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1635,8 +1550,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1661,8 +1575,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1680,8 +1593,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1699,8 +1611,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1725,8 +1636,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1743,8 +1653,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1761,8 +1670,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1787,8 +1695,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1807,8 +1714,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1825,8 +1731,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1844,8 +1749,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1866,8 +1770,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1888,8 +1791,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1907,8 +1809,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1926,8 +1827,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1945,8 +1845,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1966,8 +1865,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -1985,8 +1883,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2007,8 +1904,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2029,8 +1925,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2048,8 +1943,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2067,8 +1961,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2086,8 +1979,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2105,8 +1997,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2127,8 +2018,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2149,8 +2039,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2168,8 +2057,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2190,8 +2078,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2212,8 +2099,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2238,8 +2124,7 @@ func TestLoadEnv(t *testing.T) {
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 				}),
 				MockModule(),
 			))
@@ -2269,8 +2154,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2288,8 +2172,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2307,8 +2190,7 @@ func TestLoadEnv(t *testing.T) {
 		c := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			fx.Replace(corecomp.MockParams{
-				Params:      corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
-				SetupConfig: true,
+				Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
 			}),
 			MockModule(),
 		))
@@ -2340,13 +2222,11 @@ func TestFargateConfig(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-
+			env.SetFeatures(t, data.features...)
 			c := fxutil.Test[Component](t, fx.Options(
 				corecomp.MockModule(),
 				fx.Replace(corecomp.MockParams{
-					Params:      corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
-					Features:    data.features,
-					SetupConfig: true,
+					Params: corecomp.Params{ConfFilePath: "./testdata/no_apm_config.yaml"},
 				}),
 				MockModule(),
 			))
@@ -2361,7 +2241,6 @@ func TestFargateConfig(t *testing.T) {
 
 func TestSetMaxMemCPU(t *testing.T) {
 	t.Run("default, non-containerized", func(t *testing.T) {
-
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			MockModule(),
@@ -2376,7 +2255,6 @@ func TestSetMaxMemCPU(t *testing.T) {
 	})
 
 	t.Run("default, containerized", func(t *testing.T) {
-
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
 			MockModule(),
@@ -2391,7 +2269,6 @@ func TestSetMaxMemCPU(t *testing.T) {
 	})
 
 	t.Run("limits set, non-containerized", func(t *testing.T) {
-
 		overrides := map[string]interface{}{
 			"apm_config.max_cpu_percent": "20",
 			"apm_config.max_memory":      "200",
@@ -2402,7 +2279,6 @@ func TestSetMaxMemCPU(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -2412,7 +2288,6 @@ func TestSetMaxMemCPU(t *testing.T) {
 	})
 
 	t.Run("limits set, containerized", func(t *testing.T) {
-
 		overrides := map[string]interface{}{
 			"apm_config.max_cpu_percent": "30",
 			"apm_config.max_memory":      "300",
@@ -2423,7 +2298,6 @@ func TestSetMaxMemCPU(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 
@@ -2439,7 +2313,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			corecomp.MockModule(),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.False(t, cfg.PeerTagsAggregation)
@@ -2456,7 +2329,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
@@ -2472,7 +2344,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
@@ -2488,7 +2359,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
@@ -2504,7 +2374,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.False(t, cfg.PeerTagsAggregation)
@@ -2521,7 +2390,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Equal(t, []string{"user_peer_tag"}, cfg.PeerTags)
@@ -2537,7 +2405,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
@@ -2555,7 +2422,6 @@ func TestPeerTagsAggregation(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
@@ -2569,7 +2435,6 @@ func TestComputeStatsBySpanKind(t *testing.T) {
 			corecomp.MockModule(),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 
 		require.NotNil(t, cfg)
@@ -2586,7 +2451,6 @@ func TestComputeStatsBySpanKind(t *testing.T) {
 			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
-		// underlying config
 		cfg := config.Object()
 
 		require.NotNil(t, cfg)
@@ -2596,9 +2460,6 @@ func TestComputeStatsBySpanKind(t *testing.T) {
 
 func TestGenerateInstallSignature(t *testing.T) {
 	cfgDir := t.TempDir()
-	defer func() {
-		os.RemoveAll(cfgDir)
-	}()
 	cfgContent, err := os.ReadFile("./testdata/full.yaml")
 	assert.NoError(t, err)
 	cfgFile := filepath.Join(cfgDir, "full.yaml")
@@ -2608,8 +2469,7 @@ func TestGenerateInstallSignature(t *testing.T) {
 	c := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: cfgFile},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: cfgFile},
 		}),
 		MockModule(),
 	))
@@ -2637,28 +2497,30 @@ func TestGenerateInstallSignature(t *testing.T) {
 }
 
 func TestMockConfig(t *testing.T) {
-	os.Setenv("DD_SITE", "datadoghq.eu")
-	defer func() { os.Unsetenv("DD_SITE") }()
-
+	t.Setenv("DD_SITE", "datadoghq.eu")
 	config := fxutil.Test[Component](t, fx.Options(
 		fx.Supply(corecomp.Params{}),
 		corecomp.MockModule(),
 		MockModule(),
 	))
-	// underlying config
 	cfg := config.Object()
 	require.NotNil(t, cfg)
 
-	// values aren't set from env..
-	assert.NotEqual(t, "datadoghq.eu", cfg.Site)
+	assert.Equal(t, true, cfg.Enabled)
+	assert.Equal(t, "datadoghq.eu", cfg.Site)
+}
 
-	// but defaults are set
+func TestMockDefaultConfig(t *testing.T) {
+	config := fxutil.Test[Component](t, fx.Options(
+		fx.Supply(corecomp.Params{}),
+		corecomp.MockModule(),
+		MockModule(),
+	))
+	cfg := config.Object()
+	require.NotNil(t, cfg)
+
 	assert.Equal(t, true, cfg.Enabled)
 	assert.Equal(t, "datadoghq.com", cfg.Site)
-
-	// but can be set by the mock
-	// config.(Mock).Set("app_key", "newvalue")
-	// require.Equal(t, "newvalue", config.GetString("app_key"))
 }
 
 func TestGetCoreConfigHandler(t *testing.T) {
@@ -2706,8 +2568,7 @@ func TestDisableReceiverConfig(t *testing.T) {
 	config := fxutil.Test[Component](t, fx.Options(
 		corecomp.MockModule(),
 		fx.Replace(corecomp.MockParams{
-			Params:      corecomp.Params{ConfFilePath: "./testdata/disable_receiver.yaml"},
-			SetupConfig: true,
+			Params: corecomp.Params{ConfFilePath: "./testdata/disable_receiver.yaml"},
 		}),
 		MockModule(),
 	))

--- a/go.mod
+++ b/go.mod
@@ -645,7 +645,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/api v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/config/mock v0.0.0-20240726104123-0f372a5f7b15
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/remote v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config => ../config
 	github.com/DataDog/datadog-agent/pkg/config/env => ../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../config/utils
@@ -50,6 +51,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3 // indirect

--- a/pkg/collector/corechecks/sbom/check_test.go
+++ b/pkg/collector/corechecks/sbom/check_test.go
@@ -108,7 +108,7 @@ host_heartbeat_validity_seconds: 1000000
 }
 
 func TestFactory(t *testing.T) {
-	cfg := fxutil.Test[config.Component](t, config.MockModule())
+	cfg := config.NewMock(t)
 	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),

--- a/pkg/config/legacy_converter.go
+++ b/pkg/config/legacy_converter.go
@@ -6,8 +6,6 @@
 package config
 
 import (
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -25,10 +23,5 @@ func (c *LegacyConfigConverter) Set(key string, value interface{}) {
 
 // NewConfigConverter is creating and returning a config converter
 func NewConfigConverter() *LegacyConfigConverter {
-	// Configure Datadog global configuration
-	newCfg := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
-	// Configuration defaults
-	pkgconfigsetup.SetDatadog(newCfg)
-	pkgconfigsetup.InitConfig(newCfg)
-	return &LegacyConfigConverter{newCfg}
+	return &LegacyConfigConverter{pkgconfigsetup.Datadog()}
 }

--- a/pkg/config/mock/go.mod
+++ b/pkg/config/mock/go.mod
@@ -49,6 +49,7 @@ replace github.com/DataDog/datadog-agent/pkg/util/testutil => ../../../pkg/util/
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -68,6 +69,7 @@ require (
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -78,6 +80,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -96,4 +99,5 @@ require (
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -7,12 +7,14 @@
 package mock
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -43,26 +45,21 @@ func (c *mockConfig) SetKnown(key string) {
 
 // New creates a mock for the config
 func New(t testing.TB) model.Config {
-	// We only check isConfigMocked when registering a cleanup function. 'isConfigMocked' avoids nested calls to
-	// Mock to reset the config to a blank state. This way we have only one mock per test and test helpers can call
-	// Mock.
-	if t != nil {
+	m.Lock()
+	defer m.Unlock()
+	if isConfigMocked {
+		// The configuration is already mocked.
+		return &mockConfig{setup.Datadog()}
+	}
+
+	isConfigMocked = true
+	originalDatadogConfig := setup.Datadog()
+	t.Cleanup(func() {
 		m.Lock()
 		defer m.Unlock()
-		if isConfigMocked {
-			// The configuration is already mocked.
-			return &mockConfig{setup.Datadog()}
-		}
-
-		isConfigMocked = true
-		originalDatadogConfig := setup.Datadog()
-		t.Cleanup(func() {
-			m.Lock()
-			defer m.Unlock()
-			isConfigMocked = false
-			setup.SetDatadog(originalDatadogConfig)
-		})
-	}
+		isConfigMocked = false
+		setup.SetDatadog(originalDatadogConfig)
+	})
 
 	// Configure Datadog global configuration
 	newCfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
@@ -70,6 +67,25 @@ func New(t testing.TB) model.Config {
 	setup.SetDatadog(newCfg)
 	setup.InitConfig(newCfg)
 	return &mockConfig{newCfg}
+}
+
+// NewFromYAML creates a mock for the config and load the give YAML
+func NewFromYAML(t testing.TB, yamlData string) model.Config {
+	conf := New(t)
+	conf.SetConfigType("yaml")
+	err := conf.ReadConfig(bytes.NewBuffer([]byte(yamlData)))
+	require.NoError(t, err)
+	return conf
+}
+
+// NewFromFile creates a mock for the config and load the give YAML
+func NewFromFile(t testing.TB, yamlFilePath string) model.Config {
+	conf := New(t)
+	conf.SetConfigType("yaml")
+	conf.SetConfigFile(yamlFilePath)
+	err := conf.ReadInConfig()
+	require.NoErrorf(t, err, "error loading yaml config file '%s'", yamlFilePath)
+	return conf
 }
 
 // NewSystemProbe creates a mock for the system-probe config

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -108,29 +109,26 @@ const (
 var (
 	datadog     pkgconfigmodel.Config
 	systemProbe pkgconfigmodel.Config
-)
 
-// Datadog returns the current agent configuration
-func Datadog() pkgconfigmodel.Config {
-	return datadog
-}
+	datadogMutex     = sync.RWMutex{}
+	systemProbeMutex = sync.RWMutex{}
+)
 
 // SetDatadog sets the the reference to the agent configuration.
 // This is currently used by the legacy converter and config mocks and should not be user anywhere else. Once the
 // legacy converter and mock have been migrated we will remove this function.
 func SetDatadog(cfg pkgconfigmodel.Config) {
+	datadogMutex.Lock()
+	defer datadogMutex.Unlock()
 	datadog = cfg
-}
-
-// SystemProbe returns the current SystemProbe configuration
-func SystemProbe() pkgconfigmodel.Config {
-	return systemProbe
 }
 
 // SetSystemProbe sets the the reference to the systemProbe configuration.
 // This is currently used by the config mocks and should not be user anywhere else. Once the mocks have been migrated we
 // will remove this function.
 func SetSystemProbe(cfg pkgconfigmodel.Config) {
+	systemProbeMutex.Lock()
+	defer systemProbeMutex.Unlock()
 	systemProbe = cfg
 }
 
@@ -1907,9 +1905,7 @@ func LoadDatadogCustom(config pkgconfigmodel.Config, origin string, secretResolv
 	err := LoadCustom(config, additionalKnownEnvVars)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
-			log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
-		} else {
-			log.Warnf("Error loading config: %v", err)
+			return warnings, log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
 		}
 		return warnings, err
 	}

--- a/pkg/config/setup/config_accessor.go
+++ b/pkg/config/setup/config_accessor.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !test
+
+package setup
+
+import pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+
+// Datadog returns the current agent configuration
+func Datadog() pkgconfigmodel.Config {
+	return datadog
+}
+
+// SystemProbe returns the current SystemProbe configuration
+func SystemProbe() pkgconfigmodel.Config {
+	return systemProbe
+}

--- a/pkg/config/setup/config_test_accessor.go
+++ b/pkg/config/setup/config_test_accessor.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package setup
+
+import pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+
+// Datadog returns the current agent configuration
+func Datadog() pkgconfigmodel.Config {
+	datadogMutex.RLock()
+	defer datadogMutex.RUnlock()
+	return datadog
+}
+
+// SystemProbe returns the current SystemProbe configuration
+func SystemProbe() pkgconfigmodel.Config {
+	systemProbeMutex.RLock()
+	defer systemProbeMutex.RUnlock()
+	return systemProbe
+}

--- a/pkg/config/setup/test_config_accessor.go
+++ b/pkg/config/setup/test_config_accessor.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package setup
+
+// This file contains the accessor for the configuration when running tests. This version offer a way to set the
+// different configurations at runtime.

--- a/pkg/logs/auditor/go.mod
+++ b/pkg/logs/auditor/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/client/go.mod
+++ b/pkg/logs/client/go.mod
@@ -15,6 +15,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -15,6 +15,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/sds/go.mod
+++ b/pkg/logs/sds/go.mod
@@ -15,6 +15,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/sender/go.mod
+++ b/pkg/logs/sender/go.mod
@@ -15,6 +15,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../config/utils

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../config/utils

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -21,6 +21,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../config/env
 	github.com/DataDog/datadog-agent/pkg/config/logs => ../config/logs/
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../config/setup/
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../config/utils/
@@ -93,6 +94,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3 // indirect

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -59,7 +59,7 @@ func TestStartEnabledTrueInvalidConfig(t *testing.T) {
 	assert.IsType(t, noopTraceAgent{}, agent)
 }
 
-func TestStartEnabledTrueValidConfigUnvalidPath(t *testing.T) {
+func TestStartEnabledTrueValidConfigInvalidPath(t *testing.T) {
 	setupTraceAgentTest(t)
 
 	lambdaSpanChan := make(chan *pb.Span)

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -83,13 +83,13 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 		core.MockBundle(),
 		fx.Replace(compcfg.MockParams{
 			Overrides: overrides,
-			Features:  []env.Feature{env.Docker},
 		}),
 		wmcatalog.GetCatalog(),
 		workloadmetafx.Module(workloadmeta.NewParams()),
 		taggerimpl.Module(),
 		fx.Supply(tagger.NewTaggerParams()),
 	))
+	env.SetFeatures(suite.T(), env.Docker)
 	suite.wmeta = deps.WMeta
 	suite.telemetryStore = acTelemetry.NewStore(deps.Telemetry)
 	suite.dockerutil, err = docker.GetDockerUtil()

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -34,6 +34,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ./../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ./../../pkg/config/env
+	github.com/DataDog/datadog-agent/pkg/config/mock => ./../../pkg/config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ./../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/setup => ./../../pkg/config/setup
 	github.com/DataDog/datadog-agent/pkg/config/utils => ./../../pkg/config/utils
@@ -122,6 +123,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.56.0-rc.3 // indirect


### PR DESCRIPTION
### What does this PR do?

This prevent issue where the two mocks were created and would hold different configuration for different part of the code base.
    
This also align the way we use mocks for configuration across the code base.
    
Finally this is the first step toward deprecated the use of Fx for mocks in the code base. For more see
https://datadoghq.dev/datadog-agent/components/testing/.

### Describe how to test/QA your changes

Running test and a green CI is enough