### PR TITLE
[APM] Do not crash on UDS listener failure

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -279,17 +279,18 @@ func (r *HTTPReceiver) Start() {
 		if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
 			ln, err := r.listenUnix(path)
 			if err != nil {
+				log.Errorf("Error creating UDS listener: %v", err)
 				r.telemetryCollector.SendStartupError(telemetry.CantStartUdsServer, err)
-				killProcess("Error creating UDS listener: %v", err)
+			} else {
+				go func() {
+					defer watchdog.LogOnPanic(r.statsd)
+					if err := r.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+						log.Errorf("Could not start UDS server: %v. UDS receiver disabled.", err)
+						r.telemetryCollector.SendStartupError(telemetry.CantStartUdsServer, err)
+					}
+				}()
+				log.Infof("Listening for traces at unix://%s", path)
 			}
-			go func() {
-				defer watchdog.LogOnPanic(r.statsd)
-				if err := r.server.Serve(ln); err != nil && err != http.ErrServerClosed {
-					log.Errorf("Could not start UDS server: %v. UDS receiver disabled.", err)
-					r.telemetryCollector.SendStartupError(telemetry.CantStartUdsServer, err)
-				}
-			}()
-			log.Infof("Listening for traces at unix://%s", path)
 		} else {
 			log.Errorf("Could not start UDS listener: socket directory does not exist: %s", path)
 		}

--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -114,6 +115,18 @@ func TestHTTPReceiverStart(t *testing.T) {
 			return true, port, socket, []string{
 				fmt.Sprintf("Listening for traces at http://localhost:%d", port),
 				fmt.Sprintf("Listening for traces at unix://%s", socket),
+			}
+		},
+		"err_uds": func() (bool, int, string, []string) {
+			dir := t.TempDir()
+			err := os.Chmod(dir, 0555) // read-execute only
+			assert.NoError(t, err)
+
+			port := freeTCPPort()
+			socket := filepath.Join(dir, "apm.socket")
+			return true, port, socket, []string{
+				fmt.Sprintf("Listening for traces at http://localhost:%d", port),
+				fmt.Sprintf("Error creating UDS listener: listen unix %s: bind: permission denied", socket),
 			}
 		},
 	} {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Failing to create the UDS listener (tipically occurred due to permission issue) should not result on a process crash.

This commit changes the startup issue to just logging the error, and thus having the same behavior as the dogstatsd UDS startup (log the error, not crash)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Since Agent 7.57 the trace-agent has a default UDS path on which the UDS listener will be created. If the directory exists, but the process lacks the necessary permissions, the process is currently crashing. See https://github.com/DataDog/datadog-agent/issues/29155

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

QA done