### PR TITLE
[USM] provide pid to file reigstery cleanup

### DIFF
--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -42,7 +42,7 @@ func TestClearSanity(t *testing.T) {
 		cmd, err := testutil.OpenFromAnotherProcess(t, target)
 		require.NoError(t, err)
 		path1Pids = append(path1Pids, uint32(cmd.Process.Pid))
-		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t))
+		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t), IgnoreCB)
 	}
 	path2Pids := make([]uint32, 0)
 	for i := 0; i < 2; i++ {
@@ -51,7 +51,7 @@ func TestClearSanity(t *testing.T) {
 		cmd, err := testutil.OpenFromAnotherProcess(t, target)
 		require.NoError(t, err)
 		path2Pids = append(path2Pids, uint32(cmd.Process.Pid))
-		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t))
+		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t), IgnoreCB)
 	}
 
 	assert.Len(t, r.byPID, len(path1Pids)+len(path2Pids))
@@ -87,7 +87,7 @@ func TestClearLeakedPathID(t *testing.T) {
 		cmd, err := testutil.OpenFromAnotherProcess(t, target)
 		require.NoError(t, err)
 		path1Pids = append(path1Pids, uint32(cmd.Process.Pid))
-		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t))
+		_ = r.Register(target, uint32(cmd.Process.Pid), verifyPIDInFilePath(t), verifyPIDInFilePath(t), IgnoreCB)
 	}
 
 	assert.Len(t, r.byPID, len(path1Pids))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The PR tries as a best effort to guarantee `unregister` callback gets the PID of the program to remove.
It should not affect native-library, but only go-tls in a follow up PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Provide all context available while trying to unregistering a binary.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
