### PR TITLE
[oracle] Add oracle_client_lib_dir parameter

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -90,9 +90,9 @@ instances:
     # oracle_client: false
 
     ## @param oracle_client_lib_dir - boolean - optional
-    ## Specify the directory with Oracle client libraries. Relevan only if `oracle_client = true`.
+    ## Specify the directory with Oracle client libraries. Relevant only if `oracle_client = true`.
     #
-    # oracle_client: <ORACLE_CLIENT_DIR>
+    # oracle_client_lib_dir: <ORACLE_CLIENT_LIB_DIR>
 
     ## @param username - string - required
     ## Username for the Datadog-Oracle server check user. The user has to exist in CDB.

--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -89,6 +89,11 @@ instances:
     #
     # oracle_client: false
 
+    ## @param oracle_client_lib_dir - boolean - optional
+    ## Specify the directory with Oracle client libraries. Relevan only if `oracle_client = true`.
+    #
+    # oracle_client: <ORACLE_CLIENT_DIR>
+
     ## @param username - string - required
     ## Username for the Datadog-Oracle server check user. The user has to exist in CDB.
     #

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -124,16 +124,17 @@ type locksConfig struct {
 
 // ConnectionConfig store the database connection information
 type ConnectionConfig struct {
-	Server       string `yaml:"server"`
-	Port         int    `yaml:"port"`
-	ServiceName  string `yaml:"service_name"`
-	Username     string `yaml:"username"`
-	Password     string `yaml:"password"`
-	TnsAlias     string `yaml:"tns_alias"`
-	TnsAdmin     string `yaml:"tns_admin"`
-	Protocol     string `yaml:"protocol"`
-	Wallet       string `yaml:"wallet"`
-	OracleClient bool   `yaml:"oracle_client"`
+	Server             string `yaml:"server"`
+	Port               int    `yaml:"port"`
+	ServiceName        string `yaml:"service_name"`
+	Username           string `yaml:"username"`
+	Password           string `yaml:"password"`
+	TnsAlias           string `yaml:"tns_alias"`
+	TnsAdmin           string `yaml:"tns_admin"`
+	Protocol           string `yaml:"protocol"`
+	Wallet             string `yaml:"wallet"`
+	OracleClient       bool   `yaml:"oracle_client"`
+	OracleClientLibDir string `yaml:"oracle_client_lib_dir"`
 }
 
 // InstanceConfig is used to deserialize integration instance config.

--- a/pkg/collector/corechecks/oracle/connection_handling.go
+++ b/pkg/collector/corechecks/oracle/connection_handling.go
@@ -10,6 +10,7 @@ package oracle
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
@@ -32,11 +33,11 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 	var oracleDriver string
 	if c.config.TnsAlias != "" {
 		connStr = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, c.config.Username, c.config.Password, c.config.TnsAlias)
-		oracleDriver = "godror"
+		oracleDriver = common.Godror
 	} else {
 		// godror ezconnect string
 		if c.config.InstanceConfig.OracleClient {
-			oracleDriver = "godror"
+			oracleDriver = common.Godror
 			protocolString := ""
 			walletString := ""
 			if c.config.Protocol == "TCPS" {
@@ -54,6 +55,10 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 			sqlx.BindDriver("oracle", sqlx.NAMED)
 		}
 	}
+	if oracleDriver == common.Godror && c.config.InstanceConfig.OracleClientLibDir != "" {
+		connStr = fmt.Sprintf(`%s libDir="%s"`, connStr, c.config.InstanceConfig.OracleClientLibDir)
+	}
+
 	c.driver = oracleDriver
 
 	log.Infof("%s driver: %s", c.logPrompt, oracleDriver)

--- a/releasenotes/notes/oracle-lib-dir-2de4d20ffb6be943.yaml
+++ b/releasenotes/notes/oracle-lib-dir-2de4d20ffb6be943.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [oracle] Add ``oracle_client_lib_dir`` config parameter.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Add `oracle_client_lib_dir` parameter. The parameter specifies the location to external Oracle client libraries.

### Motivation

Previously, the location had to be specified by setting the environment variables. This is a more convenient option.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set the `oracle_client*` variables and check if the agent is properly functioning.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
