### PR TITLE
use distinct MSI log files

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -6,7 +6,6 @@
 package installer
 
 import (
-	"fmt"
 	agentVersion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -113,7 +112,7 @@ func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 	outputDir, err := runner.GetTestOutputDir(runner.GetProfile(), s.T())
 	s.Require().NoError(err, "should get output dir")
 	s.T().Logf("Output dir: %s", outputDir)
-	s.installer = NewDatadogInstaller(s.Env(), fmt.Sprintf("%s/install.log", outputDir))
+	s.installer = NewDatadogInstaller(s.Env(), outputDir)
 }
 
 // Require instantiates a suiteAssertions for the current suite.

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_suite.go
@@ -24,7 +24,9 @@ func (s *baseInstallerSuite) freshInstall() {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.Installer().Install())
+	s.Require().NoError(s.Installer().Install(
+		installerwindows.WithMSILogFile("fresh-install.log"),
+	))
 
 	// Assert
 	s.requireInstalled()

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -67,7 +67,9 @@ func (s *testInstallerSuite) installWithExistingConfigFile() {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.Installer().Install())
+	s.Require().NoError(s.Installer().Install(
+		installerwindows.WithMSILogFile("with-config-install.log"),
+	))
 
 	// Assert
 	s.requireInstalled()
@@ -82,7 +84,9 @@ func (s *testInstallerSuite) repair() {
 	s.Require().NoError(s.Env().RemoteHost.Remove(installerwindows.BinaryPath))
 
 	// Act
-	s.Require().NoError(s.Installer().Install())
+	s.Require().NoError(s.Installer().Install(
+		installerwindows.WithMSILogFile("repair.log"),
+	))
 
 	// Assert
 	s.requireInstalled()

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
@@ -33,7 +33,10 @@ func (s *testInstallerRollbackSuite) installRollback() {
 	// Arrange
 
 	// Act
-	msiErr := s.Installer().Install(installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"))
+	msiErr := s.Installer().Install(
+		installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"),
+		installerwindows.WithMSILogFile("install-rollback.log"),
+	)
 	s.Require().Error(msiErr)
 
 	// Assert
@@ -45,7 +48,10 @@ func (s *testInstallerRollbackSuite) uninstallRollback() {
 	// Arrange
 
 	// Act
-	msiErr := s.Installer().Uninstall(installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"))
+	msiErr := s.Installer().Uninstall(
+		installerwindows.WithMSIArg("WIXFAILWHENDEFERRED=1"),
+		installerwindows.WithMSILogFile("uninstall-rollback.log"),
+	)
 	s.Require().Error(msiErr)
 
 	// Assert

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
@@ -27,7 +27,10 @@ func TestInstallerUpgrades(t *testing.T) {
 // TestUpgrades tests upgrading the stable version of the Datadog installer to the latest from the pipeline.
 func (s *testInstallerUpgradesSuite) TestUpgrades() {
 	// Arrange
-	s.Require().NoError(s.Installer().Install(installerwindows.WithInstallerURLFromInstallersJSON(pipeline.AgentS3BucketTesting, pipeline.StableChannel, s.StableInstallerVersion().PackageVersion())))
+	s.Require().NoError(s.Installer().Install(
+		installerwindows.WithInstallerURLFromInstallersJSON(pipeline.AgentS3BucketTesting, pipeline.StableChannel, s.StableInstallerVersion().PackageVersion())),
+		installerwindows.WithMSILogFile("install.log"),
+	)
 	// sanity check: make sure we did indeed install the stable version
 	s.Require().Host(s.Env().RemoteHost).
 		HasBinary(installerwindows.BinaryPath).
@@ -36,7 +39,9 @@ func (s *testInstallerUpgradesSuite) TestUpgrades() {
 
 	// Act
 	// Install "latest" from the pipeline
-	s.Require().NoError(s.Installer().Install())
+	s.Require().NoError(s.Installer().Install(
+		installerwindows.WithMSILogFile("upgrade.log"),
+	))
 
 	// Assert
 	s.Require().Host(s.Env().RemoteHost).


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add distinct log filenames to Fleet Installer MSI executions in E2E tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-982
Successive Install/Uninstall would overwrite previous log files

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
`Install` and `Uninstall` will throw an error if the log file already exists. We could generate a new unique filename instead, but this way encourages the dev to choose a descriptive name.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
N/A, test change