### PR TITLE
[PROCS-4328] Add ECS EC2 e2e test for process checks in the core agent.

### DIFF
--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -61,7 +61,7 @@ func ecsEC2CPUStressProvisioner(runInCoreAgent bool) e2e.PulumiEnvRunFunc[ecsCPU
 	}
 }
 
-func TestECSTestSuite(t *testing.T) {
+func TestECSEC2TestSuite(t *testing.T) {
 	t.Parallel()
 	s := ECSEC2Suite{}
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -6,6 +6,7 @@
 package process
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+	//"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 
@@ -25,7 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/ecs"
 )
 
-type ECSSuite struct {
+type ECSEC2Suite struct {
 	e2e.BaseSuite[ecsCPUStressEnv]
 }
 
@@ -33,7 +34,7 @@ type ecsCPUStressEnv struct {
 	environments.ECS
 }
 
-func ecsCPUStressProvisioner() e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
+func ecsEC2CPUStressProvisioner(runInCoreAgent bool) e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
 	return func(ctx *pulumi.Context, env *ecsCPUStressEnv) error {
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {
@@ -45,6 +46,7 @@ func ecsCPUStressProvisioner() e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
 			ecs.WithECSLinuxECSOptimizedNodeGroup(),
 			ecs.WithAgentOptions(
 				ecsagentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true"),
+				ecsagentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", fmt.Sprintf("%t", runInCoreAgent)),
 			),
 			ecs.WithWorkloadApp(func(e aws.Environment, clusterArn pulumi.StringInput) (*ecsComp.Workload, error) {
 				return cpustress.EcsAppDefinition(e, clusterArn)
@@ -61,17 +63,17 @@ func ecsCPUStressProvisioner() e2e.PulumiEnvRunFunc[ecsCPUStressEnv] {
 
 func TestECSTestSuite(t *testing.T) {
 	t.Parallel()
-	s := ECSSuite{}
+	s := ECSEC2Suite{}
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
-		e2e.NewTypedPulumiProvisioner("ecsCPUStress", ecsCPUStressProvisioner(), nil))}
+		e2e.NewTypedPulumiProvisioner("ecsEC2CPUStress", ecsEC2CPUStressProvisioner(false), nil))}
 
 	e2e.Run(t, &s, e2eParams...)
 }
 
-func (s *ECSSuite) TestECSProcessCheck() {
+func (s *ECSEC2Suite) TestECSEC2ProcessCheck() {
 	t := s.T()
 	// PROCS-4219
-	flake.Mark(t)
+	//flake.Mark(t)
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -84,5 +86,30 @@ func (s *ECSSuite) TestECSProcessCheck() {
 	}, 2*time.Minute, 10*time.Second)
 
 	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
+	assertContainersCollected(t, payloads, []string{"stress-ng"})
+}
+
+func (s *ECSEC2Suite) TestECSEC2ProcessCheckInCoreAgent() {
+	t := s.T()
+	// PROCS-4219
+	// flake.Mark(t)
+
+	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsCPUStress", ecsEC2CPUStressProvisioner(true), nil))
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
+	requireProcessNotCollected(t, payloads, "process-agent")
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
 }

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -18,7 +18,7 @@ import (
 
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 
-	//"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 
@@ -73,7 +73,7 @@ func TestECSEC2TestSuite(t *testing.T) {
 func (s *ECSEC2Suite) TestProcessCheck() {
 	t := s.T()
 	// PROCS-4219
-	// flake.Mark(t)
+	flake.Mark(t)
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -92,7 +92,7 @@ func (s *ECSEC2Suite) TestProcessCheck() {
 func (s *ECSEC2Suite) TestProcessCheckInCoreAgent() {
 	t := s.T()
 	// PROCS-4219
-	// flake.Mark(t)
+	flake.Mark(t)
 
 	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsEC2CPUStress", ecsEC2CPUStressProvisioner(true), nil))
 

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -70,7 +70,7 @@ func TestECSEC2TestSuite(t *testing.T) {
 	e2e.Run(t, &s, e2eParams...)
 }
 
-func (s *ECSEC2Suite) TestECSEC2ProcessCheck() {
+func (s *ECSEC2Suite) TestProcessCheck() {
 	t := s.T()
 	// PROCS-4219
 	// flake.Mark(t)
@@ -89,7 +89,7 @@ func (s *ECSEC2Suite) TestECSEC2ProcessCheck() {
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
 }
 
-func (s *ECSEC2Suite) TestECSEC2ProcessCheckInCoreAgent() {
+func (s *ECSEC2Suite) TestProcessCheckInCoreAgent() {
 	t := s.T()
 	// PROCS-4219
 	// flake.Mark(t)

--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -73,7 +73,7 @@ func TestECSEC2TestSuite(t *testing.T) {
 func (s *ECSEC2Suite) TestECSEC2ProcessCheck() {
 	t := s.T()
 	// PROCS-4219
-	//flake.Mark(t)
+	// flake.Mark(t)
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -94,7 +94,7 @@ func (s *ECSEC2Suite) TestECSEC2ProcessCheckInCoreAgent() {
 	// PROCS-4219
 	// flake.Mark(t)
 
-	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsCPUStress", ecsEC2CPUStressProvisioner(true), nil))
+	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsEC2CPUStress", ecsEC2CPUStressProvisioner(true), nil))
 
 	// Flush fake intake to remove any payloads which may have
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds an e2e test for running the process checks in the core agent in ECS EC2. The tests are marked as flakes because that issue has yet to be resolved. ECS Fargate will come at later time and in a different suite. The existing suite name was updated to reflect this so that it is better differentiated.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Running the tests locally (without the flake marker) works.

```
❯ new-e2e-tests.run --targets=./tests/process --run=TestECSEC2TestSuite
...
=== RUN   TestECSEC2TestSuite/TestECSEC2ProcessCheck
    suite.go:251: No change in provisioners, skipping environment update
=== RUN   TestECSEC2TestSuite/TestECSEC2ProcessCheckInCoreAgent
    suite.go:251: No change in provisioners, skipping environment update
    print.go:225: Stack up took 2m4.7042065s
...
--- PASS: TestECSEC2TestSuite (269.10s)
    --- PASS: TestECSEC2TestSuite/TestECSEC2ProcessCheck (40.03s)
    --- PASS: TestECSEC2TestSuite/TestECSEC2ProcessCheckInCoreAgent (145.85s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	272.150s

DONE 3 tests in 291.910s
All tests passed
```
