### PR TITLE
add startstop test with FIM disabled

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -158,6 +158,20 @@ new-e2e-windows-service-test:
     TEAM: windows-agent
     EXTRA_PARAMS: --run TestServiceBehavior
 
+# Temporary job for hunting a crash
+new-e2e-windows-service-test-nofim:
+  extends: .new_e2e_template
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - deploy_windows_testing-a7
+  rules:
+    - !reference [.on_windows_service_or_e2e_changes]
+    - !reference [.manual]
+  variables:
+    TARGETS: ./tests/windows/service-test
+    TEAM: windows-agent
+    EXTRA_PARAMS: --run TestNoFIMServiceBehavior
+
 new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64
   rules:

--- a/test/new-e2e/tests/windows/service-test/fixtures/system-probe-nofim.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/system-probe-nofim.yaml
@@ -1,0 +1,8 @@
+# enable NPM
+network_config:
+  enabled: true
+
+# enable security agent
+runtime_security_config:
+  enabled: true
+  fim_enabled: false

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -54,7 +54,6 @@ func TestNoFIMServiceBehaviorPowerShell(t *testing.T) {
 	run(t, s, systemProbeNoFIMConfig)
 }
 
-
 // TestServiceBehaviorAgentCommand tests the service behavior when controlled by Agent commands
 func TestServiceBehaviorAgentCommand(t *testing.T) {
 	s := &agentServiceCommandSuite{}

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -36,13 +36,29 @@ var agentConfig string
 //go:embed fixtures/system-probe.yaml
 var systemProbeConfig string
 
+//go:embed fixtures/system-probe-nofim.yaml
+var systemProbeNoFIMConfig string
+
 //go:embed fixtures/security-agent.yaml
 var securityAgentConfig string
+
+// TestServiceBehaviorAgentCommandNoFIM tests the service behavior when controlled by Agent commands
+func TestNoFIMServiceBehaviorAgentCommand(t *testing.T) {
+	s := &agentServiceCommandSuite{}
+	run(t, s, systemProbeNoFIMConfig)
+}
+
+// TestServiceBehaviorPowerShellNoFIM tests the service behavior when controlled by PowerShell commands
+func TestNoFIMServiceBehaviorPowerShell(t *testing.T) {
+	s := &powerShellServiceCommandSuite{}
+	run(t, s, systemProbeNoFIMConfig)
+}
+
 
 // TestServiceBehaviorAgentCommand tests the service behavior when controlled by Agent commands
 func TestServiceBehaviorAgentCommand(t *testing.T) {
 	s := &agentServiceCommandSuite{}
-	run(t, s)
+	run(t, s, systemProbeConfig)
 }
 
 type agentServiceCommandSuite struct {
@@ -78,7 +94,7 @@ func (s *agentServiceCommandSuite) SetupSuite() {
 // TestServiceBehaviorAgentCommand tests the service behavior when controlled by PowerShell commands
 func TestServiceBehaviorPowerShell(t *testing.T) {
 	s := &powerShellServiceCommandSuite{}
-	run(t, s)
+	run(t, s, systemProbeConfig)
 }
 
 type powerShellServiceCommandSuite struct {
@@ -204,7 +220,7 @@ func (s *powerShellServiceCommandSuite) TestHardExitEventLogEntry() {
 	}, 1*time.Minute, 1*time.Second, "should have hard exit messages in the event log")
 }
 
-func run[Env any](t *testing.T, s e2e.Suite[Env]) {
+func run[Env any](t *testing.T, s e2e.Suite[Env], systemProbeConfig string) {
 	opts := []e2e.SuiteOption{e2e.WithProvisioner(awsHostWindows.ProvisionerNoFakeIntake(
 		awsHostWindows.WithAgentOptions(
 			agentparams.WithAgentConfig(agentConfig),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a duplicate of the `startstop` service test but with FIM disabled, to assist in hunting a rare crash in system-probe.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-904
When the rare crash triggers we aren't getting a crash dump. Local testing indicates that disabling FIM may increase our chances of getting a crash dump.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Can be reverted when done hunting the crash.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
If the crash is FIM related this won't help :/

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
NA. test change