### PR TITLE
Log pid file removal

### DIFF
--- a/comp/core/pid/pidimpl/pid.go
+++ b/comp/core/pid/pidimpl/pid.go
@@ -55,7 +55,12 @@ func newPID(deps dependencies) (pid.Component, error) {
 
 		deps.Lc.Append(fx.Hook{
 			OnStop: func(context.Context) error {
-				_ = os.Remove(pidfilePath)
+				err = os.Remove(pidfilePath)
+				if err != nil {
+					deps.Log.Errorf("Error while removing PID file: %v", err)
+				} else {
+					deps.Log.Infof("Removed PID file: %s", pidfilePath)
+				}
 				return nil
 			}})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add logs to understand if the pid file is properly deleted
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
On redhat 8, the process.pid file appears to stay even after the process-agent stops in some cases https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/619450393/raw

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
It should be visible in the failed Redhat 8 test
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
