### PR TITLE
[CWS] fix small possible nil-ptr deref regarding profiled containers telemetry

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -190,7 +190,7 @@ func (rsa *RuntimeSecurityAgent) DispatchActivityDump(msg *api.ActivityDumpStrea
 		log.Errorf("%v", err)
 		return
 	}
-	if rsa.telemetry != nil {
+	if rsa.profContainersTelemetry != nil {
 		// register for telemetry for this container
 		imageName, imageTag := dump.GetImageNameTag()
 		rsa.profContainersTelemetry.registerProfiledContainer(imageName, imageTag)


### PR DESCRIPTION
### What does this PR do?

Since the containers running telemetry was extracted the struct pointer check is not checking the correct structure. This PR fixes this small issue (since both telemetry are enabled together there is no real risk here anyway).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
