### PR TITLE
Add UT for Kafka Producer with noAcks Configuration

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -517,6 +517,45 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 				}
 			},
 		},
+		{
+			name: "Produce - no acks required",
+			context: testContext{
+				serverPort:    kafkaPort,
+				targetAddress: targetAddress,
+				serverAddress: serverAddress,
+				extras: map[string]interface{}{
+					"topic_name": s.getTopicName(),
+				},
+			},
+			testBody: func(t *testing.T, ctx *testContext, monitor *Monitor) {
+				topicName := ctx.extras["topic_name"].(string)
+				client, err := kafka.NewClient(kafka.Options{
+					ServerAddress: ctx.targetAddress,
+					DialFn:        dialFn,
+					CustomOptions: []kgo.Opt{
+						kgo.MaxVersions(version),
+						kgo.RequiredAcks(kgo.NoAck()),
+						kgo.DisableIdempotentWrite(),
+					},
+				})
+				require.NoError(t, err)
+				ctx.clients = append(ctx.clients, client)
+				require.NoError(t, client.CreateTopic(topicName))
+
+				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
+				ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
+				require.NoError(t, client.Client.ProduceSync(ctxTimeout, record).FirstErr(), "record had a produce error while synchronously producing")
+
+				getAndValidateKafkaStats(t, monitor, fixCount(1), topicName, kafkaParsingValidation{
+					expectedNumberOfProduceRequests: fixCount(1),
+					expectedNumberOfFetchRequests:   0,
+					expectedAPIVersionProduce:       expectedAPIVersionProduce,
+					expectedAPIVersionFetch:         0,
+					tlsEnabled:                      tls,
+				}, kafkaSuccessErrorCode)
+			},
+		},
 	}
 
 	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, serverAddress, tls)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Adds a test to validate a Kafka producer configured with no acks required.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
As part of [this PR](https://github.com/DataDog/datadog-agent/pull/28526), we observed that no Kafka produce response is sent when the `ackRequired` field in the Kafka producer client is set to 0 (noAcks). To prevent future issues, we need to add a unit test for this scenario.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
