### PR TITLE
service discovery: Improve performance of getSockets

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -760,5 +761,90 @@ func BenchmarkNewProcess(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		customNewProcess(int32(os.Getpid()))
+	}
+}
+
+func getSocketsOld(p *process.Process) ([]uint64, error) {
+	FDs, err := p.OpenFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	// sockets have the following pattern "socket:[inode]"
+	var sockets []uint64
+	for _, fd := range FDs {
+		if strings.HasPrefix(fd.Path, prefix) {
+			inodeStr := strings.TrimPrefix(fd.Path[:len(fd.Path)-1], prefix)
+			sock, err := strconv.ParseUint(inodeStr, 10, 64)
+			if err != nil {
+				continue
+			}
+			sockets = append(sockets, sock)
+		}
+	}
+
+	return sockets, nil
+}
+
+const (
+	numberFDs = 100
+)
+
+func createFilesAndSockets(tb testing.TB) {
+	listeningSockets := make([]net.Listener, 0, numberFDs)
+	tb.Cleanup(func() {
+		for _, l := range listeningSockets {
+			l.Close()
+		}
+	})
+	for i := 0; i < numberFDs; i++ {
+		l, err := net.Listen("tcp", "localhost:0")
+		require.NoError(tb, err)
+		listeningSockets = append(listeningSockets, l)
+	}
+	regularFDs := make([]*os.File, 0, numberFDs)
+	tb.Cleanup(func() {
+		for _, f := range regularFDs {
+			f.Close()
+		}
+	})
+	for i := 0; i < numberFDs; i++ {
+		f, err := os.CreateTemp("", "")
+		require.NoError(tb, err)
+		regularFDs = append(regularFDs, f)
+	}
+}
+
+func TestGetSockets(t *testing.T) {
+	createFilesAndSockets(t)
+	p, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	sockets, err := getSockets(p.Pid)
+	require.NoError(t, err)
+
+	sockets2, err := getSocketsOld(p)
+	require.NoError(t, err)
+
+	require.Equal(t, sockets, sockets2)
+}
+
+func BenchmarkGetSockets(b *testing.B) {
+	createFilesAndSockets(b)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		getSockets(int32(os.Getpid()))
+	}
+}
+
+func BenchmarkOldGetSockets(b *testing.B) {
+	createFilesAndSockets(b)
+	p, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(b, err)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		getSocketsOld(p)
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Offers a slight improvement of `getSockets` to cut allocations and heap pressure.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve performance of service-discovery module

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

runtime - 5% improvement
bytes - 23% improvement
allocations - 17% improvement

```
BenchmarkGetSockets
BenchmarkGetSockets-16       	    3943	    302700 ns/op	   52671 B/op	    1049 allocs/op
BenchmarkOldGetSockets
BenchmarkOldGetSockets-16    	    3795	    319294 ns/op	   67581 B/op	    1266 allocs/op
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
