### PR TITLE
Don't fetch plans when plan_hash_value=0 (DBMON-3889)

### DIFF
--- a/pkg/collector/corechecks/oracle/statements.go
+++ b/pkg/collector/corechecks/oracle/statements.go
@@ -634,7 +634,7 @@ func (c *Check) StatementMetrics() (int, error) {
 				c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
 			}
 
-			if c.config.ExecutionPlans.Enabled && sendPlan {
+			if c.config.ExecutionPlans.Enabled && sendPlan && statementMetricRow.PlanHashValue != 0 {
 				if (i+1)%10 == 0 && time.Since(start).Seconds() >= float64(c.config.QueryMetrics.MaxRunTime) {
 					sendPlan = false
 				}

--- a/releasenotes/notes/oracle-zero-hash-plan-cb02f930b86f5bbd.yaml
+++ b/releasenotes/notes/oracle-zero-hash-plan-cb02f930b86f5bbd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [oracle] Don't try to fetch execution plans where ``plan_hash_value = 0``

--- a/releasenotes/notes/oracle-zero-hash-plan-cb02f930b86f5bbd.yaml
+++ b/releasenotes/notes/oracle-zero-hash-plan-cb02f930b86f5bbd.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [oracle] Don't try to fetch execution plans where ``plan_hash_value = 0``
+    [oracle] Don't try to fetch execution plans where ``plan_hash_value`` is ``0``


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Stop trying to fetch execution plans where `plan_hash_value = 0`.

### Motivation

This is an optmization. Queries where `plan_hash_value=0` don't have an execution plan yet, so there's no point in executing the query to fetch it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
