### PR TITLE
[EBPF] Improve pulumi error parsing for KMT diagnostics

### DIFF
--- a/test/new-e2e/system-probe/errors_test.go
+++ b/test/new-e2e/system-probe/errors_test.go
@@ -94,7 +94,7 @@ Resources:
 Duration: 6s
 `
 
-const outputSshFailed = `
+const outputSSHFailed = `
     pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 **failed** 1 error
 Diagnostics:
   pulumi:pulumi:Stack (e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877):
@@ -109,7 +109,7 @@ Resources:
 Duration: 7m35s
 `
 
-const outputSshFailedWithChangedOrder = `
+const outputSSHFailedWithChangedOrder = `
 @ updating....
  +  pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 creating (933s) error: update failed
  +  pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 **creating failed (933s)** 1 error
@@ -148,7 +148,7 @@ func TestParseDiagnostics(t *testing.T) {
 		},
 		{
 			caseName: "SSHFailed",
-			output:   outputSshFailed,
+			output:   outputSSHFailed,
 			result: pulumiError{
 				command:      "remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb",
 				arch:         "arm64",
@@ -159,7 +159,7 @@ func TestParseDiagnostics(t *testing.T) {
 		},
 		{
 			caseName: "SSHFailedWithChangedOrder",
-			output:   outputSshFailedWithChangedOrder,
+			output:   outputSSHFailedWithChangedOrder,
 			result: pulumiError{
 				command:      "remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb",
 				arch:         "arm64",

--- a/test/new-e2e/system-probe/errors_test.go
+++ b/test/new-e2e/system-probe/errors_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const output = `
+const outputLocalError = `
 Updating (gjulian-guillermo.julian-e2e-report-all-errors-ddvm):
 
     pulumi:pulumi:Stack e2elocal-gjulian-guillermo.julian-e2e-report-all-errors-ddvm running
@@ -94,12 +94,142 @@ Resources:
 Duration: 6s
 `
 
+const outputSshFailed = `
+    pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 **failed** 1 error
+Diagnostics:
+  pulumi:pulumi:Stack (e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877):
+    error: update failed
+  command:remote:Command (remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb):
+    error: proxy: after 60 failed attempts: ssh: rejected: connect failed (No route to host)
+Outputs:
+    kmt-stack: [secret]
+Resources:
+    +-8 replaced
+    349 unchanged
+Duration: 7m35s
+`
+
+const outputSshFailedWithChangedOrder = `
+@ updating....
+ +  pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 creating (933s) error: update failed
+ +  pulumi:pulumi:Stack e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877 **creating failed (933s)** 1 error
+Diagnostics:
+  command:remote:Command (remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb):
+    error: proxy: after 60 failed attempts: ssh: rejected: connect failed (No route to host)
+
+  pulumi:pulumi:Stack (e2eci-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877):
+    error: update failed
+
+Outputs:
+    kmt-stack: [secret]
+
+Resources:
+    + 357 created
+
+Duration: 15m34s
+`
+
 func TestParseDiagnostics(t *testing.T) {
-	result := parsePulumiDiagnostics(output)
-	require.NotNil(t, result)
-	require.Equal(t, "remote-gjulian-guillermo.julian-e2e-report-all-errors-ddvm-arm64-conn-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-cmd-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-mount-disk-dev-vdb", result.command)
-	require.Equal(t, "arm64", result.arch)
-	require.Equal(t, "mount-disk-dev-vdb", result.vmCommand)
-	require.Equal(t, "error: Process exited with status 127: running \" nocommand /mnt/docker && mount /dev/vdb /mnt/docker\":\nbash: line 1: nocommand: command not found\n", result.errorMessage)
-	require.Equal(t, "ubuntu_22.04", result.vmName)
+	cases := []struct {
+		caseName string
+		output   string
+		result   pulumiError
+	}{
+		{
+			caseName: "LocalError",
+			output:   outputLocalError,
+			result: pulumiError{
+				command:      "remote-gjulian-guillermo.julian-e2e-report-all-errors-ddvm-arm64-conn-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-cmd-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-mount-disk-dev-vdb",
+				arch:         "arm64",
+				vmCommand:    "mount-disk-dev-vdb",
+				errorMessage: "error: Process exited with status 127: running \" nocommand /mnt/docker && mount /dev/vdb /mnt/docker\":\nbash: line 1: nocommand: command not found\n",
+				vmName:       "ubuntu_22.04",
+			},
+		},
+		{
+			caseName: "SSHFailed",
+			output:   outputSshFailed,
+			result: pulumiError{
+				command:      "remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb",
+				arch:         "arm64",
+				vmCommand:    "mount-disk-dev-vdb",
+				vmName:       "fedora_37",
+				errorMessage: "error: proxy: after 60 failed attempts: ssh: rejected: connect failed (No route to host)\n",
+			},
+		},
+		{
+			caseName: "SSHFailedWithChangedOrder",
+			output:   outputSshFailedWithChangedOrder,
+			result: pulumiError{
+				command:      "remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb",
+				arch:         "arm64",
+				vmCommand:    "mount-disk-dev-vdb",
+				vmName:       "fedora_37",
+				errorMessage: "error: proxy: after 60 failed attempts: ssh: rejected: connect failed (No route to host)\n",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(tt *testing.T) {
+			result := parsePulumiDiagnostics(c.output)
+			require.NotNil(tt, result)
+			require.Equal(tt, c.result, *result)
+		})
+	}
+}
+
+func TestParsePulumiCommand(t *testing.T) {
+	cases := []struct {
+		caseName string
+		command  string
+		arch     string
+		vmCmd    string
+		vmName   string
+	}{
+		{
+			caseName: "NoVMSet",
+			command:  "remote-gjulian-guillermo.julian-e2e-report-all-errors-ddvm-arm64-conn-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-cmd-arm64-ubuntu_22.04-distro_arm64-ddvm-4-8192-mount-disk-dev-vdb",
+			arch:     "arm64",
+			vmCmd:    "mount-disk-dev-vdb",
+			vmName:   "ubuntu_22.04",
+		},
+		{
+			caseName: "CommandWithoutVM",
+			command:  "remote-aws-ci-634872953-4670-kernel-matrix-testing-system-probe-x86-64-44043832-x86_64-cmd-only_usm-distro_x86_64-download-with-curl",
+			arch:     "x86_64",
+			vmCmd:    "download-with-curl",
+			vmName:   "",
+		},
+		{
+			caseName: "DomainCreationCommand",
+			command:  "remote-aws-ci-632806887-4670-kernel-matrix-testing-system-probe-arm64-43913143-arm64-cmd-arm64-debian_12-distro_arm64-no_usm-ddvm-4-12288-create-nvram",
+			arch:     "arm64",
+			vmCmd:    "create-nvram",
+			vmName:   "debian_12",
+		},
+		{
+			caseName: "AlteredTagOrder",
+			command:  "remote-ci-632806887-4670-kernel-matrix-testing-system-probe-arm64-43913143-arm64-conn-arm64-ubuntu_23.10-only_usm-distro_arm64-ddvm-4-12288-cmd-arm64-ubuntu_23.10-only_usm-distro_arm64-ddvm-4-12288-set-docker-data-root",
+			arch:     "arm64",
+			vmCmd:    "set-docker-data-root",
+			vmName:   "ubuntu_23.10",
+		},
+		{
+			caseName: "CommandWithVMSet",
+			command:  "remote-ci-630160752-4670-kernel-matrix-testing-system-probe-arm64-43724877-arm64-conn-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-cmd-arm64-fedora_37-no_usm-distro_arm64-ddvm-4-12288-mount-disk-dev-vdb",
+			arch:     "arm64",
+			vmCmd:    "mount-disk-dev-vdb",
+			vmName:   "fedora_37",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(tt *testing.T) {
+			arch, vmCmd, vmName := parsePulumiComand(c.command)
+			require.Equal(tt, c.arch, arch)
+			require.Equal(tt, c.vmCmd, vmCmd)
+			require.Equal(tt, c.vmName, vmName)
+		})
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Improves the code that parses pulumi errors to send as events for KMT diagnostics.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
