### PR TITLE
include node default labels as tags in the node labels provider

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -365,7 +365,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	// 	- `statefulsets.apps`
 	// 	- `pods`
 	// 	- `nodes`
-	config.BindEnvAndSetDefault("kubernetes_resources_annotations_as_tags", map[string]map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_resources_annotations_as_tags", "{}")
 	// kubernetes_resources_labels_as_tags should be parseable as map[string]map[string]string
 	// it maps group resources to labels as tags maps
 	// a group resource has the format `{resource}.{group}`, or simply `{resource}` if it belongs to the empty group
@@ -374,7 +374,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	// 	- `statefulsets.apps`
 	// 	- `pods`
 	// 	- `nodes`
-	config.BindEnvAndSetDefault("kubernetes_resources_labels_as_tags", map[string]map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_resources_labels_as_tags", "{}")
 	config.BindEnvAndSetDefault("kubernetes_persistent_volume_claims_as_tags", true)
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 

--- a/pkg/config/utils/metadata_as_tags.go
+++ b/pkg/config/utils/metadata_as_tags.go
@@ -15,6 +15,12 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+const (
+	pods       string = "pods"
+	nodes      string = "nodes"
+	namespaces string = "namespaces"
+)
+
 // MetadataAsTags contains the labels as tags and annotations as tags for each kubernetes resource based on the user configurations of the following options ordered in increasing order of priority:
 //
 // kubernetes_pod_labels_as_tags
@@ -57,32 +63,32 @@ var _ MetadataAsTags = &metadataAsTags{}
 
 // GetPodLabelsAsTags implements MetadataAsTags#GetPodLabelsAsTags
 func (m *metadataAsTags) GetPodLabelsAsTags() map[string]string {
-	return m.labelsAsTags["pods"]
+	return m.labelsAsTags[pods]
 }
 
 // GetPodAnnotationsAsTags implements MetadataAsTags#GetPodAnnotationsAsTags
 func (m *metadataAsTags) GetPodAnnotationsAsTags() map[string]string {
-	return m.annotationsAsTags["pods"]
+	return m.annotationsAsTags[pods]
 }
 
 // GetNodeLabelsAsTags implements MetadataAsTags#GetNodeLabelsAsTags
 func (m *metadataAsTags) GetNodeLabelsAsTags() map[string]string {
-	return m.labelsAsTags["nodes"]
+	return m.labelsAsTags[nodes]
 }
 
 // GetNodeAnnotationsAsTags implements MetadataAsTags#GetNodeAnnotationsAsTags
 func (m *metadataAsTags) GetNodeAnnotationsAsTags() map[string]string {
-	return m.annotationsAsTags["nodes"]
+	return m.annotationsAsTags[nodes]
 }
 
 // GetNamespaceLabelsAsTags implements MetadataAsTags#GetNamespaceLabelsAsTags
 func (m *metadataAsTags) GetNamespaceLabelsAsTags() map[string]string {
-	return m.labelsAsTags["namespaces"]
+	return m.labelsAsTags[namespaces]
 }
 
 // GetNamespaceAnnotationsAsTags implements MetadataAsTags#GetNamespaceAnnotationsAsTags
 func (m *metadataAsTags) GetNamespaceAnnotationsAsTags() map[string]string {
-	return m.annotationsAsTags["namespaces"]
+	return m.annotationsAsTags[namespaces]
 }
 
 // GetResourcesLabelsAsTags implements MetadataAsTags#GetResourcesLabelsAsTags
@@ -137,26 +143,26 @@ func GetMetadataAsTags(c pkgconfigmodel.Reader) MetadataAsTags {
 
 	// node labels/annotations as tags
 	if nodeLabelsAsTags := c.GetStringMapString("kubernetes_node_labels_as_tags"); nodeLabelsAsTags != nil {
-		metadataAsTags.labelsAsTags["nodes"] = lowerCaseMapKeys(nodeLabelsAsTags)
+		metadataAsTags.labelsAsTags[nodes] = lowerCaseMapKeys(nodeLabelsAsTags)
 	}
 	if nodeAnnotationsAsTags := c.GetStringMapString("kubernetes_node_annotations_as_tags"); nodeAnnotationsAsTags != nil {
-		metadataAsTags.annotationsAsTags["nodes"] = lowerCaseMapKeys(nodeAnnotationsAsTags)
+		metadataAsTags.annotationsAsTags[nodes] = lowerCaseMapKeys(nodeAnnotationsAsTags)
 	}
 
 	// namespace labels/annotations as tags
 	if namespaceLabelsAsTags := c.GetStringMapString("kubernetes_namespace_labels_as_tags"); namespaceLabelsAsTags != nil {
-		metadataAsTags.labelsAsTags["namespaces"] = lowerCaseMapKeys(namespaceLabelsAsTags)
+		metadataAsTags.labelsAsTags[namespaces] = lowerCaseMapKeys(namespaceLabelsAsTags)
 	}
 	if namespaceAnnotationsAsTags := c.GetStringMapString("kubernetes_namespace_annotations_as_tags"); namespaceAnnotationsAsTags != nil {
-		metadataAsTags.annotationsAsTags["namespaces"] = lowerCaseMapKeys(namespaceAnnotationsAsTags)
+		metadataAsTags.annotationsAsTags[namespaces] = lowerCaseMapKeys(namespaceAnnotationsAsTags)
 	}
 
 	// pod labels/annotations as tags
 	if podLabelsAsTags := c.GetStringMapString("kubernetes_pod_labels_as_tags"); podLabelsAsTags != nil {
-		metadataAsTags.labelsAsTags["pods"] = lowerCaseMapKeys(podLabelsAsTags)
+		metadataAsTags.labelsAsTags[pods] = lowerCaseMapKeys(podLabelsAsTags)
 	}
 	if podAnnotationsAsTags := c.GetStringMapString("kubernetes_pod_annotations_as_tags"); podAnnotationsAsTags != nil {
-		metadataAsTags.annotationsAsTags["pods"] = lowerCaseMapKeys(podAnnotationsAsTags)
+		metadataAsTags.annotationsAsTags[pods] = lowerCaseMapKeys(podAnnotationsAsTags)
 	}
 
 	// generic resources labels/annotations as tags

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -18,21 +18,12 @@ import (
 )
 
 type mockMetadataAsTags struct {
+	configutils.MetadataAsTags
 	nodeLabelsAsTags      map[string]string
 	nodeAnnotationsAsTags map[string]string
 }
 
 var _ configutils.MetadataAsTags = &mockMetadataAsTags{}
-
-// GetPodLabelsAsTags implements MetadataAsTags#GetPodLabelsAsTags
-func (m *mockMetadataAsTags) GetPodLabelsAsTags() map[string]string {
-	panic("not implemented")
-}
-
-// GetPodAnnotationsAsTags implements MetadataAsTags#GetPodAnnotationsAsTags
-func (m *mockMetadataAsTags) GetPodAnnotationsAsTags() map[string]string {
-	panic("not implemented")
-}
 
 // GetNodeLabelsAsTags implements MetadataAsTags#GetNodeLabelsAsTags
 func (m *mockMetadataAsTags) GetNodeLabelsAsTags() map[string]string {
@@ -42,26 +33,6 @@ func (m *mockMetadataAsTags) GetNodeLabelsAsTags() map[string]string {
 // GetNodeAnnotationsAsTags implements MetadataAsTags#GetNodeAnnotationsAsTags
 func (m *mockMetadataAsTags) GetNodeAnnotationsAsTags() map[string]string {
 	return m.nodeAnnotationsAsTags
-}
-
-// GetNamespaceLabelsAsTags implements MetadataAsTags#GetNamespaceLabelsAsTags
-func (m *mockMetadataAsTags) GetNamespaceLabelsAsTags() map[string]string {
-	panic("not implemented")
-}
-
-// GetNamespaceAnnotationsAsTags implements MetadataAsTags#GetNamespaceAnnotationsAsTags
-func (m *mockMetadataAsTags) GetNamespaceAnnotationsAsTags() map[string]string {
-	panic("not implemented")
-}
-
-// GetResourcesLabelsAsTags implements MetadataAsTags#GetResourcesLabelsAsTags
-func (m *mockMetadataAsTags) GetResourcesLabelsAsTags() map[string]map[string]string {
-	panic("not implemented")
-}
-
-// GetResourcesAnnotationsAsTags implements MetadataAsTags#GetResourcesAnnotationsAsTags
-func (m *mockMetadataAsTags) GetResourcesAnnotationsAsTags() map[string]map[string]string {
-	panic("not implemented")
 }
 
 func newMockMetadataAsTags(nodeLabelsAsTags, nodeAnnotationsAsTags map[string]string) configutils.MetadataAsTags {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

See title.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix a bug. 

When merging [this](https://github.com/DataDog/datadog-agent/pull/27369) PR, which unifies computing node labels as tags and annotations as tags from the user config, we missed adding the default node labels as tags to the labels as tags that are computed from the config. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- This was not caught due to:
  - Missing Unit tests: 
     - existing unit tests were testing only the `extractTags` function which extracts the tags based on the node labels and the the node labels as tags, but was not testing the public method `GetTags` which prepares the data to call `extractTags`.
     - Adding unit tests to this public function is very complex and requires significant refactoring to the package, which we will work on later. For now, I did a small refactor in order to be able to unit test that node labels do include the default labels as tags before passing them to the `extractTags` function.
  - Missing E2E tests:
     - In E2E tests, we do test for namespace labels as tags, namespace annotations as tags, pod labels as tags and pod annotations as tags, but we don't do any tests on node labels as tags.
     - This is something that should be added to, and might be enough to avoid refactoring the package to be able to implement complete unit tests.


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
None.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Deploy the agent on a kubernetes cluster, and ensure that the `kube_node_role` is properly set on the metrics. 

Here is an example:

First ensure that you have the default node label as label on some node. 
You can add this label to a node by doing this:
```
kubectl label node kind-worker kubernetes.io/role=some-role
```

Deploy the agent and cluster agent with the default configuration.

Ensure that you can see the `kube_node_role` tag on `datadog.agent.running`:
![image](https://github.com/user-attachments/assets/6328cb1b-ee5e-4d50-9371-51fcd205acd6)


