### PR TITLE
[e2e] example of pulumi run function to create an win dev ec2 instance

### DIFF
--- a/test/new-e2e/scenarios/windows-dev/Pulumi.yaml
+++ b/test/new-e2e/scenarios/windows-dev/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: windows-dev
+description: A windows dev instance.
+runtime:
+  name: go

--- a/test/new-e2e/scenarios/windows-dev/main.go
+++ b/test/new-e2e/scenarios/windows-dev/main.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package main is the entrypoint for the windows dev setup
+package main
+
+import (
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		env, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		// replace XXXXXXXX with target custom AMI
+		vm, err := ec2.NewVM(env, "vm", ec2.WithAMI("ami-07cc1bbe145f35b58", os.WindowsDefault, os.AMD64Arch))
+		if err != nil {
+			return err
+		}
+		if err := vm.Export(ctx, nil); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add skeleton to create a windows dev vm

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Test it running from `datadog-agent` root:

```bash
pulumi up -s windev -c ddinfra:env=aws/agent-sandbox -c ddinfra:aws/defaultKeyPairName=<key pair name as stored in aws ec2> -c ddinfra:aws/defaultPublicKeyPath=<path to public ssh key> --cwd test/new-e2e/scenarios/windows-dev --yes
```

To tear it down then run

```bash
pulumi down -s windev --yes --remove
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
