### PR TITLE
[OTEL-2065] Initialize peer tags only once in stats OTel API

### DIFF
--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -61,12 +61,70 @@ func BenchmarkOTelContainerTags(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		inputs := OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys)
+		inputs := OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys, nil)
 		assert.Len(b, inputs, 1)
 		input := inputs[0]
 		concentrator.Add(input)
 		stats := concentrator.Flush(true)
 		assert.Len(b, stats.Stats, 1)
 		assert.Equal(b, stats.Stats[0].Tags, expected)
+	}
+}
+
+func BenchmarkOTelPeerTags(b *testing.B) {
+	benchmarkOTelPeerTags(b, true)
+}
+
+// This simulates the benchmark of OTLPTracesToConcentratorInputs before 
+func BenchmarkOTelPeerTags_IncludeConfiguredPeerTags(b *testing.B) {
+	benchmarkOTelPeerTags(b, false)
+}
+
+func benchmarkOTelPeerTags(b *testing.B, initOnce bool) {
+	start := time.Now().Add(-1 * time.Second)
+	end := time.Now()
+	set := componenttest.NewNopTelemetrySettings()
+	set.MeterProvider = noop.NewMeterProvider()
+	attributesTranslator, err := attributes.NewTranslator(set)
+	assert.NoError(b, err)
+
+	traces := ptrace.NewTraces()
+	rspan := traces.ResourceSpans().AppendEmpty()
+	sspan := rspan.ScopeSpans().AppendEmpty()
+	span := sspan.Spans().AppendEmpty()
+	span.SetTraceID(testTraceID)
+	span.SetSpanID(testSpanID1)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(end))
+	span.SetName("span_name")
+	span.SetKind(ptrace.SpanKindClient)
+	span.Attributes().PutStr("peer.service", "my_peer_svc")
+	span.Attributes().PutStr("rpc.service", "my_rpc_svc")
+	span.Attributes().PutStr("net.peer.name", "my_net_peer")
+
+	conf := config.New()
+	conf.Hostname = "agent_host"
+	conf.DefaultEnv = "agent_env"
+	conf.OTLPReceiver.AttributesTranslator = attributesTranslator
+	conf.PeerTagsAggregation = true
+	var peerTagKeys []string
+	if initOnce {
+		peerTagKeys = conf.ConfiguredPeerTags()
+	}
+
+	concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if !initOnce {
+			peerTagKeys = conf.ConfiguredPeerTags()
+		}
+		inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, peerTagKeys)
+		assert.Len(b, inputs, 1)
+		input := inputs[0]
+		concentrator.Add(input)
+		stats := concentrator.Flush(true)
+		assert.Len(b, stats.Stats, 1)
 	}
 }

--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -75,7 +75,7 @@ func BenchmarkOTelPeerTags(b *testing.B) {
 	benchmarkOTelPeerTags(b, true)
 }
 
-// This simulates the benchmark of OTLPTracesToConcentratorInputs before 
+// This simulates the benchmark of OTLPTracesToConcentratorInputs before https://github.com/DataDog/datadog-agent/pull/28908
 func BenchmarkOTelPeerTags_IncludeConfiguredPeerTags(b *testing.B) {
 	benchmarkOTelPeerTags(b, false)
 }

--- a/pkg/trace/stats/otel_util.go
+++ b/pkg/trace/stats/otel_util.go
@@ -33,6 +33,7 @@ func OTLPTracesToConcentratorInputs(
 	traces ptrace.Traces,
 	conf *config.AgentConfig,
 	containerTagKeys []string,
+	peerTagKeys []string,
 ) []Input {
 	spanByID, resByID, scopeByID := traceutil.IndexOTelSpans(traces)
 	topLevelByKind := conf.HasFeature("enable_otlp_compute_top_level_by_span_kind")
@@ -76,7 +77,7 @@ func OTLPTracesToConcentratorInputs(
 			chunks[ckey] = chunk
 		}
 		_, isTop := topLevelSpans[spanID]
-		chunk.Spans = append(chunk.Spans, otelSpanToDDSpan(otelspan, otelres, scopeByID[spanID], isTop, topLevelByKind, conf))
+		chunk.Spans = append(chunk.Spans, otelSpanToDDSpan(otelspan, otelres, scopeByID[spanID], isTop, topLevelByKind, conf, peerTagKeys))
 	}
 
 	inputs := make([]Input, 0, len(chunks))
@@ -107,6 +108,7 @@ func otelSpanToDDSpan(
 	lib pcommon.InstrumentationScope,
 	isTopLevel, topLevelByKind bool,
 	conf *config.AgentConfig,
+	peerTagKeys []string,
 ) *pb.Span {
 	ddspan := &pb.Span{
 		Service:  traceutil.GetOTelService(otelspan, otelres, true),
@@ -137,9 +139,6 @@ func otelSpanToDDSpan(
 		// When enable_otlp_compute_top_level_by_span_kind is true, compute stats for client-side spans
 		traceutil.SetMeasured(ddspan, true)
 	}
-	// TODO(knusbaum): Should we be getting the peer tags on every span? This is a somewhat heavy operation requiring merging,
-	// sorting, deduplicating of a list of tags.
-	peerTagKeys := conf.ConfiguredPeerTags()
 	for _, peerTagKey := range peerTagKeys {
 		if peerTagVal := traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, false, peerTagKey); peerTagVal != "" {
 			traceutil.SetMeta(ddspan, peerTagKey, peerTagVal)

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -212,7 +212,7 @@ func TestProcessOTLPTraces(t *testing.T) {
 			}
 
 			concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
-			inputs := OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys)
+			inputs := OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags())
 			for _, input := range inputs {
 				concentrator.Add(input)
 			}
@@ -274,7 +274,7 @@ func TestProcessOTLPTraces_MutliSpanInOneResAndOp(t *testing.T) {
 	conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 
 	concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
-	inputs := OTLPTracesToConcentratorInputs(traces, conf, nil)
+	inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, nil)
 	for _, input := range inputs {
 		concentrator.Add(input)
 	}

--- a/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
+++ b/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
@@ -38,6 +38,7 @@ func TestOTelAPMStatsMatch(t *testing.T) {
 	attributesTranslator, err := attributes.NewTranslator(set)
 	require.NoError(t, err)
 	tcfg := getTraceAgentCfg(attributesTranslator)
+	peerTagKeys := tcfg.ConfiguredPeerTags()
 
 	metricsClient := &statsd.NoOpClient{}
 	timingReporter := timing.New(metricsClient)
@@ -57,7 +58,7 @@ func TestOTelAPMStatsMatch(t *testing.T) {
 	fakeAgent1.Ingest(ctx, traces)
 
 	// fakeAgent2 calls the new API in Concentrator that directly calculates APM stats for OTLP traces
-	inputs := stats.OTLPTracesToConcentratorInputs(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName})
+	inputs := stats.OTLPTracesToConcentratorInputs(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName}, peerTagKeys)
 	for _, input := range inputs {
 		fakeAgent2.Concentrator.Add(input)
 	}


### PR DESCRIPTION
### What does this PR do?

Modify the `OTLPTracesToConcentratorInputs` API to accept peer tag keys, so that peer tag keys can just be initialized once in DD connector.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/trace/stats
cpu: Apple M1 Max
BenchmarkOTelPeerTags-10                              	    1000	     11333 ns/op	    6910 B/op	      74 allocs/op
BenchmarkOTelPeerTags_IncludeConfiguredPeerTags-10    	    1000	     15244 ns/op	   11697 B/op	      85 allocs/op
```

### Motivation

Currently the new OTel stats API in DD connector initializes the peer tag keys upon every payload. `ConfiguredPeerTags` is expensive, peer tag keys are static in DD connector, so we should instead only initialize peerTagKeys once in DD connector and pass them as an argument to the API.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

N/A this is only expected to be used in DD connector