### PR TITLE
trace: allow http2 plaintext on trace server

### DIFF
--- a/cmd/serverless/dependencies_linux_amd64.txt
+++ b/cmd/serverless/dependencies_linux_amd64.txt
@@ -782,6 +782,7 @@ golang.org/x/mod/semver
 golang.org/x/net/http/httpguts
 golang.org/x/net/http/httpproxy
 golang.org/x/net/http2
+golang.org/x/net/http2/h2c
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/socks

--- a/cmd/serverless/dependencies_linux_arm64.txt
+++ b/cmd/serverless/dependencies_linux_arm64.txt
@@ -781,6 +781,7 @@ golang.org/x/mod/semver
 golang.org/x/net/http/httpguts
 golang.org/x/net/http/httpproxy
 golang.org/x/net/http2
+golang.org/x/net/http2/h2c
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/socks

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/metric v1.31.0
 	go.uber.org/atomic v1.11.0
+	golang.org/x/net v0.30.0
 	golang.org/x/sys v0.26.0
 	golang.org/x/time v0.7.0
 	google.golang.org/grpc v1.64.0
@@ -102,7 +103,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect

--- a/releasenotes/notes/apm-h2-c4a1794bbf42f4a6.yaml
+++ b/releasenotes/notes/apm-h2-c4a1794bbf42f4a6.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The trace agent server can now accept request with http1.1 or h2 plaintext
+    protocol. This allows clients to avoid creating too much connections and
+    rely on http2 to multi plex many requests.


### PR DESCRIPTION
### What does this PR do?

This patch proposes to allow http2 plain text on the trace server.

### Motivation

Being able to expose the trace server in http2, would allow client to use a single connection to send their traffic. A typical example is `Envoy` sending traces, could use a single connection, and therefore use less file descriptors. Under high load, this can make a significant difference.

### Additional Notes

### Possible Drawbacks / Trade-offs

Golang does not support `h2c` client upgrade. For unit tests, I therefore had to use `curl` exec.

### Describe how to test/QA your changes

curl can be used to test the server:
```
$ curl -d "[]" http://localhost:8326/v0.4/traces -v --http2
* Host localhost:8326 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8326...
* connect to ::1 port 8326 from ::1 port 52173 failed: Connection refused
*   Trying 127.0.0.1:8326...
* Connected to localhost (127.0.0.1) port 8326
> POST /v0.4/traces HTTP/1.1
> Host: localhost:8326
> User-Agent: curl/8.7.1
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA
> Content-Length: 2
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 2 bytes
< HTTP/1.1 101 Switching Protocols
< Connection: Upgrade
< Upgrade: h2c
<
* Received 101, Switching to HTTP/2
< HTTP/2 200
< content-type: application/json
< datadog-agent-state: 9b83d72c7b384dee9d5ed57689cb050ed2721b1fedcef4f7b1a4544b99d12bfc
< datadog-agent-version:
< content-length: 23
< date: Fri, 01 Nov 2024 17:07:17 GMT
<
{"rate_by_service":{}}
* Connection #0 to host localhost left intact
```