### PR TITLE
Add agent user param to installer

### DIFF
--- a/test/new-e2e/tests/installer/windows/datadog_installer.go
+++ b/test/new-e2e/tests/installer/windows/datadog_installer.go
@@ -213,7 +213,13 @@ func (d *DatadogInstaller) Install(opts ...Option) error {
 }
 
 // Uninstall will attempt to uninstall the Datadog Installer on the remote host.
-func (d *DatadogInstaller) Uninstall() error {
+func (d *DatadogInstaller) Uninstall(opts ...Option) error {
+	params := Params{}
+	err := optional.ApplyOptions(&params, opts)
+	if err != nil {
+		return nil
+	}
+
 	productCode, err := windowsCommon.GetProductCodeByName(d.env.RemoteHost, "Datadog Installer")
 	if err != nil {
 		return err
@@ -223,7 +229,11 @@ func (d *DatadogInstaller) Uninstall() error {
 	if logPath == "" {
 		logPath = filepath.Join(os.TempDir(), "uninstall.log")
 	}
-	return windowsCommon.UninstallMSI(d.env.RemoteHost, productCode, logPath)
+	msiArgs := ""
+	if params.msiArgs != nil {
+		msiArgs = strings.Join(params.msiArgs, " ")
+	}
+	return windowsCommon.MsiExec(d.env.RemoteHost, "/x", productCode, msiArgs, logPath)
 }
 
 // GetExperimentDirFor is the path to the experiment symbolic link on disk

--- a/test/new-e2e/tests/installer/windows/datadog_installer.go
+++ b/test/new-e2e/tests/installer/windows/datadog_installer.go
@@ -36,6 +36,8 @@ const (
 	ServiceName string = "Datadog Installer"
 	// ConfigPath is the location of the Datadog Installer's configuration on disk
 	ConfigPath string = "C:\\ProgramData\\Datadog\\datadog.yaml"
+	// RegistryKeyPath is the root registry key that the Datadog Installer uses to store some state
+	RegistryKeyPath string = `HKLM:\SOFTWARE\Datadog\Datadog Installer`
 )
 
 var (

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -128,3 +128,24 @@ func (r *RemoteWindowsHostAssertions) HasBinary(path string) *RemoteWindowsBinar
 		binaryPath:                  path,
 	}
 }
+
+// HasRegistryKey checks if a registry key exists on the remote host.
+func (r *RemoteWindowsHostAssertions) HasRegistryKey(key string) *RemoteWindowsRegistryKeyAssertions {
+	r.suite.T().Helper()
+	exists, err := common.RegistryKeyExists(r.remoteHost, key)
+	r.require.NoError(err)
+	r.require.True(exists)
+	return &RemoteWindowsRegistryKeyAssertions{
+		RemoteWindowsHostAssertions: r,
+		keyPath:                     key,
+	}
+}
+
+// HasNoRegistryKey checks if a registry key does not exist on the remote host.
+func (r *RemoteWindowsHostAssertions) HasNoRegistryKey(key string) *RemoteWindowsHostAssertions {
+	r.suite.T().Helper()
+	exists, err := common.RegistryKeyExists(r.remoteHost, key)
+	r.require.NoError(err)
+	r.require.False(exists)
+	return r
+}

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_registry_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_registry_asserts.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package assertions
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+)
+
+// RemoteWindowsRegistryKeyAssertions is a type that extends the RemoteWindowsHostAssertions to add assertions
+// specific to a Windows registry.
+type RemoteWindowsRegistryKeyAssertions struct {
+	*RemoteWindowsHostAssertions
+	keyPath string
+}
+
+// WithValueEqual verifies the value of a registry key matches what's expected.
+func (r *RemoteWindowsRegistryKeyAssertions) WithValueEqual(value, expected string) *RemoteWindowsRegistryKeyAssertions {
+	r.suite.T().Helper()
+	actual, err := common.GetRegistryValue(r.remoteHost, r.keyPath, value)
+	r.require.NoError(err, "could not get registry value")
+	r.require.Equal(expected, actual, "registry value should be equal")
+	return r
+}

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package installertests implements E2E tests for the Datadog installer package on Windows
 package installertests
 
 import (

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
@@ -27,7 +27,7 @@ func (s *baseInstallerSuite) freshInstall() {
 	s.Require().NoError(s.Installer().Install())
 
 	// Assert
-	s.assertInstalled()
+	s.requireInstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		// the service cannot start because of the missing API key
@@ -47,7 +47,7 @@ func (s *baseInstallerSuite) startServiceWithConfigFile() {
 		WithStatus("Running")
 }
 
-func (s *baseInstallerSuite) assertInstalled() {
+func (s *baseInstallerSuite) requireInstalled() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasBinary(installerwindows.BinaryPath).
 		WithSignature(agent.GetCodeSignatureThumbprints()).
@@ -60,7 +60,7 @@ func (s *baseInstallerSuite) assertInstalled() {
 		WithValueEqual("installedUser", agent.DefaultAgentUserName)
 }
 
-func (s *baseInstallerSuite) assertUninstalled() {
+func (s *baseInstallerSuite) requireUninstalled() {
 	s.Require().Host(s.Env().RemoteHost).
 		NoFileExists(installerwindows.BinaryPath).
 		HasNoService(installerwindows.ServiceName).

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package installertests implements E2E tests for the Datadog installer package on Windows
+package installertests
+
+import (
+	"embed"
+	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
+//go:embed fixtures/sample_config
+var fixturesFS embed.FS
+
+// baseInstallerSuite is the base test suite for tests of the installer MSI
+type baseInstallerSuite struct {
+	installerwindows.BaseInstallerSuite
+}
+
+func (s *baseInstallerSuite) freshInstall() {
+	// Arrange
+
+	// Act
+	s.Require().NoError(s.Installer().Install())
+
+	// Assert
+	s.assertInstalled()
+	s.Require().Host(s.Env().RemoteHost).
+		HasAService(installerwindows.ServiceName).
+		// the service cannot start because of the missing API key
+		WithStatus("Stopped")
+}
+
+func (s *baseInstallerSuite) startServiceWithConfigFile() {
+	// Arrange
+	s.Env().RemoteHost.CopyFileFromFS(fixturesFS, "fixtures/sample_config", installerwindows.ConfigPath)
+
+	// Act
+	s.Require().NoError(common.StartService(s.Env().RemoteHost, installerwindows.ServiceName))
+
+	// Assert
+	s.Require().Host(s.Env().RemoteHost).
+		HasAService(installerwindows.ServiceName).
+		WithStatus("Running")
+}
+
+func (s *baseInstallerSuite) assertInstalled() {
+	s.Require().Host(s.Env().RemoteHost).
+		HasBinary(installerwindows.BinaryPath).
+		WithSignature(agent.GetCodeSignatureThumbprints()).
+		WithVersionMatchPredicate(func(version string) {
+			s.Require().NotEmpty(version)
+		}).
+		HasAService(installerwindows.ServiceName).
+		WithIdentity(common.GetIdentityForSID(common.LocalSystemSID)).
+		HasRegistryKey(installerwindows.RegistryKeyPath).
+		WithValueEqual("installedUser", agent.DefaultAgentUserName)
+}
+
+func (s *baseInstallerSuite) assertUninstalled() {
+	s.Require().Host(s.Env().RemoteHost).
+		NoFileExists(installerwindows.BinaryPath).
+		HasNoService(installerwindows.ServiceName).
+		HasNoRegistryKey(installerwindows.RegistryKeyPath)
+}

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -7,20 +7,15 @@
 package installertests
 
 import (
-	"embed"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awsHostWindows "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	"testing"
 )
 
-//go:embed fixtures/sample_config
-var fixturesFS embed.FS
-
 type testInstallerSuite struct {
-	installerwindows.BaseInstallerSuite
+	baseInstallerSuite
 }
 
 // TestInstaller tests the installation of the Datadog installer on a system.
@@ -43,25 +38,6 @@ func (s *testInstallerSuite) TestInstalls() {
 	})
 }
 
-func (s *testInstallerSuite) freshInstall() {
-	// Arrange
-
-	// Act
-	s.Require().NoError(s.Installer().Install())
-
-	// Assert
-	s.Require().Host(s.Env().RemoteHost).
-		HasBinary(installerwindows.BinaryPath).
-		WithSignature(agent.GetCodeSignatureThumbprints()).
-		WithVersionMatchPredicate(func(version string) {
-			s.Require().NotEmpty(version)
-		}).
-		HasAService(installerwindows.ServiceName).
-		// the service cannot start because of the missing API key
-		WithStatus("Stopped").
-		WithIdentity(common.GetIdentityForSID(common.LocalSystemSID))
-}
-
 func (s *testInstallerSuite) startServiceWithConfigFile() {
 	// Arrange
 	s.Env().RemoteHost.CopyFileFromFS(fixturesFS, "fixtures/sample_config", installerwindows.ConfigPath)
@@ -82,9 +58,8 @@ func (s *testInstallerSuite) uninstall() {
 	s.Require().NoError(s.Installer().Uninstall())
 
 	// Assert
+	s.assertUninstalled()
 	s.Require().Host(s.Env().RemoteHost).
-		NoFileExists(installerwindows.BinaryPath).
-		HasNoService(installerwindows.ServiceName).
 		FileExists(installerwindows.ConfigPath)
 }
 
@@ -95,6 +70,7 @@ func (s *testInstallerSuite) installWithExistingConfigFile() {
 	s.Require().NoError(s.Installer().Install())
 
 	// Assert
+	s.assertInstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		WithStatus("Running")
@@ -109,6 +85,7 @@ func (s *testInstallerSuite) repair() {
 	s.Require().NoError(s.Installer().Install())
 
 	// Assert
+	s.assertInstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		WithStatus("Running")

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -58,7 +58,7 @@ func (s *testInstallerSuite) uninstall() {
 	s.Require().NoError(s.Installer().Uninstall())
 
 	// Assert
-	s.assertUninstalled()
+	s.requireUninstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		FileExists(installerwindows.ConfigPath)
 }
@@ -70,7 +70,7 @@ func (s *testInstallerSuite) installWithExistingConfigFile() {
 	s.Require().NoError(s.Installer().Install())
 
 	// Assert
-	s.assertInstalled()
+	s.requireInstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		WithStatus("Running")
@@ -85,7 +85,7 @@ func (s *testInstallerSuite) repair() {
 	s.Require().NoError(s.Installer().Install())
 
 	// Assert
-	s.assertInstalled()
+	s.requireInstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		WithStatus("Running")

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package installertests implements E2E tests for the Datadog installer package on Windows
+package installertests
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awsHostWindows "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
+	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"testing"
+)
+
+type testInstallerRollbackSuite struct {
+	baseInstallerSuite
+}
+
+// TestInstaller tests the installation of the Datadog installer on a system.
+func TestInstallerRollback(t *testing.T) {
+	e2e.Run(t, &testInstallerRollbackSuite{}, e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake()))
+}
+
+// TestInstalls tests installing and uninstalling the latest version of the Datadog installer from the pipeline.
+func (s *testInstallerRollbackSuite) TestInstallerRollback() {
+	s.Run("Fresh install rollback", s.installRollback)
+	s.Run("Fresh install", s.freshInstall)
+	s.Run("uninstall rollback", s.uninstallRollback)
+	s.Run("Start service with a configuration file", s.startServiceWithConfigFile)
+}
+
+// installRollback
+func (s *testInstallerRollbackSuite) installRollback() {
+	// Arrange
+
+	// Act
+	msiErr := s.Installer().Install(installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"))
+	s.Require().Error(msiErr)
+
+	// Assert
+	s.assertUninstalled()
+}
+
+// uninstallRollback
+func (s *testInstallerRollbackSuite) uninstallRollback() {
+	// Arrange
+
+	// Act
+	msiErr := s.Installer().Uninstall(installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"))
+	s.Require().Error(msiErr)
+
+	// Assert
+	s.assertInstalled()
+}

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
@@ -37,7 +37,7 @@ func (s *testInstallerRollbackSuite) installRollback() {
 	s.Require().Error(msiErr)
 
 	// Assert
-	s.assertUninstalled()
+	s.requireUninstalled()
 }
 
 // uninstallRollback
@@ -49,5 +49,5 @@ func (s *testInstallerRollbackSuite) uninstallRollback() {
 	s.Require().Error(msiErr)
 
 	// Assert
-	s.assertInstalled()
+	s.requireInstalled()
 }

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package installertests implements E2E tests for the Datadog installer package on Windows
 package installertests
 
 import (
@@ -17,12 +16,11 @@ type testInstallerRollbackSuite struct {
 	baseInstallerSuite
 }
 
-// TestInstaller tests the installation of the Datadog installer on a system.
+// TestInstallerRollback tests the MSI rollback of the Datadog Installer on a system.
 func TestInstallerRollback(t *testing.T) {
 	e2e.Run(t, &testInstallerRollbackSuite{}, e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake()))
 }
 
-// TestInstalls tests installing and uninstalling the latest version of the Datadog installer from the pipeline.
 func (s *testInstallerRollbackSuite) TestInstallerRollback() {
 	s.Run("Fresh install rollback", s.installRollback)
 	s.Run("Fresh install", s.freshInstall)

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/AgentCustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/AgentCustomActions.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomAction.cs" />
+    <Compile Include="InstallStateCustomActions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -162,9 +162,9 @@ namespace Datadog.AgentCustomActions
         }
 
         [CustomAction]
-        public static ActionResult UninstallWriteInstallState(Session session)
+        public static ActionResult DeleteInstallState(Session session)
         {
-            return new WriteInstallStateCA(new SessionWrapper(session)).UninstallWriteInstallState();
+            return new WriteInstallStateCA(new SessionWrapper(session)).DeleteInstallState();
         }
 
         [CustomAction]

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -1,3 +1,4 @@
+using Datadog.CustomActions;
 using Microsoft.Deployment.WindowsInstaller;
 
 namespace Datadog.AgentCustomActions
@@ -37,13 +38,13 @@ namespace Datadog.AgentCustomActions
         [CustomAction]
         public static ActionResult ReadInstallState(Session session)
         {
-            return Datadog.CustomActions.InstallStateCustomActions.ReadInstallState(session);
+            return new ReadInstallStateCA(new SessionWrapper(session)).ReadInstallState();
         }
 
         [CustomAction]
         public static ActionResult WriteInstallState(Session session)
         {
-            return Datadog.CustomActions.InstallStateCustomActions.WriteInstallState(session);
+            return new WriteInstallStateCA(new SessionWrapper(session)).WriteInstallState();
         }
 
         [CustomAction]
@@ -163,7 +164,7 @@ namespace Datadog.AgentCustomActions
         [CustomAction]
         public static ActionResult UninstallWriteInstallState(Session session)
         {
-            return Datadog.CustomActions.InstallStateCustomActions.UninstallWriteInstallState(session);
+            return new WriteInstallStateCA(new SessionWrapper(session)).UninstallWriteInstallState();
         }
 
         [CustomAction]

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -1,0 +1,281 @@
+using Datadog.CustomActions;
+using Datadog.CustomActions.Interfaces;
+using Datadog.CustomActions.Native;
+using Microsoft.Deployment.WindowsInstaller;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Datadog.AgentCustomActions
+{
+    public class ReadInstallStateCA : Datadog.CustomActions.InstallStateCustomActions
+    {
+        public ReadInstallStateCA(ISession session) : base(session)
+        {
+        }
+
+        public ReadInstallStateCA(ISession session,
+            IRegistryServices registryServices,
+            IServiceController serviceController,
+            INativeMethods nativeMethods)
+            : base(session, registryServices, serviceController, nativeMethods)
+        {
+        }
+
+        /// <summary>
+        /// Assigns WIX properties that were not provided by the user to their registry values.
+        /// </summary>
+        /// <remarks>
+        /// Custom Action that runs (only once) in either the InstallUISequence or the InstallExecuteSequence.
+        ///
+        /// During removing-for-upgrade the installer being removed does not receive any properties from the
+        /// installer being installed, only UPGRADINGPRODUCTCODE is set. Thus the state for the installer being
+        /// removed will come from the registry values only.
+        /// </remarks>
+        public ActionResult ReadInstallState()
+        {
+            try
+            {
+                using var subkey =
+                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
+                if (subkey != null)
+                {
+                    LoadAgentUserProperty(subkey);
+                    RegistryValueProperty(_session, "PROJECTLOCATION", subkey, "InstallPath");
+                    RegistryValueProperty(_session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
+                }
+
+                GetWindowsBuildVersion();
+                SetDDDriverRollback();
+                SetRemoveFolderExProperties();
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Error reading install state: {e}");
+                return ActionResult.Failure;
+            }
+
+            return ActionResult.Success;
+        }
+
+        // <summary>
+        // Sets driver-specific properties to 1 if the driver services should be removed on rollback.
+        // </summary>
+        // <remarks>
+        // Previous versions of the installer did not remove the driver services on rollback.
+        // In order to remain compatible with these versions, we must not remove the driver services
+        // when rolling back to these versions.
+        // </remarks>
+        public void SetDDDriverRollback()
+        {
+            var upgradeDetected = _session["WIX_UPGRADE_DETECTED"];
+
+            if (!string.IsNullOrEmpty(upgradeDetected)) // This is an upgrade, conditionally set rollback flags.
+            {
+                var versionString = _nativeMethods.GetVersionString(upgradeDetected);
+                // Using Version class
+                // https://learn.microsoft.com/en-us/dotnet/api/system.version?view=net-8.0
+                var currentVersion = new Version(versionString);
+                Version procmonDriverMinimumVersion;
+                Version driverRollbackMinimumVersion;
+
+                // Check major version
+                if (versionString[0] == '7')
+                {
+                    procmonDriverMinimumVersion = new Version("7.52");
+                    driverRollbackMinimumVersion = new Version("7.56");
+                }
+                else
+                {
+                    procmonDriverMinimumVersion = new Version("6.52");
+                    driverRollbackMinimumVersion = new Version("6.56");
+                }
+
+                var compareResult = currentVersion.CompareTo(driverRollbackMinimumVersion);
+                if (compareResult < 0) // currentVersion is less than minimumVersion
+                {
+                    // case: upgrading from a version that did not implement driver rollback
+                    // Clear NPM flag to ensure NPM service is not deleted on rollback.
+                    _session["DDDRIVERROLLBACK_NPM"] = "";
+
+                    var compare_52 = currentVersion.CompareTo(procmonDriverMinimumVersion);
+                    if (compare_52 < 0) //currentVersion is less than 6.52/7.52
+                    {
+                        // case: upgrading from a version that did not the include procmon driver
+                        // Set PROCMON flag to ensure procmon driver is deleted on rollback.
+                        _session["DDDRIVERROLLBACK_PROCMON"] = "1";
+                    }
+                    else
+                    {
+                        _session["DDDRIVERROLLBACK_PROCMON"] = "";
+                    }
+                }
+                else // currentVersion is not less than minimumVersion
+                {
+                    _session["DDDRIVERROLLBACK_NPM"] = "1";
+                    _session["DDDRIVERROLLBACK_PROCMON"] = "1";
+                }
+            }
+            else // This is a fresh install, set rollback flags to ensure drivers are deleted on rollback.
+            {
+                _session["DDDRIVERROLLBACK_NPM"] = "1";
+                _session["DDDRIVERROLLBACK_PROCMON"] = "1";
+            }
+
+            _session.Log($"DDDriverRollback_NPM: {_session["DDDRIVERROLLBACK_NPM"]}");
+            _session.Log($"DDDriverRollback_Procmon: {_session["DDDRIVERROLLBACK_PROCMON"]}");
+        }
+
+        /// <summary>
+        /// Sets the properties used by the WiX util RemoveFolderEx to cleanup non-tracked paths.
+        ///
+        /// https://wixtoolset.org/docs/v3/xsd/util/removefolderex/
+        /// </summary>
+        /// <remarks>
+        /// RemoveFolderEx only takes a property as input, not IDs or paths, meaning we can't
+        /// pass something like $PROJECTLOCATION\bin\agent in WiX. Instead, we have to set
+        /// the properties in a custom action.
+        ///
+        /// The RemoveFolderEx elements in WiX are configured to only run at uninstall time,
+        /// so the properties values are only relevant then. However, the WixRemoveFolderEx
+        /// custom action will fail fast if any of the properties are empty. So we must always
+        /// provide a value to the properties to prevent an error in the log and to accomodate other
+        /// uses of RemoveFolderEx that run at other times (at time of writing there are none).
+        /// Though this error does not stop the installer, it will ignore it and continue.
+        ///
+        /// RemoveFolderEx handles rollback and will restore any file paths that it deletes.
+        ///
+        /// We specify specific subdirectories under PROJECTLOCATION instead of specifying PROJECTLOCATION
+        /// itself to reduce the impact when the Agent is erroneously installed to an existing directory.
+        ///
+        /// This action copies PROJECTLOCATION and thus changes to PROJECTLOCATION will not be reflected
+        /// in these properties. This should not be an issue since PROJECTLOCATION should not change during
+        /// uninstallation.
+        /// </remarks>
+        private void SetRemoveFolderExProperties()
+        {
+            var installDir = _session["PROJECTLOCATION"];
+            if (string.IsNullOrEmpty(installDir))
+            {
+                if (!string.IsNullOrEmpty(_session["REMOVE"]))
+                {
+                    _session.Log(
+                        "PROJECTLOCATION is not set, cannot set RemoveFolderEx properties, some files may be left behind in the installation directory.");
+                }
+
+                return;
+                // We cannot throw an exception here because the installer will fail. This case can happen, for example,
+                // if the cleanup script deleted the registry keys before running the uninstaller.
+            }
+
+            foreach (var entry in PathsToRemoveOnUninstall())
+            {
+                _session[entry.Key] = Path.Combine(installDir, entry.Value);
+            }
+        }
+
+        public static Dictionary<string, string> PathsToRemoveOnUninstall()
+        {
+            var pathPropertyMap = new Dictionary<string, string>();
+            var paths = new List<string>
+            {
+                "bin\\agent",
+                "embedded3",
+                // embedded2 only exists in Agent 6, so an error will be logged, but install will continue
+                "embedded2",
+            };
+            for (var i = 0; i < paths.Count; i++)
+            {
+                // property names are a maximum of 72 characters (can't find a source for this, but can verify in Property table schema in Orca)
+                // WixRemoveFolderEx creates properties like PROJECTLOCATION_0 so mimic that here.
+                // include lowercase letters so the property isn't made public.
+                pathPropertyMap.Add($"dd_PROJECTLOCATION_{i}", paths[i]);
+            }
+
+            return pathPropertyMap;
+        }
+    }
+
+    public class WriteInstallStateCA : Datadog.CustomActions.InstallStateCustomActions
+    {
+        public WriteInstallStateCA(ISession session) : base(session)
+        {
+        }
+
+        /// <summary>
+        /// Deferred custom action that stores properties in the registry
+        /// </summary>
+        /// <remarks>
+        /// WiX RegistryValue elements are only written when their parent Feature is installed. This means
+        /// that on change/modify operations the registry keys are not updated. This custom action writes
+        /// the properties to the registry that we need to change during change/modify installer operations.
+        /// </remarks>
+        public ActionResult WriteInstallState()
+        {
+            try
+            {
+                using var subkey =
+                    _registryServices.CreateRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
+                if (subkey == null)
+                {
+                    throw new Exception("Unable to create agent registry key");
+                }
+
+                StoreAgentUserInRegistry(subkey);
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Error storing registry properties: {e}");
+                return ActionResult.Failure;
+            }
+
+            return ActionResult.Success;
+        }
+
+
+        /// <summary>
+        /// Uninstall CA that removes the changes from the WriteInstallState CA
+        /// </summary>
+        /// <remarks>
+        /// If these registry values are not removed then MSI won't remove the key.
+        /// </remarks>
+        public ActionResult UninstallWriteInstallState()
+        {
+            try
+            {
+                using var subkey =
+                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey,
+                        writable: true);
+                if (subkey == null)
+                {
+                    // registry key does not exist, nothing to do
+                    _session.Log(
+                        $"Registry key HKLM\\{Constants.DatadogAgentRegistryKey} does not exist, there are no values to remove.");
+                    return ActionResult.Success;
+                }
+
+                foreach (var value in new[] { "installedDomain", "installedUser" })
+                {
+                    try
+                    {
+                        subkey.DeleteValue(value);
+                    }
+                    catch (Exception e)
+                    {
+                        // Don't print stack trace as it may be seen as a terminal error by readers of the log.
+                        _session.Log($"Warning, cannot removing registry value: {e.Message}");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Warning, could not access registry key {Constants.DatadogAgentRegistryKey}: {e}");
+                // This step can fail without failing the un-installation.
+            }
+
+            return ActionResult.Success;
+        }
+    }
+
+
+}

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -66,7 +66,7 @@ namespace Datadog.AgentCustomActions
         // In order to remain compatible with these versions, we must not remove the driver services
         // when rolling back to these versions.
         // </remarks>
-        public void SetDDDriverRollback()
+        private void SetDDDriverRollback()
         {
             var upgradeDetected = _session["WIX_UPGRADE_DETECTED"];
 

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -254,18 +254,7 @@ namespace Datadog.AgentCustomActions
                     return ActionResult.Success;
                 }
 
-                foreach (var value in new[] { "installedDomain", "installedUser" })
-                {
-                    try
-                    {
-                        subkey.DeleteValue(value);
-                    }
-                    catch (Exception e)
-                    {
-                        // Don't print stack trace as it may be seen as a terminal error by readers of the log.
-                        _session.Log($"Warning, cannot removing registry value: {e.Message}");
-                    }
-                }
+                RemoveAgentUserInRegistry(subkey);
             }
             catch (Exception e)
             {
@@ -276,6 +265,4 @@ namespace Datadog.AgentCustomActions
             return ActionResult.Success;
         }
     }
-
-
 }

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -239,7 +239,7 @@ namespace Datadog.AgentCustomActions
         /// <remarks>
         /// If these registry values are not removed then MSI won't remove the key.
         /// </remarks>
-        public ActionResult UninstallWriteInstallState()
+        public ActionResult DeleteInstallState()
         {
             try
             {

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
@@ -100,6 +100,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\AgentCustomActions\AgentCustomActions.csproj">
+      <Project>{1e5b725c-f738-4141-8dae-a8cb2fb1f10e}</Project>
+      <Name>AgentCustomActions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\CustomActions\CustomActions.csproj">
       <Project>{461CE844-4B07-47BA-B2D2-5415ABD36792}</Project>
       <Name>CustomActions</Name>

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/InstallState/InstallStateTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/InstallState/InstallStateTestSetup.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
-using System.ServiceProcess;
 using AutoFixture;
-using Datadog.CustomActions;
+using Datadog.AgentCustomActions;
 using Datadog.CustomActions.Interfaces;
 using Datadog.CustomActions.Native;
 using Moq;
+using System.Collections.Generic;
 
 namespace CustomActions.Tests.InstallState
 {
@@ -22,9 +21,9 @@ namespace CustomActions.Tests.InstallState
             ServiceController.SetupGet(s => s.Services).Returns(new WindowsService[] { });
         }
 
-        public InstallStateCustomActions Create()
+        public ReadInstallStateCA Create()
         {
-            return new InstallStateCustomActions(
+            return new ReadInstallStateCA(
                 Session.Object,
                 RegistryServices.Object,
                 ServiceController.Object,

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/InstallState/InstallStateTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/InstallState/InstallStateTests.cs
@@ -23,6 +23,8 @@ namespace CustomActions.Tests.InstallState
             Test.Properties.Should()
                 .NotContainKeys(
                     "DDAGENTUSER_NAME",
+                    "DDAGENT_installedDomain",
+                    "DDAgent_installedUser",
                     "PROJECTLOCATION",
                     "APPLICATIONDATADIRECTORY",
                     "DDAGENT_WINDOWSBUILD").And
@@ -52,6 +54,8 @@ namespace CustomActions.Tests.InstallState
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_NAME", @"testDomain\testUser").And
+                .Contain("DDAGENT_installedDomain", "testDomain").And
+                .Contain("DDAGENT_installedUser", "testUser").And
                 .Contain("PROJECTLOCATION", @"C:\datadog").And
                 .Contain("APPLICATIONDATADIRECTORY", @"D:\data").And
                 .Contain("DDAGENT_WINDOWSBUILD", "z_1234567890");

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
@@ -1,11 +1,8 @@
 using Datadog.CustomActions.Extensions;
 using Datadog.CustomActions.Interfaces;
 using Datadog.CustomActions.Native;
-using Microsoft.Deployment.WindowsInstaller;
 using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Security.Principal;
 using ServiceController = Datadog.CustomActions.Native.ServiceController;
 
@@ -16,31 +13,11 @@ namespace Datadog.CustomActions
 
     public class InstallStateCustomActions
     {
-        private readonly ISession _session;
-        private readonly IRegistryServices _registryServices;
-        private readonly IServiceController _serviceController;
+        protected readonly ISession _session;
+        protected readonly IRegistryServices _registryServices;
+        protected readonly IServiceController _serviceController;
 
-        private readonly INativeMethods _nativeMethods;
-
-        public static Dictionary<string, string> PathsToRemoveOnUninstall()
-        {
-            var pathPropertyMap = new Dictionary<string, string>();
-            var paths = new List<string>
-            {
-                "bin\\agent",
-                "embedded3",
-                // embedded2 only exists in Agent 6, so an error will be logged, but install will continue
-                "embedded2",
-            };
-            for (var i = 0; i < paths.Count; i++)
-            {
-                // property names are a maximum of 72 characters (can't find a source for this, but can verify in Property table schema in Orca)
-                // WixRemoveFolderEx creates properties like PROJECTLOCATION_0 so mimic that here.
-                // include lowercase letters so the property isn't made public.
-                pathPropertyMap.Add($"dd_PROJECTLOCATION_{i}", paths[i]);
-            }
-            return pathPropertyMap;
-        }
+        protected readonly INativeMethods _nativeMethods;
 
         public InstallStateCustomActions(
             ISession session,
@@ -67,7 +44,7 @@ namespace Datadog.CustomActions
         /// If the WIX property <c>propertyName</c> does not have a value, assign it the value returned by <c>handler</c>.
         /// This gives precedence to properties provided on the command line over the registry values.
         /// </summary>
-        private static void RegistryProperty(ISession session, string propertyName, GetRegistryPropertyHandler handler)
+        public static void RegistryProperty(ISession session, string propertyName, GetRegistryPropertyHandler handler)
         {
             if (string.IsNullOrEmpty(session[propertyName]))
             {
@@ -95,7 +72,7 @@ namespace Datadog.CustomActions
         /// Convenience wrapper of <c>RegistryProperty</c> for properties that have an exact 1:1 mapping to a registry value
         /// and don't require additional processing.
         /// </summary>
-        private static void RegistryValueProperty(ISession session, string propertyName, IRegistryKey registryKey,
+        public static void RegistryValueProperty(ISession session, string propertyName, IRegistryKey registryKey,
             string registryValue)
         {
             RegistryProperty(session, propertyName,
@@ -103,107 +80,43 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
-        /// Assigns WIX properties that were not provided by the user to their registry values.
+        /// Sets the WIX property DDAGENTUSER_NAME
         /// </summary>
         /// <remarks>
-        /// Custom Action that runs (only once) in either the InstallUISequence or the InstallExecuteSequence.
-        ///
-        /// During removing-for-upgrade the installer being removed does not receive any properties from the
-        /// installer being installed, only UPGRADINGPRODUCTCODE is set. Thus the state for the installer being
-        /// removed will come from the registry values only.
+        /// The user account can be provided to the installer by
+        /// * The registry
+        /// * The command line
+        /// * The agent user dialog
+        /// The user account domain and name are stored separately in the registry
+        /// but are passed together on the command line and the agent user dialog.
+        /// This function will combine the registry properties if they exist.
+        /// Preference is given to creds provided on the command line and the agent user dialog.
+        /// For UI installs it ensures that the agent user dialog is pre-populated.
         /// </remarks>
-        public ActionResult ReadInstallState()
+        protected void LoadAgentUserProperty(IRegistryKey subkey)
         {
-            try
-            {
-                using var subkey =
-                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
-                if (subkey != null)
+            RegistryProperty(_session, "DDAGENTUSER_NAME",
+                () =>
                 {
-                    // DDAGENTUSER_NAME
-                    //
-                    // The user account can be provided to the installer by
-                    // * The registry
-                    // * The command line
-                    // * The agent user dialog
-                    // The user account domain and name are stored separately in the registry
-                    // but are passed together on the command line and the agent user dialog.
-                    // This function will combine the registry properties if they exist.
-                    // Preference is given to creds provided on the command line and the agent user dialog.
-                    // For UI installs it ensures that the agent user dialog is pre-populated.
-                    RegistryProperty(_session, "DDAGENTUSER_NAME",
-                        () =>
-                        {
-                            var domain = subkey.GetValue("installedDomain")?.ToString();
-                            var user = subkey.GetValue("installedUser")?.ToString();
-                            if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user))
-                            {
-                                return $"{domain}\\{user}";
-                            }
+                    var domain = subkey.GetValue("installedDomain")?.ToString();
+                    var user = subkey.GetValue("installedUser")?.ToString();
+                    if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user))
+                    {
+                        return $"{domain}\\{user}";
+                    }
 
-                            return string.Empty;
-                        });
-
-                    RegistryValueProperty(_session, "PROJECTLOCATION", subkey, "InstallPath");
-                    RegistryValueProperty(_session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
-                }
-
-                GetWindowsBuildVersion();
-                SetDDDriverRollback();
-                SetRemoveFolderExProperties();
-            }
-            catch (Exception e)
-            {
-                _session.Log($"Error reading install state: {e}");
-                return ActionResult.Failure;
-            }
-
-            return ActionResult.Success;
+                    return string.Empty;
+                });
         }
 
-        /// <summary>
-        /// Sets the properties used by the WiX util RemoveFolderEx to cleanup non-tracked paths.
-        ///
-        /// https://wixtoolset.org/docs/v3/xsd/util/removefolderex/
-        /// </summary>
-        /// <remarks>
-        /// RemoveFolderEx only takes a property as input, not IDs or paths, meaning we can't
-        /// pass something like $PROJECTLOCATION\bin\agent in WiX. Instead, we have to set
-        /// the properties in a custom action.
-        ///
-        /// The RemoveFolderEx elements in WiX are configured to only run at uninstall time,
-        /// so the properties values are only relevant then. However, the WixRemoveFolderEx
-        /// custom action will fail fast if any of the properties are empty. So we must always
-        /// provide a value to the properties to prevent an error in the log and to accomodate other
-        /// uses of RemoveFolderEx that run at other times (at time of writing there are none).
-        /// Though this error does not stop the installer, it will ignore it and continue.
-        ///
-        /// RemoveFolderEx handles rollback and will restore any file paths that it deletes.
-        ///
-        /// We specify specific subdirectories under PROJECTLOCATION instead of specifying PROJECTLOCATION
-        /// itself to reduce the impact when the Agent is erroneously installed to an existing directory.
-        ///
-        /// This action copies PROJECTLOCATION and thus changes to PROJECTLOCATION will not be reflected
-        /// in these properties. This should not be an issue since PROJECTLOCATION should not change during
-        /// uninstallation.
-        /// </remarks>
-        private void SetRemoveFolderExProperties()
+        protected void StoreAgentUserInRegistry(IRegistryKey subkey)
         {
-            var installDir = _session["PROJECTLOCATION"];
-            if (string.IsNullOrEmpty(installDir))
-            {
-                if (!string.IsNullOrEmpty(_session["REMOVE"]))
-                {
-                    _session.Log("PROJECTLOCATION is not set, cannot set RemoveFolderEx properties, some files may be left behind in the installation directory.");
-                }
-                return;
-                // We cannot throw an exception here because the installer will fail. This case can happen, for example,
-                // if the cleanup script deleted the registry keys before running the uninstaller.
-            }
-            foreach (var entry in PathsToRemoveOnUninstall())
-            {
-                _session[entry.Key] = Path.Combine(installDir, entry.Value);
-            }
+            _session.Log($"Storing installedDomain={_session.Property("DDAGENTUSER_PROCESSED_DOMAIN")}");
+            subkey.SetValue("installedDomain", _session.Property("DDAGENTUSER_PROCESSED_DOMAIN"),
+                RegistryValueKind.String);
+            _session.Log($"Storing installedUser={_session.Property("DDAGENTUSER_PROCESSED_NAME")}");
+            subkey.SetValue("installedUser", _session.Property("DDAGENTUSER_PROCESSED_NAME"),
+                RegistryValueKind.String);
         }
 
         /// <summary>
@@ -228,178 +141,8 @@ namespace Datadog.CustomActions
             }
         }
 
-        // <summary>
-        // Sets driver-specific properties to 1 if the driver services should be removed on rollback.
-        // </summary>
-        // <remarks>
-        // Previous versions of the installer did not remove the driver services on rollback.
-        // In order to remain compatible with these versions, we must not remove the driver services
-        // when rolling back to these versions.
-        // </remarks>
-        public void SetDDDriverRollback()
-        {
-            var upgradeDetected = _session["WIX_UPGRADE_DETECTED"];
-
-            if (!string.IsNullOrEmpty(upgradeDetected)) // This is an upgrade, conditionally set rollback flags.
-            {
-                var versionString = _nativeMethods.GetVersionString(upgradeDetected);
-                // Using Version class
-                // https://learn.microsoft.com/en-us/dotnet/api/system.version?view=net-8.0
-                var currentVersion = new Version(versionString);
-                Version procmonDriverMinimumVersion;
-                Version driverRollbackMinimumVersion;
-
-                // Check major version
-                if (versionString[0] == '7')
-                {
-                    procmonDriverMinimumVersion = new Version("7.52");
-                    driverRollbackMinimumVersion = new Version("7.56");
-                }
-                else
-                {
-                    procmonDriverMinimumVersion = new Version("6.52");
-                    driverRollbackMinimumVersion = new Version("6.56");
-                }
-
-                var compareResult = currentVersion.CompareTo(driverRollbackMinimumVersion);
-                if (compareResult < 0) // currentVersion is less than minimumVersion
-                {
-                    // case: upgrading from a version that did not implement driver rollback
-                    // Clear NPM flag to ensure NPM service is not deleted on rollback.
-                    _session["DDDRIVERROLLBACK_NPM"] = "";
-
-                    var compare_52 = currentVersion.CompareTo(procmonDriverMinimumVersion);
-                    if (compare_52 < 0) //currentVersion is less than 6.52/7.52
-                    {
-                        // case: upgrading from a version that did not the include procmon driver
-                        // Set PROCMON flag to ensure procmon driver is deleted on rollback.
-                        _session["DDDRIVERROLLBACK_PROCMON"] = "1";
-                    }
-                    else
-                    {
-                        _session["DDDRIVERROLLBACK_PROCMON"] = "";
-                    }
-                }
-                else // currentVersion is not less than minimumVersion
-                {
-                    _session["DDDRIVERROLLBACK_NPM"] = "1";
-                    _session["DDDRIVERROLLBACK_PROCMON"] = "1";
-                }
-            }
-            else  // This is a fresh install, set rollback flags to ensure drivers are deleted on rollback.
-            {
-                _session["DDDRIVERROLLBACK_NPM"] = "1";
-                _session["DDDRIVERROLLBACK_PROCMON"] = "1";
-            }
-            _session.Log($"DDDriverRollback_NPM: {_session["DDDRIVERROLLBACK_NPM"]}");
-            _session.Log($"DDDriverRollback_Procmon: {_session["DDDRIVERROLLBACK_PROCMON"]}");
-        }
-
-        public static ActionResult ReadInstallState(Session session)
-        {
-            return new InstallStateCustomActions(new SessionWrapper(session)).ReadInstallState();
-        }
-
-        public static ActionResult ReadWindowsVersion(Session session)
-        {
-            new InstallStateCustomActions(new SessionWrapper(session)).GetWindowsBuildVersion();
-            return ActionResult.Success;
-        }
-
-        /// <summary>
-        /// Deferred custom action that stores properties in the registry
-        /// </summary>
-        /// <remarks>
-        /// WiX RegistryValue elements are only written when their parent Feature is installed. This means
-        /// that on change/modify operations the registry keys are not updated. This custom action writes
-        /// the properties to the registry that we need to change during change/modify installer operations.
-        /// </remarks>
-        public ActionResult WriteInstallState()
-        {
-            try
-            {
-                using var subkey =
-                    _registryServices.CreateRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
-                if (subkey == null)
-                {
-                    throw new Exception("Unable to create agent registry key");
-                }
-
-                _session.Log($"Storing installedDomain={_session.Property("DDAGENTUSER_PROCESSED_DOMAIN")}");
-                subkey.SetValue("installedDomain", _session.Property("DDAGENTUSER_PROCESSED_DOMAIN"),
-                    RegistryValueKind.String);
-                _session.Log($"Storing installedUser={_session.Property("DDAGENTUSER_PROCESSED_NAME")}");
-                subkey.SetValue("installedUser", _session.Property("DDAGENTUSER_PROCESSED_NAME"),
-                    RegistryValueKind.String);
-            }
-            catch (Exception e)
-            {
-                _session.Log($"Error storing registry properties: {e}");
-                return ActionResult.Failure;
-            }
-
-            return ActionResult.Success;
-        }
-
-        public static ActionResult WriteInstallState(Session session)
-        {
-            return new InstallStateCustomActions(new SessionWrapper(session)).WriteInstallState();
-        }
-
-
-        /// <summary>
-        /// Uninstall CA that removes the changes from the WriteInstallState CA
-        /// </summary>
-        /// <remarks>
-        /// If these registry values are not removed then MSI won't remove the key.
-        /// </remarks>
-        public ActionResult UninstallWriteInstallState()
-        {
-            try
-            {
-                using var subkey =
-                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey,
-                        writable: true);
-                if (subkey == null)
-                {
-                    // registry key does not exist, nothing to do
-                    _session.Log(
-                        $"Registry key HKLM\\{Constants.DatadogAgentRegistryKey} does not exist, there are no values to remove.");
-                    return ActionResult.Success;
-                }
-
-                foreach (var value in new[]
-                         {
-                             "installedDomain",
-                             "installedUser"
-                         })
-                {
-                    try
-                    {
-                        subkey.DeleteValue(value);
-                    }
-                    catch (Exception e)
-                    {
-                        // Don't print stack trace as it may be seen as a terminal error by readers of the log.
-                        _session.Log($"Warning, cannot removing registry value: {e.Message}");
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                _session.Log($"Warning, could not access registry key {Constants.DatadogAgentRegistryKey}: {e}");
-                // This step can fail without failing the un-installation.
-            }
-
-            return ActionResult.Success;
-        }
-
-        public static ActionResult UninstallWriteInstallState(Session session)
-        {
-            return new InstallStateCustomActions(new SessionWrapper(session)).UninstallWriteInstallState();
-        }
-
-        public static SecurityIdentifier GetPreviousAgentUser(ISession session, IRegistryServices registryServices, INativeMethods nativeMethods)
+        public static SecurityIdentifier GetPreviousAgentUser(ISession session, IRegistryServices registryServices,
+            INativeMethods nativeMethods)
         {
             try
             {
@@ -409,6 +152,7 @@ namespace Datadog.CustomActions
                 {
                     throw new Exception("Datadog registry key does not exist");
                 }
+
                 var domain = subkey.GetValue("installedDomain")?.ToString();
                 var user = subkey.GetValue("installedUser")?.ToString();
                 if (string.IsNullOrEmpty(domain) || string.IsNullOrEmpty(user))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
@@ -7,6 +7,6 @@ namespace Datadog.CustomActions.Interfaces
         IRegistryKey CreateRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable);
-        public void DeleteSubKey(Registries registry, string path);
+        void DeleteSubKey(Registries registry, string path);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
@@ -7,5 +7,6 @@ namespace Datadog.CustomActions.Interfaces
         IRegistryKey CreateRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable);
+        public void DeleteSubKey(Registries registry, string path);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
@@ -1,6 +1,6 @@
-using System.Security.AccessControl;
 using Datadog.CustomActions.Interfaces;
 using Microsoft.Win32;
+using System.Security.AccessControl;
 
 namespace Datadog.CustomActions.Native
 {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
@@ -48,6 +48,12 @@ namespace Datadog.CustomActions.Native
             return new RegistryKey(key);
         }
 
+        /// <summary>
+        /// Delete key if it is empty.
+        /// </summary>
+        /// <remarks>
+        /// https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey.deletesubkey
+        /// </remarks>
         public void DeleteSubKey(Registries registry, string path)
         {
             var key = registry switch

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
@@ -47,5 +47,20 @@ namespace Datadog.CustomActions.Native
 
             return new RegistryKey(key);
         }
+
+        public void DeleteSubKey(Registries registry, string path)
+        {
+            var key = registry switch
+            {
+                Registries.LocalMachine => Registry.LocalMachine,
+                _ => null
+            };
+
+            if (key == null)
+            {
+                return;
+            }
+            key.DeleteSubKey(path, false);
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/Constants.cs
@@ -3,14 +3,6 @@ namespace Datadog.InstallerCustomActions
 {
     public class Constants
     {
-        public const string AgentServiceName = "datadogagent";
-        public const string TraceAgentServiceName = "datadog-trace-agent";
-        public const string ProcessAgentServiceName = "datadog-process-agent";
-        public const string SystemProbeServiceName = "datadog-system-probe";
-        public const string SecurityAgentServiceName = "datadog-security-agent";
-        public const string NpmServiceName = "ddnpm";
-        public const string ProcmonServiceName = "ddprocmon";
-
         // Key under HKLM that contains our options
         public const string DatadogInstallerRegistryKey = @"Software\Datadog\Datadog Installer";
     }

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/Constants.cs
@@ -1,0 +1,17 @@
+// ReSharper disable InconsistentNaming
+namespace Datadog.InstallerCustomActions
+{
+    public class Constants
+    {
+        public const string AgentServiceName = "datadogagent";
+        public const string TraceAgentServiceName = "datadog-trace-agent";
+        public const string ProcessAgentServiceName = "datadog-process-agent";
+        public const string SystemProbeServiceName = "datadog-system-probe";
+        public const string SecurityAgentServiceName = "datadog-security-agent";
+        public const string NpmServiceName = "ddnpm";
+        public const string ProcmonServiceName = "ddprocmon";
+
+        // Key under HKLM that contains our options
+        public const string DatadogInstallerRegistryKey = @"Software\Datadog\Datadog Installer";
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
@@ -1,3 +1,4 @@
+using Datadog.CustomActions;
 using Microsoft.Deployment.WindowsInstaller;
 
 namespace Datadog.InstallerCustomActions
@@ -24,9 +25,15 @@ namespace Datadog.InstallerCustomActions
         }
 
         [CustomAction]
-        public static ActionResult ReadWindowsVersion(Session session)
+        public static ActionResult ReadInstallState(Session session)
         {
-            return Datadog.CustomActions.InstallStateCustomActions.ReadWindowsVersion(session);
+            return new ReadInstallStateCA(new SessionWrapper(session)).ReadInstallState();
+        }
+
+        [CustomAction]
+        public static ActionResult WriteInstallState(Session session)
+        {
+            return new WriteInstallStateCA(new SessionWrapper(session)).WriteInstallState();
         }
 
         [CustomAction]

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
@@ -37,6 +37,12 @@ namespace Datadog.InstallerCustomActions
         }
 
         [CustomAction]
+        public static ActionResult UninstallWriteInstallState(Session session)
+        {
+            return new WriteInstallStateCA(new SessionWrapper(session)).UninstallWriteInstallState();
+        }
+
+        [CustomAction]
         public static ActionResult ReadConfig(Session session)
         {
             return Datadog.CustomActions.ConfigCustomActions.ReadConfig(session);

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
@@ -37,9 +37,9 @@ namespace Datadog.InstallerCustomActions
         }
 
         [CustomAction]
-        public static ActionResult UninstallWriteInstallState(Session session)
+        public static ActionResult DeleteInstallState(Session session)
         {
-            return new WriteInstallStateCA(new SessionWrapper(session)).UninstallWriteInstallState();
+            return new WriteInstallStateCA(new SessionWrapper(session)).DeleteInstallState();
         }
 
         [CustomAction]

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
@@ -47,5 +47,11 @@ namespace Datadog.InstallerCustomActions
         {
             return Datadog.CustomActions.ConfigCustomActions.WriteConfig(session);
         }
+
+        [CustomAction]
+        public static ActionResult ProcessDdAgentUserCredentials(Session session)
+        {
+            return Datadog.CustomActions.ProcessUserCustomActions.ProcessDdAgentUserCredentials(session);
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallStateCustomActions.cs
@@ -1,0 +1,84 @@
+using Datadog.CustomActions.Interfaces;
+using Datadog.CustomActions.Native;
+using Microsoft.Deployment.WindowsInstaller;
+using System;
+
+namespace Datadog.InstallerCustomActions
+{
+
+    public class ReadInstallStateCA : Datadog.CustomActions.InstallStateCustomActions
+    {
+        public ReadInstallStateCA(ISession session) : base(session)
+        {
+        }
+
+        /// <summary>
+        /// Assigns WIX properties that were not provided by the user to their registry values.
+        /// </summary>
+        /// <remarks>
+        /// Custom Action that runs (only once) in either the InstallUISequence or the InstallExecuteSequence.
+        ///
+        /// During removing-for-upgrade the installer being removed does not receive any properties from the
+        /// installer being installed, only UPGRADINGPRODUCTCODE is set. Thus the state for the installer being
+        /// removed will come from the registry values only.
+        /// </remarks>
+        public ActionResult ReadInstallState()
+        {
+            try
+            {
+                using var subkey =
+                    _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogInstallerRegistryKey);
+                if (subkey != null)
+                {
+                    LoadAgentUserProperty(subkey);
+                }
+
+                GetWindowsBuildVersion();
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Error reading install state: {e}");
+                return ActionResult.Failure;
+            }
+
+            return ActionResult.Success;
+        }
+    }
+
+    public class WriteInstallStateCA : Datadog.CustomActions.InstallStateCustomActions
+    {
+        public WriteInstallStateCA(ISession session) : base(session)
+        {
+        }
+
+        /// <summary>
+        /// Deferred custom action that stores properties in the registry
+        /// </summary>
+        /// <remarks>
+        /// WiX RegistryValue elements are only written when their parent Feature is installed. This means
+        /// that on change/modify operations the registry keys are not updated. This custom action writes
+        /// the properties to the registry that we need to change during change/modify installer operations.
+        /// </remarks>
+        public ActionResult WriteInstallState()
+        {
+            try
+            {
+                using var subkey =
+                    _registryServices.CreateRegistryKey(Registries.LocalMachine, Constants.DatadogInstallerRegistryKey);
+                if (subkey == null)
+                {
+                    throw new Exception("Unable to create agent registry key");
+                }
+
+                StoreAgentUserInRegistry(subkey);
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Error storing registry properties: {e}");
+                return ActionResult.Failure;
+            }
+
+            return ActionResult.Success;
+        }
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallStateCustomActions.cs
@@ -84,7 +84,7 @@ namespace Datadog.InstallerCustomActions
         /// <summary>
         /// Uninstall CA that removes the changes from the WriteInstallState CA
         /// </summary>
-        public ActionResult UninstallWriteInstallState()
+        public ActionResult DeleteInstallState()
         {
             try
             {

--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallerCustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/InstallerCustomActions.csproj
@@ -69,7 +69,9 @@
     <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Constants.cs" />
     <Compile Include="CustomAction.cs" />
+    <Compile Include="InstallStateCustomActions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="CustomAction.config" />
   </ItemGroup>

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -24,7 +24,7 @@ namespace WixSetup.Datadog_Agent
 
         public ManagedAction WriteInstallState { get; }
 
-        public ManagedAction UninstallWriteInstallState { get; }
+        public ManagedAction DeleteInstallState { get; }
 
         public ManagedAction ProcessDdAgentUserCredentials { get; }
 
@@ -510,9 +510,9 @@ namespace WixSetup.Datadog_Agent
                 .SetProperties("DDAGENTUSER_PROCESSED_DOMAIN=[DDAGENTUSER_PROCESSED_DOMAIN], " +
                                "DDAGENTUSER_PROCESSED_NAME=[DDAGENTUSER_PROCESSED_NAME]");
 
-            UninstallWriteInstallState = new CustomAction<CustomActions>(
-                    new Id(nameof(UninstallWriteInstallState)),
-                    CustomActions.UninstallWriteInstallState,
+            DeleteInstallState = new CustomAction<CustomActions>(
+                    new Id(nameof(DeleteInstallState)),
+                    CustomActions.DeleteInstallState,
                     Return.check,
                     // Since this CA removes registry values it must run before the built-in RemoveRegistryValues
                     // so that the built-in registry keys can be removed if they are empty.

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -1,9 +1,10 @@
+using Datadog.AgentCustomActions;
+using Datadog.CustomActions;
+using NineDigit.WixSharpExtensions;
 using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using Datadog.CustomActions;
-using NineDigit.WixSharpExtensions;
 using WixSharp;
 using WixSharp.CommonTasks;
 
@@ -372,7 +373,7 @@ namespace WixSetup.Datadog_Agent
             // may contain untracked files.
             // These properties are set in the ReadInstallState custom action.
             // https://wixtoolset.org/docs/v3/xsd/util/removefolderex/
-            foreach (var property in InstallStateCustomActions.PathsToRemoveOnUninstall().Keys)
+            foreach (var property in ReadInstallStateCA.PathsToRemoveOnUninstall().Keys)
             {
                 datadogAgentFolder.Add(
                     new RemoveFolderEx

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
@@ -1,7 +1,6 @@
+using NineDigit.WixSharpExtensions;
 using System;
 using System.IO;
-using System.Windows;
-using NineDigit.WixSharpExtensions;
 using WixSetup.Datadog_Agent;
 using WixSharp;
 using WixSharp.CommonTasks;
@@ -53,6 +52,16 @@ namespace WixSetup.Datadog_Installer
                     // Can't use %CommonAppDataFolder% because it's a Wix property.
                     Value = @"C:\ProgramData\Datadog",
                     AttributesDefinition = "Secure=yes",
+                },
+                // User provided password property
+                new Property("DDAGENTUSER_PASSWORD")
+                {
+                    AttributesDefinition = "Hidden=yes"
+                },
+                // ProcessDDAgentUserCredentials CustomAction processed password property
+                new Property("DDAGENTUSER_PROCESSED_PASSWORD")
+                {
+                    AttributesDefinition = "Hidden=yes"
                 },
                 new Dir(@"%ProgramFiles%\Datadog\Datadog Installer",
                     new WixSharp.File(@"C:\opt\datadog-installer\datadog-installer.exe",

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstallerCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstallerCustomActions.cs
@@ -11,8 +11,8 @@ namespace WixSetup.Datadog_Installer
         public ManagedAction ReadInstallState { get; }
         public ManagedAction WriteInstallState { get; }
         public ManagedAction RollbackWriteInstallState { get; }
-        public ManagedAction UninstallWriteInstallState { get; }
-        public ManagedAction RollbackUninstallWriteInstallState { get; }
+        public ManagedAction DeleteInstallState { get; }
+        public ManagedAction RollbackDeleteInstallState { get; }
         public ManagedAction OpenMsiLog { get; }
         public ManagedAction ProcessDdAgentUserCredentials { get; }
 
@@ -119,7 +119,7 @@ namespace WixSetup.Datadog_Installer
 
             RollbackWriteInstallState = new CustomAction<CustomActions>(
                     new Id(nameof(RollbackWriteInstallState)),
-                    CustomActions.UninstallWriteInstallState,
+                    CustomActions.DeleteInstallState,
                     Return.check,
                     When.Before,
                     new Step(WriteInstallState.Id),
@@ -135,9 +135,9 @@ namespace WixSetup.Datadog_Installer
                                "DDAGENT_installedDomain=[DDAGENT_installedDomain], " +
                                "DDAGENT_installedUser=[DDAGENT_installedUser]");
 
-            UninstallWriteInstallState = new CustomAction<CustomActions>(
-                new Id(nameof(UninstallWriteInstallState)),
-                CustomActions.UninstallWriteInstallState,
+            DeleteInstallState = new CustomAction<CustomActions>(
+                new Id(nameof(DeleteInstallState)),
+                CustomActions.DeleteInstallState,
                 Return.check,
                 // Since this CA removes registry values it must run before the built-in RemoveRegistryValues
                 // so that the built-in registry keys can be removed if they are empty.
@@ -151,12 +151,12 @@ namespace WixSetup.Datadog_Installer
             };
 
 
-            RollbackUninstallWriteInstallState = new CustomAction<CustomActions>(
-                new Id(nameof(RollbackUninstallWriteInstallState)),
+            RollbackDeleteInstallState = new CustomAction<CustomActions>(
+                new Id(nameof(RollbackDeleteInstallState)),
                 CustomActions.WriteInstallState,
                 Return.check,
                 When.Before,
-                new Step(UninstallWriteInstallState.Id),
+                new Step(DeleteInstallState.Id),
                 Conditions.Uninstalling | Conditions.RemovingForUpgrade
             )
             {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add support for agent user params to Datadog Installer MSI

Store agent user in registry

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Need to save the Agent user in order to provide it to the Agent installer

https://datadoghq.atlassian.net/browse/WINA-967

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Moves Agent MSI specific install state operations from `CustomActions` to `AgentCustomActions`

currently based on https://github.com/DataDog/datadog-agent/pull/28722, will update after merge

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
no upgrade-rollback test since we don't have an MSI to upgrade from that includes the rollback actions

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Adds E2E tests to check registry keys during install, uninstall, and rollback