### PR TITLE
[EBPF] Replace generated pointers to structs with uintptr

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -44,6 +44,10 @@ func main() {
 	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(` + strings.Join(int8variableNames, "|") + `)(\s+)\[(\d+)\]u?int8`)
 	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
+	// Convert generated pointers to CGo structs to uintptr
+	convertPointerToUint64Regex := regexp.MustCompile(`\*_Ctype_struct_(\w+)`)
+	b = convertPointerToUint64Regex.ReplaceAll(b, []byte("uintptr"))
+
 	b, err = format.Source(b)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -77,12 +77,12 @@ type PIDFD struct {
 	Fd  uint32
 }
 type UDPRecvSock struct {
-	Sk  *_Ctype_struct_sock
-	Msg *_Ctype_struct_msghdr
+	Sk  uintptr
+	Msg uintptr
 }
 type BindSyscallArgs struct {
-	Addr *_Ctype_struct_sockaddr
-	Sk   *_Ctype_struct_sock
+	Addr uintptr
+	Sk   uintptr
 }
 type ProtocolStack struct {
 	Api         uint8

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -516,7 +516,7 @@ def ninja_cgo_type_files(nw: NinjaWriter):
             inputs=[f],
             outputs=[os.path.join(in_dir, out_file)],
             rule="godefs",
-            implicit=headers,
+            implicit=headers + [script_path],
             variables={
                 "in_dir": in_dir,
                 "in_file": in_file,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Changes the `genpost` code to generate `uintptr` types instead of `*_Ctype_struct_...` types, as the pointers are not valid on the Go side anyways, and the pointer types  cause problems with batch iterators (related: https://github.com/DataDog/datadog-agent/pull/29220) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
