### PR TITLE
[e2e] recreate stack on cloud init timeout

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -36,5 +36,10 @@ func getKnownErrors() []knownError {
 			errorMessage: "Resource provider reported that the resource did not exist while updating",
 			retryType:    reCreate,
 		},
+		{
+			// https://datadoghq.atlassian.net/browse/ADXT-558
+			errorMessage: "Process exited with status 2: running \" sudo cloud-init status --wait\"",
+			retryType:    reCreate,
+		},
 	}
 }


### PR DESCRIPTION
It means the VM is no longer reachable

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Recreate stack on `cloud-init` command timeout

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

[ADXT-558](https://datadoghq.atlassian.net/browse/ADXT-558)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The error `Process exited with status 2: running \" sudo cloud-init status --wait\"` means the VM is no longer reachable, as other timeouts we should recreate the VM instead of insisting reaching out to a VM that does not want to talk with us anymore

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->


[ADXT-558]: https://datadoghq.atlassian.net/browse/ADXT-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ