### PR TITLE
[gitlab] introduce versioning for otel images

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -57,14 +57,6 @@ include:
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
 
-.deploy_containers-a7-ot_external:
-  extends: .deploy_containers-a7-base-ot
-  parallel:
-    matrix:
-      - JMX:
-          - ""
-          - "-jmx"
-
 deploy_containers-a7:
   extends: .deploy_containers-a7_external
   rules:
@@ -105,10 +97,15 @@ deploy_containers-a7_internal-rc:
 
 
 deploy_containers-ot:
-  extends: .deploy_containers-a7-ot_external
+  extends: .deploy_containers-a7-base-ot
   rules:
     - when: manual
       allow_failure: true
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
 
 
 #

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -45,6 +45,25 @@ include:
           - "-servercore"
           - "-linux"
 
+.deploy_containers-a7-base-ot:
+  extends: .docker_publish_job_definition
+  stage: deploy_containers
+  variables:
+    AGENT_REPOSITORY: agent
+    IMG_REGISTRIES: public
+  dependencies: []
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
+    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
+
+.deploy_containers-a7-ot_external:
+  extends: .deploy_containers-a7-base-ot
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
 
 deploy_containers-a7:
   extends: .deploy_containers-a7_external
@@ -86,22 +105,10 @@ deploy_containers-a7_internal-rc:
 
 
 deploy_containers-ot:
-  extends: .docker_publish_job_definition
-  stage: deploy_containers
+  extends: .deploy_containers-a7-ot_external
   rules:
     - when: manual
       allow_failure: true
-  variables:
-    AGENT_REPOSITORY: agent
-    IMG_REGISTRIES: public
-    VERSION: 7
-  dependencies: []
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta
-      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-arm64
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta-jmx
 
 
 #
@@ -129,7 +136,6 @@ deploy_containers_latest-a7:
         IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
-
 deploy_containers_latest-a7_internal:
   extends: .docker_publish_job_definition
   stage: deploy_containers
@@ -142,7 +148,6 @@ deploy_containers_latest-a7_internal:
         IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx
 
-
 deploy_containers_latest-dogstatsd:
   extends: .docker_publish_job_definition
   stage: deploy_containers
@@ -152,3 +157,22 @@ deploy_containers_latest-dogstatsd:
   variables:
     IMG_SOURCES: ${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
+
+deploy_containers_latest-ot:
+  extends: .docker_publish_job_definition
+  stage: deploy_containers
+  rules:
+    - when: manual
+      allow_failure: true
+  variables:
+    AGENT_REPOSITORY: agent
+    IMG_REGISTRIES: public
+    VERSION: 7
+  dependencies: []
+  parallel:
+    matrix:
+      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta
+      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-arm64
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta-jmx
+

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -48,14 +48,13 @@ include:
 .deploy_containers-a7-base-ot:
   extends: .docker_publish_job_definition
   stage: deploy_containers
+  rules:
+    - when: manual
+      allow_failure: true
   variables:
     AGENT_REPOSITORY: agent
     IMG_REGISTRIES: public
   dependencies: []
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
-    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
 
 deploy_containers-a7:
   extends: .deploy_containers-a7_external
@@ -98,9 +97,10 @@ deploy_containers-a7_internal-rc:
 
 deploy_containers-ot:
   extends: .deploy_containers-a7-base-ot
-  rules:
-    - when: manual
-      allow_failure: true
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
+    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
   parallel:
     matrix:
       - JMX:
@@ -156,16 +156,9 @@ deploy_containers_latest-dogstatsd:
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
 
 deploy_containers_latest-ot:
-  extends: .docker_publish_job_definition
-  stage: deploy_containers
-  rules:
-    - when: manual
-      allow_failure: true
+  extends: .deploy_containers-a7-base-ot
   variables:
-    AGENT_REPOSITORY: agent
-    IMG_REGISTRIES: public
     VERSION: 7
-  dependencies: []
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR adds publishing of stable image tags for OTel beta. This results in two sets of images:
`latest` -> `agent:7-ot-beta[-jmx]`
`stable` -> `agent:${VERSION}-ot-beta[-jmx]` 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Allow customers to be pinned to specific version, while continuing support of a `latest`-style tag supporting customers who want to be on the bleeding edge.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
```
otel-agent version
```
should be aligned with:
```
datadog-agent version
```

Additionally, for OTel extended testing (out-of-scope for non-OTel teams), we should validate the metadata payload submitted contains consistent versioning with the `otel-agent version` output (while the OTel versioning being reported should be preserved for the flare extension). 
