### PR TITLE
(fleet) add remote config client state to the daemon status

### DIFF
--- a/cmd/installer/subcommands/daemon/status.tmpl
+++ b/cmd/installer/subcommands/daemon/status.tmpl
@@ -14,7 +14,9 @@ Datadog Installer v{{ htmlSafe .Version }}
   {{- end }}
   {{- if eq $name "datadog-apm-inject" }}{{ template "datadog-apm-inject" $.ApmInjectionStatus }}{{ end }}
 {{ end -}}
-
+{{- if .RemoteConfigState }}
+{{ template "remote-config-state" $.RemoteConfigState }}
+{{- end -}}
 
 {{- define "datadog-apm-inject" }}
   Instrumentation status:
@@ -31,3 +33,25 @@ Datadog Installer v{{ htmlSafe .Version }}
       {{ redText "●" }} Docker: Not instrumented
     {{- end }}
 {{- end -}}
+
+{{- define "remote-config-state" }}
+  Remote configuration client state:
+  {{ range . }}
+    {{ boldText .Package }}
+      StableVersion: {{ .StableVersion }}
+      ExperimentVersion: {{ .ExperimentVersion }}
+      StableConfigVersion: {{ .StableConfigVersion }}
+      ExperimentConfigVersion: {{ .ExperimentConfigVersion }}
+      RemoteConfigVersion: {{ .RemoteConfigVersion }}
+      Task:
+        {{- if .Task }}
+          Id: {{ .Task.Id }}
+          State: {{ .Task.State }}
+          {{- if .Task.Error }}
+            Error: {{ .Task.Error }}
+          {{- end }}
+        {{- else }}
+          No task available
+        {{- end }}
+  {{ end }}
+{{- end }}

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -56,6 +56,7 @@ type Daemon interface {
 
 	GetPackage(pkg string, version string) (Package, error)
 	GetState() (map[string]repository.State, error)
+	GetRemoteConfigState() []*pbgo.PackageState
 	GetAPMInjectionStatus() (APMInjectionStatus, error)
 }
 
@@ -117,6 +118,14 @@ func (d *daemonImpl) GetState() (map[string]repository.State, error) {
 	defer d.m.Unlock()
 
 	return d.installer.States()
+}
+
+// GetRemoteConfigState returns the remote config state.
+func (d *daemonImpl) GetRemoteConfigState() []*pbgo.PackageState {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	return d.rc.GetState()
 }
 
 // GetAPMInjectionStatus returns the APM injection status. This is not done in the service

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -126,7 +126,11 @@ func (c *testRemoteConfigClient) Subscribe(product string, fn func(update map[st
 	c.listeners[product] = append(c.listeners[product], client.Handler(fn))
 }
 
-func (c *testRemoteConfigClient) SetUpdaterPackagesState(_ []*pbgo.PackageState) {
+func (c *testRemoteConfigClient) SetInstallerState(_ []*pbgo.PackageState) {
+}
+
+func (c *testRemoteConfigClient) GetInstallerState() []*pbgo.PackageState {
+	return nil
 }
 
 func (c *testRemoteConfigClient) SubmitCatalog(catalog catalog) {
@@ -284,11 +288,8 @@ func TestRemoteRequest(t *testing.T) {
 	defer i.Stop()
 
 	testStablePackage := Package{
-		Name:     "test-package",
-		Version:  "0.0.1",
-		URL:      "oci://example.com/test-package@sha256:2fa082d512a120a814e32ddb80454efce56595b5c84a37cc1a9f90cf9cc7ba85",
-		Platform: runtime.GOOS,
-		Arch:     runtime.GOARCH,
+		Name:    "test-package",
+		Version: "0.0.1",
 	}
 	testExperimentPackage := Package{
 		Name:     "test-package",

--- a/pkg/fleet/daemon/local_api.go
+++ b/pkg/fleet/daemon/local_api.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
@@ -31,6 +32,7 @@ type StatusResponse struct {
 	Version            string                      `json:"version"`
 	Packages           map[string]repository.State `json:"packages"`
 	ApmInjectionStatus APMInjectionStatus          `json:"apm_injection_status"`
+	RemoteConfigState  []*pbgo.PackageState        `json:"remote_config_state"`
 }
 
 // APMInjectionStatus contains the instrumentation status of the APM injection.
@@ -134,6 +136,7 @@ func (l *localAPIImpl) status(w http.ResponseWriter, _ *http.Request) {
 		Version:            version.AgentVersion,
 		Packages:           packages,
 		ApmInjectionStatus: apmStatus,
+		RemoteConfigState:  l.daemon.GetRemoteConfigState(),
 	}
 }
 

--- a/pkg/fleet/daemon/local_api_test.go
+++ b/pkg/fleet/daemon/local_api_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -65,6 +66,11 @@ func (m *testDaemon) GetState() (map[string]repository.State, error) {
 	return args.Get(0).(map[string]repository.State), args.Error(1)
 }
 
+func (m *testDaemon) GetRemoteConfigState() []*pbgo.PackageState {
+	args := m.Called()
+	return args.Get(0).([]*pbgo.PackageState)
+}
+
 func (m *testDaemon) GetAPMInjectionStatus() (APMInjectionStatus, error) {
 	args := m.Called()
 	return args.Get(0).(APMInjectionStatus), args.Error(1)
@@ -112,6 +118,7 @@ func TestAPIStatus(t *testing.T) {
 		},
 	}
 	api.i.On("GetState").Return(installerState, nil)
+	api.i.On("GetRemoteConfigState").Return([]*pbgo.PackageState(nil))
 	api.i.On("GetAPMInjectionStatus").Return(APMInjectionStatus{}, nil)
 
 	resp, err := api.c.Status()

--- a/pkg/fleet/daemon/remote_config.go
+++ b/pkg/fleet/daemon/remote_config.go
@@ -24,7 +24,8 @@ type remoteConfigClient interface {
 	Start()
 	Close()
 	Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
-	SetUpdaterPackagesState(packages []*pbgo.PackageState)
+	GetInstallerState() []*pbgo.PackageState
+	SetInstallerState(packages []*pbgo.PackageState)
 }
 
 type remoteConfig struct {
@@ -63,9 +64,14 @@ func (rc *remoteConfig) Close() {
 	rc.client.Close()
 }
 
-// SetState sets the state of the given package.
+// GetState gets the state of the remote config client.
+func (rc *remoteConfig) GetState() []*pbgo.PackageState {
+	return rc.client.GetInstallerState()
+}
+
+// SetState sets the state of the remote config client.
 func (rc *remoteConfig) SetState(packages []*pbgo.PackageState) {
-	rc.client.SetUpdaterPackagesState(packages)
+	rc.client.SetInstallerState(packages)
 }
 
 // Package represents a downloadable package.


### PR DESCRIPTION
This PR pulls the RC client state into the status exposed by the daemon to help with debugging and to write e2e tests.