### PR TITLE
V2 Auto Multiline Detection - Telemetry, Status page, and more config options

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -289,6 +289,21 @@ func (c *LogsConfig) AutoMultiLineEnabled(coreConfig pkgconfigmodel.Reader) bool
 	return coreConfig.GetBool("logs_config.auto_multi_line_detection")
 }
 
+// ExperimentalAutoMultiLineEnabled determines whether experimental auto multi line detection is enabled for this config.
+// NOTE - this setting is subject to change as the feature is still experimental and being tested.
+// If logs_config.experimental_auto_multi_line_detection, but the log source has AutoMultiLine explicitly set to false,
+// disable the feature.
+func (c *LogsConfig) ExperimentalAutoMultiLineEnabled(coreConfig pkgconfigmodel.Reader) bool {
+	if !coreConfig.GetBool("logs_config.experimental_auto_multi_line_detection") {
+		return false
+	}
+
+	if c.AutoMultiLine != nil && !*c.AutoMultiLine {
+		return false
+	}
+	return true
+}
+
 // ShouldProcessRawMessage returns if the raw message should be processed instead
 // of only the message content.
 // This is tightly linked to how messages are transmitted through the pipeline.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1498,6 +1498,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// Experimental auto multiline detection settings (these are subject to change until the feature is no longer experimental)
 	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
 	config.SetKnown("logs_config.auto_multi_line_detection_custom_samples")
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_detection", true)
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_datetime_detection", true)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.timestamp_detector_match_threshold", 0.5)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_max_size", 20)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -65,7 +65,7 @@ func (b *bucket) flush() *message.Message {
 
 	if b.lineCount > 1 {
 		msg.ParsingExtra.IsMultiLine = true
-		tlmTags = append(tlmTags, "line_type:multi")
+		tlmTags = append(tlmTags, "line_type:multi_line")
 		if b.tagMultiLineLogs {
 			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.AutoMultiLineTag)
 		}

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
 
 func makeHandler() (chan *message.Message, func(*message.Message)) {
@@ -35,7 +36,7 @@ func assertMessageContent(t *testing.T, m *message.Message, content string) {
 
 func TestNoAggregate(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1"), noAggregate)
 	ag.Aggregate(newMessage("2"), noAggregate)
@@ -49,7 +50,7 @@ func TestNoAggregate(t *testing.T) {
 func TestNoAggregateEndsGroup(t *testing.T) {
 
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1"), startGroup)
 	ag.Aggregate(newMessage("2"), startGroup)
@@ -62,7 +63,7 @@ func TestNoAggregateEndsGroup(t *testing.T) {
 
 func TestAggregateGroups(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	// Aggregated log
 	ag.Aggregate(newMessage("1"), startGroup)
@@ -82,7 +83,7 @@ func TestAggregateGroups(t *testing.T) {
 
 func TestAggregateDoesntStartGroup(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1"), aggregate)
 	ag.Aggregate(newMessage("2"), aggregate)
@@ -95,7 +96,7 @@ func TestAggregateDoesntStartGroup(t *testing.T) {
 
 func TestForceFlush(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1"), startGroup)
 	ag.Aggregate(newMessage("2"), aggregate)
@@ -107,7 +108,7 @@ func TestForceFlush(t *testing.T) {
 
 func TestAggregationTimer(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false)
+	ag := NewAggregator(outputFn, 100, time.Duration(1*time.Second), false, false, status.NewInfoRegistry())
 
 	assert.Nil(t, ag.FlushChan())
 	ag.Aggregate(newMessage("1"), startGroup)
@@ -124,7 +125,7 @@ func TestAggregationTimer(t *testing.T) {
 
 func TestTagTruncatedLogs(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), true, false)
+	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), true, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1234567890"), startGroup)
 	ag.Aggregate(newMessage("1"), aggregate) // Causes overflow, truncate and flush
@@ -148,7 +149,7 @@ func TestTagTruncatedLogs(t *testing.T) {
 
 func TestTagMultiLineLogs(t *testing.T) {
 	outputChan, outputFn := makeHandler()
-	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), false, true)
+	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), false, true, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("12345"), startGroup)
 	ag.Aggregate(newMessage("67890"), aggregate)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -23,6 +23,7 @@ func NewJSONDetector() *JSONDetector {
 func (j *JSONDetector) ProcessAndContinue(context *messageContext) bool {
 	if jsonRegexp.Match(context.rawMessage) {
 		context.label = noAggregate
+		context.labelAssignedBy = "JSON_detector"
 		return false
 	}
 	return true

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -21,9 +21,10 @@ type messageContext struct {
 	rawMessage []byte
 	// NOTE: tokens can be nil if the heuristic runs before the tokenizer.
 	// Heuristic implementations must check if tokens is nil before using it.
-	tokens        []tokens.Token
-	tokenIndicies []int
-	label         Label
+	tokens          []tokens.Token
+	tokenIndicies   []int
+	label           Label
+	labelAssignedBy string
 }
 
 // Heuristic is an interface representing a strategy to label log messages.
@@ -37,27 +38,37 @@ type Heuristic interface {
 // Each Heuristic operates on the output of the previous heuristic - mutating the message context.
 // A label is chosen when a herusitc signals the labeler to stop or when all herustics have been processed.
 type Labeler struct {
-	heuristics []Heuristic
+	lablerHeuristics    []Heuristic
+	analyticsHeuristics []Heuristic
 }
 
 // NewLabeler creates a new labeler with the given heuristics.
-func NewLabeler(heuristics []Heuristic) *Labeler {
+// lablerHeuristics are used to mutate the label of a log message.
+// analyticsHeuristics are used to analyze the log message and labeling process
+// for the status page and telemetry.
+func NewLabeler(lablerHeuristics []Heuristic, analyticsHeuristics []Heuristic) *Labeler {
 	return &Labeler{
-		heuristics: heuristics,
+		lablerHeuristics:    lablerHeuristics,
+		analyticsHeuristics: analyticsHeuristics,
 	}
 }
 
 // Label labels a log message.
 func (l *Labeler) Label(rawMessage []byte) Label {
 	context := &messageContext{
-		rawMessage: rawMessage,
-		tokens:     nil,
-		label:      aggregate,
+		rawMessage:      rawMessage,
+		tokens:          nil,
+		label:           aggregate,
+		labelAssignedBy: "default",
 	}
-	for _, h := range l.heuristics {
+	for _, h := range l.lablerHeuristics {
 		if !h.ProcessAndContinue(context) {
-			return context.label
+			break
 		}
+	}
+	// analyticsHeuristics are always run and don't change the final label
+	for _, h := range l.analyticsHeuristics {
+		h.ProcessAndContinue(context)
 	}
 	return context.label
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler_test.go
@@ -35,7 +35,7 @@ func TestLabelerProceedNextHeuristic(t *testing.T) {
 				return true
 			},
 		},
-	})
+	}, []Heuristic{})
 
 	assert.Equal(t, noAggregate, labeler.Label([]byte("test 123")))
 }
@@ -55,7 +55,7 @@ func TestLabelerProceedFirstHeuristicWins(t *testing.T) {
 				return true
 			},
 		},
-	})
+	}, []Heuristic{})
 
 	assert.Equal(t, startGroup, labeler.Label([]byte("test 123")))
 }
@@ -68,7 +68,7 @@ func TestLabelerDefaultLabel(t *testing.T) {
 				return false
 			},
 		},
-	})
+	}, []Heuristic{})
 
 	assert.Equal(t, aggregate, labeler.Label([]byte("test 123")))
 }
@@ -82,7 +82,7 @@ func TestLabelerPassesAlongMessageContext(t *testing.T) {
 				return false
 			},
 		},
-	})
+	}, []Heuristic{})
 
 	labeler.Label([]byte("test 123"))
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table_test.go
@@ -11,35 +11,41 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection/tokens"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
 
-func justTokens(tokens []tokens.Token, _ []int) []tokens.Token {
-	return tokens
+func makeContext(str string, label Label) *messageContext {
+	tokenizer := NewTokenizer(0)
+	ts, _ := tokenizer.tokenize([]byte(str))
+
+	return &messageContext{
+		rawMessage: []byte(str),
+		tokens:     ts,
+		label:      label,
+	}
 }
 
 func TestPatternTable(t *testing.T) {
 
-	tokenizer := NewTokenizer(0)
-	pt := NewPatternTable(5, 1)
+	pt := NewPatternTable(5, 1, status.NewInfoRegistry())
 
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 @"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 $"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 %"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 ^"))), aggregate)
+	pt.insert(makeContext("abc 123 !", aggregate))
+	pt.insert(makeContext("abc 123 @", aggregate))
+	pt.insert(makeContext("abc 123 $", aggregate))
+	pt.insert(makeContext("abc 123 %", aggregate))
+	pt.insert(makeContext("abc 123 ^", aggregate))
 
 	assert.Equal(t, 5, len(pt.table))
 
 	// Add more of the same pattern - should remain at the top and get it's count updated
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 !"))), aggregate)
+	pt.insert(makeContext("abc 123 !", aggregate))
+	pt.insert(makeContext("abc 123 !", aggregate))
 
 	assert.Equal(t, 5, len(pt.table))
 	assert.Equal(t, int64(3), pt.table[0].count)
 
 	// At this point `abc 123 @` was the last updated, so it will be evicted first
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 *"))), aggregate)
+	pt.insert(makeContext("abc 123 *", aggregate))
 
 	assert.Equal(t, 5, len(pt.table), "Table should not grow past limit")
 	dump := pt.DumpTable()
@@ -52,7 +58,7 @@ func TestPatternTable(t *testing.T) {
 	assert.Equal(t, "CCC DDD *", dump[4].TokenString)
 
 	// Should sift up to position #2
-	pt.insert(justTokens(tokenizer.tokenize([]byte("abc 123 *"))), aggregate)
+	pt.insert(makeContext("abc 123 *", aggregate))
 
 	dump = pt.DumpTable()
 
@@ -70,11 +76,11 @@ func TestPatternTable(t *testing.T) {
 	assert.Equal(t, int64(1), dump[4].Count)
 
 	// Lets pretend the whole log format totally changes for some reason, and evict the whole table.
-	pt.insert(justTokens(tokenizer.tokenize([]byte("! acb 123"))), startGroup)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("@ acb 123"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("# acb 123"))), noAggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("$ acb 123"))), aggregate)
-	pt.insert(justTokens(tokenizer.tokenize([]byte("% acb 123"))), startGroup)
+	pt.insert(makeContext("! acb 123", startGroup))
+	pt.insert(makeContext("@ acb 123", aggregate))
+	pt.insert(makeContext("# acb 123", noAggregate))
+	pt.insert(makeContext("$ acb 123", aggregate))
+	pt.insert(makeContext("% acb 123", startGroup))
 
 	dump = pt.DumpTable()
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
@@ -36,7 +36,7 @@ var knownTimestampFormats = []string{
 	"Mar 16 08:12:04",
 	"Jul 1 09:00:55",
 	"2024-10-14T22:11:20+0000",
-	"2024-07-01T14:59:55.711'+0000'",
+	"2024-07-01T14:59:55.711",
 	"2024-07-01T14:59:55.711Z",
 	"2024-08-19 12:17:55-0400",
 	"2024-06-26 02:31:29,573",
@@ -117,6 +117,7 @@ func (t *TimestampDetector) ProcessAndContinue(context *messageContext) bool {
 
 	if t.tokenGraph.MatchProbability(context.tokens).probability > t.matchThreshold {
 		context.label = startGroup
+		context.labelAssignedBy = "timestamp_detector"
 	}
 
 	return true

--- a/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector_test.go
@@ -46,6 +46,8 @@ var inputs = []testInput{
 	{startGroup, "127.0.0.1 - - [16/May/2024:19:49:17 +0000]"},
 	{startGroup, "127.0.0.1 - - [17/May/2024:13:51:52 +0000] \"GET /probe?debug=1 HTTP/1.1\" 200 0	"},
 	{startGroup, "nova-api.log.1.2017-05-16_13:53:08 2017-05-16 00:00:00.008 25746 INFO nova.osapi"},
+	{startGroup, "foo bar log 2024-11-22'T'10:10:15.455 my log line"},
+	{startGroup, "foo bar log 2024-07-01T14:59:55.711'+0000' my log line"},
 
 	// A case where the timestamp has a non-matching token in the midddle of it.
 	{startGroup, "acb def 10:10:10 foo 2024-05-15 hijk lmop"},
@@ -69,6 +71,14 @@ var inputs = []testInput{
 	{aggregate, " auth.handler: auth handler stopped"},
 	{aggregate, "10:10:10 foo :10: bar 10:10"},
 	{aggregate, "1234-1234-1234-123-21-1"},
+	{aggregate, " = '10.20.30.123' (DEBUG)"},
+	{aggregate, "192.168.1.123"},
+	{aggregate, "'192.168.1.123'"},
+	{aggregate, "10.0.0.123"},
+	{aggregate, "\"10.0.0.123\""},
+	{aggregate, "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+	{aggregate, "fd12:3456:789a:1::1"},
+	{aggregate, "2001:db8:0:1234::5678"},
 }
 
 func TestCorrectLabelIsAssigned(t *testing.T) {

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -102,6 +102,7 @@ func (j *UserSamples) ProcessAndContinue(context *messageContext) bool {
 	for _, sample := range j.samples {
 		if isMatch(sample.tokens, context.tokens, sample.matchThreshold) {
 			context.label = sample.label
+			context.labelAssignedBy = "user_sample"
 			return false
 		}
 	}

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	automultilinedetection "github.com/DataDog/datadog-agent/pkg/logs/internal/decoder/auto_multiline_detection"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
 
 // AutoMultilineHandler aggreagates multiline logs.
@@ -20,28 +21,39 @@ type AutoMultilineHandler struct {
 }
 
 // NewAutoMultilineHandler creates a new auto multiline handler.
-func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize int, flushTimeout time.Duration) *AutoMultilineHandler {
+func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize int, flushTimeout time.Duration, tailerInfo *status.InfoRegistry) *AutoMultilineHandler {
 
 	// Order is important
-	heuristics := []automultilinedetection.Heuristic{
-		automultilinedetection.NewJSONDetector(),
-		automultilinedetection.NewTokenizer(config.Datadog().GetInt("logs_config.auto_multi_line.tokenizer_max_input_bytes")),
-		automultilinedetection.NewUserSamples(config.Datadog()),
-		automultilinedetection.NewTimestampDetector(config.Datadog().GetFloat64("logs_config.auto_multi_line.timestamp_detector_match_threshold")),
-		automultilinedetection.NewPatternTable(
-			config.Datadog().GetInt("logs_config.auto_multi_line.pattern_table_max_size"),
-			config.Datadog().GetFloat64("logs_config.auto_multi_line.pattern_table_match_threshold"),
-		),
+	heuristics := []automultilinedetection.Heuristic{}
+
+	heuristics = append(heuristics, automultilinedetection.NewTokenizer(config.Datadog().GetInt("logs_config.auto_multi_line.tokenizer_max_input_bytes")))
+
+	if config.Datadog().GetBool("logs_config.auto_multi_line.enable_json_detection") {
+		heuristics = append(heuristics, automultilinedetection.NewJSONDetector())
+	}
+
+	heuristics = append(heuristics, automultilinedetection.NewUserSamples(config.Datadog()))
+
+	if config.Datadog().GetBool("logs_config.auto_multi_line.enable_datetime_detection") {
+		heuristics = append(heuristics, automultilinedetection.NewTimestampDetector(
+			config.Datadog().GetFloat64("logs_config.auto_multi_line.timestamp_detector_match_threshold")))
+	}
+
+	analyticsHeuristics := []automultilinedetection.Heuristic{automultilinedetection.NewPatternTable(
+		config.Datadog().GetInt("logs_config.auto_multi_line.pattern_table_max_size"),
+		config.Datadog().GetFloat64("logs_config.auto_multi_line.pattern_table_match_threshold"),
+		tailerInfo),
 	}
 
 	return &AutoMultilineHandler{
-		labeler: automultilinedetection.NewLabeler(heuristics),
+		labeler: automultilinedetection.NewLabeler(heuristics, analyticsHeuristics),
 		aggregator: automultilinedetection.NewAggregator(
 			outputFn,
 			maxContentSize,
 			flushTimeout,
 			config.Datadog().GetBool("logs_config.tag_truncated_logs"),
-			config.Datadog().GetBool("logs_config.tag_auto_multi_line_logs")),
+			config.Datadog().GetBool("logs_config.tag_auto_multi_line_logs"),
+			tailerInfo),
 	}
 }
 

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -98,8 +98,9 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 		}
 	}
 	if lineHandler == nil {
-		if pkgConfig.Datadog().GetBool("logs_config.experimental_auto_multi_line_detection") {
-			lineHandler = NewAutoMultilineHandler(outputFn, maxContentSize, config.AggregationTimeout(pkgConfig.Datadog()))
+		if source.Config().ExperimentalAutoMultiLineEnabled(pkgConfig.Datadog()) {
+			log.Infof("Experimental Auto multi line log detection enabled")
+			lineHandler = NewAutoMultilineHandler(outputFn, maxContentSize, config.AggregationTimeout(pkgConfig.Datadog()), tailerInfo)
 
 		} else if source.Config().AutoMultiLineEnabled(pkgConfig.Datadog()) {
 			log.Infof("Auto multi line log detection enabled")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds the finishing touches to start testing this feature against real workloads. 
This PR includes several small changes:

- Some small tuning to the timestamp detector to deal with IP addresses that occur in logs
- Added telemetry (for internal use right now, subject to change)
- Add Config options to disable the timestamp detector or json detector
- Re-use logs config option to disable auto multiline per source
- Add statistics to the verbose status page
  - small refactor to labeler ordering to support the status page data

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Example of a tailer on the verbose status page:
<img width="809" alt="Screenshot 2024-08-28 at 3 37 22 PM" src="https://github.com/user-attachments/assets/a368f121-65cb-4432-84f7-7a8d98fe2579">
<img width="837" alt="Screenshot 2024-08-28 at 3 12 36 PM" src="https://github.com/user-attachments/assets/c356a8a7-d26b-4886-b855-dc5d327b9550">


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. in `datadog.yaml`

```
logs_enabled: true
logs_config:
    experimental_auto_multi_line_detection: true
```

2. create a log integration config: 

```
  - type: file
    path: "/tmp/*.log"
    source: "brian-log-test"
    service: "brian-source"
    auto_multi_line_detection: false
```

3. send some logs - confirm that they are not being aggregated (check the status page `agent status -v`, you should not see `Auto multiline pattern stats`

4. remove the `auto_multi_line_detection: false` and send a JSON log, and a line with a timestamp  (to the same file)

5. `agent status -v` you should see `Auto multiline pattern stats` with a pattern flagged as `JSON_detector` and the other pattern with `timestamp_detector` 

6. in `datadog.yaml` add
```
logs_config:
    experimental_auto_multi_line_detection: true
    auto_multi_line:
        enable_json_detection: false
        enable_datetime_detection: false
```

6. send a json log and a log with a timestamp (to the same file) and check `agent status -v` again - you should no longer see the `JSON_detector` and `timestamp_detector` flags in the table. 

7. Spot check that the new telemetry metrics are being reported: 

`datadog.logs_agent.auto_multi_line_aggregator.flush`
`datadog.logs_agent.auto_multi_line_aggregator.multiline_matches`