### PR TITLE
[APM] Normalize ctags header on telemetry proxy

### DIFF
--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -257,8 +257,9 @@ func (f *TelemetryForwarder) setRequestHeader(req *http.Request) {
 		req.Header.Set(header.ContainerID, containerID)
 	}
 	if containerTags != "" {
-		req.Header.Set("x-datadog-container-tags", containerTags)
-		log.Debugf("Setting header x-datadog-container-tags=%s for telemetry proxy", containerTags)
+		ctagsHeader := normalizeHTTPHeader(containerTags)
+		req.Header.Set("X-Datadog-Container-Tags", ctagsHeader)
+		log.Debugf("Setting header X-Datadog-Container-Tags=%s for telemetry proxy", ctagsHeader)
 	}
 	if f.conf.InstallSignature.Found {
 		req.Header.Set("DD-Agent-Install-Id", f.conf.InstallSignature.InstallID)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Follow up on #28662 

Container Tags may container line breaks, which are incompatible with HTTP header values.

`apmtelemetry` proxy was missing this normalization, which is the same one applied on other trace-agent proxies, where line breaks are converted to underscores in order to be used as HTTP header values.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

#28662 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

N/A