### PR TITLE
Mark windows security agent test as flaky and log output

### DIFF
--- a/test/new-e2e/tests/security-agent-functional/security_agent_test.go
+++ b/test/new-e2e/tests/security-agent-functional/security_agent_test.go
@@ -12,15 +12,17 @@ import (
 	"testing"
 	"time"
 
+	componentsos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	componentsos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/require"
 )
 
 type vmSuite struct {
@@ -34,6 +36,7 @@ var (
 )
 
 func TestVMSuite(t *testing.T) {
+	flake.Mark(t)
 	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())

--- a/test/new-e2e/tests/windows/remoteexecutable.go
+++ b/test/new-e2e/tests/windows/remoteexecutable.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 )
 
 // RemoteExecutable is a helper struct to run tests on a remote host
@@ -138,15 +140,18 @@ func executeAndLogOutput(t *testing.T, vm *components.RemoteHost, command string
 	outfilename := command + ".out"
 	fullcommand := "cd " + cmdDir + ";"
 	fullcommand += command + " " + strings.Join(args, " ") + " | Out-File -Encoding ASCII -FilePath " + outfilename
-	_, err := vm.Execute(fullcommand)
-	require.NoError(t, err)
+	_, testErr := vm.Execute(fullcommand)
 
 	// get the output
 	outbytes, err := vm.ReadFile(outfilename)
-	require.NoError(t, err)
 
 	// log the output
-	for _, line := range strings.Split(string(outbytes[:]), "\n") {
-		t.Logf("TestSuite: %s", line)
+	if assert.NoError(t, err) {
+		for _, line := range strings.Split(string(outbytes[:]), "\n") {
+			t.Logf("TestSuite: %s", line)
+		}
 	}
+
+	require.NoError(t, testErr)
+
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Mark recently introduced windows security agent e2e tests as flaky and improve logging to help investigation

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
