### PR TITLE
Add params to jmxlogger.Module

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -158,8 +158,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Provide(tagger.NewTaggerParamsForCoreAgent),
 			taggerimpl.Module(),
 			autodiscoveryimpl.Module(),
-			agent.Bundle(),
-			fx.Supply(jmxloggerimpl.NewCliParams(cliParams.logFile)),
+			agent.Bundle(jmxloggerimpl.NewCliParams(cliParams.logFile)),
 		)
 	}
 

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -448,8 +448,7 @@ func getSharedFxOption() fx.Option {
 		collectorimpl.Module(),
 		process.Bundle(),
 		guiimpl.Module(),
-		agent.Bundle(),
-		fx.Supply(jmxloggerimpl.NewDefaultParams()),
+		agent.Bundle(jmxloggerimpl.NewDefaultParams()),
 		fx.Provide(func(config config.Component) healthprobe.Options {
 			return healthprobe.Options{
 				Port:           config.GetInt("health_port"),

--- a/comp/agent/bundle.go
+++ b/comp/agent/bundle.go
@@ -17,10 +17,10 @@ import (
 // team: agent-shared-components
 
 // Bundle defines the fx options for this bundle.
-func Bundle() fxutil.BundleOptions {
+func Bundle(params jmxloggerimpl.Params) fxutil.BundleOptions {
 	return fxutil.Bundle(
 		autoexitimpl.Module(),
-		jmxloggerimpl.Module(),
+		jmxloggerimpl.Module(params),
 		expvarserverimpl.Module(),
 		cloudfoundrycontainerimpl.Module(),
 	)

--- a/comp/agent/bundle_test.go
+++ b/comp/agent/bundle_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestBundleDependencies(t *testing.T) {
 	fxutil.TestBundle(t,
-		Bundle(),
+		Bundle(jmxloggerimpl.NewDefaultParams()),
 		core.MockBundle(),
 		compressionimpl.MockModule(),
 		defaultforwarder.MockModule(),
@@ -32,7 +32,6 @@ func TestBundleDependencies(t *testing.T) {
 		eventplatformimpl.MockModule(),
 		demultiplexerimpl.Module(),
 		fx.Supply(demultiplexerimpl.NewDefaultParams()),
-		fx.Supply(jmxloggerimpl.NewDefaultParams()),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	)
 }

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
@@ -20,9 +20,10 @@ import (
 )
 
 // Module defines the fx options for this component.
-func Module() fxutil.Module {
+func Module(params Params) fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newJMXLogger),
+		fx.Supply(params),
 	)
 }
 

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -217,8 +217,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				fx.Provide(func() pidmap.Component { return nil }),
 
 				getPlatformModules(),
-				jmxloggerimpl.Module(),
-				fx.Supply(jmxloggerimpl.NewDisabledParams()),
+				jmxloggerimpl.Module(jmxloggerimpl.NewDisabledParams()),
 			)
 		},
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR adds a mandatory parameter to the jmxlogger `Module()` in order to replace
```go		
agent.Bundle(),
fx.Supply(jmxloggerimpl.NewCliParams(cliParams.logFile)),
```
by
```go
agent.Bundle(jmxloggerimpl.NewCliParams(cliParams.logFile)),
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
By adding the parameter to the `Module` function, a user of jmxlogger doesn't have to guess that `jmxlogger.Params` is mandatory
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
QA done by running unit tests and E2E tests.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
