### PR TITLE
[AMLII-2015] Check agent ready before logging to it

### DIFF
--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -85,7 +85,7 @@ func (s *LinuxJournaldFakeintakeSuite) journaldLogCollection() {
 	// Restart agent and make sure it's ready before adding logs
 	_, err = s.Env().RemoteHost.Execute("sudo systemctl restart datadog-agent")
 	assert.NoErrorf(t, err, "Failed to restart the agent: %s", err)
-	s.EventuallyWithT(func(c *assert.CollectT) {
+	s.EventuallyWithT(func(_ *assert.CollectT) {
 		agentReady := s.Env().Agent.Client.IsReady()
 		assert.True(t, agentReady)
 	}, 1*time.Minute, 5*time.Second, "Agent was not ready")

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -82,8 +82,13 @@ func (s *LinuxJournaldFakeintakeSuite) journaldLogCollection() {
 	_, err := s.Env().RemoteHost.Execute("sudo usermod -a -G systemd-journal dd-agent")
 	require.NoErrorf(t, err, "Unable to adjust permissions for dd-agent user: %s", err)
 
-	// Restart agent
-	s.Env().RemoteHost.Execute("sudo systemctl restart datadog-agent")
+	// Restart agent and make sure it's ready before adding logs
+	_, err = s.Env().RemoteHost.Execute("sudo systemctl restart datadog-agent")
+	assert.NoErrorf(t, err, "Failed to restart the agent: %s", err)
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		agentReady := s.Env().Agent.Client.IsReady()
+		assert.True(t, agentReady)
+	}, 1*time.Minute, 5*time.Second, "Agent was not ready")
 
 	// Generate log
 	appendJournaldLog(s, "hello-world", 1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a condition to make sure the agent is ready before logging to it in the journald e2e test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Test was found flaky in a previous test run, this addition narrows down the source of the possible flakiness.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

`EventuallyWithT` might cause the test to wait.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure the test e2e test runs correctly.
