### PR TITLE
[CSPM] k8sconfig: handle boolean CLI flags correctly

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -669,7 +669,11 @@ func buildProc(name string, cmdline []string) proc {
 		p.flags = make(map[string]string)
 		pendingFlagValue := false
 		for i, arg := range cmdline {
-			if strings.HasPrefix(arg, "-") {
+			if strings.HasPrefix(arg, "--") && len(arg) > 2 {
+				if pendingFlagValue {
+					p.flags[cmdline[i-1]] = "true"
+				}
+				pendingFlagValue = false
 				parts := strings.SplitN(arg, "=", 2)
 				if len(parts) == 2 {
 					p.flags[parts[0]] = parts[1]
@@ -684,6 +688,9 @@ func buildProc(name string, cmdline []string) proc {
 					p.flags[arg] = ""
 				}
 			}
+		}
+		if pendingFlagValue {
+			p.flags[cmdline[len(cmdline)-1]] = "true"
 		}
 	}
 	return p

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -372,11 +372,11 @@ kubelet \
 	--protect-kernel-defaults=true \
 	--read-only-port=0 \
 	--resolv-conf=/run/systemd/resolve/resolv.conf \
-	--rotate-certificates=true \
 	--streaming-connection-idle-timeout=4h \
 	--tls-cert-file=/etc/kubernetes/certs/kubeletserver.crt \
 	--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 \
-	--tls-private-key-file=/etc/kubernetes/certs/kubeletserver.key
+	--tls-private-key-file=/etc/kubernetes/certs/kubeletserver.key \
+	--rotate-certificates
 `
 
 var aksFs = []*mockFile{
@@ -495,7 +495,7 @@ etcd \
 	--listen-peer-urls=https://192.168.5.15:2380 \
 	--name=lima-k8s \
 	--peer-cert-file=/etc/kubernetes/pki/etcd/peer.crt \
-	--peer-client-cert-auth=true \
+	--peer-client-cert-auth \
 	--peer-key-file=/etc/kubernetes/pki/etcd/peer.key \
 	--peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt \
 	--snapshot-count=10000 \


### PR DESCRIPTION
### What does this PR do?

Handling boolean CLI flags following the UNIX conventions that without an argument, they represent a truthy value.

### Motivation

K8s components can be used with boolean flags without value. 
`--peer-client-cert-auth` is equivalent to `--peer-client-cert-auth=true` or `--peer-client-cert-auth true`

### Describe how to test/QA your changes

Identify a Kubernetes deployment component configured with such boolean flags and check that the resulting resource is indeed reporting it as a TRUE value.
