### PR TITLE
Componentize the snmp subcommands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -334,6 +334,7 @@
 /comp/languagedetection/client @DataDog/container-platform
 /comp/rdnsquerier @DataDog/network-device-monitoring
 /comp/serializer/compression @DataDog/agent-metrics-logs
+/comp/snmpscan @DataDog/network-device-monitoring
 # END COMPONENTS
 
 # pkg

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -426,7 +426,7 @@ func scanDevice(connParams *snmpConnectionParams, args argsType, snmpScanner snm
 
 	err = snmpScanner.RunDeviceScan(snmp, namespace)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to perform device scan: %v\n", err)
+		return fmt.Errorf("Unable to perform device scan: %v\n", err)
 	}
 	return nil
 }

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -419,7 +419,7 @@ func scanDevice(connParams *snmpConnectionParams, args argsType, snmpScanner snm
 
 	err = snmpScanner.RunDeviceScan(snmp, namespace)
 	if err != nil {
-		return fmt.Errorf("Unable to perform device scan: %v\n", err)
+		return fmt.Errorf("unable to perform device scan: %v", err)
 	}
 	return nil
 }

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/aggregator"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
@@ -139,16 +137,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				snmpscanfx.Module(),
-				demultiplexerimpl.Module(),
+				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),
 				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithFeatures(defaultforwarder.CoreFeatures))),
-				orchestratorimpl.Module(),
+				orchestratorimpl.Module(orchestratorimpl.NewDefaultParams()),
 				eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
 				compressionimpl.Module(),
 				eventplatformreceiverimpl.Module(),
-				fx.Provide(
-					orchestratorimpl.NewDefaultParams,
-					demultiplexerimpl.NewDefaultParams,
-				),
 			)
 			if err != nil {
 				var ue configErr
@@ -193,7 +187,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			err := fxutil.OneShot(scanDevice,
 				fx.Supply(connParams, globalParams, cmd),
 				fx.Provide(func() argsType { return args }),
-				compressionimpl.Module(),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams: secrets.NewEnabledParams(),

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -12,16 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestCommand(t *testing.T) {
+func TestWalkCommand(t *testing.T) {
 	// this command has _lots_ of options, so the test just exercises a few
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "-v", "3", "-r", "10"},
-		snmpwalk,
-		func(cliParams *connectionParams, args argsType) {
+		snmpWalk,
+		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
@@ -31,9 +32,32 @@ func TestCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "--use-unconnected-udp-socket"},
-		snmpwalk,
-		func(cliParams *connectionParams, args argsType) {
+		snmpWalk,
+		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
+			require.True(t, cliParams.UseUnconnectedUDPSocket)
+		})
+}
+
+func TestScanCommand(t *testing.T) {
+	// this command has _lots_ of options, so the test just exercises a few
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"snmp", "scan", "1.2.3.4", "-v", "3", "-r", "10"},
+		scanDevice,
+		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+			require.Equal(t, argsType{"1.2.3.4"}, args)
+			require.Equal(t, "3", cliParams.Version)
+			require.Equal(t, 10, cliParams.Retries)
+			require.False(t, cliParams.UseUnconnectedUDPSocket)
+		})
+
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"snmp", "scan", "1.2.3.4", "--use-unconnected-udp-socket"},
+		scanDevice,
+		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})
 }

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -22,7 +21,7 @@ func TestWalkCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "-v", "3", "-r", "10"},
 		snmpWalk,
-		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+		func(cliParams *snmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
@@ -33,7 +32,7 @@ func TestWalkCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "--use-unconnected-udp-socket"},
 		snmpWalk,
-		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+		func(cliParams *snmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})
@@ -45,7 +44,7 @@ func TestScanCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "scan", "1.2.3.4", "-v", "3", "-r", "10"},
 		scanDevice,
-		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+		func(cliParams *snmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
@@ -56,7 +55,7 @@ func TestScanCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "scan", "1.2.3.4", "--use-unconnected-udp-socket"},
 		scanDevice,
-		func(cliParams *snmpscan.SnmpConnectionParams, args argsType) {
+		func(cliParams *snmpConnectionParams, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})

--- a/comp/README.md
+++ b/comp/README.md
@@ -616,4 +616,4 @@ Package compression provides a compression implementation based on the configura
 
 *Datadog Team*: network-device-monitoring
 
-Package snmpscan ...
+Package snmpscan is a light component that can be used to perform a scan or a walk of a particular device

--- a/comp/README.md
+++ b/comp/README.md
@@ -611,3 +611,9 @@ Package rdnsquerier provides the reverse DNS querier component.
 *Datadog Team*: agent-metrics-logs
 
 Package compression provides a compression implementation based on the configuration or available build tags.
+
+### [comp/snmpscan](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmpscan)
+
+*Datadog Team*: network-device-monitoring
+
+Package snmpscan ...

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -7,20 +7,10 @@
 package snmpscan
 
 import (
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/gosnmp/gosnmp"
-	"go.uber.org/fx"
 )
 
 // team: network-device-monitoring
-
-// Requires defines the dependencies for the snmpscan component
-type Requires struct {
-	fx.In
-	Logger        log.Component
-	Demultiplexer demultiplexer.Component
-}
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -3,22 +3,23 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-// Package snmpscan ...
+// Package snmpscan is a light component that can be used to perform a scan or a walk of a particular device
 package snmpscan
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/gosnmp/gosnmp"
+	"go.uber.org/fx"
 )
 
 // team: network-device-monitoring
 
-type SnmpConnectionParams struct {
-	// embed a SNMPConfig because it's all the same fields anyway
-	snmpparse.SNMPConfig
-	// fields that aren't part of parse.SNMPConfig
-	SecurityLevel           string
-	UseUnconnectedUDPSocket bool
+// Requires defines the dependencies for the snmpscan component
+type Requires struct {
+	fx.In
+	Logger        log.Component
+	Demultiplexer demultiplexer.Component
 }
 
 // Component is the component type.

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package snmpscan ...
+package snmpscan
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/gosnmp/gosnmp"
+)
+
+// team: network-device-monitoring
+
+type SnmpConnectionParams struct {
+	// embed a SNMPConfig because it's all the same fields anyway
+	snmpparse.SNMPConfig
+	// fields that aren't part of parse.SNMPConfig
+	SecurityLevel           string
+	UseUnconnectedUDPSocket bool
+}
+
+// Component is the component type.
+type Component interface {
+	// Triggers a device scan
+	RunDeviceScan(snmpConection *gosnmp.GoSNMP, deviceNamespace string) error
+	RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error
+}

--- a/comp/snmpscan/fx/fx.go
+++ b/comp/snmpscan/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the snmpscan component
+package fx
+
+import (
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+	snmpscanimpl "github.com/DataDog/datadog-agent/comp/snmpscan/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			snmpscanimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[snmpscan.Component](),
+	)
+}

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -1,0 +1,71 @@
+package snmpscanimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/gosnmp/gosnmp"
+)
+
+func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string) error {
+	forwarder, err := s.demux.GetEventPlatformForwarder()
+	if err != nil {
+		return fmt.Errorf("unable to get sender: %w", err)
+	}
+
+	if err := snmpConnection.Connect(); err != nil {
+		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmpConnection.LocalAddr, snmpConnection.Port, err)
+	}
+	defer snmpConnection.Conn.Close()
+	pdus, err := gatherPDUs(snmpConnection)
+	if err != nil {
+		return err
+	}
+
+	deviceID := deviceNamespace + ":" + snmpConnection.LocalAddr
+	var deviceOids []*metadata.DeviceOID
+	for _, pdu := range pdus {
+		record, err := metadata.DeviceOIDFromPDU(deviceID, pdu)
+		if err != nil {
+			s.log.Warnf("PDU parsing error: %v", err)
+			continue
+		}
+		deviceOids = append(deviceOids, record)
+	}
+
+	metadataPayloads := metadata.BatchDeviceScan(deviceNamespace, time.Now(), metadata.PayloadMetadataBatchSize, deviceOids)
+	for _, payload := range metadataPayloads {
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			s.log.Errorf("Error marshalling device metadata: %v", err)
+			continue
+		}
+		m := message.NewMessage(payloadBytes, nil, "", 0)
+		s.log.Debugf("Device OID metadata payload is %d bytes", len(payloadBytes))
+		s.log.Tracef("Device OID metadata payload: %s", string(payloadBytes))
+		if err := forwarder.SendEventPlatformEventBlocking(m, eventplatform.EventTypeNetworkDevicesMetadata); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// gatherPDUs returns PDUs from the given SNMP device that should cover ever
+// scalar value and at least one row of every table.
+func gatherPDUs(snmp *gosnmp.GoSNMP) ([]*gosnmp.SnmpPDU, error) {
+	var pdus []*gosnmp.SnmpPDU
+	err := gosnmplib.ConditionalWalk(snmp, "", false, func(dataUnit gosnmp.SnmpPDU) (string, error) {
+		pdus = append(pdus, &dataUnit)
+		return gosnmplib.SkipOIDRowsNaive(dataUnit.Name), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pdus, nil
+}

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -7,7 +7,6 @@ package snmpscanimpl
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -18,11 +17,6 @@ import (
 )
 
 func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string) error {
-	forwarder, err := s.demux.GetEventPlatformForwarder()
-	if err != nil {
-		return fmt.Errorf("unable to get sender: %w", err)
-	}
-
 	pdus, err := gatherPDUs(snmpConnection)
 	if err != nil {
 		return err
@@ -49,7 +43,7 @@ func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceName
 		m := message.NewMessage(payloadBytes, nil, "", 0)
 		s.log.Debugf("Device OID metadata payload is %d bytes", len(payloadBytes))
 		s.log.Tracef("Device OID metadata payload: %s", string(payloadBytes))
-		if err := forwarder.SendEventPlatformEventBlocking(m, eventplatform.EventTypeNetworkDevicesMetadata); err != nil {
+		if err := s.epforwarder.SendEventPlatformEventBlocking(m, eventplatform.EventTypeNetworkDevicesMetadata); err != nil {
 			return err
 		}
 	}

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package snmpscanimpl
 
 import (

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -23,10 +23,6 @@ func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceName
 		return fmt.Errorf("unable to get sender: %w", err)
 	}
 
-	if err := snmpConnection.Connect(); err != nil {
-		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmpConnection.LocalAddr, snmpConnection.Port, err)
-	}
-	defer snmpConnection.Conn.Close()
 	pdus, err := gatherPDUs(snmpConnection)
 	if err != nil {
 		return err

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 )
@@ -29,9 +30,13 @@ type Provides struct {
 
 // NewComponent creates a new snmpscan component
 func NewComponent(reqs Requires) (Provides, error) {
+	forwarder, err := reqs.Demultiplexer.GetEventPlatformForwarder()
+	if err != nil {
+		return Provides{}, err
+	}
 	scanner := snmpScannerImpl{
-		log:   reqs.Logger,
-		demux: reqs.Demultiplexer,
+		log:         reqs.Logger,
+		epforwarder: forwarder,
 	}
 	provides := Provides{
 		Comp: scanner,
@@ -40,6 +45,6 @@ func NewComponent(reqs Requires) (Provides, error) {
 }
 
 type snmpScannerImpl struct {
-	log   log.Component
-	demux demultiplexer.Component
+	log         log.Component
+	epforwarder eventplatform.Forwarder
 }

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package snmpscanimpl implements the snmpscan component interface
+package snmpscanimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+)
+
+// Requires defines the dependencies for the snmpscan component
+type Requires struct {
+	// Remove this field if the component has no lifecycle hooks
+	Lifecycle     compdef.Lifecycle
+	Logger        log.Component
+	Demultiplexer demultiplexer.Component
+}
+
+// Provides defines the output of the snmpscan component
+type Provides struct {
+	Comp       snmpscan.Component
+	RCListener rcclienttypes.TaskListenerProvider
+}
+
+// NewComponent creates a new snmpscan component
+func NewComponent(reqs Requires) (Provides, error) {
+	scanner := snmpScannerImpl{
+		log:   reqs.Logger,
+		demux: reqs.Demultiplexer,
+	}
+	provides := Provides{
+		Comp: scanner,
+		// RCListener: rcclienttypes.NewTaskListener(scanner.onAgentTaskEvent),
+	}
+	return provides, nil
+}
+
+type snmpScannerImpl struct {
+	log   log.Component
+	demux demultiplexer.Component
+}
+
+// func (s snmpScannerImpl) onAgentTaskEvent(taskType rcclienttypes.TaskType, task rcclienttypes.AgentTaskConfig) (bool, error) {
+// 	return false, nil
+// }

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -9,9 +9,17 @@ package snmpscanimpl
 import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 )
+
+// Requires defines the dependencies for the snmpscan component
+type Requires struct {
+	compdef.In
+	Logger        log.Component
+	Demultiplexer demultiplexer.Component
+}
 
 // Provides defines the output of the snmpscan component
 type Provides struct {
@@ -20,7 +28,7 @@ type Provides struct {
 }
 
 // NewComponent creates a new snmpscan component
-func NewComponent(reqs snmpscan.Requires) (Provides, error) {
+func NewComponent(reqs Requires) (Provides, error) {
 	scanner := snmpScannerImpl{
 		log:   reqs.Logger,
 		demux: reqs.Demultiplexer,

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -9,18 +9,9 @@ package snmpscanimpl
 import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	compdef "github.com/DataDog/datadog-agent/comp/def"
 	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 )
-
-// Requires defines the dependencies for the snmpscan component
-type Requires struct {
-	// Remove this field if the component has no lifecycle hooks
-	Lifecycle     compdef.Lifecycle
-	Logger        log.Component
-	Demultiplexer demultiplexer.Component
-}
 
 // Provides defines the output of the snmpscan component
 type Provides struct {
@@ -29,14 +20,13 @@ type Provides struct {
 }
 
 // NewComponent creates a new snmpscan component
-func NewComponent(reqs Requires) (Provides, error) {
+func NewComponent(reqs snmpscan.Requires) (Provides, error) {
 	scanner := snmpScannerImpl{
 		log:   reqs.Logger,
 		demux: reqs.Demultiplexer,
 	}
 	provides := Provides{
 		Comp: scanner,
-		// RCListener: rcclienttypes.NewTaskListener(scanner.onAgentTaskEvent),
 	}
 	return provides, nil
 }
@@ -45,7 +35,3 @@ type snmpScannerImpl struct {
 	log   log.Component
 	demux demultiplexer.Component
 }
-
-// func (s snmpScannerImpl) onAgentTaskEvent(taskType rcclienttypes.TaskType, task rcclienttypes.AgentTaskConfig) (bool, error) {
-// 	return false, nil
-// }

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 //go:build test
 
 package snmpscanimpl

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -1,0 +1,36 @@
+//go:build test
+
+package snmpscanimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+)
+
+func TestSnmpScanComp(t *testing.T) {
+	deps := fxutil.Test[snmpscan.Requires](
+		t,
+		fx.Supply(core.BundleParams{}),
+		demultiplexerimpl.MockModule(),
+		core.MockBundle(),
+	)
+	snmpScanner, err := NewComponent(deps)
+	assert.NoError(t, err)
+
+	snmpConnection := gosnmp.Default
+	snmpConnection.LocalAddr = "127.0.0.1"
+	snmpConnection.Port = 0
+
+	err = snmpScanner.Comp.RunDeviceScan(snmpConnection, "default")
+	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
+
+	err = snmpScanner.Comp.RunDeviceScan(snmpConnection, "default")
+	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
+}

--- a/comp/snmpscan/impl/walkdevice.go
+++ b/comp/snmpscan/impl/walkdevice.go
@@ -1,0 +1,57 @@
+package snmpscanimpl
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/gosnmp/gosnmp"
+)
+
+// RunSnmpWalk prints every SNMP value, in the style of the unix snmpwalk command.
+func (s snmpScannerImpl) RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error {
+	// Perform a snmpwalk using Walk for all versions
+	if err := snmpConection.Walk(firstOid, printValue); err != nil {
+		return fmt.Errorf("unable to walk SNMP agent on %s:%d: %w", snmpConection.Target, snmpConection.Port, err)
+	}
+
+	return nil
+}
+
+// printValue prints a PDU in a similar style to snmpwalk -Ont
+func printValue(pdu gosnmp.SnmpPDU) error {
+	fmt.Printf("%s = ", pdu.Name)
+
+	switch pdu.Type {
+	case gosnmp.OctetString:
+		b := pdu.Value.([]byte)
+		if !gosnmplib.IsStringPrintable(b) {
+			var strBytes []string
+			for _, bt := range b {
+				strBytes = append(strBytes, strings.ToUpper(hex.EncodeToString([]byte{bt})))
+			}
+			fmt.Print("Hex-STRING: " + strings.Join(strBytes, " ") + "\n")
+		} else {
+			fmt.Printf("STRING: %s\n", string(b))
+		}
+	case gosnmp.ObjectIdentifier:
+		fmt.Printf("OID: %s\n", pdu.Value)
+	case gosnmp.TimeTicks:
+		fmt.Print(pdu.Value, "\n")
+	case gosnmp.Counter32:
+		fmt.Printf("Counter32: %d\n", pdu.Value.(uint))
+	case gosnmp.Counter64:
+		fmt.Printf("Counter64: %d\n", pdu.Value.(uint64))
+	case gosnmp.Integer:
+		fmt.Printf("INTEGER: %d\n", pdu.Value.(int))
+	case gosnmp.Gauge32:
+		fmt.Printf("Gauge32: %d\n", pdu.Value.(uint))
+	case gosnmp.IPAddress:
+		fmt.Printf("IpAddress: %s\n", pdu.Value.(string))
+	default:
+		fmt.Printf("TYPE %d: %d\n", pdu.Type, gosnmp.ToBigInt(pdu.Value))
+	}
+
+	return nil
+}

--- a/comp/snmpscan/impl/walkdevice.go
+++ b/comp/snmpscan/impl/walkdevice.go
@@ -15,10 +15,10 @@ import (
 )
 
 // RunSnmpWalk prints every SNMP value, in the style of the unix snmpwalk command.
-func (s snmpScannerImpl) RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error {
+func (s snmpScannerImpl) RunSnmpWalk(snmpConnection *gosnmp.GoSNMP, firstOid string) error {
 	// Perform a snmpwalk using Walk for all versions
-	if err := snmpConection.Walk(firstOid, printValue); err != nil {
-		return fmt.Errorf("unable to walk SNMP agent on %s:%d: %w", snmpConection.Target, snmpConection.Port, err)
+	if err := snmpConnection.Walk(firstOid, printValue); err != nil {
+		return fmt.Errorf("unable to walk SNMP agent on %s:%d: %w", snmpConnection.Target, snmpConnection.Port, err)
 	}
 
 	return nil

--- a/comp/snmpscan/impl/walkdevice.go
+++ b/comp/snmpscan/impl/walkdevice.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package snmpscanimpl
 
 import (

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -11,26 +11,30 @@ package mock
 import (
 	"testing"
 
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/gosnmp/gosnmp"
 )
 
-type mock struct{}
+type mock struct {
+	Logger log.Component
+}
 
+// Provides that defines the output of mocked snmpscan component
 type Provides struct {
 	comp snmpscan.Component
 }
 
-// New returns a mock compressor
+// New returns a mock snmpscanner
 func New(*testing.T) Provides {
 	return Provides{
 		comp: mock{},
 	}
 }
 
-func (m mock) RunDeviceScan(snmpConection *gosnmp.GoSNMP, deviceNamespace string) error {
+func (m mock) RunDeviceScan(_ *gosnmp.GoSNMP, _ string) error {
 	return nil
 }
-func (m mock) RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error {
+func (m mock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
 	return nil
 }

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the snmpscan component
+package mock
+
+import (
+	"testing"
+
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+)
+
+// Mock returns a mock for snmpscan component.
+func Mock(t *testing.T) snmpscan.Component {
+	// TODO: Implement the snmpscan mock
+	return nil
+}

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -12,10 +12,25 @@ import (
 	"testing"
 
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+	"github.com/gosnmp/gosnmp"
 )
 
-// Mock returns a mock for snmpscan component.
-func Mock(t *testing.T) snmpscan.Component {
-	// TODO: Implement the snmpscan mock
+type mock struct{}
+
+type Provides struct {
+	comp snmpscan.Component
+}
+
+// New returns a mock compressor
+func New(*testing.T) Provides {
+	return Provides{
+		comp: mock{},
+	}
+}
+
+func (m mock) RunDeviceScan(snmpConection *gosnmp.GoSNMP, deviceNamespace string) error {
+	return nil
+}
+func (m mock) RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error {
 	return nil
 }


### PR DESCRIPTION
Componentize the "walk" and "scan" SNMP commands. This is to allow registering a new "AgentTaskListener" with remote-config that will later call the RunDeviceScan method of the component