### PR TITLE
[CWS] optimize `HostProc` function

### DIFF
--- a/pkg/util/kernel/fs_test.go
+++ b/pkg/util/kernel/fs_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package kernel
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func BenchmarkHostProc(b *testing.B) {
+	_ = ProcFSRoot()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		res := HostProc("a", "b", "c", "d")
+		runtime.KeepAlive(res)
+	}
+}
+
+func TestHostProc(t *testing.T) {
+	entries := [][]string{
+		nil,
+		{"a", "b", "c", "d"},
+		{"self", "mountinfo"},
+		{"10", "fd", "3"},
+		{"a"},
+	}
+
+	legacyHostProc := func(combineWith ...string) string {
+		return filepath.Join(ProcFSRoot(), filepath.Join(combineWith...))
+	}
+
+	for _, entry := range entries {
+		t.Run(strings.Join(entry, "/"), func(t *testing.T) {
+			v1 := HostProc(entry...)
+			v2 := legacyHostProc(entry...)
+			if v1 != v2 {
+				t.Errorf("v1: %v, v1: %v", v1, v2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new `HostProcV2` that is an optimized version of `HostProc` removing the need to call `filepath.Join` twice (and thus `filepath.Clean` twice..).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
