### PR TITLE
[NETPATH-297] Update timeout to be per hop instead of per path

### DIFF
--- a/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
@@ -6,7 +6,7 @@ init_config:
     # min_collection_interval: 60
 
     ## @param timeout - integer - optional - default: 1000
-    ## Specifies how much time in milliseconds traceroute should
+    ## Specifies how much time in milliseconds the traceroute should
     ## wait for a response from each hop before timing out.
     #
     # timeout: 1000
@@ -37,7 +37,7 @@ instances:
     # max_ttl: <PORT>
 
     ## @param timeout - integer - optional - default: 1000
-    ## Specifies how much time in milliseconds traceroute should
+    ## Specifies how much time in milliseconds the traceroute should
     ## wait for a response from each hop before timing out.
     #
     # timeout: 1000

--- a/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
@@ -6,8 +6,8 @@ init_config:
     # min_collection_interval: 60
 
     ## @param timeout - integer - optional - default: 1000
-    ## Specifies how much time traceroute should wait for a response
-    ## from each hop before timing out.
+    ## Specifies how much time in milliseconds traceroute should
+    ## wait for a response from each hop before timing out.
     #
     # timeout: 1000
 
@@ -37,8 +37,8 @@ instances:
     # max_ttl: <PORT>
 
     ## @param timeout - integer - optional - default: 1000
-    ## Specifies how much time traceroute should wait for a response
-    ## from each hop before timing out.
+    ## Specifies how much time in milliseconds traceroute should
+    ## wait for a response from each hop before timing out.
     #
     # timeout: 1000
 

--- a/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
@@ -5,11 +5,11 @@ init_config:
     #
     # min_collection_interval: 60
 
-    ## @param timeout - integer - optional - default: 10000
-    ## Specifies how much time the full traceroute should take
-    ## in milliseconds
+    ## @param timeout - integer - optional - default: 1000
+    ## Specifies how much time traceroute should wait for a response
+    ## from each hop before timing out.
     #
-    # timeout: 10000
+    # timeout: 1000
 
 # Network Path integration is used to monitor individual endpoints.
 # Supported platforms are Linux and Windows. macOS is not supported yet.
@@ -36,11 +36,11 @@ instances:
     #
     # max_ttl: <PORT>
 
-    ## @param timeout - integer - optional - default: 10000
-    ## Specifies how much time the full traceroute should take
-    ## in milliseconds
+    ## @param timeout - integer - optional - default: 1000
+    ## Specifies how much time traceroute should wait for a response
+    ## from each hop before timing out.
     #
-    # timeout: 10000
+    # timeout: 1000
 
     ## @param min_collection_interval - number - optional - default: 60
     ## Specifies how frequently we should probe the endpoint.

--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -98,8 +98,8 @@ func (t *traceroute) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 func (t *traceroute) Close() {}
 
 func logTracerouteRequests(cfg tracerouteutil.Config, client string, runCount uint64, start time.Time) {
-	args := []interface{}{cfg.DestHostname, client, cfg.DestPort, cfg.MaxTTL, cfg.Timeout, runCount, time.Since(start)}
-	msg := "Got request on /traceroute/%s?client_id=%s&port=%d&maxTTL=%d&timeout=%d (count: %d): retrieved traceroute in %s"
+	args := []interface{}{cfg.DestHostname, client, cfg.DestPort, cfg.MaxTTL, cfg.Timeout, cfg.Protocol, runCount, time.Since(start)}
+	msg := "Got request on /traceroute/%s?client_id=%s&port=%d&maxTTL=%d&timeout=%d&protocol=%s (count: %d): retrieved traceroute in %s"
 	switch {
 	case runCount <= 5, runCount%20 == 0:
 		log.Infof(msg, args...)

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -36,6 +36,7 @@ hostname: 1.2.3.4
 				MinCollectionInterval: time.Duration(60) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -71,6 +72,7 @@ min_collection_interval: 10
 				MinCollectionInterval: time.Duration(42) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -86,6 +88,7 @@ min_collection_interval: 10
 				MinCollectionInterval: time.Duration(10) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -98,6 +101,7 @@ hostname: 1.2.3.4
 				MinCollectionInterval: time.Duration(1) * time.Minute,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -115,6 +119,7 @@ destination_service: service-b
 				MinCollectionInterval: time.Duration(60) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -130,6 +135,7 @@ protocol: udp
 				Namespace:             "my-namespace",
 				Protocol:              payload.ProtocolUDP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -145,6 +151,7 @@ protocol: UDP
 				Namespace:             "my-namespace",
 				Protocol:              payload.ProtocolUDP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -160,6 +167,7 @@ protocol: TCP
 				Namespace:             "my-namespace",
 				Protocol:              payload.ProtocolTCP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -177,6 +185,7 @@ min_collection_interval: 10
 				MinCollectionInterval: time.Duration(42) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               50000 * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -195,6 +204,7 @@ timeout: 70000
 				MinCollectionInterval: time.Duration(42) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               50000 * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -212,6 +222,7 @@ timeout: 70000
 				MinCollectionInterval: time.Duration(42) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               70000 * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -228,6 +239,7 @@ min_collection_interval: 10
 				MinCollectionInterval: time.Duration(42) * time.Second,
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 			},
 		},
 		{
@@ -241,6 +253,61 @@ min_collection_interval: 10
 timeout: -1
 `),
 			expectedError: "timeout must be > 0",
+		},
+		{
+			name: "maxTTL from instance config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+max_ttl: 50
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                50,
+			},
+		},
+		{
+			name: "maxTTL from instance config preferred over init config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+max_ttl: 50
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+max_ttl: 64
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                50,
+			},
+		},
+		{
+			name: "maxTTL from init config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+max_ttl: 64
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                64,
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -107,7 +107,7 @@ const (
 	// DefaultNetworkPathTimeout defines the default timeout for a network path test
 	DefaultNetworkPathTimeout = 1000
 
-	// DefaultMaxTTL defines the default maximum TTL for traceroute tests
+	// DefaultNetworkPathMaxTTL defines the default maximum TTL for traceroute tests
 	DefaultNetworkPathMaxTTL = 30
 )
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -105,7 +105,10 @@ const (
 	DefaultMaxMessageSizeBytes = 256 * 1000
 
 	// DefaultNetworkPathTimeout defines the default timeout for a network path test
-	DefaultNetworkPathTimeout = 10000
+	DefaultNetworkPathTimeout = 1000
+
+	// DefaultMaxTTL defines the default maximum TTL for traceroute tests
+	DefaultNetworkPathMaxTTL = 30
 )
 
 // datadog is the global configuration object
@@ -437,7 +440,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("network_path.connections_monitoring.enabled", false)
 	config.BindEnvAndSetDefault("network_path.collector.workers", 4)
 	config.BindEnvAndSetDefault("network_path.collector.timeout", DefaultNetworkPathTimeout)
-	config.BindEnvAndSetDefault("network_path.collector.max_ttl", 30)
+	config.BindEnvAndSetDefault("network_path.collector.max_ttl", DefaultNetworkPathMaxTTL)
 	config.BindEnvAndSetDefault("network_path.collector.input_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_contexts_limit", 10000)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -665,7 +665,7 @@ func TestNetworkPathDefaults(t *testing.T) {
 
 	assert.Equal(t, false, config.GetBool("network_path.connections_monitoring.enabled"))
 	assert.Equal(t, 4, config.GetInt("network_path.collector.workers"))
-	assert.Equal(t, 10000, config.GetInt("network_path.collector.timeout"))
+	assert.Equal(t, 1000, config.GetInt("network_path.collector.timeout"))
 	assert.Equal(t, 30, config.GetInt("network_path.collector.max_ttl"))
 	assert.Equal(t, 1000, config.GetInt("network_path.collector.input_chan_size"))
 	assert.Equal(t, 1000, config.GetInt("network_path.collector.processing_chan_size"))

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -42,8 +42,6 @@ const (
 	DefaultNumPaths = 1
 	// DefaultMinTTL defines the default minimum TTL
 	DefaultMinTTL = 1
-	// DefaultMaxTTL defines the default maximum TTL
-	DefaultMaxTTL = 30
 	// DefaultDelay defines the default delay
 	DefaultDelay = 50 //msec
 	// DefaultOutputFormat defines the default output format
@@ -117,12 +115,12 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg Config) (payload.Network
 
 	maxTTL := cfg.MaxTTL
 	if maxTTL == 0 {
-		maxTTL = DefaultMaxTTL
+		maxTTL = setup.DefaultNetworkPathMaxTTL
 	}
 
 	var timeout time.Duration
 	if cfg.Timeout == 0 {
-		timeout = setup.DefaultNetworkPathTimeout * time.Millisecond
+		timeout = setup.DefaultNetworkPathTimeout * time.Duration(maxTTL) * time.Millisecond
 	} else {
 		timeout = cfg.Timeout
 	}

--- a/pkg/networkpath/traceroute/tcp/tcpv4.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4.go
@@ -103,15 +103,9 @@ func (t *TCPv4) TracerouteSequential() (*Results, error) {
 	// hops should be of length # of hops
 	hops := make([]*Hop, 0, t.MaxTTL-t.MinTTL)
 
-	// TODO: better logic around timeout for sequential is needed
-	// right now we're just hacking around the existing
-	// need to convert uint8 to int for proper conversion to
-	// time.Duration
-	timeout := t.Timeout / time.Duration(int(t.MaxTTL-t.MinTTL))
-
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
 		seqNumber := rand.Uint32()
-		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, timeout)
+		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)
 		}

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -201,7 +201,7 @@ func (r *RemoteSysProbeUtil) GetPing(clientID string, host string, count int, in
 // GetTraceroute returns the results of a traceroute to a host
 func (r *RemoteSysProbeUtil) GetTraceroute(clientID string, host string, port uint16, protocol nppayload.Protocol, maxTTL uint8, timeout time.Duration) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
-	log.Infof("Network Path traceroute HTTP request timeout: %s, timeout: %s, multiplication result: %s", httpTimeout, timeout, timeout*time.Duration(maxTTL))
+	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -200,7 +200,9 @@ func (r *RemoteSysProbeUtil) GetPing(clientID string, host string, count int, in
 
 // GetTraceroute returns the results of a traceroute to a host
 func (r *RemoteSysProbeUtil) GetTraceroute(clientID string, host string, port uint16, protocol nppayload.Protocol, maxTTL uint8, timeout time.Duration) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+10*time.Second) // allow extra time for the system probe communication overhead
+	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
+	log.Infof("Network Path traceroute HTTP request timeout: %s, timeout: %s, multiplication result: %s", httpTimeout, timeout, timeout*time.Duration(maxTTL))
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s", tracerouteURL, host, clientID, port, maxTTL, timeout, protocol), nil)

--- a/releasenotes/notes/network-path-change-timeout-configuration-4ccec24497bd1574.yaml
+++ b/releasenotes/notes/network-path-change-timeout-configuration-4ccec24497bd1574.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Changes behavior of the timeout for Network Path. Previously, the timeout
+    signified the total time to wait for a full traceroute to complete. Now,
+    the timeout signifies the time to wait for each hop in the traceroute.
+    Additionally, the default timeout has been changed to 1000ms.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This changes the behavior of `timeout` in the configuration of Network path. Previously, the `timeout` field controlled the timeout for the entire path trace. The default timeout has been updated to be `1000` which translates to 1 second per hop.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Other traceroute tools use this to configure their timeouts, some call this value "waittime". In the future this should allow us to more easily change the underlying implementation e.g. running traceroute serially or in parallel without the timeout having different meanings depending on the implementation.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
