### PR TITLE
[ASCII-2214] Replace GUI URL target from 127.0.0.1 to localhost (#28602)

### DIFF
--- a/cmd/agent/subcommands/launchgui/command.go
+++ b/cmd/agent/subcommands/launchgui/command.go
@@ -8,6 +8,7 @@ package launchgui
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 // cliParams are the command-line arguments for this subcommand
@@ -53,6 +55,14 @@ func launchGui(config config.Component, _ *cliParams, _ log.Component) error {
 		return fmt.Errorf("GUI not enabled: to enable, please set an appropriate port in your datadog.yaml file")
 	}
 
+	// 'http://localhost' is preferred over 'http://127.0.0.1' due to Internet Explorer behavior.
+	// Internet Explorer High Security Level does not support setting cookies via HTTP Header response.
+	// By default, 'http://localhost' is categorized as an "intranet" website, which is considered safer and allowed to use cookies. This is not the case for 'http://127.0.0.1'.
+	guiHost, err := system.IsLocalAddress(config.GetString("GUI_host"))
+	if err != nil {
+		return fmt.Errorf("GUI server host is not a local address: %s", err)
+	}
+
 	endpoint, err := apiutil.NewIPCEndpoint(config, "/agent/gui/intent")
 	if err != nil {
 		return err
@@ -63,12 +73,14 @@ func launchGui(config config.Component, _ *cliParams, _ log.Component) error {
 		return err
 	}
 
+	guiAddress := net.JoinHostPort(guiHost, guiPort)
+
 	// Open the GUI in a browser, passing the authorization tokens as parameters
-	err = open("http://127.0.0.1:" + guiPort + "/auth?intent=" + string(intentToken))
+	err = open("http://" + guiAddress + "/auth?intent=" + string(intentToken))
 	if err != nil {
 		return fmt.Errorf("error opening GUI: " + err.Error())
 	}
 
-	fmt.Printf("GUI opened at 127.0.0.1:" + guiPort + "\n")
+	fmt.Printf("GUI opened at %s\n", guiAddress)
 	return nil
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1017,6 +1017,11 @@ func agent(config pkgconfigmodel.Setup) {
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
 
+	// Agent GUI access host
+	// 		'http://localhost' is preferred over 'http://127.0.0.1' due to Internet Explorer behavior.
+	// 		Internet Explorer High Security Level does not support setting cookies via HTTP Header response.
+	// 		By default, 'http://localhost' is categorized as an "intranet" website, which is considered safer and allowed to use cookies. This is not the case for 'http://127.0.0.1'.
+	config.BindEnvAndSetDefault("GUI_host", "localhost")
 	// Agent GUI access port
 	config.BindEnvAndSetDefault("GUI_port", defaultGuiPort)
 	config.BindEnvAndSetDefault("GUI_session_expiration", 0)

--- a/releasenotes/notes/fix-gui-on-IE-47df61d9be4d3eb6.yaml
+++ b/releasenotes/notes/fix-gui-on-IE-47df61d9be4d3eb6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue causing GUI to fail when opening with Internet Explorer on Windows.


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/pull/28602 for 7.56.2 release 