### PR TITLE
[PROCS-4207] Add process-agent introspection for staying alive in containerized environments

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -53,6 +53,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta/collector"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -61,16 +62,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
-)
-
-const (
-	agent6DisabledMessage = `process-agent not enabled.
-Set env var DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED=true or add
-process_config:
-  process_collection:
-    enabled: true
-to your datadog.yaml file.
-Exiting.`
 )
 
 // errAgentDisabled indicates that the process-agent wasn't enabled through environment variable or config.
@@ -206,6 +197,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			_ profiler.Component,
 			_ expvars.Component,
 			_ apiserver.Component,
+			cfg config.Component,
 			_ optional.Option[configsync.Component],
 			// TODO: This is needed by the container-provider which is not currently a component.
 			// We should ensure the tagger is a dependency when converting to a component.
@@ -214,7 +206,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			processAgent agent.Component,
 			_ autoexit.Component,
 		) error {
-			if !processAgent.Enabled() {
+			if !processAgent.Enabled() && !collector.Enabled(cfg) {
 				return errAgentDisabled
 			}
 			return nil
@@ -234,33 +226,23 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		settingsimpl.Module(),
 	)
 
-	if err := app.Err(); err != nil {
-
-		if errors.Is(err, errAgentDisabled) {
-			log.Info("process-agent is not enabled, exiting...")
-			return nil
-		}
-
-		// At this point it is not guaranteed that the logger has been successfully initialized. We should fall back to
-		// stdout just in case.
-		if appInitDeps.Logger == nil {
-			fmt.Println("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
-		} else {
-			appInitDeps.Logger.Critical("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
-		}
-		return err
-	}
-
-	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.
-	if !shouldEnableProcessAgent(appInitDeps.Checks, appInitDeps.Config) {
-		log.Infof(agent6DisabledMessage)
-		return nil
-	}
-
 	err := app.Start(ctx)
 	if err != nil {
-		log.Criticalf("Failed to start process agent: %v", err)
-		return err
+		if errors.Is(err, errAgentDisabled) {
+			if !shouldStayAlive(appInitDeps.Config) {
+				log.Info("process-agent is not enabled, exiting...")
+				return nil
+			}
+		} else {
+			// At this point it is not guaranteed that the logger has been successfully initialized. We should fall back to
+			// stdout just in case.
+			if appInitDeps.Logger == nil {
+				fmt.Println("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
+			} else {
+				appInitDeps.Logger.Critical("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
+			}
+			return err
+		}
 	}
 
 	// Wait for exit signal
@@ -279,19 +261,6 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 	}
 
 	return nil
-}
-
-func anyChecksEnabled(checks []types.CheckComponent) bool {
-	for _, check := range checks {
-		if check.Object().IsEnabled() {
-			return true
-		}
-	}
-	return false
-}
-
-func shouldEnableProcessAgent(checks []types.CheckComponent, cfg ddconfig.Reader) bool {
-	return anyChecksEnabled(checks) || collector.Enabled(cfg)
 }
 
 type miscDeps struct {
@@ -338,4 +307,16 @@ func initMisc(deps miscDeps) error {
 	})
 
 	return nil
+}
+
+// shouldStayAlive determines whether the process agent should stay alive when no checks are running.
+// This can happen when the checks are running on the core agent but a process agent container is
+// still brought up. The process-agent is kept alive to prevent crash loops.
+func shouldStayAlive(cfg ddconfig.Reader) bool {
+	if env.IsKubernetes() && cfg.GetBool("process_config.run_in_core_agent.enabled") {
+		log.Warn("The process-agent is staying alive to prevent crash loops due to the checks running on the core agent. Thus, the process-agent is idle. Update your Helm chart or Datadog Operator to the latest version to prevent this (https://docs.datadoghq.com/containers/kubernetes/installation/).")
+		return true
+	}
+
+	return false
 }

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -103,7 +103,8 @@ func (c *Collector) run(ctx context.Context, containerProvider proccontainers.Co
 
 // Enabled checks to see if we should enable the local process collector.
 // Since it's job is to collect processes when the process check is disabled, we only enable it when `process_config.process_collection.enabled` == false
-// Additionally, if the remote process collector is not enabled in the core agent, there is no reason to collect processes. Therefore, we check `language_detection.enabled`
+// Additionally, if the remote process collector is not enabled in the core agent, there is no reason to collect processes. Therefore, we check `language_detection.enabled`.
+// We also check `process_config.run_in_core_agent.enabled` because this collector should only be used when the core agent collector is not running.
 // Finally, we only want to run this collector in the process agent, so if we're running as anything else we should disable the collector.
 func Enabled(cfg config.Reader) bool {
 	if cfg.GetBool("process_config.process_collection.enabled") {
@@ -113,5 +114,10 @@ func Enabled(cfg config.Reader) bool {
 	if !cfg.GetBool("language_detection.enabled") {
 		return false
 	}
+
+	if cfg.GetBool("process_config.run_in_core_agent.enabled") {
+		return false
+	}
+
 	return true
 }

--- a/releasenotes/notes/process-agent-introspection-1cce43cb91e957d2.yaml
+++ b/releasenotes/notes/process-agent-introspection-1cce43cb91e957d2.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The process agent will no longer exit prematurely when language detection is enabled or
+    when there is a misconfiguration stemming from `process_config.run_in_core_agent.enabled`'s
+    default enablement in Kubernetes.

--- a/test/new-e2e/tests/language-detection/etc/process_config_no_check.yaml
+++ b/test/new-e2e/tests/language-detection/etc/process_config_no_check.yaml
@@ -1,6 +1,10 @@
 process_config:
   process_collection:
     enabled: false
+  container_collection:
+    enabled: false
+  process_discovery:
+    enabled: false
   intervals:
     process: 1
 language_detection:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

* Refactors process-agent exit logic to remove redundant error check as `app.Err()` is already checked in `app.Start()`.
* Add a stay alive check to the process agent which passes under the following scenarios:
  * The process-agent needs to perform language detection (this was a bug)
  * The process-agent is running on Kubernetes when it shouldn't due to `process_config.run_in_core_agent.enabled` being set to `true.

### Motivation

PROCS-4207

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

E2E tests for processes and language detection (after updates) should catch regressions.

Additionally, a future scenario when `process_config.run_in_core_agent.enabled` is true by default can be manually tested using Datadog Operator 1.5.0 (outdated).

Expected log shown:
```
2024-08-29 20:19:45 UTC | PROCESS | WARN | (command/main_common.go:326 in shouldStayAlive) | The process-agent is staying alive to prevent crash loops due to the checks running on the core agent. Thus, the process-agent is idle. Update your installer to the latest version to prevent this.
``` 
And the process agent does not crashloop:
```
❯ kubectl get pod/datadog-agent-ffmdn -o json | jq '.spec.containers[].name'
"agent"
"trace-agent"
"process-agent"
```
