### PR TITLE
fix oom kill cgroup name to be victim

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/cgroup.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/cgroup.h
@@ -9,28 +9,32 @@
 #include "bpf_tracing.h"
 #include "bpf_builtins.h"
 
+static __always_inline int get_cgroup_name_for_task(struct task_struct *task, char *buf, size_t sz) {
+    bpf_memset(buf, 0, sz);
+
+    #ifdef COMPILE_CORE
+        enum cgroup_subsys_id___local {
+            memory_cgrp_id___local = 123, /* value doesn't matter */
+        };
+        int cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id___local, memory_cgrp_id___local);
+    #else
+        int cgrp_id = memory_cgrp_id;
+    #endif
+
+    const char *name = BPF_CORE_READ(task, cgroups, subsys[cgrp_id], cgroup, kn, name);
+    if (bpf_probe_read_kernel(buf, sz, name) < 0) {
+        return 0;
+    }
+    return 1;
+}
+
 static __always_inline int get_cgroup_name(char *buf, size_t sz) {
     if (!bpf_helper_exists(BPF_FUNC_get_current_task)) {
         return 0;
     }
-    bpf_memset(buf, 0, sz);
 
     struct task_struct *cur_tsk = (struct task_struct *)bpf_get_current_task();
-
-#ifdef COMPILE_CORE
-    enum cgroup_subsys_id___local {
-        memory_cgrp_id___local = 123, /* value doesn't matter */
-    };
-    int cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id___local, memory_cgrp_id___local);
-#else
-    int cgrp_id = memory_cgrp_id;
-#endif
-    const char *name = BPF_CORE_READ(cur_tsk, cgroups, subsys[cgrp_id], cgroup, kn, name);
-    if (bpf_probe_read_kernel(buf, sz, name) < 0) {
-        return 0;
-    }
-
-    return 1;
+    return get_cgroup_name_for_task(cur_tsk, buf, sz);
 }
 
 #endif /* defined(BPF_CGROUP_H) */

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
@@ -10,13 +10,13 @@
 struct oom_stats {
     char cgroup_name[129];
     // Pid of killed process
-    __u32 pid;
+    __u32 victim_pid;
     // Pid of triggering process
-    __u32 tpid;
+    __u32 trigger_pid;
     // Name of killed process
-    char comm[TASK_COMM_LEN];
+    char victim_comm[TASK_COMM_LEN];
     // Name of triggering process
-    char tcomm[TASK_COMM_LEN];
+    char trigger_comm[TASK_COMM_LEN];
     // OOM score of killed process
     __s64 score;
     // OOM score adjustment of killed process

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern-user.h
@@ -9,13 +9,13 @@
 
 struct oom_stats {
     char cgroup_name[129];
-    // Pid of triggering process
-    __u32 pid;
     // Pid of killed process
+    __u32 pid;
+    // Pid of triggering process
     __u32 tpid;
-    // Name of triggering process
-    char fcomm[TASK_COMM_LEN];
     // Name of killed process
+    char comm[TASK_COMM_LEN];
+    // Name of triggering process
     char tcomm[TASK_COMM_LEN];
     // OOM score of killed process
     __s64 score;

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -43,14 +43,13 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     // expected a pointer to stack memory. Therefore, we work on stack
     // variable and update the map value at the end
     bpf_memcpy(&new, s, sizeof(struct oom_stats));
-
     new.pid = pid;
-    get_cgroup_name(new.cgroup_name, sizeof(new.cgroup_name));
 
     struct task_struct *p = (struct task_struct *)BPF_CORE_READ(oc, chosen);
     if (!p) {
         return 0;
     }
+    get_cgroup_name_for_task(p, new.cgroup_name, sizeof(new.cgroup_name));
     BPF_CORE_READ_INTO(&new.tpid, p, pid);
     BPF_CORE_READ_INTO(&new.score, oc, chosen_points);
 #ifdef COMPILE_CORE

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -25,16 +25,17 @@
  * the statistics per pid
  */
 
-BPF_HASH_MAP(oom_stats, u32, struct oom_stats, 10240)
+BPF_HASH_MAP(oom_stats, u64, struct oom_stats, 10240)
 
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     struct oom_stats zero = {};
     struct oom_stats new = {};
+    u64 ts = bpf_ktime_get_ns();
     u32 pid = bpf_get_current_pid_tgid() >> 32;
 
-    bpf_map_update_elem(&oom_stats, &pid, &zero, BPF_NOEXIST);
-    struct oom_stats *s = bpf_map_lookup_elem(&oom_stats, &pid);
+    bpf_map_update_elem(&oom_stats, &ts, &zero, BPF_NOEXIST);
+    struct oom_stats *s = bpf_map_lookup_elem(&oom_stats, &ts);
     if (!s) {
         return 0;
     }

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -43,14 +43,14 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     // expected a pointer to stack memory. Therefore, we work on stack
     // variable and update the map value at the end
     bpf_memcpy(&new, s, sizeof(struct oom_stats));
-    new.tpid = pid;
+    new.trigger_pid = pid;
 
     struct task_struct *p = (struct task_struct *)BPF_CORE_READ(oc, chosen);
     if (!p) {
         return 0;
     }
     get_cgroup_name_for_task(p, new.cgroup_name, sizeof(new.cgroup_name));
-    BPF_CORE_READ_INTO(&new.pid, p, pid);
+    BPF_CORE_READ_INTO(&new.victim_pid, p, pid);
     BPF_CORE_READ_INTO(&new.score, oc, chosen_points);
 #ifdef COMPILE_CORE
     if (bpf_core_field_exists(p->signal->oom_score_adj)) {
@@ -62,11 +62,11 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     bpf_probe_read_kernel(&new.score_adj, sizeof(new.score_adj), &sig->oom_score_adj);
 #endif
     if (bpf_helper_exists(BPF_FUNC_get_current_comm)) {
-        bpf_get_current_comm(new.tcomm, sizeof(new.tcomm));
+        bpf_get_current_comm(new.trigger_comm, sizeof(new.trigger_comm));
     }
 
-    BPF_CORE_READ_INTO(&new.comm, p, comm);
-    new.comm[TASK_COMM_LEN - 1] = 0;
+    BPF_CORE_READ_INTO(&new.victim_comm, p, comm);
+    new.victim_comm[TASK_COMM_LEN - 1] = 0;
 
     struct mem_cgroup *memcg = NULL;
 #ifdef COMPILE_CORE

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -132,8 +132,8 @@ func (m *OOMKillCheck) Run() error {
 			triggerTypeText = "This OOM kill was invoked by the system."
 		}
 		tags = append(tags, "trigger_type:"+triggerType)
-		tags = append(tags, "trigger_process_name:"+line.FComm)
-		tags = append(tags, "process_name:"+line.TComm)
+		tags = append(tags, "trigger_process_name:"+line.TComm)
+		tags = append(tags, "process_name:"+line.Comm)
 
 		// submit counter metric
 		sender.Count("oom_kill.oom_process.count", 1, "", tags)
@@ -145,7 +145,7 @@ func (m *OOMKillCheck) Run() error {
 			SourceTypeName: CheckName,
 			EventType:      CheckName,
 			AggregationKey: containerID,
-			Title:          fmt.Sprintf("Process OOM Killed: oom_kill_process called on %s (pid: %d)", line.TComm, line.TPid),
+			Title:          fmt.Sprintf("Process OOM Killed: oom_kill_process called on %s (pid: %d)", line.Comm, line.Pid),
 			Tags:           tags,
 		}
 
@@ -156,9 +156,9 @@ func (m *OOMKillCheck) Run() error {
 			oomScoreAdj = fmt.Sprintf(", oom_score_adj: %d", line.ScoreAdj)
 		}
 		if line.Pid == line.TPid {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.FComm, line.Pid, line.Score, oomScoreAdj)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.Comm, line.Pid, line.Score, oomScoreAdj)
 		} else {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.FComm, line.Pid, line.TComm, line.TPid, line.Score, oomScoreAdj)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.TComm, line.TPid, line.Comm, line.Pid, line.Score, oomScoreAdj)
 		}
 		fmt.Fprintf(&b, "\n The process had reached %d pages in size. \n\n", line.Pages)
 		b.WriteString(triggerTypeText)

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -158,7 +158,7 @@ func (m *OOMKillCheck) Run() error {
 		if line.VictimPid == line.TriggerPid {
 			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.VictimComm, line.VictimPid, line.Score, oomScoreAdj)
 		} else {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.TriggerComm, line.TriggerComm, line.VictimComm, line.VictimPid, line.Score, oomScoreAdj)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.TriggerComm, line.TriggerPid, line.VictimComm, line.VictimPid, line.Score, oomScoreAdj)
 		}
 		fmt.Fprintf(&b, "\n The process had reached %d pages in size. \n\n", line.Pages)
 		b.WriteString(triggerTypeText)

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -132,8 +132,8 @@ func (m *OOMKillCheck) Run() error {
 			triggerTypeText = "This OOM kill was invoked by the system."
 		}
 		tags = append(tags, "trigger_type:"+triggerType)
-		tags = append(tags, "trigger_process_name:"+line.TComm)
-		tags = append(tags, "process_name:"+line.Comm)
+		tags = append(tags, "trigger_process_name:"+line.TriggerComm)
+		tags = append(tags, "process_name:"+line.VictimComm)
 
 		// submit counter metric
 		sender.Count("oom_kill.oom_process.count", 1, "", tags)
@@ -145,7 +145,7 @@ func (m *OOMKillCheck) Run() error {
 			SourceTypeName: CheckName,
 			EventType:      CheckName,
 			AggregationKey: containerID,
-			Title:          fmt.Sprintf("Process OOM Killed: oom_kill_process called on %s (pid: %d)", line.Comm, line.Pid),
+			Title:          fmt.Sprintf("Process OOM Killed: oom_kill_process called on %s (pid: %d)", line.VictimComm, line.VictimPid),
 			Tags:           tags,
 		}
 
@@ -155,10 +155,10 @@ func (m *OOMKillCheck) Run() error {
 		if line.ScoreAdj != 0 {
 			oomScoreAdj = fmt.Sprintf(", oom_score_adj: %d", line.ScoreAdj)
 		}
-		if line.Pid == line.TPid {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.Comm, line.Pid, line.Score, oomScoreAdj)
+		if line.VictimPid == line.TriggerPid {
+			fmt.Fprintf(&b, "Process `%s` (pid: %d, oom_score: %d%s) triggered an OOM kill on itself.", line.VictimComm, line.VictimPid, line.Score, oomScoreAdj)
 		} else {
-			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.TComm, line.TPid, line.Comm, line.Pid, line.Score, oomScoreAdj)
+			fmt.Fprintf(&b, "Process `%s` (pid: %d) triggered an OOM kill on process `%s` (pid: %d, oom_score: %d%s).", line.TriggerComm, line.TriggerComm, line.VictimComm, line.VictimPid, line.Score, oomScoreAdj)
 		}
 		fmt.Fprintf(&b, "\n The process had reached %d pages in size. \n\n", line.Pages)
 		b.WriteString(triggerTypeText)

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/c_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/c_types_linux.go
@@ -7,7 +7,7 @@ type oomStats struct {
 	Cgroup_name [129]byte
 	Pid         uint32
 	Tpid        uint32
-	Fcomm       [16]byte
+	Comm        [16]byte
 	Tcomm       [16]byte
 	Score       int64
 	Score_adj   int16

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/c_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/c_types_linux.go
@@ -4,14 +4,14 @@
 package oomkill
 
 type oomStats struct {
-	Cgroup_name [129]byte
-	Pid         uint32
-	Tpid        uint32
-	Comm        [16]byte
-	Tcomm       [16]byte
-	Score       int64
-	Score_adj   int16
-	Pages       uint64
-	Memcg_oom   uint32
-	Pad_cgo_0   [4]byte
+	Cgroup_name  [129]byte
+	Victim_pid   uint32
+	Trigger_pid  uint32
+	Victim_comm  [16]byte
+	Trigger_comm [16]byte
+	Score        int64
+	Score_adj    int16
+	Pages        uint64
+	Memcg_oom    uint32
+	Pad_cgo_0    [4]byte
 }

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
@@ -11,7 +11,7 @@ type OOMKillStats struct {
 	CgroupName string `json:"cgroupName"`
 	Pid        uint32 `json:"pid"`
 	TPid       uint32 `json:"tpid"`
-	FComm      string `json:"fcomm"`
+	Comm       string `json:"comm"`
 	TComm      string `json:"tcomm"`
 	Score      int64  `json:"score"`
 	ScoreAdj   int16  `json:"scoreAdj"`

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/model/oom_kill_types.go
@@ -8,13 +8,13 @@ package model
 
 // OOMKillStats contains the statistics of a given socket
 type OOMKillStats struct {
-	CgroupName string `json:"cgroupName"`
-	Pid        uint32 `json:"pid"`
-	TPid       uint32 `json:"tpid"`
-	Comm       string `json:"comm"`
-	TComm      string `json:"tcomm"`
-	Score      int64  `json:"score"`
-	ScoreAdj   int16  `json:"scoreAdj"`
-	Pages      uint64 `json:"pages"`
-	MemCgOOM   uint32 `json:"memcgoom"`
+	CgroupName  string `json:"cgroupName"`
+	VictimPid   uint32 `json:"victimPid"`
+	TriggerPid  uint32 `json:"triggerPid"`
+	VictimComm  string `json:"victimComm"`
+	TriggerComm string `json:"triggerComm"`
+	Score       int64  `json:"score"`
+	ScoreAdj    int16  `json:"scoreAdj"`
+	Pages       uint64 `json:"pages"`
+	MemCgOOM    uint32 `json:"memcgoom"`
 }

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -151,7 +151,7 @@ func (k *Probe) GetAndFlush() (results []model.OOMKillStats) {
 	}
 
 	for _, r := range results {
-		if err := k.oomMap.Delete(&r.Pid); err != nil {
+		if err := k.oomMap.Delete(&r.TriggerPid); err != nil {
 			log.Warnf("failed to delete stat: %s", err)
 		}
 	}
@@ -161,12 +161,12 @@ func (k *Probe) GetAndFlush() (results []model.OOMKillStats) {
 
 func convertStats(in oomStats) (out model.OOMKillStats) {
 	out.CgroupName = unix.ByteSliceToString(in.Cgroup_name[:])
-	out.Pid = in.Pid
-	out.TPid = in.Tpid
+	out.VictimPid = in.Victim_pid
+	out.TriggerPid = in.Trigger_pid
 	out.Score = in.Score
 	out.ScoreAdj = in.Score_adj
-	out.Comm = unix.ByteSliceToString(in.Comm[:])
-	out.TComm = unix.ByteSliceToString(in.Tcomm[:])
+	out.VictimComm = unix.ByteSliceToString(in.Victim_comm[:])
+	out.TriggerComm = unix.ByteSliceToString(in.Trigger_comm[:])
 	out.Pages = in.Pages
 	out.MemCgOOM = in.Memcg_oom
 	return

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -34,7 +34,7 @@ const oomMapName = "oom_stats"
 // Probe is the eBPF side of the OOM Kill check
 type Probe struct {
 	m      *manager.Manager
-	oomMap *maps.GenericMap[uint32, oomStats]
+	oomMap *maps.GenericMap[uint64, oomStats]
 }
 
 // NewProbe creates a [Probe]
@@ -117,7 +117,7 @@ func startOOMKillProbe(buf bytecode.AssetReader, managerOptions manager.Options)
 		return nil, fmt.Errorf("failed to start manager: %w", err)
 	}
 
-	oomMap, err := maps.GetMap[uint32, oomStats](m, oomMapName)
+	oomMap, err := maps.GetMap[uint64, oomStats](m, oomMapName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get map '%s': %w", oomMapName, err)
 	}
@@ -139,19 +139,21 @@ func (k *Probe) Close() {
 
 // GetAndFlush gets the stats
 func (k *Probe) GetAndFlush() (results []model.OOMKillStats) {
-	var pid uint32
+	var allTimestamps []uint64
+	var ts uint64
 	var stat oomStats
 	it := k.oomMap.Iterate()
-	for it.Next(&pid, &stat) {
+	for it.Next(&ts, &stat) {
 		results = append(results, convertStats(stat))
+		allTimestamps = append(allTimestamps, ts)
 	}
 
 	if err := it.Err(); err != nil {
 		log.Warnf("failed to iterate on OOM stats while flushing: %s", err)
 	}
 
-	for _, r := range results {
-		if err := k.oomMap.Delete(&r.TriggerPid); err != nil {
+	for _, ts := range allTimestamps {
+		if err := k.oomMap.Delete(&ts); err != nil {
 			log.Warnf("failed to delete stat: %s", err)
 		}
 	}

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -165,7 +165,7 @@ func convertStats(in oomStats) (out model.OOMKillStats) {
 	out.TPid = in.Tpid
 	out.Score = in.Score
 	out.ScoreAdj = in.Score_adj
-	out.FComm = unix.ByteSliceToString(in.Fcomm[:])
+	out.Comm = unix.ByteSliceToString(in.Comm[:])
 	out.TComm = unix.ByteSliceToString(in.Tcomm[:])
 	out.Pages = in.Pages
 	out.MemCgOOM = in.Memcg_oom

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -104,7 +104,7 @@ func TestOOMKillProbe(t *testing.T) {
 		assert.Equal(t, result.TPid, result.Pid, "tpid == pid")
 		assert.NotZero(t, result.Score, "score")
 		assert.Equal(t, int16(42), result.ScoreAdj, "score adj")
-		assert.Equal(t, "dd", result.FComm, "fcomm")
+		assert.Equal(t, "dd", result.Comm, "comm")
 		assert.Equal(t, "dd", result.TComm, "tcomm")
 		assert.NotZero(t, result.Pages, "pages")
 		assert.Equal(t, uint32(1), result.MemCgOOM, "memcg oom")

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -92,7 +92,7 @@ func TestOOMKillProbe(t *testing.T) {
 		var result model.OOMKillStats
 		require.Eventually(t, func() bool {
 			for _, r := range oomKillProbe.GetAndFlush() {
-				if r.TPid == uint32(cmd.Process.Pid) {
+				if r.TriggerPid == uint32(cmd.Process.Pid) {
 					result = r
 					return true
 				}
@@ -101,11 +101,11 @@ func TestOOMKillProbe(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "failed to find an OOM killed process with pid %d", cmd.Process.Pid)
 
 		assert.Regexp(t, regexp.MustCompile("run-([0-9|a-z]*).scope"), result.CgroupName, "cgroup name")
-		assert.Equal(t, result.TPid, result.Pid, "tpid == pid")
+		assert.Equal(t, result.TriggerPid, result.VictimPid, "tpid == pid")
 		assert.NotZero(t, result.Score, "score")
 		assert.Equal(t, int16(42), result.ScoreAdj, "score adj")
-		assert.Equal(t, "dd", result.Comm, "comm")
-		assert.Equal(t, "dd", result.TComm, "tcomm")
+		assert.Equal(t, "dd", result.VictimComm, "victim comm")
+		assert.Equal(t, "dd", result.TriggerComm, "trigger comm")
 		assert.NotZero(t, result.Pages, "pages")
 		assert.Equal(t, uint32(1), result.MemCgOOM, "memcg oom")
 	})

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Convert []int8 to []byte in multiple generated fields from the kernel, to simplify
 	// conversion to string; see golang.org/issue/20753
-	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Comm|Tcomm)(\s+)\[(\d+)\]u?int8`)
+	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Victim_comm|Trigger_comm)(\s+)\[(\d+)\]u?int8`)
 	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
 	b, err = format.Source(b)

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Convert []int8 to []byte in multiple generated fields from the kernel, to simplify
 	// conversion to string; see golang.org/issue/20753
-	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Fcomm|Tcomm)(\s+)\[(\d+)\]u?int8`)
+	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf|Cgroup|RemoteAddr|LocalAddr|Cgroup_name|Comm|Tcomm)(\s+)\[(\d+)\]u?int8`)
 	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
 	b, err = format.Source(b)

--- a/releasenotes/notes/oom-kill-cgroup-victim-2aa7ca4e8e3ffac2.yaml
+++ b/releasenotes/notes/oom-kill-cgroup-victim-2aa7ca4e8e3ffac2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    OOM Kill Check now reports the cgroup name of the victim process rather than the triggering process.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- Uses the victim task (`oc->chosen`) when getting the cgroup name, rather than the triggering process.
- Clarifies triggering vs victim in event content

### Motivation

Reported bug by a customer.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-552

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
