### PR TITLE
usm: classification: tests: Fix failure due to port not free

### DIFF
--- a/pkg/network/protocols/http/testutil/tcp_server.go
+++ b/pkg/network/protocols/http/testutil/tcp_server.go
@@ -86,3 +86,8 @@ func (s *TCPServer) Run(done chan struct{}) error {
 
 	return nil
 }
+
+// Address returns the address of the server.
+func (s *TCPServer) Address() string {
+	return s.address
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Uses a free port for the server, to handle races and errors like 
```
    tracer_usm_linux_test.go:401: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/usm/tests/tracer_usm_linux_test.go:401
        	Error:      	Received unexpected error:
        	            	dial tcp :33727->[::1]:9111: bind: address already in use
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Found while monitoring flaky tests

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
