### PR TITLE
Sort mapNode keys to fix flaky test

### DIFF
--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -9,6 +9,7 @@ package structure
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -163,6 +164,8 @@ func (n *innerMapNodeImpl) ChildrenKeys() ([]string, error) {
 			return nil, fmt.Errorf("map node has invalid non-string key: %v", kv)
 		}
 	}
+	// map keys are iterated non-deterministically, sort them
+	slices.Sort(keys)
 	return keys, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Sort the keys returned by ChildrenKeys for a mapNode. By making the behavior deterministic, this fixes the associated unit test `TestMapGetChildNotFound` in unmarshal_test.go.

### Motivation

Fix flakey test.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Behavior covered by unit tests.
