### PR TITLE
Check container symlink when a new source is scheduled

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -277,6 +277,10 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 		if s.tailers.Count() >= s.tailingLimit {
 			return
 		}
+
+		if fileprovider.ShouldIgnore(s.validatePodContainerID, file) {
+			continue
+		}
 		if tailer, isTailed := s.tailers.Get(file.GetScanKey()); isTailed {
 			// the file is already tailed, update the existing tailer's source so that the tailer
 			// uses this new source going forward

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -132,7 +132,7 @@ func (p *FileProvider) addFilesToTailList(validatePodContainerID bool, inputFile
 	// Add each file one by one up to the limit
 	for j := 0; j < len(inputFiles) && len(filesToTail) < p.filesLimit; j++ {
 		file := inputFiles[j]
-		if shouldIgnore(validatePodContainerID, file) {
+		if ShouldIgnore(validatePodContainerID, file) {
 			continue
 		}
 		filesToTail = append(filesToTail, file)
@@ -348,7 +348,7 @@ func (p *FileProvider) applyOrdering(files []*tailer.File) {
 	}
 }
 
-// shouldIgnore resolves symlinks in /var/log/containers in order to use that redirection
+// ShouldIgnore resolves symlinks in /var/log/containers in order to use that redirection
 // to validate that we will be reading a file for the correct container.
 //
 // We have to make sure that the file we just detected is tagged with the correct
@@ -361,7 +361,7 @@ func (p *FileProvider) applyOrdering(files []*tailer.File) {
 // See these links for more info:
 //   - https://github.com/kubernetes/kubernetes/issues/58638
 //   - https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/105
-func shouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
+func ShouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
 	// this method needs a source config to detect whether we should ignore that file or not
 	if file == nil || file.Source == nil || file.Source.Config() == nil {
 		return false

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -679,21 +679,21 @@ func TestContainerIDInContainerLogFile(t *testing.T) {
 	}
 
 	// we've found a symlink validating that the file we have just scanned is concerning the container we're currently processing for this source
-	assert.False(shouldIgnore(true, &file), "the file existing in ContainersLogsDir is pointing to the same container, scanned file should be tailed")
+	assert.False(ShouldIgnore(true, &file), "the file existing in ContainersLogsDir is pointing to the same container, scanned file should be tailed")
 
 	// now, let's change the container for which we are trying to scan files,
 	// because the symlink is pointing from another container, we should ignore
 	// that log file
 	file.Source.Config().Identifier = "1234123412341234123412341234123412341234123412341234123412341234"
-	assert.True(shouldIgnore(true, &file), "the file existing in ContainersLogsDir is not pointing to the same container, scanned file should be ignored")
+	assert.True(ShouldIgnore(true, &file), "the file existing in ContainersLogsDir is not pointing to the same container, scanned file should be ignored")
 
 	// in this scenario, no link is found in /var/log/containers, thus, we should not ignore the file
 	os.Remove("/tmp/myapp_my-namespace_myapp-abcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcdabcdefabcdefabcd.log")
-	assert.False(shouldIgnore(true, &file), "no files existing in ContainersLogsDir, we should not ignore the file we have just scanned")
+	assert.False(ShouldIgnore(true, &file), "no files existing in ContainersLogsDir, we should not ignore the file we have just scanned")
 
 	// in this scenario, the file we've found doesn't look like a container ID
 	os.Symlink("/var/log/pods/file-uuid-foo-bar.log", "/tmp/myapp_my-namespace_myapp-thisisnotacontainerIDevenifthisispointingtothecorrectfile.log")
-	assert.False(shouldIgnore(true, &file), "no container ID found, we don't want to ignore this scanned file")
+	assert.False(ShouldIgnore(true, &file), "no container ID found, we don't want to ignore this scanned file")
 }
 
 func TestContainerPathsAreCorrectlyIgnored(t *testing.T) {

--- a/releasenotes/notes/fix-short-lived-container-schedule-87fc0be81e7e160d.yaml
+++ b/releasenotes/notes/fix-short-lived-container-schedule-87fc0be81e7e160d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a rare issue where short-lived containers could cause 
+    logs to be sent with the wrong container ID.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
[AMLII-1999](https://datadoghq.atlassian.net/browse/AMLII-1999)


Fixes an edge case bug where a container log in kubernetes can be assinged the wrong container ID:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/351f50c6-a980-4de7-9b06-0f6939fd66ea">
NOTE: in the screenshot above - the log file and container ID pair should always be the same, but it's not. 


This bug occurs when:
- there are short lived containers (new containers spawn in the same pod with new container IDs)
- there are bytes buffered in the decoder that have not yet been flushed (multiline rule that doesn't match anything, or very slow moving logs)

The reason this happens is: when a new source is scheduled we schedule file sources. This codepath differs slightly from the scanner that runs every 10 seconds. The scanner will always check container symlinks to make sure the pod log file is associated with the correct container ID. The code that schedules a new file source when a new container is detected was not running this check. As a result, the previous tailer's source gets updated to the (new) incorrect source. So any remaining bytes that are in the decoder get the wrong source attached to their message which tags it with the wrong container ID. 

This PR ads the symlink check to prevent this from happening. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This is very tricky to reproduce so follow these steps carefully. There is a timing element, so if it doesn't work the first time you may have to try again. These steps assume you are using `minikube` locally with it's build-in docker driver. If you don't use minikube, make sure you have access to the underlying node and container runtime!

1. Deploy the agent with a specific configuraiton: 
- a container that emits logs
- a multiline rule that will never match

Here is a k8s deployment that sets this up for you (Don't forget to set the API key and the correct agent image!)

```
# Run these to setup agent permissions in your cluster
# https://docs.datadoghq.com/containers/guide/kubernetes_daemonset

apiVersion: apps/v1
kind: Deployment
metadata:
  name: log-generator
spec:
  replicas: 1
  selector:
    matchLabels:
      app: log-generator
  template:
    metadata:
      labels:
        app: log-generator
      annotations:
        ad.datadoghq.com/log-generator.logs: >-
          [{
            "source": "logger",
            "service": "logger",
            "log_processing_rules": [{
              "type": "multi_line",
              "name": "never match",
              "pattern" : "this will never match"
            }]
          }]
    spec:
      restartPolicy: Always
      serviceAccount: datadog-agent
      containers:
      - name: log-generator
        image: busybox
        args:
        - /bin/sh
        - -c
        - |
          while true; do
            echo "$(date) - This is a log entry"
            sleep 0.05
          done
      - name: datadog-agent
        imagePullPolicy: Always
        image: datadog/agent:latest
        env:
        - name: DD_HOSTNAME
          value: "log-containers-shcedule-repro"
        - name: DD_API_KEY
          value: "$API_KEY"
        - name: DD_LOGS_ENABLED
          value: "true"
        - name: DD_LOG_LEVEL
          value: "debug"
        - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
          value: "true"
        - name: DD_KUBELET_TLS_VERIFY
          value: "false"
        - name: DOCKER_HOST
          value: "unix:///host/var/run/docker.sock"
        volumeMounts:
        - name: logcontainerpath
          mountPath: /var/lib/docker/containers
        - name: kubecontainerpath
          mountPath: /var/log/containers
        - name: logpodpath
          mountPath: /var/log/pods
        - mountPath: /host/var/run
          mountPropagation: None
          name: runtimesocketdir
          readOnly: true
      volumes:
      - hostPath:
          path: /var/log/pods
        name: logpodpath
      - hostPath:
          path: /var/lib/docker/containers
        name: logcontainerpath
      - hostPath:
          path: /var/log/containers
        name: kubecontainerpath
      - hostPath:
          path: /var/run
        name: runtimesocketdir
```

By default the decoder will buffer 1 second worth of logs when a multi-line pattern doesn't match. 

2. Connect to the agent container ex:
`k exec -it log-generator-f9b6b8fdf-nnq69 -c datadog-agent -- bash`

3. run `agent status | grep "log-generator"`. you should see an ouput like this: 

```
socket-fqdn: log-generator-f9b6b8fdf-nnq69
  socket-hostname: log-generator-f9b6b8fdf-nnq69
  default/log-generator-f9b6b8fdf-nnq69/log-generator
      Path: /var/log/pods/default_log-generator-f9b6b8fdf-nnq69_765c8d79-cc39-46d5-96e0-79627c36464d/log-generator/*.log
        /var/log/pods/default_log-generator-f9b6b8fdf-nnq69_765c8d79-cc39-46d5-96e0-79627c36464d/log-generator/0.log
```

4. `cd` into the folder with the logs: `cd /var/log/pods/default_log-generator-f9b6b8fdf-nnq69_765c8d79-cc39-46d5-96e0-79627c36464d/log-generator/`

5. run `ls -la` this will print out the symlink the log file points to. In this path, you can find the conatiner id: 

```
ls -la
total 12
drwxr-xr-x 2 root root 4096 Aug 23 15:05 .
drwxr-xr-x 4 root root 4096 Aug 23 15:05 ..
lrwxrwxrwx 1 root root  165 Aug 23 15:05 0.log -> /var/lib/docker/containers/b8331e00ea8c48efc21cbec54b7298eb652c283902a26ae16e06bbc8b6c1542c/b8331e00ea8c48efc21cbec54b7298eb652c283902a26ae16e06bbc8b6c1542c-json.log
```

6. In a new shell on your host, run `minikube ssh`
7. kill the underlying container (copy the id from the previous step):
`docker kill b8331e00ea8c48efc21cbec54b7298eb652c283902a26ae16e06bbc8b6c1542c`

8. back in the agent shell run `ls` you should see two log files now: `0.log 1.log`

At this point we should have reproduced the issue: the `0.log` still symlinks to the old container. With a little bit of luck, there were some buffered logs in the decoder when you killed the container.

9. Check the logs explorer:
<img width="780" alt="Screenshot 2024-08-23 at 11 35 34 AM" src="https://github.com/user-attachments/assets/bf907817-2684-49fb-a320-01423ec4ef01">

The log file and container ID should change at the same time. 

10. Look at the agent logs for a log line like: `We were about to tail a file attached to the wrong container`. One of the id's should be the container you killed in the step above. 

I'd suggest running steps 3-10 a couple of times (can do it on each consecutive file) to ensure we didn't just get lucky with buffer flush timing. 



[AMLII-1999]: https://datadoghq.atlassian.net/browse/AMLII-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ