### PR TITLE
[CWS] extract security agent AD storage telemetry from containers telemetry

### DIFF
--- a/pkg/security/agent/telemetry_linux.go
+++ b/pkg/security/agent/telemetry_linux.go
@@ -61,7 +61,7 @@ func (t *telemetry) registerProfiledContainer(name, tag string) {
 	}
 }
 
-func (t *telemetry) run(ctx context.Context, rsa *RuntimeSecurityAgent) {
+func (t *telemetry) run(ctx context.Context) {
 	log.Info("started collecting Runtime Security Agent telemetry")
 	defer log.Info("stopping Runtime Security Agent telemetry")
 
@@ -77,9 +77,6 @@ func (t *telemetry) run(ctx context.Context, rsa *RuntimeSecurityAgent) {
 		case <-metricsTicker.C:
 			if err := t.reportContainers(); err != nil {
 				log.Debugf("couldn't report containers: %v", err)
-			}
-			if rsa.storage != nil {
-				rsa.storage.SendTelemetry()
 			}
 		case <-profileCounterTicker.C:
 			if err := t.reportProfiledContainers(); err != nil {

--- a/pkg/security/agent/telemetry_others.go
+++ b/pkg/security/agent/telemetry_others.go
@@ -14,4 +14,4 @@ type telemetry struct{}
 
 func (t *telemetry) registerProfiledContainer(_, _ string) {}
 
-func (t *telemetry) run(_ context.Context, _ *RuntimeSecurityAgent) {}
+func (t *telemetry) run(_ context.Context) {}


### PR DESCRIPTION
### What does this PR do?

The containers telemetry currently reports 3 kinds of telemetry:
- the `.containers_running` metrics
- the metric related to profiled containers
- the metrics related to the security agent activity dump storage

The end goal is to move the `.containers_running` metrics to the system-probe. To do that this PR extracts the "metrics related to the security agent activity dump storage" part to a separate function that will stay running in the security agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
