### PR TITLE
refactor pkg/config references in cmd/cluster-agent and others

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -55,7 +55,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
@@ -144,7 +144,7 @@ func run(
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 	defer mainCtxCancel() // Calling cancel twice is safe
 
-	if !pkgconfig.Datadog().IsSet("api_key") {
+	if !pkgconfigsetup.Datadog().IsSet("api_key") {
 		pkglog.Critical("no API key configured, exiting")
 		return nil
 	}
@@ -174,7 +174,7 @@ func run(
 		return err
 	}
 
-	common.LoadComponents(secretResolver, wmeta, ac, pkgconfig.Datadog().GetString("confd_path"))
+	common.LoadComponents(secretResolver, wmeta, ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 
 	// Set up check collector
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(optional.NewOption(collector), demultiplexer, logReceiver), true)
@@ -217,19 +217,19 @@ func run(
 }
 
 func initializeCCCache(ctx context.Context) error {
-	pollInterval := time.Second * time.Duration(pkgconfig.Datadog().GetInt("cloud_foundry_cc.poll_interval"))
+	pollInterval := time.Second * time.Duration(pkgconfigsetup.Datadog().GetInt("cloud_foundry_cc.poll_interval"))
 	_, err := cloudfoundry.ConfigureGlobalCCCache(
 		ctx,
-		pkgconfig.Datadog().GetString("cloud_foundry_cc.url"),
-		pkgconfig.Datadog().GetString("cloud_foundry_cc.client_id"),
-		pkgconfig.Datadog().GetString("cloud_foundry_cc.client_secret"),
-		pkgconfig.Datadog().GetBool("cloud_foundry_cc.skip_ssl_validation"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.url"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.client_id"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_cc.client_secret"),
+		pkgconfigsetup.Datadog().GetBool("cloud_foundry_cc.skip_ssl_validation"),
 		pollInterval,
-		pkgconfig.Datadog().GetInt("cloud_foundry_cc.apps_batch_size"),
-		pkgconfig.Datadog().GetBool("cluster_agent.refresh_on_cache_miss"),
-		pkgconfig.Datadog().GetBool("cluster_agent.serve_nozzle_data"),
-		pkgconfig.Datadog().GetBool("cluster_agent.sidecars_tags"),
-		pkgconfig.Datadog().GetBool("cluster_agent.isolation_segments_tags"),
+		pkgconfigsetup.Datadog().GetInt("cloud_foundry_cc.apps_batch_size"),
+		pkgconfigsetup.Datadog().GetBool("cluster_agent.refresh_on_cache_miss"),
+		pkgconfigsetup.Datadog().GetBool("cluster_agent.serve_nozzle_data"),
+		pkgconfigsetup.Datadog().GetBool("cluster_agent.sidecars_tags"),
+		pkgconfigsetup.Datadog().GetBool("cluster_agent.isolation_segments_tags"),
 		nil,
 	)
 	if err != nil {
@@ -239,11 +239,11 @@ func initializeCCCache(ctx context.Context) error {
 }
 
 func initializeBBSCache(ctx context.Context) error {
-	pollInterval := time.Second * time.Duration(pkgconfig.Datadog().GetInt("cloud_foundry_bbs.poll_interval"))
+	pollInterval := time.Second * time.Duration(pkgconfigsetup.Datadog().GetInt("cloud_foundry_bbs.poll_interval"))
 	// NOTE: we can't use GetPollInterval in ConfigureGlobalBBSCache, as that causes import cycle
 
-	includeListString := pkgconfig.Datadog().GetStringSlice("cloud_foundry_bbs.env_include")
-	excludeListString := pkgconfig.Datadog().GetStringSlice("cloud_foundry_bbs.env_exclude")
+	includeListString := pkgconfigsetup.Datadog().GetStringSlice("cloud_foundry_bbs.env_include")
+	excludeListString := pkgconfigsetup.Datadog().GetStringSlice("cloud_foundry_bbs.env_exclude")
 
 	includeList := make([]*regexp.Regexp, len(includeListString))
 	excludeList := make([]*regexp.Regexp, len(excludeListString))
@@ -266,10 +266,10 @@ func initializeBBSCache(ctx context.Context) error {
 
 	bc, err := cloudfoundry.ConfigureGlobalBBSCache(
 		ctx,
-		pkgconfig.Datadog().GetString("cloud_foundry_bbs.url"),
-		pkgconfig.Datadog().GetString("cloud_foundry_bbs.ca_file"),
-		pkgconfig.Datadog().GetString("cloud_foundry_bbs.cert_file"),
-		pkgconfig.Datadog().GetString("cloud_foundry_bbs.key_file"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.url"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.ca_file"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.cert_file"),
+		pkgconfigsetup.Datadog().GetString("cloud_foundry_bbs.key_file"),
 		pollInterval,
 		includeList,
 		excludeList,

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -20,12 +20,14 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 
+	"github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/cihub/seelog"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 
 	admiv1 "k8s.io/api/admission/v1"
 	admiv1beta1 "k8s.io/api/admission/v1beta1"
@@ -101,19 +103,19 @@ func (s *Server) Register(uri string, webhookName string, f WebhookFunc, dc dyna
 // Run starts the kubernetes admission webhook server.
 func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error {
 	var tlsMinVersion uint16 = tls.VersionTLS13
-	if config.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
+	if pkgconfigsetup.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
 		tlsMinVersion = tls.VersionTLS10
 	}
 
-	logWriter, _ := config.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := pkglogsetup.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
 	server := &http.Server{
-		Addr:     fmt.Sprintf(":%d", config.Datadog().GetInt("admission_controller.port")),
+		Addr:     fmt.Sprintf(":%d", pkgconfigsetup.Datadog().GetInt("admission_controller.port")),
 		Handler:  s.mux,
 		ErrorLog: stdLog.New(logWriter, "Error from the admission controller http API server: ", 0),
 		TLSConfig: &tls.Config{
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secretNs := common.GetResourcesNamespace()
-				secretName := config.Datadog().GetString("admission_controller.certificate.secret_name")
+				secretName := pkgconfigsetup.Datadog().GetString("admission_controller.certificate.secret_name")
 				cert, err := certificate.GetCertificateFromSecret(secretNs, secretName, client)
 				if err != nil {
 					log.Errorf("Couldn't fetch certificate: %v", err)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -144,7 +144,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 		}
 	}
 
-	logFile := config.Datadog().GetString("log_file")
+	logFile := pkgconfigsetup.Datadog().GetString("log_file")
 	if logFile == "" {
 		logFile = path.DefaultDCALogFile
 	}

--- a/cmd/cluster-agent/api/listener.go
+++ b/cmd/cluster-agent/api/listener.go
@@ -14,10 +14,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // getListener returns a listening connection
 func getListener() (net.Listener, error) {
-	return net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", config.Datadog().GetInt("cluster_agent.cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")))
 }

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -41,9 +41,10 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 )
 
 var (
@@ -79,10 +80,10 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 		return fmt.Errorf("unable to create the api server: %v", err)
 	}
 	// Internal token
-	util.CreateAndSetAuthToken(pkgconfig.Datadog()) //nolint:errcheck
+	util.CreateAndSetAuthToken(pkgconfigsetup.Datadog()) //nolint:errcheck
 
 	// DCA client token
-	util.InitDCAAuthToken(pkgconfig.Datadog()) //nolint:errcheck
+	util.InitDCAAuthToken(pkgconfigsetup.Datadog()) //nolint:errcheck
 
 	// create cert
 	hosts := []string{"127.0.0.1", "localhost"}
@@ -107,12 +108,12 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 		MinVersion:   tls.VersionTLS13,
 	}
 
-	if pkgconfig.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
+	if pkgconfigsetup.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
 		tlsConfig.MinVersion = tls.VersionTLS10
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := pkgconfig.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
+	logWriter, _ := pkglogsetup.NewTLSHandshakeErrorWriter(4, seelog.WarnLvl)
 
 	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
 		if token != util.GetDCAAuthToken() {
@@ -132,7 +133,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 		taggerServer: taggerserver.NewServer(taggerComp),
 	})
 
-	timeout := pkgconfig.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second
+	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second
 	srv := grpcutil.NewMuxedGRPCServer(
 		listener.Addr().String(),
 		tlsConfig,

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestValidateTokenMiddleware(t *testing.T) {
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("cluster_agent.auth_token", "abc123")
-	util.InitDCAAuthToken(config.Datadog())
+	util.InitDCAAuthToken(pkgconfigsetup.Datadog())
 
 	tests := []struct {
 		path, authToken    string

--- a/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go
+++ b/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go
@@ -15,7 +15,7 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -23,7 +23,7 @@ import (
 func installCloudFoundryMetadataEndpoints(r *mux.Router) {
 	r.HandleFunc("/tags/cf/apps/{nodeName}", api.WithTelemetryWrapper("getCFAppsMetadataForNode", getCFAppsMetadataForNode)).Methods("GET")
 
-	if config.Datadog().GetBool("cluster_agent.serve_nozzle_data") {
+	if pkgconfigsetup.Datadog().GetBool("cluster_agent.serve_nozzle_data") {
 		r.HandleFunc("/cf/apps/{guid}", api.WithTelemetryWrapper("getCFApplication", getCFApplication)).Methods("GET")
 		r.HandleFunc("/cf/apps", api.WithTelemetryWrapper("getCFApplications", getCFApplications)).Methods("GET")
 		r.HandleFunc("/cf/org_quotas", api.WithTelemetryWrapper("getCFOrgQuotas", getCFOrgQuotas)).Methods("GET")

--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	cctypes "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	dcautil "github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -193,7 +193,7 @@ func validateClientIP(addr string) (string, error) {
 		return "", fmt.Errorf("cannot parse CLC runner address: %s", addr)
 	}
 
-	if addr == "" && config.Datadog().GetBool("cluster_checks.advanced_dispatching_enabled") {
+	if addr == "" && pkgconfigsetup.Datadog().GetBool("cluster_checks.advanced_dispatching_enabled") {
 		log.Warn("Cluster check dispatching error: cannot get runner IP from http headers. advanced_dispatching_enabled requires agent 6.17 or above.")
 	}
 

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/mux"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -21,7 +21,7 @@ import (
 // InstallMetadataEndpoints registers endpoints for metadata
 func InstallMetadataEndpoints(r *mux.Router, w workloadmeta.Component) {
 	log.Debug("Registering metadata endpoints")
-	if config.Datadog().GetBool("cloud_foundry") {
+	if pkgconfigsetup.Datadog().GetBool("cloud_foundry") {
 		installCloudFoundryMetadataEndpoints(r)
 	} else {
 		installKubernetesMetadataEndpoints(r, w)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
@@ -109,7 +109,7 @@ func getNodeLabels(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Co
 }
 
 func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
-	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Annotations }, "annotations", config.Datadog().GetStringSlice("kubernetes_node_annotations_as_host_aliases"))
+	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Annotations }, "annotations", pkgconfigsetup.Datadog().GetStringSlice("kubernetes_node_annotations_as_host_aliases"))
 }
 
 // getNamespaceMetadataWithTransformerFunc is used when the node agent hits the DCA for some (or all) metadata of a specific namespace

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -20,7 +20,7 @@ import (
 	datadogclient "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/externalmetrics"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -55,7 +55,7 @@ func RunServer(ctx context.Context, apiCl *as.APIClient, datadogCl optional.Opti
 	cmd.FlagSet = pflag.NewFlagSet(cmd.Name, pflag.ExitOnError)
 
 	var c []string
-	for k, v := range config.Datadog().GetStringMapString(metricsServerConf) {
+	for k, v := range pkgconfigsetup.Datadog().GetStringMapString(metricsServerConf) {
 		c = append(c, fmt.Sprintf("--%s=%s", k, v))
 	}
 
@@ -95,7 +95,7 @@ func (a *DatadogMetricsAdapter) makeProviderOrDie(ctx context.Context, apiCl *as
 		return nil, err
 	}
 
-	if config.Datadog().GetBool("external_metrics_provider.use_datadogmetric_crd") {
+	if pkgconfigsetup.Datadog().GetBool("external_metrics_provider.use_datadogmetric_crd") {
 		if dc, ok := datadogCl.Get(); ok {
 			return externalmetrics.NewDatadogMetricProvider(ctx, apiCl, dc)
 		}
@@ -122,9 +122,9 @@ func (a *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	if !a.FlagSet.Lookup("secure-port").Changed {
 		// Ensure backward compatibility. 443 by default, but will error out if incorrectly set.
 		// refer to apiserver code in k8s.io/apiserver/pkg/server/option/serving.go
-		a.SecureServing.BindPort = config.Datadog().GetInt("external_metrics_provider.port")
+		a.SecureServing.BindPort = pkgconfigsetup.Datadog().GetInt("external_metrics_provider.port")
 		// Default in External Metrics is TLS 1.2
-		if !config.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
+		if !pkgconfigsetup.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
 			a.SecureServing.MinTLSVersion = tlsVersion13Str
 		}
 	}

--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -11,7 +11,7 @@ package check
 import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgcommon "github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
@@ -22,7 +22,7 @@ import (
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	ctx, _ := pkgcommon.GetMainCtxCancel()
 	// Create the Leader election engine without initializing it
-	if pkgconfig.Datadog().GetBool("leader_election") {
+	if pkgconfigsetup.Datadog().GetBool("leader_election") {
 		leaderelection.CreateGlobalLeaderEngine(ctx)
 	}
 

--- a/cmd/cluster-agent/subcommands/config/command.go
+++ b/cmd/cluster-agent/subcommands/config/command.go
@@ -14,9 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/spf13/cobra"
 )
@@ -40,7 +40,7 @@ func newSettingsClient() (settings.Client, error) {
 
 	apiConfigURL := fmt.Sprintf(
 		"https://localhost:%v/config",
-		pkgconfig.Datadog().GetInt("cluster_agent.cmd_port"),
+		pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"),
 	)
 
 	return settingshttp.NewClient(c, apiConfigURL, "datadog-cluster-agent", settingshttp.NewHTTPClientOptions(util.LeaveConnectionOpen)), nil

--- a/cmd/cluster-agent/subcommands/metamap/command.go
+++ b/cmd/cluster-agent/subcommands/metamap/command.go
@@ -20,7 +20,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/status/render"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -71,13 +71,13 @@ func getMetadataMap(nodeName string) error {
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	var urlstr string
 	if nodeName == "" {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/tags/pod", pkgconfig.Datadog().GetInt("cluster_agent.cmd_port"))
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/tags/pod", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
 	} else {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/tags/pod/%s", pkgconfig.Datadog().GetInt("cluster_agent.cmd_port"), nodeName)
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/tags/pod/%s", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"), nodeName)
 	}
 
 	// Set session token
-	e = util.SetAuthToken(pkgconfig.Datadog())
+	e = util.SetAuthToken(pkgconfigsetup.Datadog())
 	if e != nil {
 		return e
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -73,9 +73,9 @@ import (
 	clusteragentMetricsStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstatus"
 	orchestratorStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/orchestrator"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	hostnameStatus "github.com/DataDog/datadog-agent/pkg/status/clusteragent/hostname"
 	endpointsStatus "github.com/DataDog/datadog-agent/pkg/status/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -339,7 +339,7 @@ func start(log log.Component,
 	// Initialize and start remote configuration client
 	var rcClient *rcclient.Client
 	rcserv, isSet := rcService.Get()
-	if pkgconfig.IsRemoteConfigEnabled(config) && isSet {
+	if pkgconfigsetup.IsRemoteConfigEnabled(config) && isSet {
 		var products []string
 		if config.GetBool("admission_controller.auto_instrumentation.patcher.enabled") {
 			products = append(products, state.ProductAPMTracing)

--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -44,12 +44,12 @@ func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmet
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(coreconfig.Datadog(), logsConfig, endpointPrefix, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(pkgconfigsetup.Datadog(), logsConfig, endpointPrefix, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints(coreconfig.Datadog(), intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+		endpoints, err = config.BuildHTTPEndpoints(pkgconfigsetup.Datadog(), intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
 		if err == nil {
-			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, coreconfig.Datadog())
-			endpoints, err = config.BuildEndpoints(coreconfig.Datadog(), httpConnectivity, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, pkgconfigsetup.Datadog())
+			endpoints, err = config.BuildEndpoints(pkgconfigsetup.Datadog(), httpConnectivity, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
 		}
 	}
 
@@ -68,7 +68,7 @@ func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*c
 }
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
-	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", coreconfig.Datadog())
+	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", pkgconfigsetup.Datadog())
 	return newLogContext(logsConfigComplianceKeys, "cspm-intake.")
 }
 
@@ -79,8 +79,8 @@ func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Comp
 	}
 	stopper.Add(ctx)
 
-	configDir := coreconfig.Datadog().GetString("compliance_config.dir")
-	checkInterval := coreconfig.Datadog().GetDuration("compliance_config.check_interval")
+	configDir := pkgconfigsetup.Datadog().GetString("compliance_config.dir")
+	checkInterval := pkgconfigsetup.Datadog().GetDuration("compliance_config.check_interval")
 
 	hname, err := hostname.Get(context.TODO())
 	if err != nil {

--- a/cmd/cluster-agent/subcommands/status/command.go
+++ b/cmd/cluster-agent/subcommands/status/command.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -80,7 +80,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 
 	url := url.URL{
 		Scheme:   "https",
-		Host:     fmt.Sprintf("localhost:%v", pkgconfig.Datadog().GetInt("cluster_agent.cmd_port")),
+		Host:     fmt.Sprintf("localhost:%v", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")),
 		Path:     "/status",
 		RawQuery: v.Encode(),
 	}

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -37,7 +37,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -479,7 +479,7 @@ func (ac *AutoConfig) processNewConfig(config integration.Config) integration.Co
 // AddListeners tries to initialise the listeners listed in the given configs. A first
 // try is done synchronously. If a listener fails with a ErrWillRetry, the initialization
 // will be re-triggered later until success or ErrPermaFail.
-func (ac *AutoConfig) AddListeners(listenerConfigs []config.Listeners) {
+func (ac *AutoConfig) AddListeners(listenerConfigs []pkgconfigsetup.Listeners) {
 	ac.addListenerCandidates(listenerConfigs)
 	remaining := ac.initListenerCandidates()
 	if !remaining {
@@ -495,7 +495,7 @@ func (ac *AutoConfig) AddListeners(listenerConfigs []config.Listeners) {
 	}
 }
 
-func (ac *AutoConfig) addListenerCandidates(listenerConfigs []config.Listeners) {
+func (ac *AutoConfig) addListenerCandidates(listenerConfigs []pkgconfigsetup.Listeners) {
 	ac.m.Lock()
 	defer ac.m.Unlock()
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -35,8 +35,9 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
@@ -86,7 +87,7 @@ func (l *MockListener) fakeFactory(listeners.Config, *acTelemetry.Store) (listen
 	return l, nil
 }
 
-var mockListenenerConfig = config.Listeners{
+var mockListenenerConfig = pkgconfigsetup.Listeners{
 	Name: "mock",
 }
 
@@ -173,14 +174,15 @@ type AutoConfigTestSuite struct {
 
 // SetupSuite saves the original listener registry
 func (suite *AutoConfigTestSuite) SetupSuite() {
-	config.SetupLogger(
-		config.LoggerName("test"),
+	pkglogsetup.SetupLogger(
+		pkglogsetup.LoggerName("test"),
 		"debug",
 		"",
 		"",
 		false,
 		true,
 		false,
+		pkgconfigsetup.Datadog(),
 	)
 }
 
@@ -218,7 +220,7 @@ func (suite *AutoConfigTestSuite) TestAddListener() {
 
 	ml := &MockListener{}
 	listeners.Register("mock", ml.fakeFactory, ac.serviceListenerFactories)
-	ac.AddListeners([]config.Listeners{mockListenenerConfig})
+	ac.AddListeners([]pkgconfigsetup.Listeners{mockListenenerConfig})
 
 	ac.m.Lock()
 	require.Len(suite.T(), ac.listeners, 1)
@@ -255,7 +257,7 @@ func (suite *AutoConfigTestSuite) TestStop() {
 
 	ml := &MockListener{}
 	listeners.Register("mock", ml.fakeFactory, ac.serviceListenerFactories)
-	ac.AddListeners([]config.Listeners{mockListenenerConfig})
+	ac.AddListeners([]pkgconfigsetup.Listeners{mockListenenerConfig})
 
 	ac.Stop()
 
@@ -300,7 +302,7 @@ func (suite *AutoConfigTestSuite) TestListenerRetry() {
 	}
 	listeners.Register("retry", retryFactory.make, ac.serviceListenerFactories)
 
-	configs := []config.Listeners{
+	configs := []pkgconfigsetup.Listeners{
 		{Name: "noerr"},
 		{Name: "fail"},
 		{Name: "retry"},

--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func decryptConfig(conf integration.Config, secretResolver secrets.Component) (integration.Config, error) {
-	if config.Datadog().GetBool("secret_backend_skip_checks") {
+	if pkgconfigsetup.Datadog().GetBool("secret_backend_skip_checks") {
 		log.Tracef("'secret_backend_skip_checks' is enabled, not decrypting configuration %q", conf.Name)
 		return conf, nil
 	}

--- a/comp/core/autodiscovery/common/utils/container_collect_all.go
+++ b/comp/core/autodiscovery/common/utils/container_collect_all.go
@@ -7,7 +7,7 @@ package utils
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // AddContainerCollectAllConfigs adds a config template containing an empty
@@ -15,7 +15,7 @@ import (
 // will be filtered out during config resolution if another config template
 // also has logs configuration.
 func AddContainerCollectAllConfigs(configs []integration.Config, adIdentifier string) []integration.Config {
-	if !config.Datadog().GetBool("logs_config.container_collect_all") {
+	if !pkgconfigsetup.Datadog().GetBool("logs_config.container_collect_all") {
 		return configs
 	}
 

--- a/comp/core/autodiscovery/common/utils/prometheus.go
+++ b/comp/core/autodiscovery/common/utils/prometheus.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,7 +24,7 @@ const (
 // buildInstances generates check config instances based on the Prometheus config and the object annotations
 // The second returned value is true if more than one instance is found
 func buildInstances(pc *types.PrometheusCheck, annotations map[string]string, namespacedName string) ([]integration.Data, bool) {
-	openmetricsVersion := config.Datadog().GetInt("prometheus_scrape.version")
+	openmetricsVersion := pkgconfigsetup.Datadog().GetInt("prometheus_scrape.version")
 
 	instances := []integration.Data{}
 	for k, v := range pc.AD.KubeAnnotations.Incl {

--- a/comp/core/autodiscovery/common/utils/prometheus_apiserver_test.go
+++ b/comp/core/autodiscovery/common/utils/prometheus_apiserver_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,7 +220,7 @@ func TestConfigsForService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.Datadog().SetWithoutSource("prometheus_scrape.version", tt.version)
+			pkgconfigsetup.Datadog().SetWithoutSource("prometheus_scrape.version", tt.version)
 			assert.NoError(t, tt.check.Init(tt.version))
 			assert.ElementsMatch(t, tt.want, ConfigsForService(tt.check, tt.svc))
 		})

--- a/comp/core/autodiscovery/common/utils/prometheus_kubelet_test.go
+++ b/comp/core/autodiscovery/common/utils/prometheus_kubelet_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 
 	"github.com/stretchr/testify/assert"
@@ -515,7 +515,7 @@ func TestConfigsForPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.Datadog().SetWithoutSource("prometheus_scrape.version", tt.version)
+			pkgconfigsetup.Datadog().SetWithoutSource("prometheus_scrape.version", tt.version)
 			tt.check.Init(tt.version)
 			assert.ElementsMatch(t, tt.want, ConfigsForPod(tt.check, tt.pod))
 		})

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // Component is the component type.
@@ -26,7 +26,7 @@ type Component interface {
 	ForceRanOnceFlag()
 	HasRunOnce() bool
 	GetAllConfigs() []integration.Config
-	AddListeners(listenerConfigs []config.Listeners)
+	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)
 	RemoveScheduler(name string)
 	MapOverLoadedConfigs(f func(map[string]integration.Config))

--- a/comp/core/autodiscovery/listeners/common.go
+++ b/comp/core/autodiscovery/listeners/common.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -102,7 +102,7 @@ func (f *containerFilters) IsExcluded(filter containers.FilterType, annotations 
 // getPrometheusIncludeAnnotations returns the Prometheus AD include annotations based on the Prometheus config
 func getPrometheusIncludeAnnotations() types.PrometheusAnnotations {
 	annotations := types.PrometheusAnnotations{}
-	tmpConfigString := config.Datadog().GetString("prometheus_scrape.checks")
+	tmpConfigString := pkgconfigsetup.Datadog().GetString("prometheus_scrape.checks")
 
 	var checks []*types.PrometheusCheck
 	if len(tmpConfigString) > 0 {
@@ -120,7 +120,7 @@ func getPrometheusIncludeAnnotations() types.PrometheusAnnotations {
 	}
 
 	for _, check := range checks {
-		if err := check.Init(config.Datadog().GetInt("prometheus_scrape.version")); err != nil {
+		if err := check.Init(pkgconfigsetup.Datadog().GetInt("prometheus_scrape.version")); err != nil {
 			log.Errorf("Couldn't init check configuration: %v", err)
 			continue
 		}

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	pkgcontainersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -89,7 +89,7 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 	// stopped.
 	if !container.State.Running && !container.State.FinishedAt.IsZero() {
 		finishedAt := container.State.FinishedAt
-		excludeAge := time.Duration(config.Datadog().GetInt("container_exclude_stopped_age")) * time.Hour
+		excludeAge := time.Duration(pkgconfigsetup.Datadog().GetInt("container_exclude_stopped_age")) * time.Hour
 		if time.Since(finishedAt) > excludeAge {
 			log.Debugf("container %q not running for too long, skipping", container.ID)
 			return

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -136,7 +136,7 @@ func (l *KubeletListener) createContainerService(
 	// stopped.
 	if !container.State.Running && !container.State.FinishedAt.IsZero() {
 		finishedAt := container.State.FinishedAt
-		excludeAge := time.Duration(config.Datadog().GetInt("container_exclude_stopped_age")) * time.Hour
+		excludeAge := time.Duration(pkgconfigsetup.Datadog().GetInt("container_exclude_stopped_age")) * time.Hour
 		if time.Since(finishedAt) > excludeAge {
 			log.Debugf("container %q not running for too long, skipping", container.ID)
 			return

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -172,7 +172,7 @@ func (s *service) filterTemplatesOverriddenChecks(configs map[string]integration
 // added by the config provider (AddContainerCollectAllConfigs) if the service
 // has any other templates containing logs config.
 func (s *service) filterTemplatesContainerCollectAll(configs map[string]integration.Config) {
-	if !config.Datadog().GetBool("logs_config.container_collect_all") {
+	if !pkgconfigsetup.Datadog().GetBool("logs_config.container_collect_all") {
 		return
 	}
 

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 
@@ -43,7 +43,7 @@ func TestSNMPListener(t *testing.T) {
 		}
 	}
 
-	l, err := NewSNMPListener(&config.Listeners{}, nil)
+	l, err := NewSNMPListener(&pkgconfigsetup.Listeners{}, nil)
 	assert.Equal(t, nil, err)
 	l.Listen(newSvc, delSvc)
 
@@ -142,7 +142,7 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 		}
 	}
 
-	l, err := NewSNMPListener(&config.Listeners{}, nil)
+	l, err := NewSNMPListener(&pkgconfigsetup.Listeners{}, nil)
 	assert.Equal(t, nil, err)
 	l.Listen(newSvc, delSvc)
 

--- a/comp/core/autodiscovery/listeners/staticconfig.go
+++ b/comp/core/autodiscovery/listeners/staticconfig.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
@@ -51,7 +51,7 @@ func (l *StaticConfigListener) createServices() {
 		"container_lifecycle",
 		"sbom",
 	} {
-		if enabled := config.Datadog().GetBool(staticCheck + ".enabled"); enabled {
+		if enabled := pkgconfigsetup.Datadog().GetBool(staticCheck + ".enabled"); enabled {
 			l.newService <- &StaticConfigService{adIdentifier: "_" + staticCheck}
 		}
 	}

--- a/comp/core/autodiscovery/providers/cloudfoundry.go
+++ b/comp/core/autodiscovery/providers/cloudfoundry.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -34,7 +34,7 @@ type CloudFoundryConfigProvider struct {
 }
 
 // NewCloudFoundryConfigProvider instantiates a new CloudFoundryConfigProvider from given config
-func NewCloudFoundryConfigProvider(*config.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewCloudFoundryConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
 	cfp := CloudFoundryConfigProvider{
 		lastCollected: time.Now(),
 	}

--- a/comp/core/autodiscovery/providers/cloudfoundry_nop.go
+++ b/comp/core/autodiscovery/providers/cloudfoundry_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewCloudFoundryConfigProvider instantiates a new CloudFoundryConfigProvider from given config
-var NewCloudFoundryConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewCloudFoundryConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	ddErrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -42,9 +42,9 @@ type ClusterChecksConfigProvider struct {
 // NewClusterChecksConfigProvider returns a new ConfigProvider collecting
 // cluster check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewClusterChecksConfigProvider(providerConfig *config.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
 	if providerConfig == nil {
-		providerConfig = &config.ConfigurationProviders{}
+		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
 
 	c := &ClusterChecksConfigProvider{
@@ -52,11 +52,11 @@ func NewClusterChecksConfigProvider(providerConfig *config.ConfigurationProvider
 		degradedDuration: defaultDegradedDeadline,
 	}
 
-	c.identifier = config.Datadog().GetString("clc_runner_id")
+	c.identifier = pkgconfigsetup.Datadog().GetString("clc_runner_id")
 	if c.identifier == "" {
 		c.identifier, _ = hostname.Get(context.TODO())
-		if config.Datadog().GetBool("cloud_foundry") {
-			boshID := config.Datadog().GetString("bosh_id")
+		if pkgconfigsetup.Datadog().GetBool("cloud_foundry") {
+			boshID := pkgconfigsetup.Datadog().GetString("bosh_id")
 			if boshID == "" {
 				log.Warn("configuration variable cloud_foundry is set to true, but bosh_id is empty, can't retrieve node name")
 			} else {
@@ -178,7 +178,7 @@ func (c *ClusterChecksConfigProvider) Collect(ctx context.Context) ([]integratio
 // This usually happens when scheduling a lot of checks on a CLC, especially larger checks
 // with `Configure()` implemented, like KSM Core and Orchestrator checks
 func (c *ClusterChecksConfigProvider) heartbeatSender(ctx context.Context) {
-	expirationTimeout := time.Duration(config.Datadog().GetInt("cluster_checks.node_expiration_timeout")) * time.Second
+	expirationTimeout := time.Duration(pkgconfigsetup.Datadog().GetInt("cluster_checks.node_expiration_timeout")) * time.Second
 	heartTicker := time.NewTicker(time.Second)
 	defer heartTicker.Stop()
 

--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -67,11 +67,11 @@ var doOnce sync.Once
 // InitConfigFilesReader should be called at agent startup.
 func InitConfigFilesReader(paths []string) {
 	fileCacheExpiration := 5 * time.Minute
-	if config.Datadog().GetBool("autoconf_config_files_poll") {
+	if pkgconfigsetup.Datadog().GetBool("autoconf_config_files_poll") {
 		// Removing some time (1s) to avoid races with polling interval.
 		// If cache expiration is set to be == ticker interval the cache may be used if t1B (cache read time) - t0B (ticker time) < t1A (cache store time) - t0A (ticker time).
 		// Which is likely to be the case because the code path on a cache write is slower.
-		configExpSeconds := config.Datadog().GetInt("autoconf_config_files_poll_interval") - 1
+		configExpSeconds := pkgconfigsetup.Datadog().GetInt("autoconf_config_files_poll_interval") - 1
 		// If we are below < 1, cache is basically disabled, we cannot put 0 as it's considered no expiration by cache.Cache
 		if configExpSeconds < 1 {
 			fileCacheExpiration = time.Nanosecond
@@ -243,7 +243,7 @@ func collectEntry(file os.DirEntry, path string, integrationName string, integra
 	absPath := filepath.Join(path, fileName)
 
 	// skip auto conf files based on the agent configuration
-	if fileName == "auto_conf.yaml" && containsString(config.Datadog().GetStringSlice("ignore_autoconf"), integrationName) {
+	if fileName == "auto_conf.yaml" && containsString(pkgconfigsetup.Datadog().GetStringSlice("ignore_autoconf"), integrationName) {
 		log.Infof("Skipping 'auto_conf.yaml' for integration '%s'", integrationName)
 		entry.err = fmt.Errorf("'auto_conf.yaml' for integration '%s' is skipped", integrationName)
 		return entry, integrationErrors
@@ -398,7 +398,7 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 		if fargate.IsFargateInstance() {
 			// In Fargate, since no host tags are applied in the backend,
 			// add the configured DD_TAGS/DD_EXTRA_TAGS to the instance tags.
-			tags := configUtils.GetConfiguredTags(config.Datadog(), false)
+			tags := configUtils.GetConfiguredTags(pkgconfigsetup.Datadog(), false)
 			err := dataConf.MergeAdditionalTags(tags)
 			if err != nil {
 				log.Debugf("Could not add agent-level tags to instance of %v: %v", fpath, err)

--- a/comp/core/autodiscovery/providers/consul.go
+++ b/comp/core/autodiscovery/providers/consul.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -53,9 +53,9 @@ type ConsulConfigProvider struct {
 }
 
 // NewConsulConfigProvider creates a client connection to consul and create a new ConsulConfigProvider
-func NewConsulConfigProvider(providerConfig *config.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewConsulConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
 	if providerConfig == nil {
-		providerConfig = &config.ConfigurationProviders{}
+		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
 
 	consulURL, err := url.Parse(providerConfig.TemplateURL)

--- a/comp/core/autodiscovery/providers/consul_nop.go
+++ b/comp/core/autodiscovery/providers/consul_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewConsulConfigProvider creates a client connection to consul and create a new ConsulConfigProvider
-var NewConsulConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewConsulConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/container.go
+++ b/comp/core/autodiscovery/providers/container.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -34,7 +34,7 @@ type ContainerConfigProvider struct {
 
 // NewContainerConfigProvider returns a new ConfigProvider subscribed to both container
 // and pods
-func NewContainerConfigProvider(_ *config.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+func NewContainerConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
 	return &ContainerConfigProvider{
 		workloadmetaStore: wmeta,
 		configCache:       make(map[string]map[string]integration.Config),

--- a/comp/core/autodiscovery/providers/endpointschecks.go
+++ b/comp/core/autodiscovery/providers/endpointschecks.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
@@ -35,7 +35,7 @@ type EndpointsChecksConfigProvider struct {
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewEndpointsChecksConfigProvider(providerConfig *config.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewEndpointsChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
 	c := &EndpointsChecksConfigProvider{
 		degradedDuration: defaultDegradedDeadline,
 	}
@@ -110,8 +110,8 @@ func (c *EndpointsChecksConfigProvider) Collect(ctx context.Context) ([]integrat
 // getNodename retrieves current node name from kubelet (if running on Kubernetes)
 // or bosh ID of current node (if running on Cloud Foundry).
 func getNodename(ctx context.Context) (string, error) {
-	if config.Datadog().GetBool("cloud_foundry") {
-		boshID := config.Datadog().GetString("bosh_id")
+	if pkgconfigsetup.Datadog().GetBool("cloud_foundry") {
+		boshID := pkgconfigsetup.Datadog().GetString("bosh_id")
 		if boshID == "" {
 			return "", fmt.Errorf("configuration variable cloud_foundry is set to true, but bosh_id is empty, can't retrieve node name")
 		}

--- a/comp/core/autodiscovery/providers/endpointschecks_nop.go
+++ b/comp/core/autodiscovery/providers/endpointschecks_nop.go
@@ -9,10 +9,10 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewEndpointsChecksConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewEndpointsChecksConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/etcd.go
+++ b/comp/core/autodiscovery/providers/etcd.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -37,9 +37,9 @@ type EtcdConfigProvider struct {
 }
 
 // NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
-func NewEtcdConfigProvider(providerConfig *config.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewEtcdConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
 	if providerConfig == nil {
-		providerConfig = &config.ConfigurationProviders{}
+		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
 
 	clientCfg := client.Config{

--- a/comp/core/autodiscovery/providers/etcd_nop.go
+++ b/comp/core/autodiscovery/providers/etcd_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
-var NewEtcdConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewEtcdConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/file_test.go
+++ b/comp/core/autodiscovery/providers/file_test.go
@@ -14,7 +14,7 @@ import (
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +22,7 @@ import (
 
 func TestCollect(t *testing.T) {
 	ctx := context.Background()
-	config.Datadog().SetWithoutSource("ignore_autoconf", []string{"ignored"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ignore_autoconf", []string{"ignored"})
 	paths := []string{"tests", "foo/bar"}
 
 	telemetry := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -57,7 +57,7 @@ type KubeEndpointsFileConfigProvider struct {
 }
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
-func NewKubeEndpointsFileConfigProvider(*config.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewKubeEndpointsFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
 	templates, _, err := ReadConfigFiles(WithAdvancedADOnly)
 	if err != nil {
 		return nil, err

--- a/comp/core/autodiscovery/providers/kube_endpoints_file_nop.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
-var NewKubeEndpointsFileConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeEndpointsFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_endpoints_nop.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_nop.go
@@ -9,9 +9,9 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeEndpointsConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewKubeEndpointsConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeEndpointsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_test.go
@@ -26,7 +26,7 @@ import (
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -271,7 +271,7 @@ func TestParseKubeServiceAnnotationsForEndpoints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 			if tc.hybrid {
 				cfg.SetWithoutSource("cluster_checks.support_hybrid_ignore_ad_tags", true)
 			}

--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -21,7 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -41,7 +42,7 @@ type KubeServiceConfigProvider struct {
 
 // NewKubeServiceConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewKubeServiceConfigProvider(_ *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+func NewKubeServiceConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error) {
 	// Using GetAPIClient() (no retry)
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -67,7 +68,7 @@ func NewKubeServiceConfigProvider(_ *config.ConfigurationProviders, telemetrySto
 		return nil, fmt.Errorf("cannot add event handler to services informer: %s", err)
 	}
 
-	if config.Datadog().GetBool("cluster_checks.support_hybrid_ignore_ad_tags") {
+	if pkgconfigsetup.Datadog().GetBool("cluster_checks.support_hybrid_ignore_ad_tags") {
 		log.Warnf("The `cluster_checks.support_hybrid_ignore_ad_tags` flag is" +
 			" deprecated and will be removed in a future version. Please replace " +
 			"`ad.datadoghq.com/service.ignore_autodiscovery_tags` in your service annotations" +
@@ -92,7 +93,7 @@ func (k *KubeServiceConfigProvider) Collect(ctx context.Context) ([]integration.
 	}
 	k.upToDate = true
 
-	return k.parseServiceAnnotations(services, config.Datadog())
+	return k.parseServiceAnnotations(services, pkgconfigsetup.Datadog())
 }
 
 // IsUpToDate allows to cache configs as long as no changes are detected in the apiserver
@@ -162,7 +163,7 @@ func valuesDiffer(first, second map[string]string, prefix string) bool {
 	return matchingInFirst != matchingInSecond
 }
 
-func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Service, ddConf config.Config) ([]integration.Config, error) {
+func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Service, ddConf model.Config) ([]integration.Config, error) {
 	var configs []integration.Config
 
 	setServiceIDs := map[string]struct{}{}

--- a/comp/core/autodiscovery/providers/kube_services_file.go
+++ b/comp/core/autodiscovery/providers/kube_services_file.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
@@ -22,7 +22,7 @@ type KubeServiceFileConfigProvider struct {
 }
 
 // NewKubeServiceFileConfigProvider returns a new KubeServiceFileConfigProvider
-func NewKubeServiceFileConfigProvider(*config.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewKubeServiceFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
 	return &KubeServiceFileConfigProvider{}, nil
 }
 

--- a/comp/core/autodiscovery/providers/kube_services_file_nop.go
+++ b/comp/core/autodiscovery/providers/kube_services_file_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeServiceFileConfigProvider returns a new KubeServiceFileConfigProvider
-var NewKubeServiceFileConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeServiceFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_services_nop.go
+++ b/comp/core/autodiscovery/providers/kube_services_nop.go
@@ -9,9 +9,9 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeServiceConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewKubeServiceConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeServiceConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_services_test.go
+++ b/comp/core/autodiscovery/providers/kube_services_test.go
@@ -26,7 +26,7 @@ import (
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
@@ -241,7 +241,7 @@ func TestParseKubeServiceAnnotations(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 			if tc.hybrid {
 				cfg.SetWithoutSource("cluster_checks.support_hybrid_ignore_ad_tags", true)
 			}

--- a/comp/core/autodiscovery/providers/prometheus_common.go
+++ b/comp/core/autodiscovery/providers/prometheus_common.go
@@ -7,14 +7,14 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // getPrometheusConfigs reads and initializes the openmetrics checks from the configuration
 // It defines a default openmetrics instances with default AD if the checks configuration is empty
 func getPrometheusConfigs() ([]*types.PrometheusCheck, error) {
-	checks, err := types.PrometheusScrapeChecksTransformer(config.Datadog().GetString("prometheus_scrape.checks"))
+	checks, err := types.PrometheusScrapeChecksTransformer(pkgconfigsetup.Datadog().GetString("prometheus_scrape.checks"))
 	if err != nil {
 		return []*types.PrometheusCheck{}, err
 	}
@@ -26,7 +26,7 @@ func getPrometheusConfigs() ([]*types.PrometheusCheck, error) {
 
 	validChecks := []*types.PrometheusCheck{}
 	for i, check := range checks {
-		if err := check.Init(config.Datadog().GetInt("prometheus_scrape.version")); err != nil {
+		if err := check.Init(pkgconfigsetup.Datadog().GetInt("prometheus_scrape.version")); err != nil {
 			log.Errorf("Ignoring check configuration (# %d): %v", i+1, err)
 			continue
 		}

--- a/comp/core/autodiscovery/providers/prometheus_common_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_common_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -198,7 +198,7 @@ func TestGetPrometheusConfigs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			confBytes, _ := json.Marshal(tt.config)
-			config.Datadog().SetWithoutSource("prometheus_scrape.checks", string(confBytes))
+			pkgconfigsetup.Datadog().SetWithoutSource("prometheus_scrape.checks", string(confBytes))
 			checks, err := getPrometheusConfigs()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPrometheusConfigs() error = %v, wantErr %v", err, tt.wantErr)

--- a/comp/core/autodiscovery/providers/prometheus_pods.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -28,7 +28,7 @@ type PrometheusPodsConfigProvider struct {
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewPrometheusPodsConfigProvider(*config.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewPrometheusPodsConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
 	checks, err := getPrometheusConfigs()
 	if err != nil {
 		return nil, err

--- a/comp/core/autodiscovery/providers/prometheus_pods_nop.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods_nop.go
@@ -9,9 +9,9 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewPrometheusPodsConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewPrometheusPodsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/prometheus_services.go
+++ b/comp/core/autodiscovery/providers/prometheus_services.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -66,7 +66,7 @@ type PrometheusServicesConfigProvider struct {
 }
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-func NewPrometheusServicesConfigProvider(*config.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewPrometheusServicesConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -81,7 +81,7 @@ func NewPrometheusServicesConfigProvider(*config.ConfigurationProviders, *teleme
 	var endpointsInformer infov1.EndpointsInformer
 	var endpointsLister listersv1.EndpointsLister
 
-	collectEndpoints := config.Datadog().GetBool("prometheus_scrape.service_endpoints")
+	collectEndpoints := pkgconfigsetup.Datadog().GetBool("prometheus_scrape.service_endpoints")
 	if collectEndpoints {
 		endpointsInformer = ac.InformerFactory.Core().V1().Endpoints()
 		if endpointsInformer == nil {

--- a/comp/core/autodiscovery/providers/prometheus_services_nop.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-var NewPrometheusServicesConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewPrometheusServicesConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/prometheus_services_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -259,7 +259,7 @@ func TestPrometheusServicesCollect(t *testing.T) {
 		},
 	}
 
-	config.Datadog().SetWithoutSource("prometheus_scrape.version", 2)
+	pkgconfigsetup.Datadog().SetWithoutSource("prometheus_scrape.version", 2)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/comp/core/autodiscovery/providers/providers.go
+++ b/comp/core/autodiscovery/providers/providers.go
@@ -12,17 +12,17 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // RegisterProvider adds a loader to the providers catalog
 func RegisterProvider(name string,
-	factory func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error),
+	factory func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error),
 	providerCatalog map[string]ConfigProviderFactory) {
 	RegisterProviderWithComponents(
 		name,
-		func(providerConfig *config.ConfigurationProviders, _ workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+		func(providerConfig *pkgconfigsetup.ConfigurationProviders, _ workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
 			return factory(providerConfig, telemetryStore)
 		},
 		providerCatalog,
@@ -61,7 +61,7 @@ func RegisterProviders(providerCatalog map[string]ConfigProviderFactory) {
 }
 
 // ConfigProviderFactory is any function capable to create a ConfigProvider instance
-type ConfigProviderFactory func(providerConfig *config.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error)
+type ConfigProviderFactory func(providerConfig *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error)
 
 // ConfigProvider represents a source of `integration.Config` values
 // that can either be applied immediately or resolved for a service and

--- a/comp/core/autodiscovery/providers/remote_config.go
+++ b/comp/core/autodiscovery/providers/remote_config.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -96,7 +96,7 @@ func (rc *RemoteConfigProvider) IntegrationScheduleCallback(updates map[string]s
 	defer rc.mu.Unlock()
 	var err error
 
-	allowedIntegration := config.GetRemoteConfigurationAllowedIntegrations(config.Datadog())
+	allowedIntegration := pkgconfigsetup.GetRemoteConfigurationAllowedIntegrations(pkgconfigsetup.Datadog())
 
 	newCache := make(map[string]integration.Config, 0)
 	// Now schedule everything

--- a/comp/core/autodiscovery/providers/utils.go
+++ b/comp/core/autodiscovery/providers/utils.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 const (
@@ -26,20 +26,20 @@ const (
 )
 
 func buildStoreKey(key ...string) string {
-	parts := []string{config.Datadog().GetString("autoconf_template_dir")}
+	parts := []string{pkgconfigsetup.Datadog().GetString("autoconf_template_dir")}
 	parts = append(parts, key...)
 	return path.Join(parts...)
 }
 
 // GetPollInterval computes the poll interval from the config
-func GetPollInterval(cp config.ConfigurationProviders) time.Duration {
+func GetPollInterval(cp pkgconfigsetup.ConfigurationProviders) time.Duration {
 	if cp.PollInterval != "" {
 		customInterval, err := time.ParseDuration(cp.PollInterval)
 		if err == nil {
 			return customInterval
 		}
 	}
-	return config.Datadog().GetDuration("ad_config_poll_interval") * time.Second
+	return pkgconfigsetup.Datadog().GetDuration("ad_config_poll_interval") * time.Second
 }
 
 // providerCache supports monitoring a service for changes either to the number

--- a/comp/core/autodiscovery/providers/utils_test.go
+++ b/comp/core/autodiscovery/providers/utils_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestBuildStoreKey(t *testing.T) {
@@ -28,13 +28,13 @@ func TestBuildStoreKey(t *testing.T) {
 }
 
 func TestGetPollInterval(t *testing.T) {
-	cp := config.ConfigurationProviders{}
+	cp := pkgconfigsetup.ConfigurationProviders{}
 	assert.Equal(t, GetPollInterval(cp), 10*time.Second)
-	cp = config.ConfigurationProviders{
+	cp = pkgconfigsetup.ConfigurationProviders{
 		PollInterval: "foo",
 	}
 	assert.Equal(t, GetPollInterval(cp), 10*time.Second)
-	cp = config.ConfigurationProviders{
+	cp = pkgconfigsetup.ConfigurationProviders{
 		PollInterval: "1s",
 	}
 	assert.Equal(t, GetPollInterval(cp), 1*time.Second)

--- a/comp/core/autodiscovery/providers/zookeeper.go
+++ b/comp/core/autodiscovery/providers/zookeeper.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -41,9 +41,9 @@ type ZookeeperConfigProvider struct {
 }
 
 // NewZookeeperConfigProvider returns a new Client connected to a Zookeeper backend.
-func NewZookeeperConfigProvider(providerConfig *config.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewZookeeperConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
 	if providerConfig == nil {
-		providerConfig = &config.ConfigurationProviders{}
+		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
 
 	urls := strings.Split(providerConfig.TemplateURL, ",")

--- a/comp/core/autodiscovery/providers/zookeeper_nop.go
+++ b/comp/core/autodiscovery/providers/zookeeper_nop.go
@@ -9,8 +9,8 @@ package providers
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewZookeeperConfigProvider returns a new Client connected to a Zookeeper backend.
-var NewZookeeperConfigProvider func(providerConfig *config.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewZookeeperConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)

--- a/comp/core/tagger/params.go
+++ b/comp/core/tagger/params.go
@@ -7,7 +7,7 @@ package tagger
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // AgentTypeForTagger represents agent types that tagger is used for
@@ -29,7 +29,7 @@ type Params struct {
 
 // NewTaggerParamsForCoreAgent is a constructor function for creating core agent tagger params
 func NewTaggerParamsForCoreAgent(_ config.Component) Params {
-	if pkgconfig.IsCLCRunner() {
+	if pkgconfigsetup.IsCLCRunner(pkgconfigsetup.Datadog()) {
 		return NewCLCRunnerRemoteTaggerParams()
 	}
 	return NewTaggerParams()

--- a/comp/core/tagger/taggerimpl/collectors/ecs_common.go
+++ b/comp/core/tagger/taggerimpl/collectors/ecs_common.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func addResourceTags(t *taglist.TagList, m map[string]string) {
@@ -19,7 +19,7 @@ func addResourceTags(t *taglist.TagList, m map[string]string) {
 			continue
 		}
 
-		if config.Datadog().GetBool("ecs_resource_tags_replace_colon") {
+		if pkgconfigsetup.Datadog().GetBool("ecs_resource_tags_replace_colon") {
 			k = strings.ReplaceAll(k, ":", "_")
 		}
 

--- a/comp/core/tagger/taggerimpl/collectors/ecs_common_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/ecs_common_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -51,10 +51,10 @@ func TestAddResourceTags(t *testing.T) {
 				expectedTags.AddLow("environment", "sandbox")
 				expectedTags.AddLow("project", "ecs-test")
 				expectedTags.AddLow("foo_bar_baz", "val")
-				config.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", true)
+				pkgconfigsetup.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", true)
 				return expectedTags
 			},
-			resetFunc: func() { config.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", false) },
+			resetFunc: func() { pkgconfigsetup.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", false) },
 		},
 		{
 			name: "replace colon enabled, do not replace tag value",
@@ -70,10 +70,10 @@ func TestAddResourceTags(t *testing.T) {
 				expectedTags.AddLow("environment", "sandbox")
 				expectedTags.AddLow("project", "ecs-test")
 				expectedTags.AddLow("foo_bar_baz", "val1:val2")
-				config.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", true)
+				pkgconfigsetup.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", true)
 				return expectedTags
 			},
-			resetFunc: func() { config.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", false) },
+			resetFunc: func() { pkgconfigsetup.Datadog().SetWithoutSource("ecs_resource_tags_replace_colon", false) },
 		},
 		{
 			name: "replace colon disabled",

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -360,7 +360,7 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*types.Ta
 	}
 
 	kubeServiceDisabled := false
-	for _, disabledTag := range config.Datadog().GetStringSlice("kubernetes_ad_tags_disabled") {
+	for _, disabledTag := range pkgconfigsetup.Datadog().GetStringSlice("kubernetes_ad_tags_disabled") {
 		if disabledTag == "kube_service" {
 			kubeServiceDisabled = true
 			break
@@ -447,7 +447,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 	taskTags.AddOrchestrator(tags.TaskARN, task.ID)
 
 	if task.ClusterName != "" {
-		if !config.Datadog().GetBool("disable_cluster_name_tag_key") {
+		if !pkgconfigsetup.Datadog().GetBool("disable_cluster_name_tag_key") {
 			taskTags.AddLow(tags.ClusterName, task.ClusterName)
 		}
 		taskTags.AddLow(tags.EcsClusterName, task.ClusterName)

--- a/comp/core/tagger/taglist/taglist.go
+++ b/comp/core/tagger/taglist/taglist.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // TagList allows collector to incremental build a tag list
@@ -30,7 +30,7 @@ func NewTagList() *TagList {
 		orchestratorCardTags: make(map[string]bool),
 		highCardTags:         make(map[string]bool),
 		standardTags:         make(map[string]bool),
-		splitList:            config.Datadog().GetStringMapString("tag_value_split_separator"),
+		splitList:            pkgconfigsetup.Datadog().GetStringMapString("tag_value_split_separator"),
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
@@ -15,8 +15,8 @@ import (
 	"go.uber.org/fx"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
@@ -57,7 +57,7 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Component) error
 	}
 
 	// Detect if we're on a PCF container
-	if !config.Datadog().GetBool("cloud_foundry_buildpack") {
+	if !pkgconfigsetup.Datadog().GetBool("cloud_foundry_buildpack") {
 		return errors.NewDisabled(componentName, "Agent is not running on a CloudFoundry container")
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
@@ -15,8 +15,8 @@ import (
 	"go.uber.org/fx"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
@@ -72,10 +72,10 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Component) error
 		return err
 	}
 
-	c.nodeName = config.Datadog().GetString("bosh_id")
+	c.nodeName = pkgconfigsetup.Datadog().GetString("bosh_id")
 
 	// Check for Cluster Agent availability (will be retried at each pull)
-	c.dcaEnabled = config.Datadog().GetBool("cluster_agent.enabled")
+	c.dcaEnabled = pkgconfigsetup.Datadog().GetBool("cluster_agent.enabled")
 	c.dcaClient = c.getDCAClient()
 
 	return nil

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -20,8 +20,8 @@ import (
 	"go.uber.org/fx"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	agentErrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -430,5 +430,5 @@ func (c *collector) cacheExitInfo(id string, exitCode *int64, exitTS time.Time) 
 }
 
 func imageMetadataCollectionIsEnabled() bool {
-	return config.Datadog().GetBool("container_image.enabled")
+	return pkgconfigsetup.Datadog().GetBool("container_image.enabled")
 }

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/containerd"
@@ -23,7 +23,7 @@ import (
 )
 
 func sbomCollectionIsEnabled() bool {
-	return imageMetadataCollectionIsEnabled() && config.Datadog().GetBool("sbom.container_image.enabled")
+	return imageMetadataCollectionIsEnabled() && pkgconfigsetup.Datadog().GetBool("sbom.container_image.enabled")
 }
 
 func (c *collector) startSBOMCollection(ctx context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/containerd/network_linux.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/network_linux.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/containerd/containerd"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
@@ -48,7 +48,7 @@ func extractIP(namespace string, container containerd.Container, containerdClien
 	// of them.
 	for _, taskPid := range taskPids {
 		IPs, err := system.ParseProcessIPs(
-			config.Datadog().GetString("container_proc_root"),
+			pkgconfigsetup.Datadog().GetString("container_proc_root"),
 			int(taskPid.Pid),
 			func(ip string) bool { return ip != "127.0.0.1" },
 		)

--- a/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/docker"
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
@@ -24,11 +24,11 @@ import (
 )
 
 func imageMetadataCollectionIsEnabled() bool {
-	return config.Datadog().GetBool("container_image.enabled")
+	return pkgconfigsetup.Datadog().GetBool("container_image.enabled")
 }
 
 func sbomCollectionIsEnabled() bool {
-	return imageMetadataCollectionIsEnabled() && config.Datadog().GetBool("sbom.container_image.enabled")
+	return imageMetadataCollectionIsEnabled() && pkgconfigsetup.Datadog().GetBool("sbom.container_image.enabled")
 }
 
 func (c *collector) startSBOMCollection(ctx context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/podman/podman.go
+++ b/comp/core/workloadmeta/collectors/internal/podman/podman.go
@@ -18,8 +18,8 @@ import (
 	"go.uber.org/fx"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -68,7 +68,7 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Component) error
 	}
 
 	var dbPath string
-	dbPath = config.Datadog().GetString("podman_db_path")
+	dbPath = pkgconfigsetup.Datadog().GetString("podman_db_path")
 
 	// We verify the user-provided path exists to prevent the collector entering a failing loop.
 	if dbPath != "" && !dbIsAccessible(dbPath) {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	processwlm "github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
@@ -50,7 +50,7 @@ type collector struct {
 // NewCollector returns a new local process collector provider and an error.
 // Currently, this is only used on Linux when language detection and run in core agent are enabled.
 func NewCollector() (workloadmeta.CollectorProvider, error) {
-	wlmExtractor := processwlm.GetSharedWorkloadMetaExtractor(config.SystemProbe())
+	wlmExtractor := processwlm.GetSharedWorkloadMetaExtractor(pkgconfigsetup.SystemProbe())
 	processData := NewProcessData()
 	processData.Register(wlmExtractor)
 
@@ -81,7 +81,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 	// If process collection is disabled, the collector will gather the basic process and container data
 	// necessary for language detection.
-	if !config.Datadog().GetBool("process_config.process_collection.enabled") {
+	if !pkgconfigsetup.Datadog().GetBool("process_config.process_collection.enabled") {
 		collectionTicker := c.collectionClock.Ticker(10 * time.Second)
 		if c.containerProvider == nil {
 			c.containerProvider = proccontainers.GetSharedContainerProvider(store)

--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -25,7 +25,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -148,7 +148,7 @@ func (c *GenericCollector) startWorkloadmetaStream(maxElapsed time.Duration) err
 		default:
 		}
 
-		token, err := security.FetchAuthToken(pkgconfig.Datadog())
+		token, err := security.FetchAuthToken(pkgconfigsetup.Datadog())
 		if err != nil {
 			err = fmt.Errorf("unable to fetch authentication token: %w", err)
 			log.Warnf("unable to establish entity stream between agents, will possibly retry: %s", err)
@@ -179,7 +179,7 @@ func (c *GenericCollector) startWorkloadmetaStream(maxElapsed time.Duration) err
 
 // Run will run the generic collector streaming loop
 func (c *GenericCollector) Run() {
-	recvWithoutTimeout := pkgconfig.Datadog().GetBool("workloadmeta.remote.recv_without_timeout")
+	recvWithoutTimeout := pkgconfigsetup.Datadog().GetBool("workloadmeta.remote.recv_without_timeout")
 
 	for {
 		select {

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector.go
@@ -20,7 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
@@ -72,7 +73,7 @@ func (s *stream) Recv() (interface{}, error) {
 
 type streamHandler struct {
 	port int
-	config.Reader
+	model.Reader
 }
 
 // workloadmetaEventFromProcessEventSet converts the given ProcessEventSet into a workloadmeta.Event
@@ -119,7 +120,7 @@ func NewCollector() (workloadmeta.CollectorProvider, error) {
 		Collector: &remote.GenericCollector{
 			CollectorID: collectorID,
 			// TODO(components): make sure StreamHandler uses the config component not pkg/config
-			StreamHandler: &streamHandler{Reader: config.Datadog()},
+			StreamHandler: &streamHandler{Reader: pkgconfigsetup.Datadog()},
 			Catalog:       workloadmeta.NodeAgent,
 			Insecure:      true, // wlm extractor currently does not support TLS
 		},

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -30,7 +30,7 @@ import (
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -65,11 +65,11 @@ func (s *mockServer) StreamEntities(_ *pbgo.ProcessStreamEntitiesRequest, out pb
 
 func TestCollection(t *testing.T) {
 	// Create Auth Token for the client
-	if _, err := os.Stat(security.GetAuthTokenFilepath(pkgconfig.Datadog())); os.IsNotExist(err) {
-		security.CreateOrFetchToken(pkgconfig.Datadog())
+	if _, err := os.Stat(security.GetAuthTokenFilepath(pkgconfigsetup.Datadog())); os.IsNotExist(err) {
+		security.CreateOrFetchToken(pkgconfigsetup.Datadog())
 		defer func() {
 			// cleanup
-			os.Remove(security.GetAuthTokenFilepath(pkgconfig.Datadog()))
+			os.Remove(security.GetAuthTokenFilepath(pkgconfigsetup.Datadog()))
 		}()
 	}
 	creationTime := time.Now().Unix()

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -18,7 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/proto"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
@@ -88,7 +89,7 @@ func (s *stream) Recv() (interface{}, error) {
 type streamHandler struct {
 	port   int
 	filter *workloadmeta.Filter
-	config.Config
+	model.Config
 }
 
 // NewCollector returns a CollectorProvider to build a remote workloadmeta collector, and an error if any.
@@ -102,7 +103,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 			CollectorID: collectorID,
 			StreamHandler: &streamHandler{
 				filter: deps.Params.Filter,
-				Config: config.Datadog(),
+				Config: pkgconfigsetup.Datadog(),
 			},
 			Catalog: workloadmeta.Remote,
 		},

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/proto"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/server"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -191,11 +191,11 @@ func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 
 func TestCollection(t *testing.T) {
 	// Create Auth Token for the client
-	if _, err := os.Stat(security.GetAuthTokenFilepath(pkgconfig.Datadog())); os.IsNotExist(err) {
-		security.CreateOrFetchToken(pkgconfig.Datadog())
+	if _, err := os.Stat(security.GetAuthTokenFilepath(pkgconfigsetup.Datadog())); os.IsNotExist(err) {
+		security.CreateOrFetchToken(pkgconfigsetup.Datadog())
 		defer func() {
 			// cleanup
-			os.Remove(security.GetAuthTokenFilepath(pkgconfig.Datadog()))
+			os.Remove(security.GetAuthTokenFilepath(pkgconfigsetup.Datadog()))
 		}()
 	}
 

--- a/comp/core/workloadmeta/collectors/util/process_util_linux.go
+++ b/comp/core/workloadmeta/collectors/util/process_util_linux.go
@@ -8,7 +8,7 @@
 package util
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
@@ -20,8 +20,8 @@ func LocalProcessCollectorIsEnabled() bool {
 		return false
 	}
 
-	processChecksInCoreAgent := config.Datadog().GetBool("process_config.run_in_core_agent.enabled")
-	langDetectionEnabled := config.Datadog().GetBool("language_detection.enabled")
+	processChecksInCoreAgent := pkgconfigsetup.Datadog().GetBool("process_config.run_in_core_agent.enabled")
+	langDetectionEnabled := pkgconfigsetup.Datadog().GetBool("language_detection.enabled")
 
 	return langDetectionEnabled && processChecksInCoreAgent
 }

--- a/pkg/cli/subcommands/clusterchecks/command.go
+++ b/pkg/cli/subcommands/clusterchecks/command.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -130,7 +130,7 @@ func rebalance(_ log.Component, config config.Component, cliParams *cliParams) e
 
 	fmt.Println("Requesting a cluster check rebalance...")
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks/rebalance", pkgconfig.Datadog().GetInt("cluster_agent.cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks/rebalance", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
 
 	// Set session token
 	err := util.SetAuthToken(config)
@@ -183,7 +183,7 @@ func isolate(_ log.Component, config config.Component, cliParams *cliParams) err
 	if cliParams.checkID == "" {
 		return fmt.Errorf("checkID must be specified")
 	}
-	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks/isolate/check/%s", pkgconfig.Datadog().GetInt("cluster_agent.cmd_port"), cliParams.checkID)
+	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks/isolate/check/%s", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"), cliParams.checkID)
 
 	// Set session token
 	err := util.SetAuthToken(config)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
replaces most references to pkg/config in cmd/cluster-agent, comp/core/autodiscovery, comp/core/tagger, comp/core/workloadmeta, and pkg/cli/subcommands to respective submodule (e.g. pkg/config/model, pkg/config/setup, etc).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The majority of functions and variables were already moved to aliases with https://github.com/DataDog/datadog-agent/pull/20034; this change removes obfuscation and makes it clearer what our code is doing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
unit/integration tests should suffice since no code changes are made, just replacing references to aliases to references to the underlying functions/types