### PR TITLE
[SMP] Update lading to 0.23.0

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.21.1
+  version: 0.23.0
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
### What does this PR do?

Update lading to 0.23.0 from 0.21.1.

### Motivation

lading 0.23.0 will be a prerequisite for smp 0.17.1.

### Additional Notes

Changelogs: [0.22.0](https://github.com/DataDog/lading/releases/tag/v0.22.0), [0.23.0](https://github.com/DataDog/lading/releases/tag/v0.23.0).

### Possible Drawbacks / Trade-offs

None anticipated.

### Describe how to test/QA your changes

Ensure Regression Detector report is posted.