### PR TITLE
replace KubeMetadataEntityID with string

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util.go
@@ -8,15 +8,13 @@ package util
 import (
 	"fmt"
 	"strings"
-
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 // GenerateKubeMetadataEntityID generates and returns a unique entity id for KubernetesMetadata entity
 // for namespaced objects, the id will have the format {group}/{resourceType}/{namespace}/{name} (e.g. app/deployments/default/app )
 // for cluster scoped objects, the id will have the format {group}/{resourceType}//{name} (e.g. /nodes//master-node)
-func GenerateKubeMetadataEntityID(group, resource, namespace, name string) workloadmeta.KubeMetadataEntityID {
-	return workloadmeta.KubeMetadataEntityID(fmt.Sprintf("%s/%s/%s/%s", group, resource, namespace, name))
+func GenerateKubeMetadataEntityID(group, resource, namespace, name string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", group, resource, namespace, name)
 }
 
 // ParseKubeMetadataEntityID parses a metadata entity ID and returns the resource type, namespace and resource name.
@@ -26,7 +24,7 @@ func GenerateKubeMetadataEntityID(group, resource, namespace, name string) workl
 // - app/deployments/default/app
 // - /namespaces//default
 // If the parsed id is malformatted, this function will return empty strings and a non nil error
-func ParseKubeMetadataEntityID(id workloadmeta.KubeMetadataEntityID) (group, resource, namespace, name string, err error) {
+func ParseKubeMetadataEntityID(id string) (group, resource, namespace, name string, err error) {
 	parts := strings.Split(string(id), "/")
 	if len(parts) != 4 {
 		err := fmt.Errorf("malformatted metadata entity id: %s", id)

--- a/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/kube_metadata_util_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 func TestGenerateKubeMetadataEntityID(t *testing.T) {
@@ -22,7 +20,7 @@ func TestGenerateKubeMetadataEntityID(t *testing.T) {
 		namespace    string
 		resourceType string
 		resourceName string
-		expectedID   workloadmeta.KubeMetadataEntityID
+		expectedID   string
 	}{
 		{
 			name:         "namespace scoped resource",
@@ -53,7 +51,7 @@ func TestGenerateKubeMetadataEntityID(t *testing.T) {
 func TestParseKubeMetadataEntityID(t *testing.T) {
 	tests := []struct {
 		name              string
-		entityID          workloadmeta.KubeMetadataEntityID
+		entityID          string
 		expectedGroup     string
 		expectedName      string
 		expectedNamespace string

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -66,7 +66,7 @@ type Component interface {
 
 	// GetKubernetesMetadata returns metadata about a Kubernetes resource. It fetches
 	// the entity with kind KubernetesMetadata and the given ID.
-	GetKubernetesMetadata(id KubeMetadataEntityID) (*KubernetesMetadata, error)
+	GetKubernetesMetadata(id string) (*KubernetesMetadata, error)
 
 	// ListKubernetesMetadata returns all the kubernetes metadata objects for
 	// which the passed filter evaluates to true.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -785,9 +785,6 @@ func (o KubernetesPodOwner) String(verbose bool) string {
 	return sb.String()
 }
 
-// KubeMetadataEntityID is a unique ID for Kube Metadata Entity
-type KubeMetadataEntityID string
-
 // KubernetesMetadata is an Entity representing kubernetes resource metadata
 type KubernetesMetadata struct {
 	EntityID

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -376,7 +376,7 @@ func (w *workloadmeta) GetImage(id string) (*wmdef.ContainerImageMetadata, error
 }
 
 // GetKubernetesMetadata implements Store#GetKubernetesMetadata.
-func (w *workloadmeta) GetKubernetesMetadata(id wmdef.KubeMetadataEntityID) (*wmdef.KubernetesMetadata, error) {
+func (w *workloadmeta) GetKubernetesMetadata(id string) (*wmdef.KubernetesMetadata, error) {
 	entity, err := w.getEntityByKind(wmdef.KindKubernetesMetadata, string(id))
 	if err != nil {
 		return nil, err

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics.go
@@ -61,11 +61,11 @@ func entityIDsFromAttributes(attrs pcommon.Map) []types.EntityID {
 		}
 	}
 	if namespace, ok := attrs.Get(conventions.AttributeK8SNamespaceName); ok {
-		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesMetadata, string(util.GenerateKubeMetadataEntityID("", "namespaces", "", namespace.AsString()))))
+		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesMetadata, util.GenerateKubeMetadataEntityID("", "namespaces", "", namespace.AsString())))
 	}
 
 	if nodeName, ok := attrs.Get(conventions.AttributeK8SNodeName); ok {
-		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesMetadata, string(util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName.AsString()))))
+		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesMetadata, util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName.AsString())))
 	}
 	if podUID, ok := attrs.Get(conventions.AttributeK8SPodUID); ok {
 		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesPodUID, podUID.AsString()))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
removes the KubeMetadataEntityID alias inside workloadmeta which was simply another name for string

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Converting an OTel Agent package to a module would no longer rely on workloadmeta/def; this dependency would make it much easier to build the OTel agent for customer collector workflow. Additionally, this alias has no additional functionality besides just giving another name, so it is only making the codebase more difficult to understand without giving benefits.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We would not need to create/convert more packages (specifically workloadmeta) to go modules and support them down the road.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
If additional functionality/differentiation from go string type for KubeMetadataEntityID is planned down the road, the type would have to be re-introduced.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
run integration/unit tests