### PR TITLE
[ksm] Allow collecting pod metrics from the Kubelet

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -238,15 +238,15 @@ func (f *extendedPodFactory) ExpectedType() interface{} {
 }
 
 // ListWatch returns a ListerWatcher for v1.Pod
-//
-//nolint:revive // TODO(CINT) Fix revive linter
 func (f *extendedPodFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(clientset.Interface)
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
 			return client.CoreV1().Pods(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
 			return client.CoreV1().Pods(ns).Watch(context.TODO(), opts)
 		},
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -28,6 +28,7 @@ import (
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -149,6 +150,26 @@ type KSMConfig struct {
 
 	// UseAPIServerCache enables the use of the API server cache for the check
 	UseAPIServerCache bool `yaml:"use_apiserver_cache"`
+
+	// CollectPodsFromKubelet enables the collection of pods from the kubelet
+	// instead of the Kubernetes API server.
+	//
+	// This is meant to be enabled when the check is running on the node agent.
+	// This is useful in clusters with a large number of pods where emitting pod
+	// metrics from a single instance might be too much.
+	//
+	// One thing to note is that when the node agent collects metrics from the
+	// kubelet and the cluster agent or cluster check runner collects metrics
+	// for other resources, label joins are not supported for pod metrics if the
+	// join source is not a pod.
+	CollectPodsFromKubelet bool `yaml:"collect_pods_from_kubelet"`
+
+	// CollectOnlyUnassignedPods enables pod collection only for unassigned
+	// pods. This is meant to be enabled when the check is running on the
+	// cluster agent or the cluster check runner and "CollectPodsFromKubelet" is
+	// enabled on the node agents, because unassigned pods cannot be collected
+	// from node agents.
+	CollectOnlyUnassignedPods bool `yaml:"collect_only_unassigned_pods"`
 }
 
 // KSMCheck wraps the config and the metric stores needed to run the check
@@ -160,6 +181,7 @@ type KSMCheck struct {
 	telemetry            *telemetryCache
 	cancel               context.CancelFunc
 	isCLCRunner          bool
+	isRunningOnNodeAgent bool
 	clusterNameTagValue  string
 	clusterNameRFC1123   string
 	metricNamesMapper    map[string]string
@@ -337,6 +359,32 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 		return err
 	}
 
+	if k.instance.CollectPodsFromKubelet {
+		if k.isRunningOnNodeAgent {
+			// If the check is running in a node agent, we can collect pods from
+			// the kubelet but only if it's the only collector enabled. When
+			// there are more collectors enabled, we need leader election and
+			// pods would only be collected from one of the agents.
+			if len(collectors) == 1 && collectors[0] == "pods" {
+				builder.WithPodCollectionFromKubelet()
+			} else {
+				log.Warnf("collect_pods_from_kubelet is enabled but it's only supported when the only collector enabled is pods, " +
+					"so the check will collect pods from the API server instead of the Kubelet")
+			}
+		} else {
+			log.Warnf("collect_pods_from_kubelet is enabled but KSM is running in the cluster agent or cluster check runner, " +
+				"so the check will collect pods from the API server instead of the Kubelet")
+		}
+	}
+
+	if k.instance.CollectOnlyUnassignedPods {
+		if k.isRunningOnNodeAgent {
+			log.Warnf("collect_only_unassigned_pods is enabled but KSM is running in a node agent, so the option will be ignored")
+		} else {
+			builder.WithUnassignedPodsCollection()
+		}
+	}
+
 	// Start the collection process
 	k.allStores = builder.BuildStores()
 
@@ -478,9 +526,16 @@ func (k *KSMCheck) Run() error {
 	// Note that by design, some metrics cannot have hostnames (e.g kubernetes_state.pod.unschedulable)
 	sender.DisableDefaultHostname(true)
 
+	// If KSM is running in the node agent, and it's configured to collect only
+	// pods and from the node agent, we don't need to run leader election,
+	// because each node agent is responsible for collecting its own pods.
+	podsFromKubeletInNodeAgent := k.isRunningOnNodeAgent &&
+		k.instance.CollectPodsFromKubelet &&
+		len(k.instance.Collectors) == 1 && k.instance.Collectors[0] == "pods"
+
 	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
 	// we also do a safety check for dedicated runners to avoid trying the leader election
-	if !k.isCLCRunner || !k.instance.LeaderSkip {
+	if (!k.isCLCRunner || !k.instance.LeaderSkip) && !podsFromKubeletInNodeAgent {
 		// Only run if Leader Election is enabled.
 		if !ddconfig.Datadog().GetBool("leader_election") {
 			return log.Error("Leader Election not enabled. The cluster-agent will not run the kube-state-metrics core check.")
@@ -868,13 +923,14 @@ func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins
 
 func newKSMCheck(base core.CheckBase, instance *KSMConfig) *KSMCheck {
 	return &KSMCheck{
-		CheckBase:          base,
-		instance:           instance,
-		telemetry:          newTelemetryCache(),
-		isCLCRunner:        ddconfig.IsCLCRunner(),
-		metricNamesMapper:  defaultMetricNamesMapper(),
-		metricAggregators:  defaultMetricAggregators(),
-		metricTransformers: defaultMetricTransformers(),
+		CheckBase:            base,
+		instance:             instance,
+		telemetry:            newTelemetryCache(),
+		isCLCRunner:          ddconfig.IsCLCRunner(),
+		isRunningOnNodeAgent: flavor.GetFlavor() != flavor.ClusterAgent && !ddconfig.IsCLCRunner(),
+		metricNamesMapper:    defaultMetricNamesMapper(),
+		metricAggregators:    defaultMetricAggregators(),
+		metricTransformers:   defaultMetricTransformers(),
 
 		// metadata metrics are useful for label joins
 		// but shouldn't be submitted to Datadog

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -68,6 +68,37 @@ var extendedCollectors = map[string]string{
 
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 
+type podCollectionMode string
+
+const (
+	// defaultPodCollection is the default mode where pods are collected from
+	// the API server.
+	defaultPodCollection podCollectionMode = "default"
+
+	// nodeKubeletPodCollection is the mode where pods are collected from the
+	// kubelet.
+	//
+	// This is meant to be enabled when the check is running on the node agent.
+	// This is useful in clusters with a large number of pods where emitting pod
+	// metrics from a single instance might be too much and cause performance
+	// issues.
+	//
+	// One thing to note is that when the node agent collects metrics from the
+	// kubelet and the cluster agent or cluster check runner collects metrics
+	// for other resources, label joins are not supported for pod metrics if the
+	// join source is not a pod.
+	nodeKubeletPodCollection podCollectionMode = "node_kubelet"
+
+	// clusterUnassignedPodCollection is the mode where pods are collected from
+	// the API server but only unassigned pods.
+	//
+	// This is meant to be enabled when the check is running on the cluster
+	// agent or the cluster check runner and "nodeKubeletPodCollection" is
+	// enabled on the node agents, because unassigned pods cannot be collected
+	// from node agents.
+	clusterUnassignedPodCollection podCollectionMode = "cluster_unassigned"
+)
+
 // KSMConfig contains the check config parameters
 type KSMConfig struct {
 	// Collectors defines the resource type collectors.
@@ -151,25 +182,9 @@ type KSMConfig struct {
 	// UseAPIServerCache enables the use of the API server cache for the check
 	UseAPIServerCache bool `yaml:"use_apiserver_cache"`
 
-	// CollectPodsFromKubelet enables the collection of pods from the kubelet
-	// instead of the Kubernetes API server.
-	//
-	// This is meant to be enabled when the check is running on the node agent.
-	// This is useful in clusters with a large number of pods where emitting pod
-	// metrics from a single instance might be too much.
-	//
-	// One thing to note is that when the node agent collects metrics from the
-	// kubelet and the cluster agent or cluster check runner collects metrics
-	// for other resources, label joins are not supported for pod metrics if the
-	// join source is not a pod.
-	CollectPodsFromKubelet bool `yaml:"collect_pods_from_kubelet"`
-
-	// CollectOnlyUnassignedPods enables pod collection only for unassigned
-	// pods. This is meant to be enabled when the check is running on the
-	// cluster agent or the cluster check runner and "CollectPodsFromKubelet" is
-	// enabled on the node agents, because unassigned pods cannot be collected
-	// from node agents.
-	CollectOnlyUnassignedPods bool `yaml:"collect_only_unassigned_pods"`
+	// PodCollectionMode defines how pods are collected.
+	// Accepted values are: "default", "node_kubelet", and "cluster_unassigned".
+	PodCollectionMode podCollectionMode `yaml:"pod_collection_mode"`
 }
 
 // KSMCheck wraps the config and the metric stores needed to run the check
@@ -359,31 +374,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 		return err
 	}
 
-	if k.instance.CollectPodsFromKubelet {
-		if k.isRunningOnNodeAgent {
-			// If the check is running in a node agent, we can collect pods from
-			// the kubelet but only if it's the only collector enabled. When
-			// there are more collectors enabled, we need leader election and
-			// pods would only be collected from one of the agents.
-			if len(collectors) == 1 && collectors[0] == "pods" {
-				builder.WithPodCollectionFromKubelet()
-			} else {
-				log.Warnf("collect_pods_from_kubelet is enabled but it's only supported when the only collector enabled is pods, " +
-					"so the check will collect pods from the API server instead of the Kubelet")
-			}
-		} else {
-			log.Warnf("collect_pods_from_kubelet is enabled but KSM is running in the cluster agent or cluster check runner, " +
-				"so the check will collect pods from the API server instead of the Kubelet")
-		}
-	}
-
-	if k.instance.CollectOnlyUnassignedPods {
-		if k.isRunningOnNodeAgent {
-			log.Warnf("collect_only_unassigned_pods is enabled but KSM is running in a node agent, so the option will be ignored")
-		} else {
-			builder.WithUnassignedPodsCollection()
-		}
-	}
+	k.configurePodCollection(builder, collectors)
 
 	// Start the collection process
 	k.allStores = builder.BuildStores()
@@ -529,9 +520,7 @@ func (k *KSMCheck) Run() error {
 	// If KSM is running in the node agent, and it's configured to collect only
 	// pods and from the node agent, we don't need to run leader election,
 	// because each node agent is responsible for collecting its own pods.
-	podsFromKubeletInNodeAgent := k.isRunningOnNodeAgent &&
-		k.instance.CollectPodsFromKubelet &&
-		len(k.instance.Collectors) == 1 && k.instance.Collectors[0] == "pods"
+	podsFromKubeletInNodeAgent := k.isRunningOnNodeAgent && k.instance.PodCollectionMode == nodeKubeletPodCollection
 
 	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
 	// we also do a safety check for dedicated runners to avoid trying the leader election
@@ -847,6 +836,43 @@ func (k *KSMCheck) initTags() {
 
 	if !k.instance.DisableGlobalTags {
 		k.instance.Tags = append(k.instance.Tags, configUtils.GetConfiguredTags(k.agentConfig, false)...)
+	}
+}
+
+func (k *KSMCheck) configurePodCollection(builder *kubestatemetrics.Builder, collectors []string) {
+	switch k.instance.PodCollectionMode {
+	case "":
+		k.instance.PodCollectionMode = defaultPodCollection
+	case defaultPodCollection:
+		// No need to do anything
+	case nodeKubeletPodCollection:
+		if k.isRunningOnNodeAgent {
+			// If the check is running in a node agent, we can collect pods from
+			// the kubelet but only if it's the only collector enabled. When
+			// there are more collectors enabled, we need leader election and
+			// pods would only be collected from one of the agents.
+			if len(collectors) == 1 && collectors[0] == "pods" {
+				builder.WithPodCollectionFromKubelet()
+			} else {
+				log.Warnf("pod collection from the Kubelet is enabled but it's only supported when the only collector enabled is pods, " +
+					"so the check will collect pods from the API server instead of the Kubelet")
+				k.instance.PodCollectionMode = defaultPodCollection
+			}
+		} else {
+			log.Warnf("pod collection from the Kubelet is enabled but KSM is running in the cluster agent or cluster check runner, " +
+				"so the check will collect pods from the API server instead of the Kubelet")
+			k.instance.PodCollectionMode = defaultPodCollection
+		}
+	case clusterUnassignedPodCollection:
+		if k.isRunningOnNodeAgent {
+			log.Warnf("collection of unassigned pods is enabled but KSM is running in a node agent, so the option will be ignored")
+			k.instance.PodCollectionMode = defaultPodCollection
+		} else {
+			builder.WithUnassignedPodsCollection()
+		}
+	default:
+		log.Warnf("invalid pod collection mode %q, falling back to the default mode", k.instance.PodCollectionMode)
+		k.instance.PodCollectionMode = defaultPodCollection
 	}
 }
 

--- a/pkg/kubestatemetrics/builder/kubelet_pods.go
+++ b/pkg/kubestatemetrics/builder/kubelet_pods.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && kubelet
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PodWatcher is an interface for a component that watches for changes in pods
+type PodWatcher interface {
+	PullChanges(ctx context.Context) ([]*kubelet.Pod, error)
+	Expire() ([]string, error)
+}
+
+func (b *Builder) startKubeletPodWatcher(store cache.Store, namespace string) {
+	podWatcher, err := kubelet.NewPodWatcher(15 * time.Second)
+	if err != nil {
+		log.Warnf("Failed to create pod watcher: %s", err)
+	}
+
+	ticker := time.NewTicker(5 * time.Second)
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				err = updateStore(b.ctx, store, podWatcher, namespace)
+				if err != nil {
+					log.Errorf("Failed to update store: %s", err)
+				}
+
+			case <-b.ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func updateStore(ctx context.Context, store cache.Store, podWatcher PodWatcher, namespace string) error {
+	pods, err := podWatcher.PullChanges(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to pull changes from pod watcher: %w", err)
+	}
+
+	for _, pod := range pods {
+		if namespace != corev1.NamespaceAll && pod.Metadata.Namespace != namespace {
+			continue
+		}
+
+		kubePod := kubelet.ConvertKubeletPodToK8sPod(pod)
+
+		err = store.Add(kubePod)
+		if err != nil {
+			log.Warnf("Failed to add pod to KSM store: %s", err)
+		}
+	}
+
+	expiredEntities, err := podWatcher.Expire()
+	if err != nil {
+		return fmt.Errorf("failed to expire pods: %w", err)
+	}
+
+	for _, expiredEntity := range expiredEntities {
+		// Expire() returns both pods and containers, we only care
+		// about pods
+		if !strings.HasPrefix(expiredEntity, kubelet.KubePodPrefix) {
+			continue
+		}
+
+		// Only the UID is needed to be able to delete
+		expiredPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(strings.TrimPrefix(expiredEntity, kubelet.KubePodPrefix)),
+			},
+		}
+
+		err = store.Delete(&expiredPod)
+		if err != nil {
+			log.Warnf("Failed to delete pod from KSM store: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/kubestatemetrics/builder/kubelet_pods_stub.go
+++ b/pkg/kubestatemetrics/builder/kubelet_pods_stub.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && !kubelet
+
+package builder
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+func (b *Builder) startKubeletPodWatcher(_ cache.Store, _ string) {
+	// Do nothing
+}

--- a/pkg/kubestatemetrics/builder/kubelet_pods_test.go
+++ b/pkg/kubestatemetrics/builder/kubelet_pods_test.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && kubelet
+
+package builder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+type MockPodWatcher struct {
+	mock.Mock
+}
+
+func (m *MockPodWatcher) PullChanges(ctx context.Context) ([]*kubelet.Pod, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*kubelet.Pod), args.Error(1)
+}
+
+func (m *MockPodWatcher) Expire() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+type MockStore struct {
+	mock.Mock
+}
+
+func (m *MockStore) Add(obj interface{}) error {
+	args := m.Called(obj)
+	return args.Error(0)
+}
+
+func (m *MockStore) Delete(obj interface{}) error {
+	args := m.Called(obj)
+	return args.Error(0)
+}
+
+func (m *MockStore) Update(_ interface{}) error {
+	// Unused in this test
+	return nil
+}
+
+func (m *MockStore) List() []interface{} {
+	// Unused in this test
+	return nil
+}
+
+func (m *MockStore) ListKeys() []string {
+	// Unused in this test
+	return nil
+}
+
+func (m *MockStore) Get(_ interface{}) (item interface{}, exists bool, err error) {
+	// Unused in this test
+	return nil, false, nil
+}
+
+func (m *MockStore) GetByKey(_ string) (item interface{}, exists bool, err error) {
+	// Unused in this test
+	return nil, false, nil
+}
+
+func (m *MockStore) Replace(_ []interface{}, _ string) error {
+	// Unused in this test
+	return nil
+}
+
+func (m *MockStore) Resync() error {
+	// Unused in this test
+	return nil
+}
+
+func TestUpdateStore_AddPodToStore(t *testing.T) {
+	store := new(MockStore)
+	podWatcher := new(MockPodWatcher)
+
+	kubeletPod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "12345",
+		},
+	}
+
+	kubernetesPod := kubelet.ConvertKubeletPodToK8sPod(kubeletPod)
+
+	podWatcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
+	podWatcher.On("Expire").Return([]string{}, nil)
+	store.On("Add", kubernetesPod).Return(nil)
+
+	err := updateStore(context.TODO(), store, podWatcher, "default")
+	assert.NoError(t, err)
+
+	store.AssertCalled(t, "Add", kubernetesPod)
+}
+
+func TestUpdateStore_FilterPodsByNamespace(t *testing.T) {
+	store := new(MockStore)
+	podWatcher := new(MockPodWatcher)
+
+	kubeletPod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "test-pod",
+			Namespace: "other-namespace",
+			UID:       "12345",
+		},
+	}
+
+	store.On("Add", mock.Anything).Return(nil)
+	podWatcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
+	podWatcher.On("Expire").Return([]string{}, nil)
+
+	err := updateStore(context.TODO(), store, podWatcher, "default")
+	assert.NoError(t, err)
+
+	// Add() shouldn't be called because the pod is in a different namespace
+	store.AssertNotCalled(t, "Add", mock.Anything)
+}
+
+func TestUpdateStore_HandleExpiredPods(t *testing.T) {
+	store := new(MockStore)
+	podWatcher := new(MockPodWatcher)
+	podUID := "kubernetes_pod://pod-12345"
+	kubernetesPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("pod-12345"),
+		},
+	}
+
+	podWatcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{}, nil)
+	podWatcher.On("Expire").Return([]string{podUID}, nil)
+	store.On("Delete", &kubernetesPod).Return(nil)
+
+	err := updateStore(context.TODO(), store, podWatcher, "default")
+	assert.NoError(t, err)
+
+	store.AssertCalled(t, "Delete", &kubernetesPod)
+}
+
+func TestUpdateStore_HandleExpiredContainers(t *testing.T) {
+	store := new(MockStore)
+	podWatcher := new(MockPodWatcher)
+
+	podWatcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{}, nil)
+	podWatcher.On("Expire").Return([]string{"container-12345"}, nil)
+
+	err := updateStore(context.TODO(), store, podWatcher, "default")
+	assert.NoError(t, err)
+
+	// Delete() shouldn't be called because the expired entity is not a pod
+	store.AssertNotCalled(t, "Delete", mock.Anything)
+}

--- a/pkg/util/kubernetes/kubelet/conversion.go
+++ b/pkg/util/kubernetes/kubelet/conversion.go
@@ -1,0 +1,348 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet && kubeapiserver
+
+package kubelet
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ConvertKubeletPodToK8sPod converts a Pod to a Kubernetes Pod.
+// The Pod in this package is a simplification of the one in the Kubernetes
+// library, so the result will not contain all the fields. That's OK, because
+// this function is only called from the KSM check, so we only need to convert
+// the fields that are used by the check.
+func ConvertKubeletPodToK8sPod(pod *Pod) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Metadata.Name,
+			UID:       types.UID(pod.Metadata.UID),
+			Namespace: pod.Metadata.Namespace,
+			CreationTimestamp: metav1.Time{
+				Time: pod.Metadata.CreationTimestamp,
+			},
+			Annotations:     pod.Metadata.Annotations,
+			Labels:          pod.Metadata.Labels,
+			OwnerReferences: convertToK8sOwnerReferences(pod.Metadata.Owners),
+		},
+		Spec: corev1.PodSpec{
+			HostNetwork:       pod.Spec.HostNetwork,
+			NodeName:          pod.Spec.NodeName,
+			InitContainers:    convertToK8sContainers(pod.Spec.InitContainers),
+			Containers:        convertToK8sContainers(pod.Spec.Containers),
+			Volumes:           convertToK8sVolumes(pod.Spec.Volumes),
+			PriorityClassName: pod.Spec.PriorityClassName,
+			SecurityContext:   convertToK8sPodSecurityContext(pod.Spec.SecurityContext),
+			RuntimeClassName:  pod.Spec.RuntimeClassName,
+			Tolerations:       convertToK8sPodTolerations(pod.Spec.Tolerations),
+		},
+		Status: corev1.PodStatus{
+			Phase:                 corev1.PodPhase(pod.Status.Phase),
+			HostIP:                pod.Status.HostIP,
+			PodIP:                 pod.Status.PodIP,
+			ContainerStatuses:     convertToK8sContainerStatuses(pod.Status.Containers),
+			InitContainerStatuses: convertToK8sContainerStatuses(pod.Status.InitContainers),
+			Conditions:            convertToK8sConditions(pod.Status.Conditions),
+			QOSClass:              corev1.PodQOSClass(pod.Status.QOSClass),
+			StartTime: &metav1.Time{
+				Time: pod.Status.StartTime,
+			},
+			Reason: pod.Status.Reason,
+		},
+	}
+}
+
+func convertToK8sOwnerReferences(owners []PodOwner) []metav1.OwnerReference {
+	if owners == nil {
+		return nil
+	}
+
+	k8sOwnerReferences := make([]metav1.OwnerReference, len(owners))
+	for i, owner := range owners {
+		k8sOwnerReferences[i] = metav1.OwnerReference{
+			Kind:       owner.Kind,
+			Name:       owner.Name,
+			Controller: owner.Controller,
+		}
+	}
+	return k8sOwnerReferences
+}
+
+func convertToK8sContainers(containerSpecs []ContainerSpec) []corev1.Container {
+	if containerSpecs == nil {
+		return nil
+	}
+
+	k8sContainers := make([]corev1.Container, len(containerSpecs))
+	for i, containerSpec := range containerSpecs {
+		k8sContainers[i] = corev1.Container{
+			Name:            containerSpec.Name,
+			Image:           containerSpec.Image,
+			Ports:           convertToK8sContainerPorts(containerSpec.Ports),
+			ReadinessProbe:  convertToK8sProbe(containerSpec.ReadinessProbe),
+			Env:             convertToK8sEnvVars(containerSpec.Env),
+			SecurityContext: convertToK8sContainerSecurityContext(containerSpec.SecurityContext),
+			Resources:       convertToK8sResourceRequirements(containerSpec.Resources),
+		}
+	}
+	return k8sContainers
+}
+
+func convertToK8sVolumes(volumeSpecs []VolumeSpec) []corev1.Volume {
+	if volumeSpecs == nil {
+		return nil
+	}
+
+	k8sVolumes := make([]corev1.Volume, len(volumeSpecs))
+	for i, volumeSpec := range volumeSpecs {
+		k8sVolumes[i] = corev1.Volume{
+			Name: volumeSpec.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: convertToK8sPersistentVolumeClaim(volumeSpec.PersistentVolumeClaim),
+				Ephemeral:             convertToK8sEphemeralVolume(volumeSpec.Ephemeral),
+			},
+		}
+	}
+	return k8sVolumes
+}
+
+func convertToK8sPodSecurityContext(podSecurityContextSpec *PodSecurityContextSpec) *corev1.PodSecurityContext {
+	if podSecurityContextSpec == nil {
+		return nil
+	}
+
+	runAsUser := int64(podSecurityContextSpec.RunAsUser)
+	runAsGroup := int64(podSecurityContextSpec.RunAsGroup)
+	fsGroup := int64(podSecurityContextSpec.FsGroup)
+
+	return &corev1.PodSecurityContext{
+		RunAsUser:  &runAsUser,
+		RunAsGroup: &runAsGroup,
+		FSGroup:    &fsGroup,
+	}
+}
+
+func convertToK8sContainerPorts(containerPortSpecs []ContainerPortSpec) []corev1.ContainerPort {
+	if containerPortSpecs == nil {
+		return nil
+	}
+
+	k8sPorts := make([]corev1.ContainerPort, len(containerPortSpecs))
+	for i, containerPortSpec := range containerPortSpecs {
+		k8sPorts[i] = corev1.ContainerPort{
+			ContainerPort: int32(containerPortSpec.ContainerPort),
+			HostPort:      int32(containerPortSpec.HostPort),
+			Name:          containerPortSpec.Name,
+			Protocol:      corev1.Protocol(containerPortSpec.Protocol),
+		}
+	}
+	return k8sPorts
+}
+
+func convertToK8sProbe(containerProbe *ContainerProbe) *corev1.Probe {
+	if containerProbe == nil {
+		return nil
+	}
+	return &corev1.Probe{
+		InitialDelaySeconds: int32(containerProbe.InitialDelaySeconds),
+	}
+}
+
+func convertToK8sEnvVars(envVars []EnvVar) []corev1.EnvVar {
+	if envVars == nil {
+		return nil
+	}
+
+	k8sEnvVars := make([]corev1.EnvVar, len(envVars))
+	for i, envVar := range envVars {
+		k8sEnvVars[i] = corev1.EnvVar{
+			Name:  envVar.Name,
+			Value: envVar.Value,
+		}
+	}
+	return k8sEnvVars
+}
+
+func convertToK8sContainerSecurityContext(containerSecurityContextSpec *ContainerSecurityContextSpec) *corev1.SecurityContext {
+	if containerSecurityContextSpec == nil {
+		return nil
+	}
+	return &corev1.SecurityContext{
+		Capabilities:   convertToK8sCapabilities(containerSecurityContextSpec.Capabilities),
+		Privileged:     containerSecurityContextSpec.Privileged,
+		SeccompProfile: convertToK8sSeccompProfile(containerSecurityContextSpec.SeccompProfile),
+	}
+}
+
+func convertToK8sCapabilities(capabilities *CapabilitiesSpec) *corev1.Capabilities {
+	if capabilities == nil {
+		return nil
+	}
+
+	res := &corev1.Capabilities{}
+
+	for _, addCapability := range capabilities.Add {
+		res.Add = append(res.Add, corev1.Capability(addCapability))
+	}
+
+	for _, dropCapability := range capabilities.Drop {
+		res.Drop = append(res.Drop, corev1.Capability(dropCapability))
+	}
+
+	return res
+}
+
+func convertToK8sSeccompProfile(seccompProfileSpec *SeccompProfileSpec) *corev1.SeccompProfile {
+	if seccompProfileSpec == nil {
+		return nil
+	}
+	return &corev1.SeccompProfile{
+		Type:             corev1.SeccompProfileType(seccompProfileSpec.Type),
+		LocalhostProfile: seccompProfileSpec.LocalhostProfile,
+	}
+}
+
+func convertToK8sResourceRequirements(containerResourcesSpec *ContainerResourcesSpec) corev1.ResourceRequirements {
+	if containerResourcesSpec == nil {
+		return corev1.ResourceRequirements{}
+	}
+	return corev1.ResourceRequirements{
+		Requests: convertToK8sResourceList(containerResourcesSpec.Requests),
+		Limits:   convertToK8sResourceList(containerResourcesSpec.Limits),
+	}
+}
+
+func convertToK8sResourceList(resourceList ResourceList) corev1.ResourceList {
+	k8sResourceList := make(corev1.ResourceList)
+	for k, v := range resourceList {
+		k8sResourceList[corev1.ResourceName(k)] = v
+	}
+	return k8sResourceList
+}
+
+func convertToK8sPersistentVolumeClaim(persistentVolumeClaimSpec *PersistentVolumeClaimSpec) *corev1.PersistentVolumeClaimVolumeSource {
+	if persistentVolumeClaimSpec == nil {
+		return nil
+	}
+	return &corev1.PersistentVolumeClaimVolumeSource{
+		ClaimName: persistentVolumeClaimSpec.ClaimName,
+		ReadOnly:  persistentVolumeClaimSpec.ReadOnly,
+	}
+}
+
+func convertToK8sEphemeralVolume(ephemeralSpec *EphemeralSpec) *corev1.EphemeralVolumeSource {
+	if ephemeralSpec == nil {
+		return nil
+	}
+	return &corev1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        ephemeralSpec.VolumeClaimTemplate.Metadata.Name,
+				UID:         types.UID(ephemeralSpec.VolumeClaimTemplate.Metadata.UID),
+				Annotations: ephemeralSpec.VolumeClaimTemplate.Metadata.Annotations,
+				Labels:      ephemeralSpec.VolumeClaimTemplate.Metadata.Labels,
+			},
+		},
+	}
+}
+
+func convertToK8sContainerStatuses(containerStatuses []ContainerStatus) []corev1.ContainerStatus {
+	if containerStatuses == nil {
+		return nil
+	}
+
+	k8sStatuses := make([]corev1.ContainerStatus, len(containerStatuses))
+	for i, containerStatus := range containerStatuses {
+		k8sStatuses[i] = corev1.ContainerStatus{
+			Name:                 containerStatus.Name,
+			Image:                containerStatus.Image,
+			ImageID:              containerStatus.ImageID,
+			ContainerID:          containerStatus.ID,
+			Ready:                containerStatus.Ready,
+			RestartCount:         int32(containerStatus.RestartCount),
+			State:                convertToK8sContainerState(containerStatus.State),
+			LastTerminationState: convertToK8sContainerState(containerStatus.LastState),
+		}
+	}
+	return k8sStatuses
+}
+
+func convertToK8sContainerState(containerState ContainerState) corev1.ContainerState {
+	return corev1.ContainerState{
+		Waiting:    convertToK8sContainerStateWaiting(containerState.Waiting),
+		Running:    convertToK8sContainerStateRunning(containerState.Running),
+		Terminated: convertToK8sContainerStateTerminated(containerState.Terminated),
+	}
+}
+
+func convertToK8sContainerStateWaiting(containerStateWaiting *ContainerStateWaiting) *corev1.ContainerStateWaiting {
+	if containerStateWaiting == nil {
+		return nil
+	}
+	return &corev1.ContainerStateWaiting{
+		Reason: containerStateWaiting.Reason,
+	}
+}
+
+func convertToK8sContainerStateRunning(containerStateRunning *ContainerStateRunning) *corev1.ContainerStateRunning {
+	if containerStateRunning == nil {
+		return nil
+	}
+	return &corev1.ContainerStateRunning{
+		StartedAt: metav1.Time{Time: containerStateRunning.StartedAt},
+	}
+}
+
+func convertToK8sContainerStateTerminated(containerStateTerminated *ContainerStateTerminated) *corev1.ContainerStateTerminated {
+	if containerStateTerminated == nil {
+		return nil
+	}
+	return &corev1.ContainerStateTerminated{
+		ExitCode:   containerStateTerminated.ExitCode,
+		StartedAt:  metav1.Time{Time: containerStateTerminated.StartedAt},
+		FinishedAt: metav1.Time{Time: containerStateTerminated.FinishedAt},
+		Reason:     containerStateTerminated.Reason,
+	}
+}
+
+func convertToK8sConditions(conditions []Conditions) []corev1.PodCondition {
+	if conditions == nil {
+		return nil
+	}
+
+	k8sConditions := make([]corev1.PodCondition, len(conditions))
+	for i, condition := range conditions {
+		k8sConditions[i] = corev1.PodCondition{
+			Type:   corev1.PodConditionType(condition.Type),
+			Status: corev1.ConditionStatus(condition.Status),
+		}
+	}
+	return k8sConditions
+}
+
+func convertToK8sPodTolerations(tolerations []Toleration) []corev1.Toleration {
+	if tolerations == nil {
+		return nil
+	}
+
+	k8sTolerations := make([]corev1.Toleration, len(tolerations))
+	for i, toleration := range tolerations {
+		k8sTolerations[i] = corev1.Toleration{
+			Key:               toleration.Key,
+			Operator:          corev1.TolerationOperator(toleration.Operator),
+			Value:             toleration.Value,
+			Effect:            corev1.TaintEffect(toleration.Effect),
+			TolerationSeconds: toleration.TolerationSeconds,
+		}
+	}
+	return k8sTolerations
+}

--- a/pkg/util/kubernetes/kubelet/conversion_test.go
+++ b/pkg/util/kubernetes/kubelet/conversion_test.go
@@ -1,0 +1,299 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet && kubeapiserver
+
+package kubelet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func TestConvertKubeletPodToK8sPod(t *testing.T) {
+	now := time.Now()
+
+	pod := &Pod{
+		Metadata: PodMetadata{
+			Name:              "test-pod",
+			UID:               "12345",
+			Namespace:         "default",
+			CreationTimestamp: now,
+			Annotations: map[string]string{
+				"annotation-key": "annotation-value",
+			},
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+			Owners: []PodOwner{
+				{
+					Kind:       "ReplicaSet",
+					Name:       "rs1",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: Spec{
+			HostNetwork: true,
+			NodeName:    "node1",
+			InitContainers: []ContainerSpec{
+				{
+					Name:  "init-container",
+					Image: "init-image",
+				},
+			},
+			Containers: []ContainerSpec{
+				{
+					Name:  "main-container",
+					Image: "main-image",
+					Ports: []ContainerPortSpec{
+						{
+							ContainerPort: 7777,
+							HostPort:      8888,
+							Name:          "port",
+							Protocol:      "TCP",
+						},
+					},
+					ReadinessProbe: &ContainerProbe{
+						InitialDelaySeconds: 10,
+					},
+					Env: []EnvVar{
+						{
+							Name:  "SOME_ENV",
+							Value: "some_env_value",
+						},
+					},
+					SecurityContext: &ContainerSecurityContextSpec{
+						Capabilities: &CapabilitiesSpec{
+							Add:  []string{"CAP_SYS_ADMIN"},
+							Drop: []string{"CAP_NET_RAW"},
+						},
+						Privileged: ptr.To(true),
+						SeccompProfile: &SeccompProfileSpec{
+							Type:             SeccompProfileTypeRuntimeDefault,
+							LocalhostProfile: ptr.To("localhost-profile"),
+						},
+					},
+					Resources: &ContainerResourcesSpec{
+						Requests: ResourceList{
+							"cpu":    resource.MustParse("100m"),
+							"memory": resource.MustParse("200Mi"),
+						},
+						Limits: ResourceList{
+							"cpu":    resource.MustParse("200m"),
+							"memory": resource.MustParse("400Mi"),
+						},
+					},
+				},
+			},
+			Volumes: []VolumeSpec{
+				{
+					Name: "volume1",
+					PersistentVolumeClaim: &PersistentVolumeClaimSpec{
+						ClaimName: "some-claim",
+						ReadOnly:  true,
+					},
+				},
+			},
+			PriorityClassName: "high-priority",
+			SecurityContext: &PodSecurityContextSpec{
+				RunAsUser:  1000,
+				RunAsGroup: 2000,
+				FsGroup:    3000,
+			},
+			RuntimeClassName: ptr.To("runtime-class"),
+			Tolerations: []Toleration{
+				{
+					Key:      "key1",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+		},
+		Status: Status{
+			Phase:  "Running",
+			HostIP: "192.168.1.1",
+			PodIP:  "10.0.0.1",
+			Containers: []ContainerStatus{
+				{
+					Name:  "main-container",
+					Image: "main-image",
+					Ready: true,
+					State: ContainerState{
+						Running: &ContainerStateRunning{
+							StartedAt: now,
+						},
+					},
+				},
+			},
+			InitContainers: []ContainerStatus{
+				{
+					Name:  "init-container",
+					Image: "init-image",
+					Ready: true,
+				},
+			},
+			Conditions: []Conditions{
+				{
+					Type:   "Ready",
+					Status: "True",
+				},
+			},
+			QOSClass:  "BestEffort",
+			StartTime: now,
+			Reason:    "Started",
+		},
+	}
+
+	expectedPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pod",
+			UID:               types.UID("12345"),
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now),
+			Annotations: map[string]string{
+				"annotation-key": "annotation-value",
+			},
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       "rs1",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			HostNetwork: true,
+			NodeName:    "node1",
+			InitContainers: []corev1.Container{
+				{
+					Name:  "init-container",
+					Image: "init-image",
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "main-container",
+					Image: "main-image",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 7777,
+							HostPort:      8888,
+							Name:          "port",
+							Protocol:      "TCP",
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						InitialDelaySeconds: 10,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "SOME_ENV",
+							Value: "some_env_value",
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add:  []corev1.Capability{"CAP_SYS_ADMIN"},
+							Drop: []corev1.Capability{"CAP_NET_RAW"},
+						},
+						Privileged: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type:             corev1.SeccompProfileTypeRuntimeDefault,
+							LocalhostProfile: ptr.To("localhost-profile"),
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource.MustParse("100m"),
+							"memory": resource.MustParse("200Mi"),
+						},
+						Limits: corev1.ResourceList{
+							"cpu":    resource.MustParse("200m"),
+							"memory": resource.MustParse("400Mi"),
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "volume1",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "some-claim",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			PriorityClassName: "high-priority",
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:  ptr.To[int64](1000),
+				RunAsGroup: ptr.To[int64](2000),
+				FSGroup:    ptr.To[int64](3000),
+			},
+			RuntimeClassName: ptr.To("runtime-class"),
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "key1",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodPhase("Running"),
+			HostIP: "192.168.1.1",
+			PodIP:  "10.0.0.1",
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "main-container",
+					Image: "main-image",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{
+								Time: now,
+							},
+						},
+					},
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "init-container",
+					Image: "init-image",
+					Ready: true,
+				},
+			},
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodConditionType("Ready"),
+					Status: corev1.ConditionStatus("True"),
+				},
+			},
+			QOSClass: corev1.PodQOSClass("BestEffort"),
+			StartTime: &metav1.Time{
+				Time: now,
+			},
+			Reason: "Started",
+		},
+	}
+
+	assert.Equal(t, expectedPod, ConvertKubeletPodToK8sPod(pod))
+}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -28,20 +28,22 @@ type PodList struct {
 
 // PodMetadata contains fields for unmarshalling a pod's metadata
 type PodMetadata struct {
-	Name        string            `json:"name,omitempty"`
-	UID         string            `json:"uid,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	ResVersion  string            `json:"resourceVersion,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Owners      []PodOwner        `json:"ownerReferences,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	UID               string            `json:"uid,omitempty"`
+	Namespace         string            `json:"namespace,omitempty"`
+	ResVersion        string            `json:"resourceVersion,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Owners            []PodOwner        `json:"ownerReferences,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp,omitempty"`
 }
 
 // PodOwner contains fields for unmarshalling a Pod.Metadata.Owners
 type PodOwner struct {
-	Kind string `json:"kind,omitempty"`
-	Name string `json:"name,omitempty"`
-	ID   string `json:"uid,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ID         string `json:"uid,omitempty"`
+	Controller *bool  `json:"controller,omitempty"`
 }
 
 // Spec contains fields for unmarshalling a Pod.Spec
@@ -54,6 +56,7 @@ type Spec struct {
 	PriorityClassName string                  `json:"priorityClassName,omitempty"`
 	SecurityContext   *PodSecurityContextSpec `json:"securityContext,omitempty"`
 	RuntimeClassName  *string                 `json:"runtimeClassName,omitempty"`
+	Tolerations       []Toleration            `json:"tolerations,omitempty"`
 }
 
 // PodSecurityContextSpec contains fields for unmarshalling a Pod.Spec.SecurityContext
@@ -72,6 +75,15 @@ type ContainerSpec struct {
 	Env             []EnvVar                      `json:"env,omitempty"`
 	SecurityContext *ContainerSecurityContextSpec `json:"securityContext,omitempty"`
 	Resources       *ContainerResourcesSpec       `json:"resources,omitempty"`
+}
+
+// Toleration contains fields for unmarshalling a Pod.Spec.Tolerations
+type Toleration struct {
+	Key               string `json:"key,omitempty"`
+	Operator          string `json:"operator,omitempty"`
+	Value             string `json:"value,omitempty"`
+	Effect            string `json:"effect,omitempty"`
+	TolerationSeconds *int64 `json:"tolerationSeconds,omitempty"`
 }
 
 // ResourceName is the key to fields in in Pod.Spec.Containers.Resources
@@ -155,6 +167,7 @@ type VolumeSpec struct {
 // PersistentVolumeClaimSpec contains fields for unmarshalling a Pod.Spec.Volumes.PersistentVolumeClaim
 type PersistentVolumeClaimSpec struct {
 	ClaimName string `json:"claimName"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
 }
 
 // EphemeralSpec contains fields for unmarshalling a Pod.Spec.Volumes.Ephemeral
@@ -177,6 +190,8 @@ type Status struct {
 	AllContainers  []ContainerStatus
 	Conditions     []Conditions `json:"conditions,omitempty"`
 	QOSClass       string       `json:"qosClass,omitempty"`
+	StartTime      time.Time    `json:"startTime,omitempty"`
+	Reason         string       `json:"reason,omitempty"`
 }
 
 // GetAllContainers returns the list of init and regular containers

--- a/releasenotes-dca/notes/ksm-pods-in-node-agent-13d9041602521d42.yaml
+++ b/releasenotes-dca/notes/ksm-pods-in-node-agent-13d9041602521d42.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Kubernetes State Metrics (KSM) check can now be configured to collect
+    pods from the Kubelet in node agents instead of collecting them from the API
+    Server in the Cluster Agent or the Cluster check runners. This is useful in
+    clusters with a large number of pods where emitting pod metrics from a
+    single check instance can cause performance issues due to the large number
+    of metrics emitted.

--- a/releasenotes/notes/ksm-pods-in-node-agent-13d9041602521d42.yaml
+++ b/releasenotes/notes/ksm-pods-in-node-agent-13d9041602521d42.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Kubernetes State Metrics (KSM) check can now be configured to collect
+    pods from the Kubelet in node agents instead of collecting them from the API
+    Server in the Cluster Agent or the Cluster check runners. This is useful in
+    clusters with a large number of pods where emitting pod metrics from a
+    single check instance can cause performance issues due to the large number
+    of metrics emitted.


### PR DESCRIPTION
### What does this PR do?

This PR introduces an option in the Kubernetes State Metrics (KSM) check to be able to collect pods from the Kubelet in node agents instead of collecting them from the API Server in the Cluster Agent or the Cluster check runners.

This is useful in clusters with a large number of pods where emitting pod metrics from a single check instance might be too much and causes issues like: long execution time, interference with other checks, high cpu/mem requirements, and instability issues in general.

The new option is `pod_collection_mode` and it accepts these values:
- "" or "default": current behavior (this is the default).
- "node_kubelet": collects pods from the Kubelet. This is meant to be enabled when the check is running on the node agent.
- "cluster_unassigned": collects pods from the API server, but only the unassigned ones. This is meant to be enabled when the check is running on the cluster agent or the cluster check runner and "node_kubelet" is enabled in the node agents, because unassigned pods cannot be collected from node agents.

One thing to note is that when the node agent collects metrics from the kubelet and the cluster agent or cluster check runner collects metrics for other resources, label joins are not supported for pod metrics if the join source is not a pod.

There are some things that could be optimized or organized a bit better. For example, I'd like to use workloadmeta instead of the pod watcher in the reflector. But I prefer to start with a simple solution. I'll optimize and reorganize things in future PRs if needed.

### Describe how to test/QA your changes

This is the minimal config needed to enable the feature using the helm chart:
```yaml
datadog:
  kubelet:
    tlsVerify: false # Local cluster for testing
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
            - pods
          pod_collection_mode: "node_kubelet"
clusterAgent:
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - pod_collection_mode: "cluster_unassigned"
```

The idea is to verify that using this config we get the same metrics with the same tags as when using the current way of running the KSM check. I have a notebook for this, ask me.
We also need to check that this doesn't introduce any performance issue on the node agents. I'm currently checking this on some internal clusters. Ask me for more details.