### PR TITLE
[CWS] Use a single TTL-based cache implementation

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1289,7 +1289,6 @@ core,github.com/hashicorp/go-sockaddr,MPL-2.0,"Copyright © 2014-2018 HashiCorp,
 core,github.com/hashicorp/go-version,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
-core,github.com/hashicorp/golang-lru/v2/expirable,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2/internal,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"

--- a/go.mod
+++ b/go.mod
@@ -602,7 +602,7 @@ require (
 	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/errdefs v0.1.0
 	github.com/distribution/reference v0.6.0
-	github.com/jellydator/ttlcache/v3 v3.0.1
+	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/kouhin/envflag v0.0.0-20150818174321-0e9a86061649
 	github.com/lorenzosaino/go-sysctl v0.3.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1741,8 +1741,8 @@ github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInw
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
-github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jlaffaye/ftp v0.0.0-20180404123514-2403248fa8cc/go.mod h1:lli8NYPQOFy3O++YmYbqVgOcQ1JPCwdOy+5zSjKJ9qY=

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/jellydator/ttlcache/v3"
 )
 
 var (
@@ -304,7 +304,7 @@ func NewMutableStringVariable() *MutableStringVariable {
 
 // MutableStringArrayVariable describes a mutable string array variable
 type MutableStringArrayVariable struct {
-	*expirable.LRU[string, bool]
+	LRU *ttlcache.Cache[string, bool]
 }
 
 // Set the variable with the specified value
@@ -314,7 +314,7 @@ func (m *MutableStringArrayVariable) Set(_ *Context, values interface{}) error {
 	}
 
 	for _, v := range values.([]string) {
-		m.LRU.Add(v, true)
+		m.LRU.Set(v, true, ttlcache.DefaultTTL)
 	}
 	return nil
 }
@@ -323,10 +323,10 @@ func (m *MutableStringArrayVariable) Set(_ *Context, values interface{}) error {
 func (m *MutableStringArrayVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
-		m.LRU.Add(value, true)
+		m.LRU.Set(value, true, ttlcache.DefaultTTL)
 	case []string:
 		for _, v := range value {
-			m.LRU.Add(v, true)
+			m.LRU.Set(v, true, ttlcache.DefaultTTL)
 		}
 	default:
 		return errAppendNotSupported
@@ -349,7 +349,9 @@ func NewMutableStringArrayVariable(size int, ttl time.Duration) *MutableStringAr
 		size = defaultMaxVariables
 	}
 
-	lru := expirable.NewLRU[string, bool](size, nil, ttl)
+	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(size)), ttlcache.WithTTL[string, bool](ttl))
+	go lru.Start()
+
 	return &MutableStringArrayVariable{
 		LRU: lru,
 	}
@@ -433,7 +435,7 @@ func (v *GlobalVariables) GetVariable(_ string, value interface{}, opts Variable
 
 // Variables holds a set of variables
 type Variables struct {
-	lru *expirable.LRU[string, interface{}]
+	lru *ttlcache.Cache[string, interface{}]
 	ttl time.Duration
 }
 
@@ -444,36 +446,46 @@ func NewVariables() *Variables {
 
 // GetBool returns the boolean value of the specified variable
 func (v *Variables) GetBool(name string) bool {
-	value, _ := v.lru.Get(name)
-	bval, _ := value.(bool)
+	var bval bool
+	if item := v.lru.Get(name); item != nil {
+		bval, _ = item.Value().(bool)
+	}
 	return bval
 }
 
 // GetInt returns the integer value of the specified variable
 func (v *Variables) GetInt(name string) int {
-	value, _ := v.lru.Get(name)
-	ival, _ := value.(int)
+	var ival int
+	if item := v.lru.Get(name); item != nil {
+		ival, _ = item.Value().(int)
+	}
 	return ival
 }
 
 // GetString returns the string value of the specified variable
 func (v *Variables) GetString(name string) string {
-	value, _ := v.lru.Get(name)
-	sval, _ := value.(string)
+	var sval string
+	if item := v.lru.Get(name); item != nil {
+		sval, _ = item.Value().(string)
+	}
 	return sval
 }
 
 // GetStringArray returns the string array value of the specified variable
 func (v *Variables) GetStringArray(name string) []string {
-	value, _ := v.lru.Get(name)
-	slval, _ := value.([]string)
+	var slval []string
+	if item := v.lru.Get(name); item != nil {
+		slval, _ = item.Value().([]string)
+	}
 	return slval
 }
 
 // GetIntArray returns the integer array value of the specified variable
 func (v *Variables) GetIntArray(name string) []int {
-	value, _ := v.lru.Get(name)
-	ilval, _ := value.([]int)
+	var ilval []int
+	if item := v.lru.Get(name); item != nil {
+		ilval, _ = item.Value().([]int)
+	}
 	return ilval
 }
 
@@ -483,12 +495,13 @@ const defaultMaxVariables = 100
 func (v *Variables) Set(name string, value interface{}) bool {
 	existed := false
 	if v.lru == nil {
-		v.lru = expirable.NewLRU[string, interface{}](defaultMaxVariables, nil, v.ttl)
+		v.lru = ttlcache.New(ttlcache.WithCapacity[string, interface{}](uint64(defaultMaxVariables)), ttlcache.WithTTL[string, interface{}](v.ttl))
+		go v.lru.Start()
 	} else {
-		_, existed = v.lru.Get(name)
+		existed = v.lru.Get(name) != nil
 	}
 
-	v.lru.Add(name, value)
+	v.lru.Set(name, value, ttlcache.DefaultTTL)
 	return !existed
 }
 

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/skydive-project/go-debouncer v1.0.0
 	github.com/spf13/cast v1.7.0
 	github.com/stretchr/testify v1.9.0

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -30,6 +30,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -57,6 +59,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
 golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -342,9 +342,9 @@ func TestActionSetVariableTTL(t *testing.T) {
 	assert.NotNil(t, stringArrayVar)
 	assert.True(t, ok)
 
-	assert.True(t, stringArrayVar.Contains("foo"))
+	assert.True(t, stringArrayVar.LRU.Has("foo"))
 	time.Sleep(time.Second + 100*time.Millisecond)
-	assert.False(t, stringArrayVar.Contains("foo"))
+	assert.False(t, stringArrayVar.LRU.Has("foo"))
 }
 
 func TestActionSetVariableConflict(t *testing.T) {

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/alecthomas/participle v0.7.1 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/jellydator/ttlcache/v3 v3.3.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	golang.org/x/sync v0.8.0 // indirect
 )

--- a/pkg/security/seclwin/go.sum
+++ b/pkg/security/seclwin/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1p
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
@@ -14,6 +14,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

The goal of this PR is to only make use of a single go package to provide a TTL-based cache.
The PR is replacing `github.com/hashicorp/golang-lru/v2/expirable` in favor of `github.com/jellydator/ttlcache/v3` because the latter offers a more flexible API (in particular the item expiration go routine can be started separately from cache initialization).

This is expected to have no functional change.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
