### PR TITLE
[CWS] fix usage of the secl dependency on darwin, and policy loading from outside the agent

### DIFF
--- a/pkg/security/secl/model/consts_darwin.go
+++ b/pkg/security/secl/model/consts_darwin.go
@@ -5,15 +5,16 @@
 
 package model
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"golang.org/x/sys/unix"
+)
 
 var (
 	errorConstants = map[string]int{}
 	// KernelCapabilityConstants list of kernel capabilities
 	KernelCapabilityConstants = map[string]uint64{}
-	// SignalConstants list of signals
-	SignalConstants        = map[string]int{}
-	addressFamilyConstants = map[string]uint16{}
+	addressFamilyConstants    = map[string]uint16{}
 )
 
 var (
@@ -23,6 +24,11 @@ var (
 		"VM_READ":  0x1,
 		"VM_WRITE": 0x2,
 		"VM_EXEC":  0x4,
+	}
+
+	// SignalConstants on darwin are used by some dd-go tests, so we need them on darwin as well
+	SignalConstants = map[string]int{
+		"SIGKILL": int(unix.SIGKILL),
 	}
 )
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -148,6 +148,7 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, pRules []*Policy
 	return result
 }
 
+// PopulateFieldsWithRuleActionsData populates the fields with the data from the rule actions
 func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, opts PolicyLoaderOpts) *multierror.Error {
 	var errs *multierror.Error
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -148,7 +148,7 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, pRules []*Policy
 	return result
 }
 
-func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*PolicyRule, opts PolicyLoaderOpts) *multierror.Error {
+func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, opts PolicyLoaderOpts) *multierror.Error {
 	var errs *multierror.Error
 
 	for _, rule := range policyRules {
@@ -764,7 +764,7 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 		errs = multierror.Append(errs, err)
 	}
 
-	if err := rs.populateFieldsWithRuleActionsData(allRules, opts); err.ErrorOrNil() != nil {
+	if err := rs.PopulateFieldsWithRuleActionsData(allRules, opts); err.ErrorOrNil() != nil {
 		errs = multierror.Append(errs, err)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR:
- ensures `SIGKILL` is defined in `SignalConstants` on macOS/Darwin, as this is used in some dd-go tests
- make `PopulateFieldsWithRuleActionsData` public, as this needs to be used to fix-up the actions in rulesets. Needed for backend validation

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
