### PR TITLE
refactor references to pkg/config in cmd/agent

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -20,8 +20,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	confad "github.com/DataDog/datadog-agent/pkg/config/autodiscovery"
+	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -45,34 +46,34 @@ func setupAutoDiscovery(confSearchPaths []string, wmeta workloadmeta.Component, 
 
 	ac.AddConfigProvider(
 		providers.NewFileConfigProvider(acTelemetryStore),
-		config.Datadog().GetBool("autoconf_config_files_poll"),
-		time.Duration(config.Datadog().GetInt("autoconf_config_files_poll_interval"))*time.Second,
+		pkgconfigsetup.Datadog().GetBool("autoconf_config_files_poll"),
+		time.Duration(pkgconfigsetup.Datadog().GetInt("autoconf_config_files_poll_interval"))*time.Second,
 	)
 
 	// Autodiscovery cannot easily use config.RegisterOverrideFunc() due to Unmarshalling
 	extraConfigProviders, extraConfigListeners := confad.DiscoverComponentsFromConfig()
 
-	var extraEnvProviders []config.ConfigurationProviders
-	var extraEnvListeners []config.Listeners
-	if config.IsAutoconfigEnabled() && !config.IsCLCRunner() {
+	var extraEnvProviders []pkgconfigsetup.ConfigurationProviders
+	var extraEnvListeners []pkgconfigsetup.Listeners
+	if pkgconfigenv.IsAutoconfigEnabled(pkgconfigsetup.Datadog()) && !pkgconfigsetup.IsCLCRunner(pkgconfigsetup.Datadog()) {
 		extraEnvProviders, extraEnvListeners = confad.DiscoverComponentsFromEnv()
 	}
 
 	// Register additional configuration providers
-	var configProviders []config.ConfigurationProviders
-	var uniqueConfigProviders map[string]config.ConfigurationProviders
-	err := config.Datadog().UnmarshalKey("config_providers", &configProviders)
+	var configProviders []pkgconfigsetup.ConfigurationProviders
+	var uniqueConfigProviders map[string]pkgconfigsetup.ConfigurationProviders
+	err := pkgconfigsetup.Datadog().UnmarshalKey("config_providers", &configProviders)
 
 	if err == nil {
-		uniqueConfigProviders = make(map[string]config.ConfigurationProviders, len(configProviders)+len(extraEnvProviders)+len(configProviders))
+		uniqueConfigProviders = make(map[string]pkgconfigsetup.ConfigurationProviders, len(configProviders)+len(extraEnvProviders)+len(configProviders))
 		for _, provider := range configProviders {
 			uniqueConfigProviders[provider.Name] = provider
 		}
 
 		// Add extra config providers
-		for _, name := range config.Datadog().GetStringSlice("extra_config_providers") {
+		for _, name := range pkgconfigsetup.Datadog().GetStringSlice("extra_config_providers") {
 			if _, found := uniqueConfigProviders[name]; !found {
-				uniqueConfigProviders[name] = config.ConfigurationProviders{Name: name, Polling: true}
+				uniqueConfigProviders[name] = pkgconfigsetup.ConfigurationProviders{Name: name, Polling: true}
 			} else {
 				log.Infof("Duplicate AD provider from extra_config_providers discarded as already present in config_providers: %s", name)
 			}
@@ -87,7 +88,7 @@ func setupAutoDiscovery(confSearchPaths []string, wmeta workloadmeta.Component, 
 		}
 
 		if enableContainerProvider {
-			uniqueConfigProviders[names.KubeContainer] = config.ConfigurationProviders{Name: names.KubeContainer}
+			uniqueConfigProviders[names.KubeContainer] = pkgconfigsetup.ConfigurationProviders{Name: names.KubeContainer}
 		}
 
 		for _, provider := range extraConfigProviders {
@@ -123,12 +124,12 @@ func setupAutoDiscovery(confSearchPaths []string, wmeta workloadmeta.Component, 
 		}
 	}
 
-	var listeners []config.Listeners
-	err = config.Datadog().UnmarshalKey("listeners", &listeners)
+	var listeners []pkgconfigsetup.Listeners
+	err = pkgconfigsetup.Datadog().UnmarshalKey("listeners", &listeners)
 	if err == nil {
 		// Add extra listeners
-		for _, name := range config.Datadog().GetStringSlice("extra_listeners") {
-			listeners = append(listeners, config.Listeners{Name: name})
+		for _, name := range pkgconfigsetup.Datadog().GetStringSlice("extra_listeners") {
+			listeners = append(listeners, pkgconfigsetup.Listeners{Name: name})
 		}
 
 		// The "docker" and "ecs" listeners were replaced with the

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -28,8 +28,8 @@ func GetPythonPaths() []string {
 	return []string{
 		path.GetDistPath(), // common modules are shipped in the dist path directly or under the "checks/" sub-dir
 		path.PyChecksPath,  // integrations-core legacy checks
-		filepath.Join(path.GetDistPath(), "checks.d"),    // custom checks in the "checks.d/" sub-dir of the dist path
-		config.Datadog().GetString("additional_checksd"), // custom checks, least precedent check location
+		filepath.Join(path.GetDistPath(), "checks.d"),            // custom checks in the "checks.d/" sub-dir of the dist path
+		pkgconfigsetup.Datadog().GetString("additional_checksd"), // custom checks, least precedent check location
 	}
 }
 
@@ -43,10 +43,10 @@ func GetVersion(w http.ResponseWriter, _ *http.Request) {
 
 // NewSettingsClient returns a configured runtime settings client.
 func NewSettingsClient() (settings.Client, error) {
-	ipcAddress, err := config.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, err
 	}
 	hc := util.GetClient(false)
-	return settingshttp.NewClient(hc, fmt.Sprintf("https://%v:%v/agent/config", ipcAddress, config.Datadog().GetInt("cmd_port")), "agent", settingshttp.NewHTTPClientOptions(util.LeaveConnectionOpen)), nil
+	return settingshttp.NewClient(hc, fmt.Sprintf("https://%v:%v/agent/config", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port")), "agent", settingshttp.NewHTTPClientOptions(util.LeaveConnectionOpen)), nil
 }

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/messagestrings"
@@ -48,11 +48,11 @@ func CheckAndUpgradeConfig() error {
 		log.Debug("Previous config file not found, not upgrading")
 		return nil
 	}
-	config.Datadog().AddConfigPath(path.DefaultConfPath)
-	_, err := config.LoadWithoutSecret()
+	pkgconfigsetup.Datadog().AddConfigPath(path.DefaultConfPath)
+	_, err := pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil)
 	if err == nil {
 		// was able to read config, check for api key
-		if config.Datadog().GetString("api_key") != "" {
+		if pkgconfigsetup.Datadog().GetString("api_key") != "" {
 			log.Debug("Datadog.yaml found, and API key present.  Not upgrading config")
 			return nil
 		}

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -7,13 +7,12 @@ package common
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/settings"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // SetupInternalProfiling is a common helper to configure runtime settings for internal profiling.
-func SetupInternalProfiling(settings settings.Component, cfg config.Reader, configPrefix string) {
+func SetupInternalProfiling(settings settings.Component, cfg model.Reader, configPrefix string) {
 	if v := cfg.GetInt(configPrefix + "internal_profiling.block_profile_rate"); v > 0 {
 		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v, model.SourceAgentRuntime); err != nil {
 			log.Errorf("Error setting block profile rate: %v", err)

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -18,8 +18,8 @@ import (
 	"github.com/fatih/color"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/legacy"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // TransformationFunc type represents transformation applicable to byte slices
@@ -30,7 +30,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	datadogConfPath := filepath.Join(oldConfigDir, "datadog.conf")
 	datadogYamlPath := filepath.Join(newConfigDir, "datadog.yaml")
 	traceAgentConfPath := filepath.Join(newConfigDir, "trace-agent.conf")
-	configConverter := config.NewConfigConverter()
+	configConverter := legacy.NewConfigConverter()
 	const cfgExt = ".yaml"
 	const dirExt = ".d"
 
@@ -52,14 +52,14 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// setup the configuration system
-	config.Datadog().AddConfigPath(newConfigDir)
-	_, err = config.LoadWithoutSecret()
+	pkgconfigsetup.Datadog().AddConfigPath(newConfigDir)
+	_, err = pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil)
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}
 
 	// we won't overwrite the conf file if it contains a valid api_key
-	if config.Datadog().GetString("api_key") != "" && !force {
+	if pkgconfigsetup.Datadog().GetString("api_key") != "" && !force {
 		return fmt.Errorf("%s seems to contain a valid configuration, run the command again with --force or -f to overwrite it",
 			datadogYamlPath)
 	}
@@ -136,7 +136,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// marshal the config object to YAML
-	b, err := yaml.Marshal(config.Datadog().AllSettings())
+	b, err := yaml.Marshal(pkgconfigsetup.Datadog().AllSettings())
 	if err != nil {
 		return fmt.Errorf("unable to marshal config to YAML: %v", err)
 	}

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fatih/color"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/legacy"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -30,7 +31,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	datadogConfPath := filepath.Join(oldConfigDir, "datadog.conf")
 	datadogYamlPath := filepath.Join(newConfigDir, "datadog.yaml")
 	traceAgentConfPath := filepath.Join(newConfigDir, "trace-agent.conf")
-	configConverter := legacy.NewConfigConverter()
+	configConverter := config.NewConfigConverter()
 	const cfgExt = ".yaml"
 	const dirExt = ".d"
 

--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -18,8 +18,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/syndtr/gocapability/capability"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -68,7 +68,7 @@ func procMount() error {
 	if !haveEgid {
 		groups = append(groups, egid)
 	}
-	path := config.Datadog().GetString("container_proc_root")
+	path := pkgconfigsetup.Datadog().GetString("container_proc_root")
 	if env.IsContainerized() && path != "/proc" {
 		path = filepath.Join(path, "1/mounts")
 	} else {

--- a/cmd/agent/common/test_helpers.go
+++ b/cmd/agent/common/test_helpers.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // SetupConfigForTest fires up the configuration system and returns warnings if any.
-func SetupConfigForTest(confFilePath string) (*config.Warnings, error) {
-	cfg := config.Datadog()
+func SetupConfigForTest(confFilePath string) (*model.Warnings, error) {
+	cfg := pkgconfigsetup.Datadog()
 	origin := "datadog.yaml"
 	// set the paths where a config file is expected
 	if len(confFilePath) != 0 {
@@ -36,7 +37,7 @@ func SetupConfigForTest(confFilePath string) (*config.Warnings, error) {
 	}
 	cfg.AddConfigPath(path.DefaultConfPath)
 	// load the configuration
-	warnings, err := config.LoadDatadogCustom(cfg, origin, optional.NewNoneOption[secrets.Component](), nil)
+	warnings, err := pkgconfigsetup.LoadDatadogCustom(cfg, origin, optional.NewNoneOption[secrets.Component](), nil)
 	if err != nil {
 		// special-case permission-denied with a clearer error message
 		if errors.Is(err, fs.ErrPermission) {

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -30,7 +30,7 @@ import (
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -331,7 +331,7 @@ func printPayload(name payloadName, _ log.Component, config config.Component) er
 	}
 
 	c := util.GetClient(false)
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/dogstatsd/command.go
+++ b/cmd/agent/subcommands/dogstatsd/command.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -81,7 +81,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 func triggerDump(config cconfig.Component) (string, error) {
 	c := util.GetClient(false)
-	addr, err := pkgconfig.GetIPCAddress()
+	addr, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
@@ -102,7 +102,7 @@ func dogstatsdCapture(_ log.Component, config config.Component, cliParams *cliPa
 
 	conn, err := grpc.DialContext( //nolint:staticcheck // TODO (ASC) fix grpc.DialContext is deprecated
 		ctx,
-		fmt.Sprintf(":%v", pkgconfig.Datadog().GetInt("cmd_port")),
+		fmt.Sprintf(":%v", pkgconfigsetup.Datadog().GetInt("cmd_port")),
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -26,7 +26,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/impl"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
@@ -113,7 +113,7 @@ func dogstatsdReplay(_ log.Component, config config.Component, cliParams *cliPar
 
 	apiconn, err := grpc.DialContext( //nolint:staticcheck // TODO (ASC) fix grpc.DialContext is deprecated
 		ctx,
-		fmt.Sprintf(":%v", pkgconfig.Datadog().GetInt("cmd_port")),
+		fmt.Sprintf(":%v", pkgconfigsetup.Datadog().GetInt("cmd_port")),
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
@@ -133,7 +133,7 @@ func dogstatsdReplay(_ log.Component, config config.Component, cliParams *cliPar
 		return err
 	}
 
-	s := pkgconfig.Datadog().GetString("dogstatsd_socket")
+	s := pkgconfigsetup.Datadog().GetString("dogstatsd_socket")
 	if s == "" {
 		return fmt.Errorf("Dogstatsd UNIX socket disabled")
 	}
@@ -150,7 +150,7 @@ func dogstatsdReplay(_ log.Component, config config.Component, cliParams *cliPar
 	defer syscall.Close(sk)
 
 	err = syscall.SetsockoptInt(sk, syscall.SOL_SOCKET, syscall.SO_SNDBUF,
-		pkgconfig.Datadog().GetInt("dogstatsd_buffer_size"))
+		pkgconfigsetup.Datadog().GetInt("dogstatsd_buffer_size"))
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 
@@ -71,11 +71,11 @@ func requestDogstatsdStats(_ log.Component, config config.Component, cliParams *
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/dogstatsd-stats", ipcAddress, pkgconfig.Datadog().GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%v:%v/agent/dogstatsd-stats", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
 
 	// Set session token
 	e = util.SetAuthToken(config)

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -49,8 +49,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -168,7 +168,7 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 	type pprofGetter func(path string) ([]byte, error)
 
 	tcpGet := func(portConfig string) pprofGetter {
-		pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfig.Datadog().GetInt(portConfig))
+		pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfigsetup.Datadog().GetInt(portConfig))
 		return func(path string) ([]byte, error) {
 			return util.DoGet(c, pprofURL+path, util.LeaveConnectionOpen)
 		}
@@ -224,15 +224,15 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port"), seconds),
 	}
 
-	if pkgconfig.Datadog().GetBool("process_config.enabled") ||
-		pkgconfig.Datadog().GetBool("process_config.container_collection.enabled") ||
-		pkgconfig.Datadog().GetBool("process_config.process_collection.enabled") {
+	if pkgconfigsetup.Datadog().GetBool("process_config.enabled") ||
+		pkgconfigsetup.Datadog().GetBool("process_config.container_collection.enabled") ||
+		pkgconfigsetup.Datadog().GetBool("process_config.process_collection.enabled") {
 
 		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port"), seconds)
 	}
 
-	if pkgconfig.Datadog().GetBool("apm_config.enabled") {
-		traceCpusec := pkgconfig.Datadog().GetInt("apm_config.receiver_timeout")
+	if pkgconfigsetup.Datadog().GetBool("apm_config.enabled") {
+		traceCpusec := pkgconfigsetup.Datadog().GetInt("apm_config.receiver_timeout")
 		if traceCpusec > seconds {
 			// do not exceed requested duration
 			traceCpusec = seconds
@@ -244,8 +244,8 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port"), traceCpusec)
 	}
 
-	if pkgconfig.SystemProbe().GetBool("system_probe_config.enabled") {
-		probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
+	if pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enabled") {
+		probeUtil, probeUtilErr := net.GetRemoteSystemProbeUtil(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 
 		if !errors.Is(probeUtilErr, net.ErrNotImplemented) {
 			sysProbeGet := func() pprofGetter {
@@ -386,16 +386,16 @@ func makeFlare(flareComp flare.Component,
 func requestArchive(flareComp flare.Component, pdata flare.ProfileData) (string, error) {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the agent to build the flare archive."))
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error getting IPC address for the agent: %s", err)))
 		return createArchive(flareComp, pdata, err)
 	}
 
-	urlstr := fmt.Sprintf("https://%v:%v/agent/flare", ipcAddress, pkgconfig.Datadog().GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%v:%v/agent/flare", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
 
 	// Set session token
-	if err = util.SetAuthToken(pkgconfig.Datadog()); err != nil {
+	if err = util.SetAuthToken(pkgconfigsetup.Datadog()); err != nil {
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error: %s", err)))
 		return createArchive(flareComp, pdata, err)
 	}

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
@@ -556,7 +556,7 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	downloaderCmd.Env = environ
 
 	// Proxy support
-	proxies := pkgconfig.Datadog().GetProxies()
+	proxies := pkgconfigsetup.Datadog().GetProxies()
 	if proxies != nil {
 		downloaderCmd.Env = append(downloaderCmd.Env,
 			fmt.Sprintf("HTTP_PROXY=%s", proxies.HTTP),
@@ -798,7 +798,7 @@ func getVersionFromReqLine(integration string, lines string) (*semver.Version, b
 }
 
 func moveConfigurationFilesOf(cliParams *cliParams, integration string) error {
-	confFolder := pkgconfig.Datadog().GetString("confd_path")
+	confFolder := pkgconfigsetup.Datadog().GetString("confd_path")
 	check := getIntegrationName(integration)
 	confFileDest := filepath.Join(confFolder, fmt.Sprintf("%s.d", check))
 	if err := os.MkdirAll(confFileDest, os.ModeDir|0755); err != nil {

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -57,7 +57,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 func state(_ *cliParams, config config.Component) error {
-	if !pkgconfig.IsRemoteConfigEnabled(config) {
+	if !pkgconfigsetup.IsRemoteConfigEnabled(config) {
 		return errors.New("remote configuration is not enabled")
 	}
 	fmt.Println("Fetching the configuration and director repos state..")
@@ -75,12 +75,12 @@ func state(_ *cliParams, config config.Component) error {
 	}
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}
 
-	cli, err := agentgrpc.GetDDAgentSecureClient(ctx, ipcAddress, pkgconfig.GetIPCPort())
+	cli, err := agentgrpc.GetDDAgentSecureClient(ctx, ipcAddress, pkgconfigsetup.GetIPCPort())
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func state(_ *cliParams, config config.Component) error {
 	}
 
 	var stateHA *pbgo.GetStateConfigResponse
-	if pkgconfig.Datadog().GetBool("multi_region_failover.enabled") {
+	if pkgconfigsetup.Datadog().GetBool("multi_region_failover.enabled") {
 		stateHA, err = cli.GetConfigStateHA(ctx, in)
 		if err != nil {
 			return fmt.Errorf("couldn't get the HA repositories state: %w", err)

--- a/cmd/agent/subcommands/run/dependent_services_nix.go
+++ b/cmd/agent/subcommands/run/dependent_services_nix.go
@@ -6,12 +6,12 @@
 
 package run
 
-import "github.com/DataDog/datadog-agent/pkg/config"
+import "github.com/DataDog/datadog-agent/pkg/config/model"
 
 // Servicedef defines a service
 type Servicedef struct {
 	name       string
-	configKeys map[string]config.Config
+	configKeys map[string]model.Config
 }
 
 var subservices []Servicedef

--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -13,7 +13,8 @@ import (
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc/mgr"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -22,7 +23,7 @@ type serviceInitFunc func() (err error)
 // Servicedef defines a service
 type Servicedef struct {
 	name       string
-	configKeys map[string]config.Config
+	configKeys map[string]model.Config
 
 	serviceName string
 	serviceInit serviceInitFunc
@@ -31,40 +32,40 @@ type Servicedef struct {
 var subservices = []Servicedef{
 	{
 		name: "apm",
-		configKeys: map[string]config.Config{
-			"apm_config.enabled": config.Datadog(),
+		configKeys: map[string]model.Config{
+			"apm_config.enabled": pkgconfigsetup.Datadog(),
 		},
 		serviceName: "datadog-trace-agent",
 		serviceInit: apmInit,
 	},
 	{
 		name: "process",
-		configKeys: map[string]config.Config{
-			"process_config.enabled":                      config.Datadog(),
-			"process_config.process_collection.enabled":   config.Datadog(),
-			"process_config.container_collection.enabled": config.Datadog(),
-			"process_config.process_discovery.enabled":    config.Datadog(),
-			"network_config.enabled":                      config.SystemProbe(),
-			"system_probe_config.enabled":                 config.SystemProbe(),
+		configKeys: map[string]model.Config{
+			"process_config.enabled":                      pkgconfigsetup.Datadog(),
+			"process_config.process_collection.enabled":   pkgconfigsetup.Datadog(),
+			"process_config.container_collection.enabled": pkgconfigsetup.Datadog(),
+			"process_config.process_discovery.enabled":    pkgconfigsetup.Datadog(),
+			"network_config.enabled":                      pkgconfigsetup.SystemProbe(),
+			"system_probe_config.enabled":                 pkgconfigsetup.SystemProbe(),
 		},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
 	},
 	{
 		name: "sysprobe",
-		configKeys: map[string]config.Config{
-			"network_config.enabled":          config.SystemProbe(),
-			"system_probe_config.enabled":     config.SystemProbe(),
-			"windows_crash_detection.enabled": config.SystemProbe(),
-			"runtime_security_config.enabled": config.SystemProbe(),
+		configKeys: map[string]model.Config{
+			"network_config.enabled":          pkgconfigsetup.SystemProbe(),
+			"system_probe_config.enabled":     pkgconfigsetup.SystemProbe(),
+			"windows_crash_detection.enabled": pkgconfigsetup.SystemProbe(),
+			"runtime_security_config.enabled": pkgconfigsetup.SystemProbe(),
 		},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,
 	},
 	{
 		name: "cws",
-		configKeys: map[string]config.Config{
-			"runtime_security_config.enabled": config.SystemProbe(),
+		configKeys: map[string]model.Config{
+			"runtime_security_config.enabled": pkgconfigsetup.SystemProbe(),
 		},
 		serviceName: "datadog-security-agent",
 		serviceInit: securityInit,

--- a/cmd/agent/subcommands/run/internal/clcrunnerapi/clc_runner_listener.go
+++ b/cmd/agent/subcommands/run/internal/clcrunnerapi/clc_runner_listener.go
@@ -14,14 +14,14 @@ import (
 	"net"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // getCLCRunnerListener returns a listening connection for the cluster level check runner server
 // The server must only listen on the cluster check runner pod ip
 // The cluster check runner Agent won't start if the server host is not configured
 func getCLCRunnerListener() (net.Listener, error) {
-	podIP := config.Datadog().GetString("clc_runner_host")
+	podIP := pkgconfigsetup.Datadog().GetString("clc_runner_host")
 	// This is not a security feature
 	// util.IsForbidden only helps to avoid unnecessarily permissive server config
 	if util.IsForbidden(podIP) {
@@ -32,5 +32,5 @@ func getCLCRunnerListener() (net.Listener, error) {
 		// IPv6 addresses must be formatted [ip]:port
 		podIP = fmt.Sprintf("[%s]", podIP)
 	}
-	return net.Listen("tcp", fmt.Sprintf("%v:%v", podIP, config.Datadog().GetInt("clc_runner_port")))
+	return net.Listen("tcp", fmt.Sprintf("%v:%v", podIP, pkgconfigsetup.Datadog().GetInt("clc_runner_port")))
 }

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -59,7 +59,7 @@ func stop(config config.Component, _ *cliParams, _ log.Component) error {
 	if e != nil {
 		return e
 	}
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/streamep/command.go
+++ b/cmd/agent/subcommands/streamep/command.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -56,7 +56,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 //nolint:revive // TODO(CINT) Fix revive linter
 func streamEventPlatform(_ log.Component, config config.Component, cliParams *cliParams) error {
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func streamRequest(url string, body []byte, onChunk func([]byte)) error {
 	c := util.GetClient(false)
 
 	// Set session token
-	e = util.SetAuthToken(pkgconfig.Datadog())
+	e = util.SetAuthToken(pkgconfigsetup.Datadog())
 	if e != nil {
 		return e
 	}

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
@@ -84,7 +84,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 //nolint:revive // TODO(AML) Fix revive linter
 func streamLogs(_ log.Component, config config.Component, cliParams *CliParams) error {
-	ipcAddress, err := pkgconfig.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func streamRequest(url string, body []byte, duration time.Duration, onChunk func
 		c.Timeout = duration
 	}
 	// Set session token
-	e = util.SetAuthToken(pkgconfig.Datadog())
+	e = util.SetAuthToken(pkgconfigsetup.Datadog())
 	if e != nil {
 		return e
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
replaces most references to pkg/config in cmd/agent to respective submodule (e.g. pkg/config/model, pkg/config/setup, etc).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The majority of functions and variables were already moved to aliases with https://github.com/DataDog/datadog-agent/pull/20034; this change removes obfuscation and makes it clearer what our code is doing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
unit/integration tests should suffice since no code changes are made, just replacing references to aliases to references to the underlying functions/types