### PR TITLE
[CSPM] Handle unknown user/group IDs

### DIFF
--- a/pkg/compliance/utils/inputs_files.go
+++ b/pkg/compliance/utils/inputs_files.go
@@ -22,8 +22,11 @@ func GetFileUser(fi os.FileInfo) string {
 		if user, err := user.LookupId(u); err == nil {
 			return user.Username
 		}
+		if statt.Uid == 0 {
+			return "root"
+		}
 	}
-	return ""
+	return "unknown"
 }
 
 // GetFileGroup returns the file group.
@@ -33,6 +36,9 @@ func GetFileGroup(fi os.FileInfo) string {
 		if group, err := user.LookupGroupId(g); err == nil {
 			return group.Name
 		}
+		if statt.Gid == 0 {
+			return "root"
+		}
 	}
-	return ""
+	return "unknown"
 }


### PR DESCRIPTION
### What does this PR do?

Fallback on `root` or `unknown` group or user name when unable to find them using `Lookup(Group)Id`.

### Motivation

When resolving the name of a user / group from a UID that is not present in the /etc/users or /etc/groups, we want to fallback on a `unknown` value that can be then used by our rules. Also default to `root` when the uid/gid is 0.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
