### PR TITLE
[CI] Make the `invoke-unit-tests` task work for any repository path

### DIFF
--- a/internal/tools/modformatter/modformatter.go
+++ b/internal/tools/modformatter/modformatter.go
@@ -193,7 +193,7 @@ func main() {
 			if *formatFile {
 				writeNeeded = true
 				trimName := strings.Split(modname, "github.com/DataDog/datadog-agent/")[1]
-				trimPath := "." + strings.Split(*path, *repoPath)[1]
+				trimPath := "." + strings.TrimPrefix(*path, *repoPath)
 				relativePath, err := filepath.Rel(trimPath, trimName)
 				if err != nil {
 					log.Fatal(err)

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -100,9 +100,12 @@ def internal_deps_checker(ctx, formatFile=False):
     """
     Check that every required internal dependencies are correctly replaced
     """
+    repo_path = os.getcwd()
     extra_params = "--formatFile true" if formatFile else ""
     for mod in DEFAULT_MODULES.values():
-        ctx.run(f"go run ./internal/tools/modformatter/modformatter.go --path={mod.full_path()} {extra_params}")
+        ctx.run(
+            f"go run ./internal/tools/modformatter/modformatter.go --path={mod.full_path()} --repoPath={repo_path} {extra_params}"
+        )
 
 
 @task

--- a/tasks/unit_tests/go_mod_formatter_tests.py
+++ b/tasks/unit_tests/go_mod_formatter_tests.py
@@ -3,14 +3,15 @@ import subprocess
 import unittest
 
 
-def run_mod_formatter(path, formatFile=False, allow_fail=False):
+def run_mod_formatter(path, formatFile=False, allow_fail=False, repo_path=None):
+    repo_path = repo_path or os.getcwd()
     if path[0] != "/":
         path = os.path.abspath(path)
     extraArgs = ""
     if formatFile:
         extraArgs = "--formatFile true"
     proc = subprocess.run(
-        f"go run ./internal/tools/modformatter/modformatter.go --path {path} {extraArgs}",
+        f"go run ./internal/tools/modformatter/modformatter.go --path {path} --repoPath {repo_path} {extraArgs}",
         shell=True,
         capture_output=True,
     )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR fixes the `invoke-unit-tests` task when running on a repository path without the `github.com/DataDog/datadog-agent` substring.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The former code was making the assumption that the `datadog-agent` repository was in `github.com/DataDog/datadog-agent`. This is not the case for all setup, making them fail with:
```
$ inv -e invoke-unit-tests
..............................................................................F...................................................................................................................................................................................................................................
======================================================================
FAIL: test_invalid_go_mod_format (tasks.unit_tests.go_mod_formatter_tests.TestGoModFormatter.test_invalid_go_mod_format)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ec2-user/builds/PkrsTLwN/0/DataDog/datadog-agent/tasks/unit_tests/go_mod_formatter_tests.py", line 55, in test_invalid_go_mod_format
    output = run_mod_formatter("./tasks/unit_tests/testdata/go_mod_formatter/format_package_test/", formatFile=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ec2-user/builds/PkrsTLwN/0/DataDog/datadog-agent/tasks/unit_tests/go_mod_formatter_tests.py", line 18, in run_mod_formatter
    assert proc.returncode == 0, f"\n{proc.stderr.decode('utf-8')}"
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: 
panic: runtime error: index out of range [1] with length 1
goroutine 1 [running]:
main.main()
	/Users/ec2-user/builds/PkrsTLwN/0/DataDog/datadog-agent/internal/tools/modformatter/modformatter.go:191 +0x7b1
exit status 2
----------------------------------------------------------------------
Ran 306 tests in 6.119s
FAILED (failures=1)
```

Here is the more general approach to work with every setup.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
