### PR TITLE
fix(junit-upload): Upload tests even if job failed on windows

### DIFF
--- a/tasks/winbuildscripts/integrationtests.ps1
+++ b/tasks/winbuildscripts/integrationtests.ps1
@@ -17,8 +17,8 @@ $Env:PATH="$UT_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Pyt
 & inv -e install-tools
 & inv -e integration-tests
 $err = $LASTEXITCODE
-Write-Host Test result is $err
 if($err -ne 0){
     Write-Host -ForegroundColor Red "test failed $err"
     [Environment]::Exit($err)
 }
+Write-Host Test passed

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -24,8 +24,8 @@ if ($Env:TARGET_ARCH -eq "x86") {
 & inv -e security-agent.kitchen-prepare --skip-linters
 
 $err = $LASTEXITCODE
-Write-Host Test result is $err
 if($err -ne 0){
     Write-Host -ForegroundColor Red "kitchen prepare failed $err"
     [Environment]::Exit($err)
 }
+Write-Host Test passed

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -26,8 +26,8 @@ if ($err -ne 0) {
 & inv -e system-probe.kitchen-prepare --ci
 
 $err = $LASTEXITCODE
-Write-Host Test result is $err
 if($err -ne 0){
     Write-Host -ForegroundColor Red "kitchen prepare failed $err"
     [Environment]::Exit($err)
 }
+Write-Host Test passed

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -57,17 +57,15 @@ if($err -ne 0){
 & inv -e test --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --coverage --cpus 8 --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\$test_output_file $Env:EXTRA_OPTS --build-stdlib $TEST_WASHER_FLAG
 
 $err = $LASTEXITCODE
-Write-Host Test result is $err
-if($err -ne 0){
-    Write-Host -ForegroundColor Red "Tests failed $err"
-    [Environment]::Exit($err)
-}
 
-# Upload coverage reports to Codecov
+# Ignore upload failures
+$ErrorActionPreference = "Continue"
+
+# 1. Upload coverage reports to Codecov
 $Env:CODECOV_TOKEN=$(& "$UT_BUILD_ROOT\tools\ci\aws_ssm_get_wrapper.ps1" $Env:CODECOV_TOKEN_SSM_NAME)
 & inv -e coverage.upload-to-codecov $Env:COVERAGE_CACHE_FLAG
 
-$ErrorActionPreference = "Continue" # Ignore upload errors now, until we change the logic to ignore empty files in the upload script
+# 2. Upload junit files
 # Copy test files to c:\mnt for further gitlab upload
 Get-ChildItem -Path "$UT_BUILD_ROOT" -Filter "junit-out-*.xml" -Recurse | ForEach-Object {
     Copy-Item -Path $_.FullName -Destination C:\mnt
@@ -76,3 +74,9 @@ $Env:DATADOG_API_KEY=$(& "$UT_BUILD_ROOT\tools\ci\aws_ssm_get_wrapper.ps1" $Env:
 $Env:GITLAB_TOKEN=$(& "$UT_BUILD_ROOT\tools\ci\aws_ssm_get_wrapper.ps1" $Env:GITLAB_TOKEN_SSM_NAME)
 & inv -e junit-upload --tgz-path $Env:JUNIT_TAR
 
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "test failed $err"
+    [Environment]::Exit($err)
+}
+
+Write-Host Test passed


### PR DESCRIPTION
### What does this PR do?
Upload tests even if job failed on windows

### Motivation
[ACIX-417](https://datadoghq.atlassian.net/browse/ACIX-417) Test results must be raised in all situations, even in case of failure

### Tests
- [Before] Run all windows tests and pretend failure on `main` [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/618511567)
```
Test result is 1
Tests failed 1
WARNING: **/junit-out-*.xml: no matching files. Ensure that the artifact path is relative to the working directory (C:\builds\-JJsYSDF\0\DataDog\datadog-agent) 
ERROR: No files to upload        
```
- [After] Run all windows tests and pretend failure on current branch [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/618507809)
```
 Uploaded 1 files for windows-kernel-integrations_base
test failed 1
**/junit-out-*.xml: found 1 matching artifact files and directories 
Uploading artifacts as "junit" to coordinator... 201 Created  id=618507809 responseStatus=201 Created token=glcbt-64
```

[ACIX-417]: https://datadoghq.atlassian.net/browse/ACIX-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ