### PR TITLE
change security agent windows service display name for consistency

### DIFF
--- a/releasenotes/notes/security-agent-windows-service-display-name-06e283e5d5840148.yaml
+++ b/releasenotes/notes/security-agent-windows-service-display-name-06e283e5d5840148.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Change ``datadog-security-agent`` display name from  ``Datadog Security Service`` to
+    Change the ``datadog-security-agent`` Windows service display name from  ``Datadog Security Service`` to
     ``Datadog Security Agent`` for consistency with other Agent services.

--- a/releasenotes/notes/security-agent-windows-service-display-name-06e283e5d5840148.yaml
+++ b/releasenotes/notes/security-agent-windows-service-display-name-06e283e5d5840148.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Change ``datadog-security-agent`` display name from  ``Datadog Security Service`` to
+    ``Datadog Security Agent`` for consistency with other Agent services.

--- a/test/new-e2e/tests/windows/install-test/service-test/tester.go
+++ b/test/new-e2e/tests/windows/install-test/service-test/tester.go
@@ -126,7 +126,7 @@ func (t *Tester) ExpectedServiceConfig() (windowsCommon.ServiceConfigMap, error)
 	m["datadogagent"].DisplayName = "Datadog Agent"
 	m["datadog-trace-agent"].DisplayName = "Datadog Trace Agent"
 	m["datadog-process-agent"].DisplayName = "Datadog Process Agent"
-	m["datadog-security-agent"].DisplayName = "Datadog Security Service"
+	m["datadog-security-agent"].DisplayName = "Datadog Security Agent"
 	m["datadog-system-probe"].DisplayName = "Datadog System Probe"
 	m["ddnpm"].DisplayName = "Datadog Network Performance Monitor"
 	m["ddprocmon"].DisplayName = "Datadog Process Monitor"

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -516,7 +516,7 @@ namespace WixSetup.Datadog_Agent
             var securityAgentService = GenerateDependentServiceInstaller(
                 new Id("ddagentsecurityservice"),
                 Constants.SecurityAgentServiceName,
-                "Datadog Security Service",
+                "Datadog Security Agent",
                 "Send Security events to Datadog",
                 "[DDAGENTUSER_PROCESSED_FQ_NAME]",
                 "[DDAGENTUSER_PROCESSED_PASSWORD]");


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change the ``datadog-security-agent`` Windows service display name from  ``Datadog Security Service`` to``Datadog Security Agent`` for consistency with other Agent services.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-985

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
