### PR TITLE
fix(APMON-1429): apply security context to all init containers

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -568,8 +568,7 @@ func (w *Webhook) initContainerMutators() containerMutators {
 	}
 }
 
-func (w *Webhook) newInjector(startTime time.Time, pod *corev1.Pod) podMutator {
-	var opts []injectorOption
+func (w *Webhook) newInjector(startTime time.Time, pod *corev1.Pod, opts ...injectorOption) podMutator {
 	for _, e := range []annotationExtractor[injectorOption]{
 		injectorVersionAnnotationExtractor,
 		injectorImageAnnotationExtractor,
@@ -599,9 +598,11 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
-		injector              = w.newInjector(time.Now(), pod)
 		initContainerMutators = w.initContainerMutators()
-		containerMutators     = containerMutators{
+		injector              = w.newInjector(time.Now(), pod, injectorWithLibRequirementOptions(libRequirementOptions{
+			initContainerMutators: initContainerMutators,
+		}))
+		containerMutators = containerMutators{
 			config.languageDetection.containerMutator(w.version),
 		}
 	)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
@@ -75,6 +75,7 @@ type injector struct {
 	registry   string
 	injected   bool
 	injectTime time.Time
+	opts       libRequirementOptions
 }
 
 func (i *injector) initContainer() initContainer {
@@ -114,7 +115,8 @@ func (i *injector) initContainer() initContainer {
 
 func (i *injector) requirements() libRequirement {
 	return libRequirement{
-		initContainers: []initContainer{i.initContainer()},
+		libRequirementOptions: i.opts,
+		initContainers:        []initContainer{i.initContainer()},
 		volumes: []volume{
 			sourceVolume,
 			etcVolume,
@@ -150,6 +152,12 @@ var injectorVersionAnnotationExtractor = annotationExtractor[injectorOption]{
 var injectorImageAnnotationExtractor = annotationExtractor[injectorOption]{
 	key: "admission.datadoghq.com/apm-inject.custom-image",
 	do:  infallibleFn(injectorWithImageName),
+}
+
+func injectorWithLibRequirementOptions(opts libRequirementOptions) injectorOption {
+	return func(i *injector) {
+		i.opts = opts
+	}
 }
 
 func injectorWithImageName(name string) injectorOption {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector_test.go
@@ -11,10 +11,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestInjectorOptions(t *testing.T) {
 	i := newInjector(time.Now(), "registry", "1")
 	require.Equal(t, "registry/apm-inject:1", i.image)
+}
+
+func TestInjectorLibRequirements(t *testing.T) {
+	mutators := containerMutators{
+		containerSecurityContext{
+			&corev1.SecurityContext{
+				AllowPrivilegeEscalation: pointer.Ptr(false),
+			},
+		},
+	}
+	i := newInjector(time.Now(), "registry", "1",
+		injectorWithLibRequirementOptions(libRequirementOptions{initContainerMutators: mutators}),
+	)
+
+	opts := i.requirements().libRequirementOptions
+	require.Equal(t, 1, len(opts.initContainerMutators))
+
+	container := corev1.Container{}
+	err := opts.initContainerMutators[0].mutateContainer(&container)
+	require.NoError(t, err)
+
+	require.Equal(t, &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Ptr(false),
+	}, container.SecurityContext)
 }


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/APMON-1429

Ensures that `initSecurityContext` parameters are applied to all init containers that are injected via auto-instrumentation.

### Motivation

During QA testing of https://datadoghq.atlassian.net/browse/APMON-1368 I noticed that we didn't propagate the security context to the `inject` init container. 

### Additional Notes

This passes through the same `initContainerMutators` to the injector `requirements` as we do for the rest of the library requirements.


### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

- [x] Added regression tests to make sure that all init containers get the security context applied.
- [x] Manual QA with built image and validating security contexts applied to all initContainers. 