### PR TITLE
Make it shared global variable TLSAwareCounter in 'telemetry' package

### DIFF
--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -14,66 +14,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// tlsAwareCounter is a TLS aware counter, it has a plain counter and a counter for TLS.
-// It enables the use of a single metric that increments based on the encryption, avoiding the need for separate metrics for eash use-case.
-type tlsAwareCounter struct {
-	counterPlain *libtelemetry.Counter
-	counterTLS   *libtelemetry.Counter
-}
-
-// newTLSAwareCounter creates and returns a new instance of TLSCounter
-func newTLSAwareCounter(metricGroup *libtelemetry.MetricGroup, metricName string, tags ...string) *tlsAwareCounter {
-	return &tlsAwareCounter{
-		counterPlain: metricGroup.NewCounter(metricName, append(tags, "encrypted:false")...),
-		counterTLS:   metricGroup.NewCounter(metricName, append(tags, "encrypted:true")...),
-	}
-}
-
-// add adds the given delta to the counter based on the encryption.
-func (c *tlsAwareCounter) add(delta int64, isTLS bool) {
-	if isTLS {
-		c.counterTLS.Add(delta)
-		return
-	}
-	c.counterPlain.Add(delta)
-}
-
-// get returns the counter value based on the encryption.
-func (c *tlsAwareCounter) get(isTLS bool) int64 {
-	if isTLS {
-		return c.counterTLS.Get()
-	}
-	return c.counterPlain.Get()
-}
-
 type kernelTelemetry struct {
 	// metricGroup is used here mostly for building the log message below
 	metricGroup *libtelemetry.MetricGroup
 
 	// http2requests Count of HTTP/2 requests seen
-	http2requests *tlsAwareCounter
+	http2requests *libtelemetry.TLSAwareCounter
 	// http2responses Count of HTTP/2 responses seen
-	http2responses *tlsAwareCounter
+	http2responses *libtelemetry.TLSAwareCounter
 	// endOfStream Count of END_OF_STREAM flags seen
-	endOfStream *tlsAwareCounter
+	endOfStream *libtelemetry.TLSAwareCounter
 	// endOfStreamRST Count of RST flags seen
-	endOfStreamRST *tlsAwareCounter
+	endOfStreamRST *libtelemetry.TLSAwareCounter
 	// pathSizeBucket Count of path sizes divided into buckets.
-	pathSizeBucket [http2PathBuckets + 1]*tlsAwareCounter
+	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.TLSAwareCounter
 	// literalValueExceedsFrame Count of times we couldn't retrieve the literal value due to reaching the end of the frame.
-	literalValueExceedsFrame *tlsAwareCounter
+	literalValueExceedsFrame *libtelemetry.TLSAwareCounter
 	// exceedingMaxInterestingFrames Count of times we reached the max number of frames per iteration.
-	exceedingMaxInterestingFrames *tlsAwareCounter
+	exceedingMaxInterestingFrames *libtelemetry.TLSAwareCounter
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
-	exceedingMaxFramesToFilter *tlsAwareCounter
+	exceedingMaxFramesToFilter *libtelemetry.TLSAwareCounter
 	// fragmentedFrameCountRST Count of times we have seen a fragmented RST frame.
-	fragmentedFrameCountRST *tlsAwareCounter
+	fragmentedFrameCountRST *libtelemetry.TLSAwareCounter
 	// fragmentedHeadersFrameEOSCount Count of times we have seen a fragmented headers frame with EOS.
-	fragmentedHeadersFrameEOSCount *tlsAwareCounter
+	fragmentedHeadersFrameEOSCount *libtelemetry.TLSAwareCounter
 	// fragmentedHeadersFrameCount Count of times we have seen a fragmented headers frame.
-	fragmentedHeadersFrameCount *tlsAwareCounter
+	fragmentedHeadersFrameCount *libtelemetry.TLSAwareCounter
 	// fragmentedDataFrameEOSCount Count of times we have seen a fragmented data frame with EOS.
-	fragmentedDataFrameEOSCount *tlsAwareCounter
+	fragmentedDataFrameEOSCount *libtelemetry.TLSAwareCounter
 	// telemetryLastState represents the latest HTTP2 eBPF Kernel telemetry observed from the kernel
 	telemetryLastState HTTP2Telemetry
 }
@@ -83,20 +51,20 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 	metricGroup := libtelemetry.NewMetricGroup("usm.http2", libtelemetry.OptPrometheus)
 	http2KernelTel := &kernelTelemetry{
 		metricGroup:                    metricGroup,
-		http2requests:                  newTLSAwareCounter(metricGroup, "requests"),
-		http2responses:                 newTLSAwareCounter(metricGroup, "responses"),
-		endOfStream:                    newTLSAwareCounter(metricGroup, "eos"),
-		endOfStreamRST:                 newTLSAwareCounter(metricGroup, "rst"),
-		literalValueExceedsFrame:       newTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
-		exceedingMaxInterestingFrames:  newTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
-		exceedingMaxFramesToFilter:     newTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter"),
-		fragmentedDataFrameEOSCount:    newTLSAwareCounter(metricGroup, "exceeding_data_end_data_eos"),
-		fragmentedHeadersFrameCount:    newTLSAwareCounter(metricGroup, "exceeding_data_end_headers"),
-		fragmentedHeadersFrameEOSCount: newTLSAwareCounter(metricGroup, "exceeding_data_end_headers_eos"),
-		fragmentedFrameCountRST:        newTLSAwareCounter(metricGroup, "exceeding_data_end_rst")}
+		http2requests:                  libtelemetry.NewTLSAwareCounter(metricGroup, "requests"),
+		http2responses:                 libtelemetry.NewTLSAwareCounter(metricGroup, "responses"),
+		endOfStream:                    libtelemetry.NewTLSAwareCounter(metricGroup, "eos"),
+		endOfStreamRST:                 libtelemetry.NewTLSAwareCounter(metricGroup, "rst"),
+		literalValueExceedsFrame:       libtelemetry.NewTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
+		exceedingMaxInterestingFrames:  libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
+		exceedingMaxFramesToFilter:     libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter"),
+		fragmentedDataFrameEOSCount:    libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_data_eos"),
+		fragmentedHeadersFrameCount:    libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_headers"),
+		fragmentedHeadersFrameEOSCount: libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_headers_eos"),
+		fragmentedFrameCountRST:        libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_rst")}
 
 	for bucketIndex := range http2KernelTel.pathSizeBucket {
-		http2KernelTel.pathSizeBucket[bucketIndex] = newTLSAwareCounter(metricGroup, "path_size_bucket_"+(strconv.Itoa(bucketIndex+1)))
+		http2KernelTel.pathSizeBucket[bucketIndex] = libtelemetry.NewTLSAwareCounter(metricGroup, "path_size_bucket_"+(strconv.Itoa(bucketIndex+1)))
 	}
 
 	return http2KernelTel
@@ -106,15 +74,15 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 func (t *kernelTelemetry) update(tel *HTTP2Telemetry, isTLS bool) {
 	// We should only add the delta between the current eBPF map state and the last seen eBPF map state
 	telemetryDelta := tel.Sub(t.telemetryLastState)
-	t.http2requests.add(int64(telemetryDelta.Request_seen), isTLS)
-	t.http2responses.add(int64(telemetryDelta.Response_seen), isTLS)
-	t.endOfStream.add(int64(telemetryDelta.End_of_stream), isTLS)
-	t.endOfStreamRST.add(int64(telemetryDelta.End_of_stream_rst), isTLS)
-	t.literalValueExceedsFrame.add(int64(telemetryDelta.Literal_value_exceeds_frame), isTLS)
-	t.exceedingMaxInterestingFrames.add(int64(telemetryDelta.Exceeding_max_interesting_frames), isTLS)
-	t.exceedingMaxFramesToFilter.add(int64(telemetryDelta.Exceeding_max_frames_to_filter), isTLS)
+	t.http2requests.Add(int64(telemetryDelta.Request_seen), isTLS)
+	t.http2responses.Add(int64(telemetryDelta.Response_seen), isTLS)
+	t.endOfStream.Add(int64(telemetryDelta.End_of_stream), isTLS)
+	t.endOfStreamRST.Add(int64(telemetryDelta.End_of_stream_rst), isTLS)
+	t.literalValueExceedsFrame.Add(int64(telemetryDelta.Literal_value_exceeds_frame), isTLS)
+	t.exceedingMaxInterestingFrames.Add(int64(telemetryDelta.Exceeding_max_interesting_frames), isTLS)
+	t.exceedingMaxFramesToFilter.Add(int64(telemetryDelta.Exceeding_max_frames_to_filter), isTLS)
 	for bucketIndex := range t.pathSizeBucket {
-		t.pathSizeBucket[bucketIndex].add(int64(telemetryDelta.Path_size_bucket[bucketIndex]), isTLS)
+		t.pathSizeBucket[bucketIndex].Add(int64(telemetryDelta.Path_size_bucket[bucketIndex]), isTLS)
 	}
 	// Create a deep copy of the 'tel' parameter to prevent changes from the outer scope affecting the last state
 	t.telemetryLastState = *tel

--- a/pkg/network/protocols/http2/telemetry_test.go
+++ b/pkg/network/protocols/http2/telemetry_test.go
@@ -67,14 +67,14 @@ func testKernelTelemetryUpdate(t *testing.T, isTLS bool) {
 }
 
 func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kernelTelemetryGroup *kernelTelemetry, isTLS bool) {
-	assert.Equal(t, http2Telemetry.Request_seen, uint64(kernelTelemetryGroup.http2requests.get(isTLS)))
-	assert.Equal(t, http2Telemetry.Response_seen, uint64(kernelTelemetryGroup.http2responses.get(isTLS)))
-	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kernelTelemetryGroup.endOfStream.get(isTLS)))
-	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kernelTelemetryGroup.endOfStreamRST.get(isTLS)))
-	assert.Equal(t, http2Telemetry.Literal_value_exceeds_frame, uint64(kernelTelemetryGroup.literalValueExceedsFrame.get(isTLS)))
-	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kernelTelemetryGroup.exceedingMaxInterestingFrames.get(isTLS)))
-	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kernelTelemetryGroup.exceedingMaxFramesToFilter.get(isTLS)))
+	assert.Equal(t, http2Telemetry.Request_seen, uint64(kernelTelemetryGroup.http2requests.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.Response_seen, uint64(kernelTelemetryGroup.http2responses.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.End_of_stream, uint64(kernelTelemetryGroup.endOfStream.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.End_of_stream_rst, uint64(kernelTelemetryGroup.endOfStreamRST.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.Literal_value_exceeds_frame, uint64(kernelTelemetryGroup.literalValueExceedsFrame.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kernelTelemetryGroup.exceedingMaxInterestingFrames.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kernelTelemetryGroup.exceedingMaxFramesToFilter.Get(isTLS)))
 	for i, bucket := range kernelTelemetryGroup.pathSizeBucket {
-		assert.Equal(t, http2Telemetry.Path_size_bucket[i], uint64(bucket.get(isTLS)))
+		assert.Equal(t, http2Telemetry.Path_size_bucket[i], uint64(bucket.Get(isTLS)))
 	}
 }


### PR DESCRIPTION

### What does this PR do?

Define a global shared variable 'TLSAwareCounter' and its methods in the telemetry package.
Remove local variable "tlsAwareCounter" in package "http2".

### Motivation

the http2 protocol handling used this variable to differentiate between counters from the plain protocol and the TLS protocol. 
Change the scope of this variable to shared global to allow it to be used for other protocols as well.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
