### PR TITLE
USMON-1152: Remove Kafka monitor tests optimization

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -529,19 +529,17 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
 	cfg := getDefaultTestConfiguration(tls)
-	monitor := newKafkaMonitor(t, cfg)
-	if tls && cfg.EnableGoTLSSupport {
-		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(func() {
 				for _, client := range tt.context.clients {
 					client.Client.Close()
 				}
-				cleanProtocolMaps(t, "kafka", monitor.ebpfProgram.Manager.Manager)
 			})
-
+			monitor := newKafkaMonitor(t, cfg)
+			if tls && cfg.EnableGoTLSSupport {
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+			}
 			tt.testBody(t, &tt.context, monitor)
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Remove `cleanProtocolMaps` optimization from `kafka_monitor_test.go`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
While investigating the flaky Kafka tests, we discovered that the `cleanProtocolMaps` function is failing with per-cpu maps used by the Kafka monitoring eBPF programs, which could potentially cause map leaks. Therefore, we are removing this optimization temporarily until a fix is identified for this issue


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
