### PR TITLE
[e2e] dump stack resources after creation

### DIFF
--- a/test/new-e2e/pkg/e2e/pulumi_provisioner.go
+++ b/test/new-e2e/pkg/e2e/pulumi_provisioner.go
@@ -112,7 +112,7 @@ func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName st
 func dumpRawResources(resources RawResources) string {
 	var res string
 	for key, value := range resources {
-		res += fmt.Sprintf("Key: %s\nValue: %s\n\n", key, value)
+		res += fmt.Sprintf("%s: %s\n", key, value)
 	}
 	return res
 }

--- a/test/new-e2e/pkg/e2e/pulumi_provisioner.go
+++ b/test/new-e2e/pkg/e2e/pulumi_provisioner.go
@@ -12,9 +12,10 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 const (
@@ -91,7 +92,7 @@ func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName st
 		}
 
 		// Unfortunately we don't have access to Pulumi raw data
-		marshalled, err := json.Marshal(value.Value)
+		marshalled, err := json.MarshalIndent(value.Value, "", "\t")
 		if err != nil {
 			return nil, fmt.Errorf("unable to marshal output key: %s, err: %w", key, err)
 		}
@@ -99,7 +100,21 @@ func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName st
 		resources[key] = marshalled
 	}
 
+	_, err = logger.Write([]byte(fmt.Sprintf("Pulumi stack %s successfully provisioned\nResources:\n%v\n\n", stackName, dumpRawResources(resources))))
+	if err != nil {
+		// Log the error but don't fail the provisioning
+		fmt.Printf("Failed to write log: %v\n", err)
+	}
+
 	return resources, nil
+}
+
+func dumpRawResources(resources RawResources) string {
+	var res string
+	for key, value := range resources {
+		res += fmt.Sprintf("Key: %s\nValue: %s\n\n", key, value)
+	}
+	return res
 }
 
 // Diagnose runs the diagnose function if it is set diagnoseFunc

--- a/test/new-e2e/pkg/e2e/suite_utils.go
+++ b/test/new-e2e/pkg/e2e/suite_utils.go
@@ -16,6 +16,7 @@ func newTestLogger(t *testing.T) testLogger {
 }
 
 func (tl testLogger) Write(p []byte) (n int, err error) {
+	tl.t.Helper()
 	tl.t.Log(string(p))
 	return len(p), nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Dump resources at stack creation in test logs

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This can help debugging a failing test, providing the created resources information. Needed for the workshop

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Example of log after changes

```
/Users/paola.ducolin/go/src/github.com/DataDog/datadog-agent/test/new-e2e/examples/pulumi_provisioner.go:103: Pulumi stack e2e-vmSuite-b8f9735106b02376 successfully provisioned
        Resources:
        dd-Host-aws-vm: {
        	"address": "10.1.60.229",
        	"architecture": "x86_64",
        	"osFamily": 1,
        	"osFlavor": 1,
        	"osVersion": "22.04",
        	"password": "",
        	"username": "ubuntu"
        }
```

Note how the log is now prefixed by the caller line , rather than the `suite_utils:Write` line 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
