### PR TITLE
[EBPF] Fall back to single-item iterator in GenericMap

### DIFF
--- a/pkg/ebpf/maps/generic_map.go
+++ b/pkg/ebpf/maps/generic_map.go
@@ -60,11 +60,11 @@ type GenericMap[K any, V any] struct {
 }
 
 func canBinaryReadKey[K any]() bool {
-	kvalList := make([]K, 1)
-	buffer := make([]byte, unsafe.Sizeof(kvalList[0]))
+	kval := new(K)
+	buffer := make([]byte, unsafe.Sizeof(*kval))
 	reader := bytes.NewReader(buffer)
 
-	err := binary.Read(reader, binary.LittleEndian, kvalList)
+	err := binary.Read(reader, binary.LittleEndian, kval)
 
 	return err == nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Adds a check when creating a `GenericMap` object that allows the iterator to fall back to the single-item iterator when the key type is not supported by `binary.Read` (e.g., when the key is a struct with pointer fields).

### Motivation

Fix iteration errors.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
