### PR TITLE
(fleet) fix the run path when using the CDN

### DIFF
--- a/cmd/installer/subcommands/daemon/status.tmpl
+++ b/cmd/installer/subcommands/daemon/status.tmpl
@@ -7,16 +7,38 @@ Datadog Installer v{{ htmlSafe .Version }}
     {{ greenText "●" }} stable: v{{ htmlSafe $package.Stable }}
   {{- else }}
     {{ redText "●" }} stable: none
-  {{- end }}{{ if $package.Experiment }}
+  {{- end }}
+  {{- if $package.Experiment }}
     {{ yellowText "●" }} experiment: v{{ htmlSafe $package.Experiment }}
   {{- else }}
     ● experiment: none
   {{- end }}
-  {{- if eq $name "datadog-apm-inject" }}{{ template "datadog-apm-inject" $.ApmInjectionStatus }}{{ end }}
+
+  {{- if eq $name "datadog-apm-inject" }}
+    {{ template "datadog-apm-inject" $.ApmInjectionStatus }}
+  {{- end }}
+
+  {{- range $remoteConfig := $.RemoteConfigState }}
+    {{- if eq $remoteConfig.Package $name }}
+  Remote configuration client state:
+    StableVersion: {{ $remoteConfig.StableVersion }}
+    ExperimentVersion: {{ $remoteConfig.ExperimentVersion }}
+    StableConfigVersion: {{ $remoteConfig.StableConfigVersion }}
+    ExperimentConfigVersion: {{ $remoteConfig.ExperimentConfigVersion }}
+    RemoteConfigVersion: {{ $remoteConfig.RemoteConfigVersion }}
+    Task:
+      {{- if $remoteConfig.Task }}
+        Id: {{ $remoteConfig.Task.Id }}
+        State: {{ $remoteConfig.Task.State }}
+        {{- if $remoteConfig.Task.Error }}
+          Error: {{ $remoteConfig.Task.Error }}
+        {{- end }}
+      {{- else }}
+        No task available
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{ end -}}
-{{- if .RemoteConfigState }}
-{{ template "remote-config-state" $.RemoteConfigState }}
-{{- end -}}
 
 {{- define "datadog-apm-inject" }}
   Instrumentation status:
@@ -32,26 +54,4 @@ Datadog Installer v{{ htmlSafe .Version }}
     {{- else -}}
       {{ redText "●" }} Docker: Not instrumented
     {{- end }}
-{{- end -}}
-
-{{- define "remote-config-state" }}
-  Remote configuration client state:
-  {{ range . }}
-    {{ boldText .Package }}
-      StableVersion: {{ .StableVersion }}
-      ExperimentVersion: {{ .ExperimentVersion }}
-      StableConfigVersion: {{ .StableConfigVersion }}
-      ExperimentConfigVersion: {{ .ExperimentConfigVersion }}
-      RemoteConfigVersion: {{ .RemoteConfigVersion }}
-      Task:
-        {{- if .Task }}
-          Id: {{ .Task.Id }}
-          State: {{ .Task.State }}
-          {{- if .Task.Error }}
-            Error: {{ .Task.Error }}
-          {{- end }}
-        {{- else }}
-          No task available
-        {{- end }}
-  {{ end }}
 {{- end }}

--- a/pkg/fleet/internal/cdn/cdn.go
+++ b/pkg/fleet/internal/cdn/cdn.go
@@ -73,8 +73,6 @@ func (c *CDN) getOrderedLayers(ctx context.Context) ([]*layer, error) {
 	// HACK(baptiste): Create a dedicated one-shot RC service just for the configuration
 	// We should use the CDN instead
 	config := pkgconfigsetup.Datadog()
-	config.Set("run_path", "/opt/datadog-packages/datadog-installer/stable/run", model.SourceAgentRuntime)
-
 	detectenv.DetectFeatures(config)
 	hostname, err := pkghostname.Get(ctx)
 	if err != nil {
@@ -84,6 +82,7 @@ func (c *CDN) getOrderedLayers(ctx context.Context) ([]*layer, error) {
 		remoteconfig.WithAPIKey(c.env.APIKey),
 		remoteconfig.WithConfigRootOverride(c.env.Site, ""),
 		remoteconfig.WithDirectorRootOverride(c.env.Site, ""),
+		remoteconfig.WithDatabaseFileName("remote-config-cdn-tmp"),
 	}
 	service, err := remoteconfig.NewService(
 		config,


### PR DESCRIPTION
This PR removes a broken override when the CDN is used.
