### PR TITLE
[SMP] Collect telemetry from checks during SMP runs

### DIFF
--- a/test/regression/cases/basic_py_check/datadog-agent/datadog.yaml
+++ b/test/regression/cases/basic_py_check/datadog-agent/datadog.yaml
@@ -6,6 +6,7 @@ auth_token_file_path: /tmp/agent-auth-token
 cloud_provider_metadata: []
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 dd_url: http://localhost:9091
 process_config.process_dd_url: http://localhost:9092

--- a/test/regression/cases/file_tree/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_tree/datadog-agent/datadog.yaml
@@ -9,4 +9,5 @@ logs_enabled: true
 
 dd_url: http://127.0.0.1:9092
 telemetry.enabled: true
+telemetry.checks: '*'
 process_collection.enabled: false

--- a/test/regression/cases/idle/datadog-agent/datadog.yaml
+++ b/test/regression/cases/idle/datadog-agent/datadog.yaml
@@ -9,3 +9,4 @@ process_config.process_dd_url: http://localhost:9092
 cloud_provider_metadata: []
 
 telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/otel_to_otel_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/otel_to_otel_logs/datadog-agent/datadog.yaml
@@ -9,6 +9,7 @@ dd_url: http://127.0.0.1:9092
 process_config.process_dd_url: http://localhost:9093
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 apm_config:
   enabled: true

--- a/test/regression/cases/pycheck_lots_of_tags/datadog-agent/datadog.yaml
+++ b/test/regression/cases/pycheck_lots_of_tags/datadog-agent/datadog.yaml
@@ -6,6 +6,7 @@ auth_token_file_path: /tmp/agent-auth-token
 cloud_provider_metadata: []
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 memtrack_enabled: false
 

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/datadog-agent/datadog.yaml
@@ -4,6 +4,7 @@ dd_url: http://localhost:9092
 process_config.process_dd_url: http://localhost:9093
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target

--- a/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
@@ -4,6 +4,7 @@ dd_url: http://localhost:9091
 process_config.process_dd_url: http://localhost:9093
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target

--- a/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
@@ -5,6 +5,7 @@ dd_url: http://127.0.0.1:9091
 process_config.process_dd_url: http://localhost:9092
 
 telemetry.enabled: true
+telemetry.checks: '*'
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/datadog-agent/datadog.yaml
@@ -3,6 +3,9 @@ auth_token_file_path: /tmp/agent-auth-token
 dd_url: http://127.0.0.1:9091
 process_config.process_dd_url: http://localhost:9092
 
+telemetry.enabled: true
+telemetry.checks: '*'
+
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target
 # has network access.


### PR DESCRIPTION
### What does this PR do?

Configure the agent to send check telemetry during SMP runs.

### Motivation

This improves visibility into the agent in SMP runs. This is particularly useful now that default checks run in the SMP environment.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
