### PR TITLE
[CWS] Allow syscall tester to be built with gcc

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -253,10 +253,6 @@ def ninja_c_syscall_tester_common(nw, file_name, build_dir, flags=None, libs=Non
     if static:
         flags.append("-static")
 
-    additional_flags = [f"-isystem/usr/include/{uname_m}-linux-gnu"]
-    if compiler == "clang":
-        additional_flags.append(f"-D__{uname_m}__")
-
     nw.build(
         inputs=[syscall_tester_c_file],
         outputs=[syscall_tester_exe_file],
@@ -264,7 +260,7 @@ def ninja_c_syscall_tester_common(nw, file_name, build_dir, flags=None, libs=Non
         variables={
             "exeflags": flags,
             "exelibs": libs,
-            "flags": additional_flags,
+            "flags": [f"-isystem/usr/include/{uname_m}-linux-gnu"],
         },
     )
     return syscall_tester_exe_file

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -256,7 +256,7 @@ def ninja_c_syscall_tester_common(nw, file_name, build_dir, flags=None, libs=Non
     nw.build(
         inputs=[syscall_tester_c_file],
         outputs=[syscall_tester_exe_file],
-        rule="exe"+compiler,
+        rule="exe" + compiler,
         variables={
             "exeflags": flags,
             "exelibs": libs,
@@ -308,11 +308,15 @@ def build_embed_latency_tools(ctx, static=True):
 
 
 def ninja_syscall_x86_tester(ctx, build_dir, static=True, compiler='clang'):
-    return ninja_c_syscall_tester_common(ctx, "syscall_x86_tester", build_dir, flags=["-m32"], static=static, compiler=compiler)
+    return ninja_c_syscall_tester_common(
+        ctx, "syscall_x86_tester", build_dir, flags=["-m32"], static=static, compiler=compiler
+    )
 
 
 def ninja_syscall_tester(ctx, build_dir, static=True, compiler='clang'):
-    return ninja_c_syscall_tester_common(ctx, "syscall_tester", build_dir, libs=["-lpthread"], static=static, compiler=compiler)
+    return ninja_c_syscall_tester_common(
+        ctx, "syscall_tester", build_dir, libs=["-lpthread"], static=static, compiler=compiler
+    )
 
 
 def create_dir_if_needed(dir):

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -141,10 +141,10 @@ def ninja_define_co_re_compiler(nw: NinjaWriter, arch: Arch | None = None):
     )
 
 
-def ninja_define_exe_compiler(nw: NinjaWriter):
+def ninja_define_exe_compiler(nw: NinjaWriter, compiler='clang'):
     nw.rule(
-        name="execlang",
-        command="clang -MD -MF $out.d $exeflags $flags $in -o $out $exelibs",
+        name="exe"+compiler,
+        command=f"{compiler} -MD -MF $out.d $exeflags $flags $in -o $out $exelibs",
         depfile="$out.d",
     )
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -143,7 +143,7 @@ def ninja_define_co_re_compiler(nw: NinjaWriter, arch: Arch | None = None):
 
 def ninja_define_exe_compiler(nw: NinjaWriter, compiler='clang'):
     nw.rule(
-        name="exe"+compiler,
+        name="exe" + compiler,
         command=f"{compiler} -MD -MF $out.d $exeflags $flags $in -o $out $exelibs",
         depfile="$out.d",
     )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Allow using gcc to build CWS embedded syscall tester.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
