### PR TITLE
[CWS] move `containers_running` telemetry to the system-probe

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -48,7 +48,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	}
 
 	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, secmoduleOpts)
+		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, deps.WMeta, secmoduleOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -37,7 +37,6 @@ type RuntimeSecurityAgent struct {
 	connected               *atomic.Bool
 	eventReceived           *atomic.Uint64
 	activityDumpReceived    *atomic.Uint64
-	telemetry               *telemetry
 	profContainersTelemetry *profContainersTelemetry
 	endpoints               *config.Endpoints
 	cancel                  context.CancelFunc
@@ -67,11 +66,6 @@ func (rsa *RuntimeSecurityAgent) Start(reporter common.RawReporter, endpoints *c
 		// Start activity dumps listener
 		go rsa.StartActivityDumpListener()
 		go rsa.startActivityDumpStorageTelemetry(ctx)
-	}
-
-	if rsa.telemetry != nil {
-		// Send Runtime Security Agent telemetry
-		go rsa.telemetry.run(ctx)
 	}
 
 	if rsa.profContainersTelemetry != nil {

--- a/pkg/security/agent/agent_nix.go
+++ b/pkg/security/agent/agent_nix.go
@@ -24,12 +24,6 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 		return nil, err
 	}
 
-	// on windows do no telemetry
-	telemetry, err := newTelemetry(statsdClient, wmeta)
-	if err != nil {
-		return nil, errors.New("failed to initialize the telemetry reporter")
-	}
-
 	profContainersTelemetry, err := newProfContainersTelemetry(statsdClient, wmeta, opts.LogProfiledWorkloads)
 	if err != nil {
 		return nil, errors.New("failed to initialize the profiled containers telemetry reporter")
@@ -44,7 +38,6 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 	return &RuntimeSecurityAgent{
 		client:                  client,
 		hostname:                hostname,
-		telemetry:               telemetry,
 		profContainersTelemetry: profContainersTelemetry,
 		storage:                 storage,
 		running:                 atomic.NewBool(false),

--- a/pkg/security/agent/agent_windows.go
+++ b/pkg/security/agent/agent_windows.go
@@ -24,7 +24,6 @@ func NewRuntimeSecurityAgent(_ statsd.ClientInterface, hostname string, _ RSAOpt
 	return &RuntimeSecurityAgent{
 		client:               client,
 		hostname:             hostname,
-		telemetry:            nil,
 		storage:              nil,
 		running:              atomic.NewBool(false),
 		connected:            atomic.NewBool(false),

--- a/pkg/security/agent/status_provider_test.go
+++ b/pkg/security/agent/status_provider_test.go
@@ -18,7 +18,6 @@ func TestStatus(t *testing.T) {
 		agent: &RuntimeSecurityAgent{
 			client:               nil,
 			hostname:             "test",
-			telemetry:            nil,
 			storage:              nil,
 			running:              atomic.NewBool(false),
 			connected:            atomic.NewBool(false),

--- a/pkg/security/agent/telemetry_others.go
+++ b/pkg/security/agent/telemetry_others.go
@@ -10,10 +10,6 @@ package agent
 
 import "context"
 
-type telemetry struct{}
-
-func (t *telemetry) run(_ context.Context) {}
-
 type profContainersTelemetry struct{}
 
 func (t *profContainersTelemetry) registerProfiledContainer(_, _ string) {}

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -56,23 +56,19 @@ type CWSConsumer struct {
 
 // NewCWSConsumer initializes the module with options
 func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, opts Opts) (*CWSConsumer, error) {
+	crtelemetry, err := telemetry.NewContainersRunningTelemetry(cfg, evm.StatsdClient, wmeta)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancelFnc := context.WithCancel(context.Background())
 
-	var (
-		selfTester *selftests.SelfTester
-		err        error
-	)
-
+	var selfTester *selftests.SelfTester
 	if cfg.SelfTestEnabled {
 		selfTester, err = selftests.NewSelfTester(cfg, evm.Probe)
 		if err != nil {
 			seclog.Errorf("unable to instantiate self tests: %s", err)
 		}
-	}
-
-	crtelemetry, err := telemetry.NewContainersRunningTelemetry(cfg, evm.StatsdClient, wmeta)
-	if err != nil {
-		return nil, err
 	}
 
 	family, address := config.GetFamilyAddress(cfg.SocketPath)

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -54,7 +55,7 @@ type CWSConsumer struct {
 }
 
 // NewCWSConsumer initializes the module with options
-func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, opts Opts) (*CWSConsumer, error) {
+func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, opts Opts) (*CWSConsumer, error) {
 	ctx, cancelFnc := context.WithCancel(context.Background())
 
 	var (
@@ -69,7 +70,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		}
 	}
 
-	crtelemetry, err := telemetry.NewContainersRunningTelemetry(cfg, evm.StatsdClient, nil, true)
+	crtelemetry, err := telemetry.NewContainersRunningTelemetry(cfg, evm.StatsdClient, wmeta)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/module/opts.go
+++ b/pkg/security/module/opts.go
@@ -6,7 +6,9 @@
 // Package module holds module related files
 package module
 
-import "github.com/DataDog/datadog-agent/pkg/security/events"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+)
 
 // Opts define module options
 type Opts struct {

--- a/pkg/security/telemetry/containers_running_telemetry_linux.go
+++ b/pkg/security/telemetry/containers_running_telemetry_linux.go
@@ -23,6 +23,7 @@ type ContainersRunningTelemetry struct {
 	containers *ContainersTelemetry
 }
 
+// NewContainersRunningTelemetry creates a new ContainersRunningTelemetry instance
 func NewContainersRunningTelemetry(cfg *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	telemetrySender := NewSimpleTelemetrySenderFromStatsd(statsdClient)
 	containersTelemetry, err := NewContainersTelemetry(telemetrySender, wmeta)
@@ -36,6 +37,7 @@ func NewContainersRunningTelemetry(cfg *config.RuntimeSecurityConfig, statsdClie
 	}, nil
 }
 
+// Run starts the telemetry collection
 func (t *ContainersRunningTelemetry) Run(ctx context.Context) {
 	log.Info("started collecting Runtime Security Agent telemetry")
 	defer log.Info("stopping Runtime Security Agent telemetry")

--- a/pkg/security/telemetry/containers_running_telemetry_linux.go
+++ b/pkg/security/telemetry/containers_running_telemetry_linux.go
@@ -3,48 +3,40 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package agent holds agent related files
-package agent
+package telemetry
 
 import (
 	"context"
-	"errors"
 	"os"
 	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
-	sectelemetry "github.com/DataDog/datadog-agent/pkg/security/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
-// telemetry reports environment information (e.g containers running) when the runtime security component is running
-type telemetry struct {
-	containers            *sectelemetry.ContainersTelemetry
-	runtimeSecurityClient *RuntimeSecurityClient
+// ContainersRunningTelemetry reports environment information (e.g containers running) when the runtime security component is running
+type ContainersRunningTelemetry struct {
+	cfg        *config.RuntimeSecurityConfig
+	containers *ContainersTelemetry
 }
 
-func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*telemetry, error) {
-	runtimeSecurityClient, err := NewRuntimeSecurityClient()
+func NewContainersRunningTelemetry(cfg *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*ContainersRunningTelemetry, error) {
+	telemetrySender := NewSimpleTelemetrySenderFromStatsd(statsdClient)
+	containersTelemetry, err := NewContainersTelemetry(telemetrySender, wmeta)
 	if err != nil {
 		return nil, err
 	}
 
-	telemetrySender := sectelemetry.NewSimpleTelemetrySenderFromStatsd(statsdClient)
-	containersTelemetry, err := sectelemetry.NewContainersTelemetry(telemetrySender, wmeta)
-	if err != nil {
-		return nil, err
-	}
-
-	return &telemetry{
-		containers:            containersTelemetry,
-		runtimeSecurityClient: runtimeSecurityClient,
+	return &ContainersRunningTelemetry{
+		cfg:        cfg,
+		containers: containersTelemetry,
 	}, nil
 }
 
-func (t *telemetry) run(ctx context.Context) {
+func (t *ContainersRunningTelemetry) Run(ctx context.Context) {
 	log.Info("started collecting Runtime Security Agent telemetry")
 	defer log.Info("stopping Runtime Security Agent telemetry")
 
@@ -63,33 +55,19 @@ func (t *telemetry) run(ctx context.Context) {
 	}
 }
 
-func (t *telemetry) fetchConfig() (*api.SecurityConfigMessage, error) {
-	cfg, err := t.runtimeSecurityClient.GetConfig()
-	if err != nil {
-		return cfg, errors.New("couldn't fetch config from runtime security module")
-	}
-	return cfg, nil
-}
-
-func (t *telemetry) reportContainers() error {
-	// retrieve the runtime security module config
-	cfg, err := t.fetchConfig()
-	if err != nil {
-		return err
-	}
-
+func (t *ContainersRunningTelemetry) reportContainers() error {
 	var fargate bool
 	if os.Getenv("ECS_FARGATE") == "true" || os.Getenv("DD_ECS_FARGATE") == "true" || os.Getenv("DD_EKS_FARGATE") == "true" {
 		fargate = true
 	}
 
 	var metricName string
-	if cfg.RuntimeEnabled {
+	if t.cfg.RuntimeEnabled {
 		metricName = metrics.MetricSecurityAgentRuntimeContainersRunning
 		if fargate {
 			metricName = metrics.MetricSecurityAgentFargateRuntimeContainersRunning
 		}
-	} else if cfg.FIMEnabled {
+	} else if t.cfg.FIMEnabled {
 		metricName = metrics.MetricSecurityAgentFIMContainersRunning
 		if fargate {
 			metricName = metrics.MetricSecurityAgentFargateFIMContainersRunning

--- a/pkg/security/telemetry/containers_running_telemetry_others.go
+++ b/pkg/security/telemetry/containers_running_telemetry_others.go
@@ -15,10 +15,13 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
+// ContainersRunningTelemetry reports environment information (e.g containers running) when the runtime security component is running
 type ContainersRunningTelemetry struct{}
 
+// NewContainersRunningTelemetry creates a new ContainersRunningTelemetry instance (not supported on non-linux platforms)
 func NewContainersRunningTelemetry(_ *config.RuntimeSecurityConfig, _ statsd.ClientInterface, _ workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	return nil, nil
 }
 
+// Run starts the telemetry collection
 func (t *ContainersRunningTelemetry) Run(_ context.Context) {}

--- a/pkg/security/telemetry/containers_running_telemetry_others.go
+++ b/pkg/security/telemetry/containers_running_telemetry_others.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package telemetry
+
+import (
+	"context"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+type ContainersRunningTelemetry struct{}
+
+func NewContainersRunningTelemetry(_ *config.RuntimeSecurityConfig, _ statsd.ClientInterface, _ workloadmeta.Component, _ bool) (*ContainersRunningTelemetry, error) {
+	return nil, nil
+}
+
+func (t *ContainersRunningTelemetry) Run(_ context.Context) {}

--- a/pkg/security/telemetry/containers_running_telemetry_others.go
+++ b/pkg/security/telemetry/containers_running_telemetry_others.go
@@ -17,7 +17,7 @@ import (
 
 type ContainersRunningTelemetry struct{}
 
-func NewContainersRunningTelemetry(_ *config.RuntimeSecurityConfig, _ statsd.ClientInterface, _ workloadmeta.Component, _ bool) (*ContainersRunningTelemetry, error) {
+func NewContainersRunningTelemetry(_ *config.RuntimeSecurityConfig, _ statsd.ClientInterface, _ workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	return nil, nil
 }
 

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -809,7 +809,7 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 	if !opts.staticOpts.disableRuntimeSecurity {
 		msgSender := newFakeMsgSender(testMod)
 
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, module.Opts{EventSender: testMod, MsgSender: msgSender})
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, fxDeps.WMeta, module.Opts{EventSender: testMod, MsgSender: msgSender})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -276,7 +276,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, module.Opts{EventSender: testMod})
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, wmeta, module.Opts{EventSender: testMod})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -276,7 +276,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, wmeta, module.Opts{EventSender: testMod})
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, fxDeps.WMeta, module.Opts{EventSender: testMod})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR moves the `containers_running` telemetry to run in the system-probe as part of the CWSConsumer instead of in the security agent.

This is mostly moving things around, with the added benefice that we don't need to query the config from the system-probe anymore since we have direct access to it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Please ensure that this is working correctly on host based envs, container based envs, and double check fargate as well.
