### PR TITLE
APM: Use `compressor.Encoding()` for error log messages

### DIFF
--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -294,14 +294,14 @@ func (w *TraceWriter) serialize(pl *pb.AgentPayload) {
 	if err != nil {
 		// it will never happen, unless an invalid compression is chosen;
 		// we know gzip.BestSpeed is valid.
-		log.Errorf("Failed to initialize gzip writer. No traces can be sent: %v", err)
+		log.Errorf("Failed to initialize %s writer. No traces can be sent: %v", w.compressor.Encoding(), err)
 		return
 	}
 	if _, err := writer.Write(b); err != nil {
-		log.Errorf("Error gzipping trace payload: %v", err)
+		log.Errorf("Error %s trace payload: %v", w.compressor.Encoding(), err)
 	}
 	if err := writer.Close(); err != nil {
-		log.Errorf("Error closing gzip stream when writing trace payload: %v", err)
+		log.Errorf("Error closing %s stream when writing trace payload: %v", w.compressor.Encoding(), err)
 	}
 	sendPayloads(w.senders, p, w.syncMode)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use [compressor.Encoding()](https://github.com/DataDog/datadog-agent/blob/6e355775b3d0cb61b371c3600a55b0ed755e35ee/comp/trace/compression/def/component.go#L14-L18) for error log messages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Currently `gzip` is hardcoded in log messages.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

#26775 relates to this PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
