### PR TITLE
[CONTP-371]send failover metrics from node agent

### DIFF
--- a/comp/core/tagger/taggerimpl/remote/tagger.go
+++ b/comp/core/tagger/taggerimpl/remote/tagger.go
@@ -28,9 +28,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
-	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -99,7 +99,7 @@ func CLCRunnerOptions(config config.Component) (Options, error) {
 	}
 
 	if !opts.Disabled {
-		target, err := clusteragent.GetClusterAgentEndpoint()
+		target, err := utils.GetClusterAgentEndpoint()
 		if err != nil {
 			return opts, fmt.Errorf("unable to get cluster agent endpoint: %w", err)
 		}

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -26,7 +26,6 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -185,7 +184,7 @@ func NewOptionsWithResolvers(config config.Component, log log.Component, domainR
 
 	// domainforwarder to local DCA for autoscaling failover metrics
 	if config.GetBool("autoscaling.failover.enabled") && config.GetBool("cluster_agent.enabled") {
-		if domain, err := clusteragent.GetClusterAgentEndpoint(); err != nil {
+		if domain, err := utils.GetClusterAgentEndpoint(); err != nil {
 			log.Errorf("Could not get cluster agent endpoint for autoscaling failover metrics: %s", err)
 		} else if authToken, err := security.GetClusterAgentAuthToken(config); err != nil {
 			log.Errorf("Failed to get cluster agent auth token: ", err)

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -20,11 +20,13 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/internal/retry"
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
+	pkgresolver "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -102,7 +104,7 @@ type Options struct {
 	DisableAPIKeyChecking          bool
 	EnabledFeatures                Features
 	APIKeyValidationInterval       time.Duration
-	DomainResolvers                map[string]resolver.DomainResolver
+	DomainResolvers                map[string]pkgresolver.DomainResolver
 	ConnectionResetInterval        time.Duration
 	CompletionHandler              transaction.HTTPCompletionHandler
 }
@@ -121,14 +123,14 @@ func HasFeature(features, flag Features) bool { return features&flag != 0 }
 
 // NewOptions creates new Options with default values
 func NewOptions(config config.Component, log log.Component, keysPerDomain map[string][]string) *Options {
-	resolvers := resolver.NewSingleDomainResolvers(keysPerDomain)
+	resolvers := pkgresolver.NewSingleDomainResolvers(keysPerDomain)
 	vectorMetricsURL, err := pkgconfigsetup.GetObsPipelineURL(pkgconfigsetup.Metrics, config)
 	if err != nil {
 		log.Error("Misconfiguration of agent observability_pipelines_worker endpoint for metrics: ", err)
 	}
 	if r, ok := resolvers[utils.GetInfraEndpoint(config)]; ok && vectorMetricsURL != "" {
 		log.Debugf("Configuring forwarder to send metrics to observability_pipelines_worker: %s", vectorMetricsURL)
-		resolvers[utils.GetInfraEndpoint(config)] = resolver.NewDomainResolverWithMetricToVector(
+		resolvers[utils.GetInfraEndpoint(config)] = pkgresolver.NewDomainResolverWithMetricToVector(
 			r.GetBaseDomain(),
 			r.GetAPIKeys(),
 			vectorMetricsURL,
@@ -138,7 +140,7 @@ func NewOptions(config config.Component, log log.Component, keysPerDomain map[st
 }
 
 // NewOptionsWithResolvers creates new Options with default values
-func NewOptionsWithResolvers(config config.Component, log log.Component, domainResolvers map[string]resolver.DomainResolver) *Options {
+func NewOptionsWithResolvers(config config.Component, log log.Component, domainResolvers map[string]pkgresolver.DomainResolver) *Options {
 	validationInterval := config.GetInt("forwarder_apikey_validation_interval")
 	if validationInterval <= 0 {
 		log.Warnf(
@@ -181,6 +183,18 @@ func NewOptionsWithResolvers(config config.Component, log log.Component, domainR
 		}
 	}
 
+	// domainforwarder to local DCA for autoscaling failover metrics
+	if config.GetBool("autoscaling.failover.enabled") && config.GetBool("cluster_agent.enabled") {
+		if domain, err := clusteragent.GetClusterAgentEndpoint(); err != nil {
+			log.Errorf("Could not get cluster agent endpoint for autoscaling failover metrics: %s", err)
+		} else if authToken, err := security.GetClusterAgentAuthToken(config); err != nil {
+			log.Errorf("Failed to get cluster agent auth token: ", err)
+		} else {
+			log.Infof("Setting cluster agent domain resolver: %s", domain)
+			option.DomainResolvers[domain] = pkgresolver.NewLocalDomainResolver(domain, authToken)
+		}
+	}
+
 	return option
 }
 
@@ -207,7 +221,8 @@ type DefaultForwarder struct {
 	NumberOfWorkers int
 
 	domainForwarders map[string]*domainForwarder
-	domainResolvers  map[string]resolver.DomainResolver
+	domainResolvers  map[string]pkgresolver.DomainResolver
+	localForwarder   *domainForwarder // domain forward used for communication with the local cluster-agent
 	healthChecker    *forwarderHealth
 	internalState    *atomic.Uint32
 	m                sync.Mutex // To control Start/Stop races
@@ -228,7 +243,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 		log:              log,
 		NumberOfWorkers:  options.NumberOfWorkers,
 		domainForwarders: map[string]*domainForwarder{},
-		domainResolvers:  map[string]resolver.DomainResolver{},
+		domainResolvers:  map[string]pkgresolver.DomainResolver{},
 		internalState:    atomic.NewUint32(Stopped),
 		healthChecker: &forwarderHealth{
 			log:                   log,
@@ -239,6 +254,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 		},
 		completionHandler: options.CompletionHandler,
 		agentName:         agentName,
+		localForwarder:    nil,
 	}
 	var optionalRemovalPolicy *retry.FileRemovalPolicy
 	storageMaxSize := config.GetInt64("forwarder_storage_max_size_in_bytes")
@@ -294,7 +310,9 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 		}
 		domain, _ := utils.AddAgentVersionToDomain(domain, "app")
 		resolver.SetBaseDomain(domain)
-		if resolver.GetAPIKeys() == nil || len(resolver.GetAPIKeys()) == 0 {
+
+		_, isLocal := resolver.(*pkgresolver.LocalDomainResolver)
+		if !isLocal && (resolver.GetAPIKeys() == nil || len(resolver.GetAPIKeys()) == 0) {
 			log.Errorf("No API keys for domain '%s', dropping domain ", domain)
 		} else {
 			var domainFolderPath string
@@ -322,6 +340,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				log,
 				domain,
 				isMRF,
+				isLocal,
 				transactionContainer,
 				options.NumberOfWorkers,
 				options.ConnectionResetInterval,
@@ -474,35 +493,59 @@ func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.E
 
 	for _, payload := range payloads {
 		for domain, dr := range f.domainResolvers {
-			for _, apiKey := range dr.GetAPIKeys() {
-				t := transaction.NewHTTPTransaction()
-				t.Domain, _ = dr.Resolve(endpoint)
-				t.Endpoint = endpoint
-				t.Payload = payload
-				t.Priority = priority
-				t.Kind = kind
-				t.StorableOnDisk = storableOnDisk
-				t.Destination = payload.Destination
-				t.Headers.Set(apiHTTPHeaderKey, apiKey)
-				t.Headers.Set(versionHTTPHeaderKey, version.AgentVersion)
-				t.Headers.Set(useragentHTTPHeaderKey, fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
-				if allowArbitraryTags {
-					t.Headers.Set(arbitraryTagHTTPHeaderKey, "true")
+			drDomain, destinationType := dr.Resolve(endpoint) // drDomain is the domain with agent version if not local
+			if payload.Destination == transaction.LocalOnly {
+				// if it is local payload, we should not send it to the remote endpoint
+				if destinationType == pkgresolver.Local && endpoint == endpoints.SeriesEndpoint {
+					t := transaction.NewHTTPTransaction()
+					t.Domain = drDomain
+					t.Endpoint = endpoint
+					t.Payload = payload
+					t.Priority = priority
+					t.Kind = kind
+					t.StorableOnDisk = storableOnDisk
+					t.Destination = payload.Destination
+					t.Headers.Set("Authorization", fmt.Sprintf("Bearer %s", dr.GetBearerAuthToken()))
+					for key := range extra {
+						t.Headers.Set(key, extra.Get(key))
+					}
+					tlmTxInputCount.Inc(drDomain, endpoint.Name)
+					tlmTxInputBytes.Add(float64(t.GetPayloadSize()), domain, endpoint.Name)
+					transactionsInputCountByEndpoint.Add(endpoint.Name, 1)
+					transactionsInputBytesByEndpoint.Add(endpoint.Name, int64(t.GetPayloadSize()))
+					transactions = append(transactions, t)
 				}
+			} else {
+				for _, apiKey := range dr.GetAPIKeys() {
+					t := transaction.NewHTTPTransaction()
+					t.Domain = drDomain
+					t.Endpoint = endpoint
+					t.Payload = payload
+					t.Priority = priority
+					t.Kind = kind
+					t.StorableOnDisk = storableOnDisk
+					t.Destination = payload.Destination
+					t.Headers.Set(apiHTTPHeaderKey, apiKey)
+					t.Headers.Set(versionHTTPHeaderKey, version.AgentVersion)
+					t.Headers.Set(useragentHTTPHeaderKey, fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
+					if allowArbitraryTags {
+						t.Headers.Set(arbitraryTagHTTPHeaderKey, "true")
+					}
 
-				if f.completionHandler != nil {
-					t.CompletionHandler = f.completionHandler
+					if f.completionHandler != nil {
+						t.CompletionHandler = f.completionHandler
+					}
+
+					tlmTxInputCount.Inc(domain, endpoint.Name)
+					tlmTxInputBytes.Add(float64(t.GetPayloadSize()), domain, endpoint.Name)
+					transactionsInputCountByEndpoint.Add(endpoint.Name, 1)
+					transactionsInputBytesByEndpoint.Add(endpoint.Name, int64(t.GetPayloadSize()))
+
+					for key := range extra {
+						t.Headers.Set(key, extra.Get(key))
+					}
+					transactions = append(transactions, t)
 				}
-
-				tlmTxInputCount.Inc(domain, endpoint.Name)
-				tlmTxInputBytes.Add(float64(t.GetPayloadSize()), domain, endpoint.Name)
-				transactionsInputCountByEndpoint.Add(endpoint.Name, 1)
-				transactionsInputBytesByEndpoint.Add(endpoint.Name, int64(t.GetPayloadSize()))
-
-				for key := range extra {
-					t.Headers.Set(key, extra.Get(key))
-				}
-				transactions = append(transactions, t)
 			}
 		}
 	}

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -31,6 +31,7 @@ type domainForwarder struct {
 	isRetrying                *atomic.Bool
 	domain                    string
 	isMRF                     bool
+	isLocal                   bool
 	numberOfWorkers           int
 	highPrio                  chan transaction.Transaction // use to receive new transactions
 	lowPrio                   chan transaction.Transaction // use to retry transactions
@@ -52,6 +53,7 @@ func newDomainForwarder(
 	log log.Component,
 	domain string,
 	mrf bool,
+	isLocal bool,
 	retryQueue *retry.TransactionRetryQueue,
 	numberOfWorkers int,
 	connectionResetInterval time.Duration,
@@ -62,6 +64,7 @@ func newDomainForwarder(
 		log:                       log,
 		isRetrying:                atomic.NewBool(false),
 		isMRF:                     mrf,
+		isLocal:                   isLocal,
 		domain:                    domain,
 		numberOfWorkers:           numberOfWorkers,
 		retryQueue:                retryQueue,
@@ -210,7 +213,7 @@ func (f *domainForwarder) Start() error {
 	f.init()
 
 	for i := 0; i < f.numberOfWorkers; i++ {
-		w := NewWorker(f.config, f.log, f.highPrio, f.lowPrio, f.requeuedTransaction, f.blockedList, f.pointCountTelemetry)
+		w := NewWorker(f.config, f.log, f.highPrio, f.lowPrio, f.requeuedTransaction, f.blockedList, f.pointCountTelemetry, f.isLocal)
 		w.Start()
 		f.workers = append(f.workers, w)
 	}

--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -372,7 +372,7 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 		retry.NewPointCountTelemetryMock())
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	forwarder := newDomainForwarder(mockConfig, log, "test", false, transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain"))
+	forwarder := newDomainForwarder(mockConfig, log, "test", false, false, transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain"))
 	forwarder.blockedList.close("blocked")
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
@@ -434,7 +434,7 @@ func newDomainForwarderForTest(config config.Component, log log.Component, conne
 		telemetry,
 		retry.NewPointCountTelemetryMock())
 
-	return newDomainForwarder(config, log, "test", ha, transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain"))
+	return newDomainForwarder(config, log, "test", ha, false, transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain"))
 }
 
 func requireLenForwarderRetryQueue(t *testing.T, forwarder *domainForwarder, expectedValue int) {

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -14,6 +14,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../core/telemetry
 	github.com/DataDog/datadog-agent/comp/def => ../../def
 	github.com/DataDog/datadog-agent/comp/serializer/compression => ../../../comp/serializer/compression/
+	github.com/DataDog/datadog-agent/pkg/api => ../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../pkg/config/env
 	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../pkg/config/mock
@@ -51,25 +52,26 @@ replace (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/common v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.57.1
-	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.57.1
 	github.com/DataDog/datadog-agent/pkg/util/http v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/optional v0.57.1
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.57.1
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1
 	github.com/golang/protobuf v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.9.0
@@ -79,11 +81,11 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/def v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -204,6 +204,8 @@ const (
 	PrimaryOnly
 	// SecondaryOnly indicates the transaction should be sent to the secondary region during MRF
 	SecondaryOnly
+	// LocalOnly indicates the transaction should be sent to the local endpoint (cluster-agent) only
+	LocalOnly
 )
 
 func (d Destination) String() string {
@@ -214,6 +216,8 @@ func (d Destination) String() string {
 		return "PrimaryOnly"
 	case SecondaryOnly:
 		return "SecondaryOnly"
+	case LocalOnly:
+		return "LocalOnly"
 	default:
 		return "Unknown"
 	}

--- a/comp/forwarder/defaultforwarder/worker_test.go
+++ b/comp/forwarder/defaultforwarder/worker_test.go
@@ -29,7 +29,7 @@ func TestNewWorker(t *testing.T) {
 
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 	assert.NotNil(t, w)
 	assert.Equal(t, w.Client.Timeout, mockConfig.GetDuration("forwarder_timeout")*time.Second)
 }
@@ -42,7 +42,7 @@ func TestNewNoSSLWorker(t *testing.T) {
 	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("skip_ssl_validation", true)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 	assert.True(t, w.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 }
 
@@ -53,7 +53,7 @@ func TestWorkerStart(t *testing.T) {
 	sender := &PointSuccessfullySentMock{}
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender)
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, false)
 
 	mock := newTestTransaction()
 	mock.pointCount = 1
@@ -90,7 +90,7 @@ func TestWorkerRetry(t *testing.T) {
 	requeue := make(chan transaction.Transaction, 1)
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(fmt.Errorf("some kind of error")).Times(1)
@@ -113,7 +113,7 @@ func TestWorkerRetryBlockedTransaction(t *testing.T) {
 	requeue := make(chan transaction.Transaction, 1)
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 
 	mock := newTestTransaction()
 	mock.On("GetTarget").Return("error_url").Times(1)
@@ -136,7 +136,7 @@ func TestWorkerResetConnections(t *testing.T) {
 	requeue := make(chan transaction.Transaction, 1)
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(nil).Times(1)
@@ -181,7 +181,7 @@ func TestWorkerPurgeOnStop(t *testing.T) {
 	requeue := make(chan transaction.Transaction, 1)
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{})
+	w := NewWorker(mockConfig, log, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), &PointSuccessfullySentMock{}, false)
 	// making stopChan non blocking on insert and closing stopped channel
 	// to avoid blocking in the Stop method since we don't actually start
 	// the workder

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -15,6 +15,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/def => ../../../def
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder => ../../defaultforwarder/
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../pkg/aggregator/ckey
+	github.com/DataDog/datadog-agent/pkg/api => ../../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../pkg/config/env
 	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../pkg/config/mock
@@ -64,14 +65,15 @@ replace (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/def v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
@@ -79,7 +81,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.56.0-rc.3 // indirect
@@ -87,7 +89,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/common v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.57.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/http v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.57.1 // indirect
@@ -97,7 +99,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -108,9 +108,9 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/datadogexporter v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/processor/infraattributesprocessor v0.0.0-00010101000000-000000000000
-	github.com/DataDog/datadog-agent/pkg/api v0.56.2
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
-	github.com/DataDog/datadog-agent/pkg/version v0.57.0
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1
 	github.com/gorilla/mux v1.8.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.104.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.104.0
@@ -158,9 +158,9 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Code-Hex/go-generics-cache v1.3.1 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.123 // indirect
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.58.0-devel // indirect
@@ -191,7 +191,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.56.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -28,6 +28,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../../../../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../../../../../comp/trace/compression/impl-zstd
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../../../pkg/aggregator/ckey
+	github.com/DataDog/datadog-agent/pkg/api => ../../../../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../../../pkg/config/env
 	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../../../pkg/config/mock
@@ -125,9 +126,9 @@ require (
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.119 // indirect
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
@@ -140,6 +141,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/serializer/compression v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
@@ -148,7 +150,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.56.0-rc.3 // indirect
@@ -188,7 +190,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.26.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect
 	github.com/DataDog/go-sqllexer v0.0.16 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -17,6 +17,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface => ../../../../../forwarder/orchestrator/orchestratorinterface
 	github.com/DataDog/datadog-agent/comp/serializer/compression => ../../../../../serializer/compression/
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../../../pkg/aggregator/ckey
+	github.com/DataDog/datadog-agent/pkg/api => ../../../../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../../../../../pkg/config/env
 	github.com/DataDog/datadog-agent/pkg/config/mock => ../../../../../../pkg/config/mock
@@ -91,9 +92,9 @@ require (
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.114 // indirect
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3 // indirect
@@ -103,6 +104,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/compression v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
@@ -111,7 +113,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3 // indirect
@@ -133,7 +135,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/sketches-go v1.4.4 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -615,8 +615,8 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/agent-payload/v5 v5.0.132
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.2
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.2
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.58.0-devel
 	github.com/DataDog/datadog-agent/comp/core/log/impl v0.0.0-00010101000000-000000000000
@@ -650,14 +650,14 @@ require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/api v0.56.2
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/remote v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.2
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1
 	github.com/DataDog/datadog-agent/pkg/errors v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.56.0-rc.3
@@ -702,7 +702,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/testutil v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.1
-	github.com/DataDog/datadog-agent/pkg/version v0.57.0
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1
 	github.com/DataDog/go-libddwaf/v3 v3.4.0
 	github.com/DataDog/go-sqllexer v0.0.16
 	github.com/Datadog/dublin-traceroute v0.0.2
@@ -766,7 +766,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Code-Hex/go-generics-cache v1.3.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.0.0-20240525065430-d0b647bcb646 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -672,6 +672,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Autoscaling product
 	config.BindEnvAndSetDefault("autoscaling.workload.enabled", false)
+	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false, "DD_AUTOSCALING_FAILOVER_ENABLED")
+	config.BindEnv("autoscaling.failover.metrics", "DD_AUTOSCALING_FAILOVER_METRICS")
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -672,8 +672,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Autoscaling product
 	config.BindEnvAndSetDefault("autoscaling.workload.enabled", false)
-	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false, "DD_AUTOSCALING_FAILOVER_ENABLED")
-	config.BindEnv("autoscaling.failover.metrics", "DD_AUTOSCALING_FAILOVER_METRICS")
+	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false)
+	config.BindEnv("autoscaling.failover.metrics")
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes

--- a/pkg/config/utils/clusteragent.go
+++ b/pkg/config/utils/clusteragent.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetClusterAgentEndpoint provides a validated https endpoint from configuration keys in datadog.yaml:
+// 1st. configuration key "cluster_agent.url" (or the DD_CLUSTER_AGENT_URL environment variable),
+//
+//	add the https prefix if the scheme isn't specified
+//
+// 2nd. environment variables associated with "cluster_agent.kubernetes_service_name"
+//
+//	${dcaServiceName}_SERVICE_HOST and ${dcaServiceName}_SERVICE_PORT
+func GetClusterAgentEndpoint() (string, error) {
+	const configDcaURL = "cluster_agent.url"
+	const configDcaSvcName = "cluster_agent.kubernetes_service_name"
+
+	dcaURL := pkgconfigsetup.Datadog().GetString(configDcaURL)
+	if dcaURL != "" {
+		if strings.HasPrefix(dcaURL, "http://") {
+			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", dcaURL)
+		}
+		if !strings.Contains(dcaURL, "://") {
+			log.Tracef("Adding https scheme to %s: https://%s", dcaURL, dcaURL)
+			dcaURL = fmt.Sprintf("https://%s", dcaURL)
+		}
+		u, err := url.Parse(dcaURL)
+		if err != nil {
+			return "", err
+		}
+		if u.Scheme != "https" {
+			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", u.Scheme)
+		}
+		log.Debugf("Connecting to the configured URL for the Datadog Cluster Agent: %s", dcaURL)
+		return u.String(), nil
+	}
+
+	// Construct the URL with the Kubernetes service environment variables
+	// *_SERVICE_HOST and *_SERVICE_PORT
+	dcaSvc := pkgconfigsetup.Datadog().GetString(configDcaSvcName)
+	log.Debugf("Identified service for the Datadog Cluster Agent: %s", dcaSvc)
+	if dcaSvc == "" {
+		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %s and %s are empty", configDcaURL, configDcaSvcName)
+	}
+
+	dcaSvc = strings.ToUpper(dcaSvc)
+	dcaSvc = strings.Replace(dcaSvc, "-", "_", -1) // Kubernetes replaces "-" with "_" in the service names injected in the env var.
+
+	// host
+	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)
+	dcaSvcHost := os.Getenv(dcaSvcHostEnv)
+	if dcaSvcHost == "" {
+		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcHostEnv)
+	}
+
+	// port
+	dcaSvcPort := os.Getenv(fmt.Sprintf("%s_SERVICE_PORT", dcaSvc))
+	if dcaSvcPort == "" {
+		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcPort)
+	}
+
+	// validate the URL
+	dcaURL = fmt.Sprintf("https://%s:%s", dcaSvcHost, dcaSvcPort)
+	u, err := url.Parse(dcaURL)
+	if err != nil {
+		return "", err
+	}
+
+	return u.String(), nil
+}

--- a/pkg/config/utils/clusteragent_test.go
+++ b/pkg/config/utils/clusteragent_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	clusterAgentServiceName = "DATADOG_CLUSTER_AGENT"
+	clusterAgentServiceHost = clusterAgentServiceName + "_SERVICE_HOST"
+	clusterAgentServicePort = clusterAgentServiceName + "_SERVICE_PORT"
+)
+
+func TestGetClusterAgentEndpointEmpty(t *testing.T) {
+	configmock.New(t)
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "")
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.kubernetes_service_name", "")
+	_, err := GetClusterAgentEndpoint()
+	require.NotNil(t, err)
+}
+
+func TestGetClusterAgentEndpointFromUrl(t *testing.T) {
+	configmock.New(t)
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "https://127.0.0.1:8080")
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.kubernetes_service_name", "")
+	_, err := GetClusterAgentEndpoint()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "https://127.0.0.1")
+	_, err = GetClusterAgentEndpoint()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "127.0.0.1")
+	endpoint, err := GetClusterAgentEndpoint()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	assert.Equal(t, "https://127.0.0.1", endpoint)
+
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "127.0.0.1:1234")
+	endpoint, err = GetClusterAgentEndpoint()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	assert.Equal(t, "https://127.0.0.1:1234", endpoint)
+}
+
+func TestGetClusterAgentEndpointFromUrlInvalid(t *testing.T) {
+	configmock.New(t)
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "http://127.0.0.1:8080")
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.kubernetes_service_name", "")
+	_, err := GetClusterAgentEndpoint()
+	require.NotNil(t, err)
+
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "tcp://127.0.0.1:8080")
+	_, err = GetClusterAgentEndpoint()
+	require.NotNil(t, err)
+}
+
+func TestGetClusterAgentEndpointFromKubernetesSvc(t *testing.T) {
+	configmock.New(t)
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "")
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
+	t.Setenv(clusterAgentServiceHost, "127.0.0.1")
+	t.Setenv(clusterAgentServicePort, "443")
+
+	endpoint, err := GetClusterAgentEndpoint()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	assert.Equal(t, "https://127.0.0.1:443", endpoint)
+}
+
+func TestGetClusterAgentEndpointFromKubernetesSvcEmpty(t *testing.T) {
+	configmock.New(t)
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.url", "")
+	pkgconfigsetup.Datadog().SetWithoutSource("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
+	t.Setenv(clusterAgentServiceHost, "127.0.0.1")
+	t.Setenv(clusterAgentServicePort, "")
+
+	_, err := GetClusterAgentEndpoint()
+	require.NotNil(t, err, fmt.Sprintf("%v", err))
+
+	t.Setenv(clusterAgentServiceHost, "")
+	t.Setenv(clusterAgentServicePort, "443")
+	_, err = GetClusterAgentEndpoint()
+	require.NotNil(t, err, fmt.Sprintf("%v", err))
+}

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -17,6 +17,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface => ../../comp/forwarder/orchestrator/orchestratorinterface
 	github.com/DataDog/datadog-agent/comp/serializer/compression => ../../comp/serializer/compression
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../aggregator/ckey
+	github.com/DataDog/datadog-agent/pkg/api => ../api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../config/env
 	github.com/DataDog/datadog-agent/pkg/config/logs => ../config/logs/
@@ -63,7 +64,7 @@ replace (
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.114
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/serializer/compression v0.56.0-rc.3
@@ -77,7 +78,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/json v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.57.1
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.20.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/json-iterator/go v1.1.12
@@ -88,20 +89,21 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.56.0-rc.3 // indirect

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -462,13 +462,19 @@ func TestMarshalSplitCompressMultiplePointsLimit(t *testing.T) {
 			}
 			series := CreateIterableSeries(CreateSerieSource(rawSeries))
 
-			payloads, filteredPayloads, err := series.MarshalSplitCompressMultiple(mockConfig, compressionimpl.NewCompressor(mockConfig), func(s *metrics.Serie) bool {
-				return s.Name == "test.metrics42"
-			})
+			payloads, filteredPayloads, autoscalingFailoverPayloads, err := series.MarshalSplitCompressMultiple(mockConfig, compressionimpl.NewCompressor(mockConfig),
+				func(s *metrics.Serie) bool {
+					return s.Name == "test.metrics42"
+				},
+				func(s *metrics.Serie) bool {
+					return s.Name == "test.metrics99" || s.Name == "test.metrics98"
+				},
+			)
 			require.NoError(t, err)
 			require.Equal(t, 5, len(payloads))
 			// only one serie should be present in the filtered payload, so 5 total points, which fits in one payload
 			require.Equal(t, 1, len(filteredPayloads))
+			require.Equal(t, 1, len(autoscalingFailoverPayloads))
 		})
 	}
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -14,9 +14,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
-	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +23,7 @@ import (
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -120,7 +118,7 @@ func GetClusterAgentClient() (DCAClientInterface, error) {
 func (c *DCAClient) init() error {
 	var err error
 
-	c.clusterAgentAPIEndpoint, err = GetClusterAgentEndpoint()
+	c.clusterAgentAPIEndpoint, err = utils.GetClusterAgentEndpoint()
 	if err != nil {
 		return err
 	}
@@ -214,72 +212,6 @@ func (c *DCAClient) initHTTPClient() error {
 
 func (c *DCAClient) initLeaderClient() {
 	c.leaderClient = newLeaderClient(c.clusterAgentAPIClient, c.clusterAgentAPIEndpoint)
-}
-
-// GetClusterAgentEndpoint provides a validated https endpoint from configuration keys in datadog.yaml:
-// 1st. configuration key "cluster_agent.url" (or the DD_CLUSTER_AGENT_URL environment variable),
-//
-//	add the https prefix if the scheme isn't specified
-//
-// 2nd. environment variables associated with "cluster_agent.kubernetes_service_name"
-//
-//	${dcaServiceName}_SERVICE_HOST and ${dcaServiceName}_SERVICE_PORT
-func GetClusterAgentEndpoint() (string, error) {
-	const configDcaURL = "cluster_agent.url"
-	const configDcaSvcName = "cluster_agent.kubernetes_service_name"
-
-	dcaURL := pkgconfigsetup.Datadog().GetString(configDcaURL)
-	if dcaURL != "" {
-		if strings.HasPrefix(dcaURL, "http://") {
-			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", dcaURL)
-		}
-		if !strings.Contains(dcaURL, "://") {
-			log.Tracef("Adding https scheme to %s: https://%s", dcaURL, dcaURL)
-			dcaURL = fmt.Sprintf("https://%s", dcaURL)
-		}
-		u, err := url.Parse(dcaURL)
-		if err != nil {
-			return "", err
-		}
-		if u.Scheme != "https" {
-			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", u.Scheme)
-		}
-		log.Debugf("Connecting to the configured URL for the Datadog Cluster Agent: %s", dcaURL)
-		return u.String(), nil
-	}
-
-	// Construct the URL with the Kubernetes service environment variables
-	// *_SERVICE_HOST and *_SERVICE_PORT
-	dcaSvc := pkgconfigsetup.Datadog().GetString(configDcaSvcName)
-	log.Debugf("Identified service for the Datadog Cluster Agent: %s", dcaSvc)
-	if dcaSvc == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %s and %s are empty", configDcaURL, configDcaSvcName)
-	}
-
-	dcaSvc = strings.ToUpper(dcaSvc)
-	dcaSvc = strings.Replace(dcaSvc, "-", "_", -1) // Kubernetes replaces "-" with "_" in the service names injected in the env var.
-
-	// host
-	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)
-	dcaSvcHost := os.Getenv(dcaSvcHostEnv)
-	if dcaSvcHost == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcHostEnv)
-	}
-
-	// port
-	dcaSvcPort := os.Getenv(fmt.Sprintf("%s_SERVICE_PORT", dcaSvc))
-	if dcaSvcPort == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcPort)
-	}
-
-	// validate the URL
-	dcaURL = fmt.Sprintf("https://%s:%s", dcaSvcHost, dcaSvcPort)
-	u, err := url.Parse(dcaURL)
-	if err != nil {
-		return "", err
-	}
-
-	return u.String(), nil
 }
 
 // Version returns ClusterAgentVersion already stored in the DCAClient

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -279,11 +279,8 @@ type clusterAgentSuite struct {
 }
 
 const (
-	clusterAgentServiceName = "DATADOG_CLUSTER_AGENT"
-	clusterAgentServiceHost = clusterAgentServiceName + "_SERVICE_HOST"
-	clusterAgentServicePort = clusterAgentServiceName + "_SERVICE_PORT"
-	clusterAgentTokenValue  = "01234567890123456789012345678901"
-	clcRunnerIP             = "10.92.1.39"
+	clusterAgentTokenValue = "01234567890123456789012345678901"
+	clcRunnerIP            = "10.92.1.39"
 )
 
 func (suite *clusterAgentSuite) SetupTest() {
@@ -292,16 +289,6 @@ func (suite *clusterAgentSuite) SetupTest() {
 	suite.config.SetWithoutSource("cluster_agent.url", "")
 	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "")
 	suite.config.SetWithoutSource("clc_runner_host", clcRunnerIP)
-	os.Unsetenv(clusterAgentServiceHost)
-	os.Unsetenv(clusterAgentServicePort)
-}
-
-func (suite *clusterAgentSuite) TestGetClusterAgentEndpointEmpty() {
-	suite.config.SetWithoutSource("cluster_agent.url", "")
-	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "")
-
-	_, err := GetClusterAgentEndpoint()
-	require.NotNil(suite.T(), err)
 }
 
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmpty() {
@@ -358,64 +345,6 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenTooShort() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	_, err = security.GetClusterAgentAuthToken(suite.config)
-	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
-}
-
-func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromUrl() {
-	suite.config.SetWithoutSource("cluster_agent.url", "https://127.0.0.1:8080")
-	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "")
-	_, err := GetClusterAgentEndpoint()
-	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-
-	suite.config.SetWithoutSource("cluster_agent.url", "https://127.0.0.1")
-	_, err = GetClusterAgentEndpoint()
-	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-
-	suite.config.SetWithoutSource("cluster_agent.url", "127.0.0.1")
-	endpoint, err := GetClusterAgentEndpoint()
-	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-	assert.Equal(suite.T(), "https://127.0.0.1", endpoint)
-
-	suite.config.SetWithoutSource("cluster_agent.url", "127.0.0.1:1234")
-	endpoint, err = GetClusterAgentEndpoint()
-	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-	assert.Equal(suite.T(), "https://127.0.0.1:1234", endpoint)
-}
-
-func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromUrlInvalid() {
-	suite.config.SetWithoutSource("cluster_agent.url", "http://127.0.0.1:8080")
-	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "")
-	_, err := GetClusterAgentEndpoint()
-	require.NotNil(suite.T(), err)
-
-	suite.config.SetWithoutSource("cluster_agent.url", "tcp://127.0.0.1:8080")
-	_, err = GetClusterAgentEndpoint()
-	require.NotNil(suite.T(), err)
-}
-
-func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvc() {
-	suite.config.SetWithoutSource("cluster_agent.url", "")
-	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
-	suite.T().Setenv(clusterAgentServiceHost, "127.0.0.1")
-	suite.T().Setenv(clusterAgentServicePort, "443")
-
-	endpoint, err := GetClusterAgentEndpoint()
-	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-	assert.Equal(suite.T(), "https://127.0.0.1:443", endpoint)
-}
-
-func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvcEmpty() {
-	suite.config.SetWithoutSource("cluster_agent.url", "")
-	suite.config.SetWithoutSource("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
-	suite.T().Setenv(clusterAgentServiceHost, "127.0.0.1")
-	suite.T().Setenv(clusterAgentServicePort, "")
-
-	_, err := GetClusterAgentEndpoint()
-	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
-
-	suite.T().Setenv(clusterAgentServiceHost, "")
-	suite.T().Setenv(clusterAgentServicePort, "443")
-	_, err = GetClusterAgentEndpoint()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -31,6 +31,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ./../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ./../../comp/trace/compression/impl-zstd
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../pkg/aggregator/ckey
+	github.com/DataDog/datadog-agent/pkg/api => ../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ./../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ./../../pkg/config/env
 	github.com/DataDog/datadog-agent/pkg/config/mock => ./../../pkg/config/mock
@@ -92,7 +93,7 @@ replace (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/comp/core/config v0.57.1
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.56.0-rc.1
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.0-rc.3
@@ -109,8 +110,8 @@ require (
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.119 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.57.1 // indirect
@@ -124,13 +125,14 @@ require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.56.0-rc.3 // indirect
@@ -173,7 +175,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.57.1 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.26.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.5.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
[CONTP-371](https://datadoghq.atlassian.net/browse/CONTP-371)
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This adds the ability to send filtered series payloads to the cluster agent in local cluster. This ensures that in the rare case of an outage, the system can still collect failover metrics locally. 

also: moved GetClusterAgentEndpoint from pkg/util/clusteragent to config/utils because of go module dependency. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
There are limitations in integrating the cluster agent directly as a MRF endpoint, we've identified several key issues:
1. The Cluster Agent utilizes an authentication token instead of an API key.
2. The absence of an API key disrupts the domain resolver's functionality.
3. The inability to tailor the MRF filter for individual secondary endpoints can break MRF 

Proposed change:
1. A set of dedicated config options and metrics filter (supported by new _MarshalSplitCompressMultiple_)
2. Local domain resolver, Local domain forwarder and local http client for local endpoint that takes authToken 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Since series handler is not implemented in cluster agent yet, we can test change in local env with datadog.yaml config
```
api_key: XXXXX
telemetry.enabled: true
hostname: agent-1
autoscaling:
    failover:
        enabled: true
        metrics: datadog.agent.retry_queue_duration.bytes_per_sec
cluster_agent.enabled: true
cluster_agent.auth_token: 1234567890abcdef1234567890abcdef
cluster_agent.url: https://localhost:5002 
```
Note: we are sending series payload to https://localhost:5002/api/v2/series

Server:
Run `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout localhost.key -out localhost.crt -subj "/C=US/ST=YourState/L=YourCity/O=YourOrganization/CN=localhost"`

Create https server with source code and run:
```
package main

import (
	"fmt"
	"net/http"
	"time"
)

func main() {
	http.HandleFunc("/api/v2/series", func(w http.ResponseWriter, r *http.Request) {
		fmt.Printf("[%s] Received request: %s %s\n", time.Now(), r.Method, r.URL.Path)
		w.WriteHeader(http.StatusOK)
		w.Write([]byte("Request received"))
	})
	http.ListenAndServeTLS(":5002", "localhost.crt", "localhost.key", nil)
}
```
Result:
```
2024-08-30 05:20:03.75237676 +0000 UTC m=+107.013497883] Received request: POST /api/v2/series
[2024-08-30 05:20:18.752380295 +0000 UTC m=+122.013776307] Received request: POST /api/v2/series
[2024-08-30 05:20:33.752624094 +0000 UTC m=+137.014020105] Received request: POST /api/v2/series
[2024-08-30 05:20:48.750682795 +0000 UTC m=+152.012268321] Received request: POST /api/v2/series
[2024-08-30 05:21:03.753627385 +0000 UTC m=+167.015212953] Received request: POST /api/v2/series
[2024-08-30 05:21:18.753528253 +0000 UTC m=+182.015410835] Received request: POST /api/v2/series
[2024-08-30 05:21:33.75313001 +0000 UTC m=+197.015012467] Received request: POST /api/v2/series
```

[CONTP-371]: https://datadoghq.atlassian.net/browse/CONTP-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ