### PR TITLE
[CWS] prepare support for env block in windows model

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -799,7 +799,8 @@ func (p *WindowsProbe) handleProcessStart(ev *model.Event, start *procmon.Proces
 
 	}
 
-	pce, err := p.Resolvers.ProcessResolver.AddNewEntry(pid, uint32(start.PPid), start.ImageFile, start.CmdLine, start.OwnerSidString)
+	var envs []string // TODO
+	pce, err := p.Resolvers.ProcessResolver.AddNewEntry(pid, uint32(start.PPid), start.ImageFile, envs, start.CmdLine, start.OwnerSidString)
 	if err != nil {
 		log.Errorf("error in resolver %v", err)
 		return false

--- a/pkg/security/resolvers/process/resolver_windows.go
+++ b/pkg/security/resolvers/process/resolver_windows.go
@@ -131,13 +131,16 @@ func (p *Resolver) DeleteEntry(pid uint32, exitTime time.Time) {
 }
 
 // AddNewEntry add a new process entry to the cache
-func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, commandLine string, OwnerSidString string) (*model.ProcessCacheEntry, error) {
+func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, envs []string, commandLine string, OwnerSidString string) (*model.ProcessCacheEntry, error) {
 	e := p.processCacheEntryPool.Get()
 	e.PIDContext.Pid = pid
 	e.PPid = ppid
 	e.Process.CmdLine = utils.NormalizePath(commandLine)
 	e.Process.FileEvent.PathnameStr = utils.NormalizePath(file)
 	e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
+	e.Process.EnvsEntry = &model.EnvsEntry{
+		Values: envs,
+	}
 	e.ExecTime = time.Now()
 	e.Process.OwnerSidString = OwnerSidString
 	p.insertEntry(e)


### PR DESCRIPTION
### What does this PR do?

This PR prepares the support for the env block in the CWS windows model:
- it keeps `EnvsEntry` (to keep the unfiltered, raw env block) and `Envs` the resolvable field returning filtered env variables
- it prepares the `EnvsEntry` creation to the point where we receive the `ProcessStartNotification` from the probe.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
