### PR TITLE
service discovery: Added UTs to cover binary launched from bash scripts

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -424,10 +424,12 @@ func testCaptureWrappedCommands(t *testing.T, scriptName string, scriptContent [
 	}, 10*time.Second, 100*time.Millisecond)
 
 	if len(commandWrapper) > 0 {
-		children, err := proc.Children()
-		require.NoError(t, err)
-		require.Len(t, children, 1)
-		proc = children[0]
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			children, err := proc.Children()
+			require.NoError(t, err)
+			require.Len(t, children, 1)
+			proc = children[0]
+		}, 10*time.Second, 100*time.Millisecond)
 	}
 	t.Cleanup(func() { _ = proc.Kill() })
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -411,7 +411,7 @@ func testCaptureWrappedCommands(t *testing.T, script string, commandWrapper []st
 	// are looking at the right process.
 	if cmdline == strings.Join(commandLineArgs, " ") && len(commandWrapper) > 0 {
 		var children []*process.Process
-		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			children, err = proc.Children()
 			assert.NoError(collect, err)
 			assert.Len(collect, children, 1)

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -375,7 +375,7 @@ import socket
 import time
 
 HOST = '127.0.0.1'
-PORT = # Empty port
+PORT = 0 # Empty port
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind((HOST, PORT))

--- a/pkg/collector/corechecks/servicediscovery/module/testdata/script.py
+++ b/pkg/collector/corechecks/servicediscovery/module/testdata/script.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import socket
 import time

--- a/pkg/collector/corechecks/servicediscovery/module/testdata/script.py
+++ b/pkg/collector/corechecks/servicediscovery/module/testdata/script.py
@@ -1,0 +1,12 @@
+#! /usr/bin/python3
+
+import socket
+import time
+
+HOST = '127.0.0.1'
+PORT = 0  # Empty port
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind((HOST, PORT))
+s.listen()
+time.sleep(30)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adding 2 UTs to cover the cases where a python script is launched from a bash script, or directly from a shell, making sure service discovery captures them.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Verifying the behavior won't break in the future.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
