### PR TITLE
Switched processUsageTotal to use latest metric and enabled TestKindS…

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -167,7 +167,7 @@ new-e2e-containers:
     matrix:
       # Temporarily disable old version of Kubernetes
       # On this version, the reported kubernetes CPU usage appears to be significantly off
-      # - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
+      - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.19"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.22"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.27"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
@@ -143,7 +143,7 @@ func (p *Provider) processContainerMetric(metricType, metricName string, metricF
 		return
 	}
 
-	samples := p.sumValuesByContext(metricFam, p.getEntityIDIfContainerMetric)
+	samples := p.latestValueByContext(metricFam, p.getEntityIDIfContainerMetric)
 	for containerID, sample := range samples {
 		var tags []string
 
@@ -229,7 +229,7 @@ func (p *Provider) processUsageMetric(metricName string, metricFam *prom.MetricF
 		seenKeys[k] = false
 	}
 
-	samples := p.latestValueByContext(metricFam, p.getEntityIDIfContainerMetric)
+	samples := p.sumValuesByContext(metricFam, p.getEntityIDIfContainerMetric)
 	for containerID, sample := range samples {
 		containerName := string(sample.Metric["name"])
 		if containerName == "" {

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
@@ -229,7 +229,7 @@ func (p *Provider) processUsageMetric(metricName string, metricFam *prom.MetricF
 		seenKeys[k] = false
 	}
 
-	samples := p.sumValuesByContext(metricFam, p.getEntityIDIfContainerMetric)
+	samples := p.latestValueByContext(metricFam, p.getEntityIDIfContainerMetric)
 	for containerID, sample := range samples {
 		containerName := string(sample.Metric["name"])
 		if containerName == "" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Sometimes the `cadvisor` endpoint of the kubelet the `container_cpu_usage_seconds_total` metric twice. Grab the latest value instead of summing the values.

Enables the `TestKindSuite` e2e test on Kubernetes v1.19. This was previously disabled due to the `TestKindSuite/TestCPU/metric___kubernetes.cpu.usage.total` test consistantly failing on Kubernetes v1.19.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `TestKindSuite` e2e test was disabled on Kubernetes v1.19 due to the test consistently failing. The `TestCPU` test for `kubernetes.cpu.usage.total` appeared to be consistently double the expected value, causing the test to fail. Even when it "passed," the metric looked completely wrong, but a single point in the correct range would pass the test. [#27913](https://github.com/DataDog/datadog-agent/pull/27913) disabled the e2e test, and has examples of the test failing and "passing."

[Link to e2e data](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?fromUser=false&fullscreen_end_ts=1724263155959&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1724261355959&fullscreen_widget=5717020205158046&index=&refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ewoodthomas-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ewoodthomas-kind-cluster&view=spans&from_ts=1724261355959&to_ts=1724263155959&live=false)

On the left, you can see the expected behavior from the e2e test being run on Kubernetes v1.30. On the right you can see the difference in `kubernetes.cpu.usage.total` when testing with Kubernetes v1.19.

This behavior appeared to be fairly similar to [#11914](https://github.com/DataDog/integrations-core/pull/11914). The `cadvisor` endpoint is reporting duplicates of the `container_cpu_usage_seconds_total` metric. However, this behavior was not happening on a locally run kind cluster. This exclusively happened when the kind cluster was run on an EC2 instance like it is with the e2e tests.

Kubelet cadvisor endpoint on a kind cluster on an EC2 instance:
```
root@ewoodthomas-kind-cluster-control-plane:/# curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$DD_KUBERNETES_KUBELET_HOST:10250/metrics/cadvisor -k -H "Authorization: Bearer $(</var/run/secrets/kubernetes.io/serviceaccount/token)" | grep cpu_usage | grep stress-ng | grep -v pause
container_cpu_usage_seconds_total{container="",cpu="total",id="/kubelet/kubepods/podad8151c5-e30f-499e-a236-0149de4359bf",image="",name="",namespace="workload-cpustress",pod="stress-ng-55489c9895-fmrjn"} 13406.061114023 1724443826927
container_cpu_usage_seconds_total{container="stress-ng",cpu="total",id="/docker/84e2bed40e443a5399ba4969394a081149411a0f76aa1b99c68ae1d6280dfb12/kubelet/kubepods/podad8151c5-e30f-499e-a236-0149de4359bf/f39763cee2fb9358b7d292c511d42ac525c9553355e43daeaad167cc4f7a7cf2",image="ghcr.io/colinianking/stress-ng:409201de7458c639c68088d28ec8270ef599fe47",name="f39763cee2fb9358b7d292c511d42ac525c9553355e43daeaad167cc4f7a7cf2",namespace="workload-cpustress",pod="stress-ng-55489c9895-fmrjn"} 618.433739325 1724443820806
container_cpu_usage_seconds_total{container="stress-ng",cpu="total",id="/kubelet/kubepods/podad8151c5-e30f-499e-a236-0149de4359bf/f39763cee2fb9358b7d292c511d42ac525c9553355e43daeaad167cc4f7a7cf2",image="ghcr.io/colinianking/stress-ng:409201de7458c639c68088d28ec8270ef599fe47",name="f39763cee2fb9358b7d292c511d42ac525c9553355e43daeaad167cc4f7a7cf2",namespace="workload-cpustress",pod="stress-ng-55489c9895-fmrjn"} 620.363553503 1724443833736
```

Kubelet cadvisor endpoint on a locally run kind cluster:
```
root@kind-ethan-woodthomas-worker:/# curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$DD_KUBERNETES_KUBELET_HOST:10250/metrics/cadvisor -k -H "Authorization: Bearer $(</var/run/secrets/kubernetes.io/serviceaccount/token)" | grep cpu_usage | grep stress-ng-25 | grep -v pause
container_cpu_usage_seconds_total{container="",cpu="total",id="/kubelet/kubepods/burstable/podf49c1c44-b84b-45db-9d6f-5d8da6d2ffc5",image="",name="",namespace="workload-stress-ng",pod="stress-ng-25-55b5c68c8b-9gdww"} 364.777445 1724431758831
container_cpu_usage_seconds_total{container="stress-ng-25",cpu="total",id="/kubelet/kubepods/burstable/podf49c1c44-b84b-45db-9d6f-5d8da6d2ffc5/ae332ad73c9b9b772ac2a974ed01e9b25c16125206cd85c73856f7871d22f1d5",image="docker.io/ewoodthomas/stress-ng:v1",name="ae332ad73c9b9b772ac2a974ed01e9b25c16125206cd85c73856f7871d22f1d5",namespace="workload-stress-ng",pod="stress-ng-25-55b5c68c8b-9gdww"} 365.004447 1724431759733
```

On the EC2 instance, the same `container`, `namespace`, and `pod` triplet is reported twice. These values are then summed causing the metric to be reported as double. Using the exact same solution as [#11914](https://github.com/DataDog/integrations-core/pull/11914), simply grab the latest metric instead of summing them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
