### PR TITLE
[e2e] print warning and continue on stack remove error

### DIFF
--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -37,11 +37,14 @@ const (
 	nameSep               = "-"
 	e2eWorkspaceDirectory = "dd-e2e-workspace"
 
-	defaultStackUpTimeout      time.Duration = 60 * time.Minute
-	defaultStackCancelTimeout  time.Duration = 10 * time.Minute
-	defaultStackDestroyTimeout time.Duration = 60 * time.Minute
-	stackDeleteTimeout         time.Duration = 20 * time.Minute
-	stackUpMaxRetry                          = 2
+	defaultStackUpTimeout          time.Duration = 60 * time.Minute
+	defaultStackCancelTimeout      time.Duration = 10 * time.Minute
+	defaultStackDestroyTimeout     time.Duration = 60 * time.Minute
+	defaultStackForceRemoveTimeout time.Duration = 20 * time.Minute
+	defaultStackRemoveTimeout      time.Duration = 10 * time.Minute
+	stackUpMaxRetry                              = 2
+	stackDestroyMaxRetry                         = 2
+	stackRemoveMaxRetry                          = 2
 )
 
 var (
@@ -130,7 +133,7 @@ func (sm *StackManager) GetStack(ctx context.Context, name string, config runner
 		WithFailOnMissing(failOnMissing),
 	)
 	if err != nil {
-		errDestroy := sm.deleteStack(ctx, name, stack, nil, nil)
+		errDestroy := sm.destroyAndRemoveStack(ctx, name, stack, nil, nil)
 		if errDestroy != nil {
 			return stack, upResult, errors.Join(err, errDestroy)
 		}
@@ -238,7 +241,7 @@ func (sm *StackManager) DeleteStack(ctx context.Context, name string, logWriter 
 		stack = &newStack
 	}
 
-	return sm.deleteStack(ctx, name, stack, logWriter, nil)
+	return sm.destroyAndRemoveStack(ctx, name, stack, logWriter, nil)
 }
 
 // ForceRemoveStackConfiguration removes the configuration files pulumi creates for managing a stack.
@@ -255,7 +258,7 @@ func (sm *StackManager) ForceRemoveStackConfiguration(ctx context.Context, name 
 		return fmt.Errorf("unable to remove stack %s: stack not present", name)
 	}
 
-	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)
+	deleteContext, cancel := context.WithTimeout(ctx, defaultStackForceRemoveTimeout)
 	defer cancel()
 	return stack.Workspace().RemoveStack(deleteContext, stack.Name(), optremove.Force())
 }
@@ -265,7 +268,7 @@ func (sm *StackManager) Cleanup(ctx context.Context) []error {
 	var errors []error
 
 	sm.stacks.Range(func(stackID string, stack *auto.Stack) {
-		err := sm.deleteStack(ctx, stackID, stack, nil, nil)
+		err := sm.destroyAndRemoveStack(ctx, stackID, stack, nil, nil)
 		if err != nil {
 			errors = append(errors, common.InternalError{Err: err})
 		}
@@ -317,15 +320,7 @@ func (sm *StackManager) getProgressStreamsOnDestroy(logger io.Writer) optdestroy
 	return optdestroy.ErrorProgressStreams(logger)
 }
 
-func (sm *StackManager) deleteStack(ctx context.Context, stackID string, stack *auto.Stack, logWriter io.Writer, ddEventSender datadogEventSender) error {
-	if stack == nil {
-		return fmt.Errorf("unable to find stack, skipping deletion of: %s", stackID)
-	}
-
-	loggingOptions, err := sm.getLoggingOptions()
-	if err != nil {
-		return err
-	}
+func (sm *StackManager) destroyAndRemoveStack(ctx context.Context, stackID string, stack *auto.Stack, logWriter io.Writer, ddEventSender datadogEventSender) error {
 	var logger io.Writer
 
 	if logWriter == nil {
@@ -333,22 +328,50 @@ func (sm *StackManager) deleteStack(ctx context.Context, stackID string, stack *
 	} else {
 		logger = logWriter
 	}
-	progressStreamsDestroyOption := sm.getProgressStreamsOnDestroy(logger)
 	//initialize datadog event sender
 	if ddEventSender == nil {
 		ddEventSender = newDatadogEventSender(logger)
 	}
+
+	err := sm.destroyStack(ctx, stackID, stack, logger, ddEventSender)
+	if err != nil {
+		return err
+	}
+
+	err = sm.removeStack(ctx, stackID, stack, logger, ddEventSender)
+	if err != nil {
+		// Failing removing the stack is not a critical error, the resources are already destroyed
+		// Print the error and return nil
+		fmt.Printf("Error during stack remove: %v\n", err)
+	}
+	return nil
+}
+
+func (sm *StackManager) destroyStack(ctx context.Context, stackID string, stack *auto.Stack, logger io.Writer, ddEventSender datadogEventSender) error {
+	if stack == nil {
+		return fmt.Errorf("unable to find stack, skipping destruction of: %s", stackID)
+	}
+	if logger == nil {
+		return fmt.Errorf("unable to find logger, skipping destruction of: %s", stackID)
+	}
+
+	loggingOptions, err := sm.getLoggingOptions()
+	if err != nil {
+		return err
+	}
+
+	progressStreamsDestroyOption := sm.getProgressStreamsOnDestroy(logger)
 
 	downCount := 0
 	var destroyErr error
 	for {
 		downCount++
 		destroyContext, cancel := context.WithTimeout(ctx, defaultStackDestroyTimeout)
-		_, destroyErr = stack.Destroy(destroyContext, progressStreamsDestroyOption, optdestroy.DebugLogging(loggingOptions), optdestroy.Remove())
+		_, destroyErr = stack.Destroy(destroyContext, progressStreamsDestroyOption, optdestroy.DebugLogging(loggingOptions))
 		cancel()
 		if destroyErr == nil {
 			sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : success on Pulumi stack destroy", stackID), "", []string{"operation:destroy", "result:ok", fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", downCount)})
-			break
+			return nil
 		}
 
 		// handle timeout
@@ -365,14 +388,50 @@ func (sm *StackManager) deleteStack(ctx context.Context, stackID string, stack *
 
 		sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : error on Pulumi stack destroy", stackID), destroyErr.Error(), []string{"operation:destroy", "result:fail", fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", downCount)})
 
-		if downCount > stackUpMaxRetry {
-			fmt.Printf("Giving up on error during stack destroy: %v\n", destroyErr)
+		if downCount > stackDestroyMaxRetry {
+			fmt.Fprintf(logger, "Giving up on error during stack destroy: %v\n", destroyErr)
 			return destroyErr
 		}
-		fmt.Printf("Retrying stack on error during stack destroy: %v\n", destroyErr)
+		fmt.Fprintf(logger, "Retrying stack on error during stack destroy: %v\n", destroyErr)
+	}
+}
+
+func (sm *StackManager) removeStack(ctx context.Context, stackID string, stack *auto.Stack, logger io.Writer, ddEventSender datadogEventSender) error {
+	if stack == nil {
+		return fmt.Errorf("unable to find stack, skipping removal of: %s", stackID)
+	}
+	if logger == nil {
+		return fmt.Errorf("unable to find logger, skipping removal of: %s", stackID)
 	}
 
-	return nil
+	removeCount := 0
+	var err error
+	for {
+		removeCount++
+		removeContext, cancel := context.WithTimeout(ctx, defaultStackRemoveTimeout)
+		err = stack.Workspace().RemoveStack(removeContext, stack.Name())
+		cancel()
+		if err == nil {
+			sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : success on Pulumi stack remove", stackID), "", []string{"operation:remove", "result:ok", fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", removeCount)})
+			return nil
+		}
+
+		// handle timeout
+		contextCauseErr := context.Cause(removeContext)
+		if errors.Is(contextCauseErr, context.DeadlineExceeded) {
+			sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : timeout on Pulumi stack remove", stackID), "", []string{"operation:remove", fmt.Sprintf("stack:%s", stack.Name())})
+			fmt.Fprint(logger, "Timeout during stack remove\n")
+			continue
+		}
+
+		sendEventToDatadog(ddEventSender, fmt.Sprintf("[E2E] Stack %s : error on Pulumi stack remove", stackID), err.Error(), []string{"operation:remove", "result:fail", fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", removeCount)})
+
+		if removeCount > stackRemoveMaxRetry {
+			fmt.Fprintf(logger, "[WARNING] Giving up on error during stack remove: %v\nThe stack resources are destroyed, but we failed removing the stack state.\n", err)
+			return err
+		}
+		fmt.Printf("Retrying removing stack, error: %v\n", err)
+	}
 }
 
 func (sm *StackManager) getStack(ctx context.Context, name string, deployFunc pulumi.RunFunc, options ...GetStackOption) (*auto.Stack, auto.UpResult, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* tiny refactor of the stack manager's delete function to split back destroy and remove and handle remove's retries
* do not fail on stack remove error, as resources are correctly destroyed already  

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are seing an increase of tests impacted by an internal error at stack remove. As stack removal is not fatal, we can discard it, while keeping monitoring it. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
