### PR TITLE
sds: histogram on SDS processing latency.

### DIFF
--- a/pkg/logs/sds/scanner.go
+++ b/pkg/logs/sds/scanner.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -32,6 +33,8 @@ var (
 		"Count of SDS reconfiguration error.", telemetry.Options{DefaultMetric: true})
 	tlmSDSReconfigSuccess = telemetry.NewCounterWithOpts("sds", "reconfiguration_success", []string{"pipeline", "type"},
 		"Count of SDS reconfiguration success.", telemetry.Options{DefaultMetric: true})
+	tlmSDSProcessingLatency = telemetry.NewSimpleHistogram("sds", "processing_latency", "Processing latency histogram",
+	                 []float64{10, 250, 500, 2000, 5000, 10000}) // unit: us
 )
 
 // Scanner wraps an SDS Scanner implementation, adds reconfiguration
@@ -284,7 +287,6 @@ func interpretRCRule(userRule RuleConfig, standardRule StandardRuleConfig, defau
 		reqCapabilitiesCount := len(stdRuleDef.RequiredCapabilities)
 		if reqCapabilitiesCount > 0 {
 			if reqCapabilitiesCount > 1 {
-				// TODO(remy): telemetry
 				log.Warnf("Standard rule '%v' with multiple required capabilities: %d. Only the first one will be used", standardRule.Name, reqCapabilitiesCount)
 			}
 			received := stdRuleDef.RequiredCapabilities[0]
@@ -307,7 +309,6 @@ func interpretRCRule(userRule RuleConfig, standardRule StandardRuleConfig, defau
 	}
 
 	if defToUse.Version == -1 {
-		// TODO(remy): telemetry
 		return nil, fmt.Errorf("unsupported rule with no compatible definition")
 	}
 
@@ -358,6 +359,7 @@ func interpretRCRule(userRule RuleConfig, standardRule StandardRuleConfig, defau
 func (s *Scanner) Scan(event []byte, msg *message.Message) (bool, []byte, error) {
 	s.Lock()
 	defer s.Unlock()
+	start := time.Now()
 
 	if s.Scanner == nil {
 		return false, nil, fmt.Errorf("can't Scan with an unitialized scanner")
@@ -378,6 +380,7 @@ func (s *Scanner) Scan(event []byte, msg *message.Message) (bool, []byte, error)
 	// using a tag.
 	msg.ProcessingTags = append(msg.ProcessingTags, ScannedTag)
 
+	tlmSDSProcessingLatency.Observe(float64(time.Since(start) / 1000))
 	return scanResult.Mutated, scanResult.Event, err
 }
 

--- a/pkg/logs/sds/scanner.go
+++ b/pkg/logs/sds/scanner.go
@@ -33,7 +33,7 @@ var (
 		"Count of SDS reconfiguration error.", telemetry.Options{DefaultMetric: true})
 	tlmSDSReconfigSuccess = telemetry.NewCounterWithOpts("sds", "reconfiguration_success", []string{"pipeline", "type"},
 		"Count of SDS reconfiguration success.", telemetry.Options{DefaultMetric: true})
-	tlmSDSProcessingLatency = telemetry.NewSimpleHistogram("sds", "processing_latency", "Processing latency histogram",
+	tlmSDSProcessingLatency = telemetry.NewSimpleHistogram("sds", "processing_latency_us", "Processing latency histogram",
 	                 []float64{10, 250, 500, 2000, 5000, 10000}) // unit: us
 )
 

--- a/pkg/logs/sds/scanner.go
+++ b/pkg/logs/sds/scanner.go
@@ -33,7 +33,7 @@ var (
 		"Count of SDS reconfiguration error.", telemetry.Options{DefaultMetric: true})
 	tlmSDSReconfigSuccess = telemetry.NewCounterWithOpts("sds", "reconfiguration_success", []string{"pipeline", "type"},
 		"Count of SDS reconfiguration success.", telemetry.Options{DefaultMetric: true})
-	tlmSDSProcessingLatency = telemetry.NewSimpleHistogram("sds", "processing_latency_us", "Processing latency histogram",
+	tlmSDSProcessingLatency = telemetry.NewSimpleHistogram("sds", "processing_latency", "Processing latency histogram",
 	                 []float64{10, 250, 500, 2000, 5000, 10000}) // unit: us
 )
 


### PR DESCRIPTION
### What does this PR do?

Adds processing latency around the SDS scanner.

Note that the TODO are removed because they're not TODO anymore:
  * `L287`: the Warning log is enough for this situation, this is not an expected behaviour and there is no reason to report a metric, the log `L288` is the proper signal
  * `L310`: since an error is reported `L311`, a telemetry metric is properly reported by the caller.

### Motivation

Improve the visibility on performance, letting us better estimate the impact of the SDS processing on the whole SDS pipeline: it is not about measuring the performance but about having a signal on the potential impact on back-pressure / the logs agent pipeline.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

The Agent reports the new `processing_latency` metric on the `:5000/telemetry` route.