### PR TITLE
Fix issue causing missing kubelet.volume.* metrics

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider.go
@@ -165,7 +165,7 @@ func (p *Provider) appendPodTagsToVolumeMetrics(metricFam *prom.MetricFamily, se
 		pvcName := metric.Metric["persistentvolumeclaim"]
 		namespace := metric.Metric["namespace"]
 		if pvcName == "" || namespace == "" || p.filter.IsExcluded(nil, "", "", string(namespace)) {
-			return
+			continue
 		}
 		tags := p.MetricTags(metric)
 		if podTags := p.podUtils.GetPodTagsByPVC(string(namespace), string(pvcName)); len(podTags) > 0 {

--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
@@ -285,6 +285,16 @@ func (suite *ProviderTestSuite) TestPVCMetricsExcludedByNamespace() {
 		suite.T().Fatalf("unexpected error returned by call to provider.Provide: %v", err)
 	}
 
+	// namespace not filtered still shows up
+	podWithPVCNotFilteredTags := append(commontesting.InstanceTags, "persistentvolumeclaim:ddagent-pvc-ddagent-test-2", "namespace:unit-test")
+
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.capacity_bytes", podWithPVCNotFilteredTags)
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.used_bytes", podWithPVCNotFilteredTags)
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.available_bytes", podWithPVCNotFilteredTags)
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.inodes", podWithPVCNotFilteredTags)
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.inodes_used", podWithPVCNotFilteredTags)
+	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"kubelet.volume.stats.inodes_free", podWithPVCNotFilteredTags)
+
 	// pvc tags show up
 	podWithPVCTags := append(commontesting.InstanceTags, "persistentvolumeclaim:www-web-2", "namespace:default", "kube_namespace:default", "kube_service:nginx", "kube_stateful_set:web", "namespace:default")
 

--- a/pkg/collector/corechecks/containers/kubelet/testdata/kubelet_metrics.txt
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/kubelet_metrics.txt
@@ -445,11 +445,11 @@ kubelet_volume_stats_inodes_used{namespace="default",persistentvolumeclaim="www2
 kubelet_volume_stats_inodes_used{namespace="default",persistentvolumeclaim="web-2-ephemeralvolume"} 17955
 # HELP kubelet_volume_stats_used_bytes Number of used bytes in the volume
 # TYPE kubelet_volume_stats_used_bytes gauge
-kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 2.319220736e+09
-kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.53286656e+09
 kubelet_volume_stats_used_bytes{namespace="default",persistentvolumeclaim="www-web-2"} 2.319220736e+09
 kubelet_volume_stats_used_bytes{namespace="default",persistentvolumeclaim="www2-web-3"} 1.53286656e+09
 kubelet_volume_stats_used_bytes{namespace="default",persistentvolumeclaim="web-2-ephemeralvolume"} 1.53286656e+09
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 2.319220736e+09
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.53286656e+09
 # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
 # TYPE kubernetes_build_info gauge
 kubernetes_build_info{buildDate="2018-03-26T16:44:10Z",compiler="gc",gitCommit="fc32d2f3698e36b93322a3465f63a14e9f0eaead",gitTreeState="clean",gitVersion="v1.10.0",goVersion="go1.9.3",major="1",minor="10",platform="linux/amd64"} 1

--- a/releasenotes/notes/kubelet-core-volume-metrics-fix-a95e22dbc29dea88.yaml
+++ b/releasenotes/notes/kubelet-core-volume-metrics-fix-a95e22dbc29dea88.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes issue with the kubelet corecheck where `kubernetes.kubelet.volume.*` metrics
+    were not properly being reported if any matching namespace exclusion filter was present.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where some `kubernetes.kubelet.volume.*` metrics would not be reported if a namespace filter was present that matched any namespace present.

### Motivation

Bug fix for issue reported by customer, see linked ticket

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The bug was reproducible via unit tests, so the fix has been validated against the changes to the unit test.
