### PR TITLE
Fix flaky apiserver unit test

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -535,9 +535,9 @@ func TestUnbundledEventsTransform(t *testing.T) {
 
 			events, errors := transformer.Transform(incomingEvents)
 
-			// Sort events by title for easier comparison
+			// Sort events by title and description for easier comparison
 			sort.SliceStable(events, func(i, j int) bool {
-				return events[i].Title < events[j].Title
+				return events[i].Title+events[i].Text < events[j].Title+events[j].Text
 			})
 
 			assert.Empty(t, errors)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Fix flaky TestUnbundledEventsTransform/unbundled_events_by_Kind:ReplicaSet_and_Reason:Killing,SuccessfulDelete test

### Motivation

Second attempt at a fix, first attempt can be found here: https://github.com/DataDog/datadog-agent/pull/28715

### Additional Notes



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I manually ran the test 1000 times before and after the change:

Before:
```
$ go test -tags kubeapiserver,test -count 1000 github.com/DataDog/datadog-agent/
pkg/collector/corechecks/cluster/kubernetesapiserver | grep "FAIL: TestUnbundledEventsTransform (" 

--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.03s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.01s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.02s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)
--- FAIL: TestUnbundledEventsTransform (0.00s)

```

After:
```
$ go test -tags kubeapiserver,test -count 1000 github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetesapiserver | grep "FAIL: TestUnbundledEventsTransform ("


```
(no failures in 1000 executions)