### PR TITLE
[CWS] take `dp` lock when updating profile mapping

### DIFF
--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -252,10 +252,12 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 	}
 
 	// update profile mapping
+	dp.Lock()
 	dp.profileMapping[profileManagerSelector] = profileFSEntry{
 		path:     profilePath,
 		selector: workloadSelector,
 	}
+	dp.Unlock()
 
 	seclog.Debugf("security profile %s loaded from file system", workloadSelector)
 


### PR DESCRIPTION
### What does this PR do?

Updating the profile mapping should be done when the lock is taken, otherwise you can have a race against the stats goroutine.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
