### PR TITLE
[NDMII-3023] enrich snmp metrics with device user tags

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -181,10 +181,11 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckOK, tags, "")
 	}
 
-	d.sender.Gauge(deviceReachableMetric, utils.BoolToFloat64(deviceReachable), tags)
-	d.sender.Gauge(deviceUnreachableMetric, utils.BoolToFloat64(!deviceReachable), tags)
+	metricTags := append(tags, "dd.internal.resource:ndm_device_user_tags:"+d.GetDeviceID())
+	d.sender.Gauge(deviceReachableMetric, utils.BoolToFloat64(deviceReachable), metricTags)
+	d.sender.Gauge(deviceUnreachableMetric, utils.BoolToFloat64(!deviceReachable), metricTags)
 	if values != nil {
-		d.sender.ReportMetrics(d.config.Metrics, values, tags, d.config.DeviceID)
+		d.sender.ReportMetrics(d.config.Metrics, values, metricTags, d.config.DeviceID)
 	}
 
 	// Get a system appropriate ping check
@@ -196,8 +197,8 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 			log.Errorf("%s: failed to ping device: %s", d.config.IPAddress, err.Error())
 			pingStatus = metadata.DeviceStatusUnreachable
 			d.diagnoses.Add("error", "SNMP_FAILED_TO_PING_DEVICE", "Agent encountered an error when pinging this network device. Check agent logs for more details.")
-			d.sender.Gauge(pingReachableMetric, utils.BoolToFloat64(false), tags)
-			d.sender.Gauge(pingUnreachableMetric, utils.BoolToFloat64(true), tags)
+			d.sender.Gauge(pingReachableMetric, utils.BoolToFloat64(false), metricTags)
+			d.sender.Gauge(pingUnreachableMetric, utils.BoolToFloat64(true), metricTags)
 		} else {
 			// if ping succeeds, set pingCanConnect for use in metadata and send metrics
 			log.Debugf("%s: ping returned: %+v", d.config.IPAddress, pingResult)
@@ -206,7 +207,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 			} else {
 				pingStatus = metadata.DeviceStatusUnreachable
 			}
-			d.submitPingMetrics(pingResult, tags)
+			d.submitPingMetrics(pingResult, metricTags)
 		}
 	} else {
 		log.Tracef("%s: SNMP ping disabled for host", d.config.IPAddress)
@@ -236,7 +237,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		d.sender.ReportNetworkDeviceMetadata(d.config, values, deviceMetadataTags, collectionTime, deviceStatus, pingStatus, deviceDiagnosis)
 	}
 
-	d.submitTelemetryMetrics(startTime, tags)
+	d.submitTelemetryMetrics(startTime, metricTags)
 	d.setDeviceHostExternalTags()
 	d.interfaceBandwidthState.RemoveExpiredBandwidthUsageRates(startTime.UnixNano())
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add the internal resource tag to enrich the snmp device metrics with the user tags from REDAPL
I checked that if there is the host tag and this tag, this won't duplicate the tags

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
