### PR TITLE
languagedetection: Read binID directly from exe

### DIFF
--- a/pkg/languagedetection/privileged/privileged_detector.go
+++ b/pkg/languagedetection/privileged/privileged_detector.go
@@ -111,7 +111,7 @@ func (l *LanguageDetector) getBinID(process languagemodels.Process) (binaryID, e
 	exePath := filepath.Join(procPath, "exe")
 
 	var stat syscall.Stat_t
-	
+
 	if err := syscall.Stat(exePath, &stat); err != nil {
 		return binaryID{}, fmt.Errorf("stat binary path %s: %v", exePath, err)
 	}

--- a/pkg/languagedetection/privileged/privileged_detector.go
+++ b/pkg/languagedetection/privileged/privileged_detector.go
@@ -109,17 +109,11 @@ func MockPrivilegedDetectors(t *testing.T, newDetectors []languagemodels.Detecto
 func (l *LanguageDetector) getBinID(process languagemodels.Process) (binaryID, error) {
 	procPath := filepath.Join(l.hostProc, strconv.Itoa(int(process.GetPid())))
 	exePath := filepath.Join(procPath, "exe")
-	binPath, err := os.Readlink(exePath)
-	if err != nil {
-		return binaryID{}, fmt.Errorf("readlink %s: %v", exePath, err)
-	}
-
-	binPath = filepath.Join(procPath, "root", binPath)
 
 	var stat syscall.Stat_t
-	err = syscall.Stat(binPath, &stat)
+	err := syscall.Stat(exePath, &stat)
 	if err != nil {
-		return binaryID{}, fmt.Errorf("stat binary path %s: %v", binPath, err)
+		return binaryID{}, fmt.Errorf("stat binary path %s: %v", exePath, err)
 	}
 
 	return binaryID{

--- a/pkg/languagedetection/privileged/privileged_detector.go
+++ b/pkg/languagedetection/privileged/privileged_detector.go
@@ -111,8 +111,8 @@ func (l *LanguageDetector) getBinID(process languagemodels.Process) (binaryID, e
 	exePath := filepath.Join(procPath, "exe")
 
 	var stat syscall.Stat_t
-	err := syscall.Stat(exePath, &stat)
-	if err != nil {
+	
+	if err := syscall.Stat(exePath, &stat); err != nil {
 		return binaryID{}, fmt.Errorf("stat binary path %s: %v", exePath, err)
 	}
 

--- a/pkg/languagedetection/privileged/privileged_detector_test.go
+++ b/pkg/languagedetection/privileged/privileged_detector_test.go
@@ -111,7 +111,7 @@ func copyForkExecDelete(t *testing.T, timeout int) *exec.Cmd {
 	// cmd.Start() waits for the exec to happen so deleting the file should be
 	// safe immediately. Unclear what the sleep above is for; it's copied from
 	// the other tests.
-	os.Remove((sleepBin))
+	os.Remove(sleepBin)
 
 	t.Cleanup(func() {
 		err := cmd.Process.Kill()

--- a/pkg/languagedetection/privileged/privileged_detector_test.go
+++ b/pkg/languagedetection/privileged/privileged_detector_test.go
@@ -104,10 +104,9 @@ func copyForkExecDelete(t *testing.T, timeout int) *exec.Cmd {
 	require.NoError(t, exec.Command("cp", "/bin/sleep", sleepBin).Run())
 
 	cmd := exec.Command(sleepBin, strconv.Itoa(timeout))
-	err := cmd.Start()
+	require.NoError(t, cmd.Start())
 
 	time.Sleep(250 * time.Millisecond)
-	require.NoError(t, err)
 
 	// cmd.Start() waits for the exec to happen so deleting the file should be
 	// safe immediately. Unclear what the sleep above is for; it's copied from

--- a/pkg/languagedetection/privileged/privileged_detector_test.go
+++ b/pkg/languagedetection/privileged/privileged_detector_test.go
@@ -99,6 +99,14 @@ func TestGetBinID(t *testing.T) {
 	assert.Equal(t, binID1, binID2)
 }
 
+// copyForkExecDelete creates a scenario where the executable is not longer
+// available while it is running. We make a copy of "sleep" to a temporary path,
+// exec the copy, and delete it. This will result in the exe symlink looking
+// something like the below (note that the "(deleted)" string is part of the
+// actual content of the link), so attempting to resolve the target path will
+// not work, but stating/opening the exe file will still work.
+//
+//	/proc/123/exe -> /tmp/foo/sleep (deleted)
 func copyForkExecDelete(t *testing.T, timeout int) *exec.Cmd {
 	sleepBin := filepath.Join(t.TempDir(), "sleep")
 	require.NoError(t, exec.Command("cp", "/bin/sleep", sleepBin).Run())


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The current code tries to first read the target of the exe symbolic link and then appends that path to the proc's root, and then tries to stat(2) that.  That doesn't work if the binary is not available inside the proc's root for any reason.  However, stat(2)ing the exe itself always works, so do that instead.

For example avahi-daemon works like this:

```
 $ docker run --privileged -it --rm --platform linux/amd64 -v
 /proc/:/host/proc/:ro  --entrypoint /bin/sh alpine
 / # ls -l /host/proc/1640/exe
 lrwxrwxrwx    1 root     root             0 Aug 28 09:09
 /host/proc/1640/exe -> /usr/sbin/avahi-daemon
 / # ls -l /host/proc/1640/root
 lrwxrwxrwx    1 root     root             0 Aug 28 12:38
 /host/proc/1640/root -> /etc/avahi
 / # ls /host/proc/1640/root/usr/sbin/avahi-daemon
 ls: /host/proc/1640/root/usr/sbin/avahi-daemon: No such file or directory
 / # stat -L /host/proc/1640/exe
   File: /host/proc/1640/exe
   Size: 154120          Blocks: 304        IO Block: 4096   regular file
 Device: fc04h/64516d    Inode: 3932513     Links: 1
```

On the host:
```
 $ stat /usr/sbin/avahi-daemon
   File: /usr/sbin/avahi-daemon
   Size: 154120    	Blocks: 304        IO Block: 4096   regular file
 Device: fc04h/64516d	Inode: 3932513     Links: 1
```

As can be seen, stat(2) on the exe gets the correct details of the binary while the current method doesn't work.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Discovered due to debug prints when running service discovery tests :
```
=== RUN   TestInjectedServiceName
    mock.go:33: 2024-08-28 16:51:01 CEST | DEBUG | (pkg/languagedetection/privileged/privileged_detector.go:77 in DetectWithPrivileges) | failed to get binID: stat binary path /proc/1640/root/usr/sbin/avahi-daemon: no such file or directory
```


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
