### PR TITLE
ebpf: CPU and memory improvements to `HostProc`

### DIFF
--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -9,9 +9,11 @@ package kernel
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/moby/sys/mountinfo"
 
@@ -62,7 +64,47 @@ var SysFSRoot = funcs.MemoizeNoError(func() string {
 
 // hostProcInternal is the testable/benchmarkable version of HostProc
 func hostProcInternal(procFsRoot string, combineWith ...string) string {
-	return filepath.Join(procFsRoot, filepath.Join(combineWith...))
+	const sepLen = len(string(filepath.Separator))
+
+	// pre-compute the total size of the string to avoid reallocations
+	size := len(procFsRoot)
+	allEmpty := true
+	for _, c := range combineWith {
+		if len(c) > math.MaxInt-sepLen {
+			panic("int overflow in HostProc")
+		}
+		toadd := sepLen + len(c)
+
+		if size > math.MaxInt-toadd {
+			panic("int overflow in HostProc")
+		}
+		size += toadd
+
+		if c != "" {
+			allEmpty = false
+		}
+	}
+
+	// early escape to return "" if procFsRoot is empty and all combineWith are empty
+	// this is to match the behavior of filepath.Join
+	if procFsRoot == "" && allEmpty {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(size)
+
+	builder.WriteString(procFsRoot)
+	for i, c := range combineWith {
+		// the goal is not add the separator at the very beginning if procFsRoot is empty because we want to
+		// get a relative path, again the goal is to match the behavior of filepath.Join
+		if i != 0 || procFsRoot != "" {
+			builder.WriteRune(filepath.Separator)
+		}
+		builder.WriteString(c)
+	}
+
+	return filepath.Clean(builder.String())
 }
 
 // HostProc returns the location of a host's procfs. This can and will be

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -60,10 +60,15 @@ var SysFSRoot = funcs.MemoizeNoError(func() string {
 	return "/sys"
 })
 
+// hostProcInternal is the testable/benchmarkable version of HostProc
+func hostProcInternal(procFsRoot string, combineWith ...string) string {
+	return filepath.Join(procFsRoot, filepath.Join(combineWith...))
+}
+
 // HostProc returns the location of a host's procfs. This can and will be
 // overridden when running inside a container.
 func HostProc(combineWith ...string) string {
-	return filepath.Join(ProcFSRoot(), filepath.Join(combineWith...))
+	return hostProcInternal(ProcFSRoot(), combineWith...)
 }
 
 // RootNSPID returns the current PID from the root namespace

--- a/pkg/util/kernel/fs_test.go
+++ b/pkg/util/kernel/fs_test.go
@@ -21,3 +21,33 @@ func BenchmarkHostProc(b *testing.B) {
 		runtime.KeepAlive(res)
 	}
 }
+
+func TestHostProc(t *testing.T) {
+	type testCase struct {
+		name       string
+		procFsRoot string
+		args       []string
+		expected   string
+	}
+
+	entries := []testCase{
+		{"empty", "/proc", nil, "/proc"},
+		{"single", "/proc", []string{"a"}, "/proc/a"},
+		{"multiple", "/host/proc", []string{"a", "b", "c", "d"}, "/host/proc/a/b/c/d"},
+
+		{"slash", "/proc", []string{"/a/b"}, "/proc/a/b"},
+		{"slash-empty", "/host/proc", []string{"/"}, "/host/proc"},
+
+		{"empty-host-proc", "", []string{"a", "b"}, "a/b"},
+		{"everything-empty", "", nil, ""},
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			got := hostProcInternal(entry.procFsRoot, entry.args...)
+			if entry.expected != got {
+				t.Errorf("expected: `%v`, got: `%v`", entry.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/util/kernel/fs_test.go
+++ b/pkg/util/kernel/fs_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package kernel
+
+import (
+	"runtime"
+	"testing"
+)
+
+func BenchmarkHostProc(b *testing.B) {
+	_ = ProcFSRoot()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		res := hostProcInternal("/proc", "a", "b", "c", "d")
+		runtime.KeepAlive(res)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

In some of our (CWS) code, [HostProc can be called in the hot path ](https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20datacenter%3Aus1.ddbuild.io%20&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost&event=AgAAAZHHHOvhSXaKiwAAAAAAAAAYAAAAAEFaSEhIT3Z0QUFCbVY4TFFyNEh0cHdBQQAAACQAAAAAMDE5MWM3MjEtNDQwNC00NTA0LWI0ODgtNTM1ZDM1NjY0NDRm&group_by=line&my_code=disabled&profile_type=alloc-size&profileId=AZHHHOvtAABmV8LQr4HtpwAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1725621377600&to_ts=1725624977600&live=false), as such this PR tries to improve a bit the performance characteristics of this function. To do that:
- it extracts the core algorithm in a testable function (one that does not call `ProcFsRoot` since it's a cached function with no way to override, clear it)
- adds some benchmarks
- adds some tests

Benchmarks:
```
Before:
BenchmarkHostProc-4   	 9296641	       128.1 ns/op	      24 B/op	       2 allocs/op
After:
BenchmarkHostProc-4   	15349244	        77.94 ns/op	      16 B/op	       1 allocs/op
```

Note: the panic for int overflow are there to match the `strings.Join` behavior

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
