### PR TITLE
Fix flaky apiserver unit test

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -536,7 +536,7 @@ func TestUnbundledEventsTransform(t *testing.T) {
 			events, errors := transformer.Transform(incomingEvents)
 
 			// Sort events by title for easier comparison
-			sort.Slice(events, func(i, j int) bool {
+			sort.SliceStable(events, func(i, j int) bool {
 				return events[i].Title < events[j].Title
 			})
 


### PR DESCRIPTION
### What does this PR do?

Fix flaky `TestUnbundledEventsTransform/unbundled_events_by_Kind:ReplicaSet_and_Reason:Killing,SuccessfulDelete` test

### Motivation

A change introduced by [this PR](https://github.com/DataDog/datadog-agent/pull/28342) also modified the test cases to validate that the bug was fixed. In doing so, another expected event was added to the expected event list, which contained a title that was already present in the list: `Events from the Pod default/squirtle-8fff95dbb-tsc7v`.

The test code sorts the output by event title, but `sort.Slice` does not guarantee that order will be preserved in the case of a collision, which is what is happening here. The end result is the test sometimes succeeds, when the ordering matches what is defined in the list, and [sometimes fails](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3Agithub.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fcollector%2Fcorechecks%2Fcluster%2Fkubernetesapiserver.TestUnbundledEventsTransform%2A%20-%40test.name%3ATestUnbundledEventsTransform&agg_m=count&agg_m_source=base&agg_q=%40test.full_name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=10&top_o=top&viz=stream&x_missing=true&start=1723827386996&end=1724432186996&paused=false), when the ordering is incorrect.

This PR changes the call from `sort.Slice` to `sort.SliceStable`, which should preserve the ordering in the event of a collision

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
