### PR TITLE
[NETPATH-278] Use default port for Network Traffic UDP traces

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -118,8 +118,13 @@ func (s *npCollectorImpl) ScheduleConns(conns []*model.Connection) {
 	startTime := s.TimeNowFn()
 	for _, conn := range conns {
 		remoteAddr := conn.Raddr
-		remotePort := uint16(conn.Raddr.GetPort())
 		protocol := convertProtocol(conn.GetType())
+		var remotePort uint16
+		// UDP traces should not be done to the active
+		// port
+		if protocol != payload.ProtocolUDP {
+			remotePort = uint16(conn.Raddr.GetPort())
+		}
 		if !shouldScheduleNetworkPathForConn(conn) {
 			s.logger.Tracef("Skipped connection: addr=%s, port=%d, protocol=%s", remoteAddr, remotePort, protocol)
 			continue

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -372,7 +372,7 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 				},
 			},
 			expectedPathtests: []*common.Pathtest{
-				{Hostname: "10.0.0.6", Port: uint16(161), Protocol: payload.ProtocolUDP, SourceContainerID: "testId1"},
+				{Hostname: "10.0.0.6", Port: uint16(0), Protocol: payload.ProtocolUDP, SourceContainerID: "testId1"},
 			},
 		},
 		{

--- a/releasenotes/notes/networkpath-use-default-udp-port-4145a4b3700e98f4.yaml
+++ b/releasenotes/notes/networkpath-use-default-udp-port-4145a4b3700e98f4.yaml
@@ -8,6 +8,4 @@
 ---
 enhancements:
   - |
-    For Network Traffic based paths, the default UDP port
-    traceroute port 33434, rather than the port detected by NPM,
-    is now used.
+    The default UDP port for traceroute (port 33434) is now used for Network Traffic based paths, instead of the port detected by NPM.

--- a/releasenotes/notes/networkpath-use-default-udp-port-4145a4b3700e98f4.yaml
+++ b/releasenotes/notes/networkpath-use-default-udp-port-4145a4b3700e98f4.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    For Network Traffic based paths, the default UDP port
+    traceroute port 33434, rather than the port detected by NPM,
+    is now used.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Use the default UDP traceroute port for any UDP connections detected. Tracing to the UDP port traffic is actually being sent to is less likely to actually respond to traceroute.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
While it makes sense to trace to the same port being used for TCP traffic since that port is likely to reply to a SYN packet, UDP is different and we're less likely to receive a response to the trace with dynamic paths. As a result, it makes more sense to trace to the default UDP traceroute port `33434`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run the product with Network Traffic Paths enabled. You should see log statements in the `system-probe.log` which indicate that no port was sent in the request. With a port set to `0`, the default will be used.
```
2024-09-05 13:11:24 PDT | SYS-PROBE | INFO | (cmd/system-probe/modules/traceroute.go:105 in logTracerouteRequests) | Got request on /traceroute/meet.google.com?client_id=traceroute-agent-linux&port=0&maxTTL=30&timeout=1000000000&protocol=UDP (count: 1): retrieved traceroute in 4.076460312s
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
