### PR TITLE
discovery: tests: convert cpu usage value to percentage in assertCPU

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -525,7 +525,9 @@ func assertCPU(t *testing.T, url string, pid int) {
 	// Calling getServicesMap a second time us the CPU usage percentage since the last call, which should be close to gopsutil value.
 	portMap := getServicesMap(t, url)
 	assert.Contains(t, portMap, pid)
-	assert.InDelta(t, referenceValue, portMap[pid].CPUCores*100, 0.10)
+	// gopsutil reports a percentage, while we are reporting a float between 0 and $(nproc),
+	// so we convert our value to a percentage.
+	assert.InDelta(t, referenceValue, portMap[pid].CPUCores*100, 10)
 }
 
 func TestCommandLineSanitization(t *testing.T) {

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -525,7 +525,7 @@ func assertCPU(t *testing.T, url string, pid int) {
 	// Calling getServicesMap a second time us the CPU usage percentage since the last call, which should be close to gopsutil value.
 	portMap := getServicesMap(t, url)
 	assert.Contains(t, portMap, pid)
-	assert.InDelta(t, referenceValue, portMap[pid].CPUCores, 0.10)
+	assert.InDelta(t, referenceValue, portMap[pid].CPUCores*100, 0.10)
 }
 
 func TestCommandLineSanitization(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The `assertCPU` helpers compares our CPU usage value against Gopsutil's. However, gopsutil reports a percentage, while we are reporting a float between 0 and $(nproc).

This fixes the assertion by converting our value to a percentage.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
