### PR TITLE
Fix URL for msodbcsql dep

### DIFF
--- a/omnibus/config/software/msodbcsql18.rb
+++ b/omnibus/config/software/msodbcsql18.rb
@@ -18,7 +18,7 @@ if debian_target?
     # Debian ARM64 build
     package_name = "#{base_package_name}_arm64.deb"
     source sha256: "37e692b1517f1229042c743d0f2a7191e0dcb956bbc3785a895aaa6dc328467e"
-    source url: "#{source_url_base}/debian/10/prod/pool/main/m/msodbcsql18/#{package_name}"
+    source url: "#{source_url_base}/debian/11/prod/pool/main/m/msodbcsql18/#{package_name}"
   else
     # Debian AMD64 build
     package_name = "#{base_package_name}_amd64.deb"


### PR DESCRIPTION
### What does this PR do?

Fixes a source url for the msodbcsql dependency.

### Motivation

I've been hit by this one a few times while doing local experiments with Omnibus, and never got around to fixing it: the specified URL doesn't exist.

It doesn't fail on CI builds thanks to the artifacts cache used by Omnibus, which looks up artifacts by hash. The PR that introduced the change to this URL (https://github.com/DataDog/datadog-agent/pull/26195) did some back and forth changes which resulted in the right artifact ending up in the cache (with the correct hash) but the wrong URL ending up in the code.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
