### PR TITLE
[CWS] Do not return container ID for systemd cgroups

### DIFF
--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -67,7 +67,7 @@ func GetContainerFromCgroup(cgroup string) (string, CGroupFlags) {
 // GetCgroupFromContainer infers the container runtime from a cgroup name
 func GetCgroupFromContainer(id ContainerID, flags CGroupFlags) CGroupID {
 	for runtimePrefix, runtimeFlag := range RuntimePrefixes {
-		if uint64(flags)&0b111 == uint64(runtimeFlag) {
+		if flags&CGroupManagerMask == CGroupFlags(runtimeFlag) {
 			return CGroupID(runtimePrefix + string(id))
 		}
 	}

--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -80,7 +80,7 @@ func FindContainerID(s string) (string, uint64) {
 // GetCGroupContext returns the cgroup ID and the sanitized container ID from a container id/flags tuple
 func GetCGroupContext(containerID ContainerID, cgroupFlags CGroupFlags) (CGroupID, ContainerID) {
 	cgroupID := GetCgroupFromContainer(containerID, cgroupFlags)
-	if cgroupFlags&0b111 == 0 {
+	if !cgroupFlags.IsContainer() {
 		containerID = ""
 	}
 	return CGroupID(cgroupID), ContainerID(containerID)

--- a/pkg/security/secl/containerutils/types.go
+++ b/pkg/security/secl/containerutils/types.go
@@ -14,3 +14,8 @@ type CGroupID string
 
 // CGroupFlags represents the flags of a cgroup
 type CGroupFlags uint64
+
+// IsContainer returns whether a cgroup maps to a container
+func (f CGroupFlags) IsContainer() bool {
+	return (f&0b111 != 0) && ((f & 0b111) != CGroupFlags(CGroupManagerSystemd))
+}

--- a/pkg/security/secl/containerutils/types.go
+++ b/pkg/security/secl/containerutils/types.go
@@ -15,7 +15,10 @@ type CGroupID string
 // CGroupFlags represents the flags of a cgroup
 type CGroupFlags uint64
 
+// CGroupManagerMask holds the bitmask for the cgroup manager
+const CGroupManagerMask CGroupFlags = 0b111
+
 // IsContainer returns whether a cgroup maps to a container
 func (f CGroupFlags) IsContainer() bool {
-	return (f&0b111 != 0) && ((f & 0b111) != CGroupFlags(CGroupManagerSystemd))
+	return (f&CGroupManagerMask != 0) && ((f & CGroupManagerMask) != CGroupFlags(CGroupManagerSystemd))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Return an empty container ID for systemd cgroups.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In some cases, the `container.id` field can be set for systemd cgroups.
Until we find the underlying issue, return an empty value when we detect this case.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
