### PR TITLE
stop manager before protocols

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -273,13 +273,14 @@ func (e *ebpfProgram) Start() error {
 // Close stops the ebpf program and cleans up all resources.
 func (e *ebpfProgram) Close() error {
 	e.mapCleaner.Stop()
+	ebpftelemetry.UnregisterTelemetry(e.Manager.Manager)
+	err := e.Stop(manager.CleanAll)
 	stopProtocolWrapper := func(protocol protocols.Protocol, m *manager.Manager) error {
 		protocol.Stop(m)
 		return nil
 	}
 	e.executePerProtocol(e.enabledProtocols, "stop", stopProtocolWrapper, nil)
-	ebpftelemetry.UnregisterTelemetry(e.Manager.Manager)
-	return e.Stop(manager.CleanAll)
+	return err
 }
 
 func (e *ebpfProgram) initCORE() error {


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Stops the USM ebpf-manager before the individual protocols.

### Motivation

This is to prevent a send on a closed channel in the event consumers. If the manager is not stopped, it will continue to consume from the ebpf perf/ring buffers and call callbacks. Those callbacks will try to send on a closed channel due to a race on the `closed` flag.

### Additional Notes

Technically this is a data race on the `closed` flag, but there isn't a good way to prevent it without having some performance impact.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
