### PR TITLE
[ASCII-2240]  Avoid using the global tagger inside the logs agent

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -13,11 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/sources"
-
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
 )

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -9,11 +9,13 @@
 package log
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
@@ -52,8 +54,8 @@ func CreateConfig(origin string) *Config {
 }
 
 // SetupLogAgent creates the log agent and sets the base tags
-func SetupLogAgent(conf *Config, tags map[string]string) logsAgent.ServerlessLogsAgent {
-	logsAgent, _ := serverlessLogs.SetupLogAgent(conf.Channel, sourceName, conf.source)
+func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component) logsAgent.ServerlessLogsAgent {
+	logsAgent, _ := serverlessLogs.SetupLogAgent(conf.Channel, sourceName, conf.source, tagger)
 
 	tagsArray := serverlessTag.MapToArray(tags)
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -96,8 +96,8 @@ func main() {
 }
 
 // removing these unused dependencies will cause silent crash due to fx framework
-func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Component) error {
-	cloudService, logConfig, traceAgent, metricAgent, logsAgent := setup(modeConf)
+func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Component, tagger tagger.Component) error {
+	cloudService, logConfig, traceAgent, metricAgent, logsAgent := setup(modeConf, tagger)
 
 	err := modeConf.Runner(logConfig)
 
@@ -107,7 +107,7 @@ func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Compon
 	return err
 }
 
-func setup(mode.Conf) (cloudservice.CloudService, *serverlessInitLog.Config, trace.ServerlessTraceAgent, *metrics.ServerlessMetricAgent, logsAgent.ServerlessLogsAgent) {
+func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *serverlessInitLog.Config, trace.ServerlessTraceAgent, *metrics.ServerlessMetricAgent, logsAgent.ServerlessLogsAgent) {
 	tracelog.SetLogger(corelogger{})
 
 	// load proxy settings
@@ -138,7 +138,7 @@ func setup(mode.Conf) (cloudservice.CloudService, *serverlessInitLog.Config, tra
 	if err != nil {
 		log.Debugf("Error loading config: %v\n", err)
 	}
-	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags)
+	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags, tagger)
 
 	traceAgent := setupTraceAgent(tags)
 

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/serverless/logs"
@@ -26,6 +27,9 @@ import (
 func TestTagsSetup(t *testing.T) {
 	// TODO: Fix and re-enable flaky test
 	t.Skip()
+
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	configmock.New(t)
 
@@ -38,7 +42,7 @@ func TestTagsSetup(t *testing.T) {
 
 	allTags := append(ddTags, ddExtraTags...)
 
-	_, _, traceAgent, metricAgent, _ := setup(mode.Conf{})
+	_, _, traceAgent, metricAgent, _ := setup(mode.Conf{}, fakeTagger)
 	defer traceAgent.Stop()
 	defer metricAgent.Stop()
 	assert.Subset(t, metricAgent.GetExtraTags(), allTags)

--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -77,6 +77,7 @@ github.com/DataDog/datadog-agent/comp/core/log/impl
 github.com/DataDog/datadog-agent/comp/core/secrets
 github.com/DataDog/datadog-agent/comp/core/status
 github.com/DataDog/datadog-agent/comp/core/tagger
+github.com/DataDog/datadog-agent/comp/core/tagger/noopimpl
 github.com/DataDog/datadog-agent/comp/core/tagger/telemetry
 github.com/DataDog/datadog-agent/comp/core/tagger/types
 github.com/DataDog/datadog-agent/comp/core/tagger/utils

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -77,6 +77,7 @@ github.com/DataDog/datadog-agent/comp/core/log/impl
 github.com/DataDog/datadog-agent/comp/core/secrets
 github.com/DataDog/datadog-agent/comp/core/status
 github.com/DataDog/datadog-agent/comp/core/tagger
+github.com/DataDog/datadog-agent/comp/core/tagger/noopimpl
 github.com/DataDog/datadog-agent/comp/core/tagger/telemetry
 github.com/DataDog/datadog-agent/comp/core/tagger/types
 github.com/DataDog/datadog-agent/comp/core/tagger/utils

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	taggernoop "github.com/DataDog/datadog-agent/comp/core/tagger/noopimpl"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -69,7 +71,10 @@ const (
 
 func main() {
 	// run the agent
-	err := fxutil.OneShot(runAgent)
+	err := fxutil.OneShot(
+		runAgent,
+		taggernoop.Module(),
+	)
 
 	if err != nil {
 		log.Error(err)
@@ -77,7 +82,7 @@ func main() {
 	}
 }
 
-func runAgent() {
+func runAgent(tagger tagger.Component) {
 	startTime := time.Now()
 
 	setupLambdaAgentOverrides()
@@ -113,7 +118,7 @@ func runAgent() {
 
 	go startTraceAgent(&wg, lambdaSpanChan, coldStartSpanId, serverlessDaemon)
 	go startOtlpAgent(&wg, metricAgent, serverlessDaemon)
-	go startTelemetryCollection(&wg, serverlessID, logChannel, serverlessDaemon)
+	go startTelemetryCollection(&wg, serverlessID, logChannel, serverlessDaemon, tagger)
 
 	// start appsec
 	appsecProxyProcessor := startAppSec(serverlessDaemon)
@@ -284,7 +289,7 @@ func startAppSec(serverlessDaemon *daemon.Daemon) *httpsec.ProxyLifecycleProcess
 	return appsecProxyProcessor
 }
 
-func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, logChannel chan *logConfig.ChannelMessage, serverlessDaemon *daemon.Daemon) {
+func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, logChannel chan *logConfig.ChannelMessage, serverlessDaemon *daemon.Daemon, tagger tagger.Component) {
 	defer wg.Done()
 	if os.Getenv(daemon.LocalTestEnvVar) == "true" || os.Getenv(daemon.LocalTestEnvVar) == "1" {
 		log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
@@ -308,7 +313,7 @@ func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, 
 	if logRegistrationError != nil {
 		log.Error("Can't subscribe to logs:", logRegistrationError)
 	} else {
-		logsAgent, err := serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda")
+		logsAgent, err := serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda", tagger)
 		if err != nil {
 			log.Errorf("Error setting up the logs agent: %s", err)
 		}

--- a/comp/core/tagger/noopimpl/tagger.go
+++ b/comp/core/tagger/noopimpl/tagger.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tagger implements the Tagger component. The Tagger is the central
+// source of truth for client-side entity tagging. It subscribes to workloadmeta
+// to get updates for all the entity kinds (containers, kubernetes pods,
+// kubernetes nodes, etc.) and extracts the tags for each of them. Tags are then
+// stored in memory (by the TagStore) and can be queried by the tagger.Tag()
+// method.
+
+// Package noopimpl provides a noop implementation for the tagger component
+package noopimpl
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	taggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(
+			newTaggerClient,
+		),
+	)
+}
+
+type noopTagger struct{}
+
+func (n *noopTagger) Start(ctx context.Context) error {
+	return nil
+}
+
+func (n *noopTagger) Stop() error {
+	return nil
+}
+
+func (n *noopTagger) ReplayTagger() tagger.ReplayTagger {
+	return nil
+}
+
+func (n *noopTagger) GetTaggerTelemetryStore() *telemetry.Store {
+	return nil
+}
+
+func (n *noopTagger) Tag(entity string, cardinality types.TagCardinality) ([]string, error) {
+	return nil, nil
+}
+
+func (n *noopTagger) AccumulateTagsFor(entity string, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
+	return nil
+}
+
+func (n *noopTagger) Standard(entity string) ([]string, error) {
+	return nil, nil
+}
+
+func (n *noopTagger) List() types.TaggerListResponse {
+	return types.TaggerListResponse{}
+}
+
+func (n *noopTagger) GetEntity(entityID string) (*types.Entity, error) {
+	return nil, nil
+}
+
+func (n *noopTagger) Subscribe(cardinality types.TagCardinality) chan []types.EntityEvent {
+	return make(chan []types.EntityEvent)
+}
+
+func (n *noopTagger) Unsubscribe(ch chan []types.EntityEvent) {}
+
+func (n *noopTagger) GetEntityHash(entity string, cardinality types.TagCardinality) string {
+	return ""
+}
+
+func (n *noopTagger) AgentTags(cardinality types.TagCardinality) ([]string, error) {
+	return nil, nil
+}
+
+func (n *noopTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
+	return nil, nil
+}
+
+func (n *noopTagger) SetNewCaptureTagger(newCaptureTagger tagger.Component) {}
+
+func (n *noopTagger) ResetCaptureTagger() {}
+
+func (n *noopTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {}
+
+func (n *noopTagger) ChecksCardinality() types.TagCardinality {
+	return types.LowCardinality
+}
+
+func (n *noopTagger) DogstatsdCardinality() types.TagCardinality {
+	return types.LowCardinality
+}
+
+func newTaggerClient() tagger.Component {
+	return &noopTagger{}
+}

--- a/comp/core/tagger/noopimpl/tagger.go
+++ b/comp/core/tagger/noopimpl/tagger.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
+// Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(
@@ -36,7 +37,7 @@ func Module() fxutil.Module {
 
 type noopTagger struct{}
 
-func (n *noopTagger) Start(ctx context.Context) error {
+func (n *noopTagger) Start(context.Context) error {
 	return nil
 }
 
@@ -52,15 +53,15 @@ func (n *noopTagger) GetTaggerTelemetryStore() *telemetry.Store {
 	return nil
 }
 
-func (n *noopTagger) Tag(entity string, cardinality types.TagCardinality) ([]string, error) {
+func (n *noopTagger) Tag(string, types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
-func (n *noopTagger) AccumulateTagsFor(entity string, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
+func (n *noopTagger) AccumulateTagsFor(string, types.TagCardinality, tagset.TagsAccumulator) error {
 	return nil
 }
 
-func (n *noopTagger) Standard(entity string) ([]string, error) {
+func (n *noopTagger) Standard(string) ([]string, error) {
 	return nil, nil
 }
 
@@ -68,33 +69,33 @@ func (n *noopTagger) List() types.TaggerListResponse {
 	return types.TaggerListResponse{}
 }
 
-func (n *noopTagger) GetEntity(entityID string) (*types.Entity, error) {
+func (n *noopTagger) GetEntity(string) (*types.Entity, error) {
 	return nil, nil
 }
 
-func (n *noopTagger) Subscribe(cardinality types.TagCardinality) chan []types.EntityEvent {
+func (n *noopTagger) Subscribe(types.TagCardinality) chan []types.EntityEvent {
 	return make(chan []types.EntityEvent)
 }
 
-func (n *noopTagger) Unsubscribe(ch chan []types.EntityEvent) {}
+func (n *noopTagger) Unsubscribe(chan []types.EntityEvent) {}
 
-func (n *noopTagger) GetEntityHash(entity string, cardinality types.TagCardinality) string {
+func (n *noopTagger) GetEntityHash(string, types.TagCardinality) string {
 	return ""
 }
 
-func (n *noopTagger) AgentTags(cardinality types.TagCardinality) ([]string, error) {
+func (n *noopTagger) AgentTags(types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
-func (n *noopTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
+func (n *noopTagger) GlobalTags(types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
-func (n *noopTagger) SetNewCaptureTagger(newCaptureTagger tagger.Component) {}
+func (n *noopTagger) SetNewCaptureTagger(tagger.Component) {}
 
 func (n *noopTagger) ResetCaptureTagger() {}
 
-func (n *noopTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {}
+func (n *noopTagger) EnrichTags(tagset.TagsAccumulator, taggertypes.OriginInfo) {}
 
 func (n *noopTagger) ChecksCardinality() types.TagCardinality {
 	return types.LowCardinality

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -236,7 +236,7 @@ func (a *logAgent) setupAgent() error {
 		a.log.Error(fmt.Errorf("error while reading configuration, will block until the Agents receive an SDS configuration: %v", err))
 	}
 
-	a.SetupPipeline(processingRules, a.wmeta, a.integrationsLogs, a.tagger)
+	a.SetupPipeline(processingRules, a.wmeta, a.integrationsLogs)
 	return nil
 }
 

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -49,16 +49,16 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 	// setup the launchers
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, auditor, a.tracker)
 
-	file_limits := a.config.GetInt("logs_config.open_files_limit")
-	file_validate_pod_container := a.config.GetBool("logs_config.validate_pod_container_id")
-	file_scan_period := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
-	file_wildcard_selection_mode := a.config.GetString("logs_config.file_wildcard_selection_mode")
+	fileLimits := a.config.GetInt("logs_config.open_files_limit")
+	fileValidatePodContainer := a.config.GetBool("logs_config.validate_pod_container_id")
+	fileScanPeriod := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
+	fileWildcardSelectionMode := a.config.GetString("logs_config.file_wildcard_selection_mode")
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
-		file_limits,
+		fileLimits,
 		filelauncher.DefaultSleepDuration,
-		file_validate_pod_container,
-		file_scan_period,
-		file_wildcard_selection_mode,
+		fileValidatePodContainer,
+		fileScanPeriod,
+		fileWildcardSelectionMode,
 		a.flarecontroller,
 		a.tagger))
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -48,14 +48,19 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 
 	// setup the launchers
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, auditor, a.tracker)
+
+	file_limits := a.config.GetInt("logs_config.open_files_limit")
+	file_validate_pod_container := a.config.GetBool("logs_config.validate_pod_container_id")
+	file_scan_period := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
+	file_wildcard_selection_mode := a.config.GetString("logs_config.file_wildcard_selection_mode")
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
-		a.config.GetInt("logs_config.open_files_limit"),
+		file_limits,
 		filelauncher.DefaultSleepDuration,
-		a.config.GetBool("logs_config.validate_pod_container_id"),
-		time.Duration(a.config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
-		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller,
-		a.tagger),
-	)
+		file_validate_pod_container,
+		file_scan_period,
+		file_wildcard_selection_mode,
+		a.flarecontroller,
+		a.tagger))
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))
 	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller))
 	lnchrs.AddLauncher(windowsevent.NewLauncher())

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -10,7 +10,6 @@ package agentimpl
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
@@ -33,7 +32,7 @@ import (
 )
 
 // NewAgent returns a new Logs Agent
-func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta optional.Option[workloadmeta.Component], integrationsLogs integrations.Component, tagger tagger.Component) {
+func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta optional.Option[workloadmeta.Component], integrationsLogs integrations.Component) {
 	health := health.RegisterLiveness("logs-agent")
 
 	// setup the auditor
@@ -55,12 +54,12 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 		a.config.GetBool("logs_config.validate_pod_container_id"),
 		time.Duration(a.config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
 		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller,
-		tagger),
+		a.tagger),
 	)
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))
 	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller))
 	lnchrs.AddLauncher(windowsevent.NewLauncher())
-	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, tagger))
+	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger))
 	lnchrs.AddLauncher(integrationLauncher.NewLauncher(
 		a.sources, integrationsLogs))
 

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -53,14 +53,19 @@ func (a *logAgent) SetupPipeline(
 
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, a.auditor, a.tracker)
 	lnchrs.AddLauncher(channel.NewLauncher())
-	lnchrs.AddLauncher(filelauncher.NewLauncher(
-		a.config.GetInt("logs_config.open_files_limit"),
-		filelauncher.DefaultSleepDuration,
-		a.config.GetBool("logs_config.validate_pod_container_id"),
-		time.Duration(a.config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
-		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller, a.tagger),
-	)
 
+	file_limits := a.config.GetInt("logs_config.open_files_limit")
+	file_validate_pod_container := a.config.GetBool("logs_config.validate_pod_container_id")
+	file_scan_period := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
+	file_wildcard_selection_mode := a.config.GetString("logs_config.file_wildcard_selection_mode")
+	lnchrs.AddLauncher(filelauncher.NewLauncher(
+		file_limits,
+		filelauncher.DefaultSleepDuration,
+		file_validate_pod_container,
+		file_scan_period,
+		file_wildcard_selection_mode,
+		a.flarecontroller,
+		a.tagger))
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
 	a.destinationsCtx = destinationsCtx
 	a.pipelineProvider = pipelineProvider

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -54,16 +54,16 @@ func (a *logAgent) SetupPipeline(
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, a.auditor, a.tracker)
 	lnchrs.AddLauncher(channel.NewLauncher())
 
-	file_limits := a.config.GetInt("logs_config.open_files_limit")
-	file_validate_pod_container := a.config.GetBool("logs_config.validate_pod_container_id")
-	file_scan_period := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
-	file_wildcard_selection_mode := a.config.GetString("logs_config.file_wildcard_selection_mode")
+	fileLimits := a.config.GetInt("logs_config.open_files_limit")
+	fileValidatePodContainer := a.config.GetBool("logs_config.validate_pod_container_id")
+	fileScanPeriod := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
+	fileWildcardSelectionMode := a.config.GetString("logs_config.file_wildcard_selection_mode")
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
-		file_limits,
+		fileLimits,
 		filelauncher.DefaultSleepDuration,
-		file_validate_pod_container,
-		file_scan_period,
-		file_wildcard_selection_mode,
+		fileValidatePodContainer,
+		fileScanPeriod,
+		fileWildcardSelectionMode,
 		a.flarecontroller,
 		a.tagger))
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -58,8 +58,7 @@ func (a *logAgent) SetupPipeline(
 		filelauncher.DefaultSleepDuration,
 		a.config.GetBool("logs_config.validate_pod_container_id"),
 		time.Duration(a.config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
-		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller),
-		a.tagger,
+		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller, a.tagger),
 	)
 
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -58,7 +58,9 @@ func (a *logAgent) SetupPipeline(
 		filelauncher.DefaultSleepDuration,
 		a.config.GetBool("logs_config.validate_pod_container_id"),
 		time.Duration(a.config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
-		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller))
+		a.config.GetString("logs_config.file_wildcard_selection_mode"), a.flarecontroller),
+		a.tagger,
+	)
 
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
 	a.destinationsCtx = destinationsCtx

--- a/comp/logs/agent/agentimpl/serverless.go
+++ b/comp/logs/agent/agentimpl/serverless.go
@@ -7,19 +7,22 @@ package agentimpl
 
 import (
 	"context"
+
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 
+	"go.uber.org/atomic"
+
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log/impl"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	pkgConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
-	"go.uber.org/atomic"
 )
 
 // NewServerlessLogsAgent creates a new instance of the logs agent for serverless
-func NewServerlessLogsAgent() agent.ServerlessLogsAgent {
+func NewServerlessLogsAgent(tagger tagger.Component) agent.ServerlessLogsAgent {
 	logsAgent := &logAgent{
 		log:     logComponent.NewTemporaryLoggerWithoutInit(),
 		config:  pkgConfig.Datadog(),
@@ -29,6 +32,8 @@ func NewServerlessLogsAgent() agent.ServerlessLogsAgent {
 		services:        service.NewServices(),
 		tracker:         tailers.NewTailerTracker(),
 		flarecontroller: flareController.NewFlareController(),
+
+		tagger: tagger,
 	}
 	return logsAgent
 }

--- a/comp/logs/agent/agentimpl/serverless.go
+++ b/comp/logs/agent/agentimpl/serverless.go
@@ -8,13 +8,12 @@ package agentimpl
 import (
 	"context"
 
-	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
-
 	"go.uber.org/atomic"
 
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log/impl"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
+	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	pkgConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -32,8 +31,7 @@ func NewServerlessLogsAgent(tagger tagger.Component) agent.ServerlessLogsAgent {
 		services:        service.NewServices(),
 		tracker:         tailers.NewTailerTracker(),
 		flarecontroller: flareController.NewFlareController(),
-
-		tagger: tagger,
+		tagger:          tagger,
 	}
 	return logsAgent
 }

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	logsBundle "github.com/DataDog/datadog-agent/comp/logs"
@@ -150,8 +152,18 @@ func TestGetPayload(t *testing.T) {
 		// Register an error
 		src.Status.Error(fmt.Errorf("No such file or directory"))
 		logSources.AddSource(src)
+		fakeTagger := taggerimpl.SetupFakeTagger(t)
+		defer fakeTagger.ResetTagger()
+
 		mockLogAgent := fxutil.Test[optional.Option[logagent.Mock]](
-			t, logsBundle.MockBundle(), core.MockBundle(), inventoryagentimpl.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			t,
+			logsBundle.MockBundle(),
+			core.MockBundle(),
+			inventoryagentimpl.MockModule(),
+			workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			fx.Provide(func() tagger.Component {
+				return fakeTagger
+			}),
 		)
 		logsAgent, _ := mockLogAgent.Get()
 		logsAgent.SetSources(logSources)

--- a/pkg/logs/internal/tag/provider_benchmark_test.go
+++ b/pkg/logs/internal/tag/provider_benchmark_test.go
@@ -26,7 +26,9 @@ func setupConfig(t testing.TB, tags []string) (model.Config, time.Time) {
 	return mockConfig, startTime
 }
 
-var dummyTagFunction = func(string, types.TagCardinality) ([]string, error) {
+type dummyTagAdder struct{}
+
+func (dummyTagAdder) Tag(string, types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
@@ -44,7 +46,7 @@ func BenchmarkProviderExpectedTags(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo", dummyTagFunction)
+	p := NewProvider("foo", dummyTagAdder{})
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -67,7 +69,7 @@ func BenchmarkProviderExpectedTagsEmptySlice(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo", dummyTagFunction)
+	p := NewProvider("foo", dummyTagAdder{})
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -90,7 +92,7 @@ func BenchmarkProviderExpectedTagsNil(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo", dummyTagFunction)
+	p := NewProvider("foo", dummyTagAdder{})
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -110,7 +112,7 @@ func BenchmarkProviderNoExpectedTags(b *testing.B) {
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.SetWithoutSource("logs_config.expected_tags_duration", "0")
 
-	p := NewProvider("foo", dummyTagFunction)
+	p := NewProvider("foo", dummyTagAdder{})
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -130,7 +132,7 @@ func BenchmarkProviderNoExpectedTagsNil(b *testing.B) {
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.SetWithoutSource("logs_config.expected_tags_duration", "0")
 
-	p := NewProvider("foo", dummyTagFunction)
+	p := NewProvider("foo", dummyTagAdder{})
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()

--- a/pkg/logs/internal/tag/provider_benchmark_test.go
+++ b/pkg/logs/internal/tag/provider_benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	model "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -25,6 +26,10 @@ func setupConfig(t testing.TB, tags []string) (model.Config, time.Time) {
 	return mockConfig, startTime
 }
 
+var dummyTagFunction = func(string, types.TagCardinality) ([]string, error) {
+	return nil, nil
+}
+
 func BenchmarkProviderExpectedTags(b *testing.B) {
 	b.ReportAllocs()
 
@@ -39,7 +44,7 @@ func BenchmarkProviderExpectedTags(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo")
+	p := NewProvider("foo", dummyTagFunction)
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -62,7 +67,7 @@ func BenchmarkProviderExpectedTagsEmptySlice(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo")
+	p := NewProvider("foo", dummyTagFunction)
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -85,7 +90,7 @@ func BenchmarkProviderExpectedTagsNil(b *testing.B) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "1m")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo")
+	p := NewProvider("foo", dummyTagFunction)
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -105,7 +110,7 @@ func BenchmarkProviderNoExpectedTags(b *testing.B) {
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.SetWithoutSource("logs_config.expected_tags_duration", "0")
 
-	p := NewProvider("foo")
+	p := NewProvider("foo", dummyTagFunction)
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()
@@ -125,7 +130,7 @@ func BenchmarkProviderNoExpectedTagsNil(b *testing.B) {
 	// Setting a test-friendly value for the deadline (test should not take 1m)
 	m.SetWithoutSource("logs_config.expected_tags_duration", "0")
 
-	p := NewProvider("foo")
+	p := NewProvider("foo", dummyTagFunction)
 
 	for i := 0; i < b.N; i++ {
 		p.GetTags()

--- a/pkg/logs/internal/tag/provider_test.go
+++ b/pkg/logs/internal/tag/provider_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -40,7 +41,7 @@ func TestProviderExpectedTags(t *testing.T) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "5s")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := newProviderWithClock("foo", clock)
+	p := newProviderWithClock("foo", clock, fakeTagger.Tag)
 	pp := p.(*provider)
 
 	var tt []string

--- a/pkg/logs/internal/tag/provider_test.go
+++ b/pkg/logs/internal/tag/provider_test.go
@@ -41,7 +41,7 @@ func TestProviderExpectedTags(t *testing.T) {
 	m.SetWithoutSource("logs_config.expected_tags_duration", "5s")
 	defer m.SetWithoutSource("logs_config.expected_tags_duration", 0)
 
-	p := newProviderWithClock("foo", clock, fakeTagger.Tag)
+	p := newProviderWithClock("foo", clock, fakeTagger)
 	pp := p.(*provider)
 
 	var tt []string

--- a/pkg/logs/internal/util/service_name.go
+++ b/pkg/logs/internal/util/service_name.go
@@ -8,16 +8,12 @@ package util
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// taggerFunc purpose is to ease testing ServiceNameFromTags
-var taggerFunc = tagger.StandardTags
-
 // ServiceNameFromTags returns the standard tag 'service' corresponding to a container
 // It returns an empty string if tag not found
-func ServiceNameFromTags(ctrName, taggerEntity string) string {
+func ServiceNameFromTags(ctrName, taggerEntity string, taggerFunc func(entity string) ([]string, error)) string {
 	standardTags, err := taggerFunc(taggerEntity)
 	if err != nil {
 		log.Debugf("Couldn't get standard tags for container '%s': %v", ctrName, err)

--- a/pkg/logs/internal/util/service_name_test.go
+++ b/pkg/logs/internal/util/service_name_test.go
@@ -48,8 +48,7 @@ func TestServiceNameFromTags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			taggerFunc = tt.tFunc
-			if got := ServiceNameFromTags(tt.ctrName, tt.taggerEntity); got != tt.want {
+			if got := ServiceNameFromTags(tt.ctrName, tt.taggerEntity, tt.tFunc); got != tt.want {
 				t.Errorf("ServiceNameFromTags() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/logs/launchers/container/launcher_nodocker.go
+++ b/pkg/logs/launchers/container/launcher_nodocker.go
@@ -9,6 +9,7 @@
 package container
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -24,7 +25,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new launcher
-func NewLauncher(_ *sourcesPkg.LogSources, _ optional.Option[workloadmeta.Component]) *Launcher {
+func NewLauncher(_ *sourcesPkg.LogSources, _ optional.Option[workloadmeta.Component], _ tagger.Component) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/launchers/container/launcher_test.go
+++ b/pkg/logs/launchers/container/launcher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -36,7 +37,9 @@ func (tf *testFactory) MakeTailer(source *sources.LogSource) (tailerfactory.Tail
 }
 
 func TestStartStop(t *testing.T) {
-	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component]())
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
+	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component](), fakeTagger)
 
 	sp := launchers.NewMockSourceProvider()
 	pl := pipeline.NewMockProvider()
@@ -54,7 +57,9 @@ func TestStartStop(t *testing.T) {
 }
 
 func TestAddsRemovesSource(t *testing.T) {
-	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component]())
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
+	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name}, nil
@@ -83,7 +88,9 @@ func TestAddsRemovesSource(t *testing.T) {
 }
 
 func TestCannotMakeTailer(t *testing.T) {
-	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component]())
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
+	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(_ *sources.LogSource) (tailerfactory.Tailer, error) {
 			return nil, errors.New("uhoh")
@@ -104,7 +111,9 @@ func TestCannotMakeTailer(t *testing.T) {
 }
 
 func TestCannotStartTailer(t *testing.T) {
-	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component]())
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
+	l := NewLauncher(nil, optional.NewNoneOption[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name, StartError: true}, nil

--- a/pkg/logs/launchers/container/tailerfactory/defaults.go
+++ b/pkg/logs/launchers/container/tailerfactory/defaults.go
@@ -33,7 +33,9 @@ func (tf *factory) defaultSourceAndService(source *sources.LogSource, logWhat co
 	getServiceNameFromTags := func(containerID, containerName string) string {
 		return util.ServiceNameFromTags(
 			containerName,
-			containers.BuildTaggerEntityName(containerID))
+			containers.BuildTaggerEntityName(containerID),
+			tf.tagger.Standard,
+		)
 	}
 
 	return defaultSourceAndServiceInner(source, logWhat,

--- a/pkg/logs/launchers/container/tailerfactory/factory.go
+++ b/pkg/logs/launchers/container/tailerfactory/factory.go
@@ -10,6 +10,7 @@
 package tailerfactory
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
@@ -50,18 +51,21 @@ type factory struct {
 
 	// dockerutil memoizes a DockerUtil instance; fetch this with getDockerUtil().
 	dockerutil *dockerutilPkg.DockerUtil
+
+	tagger tagger.Component
 }
 
 var _ Factory = (*factory)(nil)
 
 // New creates a new Factory.
-func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore optional.Option[workloadmeta.Component]) Factory {
+func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore optional.Option[workloadmeta.Component], tagger tagger.Component) Factory {
 	return &factory{
 		sources:           sources,
 		pipelineProvider:  pipelineProvider,
 		registry:          registry,
 		workloadmetaStore: workloadmetaStore,
 		cop:               containersorpods.NewChooser(),
+		tagger:            tagger,
 	}
 }
 

--- a/pkg/logs/launchers/container/tailerfactory/socket.go
+++ b/pkg/logs/launchers/container/tailerfactory/socket.go
@@ -55,5 +55,6 @@ func (tf *factory) makeSocketTailer(source *sources.LogSource) (Tailer, error) {
 		pipeline,
 		readTimeout,
 		tf.registry,
+		tf.tagger,
 	), nil
 }

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -52,10 +53,11 @@ type Launcher struct {
 	validatePodContainerID bool
 	scanPeriod             time.Duration
 	flarecontroller        *flareController.FlareController
+	tagger                 tagger.Component
 }
 
 // NewLauncher returns a new launcher.
-func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePodContainerID bool, scanPeriod time.Duration, wildcardMode string, flarecontroller *flareController.FlareController) *Launcher {
+func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePodContainerID bool, scanPeriod time.Duration, wildcardMode string, flarecontroller *flareController.FlareController, tagger tagger.Component) *Launcher {
 
 	var wildcardStrategy fileprovider.WildcardSelectionStrategy
 	switch wildcardMode {
@@ -79,6 +81,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 		validatePodContainerID: validatePodContainerID,
 		scanPeriod:             scanPeriod,
 		flarecontroller:        flarecontroller,
+		tagger:                 tagger,
 	}
 }
 
@@ -386,6 +389,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		SleepDuration: s.tailerSleepDuration,
 		Decoder:       decoder.NewDecoderFromSource(file.Source, tailerInfo),
 		Info:          tailerInfo,
+		TagFunction:   s.tagger.Tag,
 	}
 
 	return tailer.NewTailer(tailerOptions)
@@ -393,7 +397,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 
 func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, pattern *regexp.Regexp) *tailer.Tailer {
 	tailerInfo := t.GetInfo()
-	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo)
+	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger.Tag)
 }
 
 //nolint:revive // TODO(AML) Fix revive linter

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -389,7 +389,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		SleepDuration: s.tailerSleepDuration,
 		Decoder:       decoder.NewDecoderFromSource(file.Source, tailerInfo),
 		Info:          tailerInfo,
-		TagFunction:   s.tagger.Tag,
+		TagAdder:      s.tagger,
 	}
 
 	return tailer.NewTailer(tailerOptions)
@@ -397,7 +397,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 
 func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, pattern *regexp.Regexp) *tailer.Tailer {
 	tailerInfo := t.GetInfo()
-	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger.Tag)
+	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger)
 }
 
 //nolint:revive // TODO(AML) Fix revive linter

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	pkgConfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -49,11 +51,13 @@ type LauncherTestSuite struct {
 	source           *sources.LogSource
 	openFilesLimit   int
 	s                *Launcher
+	tagger           tagger.Mock
 }
 
 func (suite *LauncherTestSuite) SetupTest() {
 	suite.pipelineProvider = mock.NewMockProvider()
 	suite.outputChan = suite.pipelineProvider.NextPipelineChan()
+	suite.tagger = taggerimpl.SetupFakeTagger(suite.T())
 
 	var err error
 	suite.testDir = suite.T().TempDir()
@@ -72,7 +76,7 @@ func (suite *LauncherTestSuite) SetupTest() {
 	suite.source = sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: suite.configID, Path: suite.testPath})
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	suite.s = NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	suite.s = NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, suite.tagger)
 	suite.s.pipelineProvider = suite.pipelineProvider
 	suite.s.registry = auditor.NewRegistry()
 	suite.s.activeSources = append(suite.s.activeSources, suite.source)
@@ -85,6 +89,7 @@ func (suite *LauncherTestSuite) TearDownTest() {
 	suite.testFile.Close()
 	suite.testRotatedFile.Close()
 	suite.s.cleanup()
+	suite.tagger.ResetTagger()
 }
 
 func (suite *LauncherTestSuite) TestLauncherStartsTailers() {
@@ -219,6 +224,8 @@ func TestLauncherTestSuiteWithConfigID(t *testing.T) {
 func TestLauncherScanStartNewTailer(t *testing.T) {
 	var path string
 	var msg *message.Message
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	IDs := []string{"", "123456789"}
 
@@ -230,7 +237,7 @@ func TestLauncherScanStartNewTailer(t *testing.T) {
 		openFilesLimit := 2
 		sleepDuration := 20 * time.Millisecond
 		fc := flareController.NewFlareController()
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -264,12 +271,14 @@ func TestLauncherScanStartNewTailer(t *testing.T) {
 func TestLauncherWithConcurrentContainerTailer(t *testing.T) {
 	testDir := t.TempDir()
 	path := fmt.Sprintf("%s/container.log", testDir)
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	// create launcher
 	openFilesLimit := 3
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -312,12 +321,14 @@ func TestLauncherWithConcurrentContainerTailer(t *testing.T) {
 
 func TestLauncherTailFromTheBeginning(t *testing.T) {
 	testDir := t.TempDir()
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	// create launcher
 	openFilesLimit := 3
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	outputChan := launcher.pipelineProvider.NextPipelineChan()
@@ -362,6 +373,8 @@ func TestLauncherTailFromTheBeginning(t *testing.T) {
 
 func TestLauncherSetTail(t *testing.T) {
 	testDir := t.TempDir()
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path1 := fmt.Sprintf("%s/test.log", testDir)
 	path2 := fmt.Sprintf("%s/test2.log", testDir)
@@ -370,7 +383,7 @@ func TestLauncherSetTail(t *testing.T) {
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 
@@ -388,13 +401,15 @@ func TestLauncherSetTail(t *testing.T) {
 
 func TestLauncherConfigIdentifier(t *testing.T) {
 	testDir := t.TempDir()
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path := fmt.Sprintf("%s/test.log", testDir)
 	os.Create(path)
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 
@@ -412,6 +427,8 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 	var path string
 
 	testDir := t.TempDir()
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	// creates files
 	path = fmt.Sprintf("%s/1.log", testDir)
@@ -431,7 +448,7 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 	source := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
@@ -453,15 +470,16 @@ func TestLauncherScanWithTooManyFiles(t *testing.T) {
 }
 
 func TestLauncherUpdatesSourceForExistingTailer(t *testing.T) {
-
 	testDir := t.TempDir()
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path := fmt.Sprintf("%s/*.log", testDir)
 	os.Create(path)
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
 	fc := flareController.NewFlareController()
-	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+	launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 	launcher.pipelineProvider = mock.NewMockProvider()
 	launcher.registry = auditor.NewRegistry()
 
@@ -504,6 +522,8 @@ func TestLauncherScanRecentFilesWithRemoval(t *testing.T) {
 		err = os.Remove(path(name))
 		assert.Nil(t, err)
 	}
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
@@ -516,6 +536,7 @@ func TestLauncherScanRecentFilesWithRemoval(t *testing.T) {
 			validatePodContainerID: false,
 			scanPeriod:             10 * time.Second,
 			flarecontroller:        flareController.NewFlareController(),
+			tagger:                 fakeTagger,
 		}
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
@@ -557,6 +578,8 @@ func TestLauncherScanRecentFilesWithNewFiles(t *testing.T) {
 	testDir := t.TempDir()
 	baseTime := time.Date(2010, time.August, 10, 25, 0, 0, 0, time.UTC)
 	openFilesLimit := 2
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path := func(name string) string {
 		return fmt.Sprintf("%s/%s", testDir, name)
@@ -572,7 +595,7 @@ func TestLauncherScanRecentFilesWithNewFiles(t *testing.T) {
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
 		fc := flareController.NewFlareController()
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_modification_time", fc)
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_modification_time", fc, fakeTagger)
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)
@@ -621,6 +644,8 @@ func TestLauncherFileRotation(t *testing.T) {
 
 	testDir := t.TempDir()
 	openFilesLimit := 2
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path := func(name string) string {
 		return fmt.Sprintf("%s/%s", testDir, name)
@@ -633,7 +658,7 @@ func TestLauncherFileRotation(t *testing.T) {
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
 		fc := flareController.NewFlareController()
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)
@@ -686,6 +711,8 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 
 	testDir := t.TempDir()
 	openFilesLimit := 2
+	fakeTagger := taggerimpl.SetupFakeTagger(t)
+	defer fakeTagger.ResetTagger()
 
 	path := func(name string) string {
 		return fmt.Sprintf("%s/%s", testDir, name)
@@ -698,7 +725,7 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 	createLauncher := func() *Launcher {
 		sleepDuration := 20 * time.Millisecond
 		fc := flareController.NewFlareController()
-		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc)
+		launcher := NewLauncher(openFilesLimit, sleepDuration, false, 10*time.Second, "by_name", fc, fakeTagger)
 		launcher.pipelineProvider = mock.NewMockProvider()
 		launcher.registry = auditor.NewRegistry()
 		logDirectory := fmt.Sprintf("%s/*.log", testDir)

--- a/pkg/logs/tailers/docker/tailer.go
+++ b/pkg/logs/tailers/docker/tailer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
@@ -79,13 +80,13 @@ type Tailer struct {
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *sources.LogSource, outputChan chan *message.Message, erroredContainerID chan string, readTimeout time.Duration) *Tailer {
+func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *sources.LogSource, outputChan chan *message.Message, erroredContainerID chan string, readTimeout time.Duration, tagger tagger.Component) *Tailer {
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
 		decoder:            decoder.NewDecoderWithFraming(sources.NewReplaceableSource(source), dockerstream.New(containerID), framer.DockerStream, nil, status.NewInfoRegistry()),
 		Source:             source,
-		tagProvider:        tag.NewProvider(containers.BuildTaggerEntityName(containerID)),
+		tagProvider:        tag.NewProvider(containers.BuildTaggerEntityName(containerID), tagger.Tag),
 		dockerutil:         cli,
 		readTimeout:        readTimeout,
 		sleepDuration:      defaultSleepDuration,

--- a/pkg/logs/tailers/docker/tailer.go
+++ b/pkg/logs/tailers/docker/tailer.go
@@ -86,7 +86,7 @@ func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *sources.L
 		outputChan:         outputChan,
 		decoder:            decoder.NewDecoderWithFraming(sources.NewReplaceableSource(source), dockerstream.New(containerID), framer.DockerStream, nil, status.NewInfoRegistry()),
 		Source:             source,
-		tagProvider:        tag.NewProvider(containers.BuildTaggerEntityName(containerID), tagger.Tag),
+		tagProvider:        tag.NewProvider(containers.BuildTaggerEntityName(containerID), tagger),
 		dockerutil:         cli,
 		readTimeout:        readTimeout,
 		sleepDuration:      defaultSleepDuration,

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -6,6 +6,7 @@
 package logs
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -18,8 +19,8 @@ import (
 var logsScheduler *channel.Scheduler
 
 // SetupLogAgent sets up the logs agent to handle messages on the given channel.
-func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string) (logsAgent.ServerlessLogsAgent, error) {
-	agent := agentimpl.NewServerlessLogsAgent()
+func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string, tagger tagger.Component) (logsAgent.ServerlessLogsAgent, error) {
+	agent := agentimpl.NewServerlessLogsAgent(tagger)
 	err := agent.Start()
 	if err != nil {
 		log.Error("Could not start an instance of the Logs Agent:", err)


### PR DESCRIPTION
The logs agent internal packages use the tagger. 

Prior to this change it was relaying in the global tagger. With this changes, we are declaring the tagger a dependency of the Logs Agent and no longer using the global tagger. 

### QA

Unit test updated to ensure functionality remains the same. I might need some guidance from @DataDog/agent-metrics-logs to ensure this change requires manual QA or not. 