### PR TITLE
Increase PSGallery timeout to 5 minutes

### DIFF
--- a/test/new-e2e/tests/windows/powershell-module-test/install_test.go
+++ b/test/new-e2e/tests/windows/powershell-module-test/install_test.go
@@ -195,7 +195,7 @@ func (v *vmSuite) setupTestHost() {
 			v.T().Logf("Register-PSRepository failed %s", err)
 		}
 		return false
-	}, 1*time.Minute, 10*time.Second) {
+	}, 5*time.Minute, 10*time.Second) {
 		v.FailNow("Failed to set PSGallery as a trusted repository")
 	}
 	vm.MustExecute("Install-Module powershell-yaml -Repository PSGallery")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Increase timeout for E2E setup of PSGallery

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-902

Follow up to https://github.com/DataDog/datadog-agent/pull/28679

Since loop was added, we've had two failures that hung on the first command execution until the timeout is triggered
```PowerShell
Set-PSRepository PSGallery -InstallationPolicy Trusted
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
