### PR TITLE
[clusteragent/admission/mutate] Add option to create socket volumes

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
@@ -9,6 +9,7 @@ package agentsidecar
 
 import (
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -32,6 +33,12 @@ const dogstatsdSocket = socketDir + "/dsd.socket"
 // DogStatsD sockets. It needs to be different from the name used by the config
 // webhook to distinguish them easily.
 const ddSocketsVolumeName = "ddsockets"
+
+var volumeNamesInjectedByConfigWebhook = []string{
+	configWebhook.DatadogVolumeName,
+	configWebhook.DogstatsdSocketVolumeName,
+	configWebhook.TraceAgentSocketVolumeName,
+}
 
 // providerIsSupported indicates whether the provider is supported by agent sidecar injection
 func providerIsSupported(provider string) bool {
@@ -85,10 +92,7 @@ func applyFargateOverrides(pod *corev1.Pod) (bool, error) {
 		return false, fmt.Errorf("can't apply profile overrides to nil pod")
 	}
 
-	mutated := false
-
-	deleted := deleteConfigWebhookVolumeAndMounts(pod)
-	mutated = mutated || deleted
+	mutated := deleteConfigWebhookVolumesAndMounts(pod)
 
 	volume, volumeMount := socketsVolume()
 	injected := common.InjectVolume(pod, volume, volumeMount)
@@ -174,20 +178,19 @@ func socketsVolume() (corev1.Volume, corev1.VolumeMount) {
 	return volume, volumeMount
 }
 
-// deleteConfigWebhookVolumeAndMounts deletes the volume and volumeMounts added
+// deleteConfigWebhookVolumesAndMounts deletes the volume and volumeMounts added
 // by the config webhook. Returns a boolean that indicates if the pod was
 // mutated.
-func deleteConfigWebhookVolumeAndMounts(pod *corev1.Pod) bool {
-	mutated := false
-
+func deleteConfigWebhookVolumesAndMounts(pod *corev1.Pod) bool {
+	originalNumberOfVolumes := len(pod.Spec.Volumes)
 	// Delete the volume added by the config webhook
-	for i, vol := range pod.Spec.Volumes {
-		if vol.Name == configWebhook.DatadogVolumeName {
-			pod.Spec.Volumes = append(pod.Spec.Volumes[:i], pod.Spec.Volumes[i+1:]...)
-			mutated = true
-			break
-		}
-	}
+	pod.Spec.Volumes = slices.DeleteFunc(
+		pod.Spec.Volumes,
+		func(volume corev1.Volume) bool {
+			return slices.Contains(volumeNamesInjectedByConfigWebhook, volume.Name)
+		},
+	)
+	mutated := len(pod.Spec.Volumes) != originalNumberOfVolumes
 
 	deleted := deleteConfigWebhookVolumeMounts(pod.Spec.Containers)
 	mutated = mutated || deleted
@@ -204,16 +207,11 @@ func deleteConfigWebhookVolumeMounts(containers []corev1.Container) bool {
 	mutated := false
 
 	for i, container := range containers {
-		for j, volMount := range container.VolumeMounts {
-			if volMount.Name == configWebhook.DatadogVolumeName {
-				containers[i].VolumeMounts = append(
-					containers[i].VolumeMounts[:j],
-					containers[i].VolumeMounts[j+1:]...,
-				)
-				mutated = true
-				break
-			}
-		}
+		originalNumberOfVolMounts := len(container.VolumeMounts)
+		containers[i].VolumeMounts = slices.DeleteFunc(container.VolumeMounts, func(volMount corev1.VolumeMount) bool {
+			return slices.Contains(volumeNamesInjectedByConfigWebhook, volMount.Name)
+		})
+		mutated = mutated || len(container.VolumeMounts) != originalNumberOfVolMounts
 	}
 
 	return mutated

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -59,7 +59,6 @@ func TestProviderIsSupported(t *testing.T) {
 
 func TestApplyProviderOverrides(t *testing.T) {
 	mockConfig := configmock.New(t)
-	hostPathType := corev1.HostPathDirectoryOrCreate
 
 	tests := []struct {
 		name                     string
@@ -170,7 +169,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 		{
 			// This test checks that the volume and volume mounts set by the
 			// config webhook are replaced by ones that works on Fargate.
-			name:     "fargate provider - with volume set by the config webhook",
+			name:     "fargate provider - with volume set by the config webhook (when the type is not socket)",
 			provider: "fargate",
 			basePod: &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -201,8 +200,136 @@ func TestApplyProviderOverrides(t *testing.T) {
 							Name: "datadog",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Type: &hostPathType,
+									Type: pointer.Ptr(corev1.HostPathDirectoryOrCreate),
 									Path: "/var/run/datadog",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodAfterOverride: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation: "ddsockets",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ShareProcessNamespace: pointer.Ptr(true),
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_TRACE_AGENT_URL",
+									Value: "unix:///var/run/datadog/apm.socket",
+								},
+								{
+									Name:  "DD_DOGSTATSD_URL",
+									Value: "unix:///var/run/datadog/dsd.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "ddsockets",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: agentSidecarContainerName,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DD_EKS_FARGATE",
+									Value: "true",
+								},
+								{
+									Name:  "DD_APM_RECEIVER_SOCKET",
+									Value: "/var/run/datadog/apm.socket",
+								},
+								{
+									Name:  "DD_DOGSTATSD_SOCKET",
+									Value: "/var/run/datadog/dsd.socket",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "ddsockets",
+									MountPath: "/var/run/datadog",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "ddsockets",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectError:   false,
+			expectMutated: true,
+		},
+		{
+			// Same as the previous test, but this time the injected volumes are
+			// of socket type.
+			name:     "fargate provider - with volumes set by the config webhook (when the type is socket)",
+			provider: "fargate",
+			basePod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app-container",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "datadog-dogstatsd",
+									MountPath: "/var/run/datadog/dsd.socket",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "datadog-trace-agent",
+									MountPath: "/var/run/datadog/apm.socket",
+									ReadOnly:  true,
+								},
+							},
+						},
+						{
+							Name: agentSidecarContainerName,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "datadog-dogstatsd",
+									MountPath: "/var/run/datadog/dsd.socket",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "datadog-trace-agent",
+									MountPath: "/var/run/datadog/apm.socket",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "datadog-dogstatsd",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/run/datadog/dsd.socket",
+									Type: pointer.Ptr(corev1.HostPathSocket),
+								},
+							},
+						},
+						{
+							Name: "datadog-trace-agent",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/run/datadog/apm.socket",
+									Type: pointer.Ptr(corev1.HostPathSocket),
 								},
 							},
 						},

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -50,8 +50,14 @@ const (
 	socket  = "socket"
 	service = "service"
 
-	// DatadogVolumeName is the name of the volume used to mount the socket
+	// DatadogVolumeName is the name of the volume used to mount the sockets when the volume source is a directory
 	DatadogVolumeName = "datadog"
+
+	// TraceAgentSocketVolumeName is the name of the volume used to mount the trace agent socket
+	TraceAgentSocketVolumeName = "datadog-trace-agent"
+
+	// DogstatsdSocketVolumeName is the name of the volume used to mount the dogstatsd socket
+	DogstatsdSocketVolumeName = "datadog-dogstatsd"
 
 	webhookName = "agent_config"
 )
@@ -184,15 +190,10 @@ func (w *Webhook) inject(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, 
 	case service:
 		injectedConfig = common.InjectEnv(pod, agentHostServiceEnvVar)
 	case socket:
-		volume, volumeMount := buildVolume(DatadogVolumeName, config.Datadog().GetString("admission_controller.inject_config.socket_path"), true)
-		injectedVol := common.InjectVolume(pod, volume, volumeMount)
-		if injectedVol {
-			common.MarkVolumeAsSafeToEvictForAutoscaler(pod, DatadogVolumeName)
-		}
-
+		injectedVolumes := injectSocketVolumes(pod)
 		injectedEnv := common.InjectEnv(pod, traceURLSocketEnvVar)
 		injectedEnv = common.InjectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
-		injectedConfig = injectedEnv || injectedVol
+		injectedConfig = injectedVolumes || injectedEnv
 	default:
 		log.Errorf("invalid injection mode %q", w.mode)
 		return false, errors.New(metrics.InvalidInput)
@@ -249,14 +250,13 @@ func injectExternalDataEnvVar(pod *corev1.Pod) (injected bool) {
 	return
 }
 
-func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
-	pathType := corev1.HostPathDirectoryOrCreate
+func buildVolume(volumeName, path string, hostpathType corev1.HostPathType, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
 	volume := corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: path,
-				Type: &pathType,
+				Type: &hostpathType,
 			},
 		},
 	}
@@ -268,4 +268,53 @@ func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.
 	}
 
 	return volume, volumeMount
+}
+
+// injectSocketVolumes injects the volumes for the dogstatsd and trace agent
+// sockets.
+//
+// The type of the volume injected can be either a directory or a socket
+// depending on the configuration. They offer different trade-offs. Using a
+// socket ensures no lost traces or dogstatsd metrics but can cause the pod to
+// wait if the agent has issues that prevent it from creating the sockets.
+//
+// This function returns true if at least one volume was injected.
+func injectSocketVolumes(pod *corev1.Pod) bool {
+	var injectedVolNames []string
+
+	if config.Datadog().GetBool("admission_controller.inject_config.type_socket_volumes") {
+		volumes := map[string]string{
+			DogstatsdSocketVolumeName: strings.TrimPrefix(
+				config.Datadog().GetString("admission_controller.inject_config.dogstatsd_socket"), "unix://",
+			),
+			TraceAgentSocketVolumeName: strings.TrimPrefix(
+				config.Datadog().GetString("admission_controller.inject_config.trace_agent_socket"), "unix://",
+			),
+		}
+
+		for volumeName, volumePath := range volumes {
+			volume, volumeMount := buildVolume(volumeName, volumePath, corev1.HostPathSocket, true)
+			injectedVol := common.InjectVolume(pod, volume, volumeMount)
+			if injectedVol {
+				injectedVolNames = append(injectedVolNames, volumeName)
+			}
+		}
+	} else {
+		volume, volumeMount := buildVolume(
+			DatadogVolumeName,
+			config.Datadog().GetString("admission_controller.inject_config.socket_path"),
+			corev1.HostPathDirectoryOrCreate,
+			true,
+		)
+		injectedVol := common.InjectVolume(pod, volume, volumeMount)
+		if injectedVol {
+			injectedVolNames = append(injectedVolNames, DatadogVolumeName)
+		}
+	}
+
+	for _, volName := range injectedVolNames {
+		common.MarkVolumeAsSafeToEvictForAutoscaler(pod, volName)
+	}
+
+	return len(injectedVolNames) > 0
 }

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -10,6 +10,7 @@ package config
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -307,6 +308,7 @@ func TestInjectSocket(t *testing.T) {
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
+
 	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
 	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].MountPath, "/var/run/datadog")
@@ -316,6 +318,67 @@ func TestInjectSocket(t *testing.T) {
 	assert.Equal(t, pod.Spec.Volumes[0].VolumeSource.HostPath.Path, "/var/run/datadog")
 	assert.Equal(t, *pod.Spec.Volumes[0].VolumeSource.HostPath.Type, corev1.HostPathDirectoryOrCreate)
 	assert.Equal(t, "datadog", pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation])
+}
+
+func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
+	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
+	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
+	wmeta := fxutil.Test[workloadmeta.Component](
+		t,
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		fx.Replace(config.MockParams{
+			Overrides: map[string]interface{}{"admission_controller.inject_config.type_socket_volumes": true},
+		}),
+	)
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	injected, err := webhook.inject(pod, "", nil)
+	assert.Nil(t, err)
+	assert.True(t, injected)
+
+	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
+	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
+
+	expectedVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "datadog-dogstatsd",
+			MountPath: "/var/run/datadog/dsd.socket",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "datadog-trace-agent",
+			MountPath: "/var/run/datadog/apm.socket",
+			ReadOnly:  true,
+		},
+	}
+	assert.ElementsMatch(t, pod.Spec.Containers[0].VolumeMounts, expectedVolumeMounts)
+
+	expectedVolumes := []corev1.Volume{
+		{
+			Name: "datadog-dogstatsd",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/run/datadog/dsd.socket",
+					Type: pointer.Ptr(corev1.HostPathSocket),
+				},
+			},
+		},
+		{
+			Name: "datadog-trace-agent",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/run/datadog/apm.socket",
+					Type: pointer.Ptr(corev1.HostPathSocket),
+				},
+			},
+		},
+	}
+	assert.ElementsMatch(t, pod.Spec.Volumes, expectedVolumes)
+
+	safeToEvictVolumes := strings.Split(pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation], ",")
+	assert.Len(t, safeToEvictVolumes, 2)
+	assert.Contains(t, safeToEvictVolumes, "datadog-dogstatsd")
+	assert.Contains(t, safeToEvictVolumes, "datadog-trace-agent")
 }
 
 func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
@@ -339,7 +402,11 @@ func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "foo",
-							MountPath: "/var/run/datadog",
+							MountPath: "/var/run/datadog/dsd.socket",
+						},
+						{
+							Name:      "bar",
+							MountPath: "/var/run/datadog/apm.socket",
 						},
 					},
 				},

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2987,6 +2987,15 @@ api_key:
     #
     # trace_agent_socket: unix:///var/run/datadog/apm.socket
 
+    ## @param type_socket_volumes - boolean - optional - default: false
+    ## @env DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES - boolean - optional - default: false
+    ## When enabled, injected volumes are of type "Socket". This means that
+    ## injected pods will not start until the Agent creates the dogstatsd and
+    ## trace-agent sockets. This ensures no lost traces or dogstatsd metrics but
+    ## can cause the pod to wait if the agent has issues creating the sockets.
+    #
+    # type_socket_volumes: false
+
   ## @param inject_tags - custom object - optional
   ## Tags injection parameters.
   #

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -716,6 +716,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.socket_path", "/var/run/datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
+	config.BindEnvAndSetDefault("admission_controller.inject_config.type_socket_volumes", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.pod_owners_cache_validity", 10) // in minutes

--- a/releasenotes-dca/notes/admin-controller-vols-with-type-socket-dd57e8c0d3bb2c51.yaml
+++ b/releasenotes-dca/notes/admin-controller-vols-with-type-socket-dd57e8c0d3bb2c51.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a new option for the Cluster Agent
+    ("admission_controller.inject_config.type_socket_volumes") to specify that
+    injected volumes should be of type "Socket". This option is disabled by
+    default. When set to true, injected pods will not start until the Agent
+    creates the DogstatsD and trace-agent sockets. This ensures no traces or
+    DogstatsD metrics are lost, but it can cause the pod to wait if the Agent
+    has issues creating the sockets.


### PR DESCRIPTION
### What does this PR do?

Adds a new option for the Cluster Agent ("admission_controller.inject_config.type_socket_volumes") to specify that injected volumes should be of type "Socket". This option is disabled by default. When set to true, injected pods will not start until the Agent creates the dogstatsd and trace-agent sockets. This ensures no lost traces or dogstatsd metrics but can cause the pod to wait if the agent has issues creating the sockets.


### Describe how to test/QA your changes

This is covered by unit tests, but can't add e2e because it's not an option enabled by default.
To test manually, deploy using the helm chart (admission controller injection is enabled by default):
```yaml
datadog:
  kubelet:
    tlsVerify: false
clusterAgent:
  env:
    - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES
      value: true
```

Deploy a pod labeled with `admission.datadoghq.com/enabled: "true"` and check that there are two injected volumes (one for dogstatsd and another for trace-agent) and that they're of type "Socket".

Volumes:
```
   datadog-dogstatsd: 
     Type:          HostPath (bare host directory volume)
     Path:          /var/run/datadog/dsd.socket
     HostPathType:  Socket
   datadog-trace-agent:
     Type:          HostPath (bare host directory volume)
     Path:          /var/run/datadog/apm.socket
     HostPathType:  Socket
```

And associated mounts:
```
    Mounts:
      /var/run/datadog/apm.socket from datadog-trace-agent (ro)
      /var/run/datadog/dsd.socket from datadog-dogstatsd (ro)
```