### PR TITLE
feat(test_core): Display Test Visibility links as hyperlinks on gitlab logs

### DIFF
--- a/tasks/libs/civisibility.py
+++ b/tasks/libs/civisibility.py
@@ -74,7 +74,9 @@ def get_test_link_to_test_on_main(suite_name: str, test_name: str):
     }
     query_string = to_query_string(query_params)
     quoted_query_string = quote(string=query_string, safe="")
-    return f"{TEST_VISIBILITY_URL}?query={quoted_query_string}"
+    full_url = f"{TEST_VISIBILITY_URL}?query={quoted_query_string}"
+    url_element = f'<a href="{full_url}" class="gl-reset-color! gl-text-decoration-underline" rel="nofollow noopener noreferrer">Test Visibility</a>'
+    return url_element
 
 
 def to_query_string(params: dict):

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -118,7 +118,9 @@ class ModuleTestResult(ModuleResult):
                             failure_string += f"- {package} {name}\n"
 
                             if running_in_ci():
-                                failure_string += f"  See this test name on main in Test Visibility at {get_test_link_to_test_on_main(package, name)}\n"
+                                failure_string += (
+                                    f"  See this test name on main in {get_test_link_to_test_on_main(package, name)}\n"
+                                )
             else:
                 failure_string += "The test command failed, but no test failures detected in the result json."
 

--- a/tasks/unit_tests/civisibility_tests.py
+++ b/tasks/unit_tests/civisibility_tests.py
@@ -54,7 +54,8 @@ class TestCIVisibilityLinks(unittest.TestCase):
         suite_name = "github.com/DataDog/datadog-agent/totoro"
         test_name = "TestTotoro/WhenTheyWakeUp"
         result = get_test_link_to_test_on_main(suite_name, test_name)
-        expected = f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40test.name%3A%22TestTotoro%2FWhenTheyWakeUp%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftotoro%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent"
+        full_url = f"{TEST_VISIBILITY_URL}?query=test_level%3Atest%20%40test.name%3A%22TestTotoro%2FWhenTheyWakeUp%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftotoro%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent"
+        expected = f'<a href="{full_url}" class="gl-reset-color! gl-text-decoration-underline" rel="nofollow noopener noreferrer">Test Visibility</a>'
         self.assertEqual(
             result,
             expected,


### PR DESCRIPTION
### What does this PR do?
Display Test Visibility links as hyperlinks on gitlab logs

### Motivation
It's easier when you can click on a link rather than copy/pasting

### Additional Notes
Check the real logs to see the hyperlinks:
[Before](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/620213063):
![image](https://github.com/user-attachments/assets/77757678-b871-46da-ac53-c89590416083)

[After](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/620769289)
![image](https://github.com/user-attachments/assets/6931c679-60ac-4e6d-aa46-0e8ad524bbf6)


