### PR TITLE
language detection: privileged: Continue if we failed getting bin-id

### DIFF
--- a/cmd/system-probe/modules/language_detection_test.go
+++ b/cmd/system-probe/modules/language_detection_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -25,7 +26,11 @@ import (
 	languageDetectionProto "github.com/DataDog/datadog-agent/pkg/proto/pbgo/languagedetection"
 )
 
-const mockPid = 1
+var mockPid int32
+
+func init() {
+	mockPid = int32(os.Getpid())
+}
 
 func TestLanguageDetectionEndpoint(t *testing.T) {
 	mockGoLanguage := languagemodels.Language{Name: languagemodels.Go, Version: "go version go1.19.10 linux/arm64"}

--- a/pkg/languagedetection/privileged/privileged_detector.go
+++ b/pkg/languagedetection/privileged/privileged_detector.go
@@ -75,6 +75,7 @@ func (l *LanguageDetector) DetectWithPrivileges(procs []languagemodels.Process) 
 		if err != nil {
 			handleDetectorError(err)
 			log.Debug("failed to get binID:", err)
+			continue
 		}
 
 		if lang, ok := l.binaryIDCache.Get(bin); ok {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Continue to the next program if we failed getting bin-id for the current proc.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing a bug found while working on service-discovery

We would generate map empty-bin id to a language (or unknown language), and every other proc that fails to generate bin-id, would have gotten the cached language


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
