### PR TITLE
fix(run_all_tests): Re-enable all tests trigger on specific files modification

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -664,7 +664,8 @@ def get_impacted_packages(ctx, build_tags=None):
             )
 
     # Some files like tasks/gotest.py should trigger all tests
-    if should_run_all_tests(files, TRIGGER_ALL_TESTS_PATHS):
+    if should_run_all_tests(ctx, TRIGGER_ALL_TESTS_PATHS):
+        print(f"Triggering all tests because a file matching one of the {TRIGGER_ALL_TESTS_PATHS} was modified")
         return DEFAULT_MODULES.values()
 
     modified_packages = {f"github.com/DataDog/datadog-agent/{os.path.dirname(file)}" for file in files}
@@ -825,12 +826,10 @@ def get_go_module(path):
     raise Exception(f"No go.mod file found for package at {path}")
 
 
-def should_run_all_tests(files, trigger_files):
-    for trigger_file in trigger_files:
-        if len(fnmatch.filter(files, trigger_file)):
-            print(f"Triggering all tests because a file matching {trigger_file} was modified")
-            return True
-    return False
+def should_run_all_tests(ctx, trigger_files):
+    base_branch = _get_release_json_value("base_branch")
+    files = get_modified_files(ctx, base_branch=base_branch)
+    return any(len(fnmatch.filter(files, trigger_file)) for trigger_file in trigger_files)
 
 
 def get_go_modified_files(ctx):

--- a/tasks/unit_tests/go_tests.py
+++ b/tasks/unit_tests/go_tests.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from tasks.gotest import find_impacted_packages, should_run_all_tests
 
@@ -46,26 +47,30 @@ class TestUtils(unittest.TestCase):
         expected_impacted_packages = {"pkg3"}
         self.assertEqual(find_impacted_packages(dependencies, changed_files), expected_impacted_packages)
 
+    @patch("tasks.gotest._get_release_json_value", new=MagicMock())
+    @patch("tasks.gotest.get_modified_files", new=MagicMock(return_value=["pkg/foo.go", "pkg/bar.go"]))
     def test_should_run_all_tests_1(self):
-        modified_files = ["pkg/foo.go", "pkg/bar.go"]
         trigger_files = ["pkg/foo.go"]
 
-        self.assertTrue(should_run_all_tests(modified_files, trigger_files))
+        self.assertTrue(should_run_all_tests(None, trigger_files))
 
+    @patch("tasks.gotest._get_release_json_value", new=MagicMock())
+    @patch("tasks.gotest.get_modified_files", new=MagicMock(return_value=["pkg/toto/bar.go"]))
     def test_should_run_all_tests_2(self):
-        modified_files = ["pkg/toto/bar.go"]
         trigger_files = ["pkg/*"]
 
-        self.assertTrue(should_run_all_tests(modified_files, trigger_files))
+        self.assertTrue(should_run_all_tests(None, trigger_files))
 
+    @patch("tasks.gotest._get_release_json_value", new=MagicMock())
+    @patch("tasks.gotest.get_modified_files", new=MagicMock(return_value=["pkg/foo.go", "pkg/bar.go"]))
     def test_should_run_all_tests_3(self):
-        modified_files = ["pkg/foo.go", "pkg/bar.go"]
         trigger_files = ["pkg/toto/bar.go"]
 
-        self.assertFalse(should_run_all_tests(modified_files, trigger_files))
+        self.assertFalse(should_run_all_tests(None, trigger_files))
 
+    @patch("tasks.gotest._get_release_json_value", new=MagicMock())
+    @patch("tasks.gotest.get_modified_files", new=MagicMock(return_value=["pkg/foo.go", "pkg/bar.go"]))
     def test_should_run_all_tests_4(self):
-        modified_files = ["pkg/foo.go", "pkg/bar.go"]
         trigger_files = ["pkgs/*"]
 
-        self.assertFalse(should_run_all_tests(modified_files, trigger_files))
+        self.assertFalse(should_run_all_tests(None, trigger_files))


### PR DESCRIPTION
### What does this PR do?
Re-enable all tests trigger on specific files modification. This was broken by #27284

### Motivation
Ensure all tests are launched when needed.

### Tests
Detected while trying to force all tests [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/617046599) with [this commit](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/commit/963b4a56da430c46f506ce2e290e7b48c2934c51). The current PR should trigger all tests to validate the modification
