### PR TITLE
fix(fleet): Properly unset log level after a flare

### DIFF
--- a/comp/remote-config/rcclient/rcclientimpl/rcclient.go
+++ b/comp/remote-config/rcclient/rcclientimpl/rcclient.go
@@ -269,8 +269,8 @@ func (rc rcClient) agentConfigUpdateCallback(updates map[string]state.RawConfig,
 		//     - we want to change (once again) the log level through RC
 		//     - we want to fall back to the log level we had saved as fallback (in that case mergedConfig.LogLevel == "")
 		if len(mergedConfig.LogLevel) == 0 {
-			pkglog.Infof("Removing remote-config log level override, falling back to '%s'", config.Datadog().Get("log_level"))
 			config.Datadog().UnsetForSource("log_level", model.SourceRC)
+			pkglog.Infof("Removing remote-config log level override, falling back to '%s'", config.Datadog().Get("log_level"))
 		} else {
 			newLevel := mergedConfig.LogLevel
 			pkglog.Infof("Changing log level to '%s' through remote config", newLevel)

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -163,10 +163,7 @@ func (c *safeConfig) SetDefault(key string, value interface{}) {
 
 // UnsetForSource wraps Viper for concurrent access
 func (c *safeConfig) UnsetForSource(key string, source Source) {
-	c.Lock()
-	defer c.Unlock()
-	c.configSources[source].Set(key, nil)
-	c.mergeViperInstances(key)
+	c.Set(key, nil, source)
 }
 
 // mergeViperInstances is called after a change in an instance of Viper
@@ -640,6 +637,8 @@ func (c *safeConfig) MergeConfig(in io.Reader) error {
 // MergeFleetPolicy merges the configuration from the reader given with an existing config
 // it overrides the existing values with the new ones in the FleetPolicies source, and updates the main config
 // according to sources priority order.
+//
+// Note: this should only be called at startup, as notifiers won't receive a notification when this loads
 func (c *safeConfig) MergeFleetPolicy(configPath string) error {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -170,7 +170,7 @@ func (c *safeConfig) UnsetForSource(key string, source Source) {
 	c.configSources[source].Set(key, nil)
 	c.mergeViperInstances(key)
 	newValue := c.Viper.Get(key) // Can't use nil, so we get the newly computed value
-	if !reflect.DeepEqual(previousValue, nil) {
+	if previousValue != nil {
 		// if the value has not changed, do not duplicate the slice so that no callback is called
 		receivers = slices.Clone(c.notificationReceivers)
 	}

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -161,7 +161,8 @@ func (c *safeConfig) SetDefault(key string, value interface{}) {
 	c.Viper.SetDefault(key, value)
 }
 
-// UnsetForSource wraps Viper for concurrent access
+// UnsetForSource unsets a config entry for a given source
+// calls Set under the hood with a nil value
 func (c *safeConfig) UnsetForSource(key string, source Source) {
 	c.Set(key, nil, source)
 }

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -449,3 +449,20 @@ func TestParseEnvAsSliceMapString(t *testing.T) {
 	t.Setenv("DD_MAP", "__some_data__")
 	assert.Equal(t, []map[string]string{{"a": "a", "b": "b", "c": "c"}}, config.Get("map"))
 }
+
+func TestListenersUnsetForSource(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	// Create a listener that will keep track of the changes
+	logLevels := []string{}
+	config.OnUpdate(func(key string, previous, next any) {
+		nextString := next.(string)
+		logLevels = append(logLevels, nextString)
+	})
+
+	config.Set("log_level", "info", SourceFile)
+	config.Set("log_level", "debug", SourceRC)
+	config.UnsetForSource("log_level", SourceRC)
+
+	assert.Equal(t, []string{"info", "debug", "info"}, logLevels)
+}

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -455,7 +455,7 @@ func TestListenersUnsetForSource(t *testing.T) {
 
 	// Create a listener that will keep track of the changes
 	logLevels := []string{}
-	config.OnUpdate(func(key string, previous, next any) {
+	config.OnUpdate(func(_ string, _, next any) {
 		nextString := next.(string)
 		logLevels = append(logLevels, nextString)
 	})


### PR DESCRIPTION
### What does this PR do?
When sending a remote flare, customers are given the option to set the log level to debug. This log level should be reset after the flare is sent.

This isn't the case anymore following https://github.com/DataDog/datadog-agent/pull/27547:
1. When removing the log level, we call `UnsetForSource` and not `Set`
2. The callback logic doesn't exist for `UnsetForSource`, only for `Set`

It was all the more intriguing as the config properly reported `log_level: info` while the actual log level was `debug`.

This PR fixes it by making `UnsetForSource` call the listeners too

### Motivation
Log level must be reset properly

### Additional Notes
It would be nice to double check if all runtime commands do trigger the callbacks.

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Run an agent on your VM to target staging; with log level info. Then trigger a remote flare from Fleet Automation with debug logs (this will target the staging Zendesk). During the log collection the log level should be debug. Once the flare is sent, your log level should be back to info.