### PR TITLE
V2 Auto Multiline Detection - Fix truncation + Clean up logs parser tag handling

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -242,7 +242,7 @@ func TestLogsExporter(t *testing.T) {
 				outputJSON := make(map[string]interface{})
 				json.Unmarshal(output.GetContent(), &outputJSON)
 				assert.Equal(t, tt.args.logSourceName, output.Origin.Source())
-				assert.Equal(t, tt.expectedTags[i], output.Origin.Tags(nil))
+				assert.Equal(t, tt.expectedTags[i], output.Origin.Tags())
 				ans = append(ans, outputJSON)
 			}
 			assert.Equal(t, tt.want, ans)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1500,6 +1500,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.timestamp_detector_match_threshold", 0.5)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
+	config.BindEnvAndSetDefault("logs_config.tag_auto_multi_line_logs", false)
 
 	// If true, the agent looks for container logs in the location used by podman, rather
 	// than docker.  This is a temporary configuration parameter to support podman logs until

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -142,9 +142,9 @@ func TestTagTruncatedLogs(t *testing.T) {
 	assertMessageContent(t, msg, "1234567890...TRUNCATED...")
 
 	msg = <-outputChan
-	assert.False(t, msg.ParsingExtra.IsTruncated)
-	assert.Empty(t, msg.ParsingExtra.Tags)
-	assertMessageContent(t, msg, "1")
+	assert.True(t, msg.ParsingExtra.IsTruncated)
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedTag})
+	assertMessageContent(t, msg, "...TRUNCATED...1")
 
 	msg = <-outputChan
 	assert.False(t, msg.ParsingExtra.IsTruncated)
@@ -170,9 +170,9 @@ func TestTagMultiLineLogs(t *testing.T) {
 
 	msg = <-outputChan
 	assert.False(t, msg.ParsingExtra.IsMultiLine)
-	assert.False(t, msg.ParsingExtra.IsTruncated)
+	assert.True(t, msg.ParsingExtra.IsTruncated)
 	assert.Empty(t, msg.ParsingExtra.Tags)
-	assertMessageContent(t, msg, "1")
+	assertMessageContent(t, msg, "...TRUNCATED...1")
 
 	msg = <-outputChan
 	assert.False(t, msg.ParsingExtra.IsMultiLine)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -36,7 +36,7 @@ func assertMessageContent(t *testing.T, m *message.Message, content string) {
 func TestNoAggregate(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	ag.Aggregate(newMessage("1"), noAggregate)
 	ag.Aggregate(newMessage("2"), noAggregate)
@@ -50,7 +50,7 @@ func TestNoAggregate(t *testing.T) {
 func TestNoAggregateEndsGroup(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	ag.Aggregate(newMessage("1"), startGroup)
 	ag.Aggregate(newMessage("2"), startGroup)
@@ -64,7 +64,7 @@ func TestNoAggregateEndsGroup(t *testing.T) {
 func TestAggregateGroups(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	// Aggregated log
 	ag.Aggregate(newMessage("1"), startGroup)
@@ -85,7 +85,7 @@ func TestAggregateGroups(t *testing.T) {
 func TestAggregateDoesntStartGroup(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	ag.Aggregate(newMessage("1"), aggregate)
 	ag.Aggregate(newMessage("2"), aggregate)
@@ -99,7 +99,7 @@ func TestAggregateDoesntStartGroup(t *testing.T) {
 func TestForceFlush(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	ag.Aggregate(newMessage("1"), startGroup)
 	ag.Aggregate(newMessage("2"), aggregate)
@@ -112,7 +112,7 @@ func TestForceFlush(t *testing.T) {
 func TestAggregationTimer(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second))
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
 
 	assert.Nil(t, ag.FlushChan())
 	ag.Aggregate(newMessage("1"), startGroup)
@@ -125,4 +125,58 @@ func TestAggregationTimer(t *testing.T) {
 
 	assertMessageContent(t, <-outputChan, "1")
 	assertMessageContent(t, <-outputChan, "2")
+}
+
+func TestTagTruncatedLogs(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), true, false)
+
+	ag.Aggregate(newMessage("1234567890"), startGroup)
+	ag.Aggregate(newMessage("1"), aggregate) // Causes overflow, truncate and flush
+	ag.Aggregate(newMessage("2"), noAggregate)
+
+	msg := <-outputChan
+	assert.True(t, msg.ParsingExtra.IsTruncated)
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedTag})
+	assertMessageContent(t, msg, "1234567890...TRUNCATED...")
+
+	msg = <-outputChan
+	assert.False(t, msg.ParsingExtra.IsTruncated)
+	assert.Empty(t, msg.ParsingExtra.Tags)
+	assertMessageContent(t, msg, "1")
+
+	msg = <-outputChan
+	assert.False(t, msg.ParsingExtra.IsTruncated)
+	assert.Empty(t, msg.ParsingExtra.Tags)
+	assertMessageContent(t, msg, "2")
+}
+
+func TestTagMultiLineLogs(t *testing.T) {
+
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), false, true)
+
+	ag.Aggregate(newMessage("12345"), startGroup)
+	ag.Aggregate(newMessage("67890"), aggregate)
+	ag.Aggregate(newMessage("1"), aggregate) // Causes overflow, truncate and flush
+	ag.Aggregate(newMessage("2"), noAggregate)
+
+	msg := <-outputChan
+	assert.True(t, msg.ParsingExtra.IsMultiLine)
+	assert.True(t, msg.ParsingExtra.IsTruncated)
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.AutoMultiLineTag})
+	assertMessageContent(t, msg, "12345\\n67890...TRUNCATED...")
+
+	msg = <-outputChan
+	assert.False(t, msg.ParsingExtra.IsMultiLine)
+	assert.False(t, msg.ParsingExtra.IsTruncated)
+	assert.Empty(t, msg.ParsingExtra.Tags)
+	assertMessageContent(t, msg, "1")
+
+	msg = <-outputChan
+	assert.False(t, msg.ParsingExtra.IsMultiLine)
+	assert.False(t, msg.ParsingExtra.IsTruncated)
+	assert.Empty(t, msg.ParsingExtra.Tags)
+	assertMessageContent(t, msg, "2")
 }

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -31,8 +31,13 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 	}
 
 	return &AutoMultilineHandler{
-		labeler:    automultilinedetection.NewLabeler(heuristics),
-		aggregator: automultilinedetection.NewAggregator(outputFn, maxContentSize, flushTimeout),
+		labeler: automultilinedetection.NewLabeler(heuristics),
+		aggregator: automultilinedetection.NewAggregator(
+			outputFn,
+			maxContentSize,
+			flushTimeout,
+			config.Datadog().GetBool("logs_config.tag_truncated_logs"),
+			config.Datadog().GetBool("logs_config.tag_auto_multi_line_logs")),
 	}
 }
 

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"time"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -162,6 +163,9 @@ func (h *MultiLineHandler) sendBuffer() {
 		}
 		msg := message.NewRawMessage(content, h.status, h.linesLen, h.timestamp)
 		msg.ParsingExtra.IsTruncated = h.isBufferTruncated
+		if h.isBufferTruncated && coreConfig.Datadog().GetBool("logs_config.tag_truncated_logs") {
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedTag)
+		}
 		h.outputFn(msg)
 	}
 }

--- a/pkg/logs/internal/decoder/single_line_handler.go
+++ b/pkg/logs/internal/decoder/single_line_handler.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"time"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
@@ -36,6 +37,12 @@ func (h *SingleLineHandler) flush() {
 	// do nothing
 }
 
+func addTruncatedTag(msg *message.Message) {
+	if coreConfig.Datadog().GetBool("logs_config.tag_truncated_logs") {
+		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedTag)
+	}
+}
+
 // process transforms a raw line into a structured line,
 // it guarantees that the content of the line won't exceed
 // the limit and that the length of the line is properly tracked
@@ -52,7 +59,7 @@ func (h *SingleLineHandler) process(msg *message.Message) {
 		// the new line is just a remainder,
 		// adding the truncated flag at the beginning of the content
 		content = append(message.TruncatedFlag, content...)
-		msg.ParsingExtra.IsTruncated = true
+		addTruncatedTag(msg)
 	}
 
 	// how should we detect logs which are too long before rendering them?
@@ -64,7 +71,7 @@ func (h *SingleLineHandler) process(msg *message.Message) {
 		// adding the truncated flag the end of the content
 		content = append(content, message.TruncatedFlag...)
 		msg.SetContent(content) // refresh the content in the message
-		msg.ParsingExtra.IsTruncated = true
+		addTruncatedTag(msg)
 		h.outputFn(msg)
 		// make sure the following part of the line will be cut off as well
 		h.shouldTruncate = true

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -36,7 +36,7 @@ func (o *Origin) Tags() []string {
 }
 
 // TagsPayload returns the raw tag payload of the origin.
-func (o *Origin) TagsPayload(processingTags []string) []byte {
+func (o *Origin) TagsPayload() []byte {
 	var tagsPayload []byte
 
 	source := o.Source()
@@ -51,7 +51,6 @@ func (o *Origin) TagsPayload(processingTags []string) []byte {
 	var tags []string
 	tags = append(tags, o.LogSource.Config.Tags...)
 	tags = append(tags, o.tags...)
-	tags = append(tags, processingTags...)
 
 	if len(tags) > 0 {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -31,8 +31,8 @@ func NewOrigin(source *sources.LogSource) *Origin {
 // Tags returns the tags of the origin.
 //
 // The returned slice must not be modified by the caller.
-func (o *Origin) Tags(processingTags []string) []string {
-	return o.tagsToStringArray(processingTags)
+func (o *Origin) Tags() []string {
+	return o.tagsToStringArray()
 }
 
 // TagsPayload returns the raw tag payload of the origin.
@@ -63,8 +63,8 @@ func (o *Origin) TagsPayload(processingTags []string) []byte {
 }
 
 // TagsToString encodes tags to a single string, in a comma separated format
-func (o *Origin) TagsToString(processingTags []string) string {
-	tags := o.tagsToStringArray(processingTags)
+func (o *Origin) TagsToString() string {
+	tags := o.tagsToStringArray()
 
 	if tags == nil {
 		return ""
@@ -73,7 +73,7 @@ func (o *Origin) TagsToString(processingTags []string) string {
 	return strings.Join(tags, ",")
 }
 
-func (o *Origin) tagsToStringArray(processingTags []string) []string {
+func (o *Origin) tagsToStringArray() []string {
 	tags := o.tags
 
 	sourceCategory := o.LogSource.Config.SourceCategory
@@ -82,7 +82,6 @@ func (o *Origin) tagsToStringArray(processingTags []string) []string {
 	}
 
 	tags = append(tags, o.LogSource.Config.Tags...)
-	tags = append(tags, processingTags...)
 
 	return tags
 }

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -19,8 +19,8 @@ func TestSetTagsEmpty(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{})
-	assert.Equal(t, []string{}, origin.Tags(nil))
-	assert.Equal(t, "", origin.TagsToString(nil))
+	assert.Equal(t, []string{}, origin.Tags())
+	assert.Equal(t, "", origin.TagsToString())
 	assert.Equal(t, []byte{}, origin.TagsPayload(nil))
 }
 
@@ -32,9 +32,9 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	}
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
-	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags(nil))
+	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload(nil)))
-	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString(nil))
+	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString())
 }
 
 func TestSetTagsWithNoConfigTags(t *testing.T) {
@@ -45,8 +45,8 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags(nil))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString(nil))
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload(nil)))
 }
 
@@ -59,23 +59,9 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags(nil))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString(nil))
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload(nil)))
-}
-
-func TestSetTagsWithConfigTagsAndProcessingTags(t *testing.T) {
-	cfg := &config.LogsConfig{
-		Source:         "a",
-		SourceCategory: "b",
-		Tags:           []string{"c:d", "e"},
-	}
-	source := sources.NewLogSource("", cfg)
-	origin := NewOrigin(source)
-	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e", "processing:tag", "second:tag"}, origin.Tags([]string{"processing:tag", "second:tag"}))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e,processing:tag,second:tag", origin.TagsToString([]string{"processing:tag", "second:tag"}))
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz,processing:tag,second:tag\"]", string(origin.TagsPayload([]string{"processing:tag", "second:tag"})))
 }
 
 func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -21,7 +21,7 @@ func TestSetTagsEmpty(t *testing.T) {
 	origin.SetTags([]string{})
 	assert.Equal(t, []string{}, origin.Tags())
 	assert.Equal(t, "", origin.TagsToString())
-	assert.Equal(t, []byte{}, origin.TagsPayload(nil))
+	assert.Equal(t, []byte{}, origin.TagsPayload())
 }
 
 func TestTagsWithConfigTagsOnly(t *testing.T) {
@@ -33,7 +33,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload(nil)))
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
 	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString())
 }
 
@@ -47,7 +47,7 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
 	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload(nil)))
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 
 func TestSetTagsWithConfigTags(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload(nil)))
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 
 func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {

--- a/pkg/logs/processor/raw.go
+++ b/pkg/logs/processor/raw.go
@@ -58,7 +58,7 @@ func (r *rawEncoder) Encode(msg *message.Message, hostname string) error {
 		extraContent = append(extraContent, []byte(" - - ")...)
 
 		// Tags
-		tagsPayload := msg.Origin.TagsPayload(msg.ProcessingTags)
+		tagsPayload := msg.Origin.TagsPayload()
 		if len(tagsPayload) > 0 {
 			extraContent = append(extraContent, tagsPayload...)
 		} else {

--- a/pkg/logs/tailers/docker/tailer.go
+++ b/pkg/logs/tailers/docker/tailer.go
@@ -316,7 +316,10 @@ func (t *Tailer) forwardMessages() {
 			origin.Offset = output.ParsingExtra.Timestamp
 			t.setLastSince(output.ParsingExtra.Timestamp)
 			origin.Identifier = t.Identifier()
-			origin.SetTags(t.tagProvider.GetTags())
+			tags := []string{}
+			tags = append(tags, output.ParsingExtra.Tags...)
+			tags = append(tags, t.tagProvider.GetTags()...)
+			origin.SetTags(tags)
 			// XXX(remy): is it OK recreating a message here?
 			t.outputChan <- message.NewMessage(output.GetContent(), origin, output.Status, output.IngestionTimestamp)
 		}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -348,11 +348,6 @@ func (t *Tailer) forwardMessages() {
 		tags := make([]string, len(t.tags))
 		copy(tags, t.tags)
 		tags = append(tags, t.tagProvider.GetTags()...)
-
-		if output.ParsingExtra.IsTruncated && coreConfig.Datadog().GetBool("logs_config.tag_truncated_logs") {
-			tags = append(tags, message.TruncatedTag)
-		}
-
 		tags = append(tags, output.ParsingExtra.Tags...)
 		origin.SetTags(tags)
 		// Ignore empty lines once the registry offset is updated

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -69,7 +69,9 @@ func (t *Tailer) forwardMessages() {
 	}()
 	for output := range t.decoder.OutputChan {
 		if len(output.GetContent()) > 0 {
-			t.outputChan <- message.NewMessage(output.GetContent(), output.Origin, output.Status, output.IngestionTimestamp)
+			origin := message.NewOrigin(t.source)
+			origin.SetTags(output.ParsingExtra.Tags)
+			t.outputChan <- message.NewMessage(output.GetContent(), origin, output.Status, output.IngestionTimestamp)
 		}
 	}
 }
@@ -96,7 +98,6 @@ func (t *Tailer) readForever() {
 				log.Warnf("Couldn't read message from connection: %v", err)
 				return
 			}
-			origin := message.NewOrigin(t.source)
 			copiedTags := make([]string, len(t.source.Config.Tags))
 			copy(copiedTags, t.source.Config.Tags)
 			if ipAddress != "" && coreConfig.Datadog().GetBool("logs_config.use_sourcehost_tag") {
@@ -110,8 +111,9 @@ func (t *Tailer) readForever() {
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
 				copiedTags = append(copiedTags, sourceHostTag)
 			}
-			origin.SetTags(copiedTags)
-			t.decoder.InputChan <- message.NewMessage(data, origin, message.StatusInfo, 0)
+			msg := decoder.NewInput(data)
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, copiedTags...)
+			t.decoder.InputChan <- msg
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR is a followup to https://github.com/DataDog/datadog-agent/pull/28339 and sets out to cleanup how tags are handled from the parsers/decoder. Along the way I found that truncation wasn't working correctly in the new auto multiline aggregator. 

- Tag handling for parser/decoder is centralized around `ParsingExtra.Tags` instead of case by case. As a result all supported tailers now get truncated logs tags (when enabled).
- Fixes a bug in auto mulitline aggregator where truncated logs were not being handled correctly (test cases added)
- Adds option `logs_config.tag_auto_multi_line_logs` for the new auto multiline aggregator. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- e2e test cover tags in the socket tailer
- e2e test cover standard tags on the file tailer

Same QA as https://github.com/DataDog/datadog-agent/pull/28339 

Also:
1. 
in `datadog.yaml`
```
logs_enabled: true
logs_config:
    experimental_auto_multi_line_detection: true
    tag_truncated_logs: true
    tag_auto_multi_line_logs: true
    max_message_size_bytes: 200
```

2. Send these logs

```
2024-05-16 17:07:57,235 - root - ERROR - Got exception on main handler
2024-05-16 17:07:57,235 - root - ERROR - Got exception on main handler
Traceback (most recent call last):
  File "//./main.py", line 34, in <module>
    a()
  File "//./main.py", line 21, in a
    def a(): b()
  File "//./main.py", line 20, in b
    def b(): c()
  File "//./main.py", line 18, in c
    def c(): e()
  File "//./main.py", line 16, in e
    def e(): f()
  File "//./main.py", line 15, in f
    def f(): g()
NameError: name 'g' is not defined
2024-05-16 17:07:57,235 - root - ERROR - Got exception on main handler
2024-05-16 17:07:57,235 - root - ERROR - Got exception on main handler
```

3. in the logs explorer - they should be correctly truncated

<img width="565" alt="image" src="https://github.com/user-attachments/assets/753a2131-b1db-422b-a152-693fbe73914b">

4. Each log should have the correct tags (`auto_multiline` and `truncated`)

<img width="541" alt="image" src="https://github.com/user-attachments/assets/16b00f83-9e48-4cfa-ae81-ce7e17e0b6ff">



<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
