### PR TITLE
[e2e] add map of all existing e2e environment variables

### DIFF
--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -9,44 +9,44 @@ package parameters
 type StoreKey string
 
 const (
-	// APIKey config file parameter name
+	// APIKey Datadog api key
 	APIKey StoreKey = "api_key"
-	// APPKey config file parameter name
+	// APPKey Datadog app key
 	APPKey StoreKey = "app_key"
-	// Environments config file parameter name
+	// Environments space-separated cloud environments
 	Environments StoreKey = "env"
-	// ExtraResourcesTags config file parameter name
+	// ExtraResourcesTags extra tags to label resources
 	ExtraResourcesTags StoreKey = "extra_resources_tags"
-	// KeyPairName config file parameter name
+	// KeyPairName aws keypairname, used to access EC2 instances
 	KeyPairName StoreKey = "key_pair_name"
-	// PrivateKeyPassword config file parameter name
+	// PrivateKeyPassword private ssh key password
 	PrivateKeyPassword StoreKey = "private_key_password"
-	// PrivateKeyPath config file parameter name
+	// PrivateKeyPath private ssh key path
 	PrivateKeyPath StoreKey = "private_key_path"
-	// Profile config file parameter name
+	// Profile aws profile name
 	Profile StoreKey = "profile"
-	// PublicKeyPath config file parameter name
+	// PublicKeyPath public ssh key path
 	PublicKeyPath StoreKey = "public_key_path"
 	// PulumiPassword config file parameter name
 	PulumiPassword StoreKey = "pulumi_password"
-	// SkipDeleteOnFailure config file parameter name
+	// SkipDeleteOnFailure keep the stack on test failure
 	SkipDeleteOnFailure StoreKey = "skip_delete_on_failure"
-	// StackParameters config file parameter name
+	// StackParameters configuration map for the stack, in a json formatted string
 	StackParameters StoreKey = "stack_params"
-	// PipelineID config file parameter name
+	// PipelineID  used to deploy agent artifacts from a Gitlab pipeline
 	PipelineID StoreKey = "pipeline_id"
-	// CommitSHA config file parameter name
+	// CommitSHA is used to deploy agent artifacts from a specific commit, needed for docker images
 	CommitSHA StoreKey = "commit_sha"
-	// VerifyCodeSignature config file parameter name
+	// VerifyCodeSignature of the agent
 	VerifyCodeSignature StoreKey = "verify_code_signature"
-	// OutputDir config file parameter name
+	// OutputDir path to store test artifacts
 	OutputDir StoreKey = "output_dir"
-	// PulumiLogLevel config file parameter name
+	// PulumiLogLevel sets the log level for pulumi. Pulumi emits logs at log levels between 1 and 11, with 11 being the most verbose.
 	PulumiLogLevel StoreKey = "pulumi_log_level"
-	// PulumiLogToStdErr config file parameter name
+	// PulumiLogToStdErr specifies that all logs should be sent directly to stderr - making it more accessible and avoiding OS level buffering.
 	PulumiLogToStdErr StoreKey = "pulumi_log_to_stderr"
-	// PulumiVerboseProgressStreams config file parameter name
+	// PulumiVerboseProgressStreams allows specifying one or more io.Writers to redirect incremental update stdout
 	PulumiVerboseProgressStreams StoreKey = "pulumi_verbose_progress_streams"
-	// DevMode config flag parameter name
+	// DevMode allows to keep the stack after the test completes
 	DevMode StoreKey = "dev_mode"
 )

--- a/test/new-e2e/pkg/runner/parameters/store_env.go
+++ b/test/new-e2e/pkg/runner/parameters/store_env.go
@@ -6,11 +6,35 @@
 package parameters
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
 
 var _ valueStore = &envValueStore{}
+
+var envVariablesByStoreKey = map[StoreKey]string{
+	APIKey:                       "E2E_API_KEY",
+	APPKey:                       "E2E_APP_KEY",
+	Environments:                 "E2E_ENVIRONMENTS",
+	ExtraResourcesTags:           "E2E_EXTRA_RESOURCES_TAGS",
+	KeyPairName:                  "E2E_KEY_PAIR_NAME",
+	PrivateKeyPassword:           "E2E_PRIVATE_KEY_PASSWORD",
+	PrivateKeyPath:               "E2E_PRIVATE_KEY_PATH",
+	Profile:                      "E2E_PROFILE",
+	PublicKeyPath:                "E2E_PUBLIC_KEY_PATH",
+	PulumiPassword:               "E2E_PULUMI_PASSWORD",
+	SkipDeleteOnFailure:          "E2E_SKIP_DELETE_ON_FAILURE",
+	StackParameters:              "E2E_STACK_PARAMS",
+	PipelineID:                   "E2E_PIPELINE_ID",
+	CommitSHA:                    "E2E_COMMIT_SHA",
+	VerifyCodeSignature:          "E2E_VERIFY_CODE_SIGNATURE",
+	OutputDir:                    "E2E_OUTPUT_DIR",
+	PulumiLogLevel:               "E2E_PULUMI_LOG_LEVEL",
+	PulumiLogToStdErr:            "E2E_PULUMI_LOG_TO_STDERR",
+	PulumiVerboseProgressStreams: "E2E_PULUMI_VERBOSE_PROGRESS_STREAMS",
+	DevMode:                      "E2E_DEV_MODE",
+}
 
 type envValueStore struct {
 	prefix string
@@ -30,7 +54,11 @@ func newEnvValueStore(prefix string) envValueStore {
 // Get returns parameter value.
 // For env Store, the key is upper cased and added to prefix
 func (s envValueStore) get(key StoreKey) (string, error) {
-	envValueStoreKey := strings.ToUpper(s.prefix + string(key))
+	envValueStoreKey := envVariablesByStoreKey[key]
+	if envValueStoreKey == "" {
+		fmt.Printf("key [%s] not found in envValueStoreKey, converting to `strings.ToUpper(E2E_<key>)`\n", key)
+		envValueStoreKey = strings.ToUpper(s.prefix + string(key))
+	}
 	val, found := os.LookupEnv(strings.ToUpper(envValueStoreKey))
 	if !found {
 		return "", ParameterNotFoundError{key: key}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add an explicit list of E2E environment variables

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This does not change the behaviour and the mechanism of the parameter store based on environment variables, but it improves its documentation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Will add a link to this map in the e2e documentation

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
