### PR TITLE
[e2e] recreate stack on fakeintake timeout

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -18,38 +18,36 @@ const (
 type knownError struct {
 	errorMessage string
 	retryType    RetryType
-	isRegex      bool
 }
 
 func getKnownErrors() []knownError {
 	// Add here errors that are known to be flakes and that should be retried
 	return []knownError{
 		{
-			errorMessage: "i/o timeout",
+			errorMessage: `i\/o timeout`,
 			retryType:    ReCreate,
 		},
 		{
 			// https://datadoghq.atlassian.net/browse/ADXT-1
-			errorMessage: "failed attempts: dial tcp :22: connect: connection refused",
+			errorMessage: `failed attempts: dial tcp :22: connect: connection refused`,
 			retryType:    ReCreate,
 		},
 		{
 			// https://datadoghq.atlassian.net/browse/ADXT-295
-			errorMessage: "Resource provider reported that the resource did not exist while updating",
+			errorMessage: `Resource provider reported that the resource did not exist while updating`,
 			retryType:    ReCreate,
 		},
 		{
 			// https://datadoghq.atlassian.net/browse/ADXT-558
-			errorMessage: "Process exited with status 2: running \" sudo cloud-init status --wait\"",
+			errorMessage: `Process exited with status 2: running " sudo cloud-init status --wait"`,
 			retryType:    ReCreate,
 		},
 		{
-			isRegex:      true,
 			errorMessage: `waiting for ECS Service .+fakeintake-ecs.+ create\: timeout while waiting for state to become 'tfSTABLE'`,
 			retryType:    ReCreate,
 		},
 		{
-			errorMessage: "error while waiting for fakeintake",
+			errorMessage: `error while waiting for fakeintake`,
 			retryType:    ReCreate,
 		},
 	}

--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -43,7 +43,7 @@ func getKnownErrors() []knownError {
 			retryType:    ReCreate,
 		},
 		{
-			errorMessage: `waiting for ECS Service .+fakeintake-ecs.+ create\: timeout while waiting for state to become 'tfSTABLE'`,
+			errorMessage: `waiting for ECS Service .+fakeintake-ecs.+ create: timeout while waiting for state to become 'tfSTABLE'`,
 			retryType:    ReCreate,
 		},
 		{

--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -48,5 +48,9 @@ func getKnownErrors() []knownError {
 			errorMessage: `waiting for ECS Service .+fakeintake-ecs.+ create\: timeout while waiting for state to become 'tfSTABLE'`,
 			retryType:    ReCreate,
 		},
+		{
+			errorMessage: "error while waiting for fakeintake",
+			retryType:    ReCreate,
+		},
 	}
 }

--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -43,5 +43,10 @@ func getKnownErrors() []knownError {
 			errorMessage: "Process exited with status 2: running \" sudo cloud-init status --wait\"",
 			retryType:    ReCreate,
 		},
+		{
+			isRegex:      true,
+			errorMessage: `waiting for ECS Service .+fakeintake-ecs.+ create\: timeout while waiting for state to become 'tfSTABLE'`,
+			retryType:    ReCreate,
+		},
 	}
 }

--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -18,6 +18,7 @@ const (
 type knownError struct {
 	errorMessage string
 	retryType    RetryType
+	isRegex      bool
 }
 
 func getKnownErrors() []knownError {

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -56,16 +57,16 @@ var (
 	initStackManager sync.Once
 )
 
-// RetryStrategy is a function that given the current error and the number of retries, returns the type of retry to perform and a list of options to modify the configuration
-type RetryStrategy func(error, int) (RetryType, []GetStackOption)
+// RetryStrategyFromFn is a function that given the current error and the number of retries, returns the type of retry to perform and a list of options to modify the configuration
+type RetryStrategyFromFn func(error, int) (RetryType, []GetStackOption)
 
 // StackManager handles
 type StackManager struct {
 	stacks      *safeStackMap
 	knownErrors []knownError
 
-	// RetryStrategy defines how to handle retries. By default points to StackManager.getRetryStrategyFrom but can be overridden
-	RetryStrategy RetryStrategy
+	// GetRetryStrategyFrom defines how to handle retries. By default points to StackManager.getRetryStrategyFrom but can be overridden
+	GetRetryStrategyFrom RetryStrategyFromFn
 }
 
 type safeStackMap struct {
@@ -120,7 +121,7 @@ func newStackManager() (*StackManager, error) {
 		stacks:      newSafeStackMap(),
 		knownErrors: getKnownErrors(),
 	}
-	sm.RetryStrategy = sm.getRetryStrategyFrom
+	sm.GetRetryStrategyFrom = sm.getRetryStrategyFrom
 
 	return sm, nil
 }
@@ -523,7 +524,7 @@ func (sm *StackManager) getStack(ctx context.Context, name string, deployFunc pu
 			}
 		}
 
-		retryStrategy, changedOpts := sm.RetryStrategy(upError, upCount)
+		retryStrategy, changedOpts := sm.GetRetryStrategyFrom(upError, upCount)
 		sendEventToDatadog(params.DatadogEventSender, fmt.Sprintf("[E2E] Stack %s : error on Pulumi stack up", name), upError.Error(), []string{"operation:up", "result:fail", fmt.Sprintf("retry:%s", retryStrategy), fmt.Sprintf("stack:%s", stack.Name()), fmt.Sprintf("retries:%d", upCount)})
 
 		switch retryStrategy {
@@ -619,7 +620,15 @@ func (sm *StackManager) getRetryStrategyFrom(err error, upCount int) (RetryType,
 	}
 
 	for _, knownError := range sm.knownErrors {
-		if strings.Contains(err.Error(), knownError.errorMessage) {
+		if knownError.isRegex {
+			isMatch, err := regexp.MatchString(knownError.errorMessage, err.Error())
+			if err != nil {
+				fmt.Printf("Error matching regex %s: %v\n", knownError.errorMessage, err)
+			}
+			if isMatch {
+				return knownError.retryType, nil
+			}
+		} else if strings.Contains(err.Error(), knownError.errorMessage) {
 			return knownError.retryType, nil
 		}
 	}

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -620,15 +620,11 @@ func (sm *StackManager) getRetryStrategyFrom(err error, upCount int) (RetryType,
 	}
 
 	for _, knownError := range sm.knownErrors {
-		if knownError.isRegex {
-			isMatch, err := regexp.MatchString(knownError.errorMessage, err.Error())
-			if err != nil {
-				fmt.Printf("Error matching regex %s: %v\n", knownError.errorMessage, err)
-			}
-			if isMatch {
-				return knownError.retryType, nil
-			}
-		} else if strings.Contains(err.Error(), knownError.errorMessage) {
+		isMatch, err := regexp.MatchString(knownError.errorMessage, err.Error())
+		if err != nil {
+			fmt.Printf("Error matching regex %s: %v\n", knownError.errorMessage, err)
+		}
+		if isMatch {
 			return knownError.retryType, nil
 		}
 	}

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -8,12 +8,14 @@ package infra
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"io"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -224,6 +226,50 @@ func TestStackManager(t *testing.T) {
 		assert.Contains(t, mockDatadogEventSender.events[0].Title, fmt.Sprintf("[E2E] Stack %s : timeout on Pulumi stack up", stackName))
 		assert.Contains(t, mockDatadogEventSender.events[1].Title, fmt.Sprintf("[E2E] Stack %s : error on Pulumi stack up", stackName))
 		assert.Contains(t, mockDatadogEventSender.events[2].Title, fmt.Sprintf("[E2E] Stack %s : success on Pulumi stack up", stackName))
+	})
+
+	t.Run("should-return-retry-strategy-on-retriable-errors", func(t *testing.T) {
+		t.Parallel()
+
+		type testError struct {
+			name              string
+			errMessage        string
+			expectedRetryType RetryType
+		}
+
+		testErrors := []testError{
+			{
+				name:              "timeout",
+				errMessage:        "i/o timeout",
+				expectedRetryType: ReCreate,
+			},
+			{
+				name:              "connection-refused",
+				errMessage:        "failed attempts: dial tcp :22: connect: connection refused",
+				expectedRetryType: ReCreate,
+			},
+			{
+				name:              "resource-not-exist",
+				errMessage:        "Resource provider reported that the resource did not exist while updating",
+				expectedRetryType: ReCreate,
+			},
+			{
+				name:              "cloud-init-timeout",
+				errMessage:        "Process exited with status 2: running \" sudo cloud-init status --wait\"",
+				expectedRetryType: ReCreate,
+			},
+			{
+				name:              "ecs-fakeintake-timeout",
+				errMessage:        "waiting for ECS Service (arn:aws:ecs:us-east-1:669783387624:service/fakeintake-ecs/ci-633219896-4670-e2e-dockersuite-80f62edf7bcc6194-aws-fakeintake-dockervm-srv) create: timeout while waiting for state to become 'tfSTABLE' (last state: 'tfPENDING', timeout: 20m0s)",
+				expectedRetryType: ReCreate,
+			},
+		}
+
+		for _, te := range testErrors {
+			err := errors.New(te.errMessage)
+			retryType, _ := stackManager.getRetryStrategyFrom(err, 0)
+			assert.Equal(t, te.expectedRetryType, retryType, te.name)
+		}
 	})
 }
 

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -252,7 +252,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *EnvOpts) (*
 		infraEnv:   opts.InfraEnv,
 	}
 
-	stackManager.RetryStrategy = retryHandler.HandleError
+	stackManager.GetRetryStrategyFrom = retryHandler.HandleError
 	pulumiStack, upResult, pulumiErr := stackManager.GetStackNoDeleteOnFailure(
 		systemProbeTestEnv.context,
 		systemProbeTestEnv.name,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* add support for regex in stack manager's retryable errors
* recreate stack on pending ECS fakeintake task 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We had a bunch of fakeintake timing out or dropping connection at stack up yesterday

* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/633325746
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/633219896

As I want to target only fakeintake failing ECS tasks, I need to use a regex

#incident-30445

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
