### PR TITLE
[CWS] remove "ignore DD agent containers" telemetry option

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -684,8 +684,7 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	// start/stop order is important, agent need to be stopped first and started after all the others
 	// components
 	agent, err := secagent.NewRuntimeSecurityAgent(statsdClient, hostname, secagent.RSAOptions{
-		LogProfiledWorkloads:    config.GetBool("runtime_security_config.log_profiled_workloads"),
-		IgnoreDDAgentContainers: config.GetBool("runtime_security_config.telemetry.ignore_dd_agent_containers"),
+		LogProfiledWorkloads: config.GetBool("runtime_security_config.log_profiled_workloads"),
 	}, wmeta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a runtime security agent instance: %w", err)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -905,7 +905,6 @@ func InitConfig(config pkgconfigmodel.Config) {
 		config.BindEnvAndSetDefault("runtime_security_config.socket", filepath.Join(InstallPath, "run/runtime-security.sock"))
 	}
 	config.BindEnvAndSetDefault("runtime_security_config.log_profiled_workloads", false)
-	config.BindEnvAndSetDefault("runtime_security_config.telemetry.ignore_dd_agent_containers", true)
 	config.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", true)
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -48,8 +48,7 @@ type RuntimeSecurityAgent struct {
 
 // RSAOptions represents the runtime security agent options
 type RSAOptions struct {
-	LogProfiledWorkloads    bool
-	IgnoreDDAgentContainers bool
+	LogProfiledWorkloads bool
 }
 
 // Start the runtime security agent

--- a/pkg/security/agent/agent_nix.go
+++ b/pkg/security/agent/agent_nix.go
@@ -25,7 +25,7 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 	}
 
 	// on windows do no telemetry
-	telemetry, err := newTelemetry(statsdClient, wmeta, opts.IgnoreDDAgentContainers)
+	telemetry, err := newTelemetry(statsdClient, wmeta)
 	if err != nil {
 		return nil, errors.New("failed to initialize the telemetry reporter")
 	}

--- a/pkg/security/agent/telemetry_linux.go
+++ b/pkg/security/agent/telemetry_linux.go
@@ -26,7 +26,7 @@ type telemetry struct {
 	runtimeSecurityClient *RuntimeSecurityClient
 }
 
-func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component, ignoreDDAgentContainers bool) (*telemetry, error) {
+func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*telemetry, error) {
 	runtimeSecurityClient, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err
@@ -37,7 +37,6 @@ func newTelemetry(statsdClient statsd.ClientInterface, wmeta workloadmeta.Compon
 	if err != nil {
 		return nil, err
 	}
-	containersTelemetry.IgnoreDDAgent = ignoreDDAgentContainers
 
 	return &telemetry{
 		containers:            containersTelemetry,

--- a/pkg/security/telemetry/telemetry.go
+++ b/pkg/security/telemetry/telemetry.go
@@ -18,7 +18,6 @@ import (
 type ContainersTelemetry struct {
 	TelemetrySender SimpleTelemetrySender
 	MetadataStore   workloadmeta.Component
-	IgnoreDDAgent   bool
 }
 
 // NewContainersTelemetry returns a new ContainersTelemetry based on default/global objects
@@ -40,13 +39,12 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 	containers := c.ListRunningContainers()
 
 	for _, container := range containers {
-		if c.IgnoreDDAgent {
-			value := container.EnvVars["DOCKER_DD_AGENT"]
-			value = strings.ToLower(value)
-			if value == "yes" || value == "true" {
-				log.Debugf("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
-				continue
-			}
+		// ignore DD agent containers
+		value := container.EnvVars["DOCKER_DD_AGENT"]
+		value = strings.ToLower(value)
+		if value == "yes" || value == "true" {
+			log.Debugf("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
+			continue
 		}
 
 		c.TelemetrySender.Gauge(metricName, 1.0, []string{"container_id:" + container.ID})


### PR DESCRIPTION
### What does this PR do?

This option has always been true, we have no plan to change that, and this is not documented/used anywhere.
With the migration of the `containers_running` telemetry from the security agent to the system probe this config would need to be migrated, since it's not used this PR removes it altogether.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
