### PR TITLE
[otel-agent] address broken log level assignment

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -7,12 +7,28 @@ package config
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestAgentConfig(t *testing.T) {
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigTestSuite) SetupTest() {
+	datadog := pkgconfigmodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	pkgconfigsetup.SetDatadog(datadog)
+}
+
+func (suite *ConfigTestSuite) TestAgentConfig() {
+	t := suite.T()
 	fileName := "testdata/config.yaml"
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	if err != nil {
@@ -37,7 +53,8 @@ func TestAgentConfig(t *testing.T) {
 	assert.Equal(t, nil, c.Get("apm_config.features"))
 }
 
-func TestAgentConfigDefaults(t *testing.T) {
+func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
+	t := suite.T()
 	fileName := "testdata/config_default.yaml"
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	if err != nil {
@@ -58,14 +75,131 @@ func TestAgentConfigDefaults(t *testing.T) {
 	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
 }
 
-func TestNoDDExporter(t *testing.T) {
+func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	// all expected defaults
+	assert.Equal(t, "DATADOG_API_KEY", c.Get("api_key"))
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, true, c.Get("logs_enabled"))
+	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, 5, c.Get("logs_config.batch_wait"))
+	assert.Equal(t, true, c.Get("logs_config.use_compression"))
+	assert.Equal(t, true, c.Get("logs_config.force_use_http"))
+	assert.Equal(t, 6, c.Get("logs_config.compression_level"))
+	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
+	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
+	assert.Equal(t, true, c.Get("otlp_config.traces.span_name_as_resource_name"))
+	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+
+	// log_level from datadog.yaml takes precedence -> more verbose
+	assert.Equal(t, "debug", c.Get("log_level"))
+}
+
+func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlKeysAvailable() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	// log_level from datadog.yaml takes precedence -> more verbose
+	assert.Equal(t, "debug", c.Get("log_level"))
+	assert.True(t, c.GetBool("otelcollector.enabled"))
+	assert.Equal(t, "https://localhost:7777", c.GetString("otelcollector.extension_url"))
+	assert.Equal(t, 5009, c.GetInt("agent_ipc.port"))
+	assert.Equal(t, 60, c.GetInt("agent_ipc.config_refresh_interval"))
+}
+
+func (suite *ConfigTestSuite) TestLogLevelPrecedence() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_low_log_level.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	// log_level from service config takes precedence -> more verbose
+	// ddFlleName configures level warn, Telemetry defaults to info
+	assert.Equal(t, "info", c.Get("log_level"))
+}
+
+func (suite *ConfigTestSuite) TestEnvLogLevelPrecedence() {
+	t := suite.T()
+	oldval, exists := os.LookupEnv("DD_LOG_LEVEL")
+	os.Setenv("DD_LOG_LEVEL", "debug")
+	defer func() {
+		if !exists {
+			os.Unsetenv("DD_LOG_LEVEL")
+		} else {
+			os.Setenv("DD_LOG_LEVEL", oldval)
+		}
+	}()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_low_log_level.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	// log_level from service config takes precedence -> more verbose
+	// ddFlleName configures level warn, Telemetry defaults to info, env sets debug
+	assert.Equal(t, "debug", c.Get("log_level"))
+}
+
+func (suite *ConfigTestSuite) TestEnvBadLogLevel() {
+	t := suite.T()
+	oldval, exists := os.LookupEnv("DD_LOG_LEVEL")
+	os.Setenv("DD_LOG_LEVEL", "yabadabadooo")
+	defer func() {
+		if !exists {
+			os.Unsetenv("DD_LOG_LEVEL")
+		} else {
+			os.Setenv("DD_LOG_LEVEL", oldval)
+		}
+	}()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_low_log_level.yaml"
+	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	assert.Error(t, err)
+}
+
+func (suite *ConfigTestSuite) TestBadLogLevel() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_bad_log_level.yaml"
+	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+
+	// log_level from service config takes precedence -> more verbose
+	// ddFlleName configures level warn, Telemetry defaults to info
+	assert.Error(t, err)
+}
+
+func (suite *ConfigTestSuite) TestNoDDExporter() {
+	t := suite.T()
 	fileName := "testdata/config_no_dd_exporter.yaml"
 	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	assert.EqualError(t, err, "no datadog exporter found")
 }
 
-func TestMultipleDDExporters(t *testing.T) {
+func (suite *ConfigTestSuite) TestMultipleDDExporters() {
+	t := suite.T()
 	fileName := "testdata/config_multiple_dd_exporters.yaml"
 	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	assert.EqualError(t, err, "multiple datadog exporters found")
+}
+
+// TestSuite runs the CalculatorTestSuite
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
 }

--- a/cmd/otel-agent/config/testdata/datadog.yaml
+++ b/cmd/otel-agent/config/testdata/datadog.yaml
@@ -1,0 +1,12 @@
+api_key: deadbeef
+
+log_level: debug
+
+otelcollector:
+  enabled: true
+  extension_url: "https://localhost:7777"
+
+agent_ipc:
+  port: 5009
+  config_refresh_interval: 60
+

--- a/cmd/otel-agent/config/testdata/datadog_low_log_level.yaml
+++ b/cmd/otel-agent/config/testdata/datadog_low_log_level.yaml
@@ -1,0 +1,10 @@
+log_level: warn
+
+otelcollector:
+  enabled: true
+  extension_url: "https://localhost:7777"
+
+agent_ipc:
+  port: 5009
+  config_refresh_interval: 60
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR ensures that:
1) Log levels from the actual environment or datadog.yaml are accounted for.
2) Sets the most verbose level from `DD_LOG_LEVEL` (source via environment or `datadog.yaml`) or the corresponding OTel configuration telemetry logging config defined.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Impossible to set log level with our usual ops, and unexpected behavior when changing the agent logging level to a more verbose mode for troubleshooting.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Modifying `DD_LOG_LEVEL` or `datadog.yaml` `log_level` settings should now be accounted for and applied if more verbose than the OTel telemetry debug verbosity (info by default) - it used to be ignored. 