### PR TITLE
[CWS] switch auid hooks to fentry

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/login_uid.h
+++ b/pkg/security/ebpf/c/include/hooks/login_uid.h
@@ -3,12 +3,12 @@
 
 #include "helpers/syscalls.h"
 
-SEC("kprobe/audit_set_loginuid")
-int hook_audit_set_loginuid(struct pt_regs *ctx) {
+HOOK_ENTRY("audit_set_loginuid")
+int hook_audit_set_loginuid(ctx_t *ctx) {
     struct syscall_cache_t syscall = {
         .type = EVENT_LOGIN_UID_WRITE,
         .login_uid = {
-            .auid = (u32)PT_REGS_PARM1(ctx),
+            .auid = (u32)CTX_PARM1(ctx),
         },
     };
 
@@ -16,9 +16,9 @@ int hook_audit_set_loginuid(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kretprobe/audit_set_loginuid")
-int rethook_audit_set_loginuid(struct pt_regs *ctx) {
-    int retval = PT_REGS_RC(ctx);
+HOOK_EXIT("audit_set_loginuid")
+int rethook_audit_set_loginuid(ctx_t *ctx) {
+    int retval = CTX_PARMRET(ctx, 1);
     if (retval < 0) {
         return 0;
     }

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -332,8 +332,7 @@ func (k *Version) HaveLegacyPipeInodeInfoStruct() bool {
 	return k.Code != 0 && k.Code < Kernel5_5
 }
 
-// HaveFentrySupport returns whether the kernel supports fentry probes
-func (k *Version) HaveFentrySupport() bool {
+func (k *Version) commonFentryCheck(funcName string) bool {
 	if features.HaveProgramType(ebpf.Tracing) != nil {
 		return false
 	}
@@ -341,7 +340,7 @@ func (k *Version) HaveFentrySupport() bool {
 	spec := &ebpf.ProgramSpec{
 		Type:       ebpf.Tracing,
 		AttachType: ebpf.AttachTraceFEntry,
-		AttachTo:   "vfs_open",
+		AttachTo:   funcName,
 		Instructions: asm.Instructions{
 			asm.LoadImm(asm.R0, 0, asm.DWord),
 			asm.Return(),
@@ -364,6 +363,16 @@ func (k *Version) HaveFentrySupport() bool {
 	defer link.Close()
 
 	return true
+}
+
+// HaveFentrySupport returns whether the kernel supports fentry probes
+func (k *Version) HaveFentrySupport() bool {
+	return k.commonFentryCheck("vfs_open")
+}
+
+// HaveFentrySupportWithStructArgs returns whether the kernel supports fentry probes with struct arguments
+func (k *Version) HaveFentrySupportWithStructArgs() bool {
+	return k.commonFentryCheck("audit_set_loginuid")
 }
 
 // SupportBPFSendSignal returns true if the eBPF function bpf_send_signal is available

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -194,15 +194,13 @@ func (p *EBPFProbe) selectFentryMode() {
 		return
 	}
 
-	supported := p.kernelVersion.HaveFentrySupport()
-	if !supported {
+	if !p.kernelVersion.HaveFentrySupport() {
 		p.useFentry = false
 		seclog.Errorf("fentry enabled but not supported, falling back to kprobe mode")
 		return
 	}
 
-	structArgsSupported := p.kernelVersion.HaveFentrySupportWithStructArgs()
-	if !structArgsSupported {
+	if !p.kernelVersion.HaveFentrySupportWithStructArgs() {
 		p.useFentry = false
 		seclog.Warnf("fentry enabled but not supported with struct args, falling back to kprobe mode")
 		return

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -196,9 +196,19 @@ func (p *EBPFProbe) selectFentryMode() {
 
 	supported := p.kernelVersion.HaveFentrySupport()
 	if !supported {
+		p.useFentry = false
 		seclog.Errorf("fentry enabled but not supported, falling back to kprobe mode")
+		return
 	}
-	p.useFentry = supported
+
+	structArgsSupported := p.kernelVersion.HaveFentrySupportWithStructArgs()
+	if !structArgsSupported {
+		p.useFentry = false
+		seclog.Warnf("fentry enabled but not supported with struct args, falling back to kprobe mode")
+		return
+	}
+
+	p.useFentry = true
 }
 
 func (p *EBPFProbe) isNetworkNotSupported() bool {

--- a/pkg/security/tests/login_uid_test.go
+++ b/pkg/security/tests/login_uid_test.go
@@ -89,8 +89,6 @@ func TestLoginUID(t *testing.T) {
 				return err
 			}
 
-			t.Logf("test out: %s\n", string(out))
-
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR switches the auid hooks to fentry supported hooks. Because those hooks require support for hooking functions with hook arguments, the fentry check has been improved to check for that (basically checking if >= kernel 6.1 or this patch https://github.com/torvalds/linux/commit/720e6a435194fb5237833a4a7ec6aa60a78964a8#diff-10c25cae50af6c8c81a80025da7200c8afa166f20c0b39bc85a745b9105f8ce6R733).

With this PR all hooks have been migrated to fentry. This will allow a future enablement of fentry by default.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This code is already tested.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
