### PR TITLE
[AutoInstrumentation] Update default version for .NET in auto-instrumentation to v3

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -640,7 +640,7 @@ func TestExtractLibInfo(t *testing.T) {
 		},
 		{
 			lang:  "dotnet",
-			image: "registry/dd-lib-dotnet-init:v2",
+			image: "registry/dd-lib-dotnet-init:v3",
 		},
 		{
 			lang:  "ruby",
@@ -1358,7 +1358,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 		"java":   "v1",
 		"python": "v2",
 		"ruby":   "v2",
-		"dotnet": "v2",
+		"dotnet": "v3",
 		"js":     "v5",
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -113,7 +113,7 @@ func (l language) isSupported() bool {
 // If this language does not appear in supportedLanguages, it will not be injected.
 var languageVersions = map[language]string{
 	java:   "v1", // https://datadoghq.atlassian.net/browse/APMON-1064
-	dotnet: "v2", // https://datadoghq.atlassian.net/browse/APMON-1067
+	dotnet: "v3", // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: "v2", // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065

--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -40,7 +40,7 @@ var apmPackageDefaultVersions = map[string]string{
 	"datadog-apm-library-java":   "1",
 	"datadog-apm-library-ruby":   "2",
 	"datadog-apm-library-js":     "5",
-	"datadog-apm-library-dotnet": "2",
+	"datadog-apm-library-dotnet": "3",
 	"datadog-apm-library-python": "2",
 	"datadog-apm-library-php":    "1",
 }

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -34,7 +34,7 @@ func TestDefaultPackagesAPMInjectEnabled(t *testing.T) {
 		"oci://gcr.io/datadoghq/apm-library-java-package:1",
 		"oci://gcr.io/datadoghq/apm-library-ruby-package:2",
 		"oci://gcr.io/datadoghq/apm-library-js-package:5",
-		"oci://gcr.io/datadoghq/apm-library-dotnet-package:2",
+		"oci://gcr.io/datadoghq/apm-library-dotnet-package:3",
 		"oci://gcr.io/datadoghq/apm-library-python-package:2",
 	}, packages)
 }

--- a/releasenotes/notes/dotnet-lib-inject-v3-d5fb50cd7eccb116.yaml
+++ b/releasenotes/notes/dotnet-lib-inject-v3-d5fb50cd7eccb116.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Updates default .NET library used for auto-instrumentation from v2 to v3


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Updates the default version of the .NET library (when not explicitly specified) to use v3 instead of v2

### Motivation

https://datadoghq.atlassian.net/browse/APMON-1390

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

If customers are explicitly using `latest`, they will get auto-upgraded across major versions. We are comfortable with this in the SSI scenario as the impact should be very low

### Describe how to test/QA your changes

When .NET is injected via SSI, it use the v3 library by default instead 