### PR TITLE
[NPM-3110] Fix revive lint warnings for the networks team

### DIFF
--- a/pkg/network/buffer.go
+++ b/pkg/network/buffer.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package network contains logic and types for network tracing
 package network
 
 // ConnectionBuffer encapsulates a resizing buffer for ConnectionStat objects

--- a/pkg/network/buffer.go
+++ b/pkg/network/buffer.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package network
 
 // ConnectionBuffer encapsulates a resizing buffer for ConnectionStat objects

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package config implements network tracing configuration
 package config
 
 import (

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package config
 
 import (

--- a/pkg/network/config/replace_rules.go
+++ b/pkg/network/config/replace_rules.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	//nolint:revive // TODO(NET) Fix revive linter
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 

--- a/pkg/network/config/replace_rules.go
+++ b/pkg/network/config/replace_rules.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -27,7 +26,7 @@ type ReplaceRule struct {
 }
 
 func parseReplaceRules(cfg ddconfig.Config, key string) ([]*ReplaceRule, error) {
-	if !config.SystemProbe().IsSet(key) {
+	if !ddconfig.SystemProbe().IsSet(key) {
 		return nil, nil
 	}
 

--- a/pkg/network/config/sysctl/sysctl.go
+++ b/pkg/network/config/sysctl/sysctl.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package sysctl implements reading of system parameters such as system limits
 package sysctl
 
 import (

--- a/pkg/network/config/sysctl/sysctl.go
+++ b/pkg/network/config/sysctl/sysctl.go
@@ -5,7 +5,6 @@
 
 //go:build linux
 
-//nolint:revive // TODO(NET) Fix revive linter
 package sysctl
 
 import (

--- a/pkg/network/config/sysctl/sysctl_darwin.go
+++ b/pkg/network/config/sysctl/sysctl_darwin.go
@@ -5,7 +5,6 @@
 
 //go:build darwin
 
-//nolint:revive // TODO(NET) Fix revive linter
 package sysctl
 
 import (

--- a/pkg/network/config/sysctl/sysctl_darwin.go
+++ b/pkg/network/config/sysctl/sysctl_darwin.go
@@ -5,6 +5,7 @@
 
 //go:build darwin
 
+// Package sysctl implements reading of system parameters such as system limits
 package sysctl
 
 import (

--- a/pkg/network/dns/types.go
+++ b/pkg/network/dns/types.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package dns
 
 import (

--- a/pkg/network/dns/types.go
+++ b/pkg/network/dns/types.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package dns traces DNS activity and caches DNS lookups for reverse DNS capability
 package dns
 
 import (

--- a/pkg/network/ebpf/bpf_module.go
+++ b/pkg/network/ebpf/bpf_module.go
@@ -21,7 +21,6 @@ import (
 var prebuiltModulesInUse = map[string]struct{}{}
 var telemetrymu sync.Mutex
 
-//nolint:revive // TODO(NET) Fix revive linter
 func ModuleFileName(moduleName string, debug bool) string {
 	if debug {
 		return fmt.Sprintf("%s-debug.o", moduleName)
@@ -67,7 +66,6 @@ func ReadOffsetBPFModule(bpfDir string, debug bool) (bytecode.AssetReader, error
 	return readModule(bpfDir, "offset-guess", debug)
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func ReadFentryTracerModule(bpfDir string, debug bool) (bytecode.AssetReader, error) {
 	return readModule(bpfDir, "tracer-fentry", debug)
 }
@@ -77,7 +75,6 @@ func ReadConntrackBPFModule(bpfDir string, debug bool) (bytecode.AssetReader, er
 	return readModule(bpfDir, "conntrack", debug)
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func GetModulesInUse() []string {
 	telemetrymu.Lock()
 	defer telemetrymu.Unlock()

--- a/pkg/network/ebpf/conntrack.go
+++ b/pkg/network/ebpf/conntrack.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package ebpf implements tracing network events with eBPF
 package ebpf
 
 import (

--- a/pkg/network/ebpf/conntrack.go
+++ b/pkg/network/ebpf/conntrack.go
@@ -5,7 +5,6 @@
 
 //go:build linux
 
-//nolint:revive // TODO(NET) Fix revive linter
 package ebpf
 
 import (

--- a/pkg/network/encoding/marshal/dns.go
+++ b/pkg/network/encoding/marshal/dns.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package marshal
 
 import (

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -226,6 +226,9 @@ func (s StatCounters) IsZero() bool {
 	return s == StatCounters{}
 }
 
+// StatCookie A 64-bit hash designed to uniquely identify a connection.
+// In eBPF this is 32 bits but it gets re-hashed to 64 bits in userspace to
+// reduce collisions; see PR #17197 for more info.
 type StatCookie = uint64
 
 // ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -226,7 +226,6 @@ func (s StatCounters) IsZero() bool {
 	return s == StatCounters{}
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 type StatCookie = uint64
 
 // ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -70,7 +70,6 @@ func Initialized() bool {
 	return theMonitor.Load() != nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 type ProcessEventHandler interface {
 	HandleProcessEvent(*Process)
 }

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -70,6 +70,7 @@ func Initialized() bool {
 	return theMonitor.Load() != nil
 }
 
+// ProcessEventHandler represents a handler function triggered for process events
 type ProcessEventHandler interface {
 	HandleProcessEvent(*Process)
 }

--- a/pkg/network/events/network_consumer.go
+++ b/pkg/network/events/network_consumer.go
@@ -15,12 +15,10 @@ import (
 // NetworkConsumer describes a process monitoring object
 type NetworkConsumer struct{}
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (n *NetworkConsumer) Start() error {
 	return nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (n *NetworkConsumer) Stop() {
 }
 

--- a/pkg/network/events/network_consumer.go
+++ b/pkg/network/events/network_consumer.go
@@ -15,10 +15,12 @@ import (
 // NetworkConsumer describes a process monitoring object
 type NetworkConsumer struct{}
 
+// Start starts the event consumer (noop)
 func (n *NetworkConsumer) Start() error {
 	return nil
 }
 
+// Stop stops the event consumer (noop)
 func (n *NetworkConsumer) Stop() {
 }
 

--- a/pkg/network/events/network_consumer_others.go
+++ b/pkg/network/events/network_consumer_others.go
@@ -17,10 +17,12 @@ import (
 // NetworkConsumer describes a process monitoring object
 type NetworkConsumer struct{}
 
+// Start starts the event consumer (noop)
 func (n *NetworkConsumer) Start() error {
 	return fmt.Errorf("network consumer is only supported on linux")
 }
 
+// Stop stops the event consumer (noop)
 func (n *NetworkConsumer) Stop() {}
 
 // ID returns id for process monitor

--- a/pkg/network/events/network_consumer_others.go
+++ b/pkg/network/events/network_consumer_others.go
@@ -17,12 +17,10 @@ import (
 // NetworkConsumer describes a process monitoring object
 type NetworkConsumer struct{}
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (n *NetworkConsumer) Start() error {
 	return fmt.Errorf("network consumer is only supported on linux")
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (n *NetworkConsumer) Stop() {}
 
 // ID returns id for process monitor

--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package netlink
 
 import (

--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package netlink implements network connection tracking.
 package netlink
 
 import (

--- a/pkg/network/netlink/conntracker_test.go
+++ b/pkg/network/netlink/conntracker_test.go
@@ -196,8 +196,7 @@ func TestTooManyEntries(t *testing.T) {
 // Run this test with -memprofile to get an insight of how much memory is
 // allocated/used by Conntracker to store maxStateSize entries.
 // Example: go test -run TestConntrackerMemoryAllocation -memprofile mem.prof .
-//
-func TestConntrackerMemoryAllocation(t *testing.T) {
+func TestConntrackerMemoryAllocation(_t *testing.T) {
 	rt := newConntracker(10000)
 	ipGen := randomIPGen()
 

--- a/pkg/network/netlink/conntracker_test.go
+++ b/pkg/network/netlink/conntracker_test.go
@@ -197,7 +197,6 @@ func TestTooManyEntries(t *testing.T) {
 // allocated/used by Conntracker to store maxStateSize entries.
 // Example: go test -run TestConntrackerMemoryAllocation -memprofile mem.prof .
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func TestConntrackerMemoryAllocation(t *testing.T) {
 	rt := newConntracker(10000)
 	ipGen := randomIPGen()

--- a/pkg/network/netlink/consumer_test.go
+++ b/pkg/network/netlink/consumer_test.go
@@ -47,7 +47,6 @@ func TestConsumerKeepsRunningAfterCircuitBreakerTrip(t *testing.T) {
 
 	go func() {
 		defer close(exited)
-		//nolint:revive // TODO(NET) Fix revive linter
 		for range ev {
 		}
 	}()

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -25,35 +25,28 @@ func NewNoOpConntracker() Conntracker {
 // GetType returns a string describing whether the conntracker is "ebpf" or "netlink"
 func (*noOpConntracker) GetType() string { return "" }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) GetTranslationForConn(c *network.ConnectionStats) *network.IPTranslation {
 	return nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) DeleteTranslation(c *network.ConnectionStats) {
 
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) IsSampling() bool {
 	return false
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) Close() {}
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (c *noOpConntracker) DumpCachedTable(ctx context.Context) (map[uint32][]DebugConntrackEntry, error) {
 	return nil, nil
 }
 
 // Describe returns all descriptions of the collector
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) Describe(ch chan<- *prometheus.Desc) {}
 
 // Collect returns the current state of all metrics of the collector
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (*noOpConntracker) Collect(ch chan<- prometheus.Metric) {}

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -25,11 +25,11 @@ func NewNoOpConntracker() Conntracker {
 // GetType returns a string describing whether the conntracker is "ebpf" or "netlink"
 func (*noOpConntracker) GetType() string { return "" }
 
-func (*noOpConntracker) GetTranslationForConn(c *network.ConnectionStats) *network.IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(_c *network.ConnectionStats) *network.IPTranslation {
 	return nil
 }
 
-func (*noOpConntracker) DeleteTranslation(c *network.ConnectionStats) {
+func (*noOpConntracker) DeleteTranslation(_c *network.ConnectionStats) {
 
 }
 
@@ -39,14 +39,12 @@ func (*noOpConntracker) IsSampling() bool {
 
 func (*noOpConntracker) Close() {}
 
-func (c *noOpConntracker) DumpCachedTable(ctx context.Context) (map[uint32][]DebugConntrackEntry, error) {
+func (*noOpConntracker) DumpCachedTable(_ctx context.Context) (map[uint32][]DebugConntrackEntry, error) {
 	return nil, nil
 }
 
 // Describe returns all descriptions of the collector
-//
-func (*noOpConntracker) Describe(ch chan<- *prometheus.Desc) {}
+func (*noOpConntracker) Describe(_ch chan<- *prometheus.Desc) {}
 
 // Collect returns the current state of all metrics of the collector
-//
-func (*noOpConntracker) Collect(ch chan<- prometheus.Metric) {}
+func (*noOpConntracker) Collect(_ch chan<- prometheus.Metric) {}

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -127,7 +127,6 @@ func (c *Socket) fixMsg(m *netlink.Message, ml int) {
 
 // Send a netlink.Message
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) Send(m netlink.Message) error {
 	s.fixMsg(&m, nlmsgLength(len(m.Data)))
 	b, err := m.MarshalBinary()
@@ -152,7 +151,6 @@ func (s *Socket) Send(m netlink.Message) error {
 
 // Receive is not implemented. See ReceiveInto
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) Receive() ([]netlink.Message, error) {
 	return nil, errNotImplemented
 }
@@ -160,7 +158,6 @@ func (s *Socket) Receive() ([]netlink.Message, error) {
 // ReceiveAndDiscard reads netlink messages off the socket & discards them.
 // If the NLMSG_DONE flag is found in one of the messages, returns true.
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) ReceiveAndDiscard() (bool, uint32, error) {
 	for {
 		n, _, err := s.recvmsg()
@@ -206,7 +203,6 @@ func (s *Socket) ReceiveAndDiscard() (bool, uint32, error) {
 
 // ReceiveInto reads one or more netlink.Messages off the socket
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 	var netns uint32
 	n, oobn, err := s.recvmsg()
@@ -283,28 +279,24 @@ func parseNetNS(scms []unix.SocketControlMessage) uint32 {
 
 // File descriptor of the socket
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) File() *os.File {
 	return s.fd
 }
 
 // Close the socket
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) Close() error {
 	return s.fd.Close()
 }
 
 // SendMessages isn't implemented in our case
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) SendMessages(m []netlink.Message) error {
 	return errNotImplemented
 }
 
 // JoinGroup creates a new group membership
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) JoinGroup(group uint32) error {
 	return os.NewSyscallError("setsockopt", s.SetSockoptInt(
 		unix.SOL_NETLINK,
@@ -315,7 +307,6 @@ func (s *Socket) JoinGroup(group uint32) error {
 
 // LeaveGroup deletes a group membership
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) LeaveGroup(group uint32) error {
 	return os.NewSyscallError("setsockopt", s.SetSockoptInt(
 		unix.SOL_NETLINK,
@@ -326,7 +317,6 @@ func (s *Socket) LeaveGroup(group uint32) error {
 
 // SetSockoptInt sets a socket option
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) SetSockoptInt(level, opt, value int) error {
 	// Value must be in range of a C integer.
 	if value < math.MinInt32 || value > math.MaxInt32 {
@@ -347,7 +337,6 @@ func (s *Socket) SetSockoptInt(level, opt, value int) error {
 
 // GetSockoptInt gets a socket option
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) GetSockoptInt(level, opt int) (int, error) {
 	var err error
 	var v int
@@ -364,7 +353,6 @@ func (s *Socket) GetSockoptInt(level, opt int) (int, error) {
 
 // SetBPF attaches an assembled BPF program to the socket
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) SetBPF(filter []bpf.RawInstruction) error {
 	prog := unix.SockFprog{
 		Len:    uint16(len(filter)),
@@ -382,7 +370,6 @@ func (s *Socket) SetBPF(filter []bpf.RawInstruction) error {
 	return err
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) recvmsg() (int, int, error) {
 	ctrlErr := s.conn.Read(s.rawread)
 	if ctrlErr != nil {
@@ -391,7 +378,6 @@ func (s *Socket) recvmsg() (int, int, error) {
 	return s.n, s.oobn, s.readErr
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (s *Socket) rawread(fd uintptr) bool {
 	s.n, s.oobn, _, s.readErr = noallocRecvmsg(int(fd), s.recvbuf, s.oobbuf, unix.MSG_DONTWAIT)
 	return ready(s.readErr)

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -111,22 +111,21 @@ func NewSocket(netNS netns.NsHandle) (*Socket, error) {
 }
 
 // fixMsg updates the fields of m using the logic specified in Send.
-func (c *Socket) fixMsg(m *netlink.Message, ml int) {
+func (s *Socket) fixMsg(m *netlink.Message, ml int) {
 	if m.Header.Length == 0 {
 		m.Header.Length = uint32(nlmsgAlign(ml))
 	}
 
 	if m.Header.Sequence == 0 {
-		m.Header.Sequence = c.seq.Add(1)
+		m.Header.Sequence = s.seq.Add(1)
 	}
 
 	if m.Header.PID == 0 {
-		m.Header.PID = c.pid
+		m.Header.PID = s.pid
 	}
 }
 
 // Send a netlink.Message
-//
 func (s *Socket) Send(m netlink.Message) error {
 	s.fixMsg(&m, nlmsgLength(len(m.Data)))
 	b, err := m.MarshalBinary()
@@ -150,14 +149,12 @@ func (s *Socket) Send(m netlink.Message) error {
 }
 
 // Receive is not implemented. See ReceiveInto
-//
 func (s *Socket) Receive() ([]netlink.Message, error) {
 	return nil, errNotImplemented
 }
 
 // ReceiveAndDiscard reads netlink messages off the socket & discards them.
 // If the NLMSG_DONE flag is found in one of the messages, returns true.
-//
 func (s *Socket) ReceiveAndDiscard() (bool, uint32, error) {
 	for {
 		n, _, err := s.recvmsg()
@@ -202,7 +199,6 @@ func (s *Socket) ReceiveAndDiscard() (bool, uint32, error) {
 }
 
 // ReceiveInto reads one or more netlink.Messages off the socket
-//
 func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 	var netns uint32
 	n, oobn, err := s.recvmsg()
@@ -278,25 +274,21 @@ func parseNetNS(scms []unix.SocketControlMessage) uint32 {
 }
 
 // File descriptor of the socket
-//
 func (s *Socket) File() *os.File {
 	return s.fd
 }
 
 // Close the socket
-//
 func (s *Socket) Close() error {
 	return s.fd.Close()
 }
 
 // SendMessages isn't implemented in our case
-//
-func (s *Socket) SendMessages(m []netlink.Message) error {
+func (s *Socket) SendMessages(_m []netlink.Message) error {
 	return errNotImplemented
 }
 
 // JoinGroup creates a new group membership
-//
 func (s *Socket) JoinGroup(group uint32) error {
 	return os.NewSyscallError("setsockopt", s.SetSockoptInt(
 		unix.SOL_NETLINK,
@@ -306,7 +298,6 @@ func (s *Socket) JoinGroup(group uint32) error {
 }
 
 // LeaveGroup deletes a group membership
-//
 func (s *Socket) LeaveGroup(group uint32) error {
 	return os.NewSyscallError("setsockopt", s.SetSockoptInt(
 		unix.SOL_NETLINK,
@@ -316,7 +307,6 @@ func (s *Socket) LeaveGroup(group uint32) error {
 }
 
 // SetSockoptInt sets a socket option
-//
 func (s *Socket) SetSockoptInt(level, opt, value int) error {
 	// Value must be in range of a C integer.
 	if value < math.MinInt32 || value > math.MaxInt32 {
@@ -336,7 +326,6 @@ func (s *Socket) SetSockoptInt(level, opt, value int) error {
 }
 
 // GetSockoptInt gets a socket option
-//
 func (s *Socket) GetSockoptInt(level, opt int) (int, error) {
 	var err error
 	var v int
@@ -352,7 +341,6 @@ func (s *Socket) GetSockoptInt(level, opt int) (int, error) {
 }
 
 // SetBPF attaches an assembled BPF program to the socket
-//
 func (s *Socket) SetBPF(filter []bpf.RawInstruction) error {
 	prog := unix.SockFprog{
 		Len:    uint16(len(filter)),

--- a/pkg/network/netlink/testutil/conntrack.go
+++ b/pkg/network/netlink/testutil/conntrack.go
@@ -5,7 +5,6 @@
 
 //go:build linux
 
-//nolint:revive // TODO(NET) Fix revive linter
 package testutil
 
 import (
@@ -177,7 +176,6 @@ func SetupVeth6Pair(t *testing.T) (ns string) {
 	return
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func teardownVeth6Pair(t *testing.T, ns string) {
 	cmds := []string{
 		"ip link del veth1",

--- a/pkg/network/netlink/testutil/conntrack.go
+++ b/pkg/network/netlink/testutil/conntrack.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package testutil contains helper functions used for testing conntrack
 package testutil
 
 import (
@@ -97,7 +98,7 @@ func SetupDNAT6(t *testing.T) {
 		teardownDNAT6(t, ifName, linkName)
 	})
 
-	nettestutil.Ip6tablesSave(t)
+	nettestutil.IP6tablesSave(t)
 	cmds := []string{
 		fmt.Sprintf("ip link add %s type dummy", linkName),
 		fmt.Sprintf("ip address add fd00::1 dev %s", linkName),
@@ -176,7 +177,7 @@ func SetupVeth6Pair(t *testing.T) (ns string) {
 	return
 }
 
-func teardownVeth6Pair(t *testing.T, ns string) {
+func teardownVeth6Pair(t *testing.T, _ns string) {
 	cmds := []string{
 		"ip link del veth1",
 	}
@@ -234,7 +235,7 @@ func SetupCrossNsDNAT6(t *testing.T) (ns string) {
 	})
 	ns = SetupVeth6Pair(t)
 
-	nettestutil.Ip6tablesSave(t)
+	nettestutil.IP6tablesSave(t)
 	cmds := []string{
 		"ip6tables -I INPUT 1 -m conntrack --ctstate NEW,RELATED,ESTABLISHED -j ACCEPT",
 		fmt.Sprintf("ip netns exec %s ip6tables -A PREROUTING -t nat -p tcp --dport 80 -j REDIRECT --to-port 8080", ns),

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package main - single file executable
 package main
 
 import (

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package main
 
 import (

--- a/pkg/network/tags_linux.go
+++ b/pkg/network/tags_linux.go
@@ -12,17 +12,11 @@ import (
 )
 
 const (
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagGnuTLS = http.GnuTLS
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagOpenSSL = http.OpenSSL
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagGo = http.Go
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagJava = http.Java
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagTLS = http.TLS
-	//nolint:revive // TODO(NET) Fix revive linter
 	ConnTagIstio = http.Istio
 	// ConnTagNodeJS is the tag for NodeJS TLS connections
 	ConnTagNodeJS = http.NodeJS

--- a/pkg/network/tags_linux.go
+++ b/pkg/network/tags_linux.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	ConnTagGnuTLS = http.GnuTLS
+	ConnTagGnuTLS  = http.GnuTLS
 	ConnTagOpenSSL = http.OpenSSL
-	ConnTagGo = http.Go
-	ConnTagJava = http.Java
-	ConnTagTLS = http.TLS
-	ConnTagIstio = http.Istio
+	ConnTagGo      = http.Go
+	ConnTagJava    = http.Java
+	ConnTagTLS     = http.TLS
+	ConnTagIstio   = http.Istio
 	// ConnTagNodeJS is the tag for NodeJS TLS connections
 	ConnTagNodeJS = http.NodeJS
 )

--- a/pkg/network/tags_linux.go
+++ b/pkg/network/tags_linux.go
@@ -12,12 +12,18 @@ import (
 )
 
 const (
-	ConnTagGnuTLS  = http.GnuTLS
+	// ConnTagGnuTLS is the tag for GnuTLS connections
+	ConnTagGnuTLS = http.GnuTLS
+	// ConnTagOpenSSL is the tag for OpenSSL connections
 	ConnTagOpenSSL = http.OpenSSL
-	ConnTagGo      = http.Go
-	ConnTagJava    = http.Java
-	ConnTagTLS     = http.TLS
-	ConnTagIstio   = http.Istio
+	// ConnTagGo is the tag for GO TLS connections
+	ConnTagGo = http.Go
+	// ConnTagJava is the tag for Java TLS connections
+	ConnTagJava = http.Java
+	// ConnTagTLS is the tag for TLS connections in general
+	ConnTagTLS = http.TLS
+	// ConnTagIstio is the tag for Istio TLS connections
+	ConnTagIstio = http.Istio
 	// ConnTagNodeJS is the tag for NodeJS TLS connections
 	ConnTagNodeJS = http.NodeJS
 )

--- a/pkg/network/testutil/cmd.go
+++ b/pkg/network/testutil/cmd.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package testutil contains helper functions used in network tests
 package testutil
 
 import (
@@ -58,6 +59,8 @@ func RunCommandWithContext(ctx context.Context, cmd string) (string, error) {
 	return string(out), nil
 }
 
+// StartCommandCtx Runs a command with the given context, returning a handle to the command
+// and its input stream.
 func StartCommandCtx(ctx context.Context, cmd string) (*exec.Cmd, io.WriteCloser, error) {
 	args := strings.Split(cmd, " ")
 	c := exec.CommandContext(ctx, args[0], args[1:]...)

--- a/pkg/network/testutil/cmd.go
+++ b/pkg/network/testutil/cmd.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package testutil
 
 import (
@@ -59,7 +58,6 @@ func RunCommandWithContext(ctx context.Context, cmd string) (string, error) {
 	return string(out), nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func StartCommandCtx(ctx context.Context, cmd string) (*exec.Cmd, io.WriteCloser, error) {
 	args := strings.Split(cmd, " ")
 	c := exec.CommandContext(ctx, args[0], args[1:]...)

--- a/pkg/network/testutil/iptables.go
+++ b/pkg/network/testutil/iptables.go
@@ -62,7 +62,6 @@ func IptablesRestore(tb testing.TB, state []byte) {
 // Ip6tablesSave saves the current iptables state to a file
 // and returns its path
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func Ip6tablesSave(tb testing.TB) {
 	cmd := exec.Command("ip6tables-save")
 	state, err := cmd.Output()
@@ -85,7 +84,6 @@ func Ip6tablesSave(tb testing.TB) {
 
 // Ip6tablesRestore restores iptables state from a file
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func Ip6tablesRestore(tb testing.TB, state []byte) {
 	cmd := exec.Command("ip6tables-restore", "--counters")
 	cmd.Stdin = bytes.NewReader(state)

--- a/pkg/network/testutil/iptables.go
+++ b/pkg/network/testutil/iptables.go
@@ -59,10 +59,9 @@ func IptablesRestore(tb testing.TB, state []byte) {
 	assert.NoError(tb, restoreErr)
 }
 
-// Ip6tablesSave saves the current iptables state to a file
+// IP6tablesSave saves the current iptables state to a file
 // and returns its path
-//
-func Ip6tablesSave(tb testing.TB) {
+func IP6tablesSave(tb testing.TB) {
 	cmd := exec.Command("ip6tables-save")
 	state, err := cmd.Output()
 	require.NoError(tb, err)
@@ -78,13 +77,12 @@ func Ip6tablesSave(tb testing.TB) {
 	require.NoError(tb, err)
 	fullState := append(state, natState...)
 	tb.Cleanup(func() {
-		Ip6tablesRestore(tb, fullState)
+		IP6tablesRestore(tb, fullState)
 	})
 }
 
-// Ip6tablesRestore restores iptables state from a file
-//
-func Ip6tablesRestore(tb testing.TB, state []byte) {
+// IP6tablesRestore restores iptables state from a file
+func IP6tablesRestore(tb testing.TB, state []byte) {
 	cmd := exec.Command("ip6tables-restore", "--counters")
 	cmd.Stdin = bytes.NewReader(state)
 	assert.NoError(tb, cmd.Run())

--- a/pkg/network/tracer/connection/dump.go
+++ b/pkg/network/tracer/connection/dump.go
@@ -5,7 +5,6 @@
 
 //go:build linux_bpf
 
-//nolint:revive // TODO(NET) Fix revive linter
 package connection
 
 import (
@@ -23,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-//nolint:revive // TODO(NET) Fix revive linter
 
 func dumpMapsHandler(w io.Writer, manager *manager.Manager, mapName string, currentMap *ebpf.Map) {
 	switch mapName {

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -46,21 +46,14 @@ const (
 	connTracerModuleName     = "network_tracer__ebpf"
 )
 
-//nolint:revive // TODO(NET) Fix revive linter
 var EbpfTracerTelemetry = struct {
 	connections       telemetry.Gauge
 	tcpFailedConnects *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	TcpSentMiscounts *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	unbatchedTcpClose *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	unbatchedUdpClose *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	UdpSendsProcessed *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	UdpSendsMissed *prometheus.Desc
-	//nolint:revive // TODO(NET) Fix revive linter
 	UdpDroppedConns *prometheus.Desc
 	// doubleFlushAttemptsClose is a counter measuring the number of attempts to flush a closed connection twice from tcp_close
 	doubleFlushAttemptsClose *prometheus.Desc
@@ -74,19 +67,12 @@ var EbpfTracerTelemetry = struct {
 	iterationDups      telemetry.Counter
 	iterationAborts    telemetry.Counter
 
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastTcpFailedConnects *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	LastTcpSentMiscounts *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastUnbatchedTcpClose *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastUnbatchedUdpClose *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastUdpSendsProcessed *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastUdpSendsMissed *atomic.Int64
-	//nolint:revive // TODO(NET) Fix revive linter
 	lastUdpDroppedConns *atomic.Int64
 	// lastDoubleFlushAttemptsClose is a counter measuring the diff between the last two values of doubleFlushAttemptsClose
 	lastDoubleFlushAttemptsClose *atomic.Int64
@@ -204,7 +190,6 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 	}
 
 	var m *manager.Manager
-	//nolint:revive // TODO(NET) Fix revive linter
 	var tracerType TracerType = TracerTypeFentry
 	var closeTracerFn func()
 	m, closeTracerFn, err := fentry.LoadTracer(config, mgrOptions, connCloseEventHandler)

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -5,7 +5,6 @@
 
 //go:build linux_bpf
 
-//nolint:revive // TODO(NET) Fix revive linter
 package fentry
 
 import (

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -46,9 +46,7 @@ const (
 	udpSendSkb              = "kprobe__udp_send_skb"
 
 	skbFreeDatagramLocked = "skb_free_datagram_locked"
-	//nolint:revive // TODO(NET) Fix revive linter
 	__skbFreeDatagramLocked = "__skb_free_datagram_locked"
-	//nolint:revive // TODO(NET) Fix revive linter
 	skbConsumeUdp = "skb_consume_udp"
 
 	udpv6RecvMsg              = "udpv6_recvmsg"

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -26,7 +26,6 @@ import (
 
 const probeUID = "net"
 
-//nolint:revive // TODO(NET) Fix revive linter
 var ErrorNotSupported = errors.New("fentry tracer is only supported on Fargate")
 
 // LoadTracer loads a new tracer

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -5,7 +5,6 @@
 
 //go:build linux_bpf
 
-//nolint:revive // TODO(NET) Fix revive linter
 package kprobe
 
 import (

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -29,15 +29,11 @@ import (
 
 const probeUID = "net"
 
-//nolint:revive // TODO(NET) Fix revive linter
 type TracerType int
 
 const (
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypePrebuilt TracerType = iota
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeRuntimeCompiled
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeCORE
 )
 

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -23,15 +23,10 @@ import (
 type TracerType int
 
 const (
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeKProbePrebuilt TracerType = iota
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeKProbeRuntimeCompiled
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeKProbeCORE
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeFentry
-	//nolint:revive // TODO(NET) Fix revive linter
 	TracerTypeEbpfless
 )
 

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -5,7 +5,6 @@
 
 //go:build linux_bpf
 
-//nolint:revive // TODO(NET) Fix revive linter
 package offsetguess
 
 import (
@@ -45,7 +44,6 @@ type conntrackOffsetGuesser struct {
 	udpv6Enabled uint64
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 	tcpv6Enabled, udpv6Enabled := getIpv6Configuration(cfg)
 	tcpv6EnabledConst, udpv6EnabledConst := boolToUint64(tcpv6Enabled), boolToUint64(udpv6Enabled)
@@ -80,7 +78,6 @@ func (c *conntrackOffsetGuesser) Close() {
 	}
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func (c *conntrackOffsetGuesser) Probes(*config.Config) (map[probes.ProbeFuncName]struct{}, error) {
 	p := map[probes.ProbeFuncName]struct{}{}
 	enableProbe(p, probes.ConntrackHashInsert)

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -83,7 +83,6 @@ var whatString = map[GuessWhat]string{
 	GuessCtNet:         "conntrack network namespace",
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 type OffsetGuesser interface {
 	Manager() *manager.Manager
 	Probes(c *config.Config) (map[string]struct{}, error)
@@ -193,7 +192,6 @@ func setupOffsetGuesser(guesser OffsetGuesser, config *config.Config, buf byteco
 	return nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func RunOffsetGuessing(cfg *config.Config, buf bytecode.AssetReader, newGuesser func() (OffsetGuesser, error)) (editors []manager.ConstantEditor, err error) {
 	// Offset guessing has been flaky for some customers, so if it fails we'll retry it up to 5 times
 	start := time.Now()

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -675,10 +675,9 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *maps.GenericMap[ui
 			if !t.guessTCPv6 && !t.guessUDPv6 {
 				t.logAndAdvance(t.status.Offset_sk_buff_head, GuessNotApplicable)
 				return t.setReadyState(mp)
-			} else {
-				t.logAndAdvance(t.status.Offset_sk_buff_head, GuessDAddrIPv6)
-				break
 			}
+			t.logAndAdvance(t.status.Offset_sk_buff_head, GuessDAddrIPv6)
+			break
 		}
 		t.status.Offset_sk_buff_head++
 		t.status.Offset_sk_buff_head, _ = skipOverlaps(t.status.Offset_sk_buff_head, t.skBuffRanges())
@@ -1086,7 +1085,6 @@ func acceptHandler(l net.Listener) {
 // responsible for the V4 offset guessing in kernel-space and 2) using it we can obtain
 // in user-space TCP socket information such as RTT and use it for setting the expected
 // values in the `fieldValues` struct.
-//
 func TcpGetInfo(conn net.Conn) (*unix.TCPInfo, error) {
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -77,7 +77,6 @@ type tracerOffsetGuesser struct {
 	guessUDPv6 bool
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 func NewTracerOffsetGuesser() (OffsetGuesser, error) {
 	return &tracerOffsetGuesser{
 		m: &manager.Manager{
@@ -287,7 +286,6 @@ func uint32ArrayFromIPv6(ip net.IP) (addr [4]uint32, err error) {
 // IPv6LinkLocalPrefix is only exposed for testing purposes
 var IPv6LinkLocalPrefix = "fe80::"
 
-//nolint:revive // TODO(NET) Fix revive linter
 func GetIPv6LinkLocalAddress() ([]*net.UDPAddr, error) {
 	ints, err := net.Interfaces()
 	if err != nil {
@@ -677,7 +675,7 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *maps.GenericMap[ui
 			if !t.guessTCPv6 && !t.guessUDPv6 {
 				t.logAndAdvance(t.status.Offset_sk_buff_head, GuessNotApplicable)
 				return t.setReadyState(mp)
-			} else { //nolint:revive // TODO(NET) Fix revive linter
+			} else {
 				t.logAndAdvance(t.status.Offset_sk_buff_head, GuessDAddrIPv6)
 				break
 			}
@@ -1089,7 +1087,6 @@ func acceptHandler(l net.Listener) {
 // in user-space TCP socket information such as RTT and use it for setting the expected
 // values in the `fieldValues` struct.
 //
-//nolint:revive // TODO(NET) Fix revive linter
 func TcpGetInfo(conn net.Conn) (*unix.TCPInfo, error) {
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
@@ -1154,7 +1151,6 @@ func newUDPServer(addr string) (string, func(), error) {
 	return ln.LocalAddr().String(), doneFn, nil
 }
 
-//nolint:revive // TODO(NET) Fix revive linter
 var TracerOffsets tracerOffsets
 
 type tracerOffsets struct {

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -307,7 +307,6 @@ func testOffsetGuess(t *testing.T) {
 			}
 
 			var offset uint64
-			//nolint:revive // TODO(NET) Fix revive linter
 			var name offsetT = o
 			require.NoError(t, mp.Lookup(&name, &offset))
 			assert.Equal(t, offset, consts[o], "unexpected offset for %s", o)

--- a/pkg/network/tracer/testutil/tcp.go
+++ b/pkg/network/tracer/testutil/tcp.go
@@ -5,7 +5,7 @@
 
 //go:build test
 
-// Package testutil is test utilities for testing the network tracer
+// Package testutil has utilities for testing the network tracer
 package testutil
 
 import "net"

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -5,6 +5,7 @@
 
 //go:build linux_bpf
 
+// Package tracer implements the functionality of the network tracer
 package tracer
 
 import (

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -5,6 +5,7 @@
 
 //go:build (linux && !linux_bpf) || (windows && !npm) || (!linux && !windows)
 
+// Package tracer implements the functionality of the network tracer
 package tracer
 
 import (

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -5,7 +5,6 @@
 
 //go:build (linux && !linux_bpf) || (windows && !npm) || (!linux && !windows)
 
-//nolint:revive // TODO(NET) Fix revive linter
 package tracer
 
 import (

--- a/pkg/network/types/connection_key.go
+++ b/pkg/network/types/connection_key.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package types implements the definition for network connection tuples
 package types
 
 import (

--- a/pkg/network/types/connection_key.go
+++ b/pkg/network/types/connection_key.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package types
 
 import (

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -408,10 +408,10 @@ func batchConnections(
 				continue
 			}
 
-			new := int32(len(newRouteIndices))
-			newRouteIndices[c.RouteIdx] = new
+			newIdx := int32(len(newRouteIndices))
+			newRouteIndices[c.RouteIdx] = newIdx
 			batchRoutes = append(batchRoutes, routes[c.RouteIdx])
-			c.RouteIdx = new
+			c.RouteIdx = newIdx
 		}
 
 		// EncodeDomainDatabase will take the namedb (a simple slice of strings with each unique

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -408,7 +408,6 @@ func batchConnections(
 				continue
 			}
 
-			//nolint:revive // TODO(NET) Fix revive linter
 			new := int32(len(newRouteIndices))
 			newRouteIndices[c.RouteIdx] = new
 			batchRoutes = append(batchRoutes, routes[c.RouteIdx])

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(NET) Fix revive linter
 package util
 
 import (

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package util contains helper functions for processes, IP addresses, env variables, etc.
 package util
 
 import (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This fixes revive linter warnings for the Networks team - the revive linter was recently enabled but to decouple it with each team, it was done by adding linter suppressors on the offending lines. This PR does our part by deleting those suppressors and fixing the warnings.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

A small part is files owned by the process team which are noted in a comment below.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Mainly, ran the linters on linux:
`inv -e show-linters-issues --filter-team "@DataDog/Networks" --filter-linters "revive" --platforms "linux,arm64"`
But also ran them on MacOS because there were some build-tag dependent files:
`inv -e show-linters-issues --filter-team "@DataDog/Networks" --filter-linters "revive" --platforms "darwin,arm64"`
However, I also ran into some additional revive issues for some reason these two did not catch during the `git push` hook. I could rerun that linter like this:
`inv linter.go --only-modified-packages`