### PR TITLE
Increases the idle rss limit to account for the default checks

### DIFF
--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -32,4 +32,4 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "424.0 MiB"
+      upper_bound: "465.0 MiB"


### PR DESCRIPTION

### What does this PR do?

Increases the memory limit for the `idle` experiment's RSS bound check

### Motivation

Runs now execute default checks, this takes that into account.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
