### PR TITLE
[SBOM] Enable SBOM in default configuration

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1721,8 +1721,8 @@ api_key:
 
   ## uncomment the sections below to enable where the vulnerability scanning is done
 
-  ## @param host
-  ## enable the host-level check
+  ## @param enabled - boolean - optional - default: false
+  ## set to true to enable Infrastructure Vulnerabiltilies
   # host:
   #  enabled: false
 {{- if (eq .OS "linux")}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -885,6 +885,8 @@ api_key:
   # enabled: false
 
 {{ end }}
+
+
 {{ end -}}
 
 {{- if .LogsAgent }}
@@ -1707,6 +1709,28 @@ api_key:
   ## @env DD_COMPLIANCE_CONFIG_CHECK_MAX_EVENTS_PER_RUN - integer - optional - default: 100
   ##
   # check_max_events_per_run: 100
+{{ end -}}
+
+{{- if .SBOM }}
+## @param sbom
+## Enter specific configuration for the Cloud Security Management feature
+# sbom:
+  ## @param enabled - boolean - optional - default: false
+  ## set to true to enable Cloud Security Management
+  # enabled: false
+
+  ## uncomment the sections below to enable where the SBOM check is run
+
+  ## @param host
+  ## enable the host-level check
+  # host:
+  #  enabled: false
+{{- if (eq .OS "linux")}}
+
+ 
+  # container_image:
+  #   enabled: false
+{{ end -}}
 {{ end -}}
 {{- if .SystemProbe }}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1712,14 +1712,14 @@ api_key:
 {{ end -}}
 
 {{- if .SBOM }}
-## @param sbom
-## Enter specific configuration for the Cloud Security Management feature
+## @param sbom - custom object - optional
+## Enter specific configuration for the Cloud Security Management Vulnerability Management feature
 # sbom:
   ## @param enabled - boolean - optional - default: false
-  ## set to true to enable Cloud Security Management
+  ## set to true to enable Cloud Security Management Vulnerability Management
   # enabled: false
 
-  ## uncomment the sections below to enable where the SBOM check is run
+  ## uncomment the sections below to enable where the vulnerability scanning is done
 
   ## @param host
   ## enable the host-level check

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -50,7 +50,7 @@ type context struct {
 	SNMP                             bool
 	SecurityModule                   bool
 	SecurityAgent                    bool
-	SBOM							 bool // enables CSM
+	SBOM							 bool // enables CSM Vulnerability Management
 	NetworkModule                    bool // Sub-module of System Probe
 	UniversalServiceMonitoringModule bool // Sub-module of System Probe
 	DataStreamsModule                bool // Sub-module of System Probe

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -50,6 +50,7 @@ type context struct {
 	SNMP                             bool
 	SecurityModule                   bool
 	SecurityAgent                    bool
+	SBOM							 bool // enables CSM
 	NetworkModule                    bool // Sub-module of System Probe
 	UniversalServiceMonitoringModule bool // Sub-module of System Probe
 	DataStreamsModule                bool // Sub-module of System Probe
@@ -87,6 +88,7 @@ func mkContext(buildType string) context {
 		Kubelet:           true,
 		KubeApiServer:     true, // TODO: remove when phasing out from node-agent
 		Compliance:        true,
+		SBOM:			   true,
 		SNMP:              true,
 		PrometheusScrape:  true,
 		OTLP:              true,

--- a/releasenotes/notes/addsbomtoconfig-99a7cd52fa412336.yaml
+++ b/releasenotes/notes/addsbomtoconfig-99a7cd52fa412336.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the default configuration template to include the Cloud Security Management configuration options.


### PR DESCRIPTION
Enables the SBOM configuration in the configuration template.

### What does this PR do?


### Motivation

Provide configuration documentation for new feature.


### Describe how to test/QA your changes

Install a fresh version of the agent (not an upgrade).
Check the default configuration, that the `datadog.yaml` includes the `SBOM` section, and the other configs (`system-probe`, `security-agent`, etc.) do NOT include the SBOM section