### PR TITLE
[CWS] skip TestActionKillExcludeBinary in ebpfless mode

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -191,13 +191,13 @@ func TestActionKill(t *testing.T) {
 }
 
 func TestActionKillExcludeBinary(t *testing.T) {
-	SkipIfNotAvailable(t)
-
-	if !ebpfLessEnabled {
-		checkKernelCompatibility(t, "bpf_send_signal is not supported on this kernel and agent is running in container mode", func(kv *kernel.Version) bool {
-			return !kv.SupportBPFSendSignal() && env.IsContainerized()
-		})
+	if ebpfLessEnabled {
+		t.Skip("test not yet available for ebpfless")
 	}
+
+	checkKernelCompatibility(t, "bpf_send_signal is not supported on this kernel and agent is running in container mode", func(kv *kernel.Version) bool {
+		return !kv.SupportBPFSendSignal() && env.IsContainerized()
+	})
 
 	ruleDefs := []*rules.RuleDefinition{
 		{


### PR DESCRIPTION
### What does this PR do?

This PR skips `TestActionKillExcludeBinary ` in ebpfless while we investigate deeper what is happening with module reloading on ebpfless.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
