### PR TITLE
[CWS] directly call `filepath.Join` instead of `HostProc` in utils

### DIFF
--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -122,17 +123,20 @@ func ProcRootFilePath(pid uint32, file string) string {
 	return procPidPath2(pid, "root", file)
 }
 
+// we do not use `HostProc` here because of the double call to `filepath.Join`
+// and those functions can be called in a tight loop
+
 func procPidPath(pid uint32, path string) string {
-	return kernel.HostProc(strconv.FormatUint(uint64(pid), 10), path)
+	return filepath.Join(kernel.ProcFSRoot(), strconv.FormatUint(uint64(pid), 10), path)
 }
 
 func procPidPath2(pid uint32, path1 string, path2 string) string {
-	return kernel.HostProc(strconv.FormatUint(uint64(pid), 10), path1, path2)
+	return filepath.Join(kernel.ProcFSRoot(), strconv.FormatUint(uint64(pid), 10), path1, path2)
 }
 
 // ModulesPath returns the path to the modules file in /proc
 func ModulesPath() string {
-	return kernel.HostProc("modules")
+	return filepath.Join(kernel.ProcFSRoot(), "modules")
 }
 
 // GetLoginUID returns the login uid of the provided process


### PR DESCRIPTION
### What does this PR do?

While we try to understand if https://github.com/DataDog/datadog-agent/pull/29137 is a good path forward, calling directly `filepath.Join` offers the same benefits with much less risk.

The main goal is to optimize calls to `ProcRootFilePath` [that can be called in a tight loop](https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20datacenter%3Aus1.ddbuild.io%20&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost&event=AgAAAZHHHOvhSXaKiwAAAAAAAAAYAAAAAEFaSEhIT3Z0QUFCbVY4TFFyNEh0cHdBQQAAACQAAAAAMDE5MWM3MjEtNDQwNC00NTA0LWI0ODgtNTM1ZDM1NjY0NDRm&group_by=line&my_code=disabled&profile_type=alloc-size&profileId=AZHHHOvtAABmV8LQr4HtpwAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1725621377600&to_ts=1725624977600&live=false).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
