### PR TITLE
discovery: fallback on binary name if service name detection fails

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/service.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service.go
@@ -202,7 +202,9 @@ func ExtractServiceMetadata(args []string, envs map[string]string, fs fs.SubFS, 
 	exe = normalizeExeName(exe)
 
 	if detectorProvider, ok := binsWithContext[exe]; ok {
-		return detectorProvider(dc).detect(cmd[1:])
+		if metadata, ok := detectorProvider(dc).detect(cmd[1:]); ok {
+			return metadata, true
+		}
 	}
 
 	// trim trailing file extensions

--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -191,7 +191,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"--",
 				"/somewhere/index.js",
 			},
-			expectedServiceTag: "",
+			expectedServiceTag: "node",
 		},
 		{
 			name: "node js with a broken package.json",
@@ -199,7 +199,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"/usr/bin/node",
 				"./testdata/inner/index.js",
 			},
-			expectedServiceTag: "",
+			expectedServiceTag: "node",
 		},
 		{
 			name: "node js with a valid package.json",
@@ -385,6 +385,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			cmdline: []string{
 				"/usr/bin/dotnet", "run", "--project", "./projects/proj1/proj1.csproj",
 			},
+			expectedServiceTag: "dotnet",
 		},
 		{
 			name: "PHP Laravel",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR make service name detection fallback to the executable name if the framework/language specific detector fails or can not be found.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

USMON-1194

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
