### PR TITLE
[ksm] Init a single kubelet reflector for all pod collectors

### DIFF
--- a/pkg/kubestatemetrics/builder/kubelet_pods_stub.go
+++ b/pkg/kubestatemetrics/builder/kubelet_pods_stub.go
@@ -8,9 +8,24 @@
 package builder
 
 import (
+	"context"
+
 	"k8s.io/client-go/tools/cache"
 )
 
-func (b *Builder) startKubeletPodWatcher(_ cache.Store, _ string) {
-	// Do nothing
+// When the Kubelet flag is not set, we don't need a kubeletReflector, so we can
+// return a struct that does nothing
+
+type kubeletReflector struct{}
+
+func newKubeletReflector(_ []string) (kubeletReflector, error) {
+	return kubeletReflector{}, nil
+}
+
+func (kr *kubeletReflector) addStore(_ cache.Store) error {
+	return nil
+}
+
+func (kr *kubeletReflector) start(_ context.Context) error {
+	return nil
 }

--- a/pkg/kubestatemetrics/builder/kubelet_pods_test.go
+++ b/pkg/kubestatemetrics/builder/kubelet_pods_test.go
@@ -9,10 +9,11 @@ package builder
 
 import (
 	"context"
+	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -84,194 +85,139 @@ func (m *MockStore) Resync() error {
 }
 
 func TestUpdateStores_AddPods(t *testing.T) {
-	stores := []*MockStore{
-		new(MockStore),
-		new(MockStore),
-	}
-
-	watcher := new(MockPodWatcher)
-
-	kubeletPod := &kubelet.Pod{
-		Metadata: kubelet.PodMetadata{
-			Name:      "test-pod",
-			Namespace: "default",
-			UID:       "12345",
+	tests := []struct {
+		name                string
+		reflectorNamespaces []string
+		addedPodNamespace   string
+		podShouldBeAdded    bool
+	}{
+		{
+			name:                "add pod in watched namespace",
+			reflectorNamespaces: []string{"default"},
+			addedPodNamespace:   "default",
+			podShouldBeAdded:    true,
+		},
+		{
+			name:                "add pod in non-watched namespace",
+			reflectorNamespaces: []string{"default"},
+			addedPodNamespace:   "other-namespace",
+			podShouldBeAdded:    false,
+		},
+		{
+			name:                "reflector watches all pods",
+			reflectorNamespaces: []string{corev1.NamespaceAll},
+			addedPodNamespace:   "default",
+			podShouldBeAdded:    true,
 		},
 	}
 
-	kubernetesPod := kubelet.ConvertKubeletPodToK8sPod(kubeletPod)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stores := []*MockStore{
+				new(MockStore),
+				new(MockStore),
+			}
+			for _, store := range stores {
+				store.On("Add", mock.Anything).Return(nil)
+			}
 
-	watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
-	watcher.On("Expire").Return([]string{}, nil)
+			watcher := new(MockPodWatcher)
 
-	for _, store := range stores {
-		store.On("Add", kubernetesPod).Return(nil)
-	}
+			kubeletPod := &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Namespace: test.addedPodNamespace,
+					Name:      "test-pod",
+					UID:       "12345",
+				},
+			}
 
-	reflector := kubeletReflector{
-		namespaces: []string{"default"},
-		podWatcher: watcher,
-	}
-	for _, store := range stores {
-		err := reflector.addStore(store)
-		assert.NoError(t, err)
-	}
+			kubernetesPod := kubelet.ConvertKubeletPodToK8sPod(kubeletPod)
 
-	err := reflector.updateStores(context.TODO())
-	assert.NoError(t, err)
+			watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
+			watcher.On("Expire").Return([]string{}, nil)
 
-	for _, store := range stores {
-		store.AssertCalled(t, "Add", kubernetesPod)
+			reflector := kubeletReflector{
+				namespaces:         test.reflectorNamespaces,
+				watchAllNamespaces: slices.Contains(test.reflectorNamespaces, corev1.NamespaceAll),
+				podWatcher:         watcher,
+			}
+
+			for _, store := range stores {
+				err := reflector.addStore(store)
+				require.NoError(t, err)
+			}
+
+			err := reflector.updateStores(context.TODO())
+			require.NoError(t, err)
+
+			if test.podShouldBeAdded {
+				for _, store := range stores {
+					store.AssertCalled(t, "Add", kubernetesPod)
+				}
+			} else {
+				for _, store := range stores {
+					store.AssertNotCalled(t, "Add", mock.Anything)
+				}
+			}
+		})
 	}
 }
 
-func TestUpdateStores_FilterPodsByNamespace(t *testing.T) {
-	stores := []*MockStore{
-		new(MockStore),
-		new(MockStore),
-	}
-
-	for _, store := range stores {
-		store.On("Add", mock.Anything).Return(nil)
-	}
-
-	watcher := new(MockPodWatcher)
-
-	reflector := kubeletReflector{
-		namespaces: []string{"default"},
-		podWatcher: watcher,
-	}
-	for _, store := range stores {
-		err := reflector.addStore(store)
-		assert.NoError(t, err)
-	}
-
-	kubeletPod := &kubelet.Pod{
-		Metadata: kubelet.PodMetadata{
-			Name:      "test-pod",
-			Namespace: "other-namespace",
-			UID:       "12345",
+func TestUpdateStores_HandleExpired(t *testing.T) {
+	tests := []struct {
+		name                   string
+		expiredUID             string
+		expectedPodToBeDeleted *corev1.Pod
+	}{
+		{
+			name:       "expired pod",
+			expiredUID: "kubernetes_pod://pod-12345",
+			expectedPodToBeDeleted: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("pod-12345"),
+				},
+			},
+		},
+		{
+			name:                   "expired container",
+			expiredUID:             "container-12345",
+			expectedPodToBeDeleted: nil,
 		},
 	}
 
-	watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
-	watcher.On("Expire").Return([]string{}, nil)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stores := []*MockStore{
+				new(MockStore),
+				new(MockStore),
+			}
+			for _, store := range stores {
+				store.On("Delete", mock.Anything).Return(nil)
+			}
 
-	err := reflector.updateStores(context.TODO())
-	assert.NoError(t, err)
+			watcher := new(MockPodWatcher)
+			watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{}, nil)
+			watcher.On("Expire").Return([]string{test.expiredUID}, nil)
 
-	// Add() shouldn't be called because the pod is in a different namespace
-	for _, store := range stores {
-		store.AssertNotCalled(t, "Add", mock.Anything)
-	}
-}
+			reflector := kubeletReflector{
+				namespaces: []string{"default"},
+				podWatcher: watcher,
+			}
+			for _, store := range stores {
+				err := reflector.addStore(store)
+				require.NoError(t, err)
+			}
 
-func TestUpdateStores_WatchAllNamespaces(t *testing.T) {
-	stores := []*MockStore{
-		new(MockStore),
-		new(MockStore),
-	}
+			err := reflector.updateStores(context.TODO())
+			require.NoError(t, err)
 
-	for _, store := range stores {
-		store.On("Add", mock.Anything).Return(nil)
-	}
-
-	watcher := new(MockPodWatcher)
-
-	reflector := kubeletReflector{
-		watchAllNamespaces: true,
-		podWatcher:         watcher,
-	}
-	for _, store := range stores {
-		err := reflector.addStore(store)
-		assert.NoError(t, err)
-	}
-
-	kubeletPod := &kubelet.Pod{
-		Metadata: kubelet.PodMetadata{
-			Name:      "test-pod",
-			Namespace: "default",
-			UID:       "12345",
-		},
-	}
-
-	kubernetesPod := kubelet.ConvertKubeletPodToK8sPod(kubeletPod)
-
-	watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{kubeletPod}, nil)
-	watcher.On("Expire").Return([]string{}, nil)
-
-	err := reflector.updateStores(context.TODO())
-	assert.NoError(t, err)
-
-	for _, store := range stores {
-		store.AssertCalled(t, "Add", kubernetesPod)
-	}
-}
-
-func TestUpdateStores_HandleExpiredPods(t *testing.T) {
-	stores := []*MockStore{
-		new(MockStore),
-		new(MockStore),
-	}
-
-	watcher := new(MockPodWatcher)
-
-	podUID := "kubernetes_pod://pod-12345"
-	kubernetesPod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID: types.UID("pod-12345"),
-		},
-	}
-
-	watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{}, nil)
-	watcher.On("Expire").Return([]string{podUID}, nil)
-
-	for _, store := range stores {
-		store.On("Delete", &kubernetesPod).Return(nil)
-	}
-
-	reflector := kubeletReflector{
-		namespaces: []string{"default"},
-		podWatcher: watcher,
-	}
-	for _, store := range stores {
-		err := reflector.addStore(store)
-		assert.NoError(t, err)
-	}
-
-	err := reflector.updateStores(context.TODO())
-	assert.NoError(t, err)
-
-	for _, store := range stores {
-		store.AssertCalled(t, "Delete", &kubernetesPod)
-	}
-}
-
-func TestUpdateStores_HandleExpiredContainers(t *testing.T) {
-	stores := []*MockStore{
-		new(MockStore),
-		new(MockStore),
-	}
-
-	watcher := new(MockPodWatcher)
-
-	watcher.On("PullChanges", mock.Anything).Return([]*kubelet.Pod{}, nil)
-	watcher.On("Expire").Return([]string{"container-12345"}, nil)
-
-	reflector := kubeletReflector{
-		namespaces: []string{"default"},
-		podWatcher: watcher,
-	}
-	for _, store := range stores {
-		err := reflector.addStore(store)
-		assert.NoError(t, err)
-	}
-
-	err := reflector.updateStores(context.TODO())
-	assert.NoError(t, err)
-
-	// Delete() shouldn't be called because the expired entity is not a pod
-	for _, store := range stores {
-		store.AssertNotCalled(t, "Delete", mock.Anything)
+			for _, store := range stores {
+				if test.expectedPodToBeDeleted != nil {
+					store.AssertCalled(t, "Delete", test.expectedPodToBeDeleted)
+				} else {
+					store.AssertNotCalled(t, "Delete", mock.Anything)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This is an optimization for the PR that introduced the option to emit KSM pod metrics from the node agent: https://github.com/DataDog/datadog-agent/pull/28811

In that first version there was a kubelet pod watcher instantiated for each KSM metrics pod collector. By default there are two pod collectors, the standard one and the "pods_extended" one.

This PR changes that so that only one pod watcher is instantiated and used for all the collectors.
I've also simplified the tests a bit.

### Describe how to test/QA your changes

Testing https://github.com/DataDog/datadog-agent/pull/28811 plus the unit tests should be enough.
