### PR TITLE
[windows] Print time statistics when extracting modcache archive

### DIFF
--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -27,13 +27,13 @@ if "%GOMODCACHE%" == "" (
 @echo MODCACHE_XZ_FILE %MODCACHE_XZ_FILE% MODCACHE_TAR_FILE %MODCACHE_TAR_FILE% GOMODCACHE %GOMODCACHE%
 if exist %MODCACHE_XZ_FILE% (
     @echo Extracting modcache file %MODCACHE_XZ_FILE%
-    Powershell -C "7z x %MODCACHE_XZ_FILE% -o%MODCACHE_ROOT%
+    Powershell -C "7z x %MODCACHE_XZ_FILE% -o%MODCACHE_ROOT% -bt"
     dir %MODCACHE_TAR_FILE%
     REM Use -aoa to allow overwriting existing files
     REM This shouldn't have any negative impact: since modules are
     REM stored per version and hash, files that get replaced will
     REM get replaced by the same files
-    Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE% -aoa"
+    Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE% -aoa -bt"
     @echo Modcache extracted
 ) else (
     @echo %MODCACHE_XZ_FILE% not found, dependencies will be downloaded


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use `7z`'s `-bt` option to show operation duration when extracting archives. Example output:
```
Extracting archive: c:\buildroot\datadog-agent\modcache.tar.xz
--
Path = c:\buildroot\datadog-agent\modcache.tar.xz
Type = xz
Physical Size = 1269182448
Method = LZMA2:23 CRC64
Streams = 210
Blocks = 210
Cluster Size = 25169920
Everything is Ok
Size:       52819865[60](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/620153236#L60)
Compressed: 1269182448
Kernel  Time =     2.234 =    6%                 108224 MCycles
User    Time =    34.343 =   92%
Process Time =    36.578 =   98%    Virtual  Memory =     11 MB
Global  Time =    36.978 =  100%    Physical Memory =     15 MB
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Help with toubleshooting.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Windows jobs do not break, and show the time statistics.
