### PR TITLE
[CWS] split `containers_running` and profile containers telemetry

### DIFF
--- a/pkg/security/agent/agent_nix.go
+++ b/pkg/security/agent/agent_nix.go
@@ -25,10 +25,16 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 	}
 
 	// on windows do no telemetry
-	telemetry, err := newTelemetry(statsdClient, wmeta, opts.LogProfiledWorkloads, opts.IgnoreDDAgentContainers)
+	telemetry, err := newTelemetry(statsdClient, wmeta, opts.IgnoreDDAgentContainers)
 	if err != nil {
 		return nil, errors.New("failed to initialize the telemetry reporter")
 	}
+
+	profContainersTelemetry, err := newProfContainersTelemetry(statsdClient, wmeta, opts.LogProfiledWorkloads)
+	if err != nil {
+		return nil, errors.New("failed to initialize the profiled containers telemetry reporter")
+	}
+
 	// on windows do no storage manager
 	storage, err := dump.NewAgentStorageManager()
 	if err != nil {
@@ -36,13 +42,14 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 	}
 
 	return &RuntimeSecurityAgent{
-		client:               client,
-		hostname:             hostname,
-		telemetry:            telemetry,
-		storage:              storage,
-		running:              atomic.NewBool(false),
-		connected:            atomic.NewBool(false),
-		eventReceived:        atomic.NewUint64(0),
-		activityDumpReceived: atomic.NewUint64(0),
+		client:                  client,
+		hostname:                hostname,
+		telemetry:               telemetry,
+		profContainersTelemetry: profContainersTelemetry,
+		storage:                 storage,
+		running:                 atomic.NewBool(false),
+		connected:               atomic.NewBool(false),
+		eventReceived:           atomic.NewUint64(0),
+		activityDumpReceived:    atomic.NewUint64(0),
 	}, nil
 }

--- a/pkg/security/agent/prof_containers_telemetry.go
+++ b/pkg/security/agent/prof_containers_telemetry.go
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+type profContainersTelemetry struct {
+	statsdClient          statsd.ClientInterface
+	wmeta                 workloadmeta.Component
+	runtimeSecurityClient *RuntimeSecurityClient
+	profiledContainers    map[profiledContainer]struct{}
+	logProfiledWorkloads  bool
+}
+
+func newProfContainersTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component, logProfiledWorkloads bool) (*profContainersTelemetry, error) {
+	runtimeSecurityClient, err := NewRuntimeSecurityClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &profContainersTelemetry{
+		statsdClient:          statsdClient,
+		wmeta:                 wmeta,
+		runtimeSecurityClient: runtimeSecurityClient,
+		profiledContainers:    make(map[profiledContainer]struct{}),
+		logProfiledWorkloads:  logProfiledWorkloads,
+	}, nil
+}
+
+func (t *profContainersTelemetry) registerProfiledContainer(name, tag string) {
+	entry := profiledContainer{
+		name: name,
+		tag:  tag,
+	}
+
+	if entry.isValid() {
+		t.profiledContainers[entry] = struct{}{}
+	}
+}
+
+func (t *profContainersTelemetry) run(ctx context.Context) {
+	log.Info("started collecting Profiled Containers telemetry")
+	defer log.Info("stopping Profiled Containers telemetry")
+
+	profileCounterTicker := time.NewTicker(5 * time.Minute)
+	defer profileCounterTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-profileCounterTicker.C:
+			if err := t.reportProfiledContainers(); err != nil {
+				log.Debugf("couldn't report profiled containers: %v", err)
+			}
+		}
+	}
+}
+
+type profiledContainer struct {
+	name string
+	tag  string
+}
+
+func (pc *profiledContainer) isValid() bool {
+	return pc.name != "" && pc.tag != ""
+}
+
+func (t *profContainersTelemetry) fetchConfig() (*api.SecurityConfigMessage, error) {
+	cfg, err := t.runtimeSecurityClient.GetConfig()
+	if err != nil {
+		return cfg, errors.New("couldn't fetch config from runtime security module")
+	}
+	return cfg, nil
+}
+
+func (t *profContainersTelemetry) reportProfiledContainers() error {
+	cfg, err := t.fetchConfig()
+	if err != nil {
+		return err
+	}
+	if !cfg.ActivityDumpEnabled {
+		return nil
+	}
+
+	profiled := make(map[profiledContainer]bool)
+
+	runningContainers := t.wmeta.ListContainersWithFilter(workloadmeta.GetRunningContainers)
+	for _, container := range runningContainers {
+		entry := profiledContainer{
+			name: container.Image.Name,
+			tag:  container.Image.Tag,
+		}
+		if !entry.isValid() {
+			continue
+		}
+		profiled[entry] = false
+	}
+
+	doneProfiling := make([]string, 0)
+	for containerEntry := range t.profiledContainers {
+		profiled[containerEntry] = true
+		doneProfiling = append(doneProfiling, fmt.Sprintf("%s:%s", containerEntry.name, containerEntry.tag))
+	}
+
+	missing := make([]string, 0, len(profiled))
+	for entry, found := range profiled {
+		if !found {
+			missing = append(missing, fmt.Sprintf("%s:%s", entry.name, entry.tag))
+		}
+	}
+
+	if t.logProfiledWorkloads && len(missing) > 0 {
+		log.Infof("not yet profiled workloads (%d/%d): %v; finished profiling: %v", len(missing), len(profiled), missing, doneProfiling)
+	}
+	t.statsdClient.Gauge(metrics.MetricActivityDumpNotYetProfiledWorkload, float64(len(missing)), nil, 1.0)
+	return nil
+}

--- a/pkg/security/agent/prof_containers_telemetry.go
+++ b/pkg/security/agent/prof_containers_telemetry.go
@@ -129,6 +129,6 @@ func (t *profContainersTelemetry) reportProfiledContainers() error {
 	if t.logProfiledWorkloads && len(missing) > 0 {
 		log.Infof("not yet profiled workloads (%d/%d): %v; finished profiling: %v", len(missing), len(profiled), missing, doneProfiling)
 	}
-	t.statsdClient.Gauge(metrics.MetricActivityDumpNotYetProfiledWorkload, float64(len(missing)), nil, 1.0)
+	_ = t.statsdClient.Gauge(metrics.MetricActivityDumpNotYetProfiledWorkload, float64(len(missing)), nil, 1.0)
 	return nil
 }

--- a/pkg/security/agent/telemetry_linux.go
+++ b/pkg/security/agent/telemetry_linux.go
@@ -9,7 +9,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -25,11 +24,9 @@ import (
 type telemetry struct {
 	containers            *sectelemetry.ContainersTelemetry
 	runtimeSecurityClient *RuntimeSecurityClient
-	profiledContainers    map[profiledContainer]struct{}
-	logProfiledWorkloads  bool
 }
 
-func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component, logProfiledWorkloads, ignoreDDAgentContainers bool) (*telemetry, error) {
+func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component, ignoreDDAgentContainers bool) (*telemetry, error) {
 	runtimeSecurityClient, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err
@@ -45,20 +42,7 @@ func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Compon
 	return &telemetry{
 		containers:            containersTelemetry,
 		runtimeSecurityClient: runtimeSecurityClient,
-		profiledContainers:    make(map[profiledContainer]struct{}),
-		logProfiledWorkloads:  logProfiledWorkloads,
 	}, nil
-}
-
-func (t *telemetry) registerProfiledContainer(name, tag string) {
-	entry := profiledContainer{
-		name: name,
-		tag:  tag,
-	}
-
-	if entry.isValid() {
-		t.profiledContainers[entry] = struct{}{}
-	}
 }
 
 func (t *telemetry) run(ctx context.Context) {
@@ -67,8 +51,6 @@ func (t *telemetry) run(ctx context.Context) {
 
 	metricsTicker := time.NewTicker(1 * time.Minute)
 	defer metricsTicker.Stop()
-	profileCounterTicker := time.NewTicker(5 * time.Minute)
-	defer profileCounterTicker.Stop()
 
 	for {
 		select {
@@ -78,21 +60,8 @@ func (t *telemetry) run(ctx context.Context) {
 			if err := t.reportContainers(); err != nil {
 				log.Debugf("couldn't report containers: %v", err)
 			}
-		case <-profileCounterTicker.C:
-			if err := t.reportProfiledContainers(); err != nil {
-				log.Debugf("couldn't report profiled containers: %v", err)
-			}
 		}
 	}
-}
-
-type profiledContainer struct {
-	name string
-	tag  string
-}
-
-func (pc *profiledContainer) isValid() bool {
-	return pc.name != "" && pc.tag != ""
 }
 
 func (t *telemetry) fetchConfig() (*api.SecurityConfigMessage, error) {
@@ -101,48 +70,6 @@ func (t *telemetry) fetchConfig() (*api.SecurityConfigMessage, error) {
 		return cfg, errors.New("couldn't fetch config from runtime security module")
 	}
 	return cfg, nil
-}
-
-func (t *telemetry) reportProfiledContainers() error {
-	cfg, err := t.fetchConfig()
-	if err != nil {
-		return err
-	}
-	if !cfg.ActivityDumpEnabled {
-		return nil
-	}
-
-	profiled := make(map[profiledContainer]bool)
-
-	for _, container := range t.containers.ListRunningContainers() {
-		entry := profiledContainer{
-			name: container.Image.Name,
-			tag:  container.Image.Tag,
-		}
-		if !entry.isValid() {
-			continue
-		}
-		profiled[entry] = false
-	}
-
-	doneProfiling := make([]string, 0)
-	for containerEntry := range t.profiledContainers {
-		profiled[containerEntry] = true
-		doneProfiling = append(doneProfiling, fmt.Sprintf("%s:%s", containerEntry.name, containerEntry.tag))
-	}
-
-	missing := make([]string, 0, len(profiled))
-	for entry, found := range profiled {
-		if !found {
-			missing = append(missing, fmt.Sprintf("%s:%s", entry.name, entry.tag))
-		}
-	}
-
-	if t.logProfiledWorkloads && len(missing) > 0 {
-		log.Infof("not yet profiled workloads (%d/%d): %v; finished profiling: %v", len(missing), len(profiled), missing, doneProfiling)
-	}
-	t.containers.TelemetrySender.Gauge(metrics.MetricActivityDumpNotYetProfiledWorkload, float64(len(missing)), nil)
-	return nil
 }
 
 func (t *telemetry) reportContainers() error {

--- a/pkg/security/agent/telemetry_others.go
+++ b/pkg/security/agent/telemetry_others.go
@@ -12,6 +12,10 @@ import "context"
 
 type telemetry struct{}
 
-func (t *telemetry) registerProfiledContainer(_, _ string) {}
-
 func (t *telemetry) run(_ context.Context) {}
+
+type profContainersTelemetry struct{}
+
+func (t *profContainersTelemetry) registerProfiledContainer(_, _ string) {}
+
+func (t *profContainersTelemetry) run(_ context.Context) {}


### PR DESCRIPTION
### What does this PR do?

This PR splits the telemetry ran in the security agent to extract the `.containers_running` metric telemetry (that we are going to move in the system-probe), from the "container profiled" telemetry that will stay in the security agent for now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
