### PR TITLE
Reuse existing function to compute package module to fix precommit hooks

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -446,7 +446,8 @@ def get_modified_packages(ctx, build_tags=None, lint=False) -> list[GoModule]:
     modified_files = get_go_modified_files(ctx)
 
     modified_go_files = [f"./{file}" for file in modified_files]
-
+    print("Modified files:")
+    print("\n".join(modified_go_files))
     if build_tags is None:
         build_tags = []
 
@@ -454,14 +455,7 @@ def get_modified_packages(ctx, build_tags=None, lint=False) -> list[GoModule]:
     go_mod_modified_modules = set()
 
     for modified_file in modified_go_files:
-        match_precision = 0
-        best_module_path = None
-
-        # Since several modules can match the path we take only the most precise one
-        for module_path in DEFAULT_MODULES:
-            if module_path in modified_file and len(module_path) > match_precision:
-                match_precision = len(module_path)
-                best_module_path = module_path
+        best_module_path = get_go_module(modified_file)
 
         # Check if the package is in the target list of the module we want to test
         targeted = False

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -446,8 +446,7 @@ def get_modified_packages(ctx, build_tags=None, lint=False) -> list[GoModule]:
     modified_files = get_go_modified_files(ctx)
 
     modified_go_files = [f"./{file}" for file in modified_files]
-    print("Modified files:")
-    print("\n".join(modified_go_files))
+
     if build_tags is None:
         build_tags = []
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

Reuse an existing function to compute go module of a file

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix a weird behavior of the `get-modified-packages` function when `pkg/util/common.go` is modified and prevent it from happening with similar scenario

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
