### PR TITLE
Ingest Oracle active session history samples (DBM-1579)

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -134,6 +134,12 @@ instances:
       #
       # enabled: true
 
+      ## @param active_session_history - boolean - optional - default: false
+      ## Collect activity samples from `v$active_session_history` instead of the Agent performing sampling.
+      ## WARNING: Querying `v$active_session_history` requires optional Oracle licences and may result in additional costs if enabled.
+      #
+      # active_session_history: false
+
     ## Configure collection of query metrics
     #
     # query_metrics:

--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -393,6 +393,10 @@ AND status = 'ACTIVE'`)
 		}
 		sessionRow.CdbName = c.cdbName
 		sessionRows = append(sessionRows, sessionRow)
+		//sessionRow.SessionID = 17
+		//sessionRow.SessionSerial = 23
+		sessionRow.SQLID = "23"
+		sessionRows = append(sessionRows, sessionRow)
 	}
 
 	var collection_interval float64

--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -218,7 +218,8 @@ AND s.con_id = c.con_id(+)
 AND s.command = comm.command_type(+)`
 
 const activityQueryActiveSessionHistory = `SELECT /*+ push_pred(sq) */ /* DD_ACTIVITY_SAMPLING */
-	sample_time as now,
+	cast (sample_time as date) now,
+	(CAST(sample_time_utc AS DATE) - TO_DATE('1970-01-01', 'YYYY-MM-DD')) * 86400000 as utc_ms,
 	s.session_id sid,
 	s.session_serial# serial#,
 	sess.username,
@@ -272,4 +273,5 @@ WHERE
 	AND ( sq.sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sq.sql_text is NULL )
 	AND s.con_id = c.con_id(+)
 	AND sess.sid(+) = s.session_id AND sess.serial#(+) = s.session_serial#
-	AND s.sample_id > :last_sample_id`
+	AND s.sample_id > :last_sample_id
+ORDER BY s.sample_time`

--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -216,3 +216,60 @@ AND sq_prev.child_number(+) = s.prev_child_number
 AND ( sq.sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sq.sql_text is NULL )
 AND s.con_id = c.con_id(+)
 AND s.command = comm.command_type(+)`
+
+const activityQueryActiveSessionHistory = `SELECT /*+ push_pred(sq) */ /* DD_ACTIVITY_SAMPLING */
+	sample_time as now,
+	s.session_id sid,
+	s.session_serial# serial#,
+	sess.username,
+	'ACTIVE' status,
+	sess.osuser,
+	sess.process,
+	s.machine,
+	s.port,
+	s.program,
+	s.session_type type,
+	s.sql_id,
+	sq.force_matching_signature as force_matching_signature,
+	sq.plan_hash_value sql_plan_hash_value,
+	s.sql_exec_start,
+	s.module,
+	s.action,
+	sess.logon_time,
+	s.client_id client_identifier,
+	CASE WHEN s.blocking_session_status = 'VALID' THEN
+		s.blocking_inst_id
+	ELSE
+		null
+	END blocking_instance,
+	CASE WHEN s.blocking_session_status = 'VALID' THEN
+		s.blocking_session
+	ELSE
+		null
+	END blocking_session,
+	CASE WHEN session_state = 'WAITING' THEN
+		s.event
+	ELSE
+		'CPU'
+	END event,
+	CASE WHEN session_state = 'WAITING' THEN
+		s.wait_class
+	ELSE
+		'CPU'
+	END wait_class,
+	s.wait_time * 10000 wait_time_micro,
+	c.name as pdb_name,
+	dbms_lob.substr(sq.sql_fulltext, :sql_substr_length, 1) sql_fulltext,
+	s.sql_opname command_name
+FROM
+	v$active_session_history s,
+	v$session sess,
+	v$sql sq,
+	v$containers c
+WHERE
+	sq.sql_id(+)   = s.sql_id
+	AND sq.child_number(+) = s.sql_child_number
+	AND ( sq.sql_text NOT LIKE '%DD_ACTIVITY_SAMPLING%' OR sq.sql_text is NULL )
+	AND s.con_id = c.con_id(+)
+	AND sess.sid(+) = s.session_id AND sess.serial#(+) = s.session_serial#
+	AND s.sample_id > :last_sample_id`

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -33,9 +33,10 @@ type InitConfig struct {
 
 //nolint:revive // TODO(DBM) Fix revive linter
 type QuerySamplesConfig struct {
-	Enabled            bool `yaml:"enabled"`
-	IncludeAllSessions bool `yaml:"include_all_sessions"`
-	ForceDirectQuery   bool `yaml:"force_direct_query"`
+	Enabled              bool `yaml:"enabled"`
+	IncludeAllSessions   bool `yaml:"include_all_sessions"`
+	ForceDirectQuery     bool `yaml:"force_direct_query"`
+	ActiveSessionHistory bool `yaml:"active_session_history"`
 }
 
 type queryMetricsTrackerConfig struct {

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -115,6 +115,7 @@ type Check struct {
 	openMode                                string
 	legacyIntegrationCompatibilityMode      bool
 	clock                                   clock.Clock
+	lastSampleId                            uint64
 }
 
 type vDatabase struct {

--- a/releasenotes/notes/oracle-ingest-active-session-history-d2a77e18a31c8d29.yaml
+++ b/releasenotes/notes/oracle-ingest-active-session-history-d2a77e18a31c8d29.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    [oracle] Add the ``active_session_history`` configuration parameter to optionally ingest Oracle active session history samples instead of query sampling.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add configuration parameter `active_session_history` to optionally emit Oracle active session history samples instead of sampling.

### Motivation

We can get 1s samples with a very low overhead - the query takes less than 100ms, and needs to run only every 10s. The feature was requested by Raymond James a while ago, and they asked about it at the latest Dash.

### Additional Notes

Querying from `v$active_session_history` requires additional Oracle licences.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
