### PR TITLE
service discovery: Add check yaml by default

### DIFF
--- a/cmd/agent/dist/conf.d/service_discovery.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/service_discovery.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+  - {}

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,6 +52,9 @@ build do
             # load isn't supported by windows
             delete "#{conf_dir}/load.d"
 
+            # service_discovery isn't supported by windows
+            delete "#{conf_dir}/service_discovery.d"
+
             # Remove .pyc files from embedded Python
             command "del /q /s #{windows_safe_path(install_dir)}\\*.pyc"
         end

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -76,6 +76,7 @@ AGENT_CORECHECKS = [
     "orchestrator_ecs",
     "cisco_sdwan",
     "network_path",
+    "service_discovery",
 ]
 
 WINDOWS_CORECHECKS = [

--- a/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck/configcheck_nix_test.go
@@ -25,7 +25,7 @@ func TestLinuxConfigCheckSuite(t *testing.T) {
 	e2e.Run(t, &linuxConfigCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
 }
 
-// cpu, disk, file_handle, io, load, memory, network, ntp, uptime
+// cpu, disk, file_handle, io, load, memory, network, ntp, uptime, service_discovery
 func (v *linuxConfigCheckSuite) TestDefaultInstalledChecks() {
 	testChecks := []CheckConfigOutput{
 		{
@@ -80,6 +80,12 @@ func (v *linuxConfigCheckSuite) TestDefaultInstalledChecks() {
 			CheckName:  "uptime",
 			Filepath:   "file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default",
 			InstanceID: "uptime:",
+			Settings:   "{}",
+		},
+		{
+			CheckName:  "service_discovery",
+			Filepath:   "file:/etc/datadog-agent/conf.d/service_discovery.d/conf.yaml.default",
+			InstanceID: "service_discovery:",
 			Settings:   "{}",
 		},
 	}


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adding by default the service discovery check yaml file. Partially reverting PR #27228.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The service discovery is controlled by a configuration flag, hence, there is no breaking change here, but simplification for the customers

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
