### PR TITLE
discovery: Improve gunicorn name

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/python.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/python.go
@@ -125,6 +125,9 @@ func (g gunicornDetector) detect(args []string) (ServiceMetadata, bool) {
 	}
 
 	if name, ok := extractGunicornNameFrom(args); ok {
+		// gunicorn replaces the cmdline with something like "gunicorn: master
+		// [package]", so strip out the square brackets.
+		name = strings.Trim(name, "[]")
 		return NewServiceMetadata(name), true
 	}
 	return NewServiceMetadata("gunicorn"), true

--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -16,8 +16,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 )
 
 const (
@@ -535,6 +536,24 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			envs:               map[string]string{"WSGI_APP": "test:app"},
 			expectedServiceTag: "test",
+		},
+		{
+			name: "gunicorn with replaced cmdline with colon",
+			cmdline: []string{
+				"gunicorn:",
+				"master",
+				"[domains.foo.apps.bar:create_server()]",
+			},
+			expectedServiceTag: "domains.foo.apps.bar",
+		},
+		{
+			name: "gunicorn with replaced cmdline",
+			cmdline: []string{
+				"gunicorn:",
+				"master",
+				"[mcservice]",
+			},
+			expectedServiceTag: "mcservice",
 		},
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Currently, gunicorn results in service names like "[foo]" or even "[domains.foo.apps.bar" (only opening square bracket).  Trim the square brackets.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1213

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
