### PR TITLE
refactor pkg/config in security-agent and ebpf files

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -140,7 +140,7 @@ func (a *Agent) getHealth(w http.ResponseWriter, _ *http.Request) {
 func (a *Agent) makeFlare(w http.ResponseWriter, _ *http.Request) {
 	log.Infof("Making a flare")
 	w.Header().Set("Content-Type", "application/json")
-	logFile := config.Datadog().GetString("security_agent.log_file")
+	logFile := pkgconfigsetup.Datadog().GetString("security_agent.log_file")
 
 	filePath, err := flare.CreateSecurityAgentArchive(false, logFile, a.statusComponent)
 	if err != nil || filePath == "" {

--- a/cmd/security-agent/api/listener.go
+++ b/cmd/security-agent/api/listener.go
@@ -9,14 +9,14 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // newListener creates a listening connection
 func newListener() (net.Listener, error) {
-	address, err := config.GetIPCAddress()
+	address, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, err
 	}
-	return net.Listen("tcp", fmt.Sprintf("%v:%v", address, config.Datadog().GetInt("security_agent.cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("%v:%v", address, pkgconfigsetup.Datadog().GetInt("security_agent.cmd_port")))
 }

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -29,7 +29,8 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 )
 
 // Server implements security agent API server
@@ -61,7 +62,7 @@ func (s *Server) Start() error {
 	// Validate token for every request
 	r.Use(validateToken)
 
-	err := util.CreateAndSetAuthToken(config.Datadog())
+	err := util.CreateAndSetAuthToken(pkgconfigsetup.Datadog())
 	if err != nil {
 		return err
 	}
@@ -89,13 +90,13 @@ func (s *Server) Start() error {
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := config.NewLogWriter(4, seelog.ErrorLvl)
+	logWriter, _ := pkglogsetup.NewLogWriter(4, seelog.ErrorLvl)
 
 	srv := &http.Server{
 		Handler:      r,
 		ErrorLog:     stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		TLSConfig:    &tlsConfig,
-		WriteTimeout: config.Datadog().GetDuration("server_timeout") * time.Second,
+		WriteTimeout: pkgconfigsetup.Datadog().GetDuration("server_timeout") * time.Second,
 	}
 	tlsListener := tls.NewListener(s.listener, &tlsConfig)
 

--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -20,10 +20,10 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -147,13 +147,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{cmd}
 }
 func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
-	err := util.SetAuthToken(pkgconfig.Datadog())
+	err := util.SetAuthToken(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, err
 	}
 
 	c := util.GetClient(false)
-	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", pkgconfig.Datadog().GetInt("security_agent.cmd_port"))
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", pkgconfigsetup.Datadog().GetInt("security_agent.cmd_port"))
 
 	return settingshttp.NewClient(c, apiConfigURL, "security-agent", settingshttp.NewHTTPClientOptions(util.LeaveConnectionOpen)), nil
 }

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -33,7 +33,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
@@ -105,7 +105,7 @@ func evalCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", pkgconfigsetup.DefaultRuntimePoliciesDir, "Path to policies directory")
 	evalCmd.Flags().StringVar(&evalArgs.ruleID, "rule-id", "", "Rule ID to evaluate")
 	_ = evalCmd.MarkFlagRequired("rule-id")
 	evalCmd.Flags().StringVar(&evalArgs.eventFile, "event-file", "", "File of the event data")
@@ -138,7 +138,7 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 		},
 	}
 
-	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfigsetup.DefaultRuntimePoliciesDir, "Path to policies directory")
 	commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.evaluateAllPolicySources, "loaded-policies", false, "Evaluate loaded policies")
 	if runtime.GOOS == "linux" {
 		commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.windowsModel, "windows-model", false, "Evaluate policies using the Windows model")

--- a/cmd/security-agent/subcommands/runtime/deprecated_commands.go
+++ b/cmd/security-agent/subcommands/runtime/deprecated_commands.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -42,7 +42,7 @@ func checkPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command 
 		Deprecated: "please use `security-agent runtime policy check` instead",
 	}
 
-	checkPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	checkPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfigsetup.DefaultRuntimePoliciesDir, "Path to policies directory")
 
 	return []*cobra.Command{checkPoliciesCmd}
 }

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -55,10 +55,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	pkgCompliance "github.com/DataDog/datadog-agent/pkg/compliance"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -97,7 +96,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					ConfigParams:         config.NewSecurityAgentParams(params.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					SecretParams:         secrets.NewEnabledParams(),
-					LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", setup.DefaultSecurityAgentLogFile),
+					LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", pkgconfigsetup.DefaultSecurityAgentLogFile),
 				}),
 				core.Bundle(),
 				dogstatsd.ClientBundle,
@@ -123,7 +122,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return startstop.NewSerialStopper()
 				}),
 				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
-					return statsd.CreateForHostPort(setup.GetBindHost(config), config.GetInt("dogstatsd_port"))
+					return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))
 				}),
 				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, wmeta workloadmeta.Component) (status.InformationProvider, *agent.RuntimeSecurityAgent, error) {
 					hostnameDetected, err := utils.GetHostnameWithContextAndFallback(context.TODO())
@@ -284,7 +283,7 @@ func RunAgent(log log.Component, config config.Component, telemetry telemetry.Co
 
 	// Setup expvar server
 	port := config.GetString("security_agent.expvar_port")
-	pkgconfig.Datadog().Set("expvar_port", port, model.SourceAgentRuntime)
+	pkgconfigsetup.Datadog().Set("expvar_port", port, model.SourceAgentRuntime)
 	if config.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetry.Handler())
 	}

--- a/cmd/system-probe/config/adjust.go
+++ b/cmd/system-probe/config/adjust.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -18,7 +17,7 @@ import (
 var adjustMtx sync.Mutex
 
 // Adjust makes changes to the raw config based on deprecations and inferences.
-func Adjust(cfg config.Config) {
+func Adjust(cfg model.Config) {
 	adjustMtx.Lock()
 	defer adjustMtx.Unlock()
 	if cfg.GetBool(spNS("adjusted")) {
@@ -59,7 +58,7 @@ func Adjust(cfg config.Config) {
 
 // validateString validates the string configuration value at `key` using a custom provided function `valFn`.
 // If `key` is not set or `valFn` returns an error, the `defaultVal` is used instead.
-func validateString(cfg config.Config, key string, defaultVal string, valFn func(string) error) {
+func validateString(cfg model.Config, key string, defaultVal string, valFn func(string) error) {
 	if cfg.IsSet(key) {
 		if err := valFn(cfg.GetString(key)); err != nil {
 			log.Errorf("error validating `%s`: %s, using default value of `%s`", key, err, defaultVal)
@@ -72,7 +71,7 @@ func validateString(cfg config.Config, key string, defaultVal string, valFn func
 
 // validateInt validates the int configuration value at `key` using a custom provided function `valFn`.
 // If `key` is not set or `valFn` returns an error, the `defaultVal` is used instead.
-func validateInt(cfg config.Config, key string, defaultVal int, valFn func(int) error) {
+func validateInt(cfg model.Config, key string, defaultVal int, valFn func(int) error) {
 	if cfg.IsSet(key) {
 		if err := valFn(cfg.GetInt(key)); err != nil {
 			log.Errorf("error validating `%s`: %s, using default value of `%d`", key, err, defaultVal)
@@ -85,7 +84,7 @@ func validateInt(cfg config.Config, key string, defaultVal int, valFn func(int) 
 
 // validateInt64 validates the int64 configuration value at `key` using a custom provided function `valFn`.
 // If `key` is not set or `valFn` returns an error, the `defaultVal` is used instead.
-func validateInt64(cfg config.Config, key string, defaultVal int64, valFn func(int64) error) {
+func validateInt64(cfg model.Config, key string, defaultVal int64, valFn func(int64) error) {
 	if cfg.IsSet(key) {
 		if err := valFn(cfg.GetInt64(key)); err != nil {
 			log.Errorf("error validating `%s`: %s. using default value of `%d`", key, err, defaultVal)
@@ -97,7 +96,7 @@ func validateInt64(cfg config.Config, key string, defaultVal int64, valFn func(i
 }
 
 // applyDefault sets configuration `key` to `defaultVal` only if not previously set.
-func applyDefault(cfg config.Config, key string, defaultVal interface{}) {
+func applyDefault(cfg model.Config, key string, defaultVal interface{}) {
 	if !cfg.IsSet(key) {
 		cfg.Set(key, defaultVal, model.SourceAgentRuntime)
 	}
@@ -105,47 +104,47 @@ func applyDefault(cfg config.Config, key string, defaultVal interface{}) {
 
 // deprecateBool logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateBool(cfg config.Config, oldkey string, newkey string) {
-	deprecateCustom(cfg, oldkey, newkey, func(cfg config.Config) interface{} {
+func deprecateBool(cfg model.Config, oldkey string, newkey string) {
+	deprecateCustom(cfg, oldkey, newkey, func(cfg model.Config) interface{} {
 		return cfg.GetBool(oldkey)
 	})
 }
 
 // deprecateInt64 logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateInt64(cfg config.Config, oldkey string, newkey string) {
-	deprecateCustom(cfg, oldkey, newkey, func(cfg config.Config) interface{} {
+func deprecateInt64(cfg model.Config, oldkey string, newkey string) {
+	deprecateCustom(cfg, oldkey, newkey, func(cfg model.Config) interface{} {
 		return cfg.GetInt64(oldkey)
 	})
 }
 
 // deprecateGeneric logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateGeneric(cfg config.Config, oldkey string, newkey string) {
-	deprecateCustom(cfg, oldkey, newkey, func(cfg config.Config) interface{} {
+func deprecateGeneric(cfg model.Config, oldkey string, newkey string) {
+	deprecateCustom(cfg, oldkey, newkey, func(cfg model.Config) interface{} {
 		return cfg.Get(oldkey)
 	})
 }
 
 // deprecateInt logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateInt(cfg config.Config, oldkey string, newkey string) {
-	deprecateCustom(cfg, oldkey, newkey, func(cfg config.Config) interface{} {
+func deprecateInt(cfg model.Config, oldkey string, newkey string) {
+	deprecateCustom(cfg, oldkey, newkey, func(cfg model.Config) interface{} {
 		return cfg.GetInt(oldkey)
 	})
 }
 
 // deprecateString logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateString(cfg config.Config, oldkey string, newkey string) {
-	deprecateCustom(cfg, oldkey, newkey, func(cfg config.Config) interface{} {
+func deprecateString(cfg model.Config, oldkey string, newkey string) {
+	deprecateCustom(cfg, oldkey, newkey, func(cfg model.Config) interface{} {
 		return cfg.GetString(oldkey)
 	})
 }
 
 // deprecateCustom logs a deprecation message if `oldkey` is used.
 // It sets `newkey` to the value obtained from `getFn`, but only if `oldkey` is set and `newkey` is not set.
-func deprecateCustom(cfg config.Config, oldkey string, newkey string, getFn func(config.Config) interface{}) {
+func deprecateCustom(cfg model.Config, oldkey string, newkey string, getFn func(model.Config) interface{}) {
 	if cfg.IsSet(oldkey) {
 		log.Warn(deprecationMessage(oldkey, newkey))
 		if !cfg.IsSet(newkey) {
@@ -160,7 +159,7 @@ func deprecationMessage(oldkey, newkey string) string {
 }
 
 // limitMaxInt logs a warning and sets `key` to `max` if the value exceeds `max`.
-func limitMaxInt(cfg config.Config, key string, max int) {
+func limitMaxInt(cfg model.Config, key string, max int) {
 	val := cfg.GetInt(key)
 	if val > max {
 		log.Warnf("configuration key `%s` was set to `%d`, using maximum value `%d` instead", key, val, max)
@@ -169,7 +168,7 @@ func limitMaxInt(cfg config.Config, key string, max int) {
 }
 
 // limitMaxInt64 logs a warning and sets `key` to `max` if the value exceeds `max`.
-func limitMaxInt64(cfg config.Config, key string, max int64) {
+func limitMaxInt64(cfg model.Config, key string, max int64) {
 	val := cfg.GetInt64(key)
 	if val > max {
 		log.Warnf("configuration key `%s` was set to `%d`, using maximum value `%d` instead", key, val, max)

--- a/cmd/system-probe/config/adjust_npm.go
+++ b/cmd/system-probe/config/adjust_npm.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"runtime"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -24,7 +23,7 @@ const (
 	defaultMaxTrackedConnections = 65536
 )
 
-func adjustNetwork(cfg config.Config) {
+func adjustNetwork(cfg model.Config) {
 	ebpflessEnabled := cfg.GetBool(netNS("enable_ebpfless"))
 
 	limitMaxInt(cfg, spNS("max_conns_per_message"), maxConnsMessageBatchSize)

--- a/cmd/system-probe/config/adjust_security.go
+++ b/cmd/system-probe/config/adjust_security.go
@@ -9,12 +9,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-func adjustSecurity(cfg config.Config) {
-	deprecateCustom(cfg, secNS("activity_dump.cgroup_dump_timeout"), secNS("activity_dump.dump_duration"), func(cfg config.Config) interface{} {
+func adjustSecurity(cfg model.Config) {
+	deprecateCustom(cfg, secNS("activity_dump.cgroup_dump_timeout"), secNS("activity_dump.dump_duration"), func(cfg model.Config) interface{} {
 		// convert old minutes int value to time.Duration
 		return time.Duration(cfg.GetInt(secNS("activity_dump.cgroup_dump_timeout"))) * time.Minute
 	})
@@ -23,7 +22,7 @@ func adjustSecurity(cfg config.Config) {
 		cfg,
 		secNS("runtime_security_config.security_profile.anomaly_detection.auto_suppression.enabled"),
 		secNS("runtime_security_config.security_profile.auto_suppression.enabled"),
-		func(cfg config.Config) interface{} {
+		func(cfg model.Config) interface{} {
 			// convert old auto suppression parameter to the new one
 			return cfg.GetBool(secNS("runtime_security_config.security_profile.anomaly_detection.auto_suppression.enabled"))
 		},

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -9,14 +9,14 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
 const (
 	maxHTTPFrag = 512 // matches hard limit currently imposed in NPM driver
 )
 
-func adjustUSM(cfg config.Config) {
+func adjustUSM(cfg model.Config) {
 	if cfg.GetBool(smNS("enabled")) {
 		applyDefault(cfg, netNS("enable_http_monitoring"), true)
 		applyDefault(cfg, netNS("enable_https_monitoring"), true)

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
@@ -51,22 +51,22 @@ func New(configPath string, fleetPoliciesDirPath string) (*types.Config, error) 
 }
 
 func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.Config, error) {
-	aconfig.SystemProbe().SetConfigName("system-probe")
+	pkgconfigsetup.SystemProbe().SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {
 		// if the configuration file path was supplied on the command line,
 		// add that first, so it's first in line
-		aconfig.SystemProbe().AddConfigPath(configPath)
+		pkgconfigsetup.SystemProbe().AddConfigPath(configPath)
 		// If they set a config file directly, let's try to honor that
 		if strings.HasSuffix(configPath, ".yaml") {
-			aconfig.SystemProbe().SetConfigFile(configPath)
+			pkgconfigsetup.SystemProbe().SetConfigFile(configPath)
 		}
 	} else {
 		// only add default if a custom configPath was not supplied
-		aconfig.SystemProbe().AddConfigPath(defaultConfigDir)
+		pkgconfigsetup.SystemProbe().AddConfigPath(defaultConfigDir)
 	}
 	// load the configuration
-	err := aconfig.LoadCustom(aconfig.SystemProbe(), aconfig.Datadog().GetEnvVars())
+	err := pkgconfigsetup.LoadCustom(pkgconfigsetup.SystemProbe(), pkgconfigsetup.Datadog().GetEnvVars())
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			// special-case permission-denied with a clearer error message
@@ -84,10 +84,10 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 
 	// Load the remote configuration
 	if fleetPoliciesDirPath == "" {
-		fleetPoliciesDirPath = aconfig.SystemProbe().GetString("fleet_policies_dir")
+		fleetPoliciesDirPath = pkgconfigsetup.SystemProbe().GetString("fleet_policies_dir")
 	}
 	if fleetPoliciesDirPath != "" {
-		err := aconfig.SystemProbe().MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "system-probe.yaml"))
+		err := pkgconfigsetup.SystemProbe().MergeFleetPolicy(path.Join(fleetPoliciesDirPath, "system-probe.yaml"))
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +97,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 }
 
 func load() (*types.Config, error) {
-	cfg := aconfig.SystemProbe()
+	cfg := pkgconfigsetup.SystemProbe()
 	Adjust(cfg)
 
 	c := &types.Config{
@@ -114,7 +114,7 @@ func load() (*types.Config, error) {
 		HealthPort:       cfg.GetInt(spNS("health_port")),
 		TelemetryEnabled: cfg.GetBool(spNS("telemetry_enabled")),
 
-		StatsdHost: aconfig.GetBindHost(),
+		StatsdHost: pkgconfigsetup.GetBindHost(pkgconfigsetup.Datadog()),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),
 	}
 
@@ -181,12 +181,12 @@ func load() (*types.Config, error) {
 
 // SetupOptionalDatadogConfigWithDir loads the datadog.yaml config file from a given config directory but will not fail on a missing file
 func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
-	aconfig.Datadog().AddConfigPath(configDir)
+	pkgconfigsetup.Datadog().AddConfigPath(configDir)
 	if configFile != "" {
-		aconfig.Datadog().SetConfigFile(configFile)
+		pkgconfigsetup.Datadog().SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), aconfig.SystemProbe().GetEnvVars())
+	_, err := pkgconfigsetup.LoadDatadogCustom(pkgconfigsetup.Datadog(), "datadog.yaml", optional.NewNoneOption[secrets.Component](), pkgconfigsetup.SystemProbe().GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
 	if err != nil && !errors.As(err, &e) {

--- a/cmd/system-probe/modules/eventmonitor_linux.go
+++ b/cmd/system-probe/modules/eventmonitor_linux.go
@@ -10,7 +10,7 @@ package modules
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	netconfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
@@ -24,7 +24,7 @@ var EventMonitor = module.Factory{
 	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
 	Fn:               createEventMonitorModule,
 	NeedsEBPF: func() bool {
-		return !coreconfig.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled")
+		return !pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled")
 	},
 }
 

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -50,7 +50,6 @@ import (
 	compstatsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient/rcclientimpl"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -384,7 +383,7 @@ func stopSystemProbe() {
 }
 
 // setupInternalProfiling is a common helper to configure runtime settings for internal profiling.
-func setupInternalProfiling(settings settings.Component, cfg ddconfig.Reader, configPrefix string, log log.Component) {
+func setupInternalProfiling(settings settings.Component, cfg model.Reader, configPrefix string, log log.Component) {
 	if v := cfg.GetInt(configPrefix + "internal_profiling.block_profile_rate"); v > 0 {
 		if err := settings.SetRuntimeSetting("runtime_block_profile_rate", v, model.SourceAgentRuntime); err != nil {
 			log.Errorf("Error setting block profile rate: %v", err)

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
@@ -99,7 +99,7 @@ func evalCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", pkgconfigsetup.DefaultRuntimePoliciesDir, "Path to policies directory")
 	evalCmd.Flags().StringVar(&evalArgs.ruleID, "rule-id", "", "Rule ID to evaluate")
 	_ = evalCmd.MarkFlagRequired("rule-id")
 	evalCmd.Flags().StringVar(&evalArgs.eventFile, "event-file", "", "File of the event data")
@@ -132,7 +132,7 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 		},
 	}
 
-	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", pkgconfigsetup.DefaultRuntimePoliciesDir, "Path to policies directory")
 	commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.evaluateAllPolicySources, "loaded-policies", false, "Evaluate loaded policies")
 	if runtime.GOOS == "linux" {
 		commonCheckPoliciesCmd.Flags().BoolVar(&cliParams.windowsModel, "windows-model", false, "Evaluate policies using the Windows model")

--- a/comp/core/sysprobeconfig/component.go
+++ b/comp/core/sysprobeconfig/component.go
@@ -16,21 +16,22 @@
 package sysprobeconfig
 
 import (
+	"go.uber.org/fx"
+
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"go.uber.org/fx"
 )
 
 // team: ebpf-platform
 
 // Component is the component type.
 type Component interface {
-	config.ReaderWriter
+	model.ReaderWriter
 
 	// Warnings returns config warnings collected during setup.
-	Warnings() *config.Warnings
+	Warnings() *model.Warnings
 
 	// SysProbeObject returns the wrapper sysconfig
 	SysProbeObject() *sysconfigtypes.Config

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -13,7 +13,8 @@ import (
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -29,12 +30,12 @@ func Module() fxutil.Module {
 type cfg struct {
 	// this component is currently implementing a thin wrapper around pkg/config,
 	// and uses globals in that package.
-	config.Config
+	model.Config
 
 	syscfg *sysconfigtypes.Config
 
 	// warnings are the warnings generated during setup
-	warnings *config.Warnings
+	warnings *model.Warnings
 }
 
 // sysprobeconfigDependencies is an interface that mimics the fx-oriented dependencies struct (This is copied from the main agent configuration.)
@@ -64,14 +65,14 @@ func newConfig(deps dependencies) (sysprobeconfig.Component, error) {
 		return nil, err
 	}
 
-	return &cfg{Config: config.SystemProbe(), syscfg: syscfg}, nil
+	return &cfg{Config: pkgconfigsetup.SystemProbe(), syscfg: syscfg}, nil
 }
 
-func (c *cfg) Warnings() *config.Warnings {
+func (c *cfg) Warnings() *model.Warnings {
 	return c.warnings
 }
 
-func (c *cfg) Object() config.Reader {
+func (c *cfg) Object() model.Reader {
 	return c
 }
 

--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	ebpfcheck "github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	processnet "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -68,7 +68,7 @@ func (m *EBPFCheck) Configure(senderManager sender.SenderManager, _ uint64, conf
 	if err := m.config.Parse(config); err != nil {
 		return fmt.Errorf("ebpf check config: %s", err)
 	}
-	if err := processnet.CheckPath(ddconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket")); err != nil {
+	if err := processnet.CheckPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")); err != nil {
 		return fmt.Errorf("sysprobe socket: %s", err)
 	}
 
@@ -80,7 +80,7 @@ func (m *EBPFCheck) Run() error {
 	if m.sysProbeUtil == nil {
 		var err error
 		m.sysProbeUtil, err = processnet.GetRemoteSystemProbeUtil(
-			ddconfig.SystemProbe().GetString("system_probe_config.sysprobe_socket"),
+			pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket"),
 		)
 		if err != nil {
 			return fmt.Errorf("sysprobe connection: %s", err)

--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -26,7 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/oomkill/model"
-	dd_config "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	process_net "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
@@ -87,7 +87,7 @@ func (m *OOMKillCheck) Run() error {
 	}
 
 	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
+		pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	ddmaps "github.com/DataDog/datadog-agent/pkg/ebpf/maps"
@@ -86,17 +86,17 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 
-	if ddconfig.SystemProbe().GetBool("ebpf_check.kernel_bpf_stats") {
+	if pkgconfigsetup.SystemProbe().GetBool("ebpf_check.kernel_bpf_stats") {
 		probe.statsFD, err = ebpf.EnableStats(unix.BPF_STATS_RUN_TIME)
 		if err != nil {
 			log.Warnf("kernel ebpf stats failed to enable, program runtime and run count will be unavailable: %s", err)
 		}
 	}
 
-	probe.mapBuffers.keysBufferSizeLimit = uint32(ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_keys_buffer_size_bytes"))
-	probe.mapBuffers.valuesBufferSizeLimit = uint32(ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_values_buffer_size_bytes"))
-	probe.mapBuffers.iterationRestartDetectionEntries = ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.entries_for_iteration_restart_detection")
-	probe.entryCountMaxRestarts = ddconfig.SystemProbe().GetInt("ebpf_check.entry_count.max_restarts")
+	probe.mapBuffers.keysBufferSizeLimit = uint32(pkgconfigsetup.SystemProbe().GetInt("ebpf_check.entry_count.max_keys_buffer_size_bytes"))
+	probe.mapBuffers.valuesBufferSizeLimit = uint32(pkgconfigsetup.SystemProbe().GetInt("ebpf_check.entry_count.max_values_buffer_size_bytes"))
+	probe.mapBuffers.iterationRestartDetectionEntries = pkgconfigsetup.SystemProbe().GetInt("ebpf_check.entry_count.entries_for_iteration_restart_detection")
+	probe.entryCountMaxRestarts = pkgconfigsetup.SystemProbe().GetInt("ebpf_check.entry_count.max_restarts")
 
 	if isForEachElemHelperAvailable() {
 		probe.mphCache = newMapProgHelperCache()

--- a/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/model"
-	dd_config "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	process_net "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -83,7 +83,7 @@ func (t *TCPQueueLengthCheck) Run() error {
 	}
 
 	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
-		dd_config.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
+		pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -83,7 +83,7 @@ func key(pieces ...string) string {
 
 // NewConfig creates a config with ebpf-related settings
 func NewConfig() *Config {
-	cfg := aconfig.SystemProbe()
+	cfg := pkgconfigsetup.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	c := &Config{

--- a/pkg/ebpf/telemetry/errors_telemetry_test.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_test.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -48,7 +48,7 @@ type config struct {
 }
 
 func testConfig() *config {
-	cfg := aconfig.SystemProbe()
+	cfg := pkgconfigsetup.SystemProbe()
 	sysconfig.Adjust(cfg)
 
 	return &config{

--- a/pkg/eventmonitor/config/config.go
+++ b/pkg/eventmonitor/config/config.go
@@ -9,7 +9,7 @@ package config
 import (
 	"strings"
 
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -34,8 +34,8 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		// event server
-		SocketPath:       coreconfig.SystemProbe().GetString(join(evNS, "socket")),
-		EventServerBurst: coreconfig.SystemProbe().GetInt(join(evNS, "event_server.burst")),
+		SocketPath:       pkgconfigsetup.SystemProbe().GetString(join(evNS, "socket")),
+		EventServerBurst: pkgconfigsetup.SystemProbe().GetInt(join(evNS, "event_server.burst")),
 
 		// consumers
 		ProcessConsumerEnabled: getBool("process.enabled"),
@@ -54,9 +54,9 @@ func getAllKeys(key string) (string, string) {
 
 func getBool(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
+	if pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe().GetBool(deprecatedKey)
+		return pkgconfigsetup.SystemProbe().GetBool(deprecatedKey)
 	}
-	return coreconfig.SystemProbe().GetBool(newKey)
+	return pkgconfigsetup.SystemProbe().GetBool(newKey)
 }

--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -21,7 +21,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
@@ -121,7 +120,7 @@ func TestRetryLogic_Error(t *testing.T) {
 			mockCollector.On("Type").Return(tt.st)
 
 			// Set up the configuration as the default one is too slow
-			cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 			cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
 			cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
 			cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime) // Required for the ticker
@@ -186,7 +185,7 @@ func TestRetryLogic_ImageDeleted(t *testing.T) {
 	mockCollector.On("Type").Return(collectors.ContainerImageScanType)
 
 	// Set up the configuration as the default one is too slow
-	cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
 	cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
 	cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime) // Required for the ticker
@@ -251,7 +250,7 @@ func TestRetryChannelFull(t *testing.T) {
 	mockCollector.On("Type").Return(collectors.ContainerImageScanType)
 
 	// Set up the configuration
-	cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	cfg := model.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
 	cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
 	cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime) // Required for the ticker

--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
 
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 )
@@ -182,7 +182,7 @@ func (c *RuntimeSecurityClient) Close() {
 
 // NewRuntimeSecurityClient instantiates a new RuntimeSecurityClient
 func NewRuntimeSecurityClient() (*RuntimeSecurityClient, error) {
-	socketPath := coreconfig.Datadog().GetString("runtime_security_config.socket")
+	socketPath := pkgconfigsetup.Datadog().GetString("runtime_security_config.socket")
 	if socketPath == "" {
 		return nil, errors.New("runtime_security_config.socket must be set")
 	}

--- a/pkg/security/common/logs_context.go
+++ b/pkg/security/common/logs_context.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -22,7 +22,7 @@ const (
 
 // NewLogContextCompliance returns the context fields to send compliance events to the intake
 func NewLogContextCompliance() (*logsconfig.Endpoints, *client.DestinationsContext, error) {
-	logsConfigComplianceKeys := logsconfig.NewLogsConfigKeys("compliance_config.endpoints.", pkgconfig.Datadog())
+	logsConfigComplianceKeys := logsconfig.NewLogsConfigKeys("compliance_config.endpoints.", pkgconfigsetup.Datadog())
 	return NewLogContext(logsConfigComplianceKeys, "cspm-intake.", "compliance", logsconfig.DefaultIntakeOrigin, logsconfig.AgentJSONIntakeProtocol)
 }
 
@@ -39,18 +39,18 @@ func NewLogContextRuntime(useSecRuntimeTrack bool) (*logsconfig.Endpoints, *clie
 		trackType = "logs"
 	}
 
-	logsRuntimeConfigKeys := logsconfig.NewLogsConfigKeys("runtime_security_config.endpoints.", pkgconfig.Datadog())
+	logsRuntimeConfigKeys := logsconfig.NewLogsConfigKeys("runtime_security_config.endpoints.", pkgconfigsetup.Datadog())
 	return NewLogContext(logsRuntimeConfigKeys, "runtime-security-http-intake.logs.", trackType, cwsIntakeOrigin, logsconfig.DefaultIntakeProtocol)
 }
 
 // NewLogContext returns the context fields to send events to the intake
 func NewLogContext(logsConfig *logsconfig.LogsConfigKeys, endpointPrefix string, intakeTrackType logsconfig.IntakeTrackType, intakeOrigin logsconfig.IntakeOrigin, intakeProtocol logsconfig.IntakeProtocol) (*logsconfig.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := logsconfig.BuildHTTPEndpointsWithConfig(pkgconfig.Datadog(), logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
+	endpoints, err := logsconfig.BuildHTTPEndpointsWithConfig(pkgconfigsetup.Datadog(), logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
 	if err != nil {
-		endpoints, err = logsconfig.BuildHTTPEndpoints(pkgconfig.Datadog(), intakeTrackType, intakeProtocol, intakeOrigin)
+		endpoints, err = logsconfig.BuildHTTPEndpoints(pkgconfigsetup.Datadog(), intakeTrackType, intakeProtocol, intakeOrigin)
 		if err == nil {
-			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, pkgconfig.Datadog())
-			endpoints, err = logsconfig.BuildEndpoints(pkgconfig.Datadog(), httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
+			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, pkgconfigsetup.Datadog())
+			endpoints, err = logsconfig.BuildEndpoints(pkgconfigsetup.Datadog(), httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
 		}
 	}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -15,7 +15,8 @@ import (
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
@@ -301,7 +302,7 @@ func NewConfig() (*Config, error) {
 
 // NewRuntimeSecurityConfig returns the runtime security (CWS) config, build from the system probe one
 func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
-	sysconfig.Adjust(coreconfig.SystemProbe())
+	sysconfig.Adjust(pkgconfigsetup.SystemProbe())
 
 	eventTypeStrings := map[string]model.EventType{}
 
@@ -323,65 +324,65 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	rsConfig := &RuntimeSecurityConfig{
-		RuntimeEnabled:                 coreconfig.SystemProbe().GetBool("runtime_security_config.enabled"),
-		FIMEnabled:                     coreconfig.SystemProbe().GetBool("runtime_security_config.fim_enabled"),
-		WindowsFilenameCacheSize:       coreconfig.SystemProbe().GetInt("runtime_security_config.windows_filename_cache_max"),
-		WindowsRegistryCacheSize:       coreconfig.SystemProbe().GetInt("runtime_security_config.windows_registry_cache_max"),
-		ETWEventsChannelSize:           coreconfig.SystemProbe().GetInt("runtime_security_config.etw_events_channel_size"),
-		ETWEventsMaxBuffers:            coreconfig.SystemProbe().GetInt("runtime_security_config.etw_events_max_buffers"),
-		WindowsProbeBlockOnChannelSend: coreconfig.SystemProbe().GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
+		RuntimeEnabled:                 pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enabled"),
+		FIMEnabled:                     pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.fim_enabled"),
+		WindowsFilenameCacheSize:       pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.windows_filename_cache_max"),
+		WindowsRegistryCacheSize:       pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.windows_registry_cache_max"),
+		ETWEventsChannelSize:           pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.etw_events_channel_size"),
+		ETWEventsMaxBuffers:            pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.etw_events_max_buffers"),
+		WindowsProbeBlockOnChannelSend: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.windows_probe_block_on_channel_send"),
 
-		SocketPath:           coreconfig.SystemProbe().GetString("runtime_security_config.socket"),
-		EventServerBurst:     coreconfig.SystemProbe().GetInt("runtime_security_config.event_server.burst"),
-		EventServerRate:      coreconfig.SystemProbe().GetInt("runtime_security_config.event_server.rate"),
-		EventServerRetention: coreconfig.SystemProbe().GetDuration("runtime_security_config.event_server.retention"),
+		SocketPath:           pkgconfigsetup.SystemProbe().GetString("runtime_security_config.socket"),
+		EventServerBurst:     pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.burst"),
+		EventServerRate:      pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.rate"),
+		EventServerRetention: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.event_server.retention"),
 
-		SelfTestEnabled:                 coreconfig.SystemProbe().GetBool("runtime_security_config.self_test.enabled"),
-		SelfTestSendReport:              coreconfig.SystemProbe().GetBool("runtime_security_config.self_test.send_report"),
+		SelfTestEnabled:                 pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.self_test.enabled"),
+		SelfTestSendReport:              pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.self_test.send_report"),
 		RemoteConfigurationEnabled:      isRemoteConfigEnabled(),
-		RemoteConfigurationDumpPolicies: coreconfig.SystemProbe().GetBool("runtime_security_config.remote_configuration.dump_policies"),
+		RemoteConfigurationDumpPolicies: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.remote_configuration.dump_policies"),
 
-		OnDemandEnabled:            coreconfig.SystemProbe().GetBool("runtime_security_config.on_demand.enabled"),
-		OnDemandRateLimiterEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.on_demand.rate_limiter.enabled"),
+		OnDemandEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.on_demand.enabled"),
+		OnDemandRateLimiterEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.on_demand.rate_limiter.enabled"),
 
 		// policy & ruleset
-		PoliciesDir:                         coreconfig.SystemProbe().GetString("runtime_security_config.policies.dir"),
-		WatchPoliciesDir:                    coreconfig.SystemProbe().GetBool("runtime_security_config.policies.watch_dir"),
-		PolicyMonitorEnabled:                coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.enabled"),
-		PolicyMonitorPerRuleEnabled:         coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.per_rule_enabled"),
-		PolicyMonitorReportInternalPolicies: coreconfig.SystemProbe().GetBool("runtime_security_config.policies.monitor.report_internal_policies"),
+		PoliciesDir:                         pkgconfigsetup.SystemProbe().GetString("runtime_security_config.policies.dir"),
+		WatchPoliciesDir:                    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.watch_dir"),
+		PolicyMonitorEnabled:                pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.enabled"),
+		PolicyMonitorPerRuleEnabled:         pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.per_rule_enabled"),
+		PolicyMonitorReportInternalPolicies: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.report_internal_policies"),
 
-		LogPatterns: coreconfig.SystemProbe().GetStringSlice("runtime_security_config.log_patterns"),
-		LogTags:     coreconfig.SystemProbe().GetStringSlice("runtime_security_config.log_tags"),
+		LogPatterns: pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.log_patterns"),
+		LogTags:     pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.log_tags"),
 
 		// custom events
-		InternalMonitoringEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.internal_monitoring.enabled"),
+		InternalMonitoringEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.internal_monitoring.enabled"),
 
 		// activity dump
-		ActivityDumpEnabled:                   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.enabled"),
-		ActivityDumpCleanupPeriod:             coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.cleanup_period"),
-		ActivityDumpTagsResolutionPeriod:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.tags_resolution_period"),
-		ActivityDumpLoadControlPeriod:         coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.load_controller_period"),
-		ActivityDumpLoadControlMinDumpTimeout: coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.min_timeout"),
-		ActivityDumpTracedCgroupsCount:        coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
-		ActivityDumpTracedEventTypes:          parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
-		ActivityDumpCgroupDumpTimeout:         coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.dump_duration"),
-		ActivityDumpRateLimiter:               coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter"),
-		ActivityDumpCgroupWaitListTimeout:     coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.cgroup_wait_list_timeout"),
-		ActivityDumpCgroupDifferentiateArgs:   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
-		ActivityDumpLocalStorageDirectory:     coreconfig.SystemProbe().GetString("runtime_security_config.activity_dump.local_storage.output_directory"),
-		ActivityDumpLocalStorageMaxDumpsCount: coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.local_storage.max_dumps_count"),
-		ActivityDumpLocalStorageCompression:   coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.local_storage.compression"),
-		ActivityDumpSyscallMonitorPeriod:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.syscall_monitor.period"),
-		ActivityDumpMaxDumpCountPerWorkload:   coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_count_per_workload"),
-		ActivityDumpTagRulesEnabled:           coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.tag_rules.enabled"),
-		ActivityDumpSilentWorkloadsDelay:      coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.delay"),
-		ActivityDumpSilentWorkloadsTicker:     coreconfig.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.ticker"),
-		ActivityDumpWorkloadDenyList:          coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.workload_deny_list"),
-		ActivityDumpAutoSuppressionEnabled:    coreconfig.SystemProbe().GetBool("runtime_security_config.activity_dump.auto_suppression.enabled"),
+		ActivityDumpEnabled:                   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.enabled"),
+		ActivityDumpCleanupPeriod:             pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.cleanup_period"),
+		ActivityDumpTagsResolutionPeriod:      pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.tags_resolution_period"),
+		ActivityDumpLoadControlPeriod:         pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.load_controller_period"),
+		ActivityDumpLoadControlMinDumpTimeout: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.min_timeout"),
+		ActivityDumpTracedCgroupsCount:        pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.traced_cgroups_count"),
+		ActivityDumpTracedEventTypes:          parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
+		ActivityDumpCgroupDumpTimeout:         pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.dump_duration"),
+		ActivityDumpRateLimiter:               pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter"),
+		ActivityDumpCgroupWaitListTimeout:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.cgroup_wait_list_timeout"),
+		ActivityDumpCgroupDifferentiateArgs:   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
+		ActivityDumpLocalStorageDirectory:     pkgconfigsetup.SystemProbe().GetString("runtime_security_config.activity_dump.local_storage.output_directory"),
+		ActivityDumpLocalStorageMaxDumpsCount: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.local_storage.max_dumps_count"),
+		ActivityDumpLocalStorageCompression:   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.local_storage.compression"),
+		ActivityDumpSyscallMonitorPeriod:      pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.syscall_monitor.period"),
+		ActivityDumpMaxDumpCountPerWorkload:   pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_count_per_workload"),
+		ActivityDumpTagRulesEnabled:           pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.tag_rules.enabled"),
+		ActivityDumpSilentWorkloadsDelay:      pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.delay"),
+		ActivityDumpSilentWorkloadsTicker:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.silent_workloads.ticker"),
+		ActivityDumpWorkloadDenyList:          pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.workload_deny_list"),
+		ActivityDumpAutoSuppressionEnabled:    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.auto_suppression.enabled"),
 		// activity dump dynamic fields
 		ActivityDumpMaxDumpSize: func() int {
-			mds := coreconfig.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_size")
+			mds := pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.max_dump_size")
 			if mds < ADMinMaxDumSize {
 				mds = ADMinMaxDumSize
 			}
@@ -389,66 +390,66 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		},
 
 		// SBOM resolver
-		SBOMResolverEnabled:            coreconfig.SystemProbe().GetBool("runtime_security_config.sbom.enabled"),
-		SBOMResolverWorkloadsCacheSize: coreconfig.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
-		SBOMResolverHostEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
+		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled"),
+		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
+		SBOMResolverHostEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
 
 		// Hash resolver
-		HashResolverEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.hash_resolver.enabled"),
-		HashResolverEventTypes:     parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.event_types")),
-		HashResolverMaxFileSize:    coreconfig.SystemProbe().GetInt64("runtime_security_config.hash_resolver.max_file_size"),
-		HashResolverHashAlgorithms: parseHashAlgorithmStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.hash_algorithms")),
-		HashResolverMaxHashBurst:   coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_burst"),
-		HashResolverMaxHashRate:    coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_rate"),
-		HashResolverCacheSize:      coreconfig.SystemProbe().GetInt("runtime_security_config.hash_resolver.cache_size"),
-		HashResolverReplace:        coreconfig.SystemProbe().GetStringMapString("runtime_security_config.hash_resolver.replace"),
+		HashResolverEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.hash_resolver.enabled"),
+		HashResolverEventTypes:     parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.event_types")),
+		HashResolverMaxFileSize:    pkgconfigsetup.SystemProbe().GetInt64("runtime_security_config.hash_resolver.max_file_size"),
+		HashResolverHashAlgorithms: parseHashAlgorithmStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.hash_algorithms")),
+		HashResolverMaxHashBurst:   pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_burst"),
+		HashResolverMaxHashRate:    pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_rate"),
+		HashResolverCacheSize:      pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.cache_size"),
+		HashResolverReplace:        pkgconfigsetup.SystemProbe().GetStringMapString("runtime_security_config.hash_resolver.replace"),
 
 		// security profiles
-		SecurityProfileEnabled:          coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),
-		SecurityProfileMaxImageTags:     coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.max_image_tags"),
-		SecurityProfileDir:              coreconfig.SystemProbe().GetString("runtime_security_config.security_profile.dir"),
-		SecurityProfileWatchDir:         coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.watch_dir"),
-		SecurityProfileCacheSize:        coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.cache_size"),
-		SecurityProfileMaxCount:         coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.max_count"),
-		SecurityProfileRCEnabled:        coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
-		SecurityProfileDNSMatchMaxDepth: coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.dns_match_max_depth"),
+		SecurityProfileEnabled:          pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),
+		SecurityProfileMaxImageTags:     pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.max_image_tags"),
+		SecurityProfileDir:              pkgconfigsetup.SystemProbe().GetString("runtime_security_config.security_profile.dir"),
+		SecurityProfileWatchDir:         pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.watch_dir"),
+		SecurityProfileCacheSize:        pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.cache_size"),
+		SecurityProfileMaxCount:         pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.max_count"),
+		SecurityProfileRCEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
+		SecurityProfileDNSMatchMaxDepth: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.dns_match_max_depth"),
 
 		// auto suppression
-		SecurityProfileAutoSuppressionEnabled:    coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.auto_suppression.enabled"),
-		SecurityProfileAutoSuppressionEventTypes: parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.security_profile.auto_suppression.event_types")),
+		SecurityProfileAutoSuppressionEnabled:    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.auto_suppression.enabled"),
+		SecurityProfileAutoSuppressionEventTypes: parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.auto_suppression.event_types")),
 
 		// anomaly detection
-		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(coreconfig.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),
-		AnomalyDetectionDefaultMinimumStablePeriod:   coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.default_minimum_stable_period"),
-		AnomalyDetectionMinimumStablePeriods:         parseEventTypeDurations(coreconfig.SystemProbe(), "runtime_security_config.security_profile.anomaly_detection.minimum_stable_period"),
-		AnomalyDetectionWorkloadWarmupPeriod:         coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.workload_warmup_period"),
-		AnomalyDetectionUnstableProfileTimeThreshold: coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.unstable_profile_time_threshold"),
-		AnomalyDetectionUnstableProfileSizeThreshold: coreconfig.SystemProbe().GetInt64("runtime_security_config.security_profile.anomaly_detection.unstable_profile_size_threshold"),
-		AnomalyDetectionRateLimiterPeriod:            coreconfig.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.rate_limiter.period"),
-		AnomalyDetectionRateLimiterNumKeys:           coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_keys"),
-		AnomalyDetectionRateLimiterNumEventsAllowed:  coreconfig.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_events_allowed"),
-		AnomalyDetectionTagRulesEnabled:              coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled"),
-		AnomalyDetectionSilentRuleEventsEnabled:      coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled"),
-		AnomalyDetectionEnabled:                      coreconfig.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.enabled"),
+		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),
+		AnomalyDetectionDefaultMinimumStablePeriod:   pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.default_minimum_stable_period"),
+		AnomalyDetectionMinimumStablePeriods:         parseEventTypeDurations(pkgconfigsetup.SystemProbe(), "runtime_security_config.security_profile.anomaly_detection.minimum_stable_period"),
+		AnomalyDetectionWorkloadWarmupPeriod:         pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.workload_warmup_period"),
+		AnomalyDetectionUnstableProfileTimeThreshold: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.unstable_profile_time_threshold"),
+		AnomalyDetectionUnstableProfileSizeThreshold: pkgconfigsetup.SystemProbe().GetInt64("runtime_security_config.security_profile.anomaly_detection.unstable_profile_size_threshold"),
+		AnomalyDetectionRateLimiterPeriod:            pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.security_profile.anomaly_detection.rate_limiter.period"),
+		AnomalyDetectionRateLimiterNumKeys:           pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_keys"),
+		AnomalyDetectionRateLimiterNumEventsAllowed:  pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_events_allowed"),
+		AnomalyDetectionTagRulesEnabled:              pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled"),
+		AnomalyDetectionSilentRuleEventsEnabled:      pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled"),
+		AnomalyDetectionEnabled:                      pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.anomaly_detection.enabled"),
 
 		// enforcement
-		EnforcementEnabled:                      coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.enabled"),
-		EnforcementBinaryExcluded:               coreconfig.SystemProbe().GetStringSlice("runtime_security_config.enforcement.exclude_binaries"),
-		EnforcementRawSyscallEnabled:            coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.raw_syscall.enabled"),
-		EnforcementRuleSourceAllowed:            coreconfig.SystemProbe().GetStringSlice("runtime_security_config.enforcement.rule_source_allowed"),
-		EnforcementDisarmerContainerEnabled:     coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.disarmer.container.enabled"),
-		EnforcementDisarmerContainerMaxAllowed:  coreconfig.SystemProbe().GetInt("runtime_security_config.enforcement.disarmer.container.max_allowed"),
-		EnforcementDisarmerContainerPeriod:      coreconfig.SystemProbe().GetDuration("runtime_security_config.enforcement.disarmer.container.period"),
-		EnforcementDisarmerExecutableEnabled:    coreconfig.SystemProbe().GetBool("runtime_security_config.enforcement.disarmer.executable.enabled"),
-		EnforcementDisarmerExecutableMaxAllowed: coreconfig.SystemProbe().GetInt("runtime_security_config.enforcement.disarmer.executable.max_allowed"),
-		EnforcementDisarmerExecutablePeriod:     coreconfig.SystemProbe().GetDuration("runtime_security_config.enforcement.disarmer.executable.period"),
+		EnforcementEnabled:                      pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enforcement.enabled"),
+		EnforcementBinaryExcluded:               pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.enforcement.exclude_binaries"),
+		EnforcementRawSyscallEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enforcement.raw_syscall.enabled"),
+		EnforcementRuleSourceAllowed:            pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.enforcement.rule_source_allowed"),
+		EnforcementDisarmerContainerEnabled:     pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enforcement.disarmer.container.enabled"),
+		EnforcementDisarmerContainerMaxAllowed:  pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.enforcement.disarmer.container.max_allowed"),
+		EnforcementDisarmerContainerPeriod:      pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.enforcement.disarmer.container.period"),
+		EnforcementDisarmerExecutableEnabled:    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enforcement.disarmer.executable.enabled"),
+		EnforcementDisarmerExecutableMaxAllowed: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.enforcement.disarmer.executable.max_allowed"),
+		EnforcementDisarmerExecutablePeriod:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.enforcement.disarmer.executable.period"),
 
 		// User Sessions
-		UserSessionsCacheSize: coreconfig.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
+		UserSessionsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
 
 		// ebpf less
-		EBPFLessEnabled: coreconfig.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled"),
-		EBPFLessSocket:  coreconfig.SystemProbe().GetString("runtime_security_config.ebpfless.socket"),
+		EBPFLessEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled"),
+		EBPFLessSocket:  pkgconfigsetup.SystemProbe().GetString("runtime_security_config.ebpfless.socket"),
 
 		// IMDS
 		IMDSIPv4: parseIMDSIPv4(),
@@ -468,7 +469,7 @@ func (c *RuntimeSecurityConfig) IsRuntimeEnabled() bool {
 
 // parseIMDSIPv4 returns the uint32 representation of the IMDS IP set by the configuration
 func parseIMDSIPv4() uint32 {
-	ip := coreconfig.SystemProbe().GetString("runtime_security_config.imds_ipv4")
+	ip := pkgconfigsetup.SystemProbe().GetString("runtime_security_config.imds_ipv4")
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
 		return 0
@@ -479,13 +480,13 @@ func parseIMDSIPv4() uint32 {
 // If RC is globally enabled, RC is enabled for CWS, unless the CWS-specific RC value is explicitly set to false
 func isRemoteConfigEnabled() bool {
 	// This value defaults to true
-	rcEnabledInSysprobeConfig := coreconfig.SystemProbe().GetBool("runtime_security_config.remote_configuration.enabled")
+	rcEnabledInSysprobeConfig := pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.remote_configuration.enabled")
 
 	if !rcEnabledInSysprobeConfig {
 		return false
 	}
 
-	if coreconfig.IsRemoteConfigEnabled(coreconfig.Datadog()) {
+	if pkgconfigsetup.IsRemoteConfigEnabled(pkgconfigsetup.Datadog()) {
 		return true
 	}
 
@@ -502,13 +503,13 @@ func (c *RuntimeSecurityConfig) GetAnomalyDetectionMinimumStablePeriod(eventType
 
 // sanitize ensures that the configuration is properly setup
 func (c *RuntimeSecurityConfig) sanitize() error {
-	serviceName := utils.GetTagValue("service", configUtils.GetConfiguredTags(coreconfig.Datadog(), true))
+	serviceName := utils.GetTagValue("service", configUtils.GetConfiguredTags(pkgconfigsetup.Datadog(), true))
 	if len(serviceName) > 0 {
 		c.HostServiceName = serviceName
 	}
 
 	if c.IMDSIPv4 == 0 {
-		return fmt.Errorf("invalid IPv4 address: got %v", coreconfig.SystemProbe().GetString("runtime_security_config.imds_ipv4"))
+		return fmt.Errorf("invalid IPv4 address: got %v", pkgconfigsetup.SystemProbe().GetString("runtime_security_config.imds_ipv4"))
 	}
 
 	if c.EnforcementDisarmerContainerEnabled && c.EnforcementDisarmerContainerMaxAllowed <= 0 {
@@ -537,7 +538,7 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 		c.ActivityDumpTracedEventTypes = append(c.ActivityDumpTracedEventTypes, model.ExecEventType)
 	}
 
-	if formats := coreconfig.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.local_storage.formats"); len(formats) > 0 {
+	if formats := pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.local_storage.formats"); len(formats) > 0 {
 		var err error
 		c.ActivityDumpLocalStorageFormats, err = ParseStorageFormats(formats)
 		if err != nil {
@@ -558,13 +559,13 @@ func (c *RuntimeSecurityConfig) sanitizeRuntimeSecurityConfigActivityDump() erro
 
 // ActivityDumpRemoteStorageEndpoints returns the list of activity dump remote storage endpoints parsed from the agent config
 func ActivityDumpRemoteStorageEndpoints(endpointPrefix string, intakeTrackType logsconfig.IntakeTrackType, intakeProtocol logsconfig.IntakeProtocol, intakeOrigin logsconfig.IntakeOrigin) (*logsconfig.Endpoints, error) {
-	logsConfig := logsconfig.NewLogsConfigKeys("runtime_security_config.activity_dump.remote_storage.endpoints.", coreconfig.Datadog())
-	endpoints, err := logsconfig.BuildHTTPEndpointsWithConfig(coreconfig.Datadog(), logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
+	logsConfig := logsconfig.NewLogsConfigKeys("runtime_security_config.activity_dump.remote_storage.endpoints.", pkgconfigsetup.Datadog())
+	endpoints, err := logsconfig.BuildHTTPEndpointsWithConfig(pkgconfigsetup.Datadog(), logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
 	if err != nil {
-		endpoints, err = logsconfig.BuildHTTPEndpoints(coreconfig.Datadog(), intakeTrackType, intakeProtocol, intakeOrigin)
+		endpoints, err = logsconfig.BuildHTTPEndpoints(pkgconfigsetup.Datadog(), intakeTrackType, intakeProtocol, intakeOrigin)
 		if err == nil {
-			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, coreconfig.Datadog())
-			endpoints, err = logsconfig.BuildEndpoints(coreconfig.Datadog(), httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
+			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main, pkgconfigsetup.Datadog())
+			endpoints, err = logsconfig.BuildEndpoints(pkgconfigsetup.Datadog(), httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
 		}
 	}
 
@@ -591,7 +592,7 @@ func ParseEvalEventType(eventType eval.EventType) model.EventType {
 }
 
 // parseEventTypeDurations converts a map of durations indexed by event types
-func parseEventTypeDurations(cfg coreconfig.Config, prefix string) map[model.EventType]time.Duration {
+func parseEventTypeDurations(cfg pkgconfigmodel.Config, prefix string) map[model.EventType]time.Duration {
 	eventTypeMap := cfg.GetStringMap(prefix)
 	eventTypeDurations := make(map[model.EventType]time.Duration, len(eventTypeMap))
 	for eventType := range eventTypeMap {

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -9,7 +9,7 @@ package module
 import (
 	"fmt"
 
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/reporter"
@@ -73,7 +73,7 @@ func (ds *DirectMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.Secur
 
 // NewDirectMsgSender returns a new direct sender
 func NewDirectMsgSender(stopper startstop.Stopper) (*DirectMsgSender, error) {
-	useSecRuntimeTrack := pkgconfig.SystemProbe().GetBool("runtime_security_config.use_secruntime_track")
+	useSecRuntimeTrack := pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.use_secruntime_track")
 
 	endpoints, destinationsCtx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
 	if err != nil {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mailru/easyjson"
 	"go.uber.org/atomic"
 
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -508,7 +508,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	}
 
 	if as.msgSender == nil {
-		if pkgconfig.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe") {
+		if pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe") {
 			msgSender, err := NewDirectMsgSender(stopper)
 			if err != nil {
 				log.Errorf("failed to setup direct reporter: %v", err)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -141,7 +141,7 @@ type Config struct {
 
 // NewConfig returns a new Config object
 func NewConfig() (*Config, error) {
-	sysconfig.Adjust(coreconfig.SystemProbe())
+	sysconfig.Adjust(pkgconfigsetup.SystemProbe())
 
 	setEnv()
 
@@ -173,8 +173,8 @@ func NewConfig() (*Config, error) {
 		SyscallsMonitorEnabled:       getBool("syscalls_monitor.enabled"),
 
 		// event server
-		SocketPath:       coreconfig.SystemProbe().GetString(join(evNS, "socket")),
-		EventServerBurst: coreconfig.SystemProbe().GetInt(join(evNS, "event_server.burst")),
+		SocketPath:       pkgconfigsetup.SystemProbe().GetString(join(evNS, "socket")),
+		EventServerBurst: pkgconfigsetup.SystemProbe().GetInt(join(evNS, "event_server.burst")),
 
 		// runtime compilation
 		RuntimeCompilationEnabled:       getBool("runtime_compilation.enabled"),
@@ -267,41 +267,41 @@ func getAllKeys(key string) (string, string) {
 
 func isSet(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	return coreconfig.SystemProbe().IsSet(deprecatedKey) || coreconfig.SystemProbe().IsSet(newKey)
+	return pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) || pkgconfigsetup.SystemProbe().IsSet(newKey)
 }
 
 func getBool(key string) bool {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
+	if pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe().GetBool(deprecatedKey)
+		return pkgconfigsetup.SystemProbe().GetBool(deprecatedKey)
 	}
-	return coreconfig.SystemProbe().GetBool(newKey)
+	return pkgconfigsetup.SystemProbe().GetBool(newKey)
 }
 
 func getInt(key string) int {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
+	if pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe().GetInt(deprecatedKey)
+		return pkgconfigsetup.SystemProbe().GetInt(deprecatedKey)
 	}
-	return coreconfig.SystemProbe().GetInt(newKey)
+	return pkgconfigsetup.SystemProbe().GetInt(newKey)
 }
 
 func getString(key string) string {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
+	if pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe().GetString(deprecatedKey)
+		return pkgconfigsetup.SystemProbe().GetString(deprecatedKey)
 	}
-	return coreconfig.SystemProbe().GetString(newKey)
+	return pkgconfigsetup.SystemProbe().GetString(newKey)
 }
 
 func getStringSlice(key string) []string {
 	deprecatedKey, newKey := getAllKeys(key)
-	if coreconfig.SystemProbe().IsSet(deprecatedKey) {
+	if pkgconfigsetup.SystemProbe().IsSet(deprecatedKey) {
 		log.Warnf("%s has been deprecated: please set %s instead", deprecatedKey, newKey)
-		return coreconfig.SystemProbe().GetStringSlice(deprecatedKey)
+		return pkgconfigsetup.SystemProbe().GetStringSlice(deprecatedKey)
 	}
-	return coreconfig.SystemProbe().GetStringSlice(newKey)
+	return pkgconfigsetup.SystemProbe().GetStringSlice(newKey)
 }

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -18,8 +18,8 @@ import (
 	"github.com/skydive-project/go-debouncer"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -53,16 +53,16 @@ func NewRCPolicyProvider(dumpPolicies bool, setEnforcementCallback func(bool)) (
 		return nil, fmt.Errorf("failed to parse agent version: %w", err)
 	}
 
-	ipcAddress, err := config.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ipc address: %w", err)
 	}
 
-	c, err := client.NewGRPCClient(ipcAddress, config.GetIPCPort(), func() (string, error) { return security.FetchAuthToken(config.Datadog()) },
+	c, err := client.NewGRPCClient(ipcAddress, pkgconfigsetup.GetIPCPort(), func() (string, error) { return security.FetchAuthToken(pkgconfigsetup.Datadog()) },
 		client.WithAgent(agentName, agentVersion.String()),
 		client.WithProducts(state.ProductCWSDD, state.ProductCWSCustom),
 		client.WithPollInterval(securityAgentRCPollInterval),
-		client.WithDirectorRootOverride(config.Datadog().GetString("site"), config.Datadog().GetString("remote_configuration.director_root")),
+		client.WithDirectorRootOverride(pkgconfigsetup.Datadog().GetString("site"), pkgconfigsetup.Datadog().GetString("remote_configuration.director_root")),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/security/rconfig/profiles.go
+++ b/pkg/security/rconfig/profiles.go
@@ -18,8 +18,8 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -129,12 +129,12 @@ func NewRCProfileProvider() (*RCProfileProvider, error) {
 		return nil, fmt.Errorf("failed to parse agent version: %v", err)
 	}
 
-	ipcAddress, err := config.GetIPCAddress()
+	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ipc address: %w", err)
 	}
 
-	c, err := client.NewGRPCClient(ipcAddress, config.GetIPCPort(), func() (string, error) { return security.FetchAuthToken(config.Datadog()) },
+	c, err := client.NewGRPCClient(ipcAddress, pkgconfigsetup.GetIPCPort(), func() (string, error) { return security.FetchAuthToken(pkgconfigsetup.Datadog()) },
 		client.WithAgent(agentName, agentVersion.String()),
 		client.WithProducts(state.ProductCWSProfiles),
 		client.WithPollInterval(securityAgentRCPollInterval))

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -52,7 +52,7 @@ func newReporter(hostname string, stopper startstop.Stopper, sourceName, sourceT
 	stopper.Add(auditor)
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(logsconfig.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, context, agentimpl.NewStatusProvider(), hostnameimpl.NewHostnameService(), pkgconfig.Datadog())
+	pipelineProvider := pipeline.NewProvider(logsconfig.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, context, agentimpl.NewStatusProvider(), hostnameimpl.NewHostnameService(), pkgconfigsetup.Datadog())
 	pipelineProvider.Start()
 	stopper.Add(pipelineProvider)
 

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/atomic"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/host"
@@ -153,7 +153,7 @@ type Resolver struct {
 
 // NewSBOMResolver returns a new instance of Resolver
 func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*Resolver, error) {
-	sbomScanner, err := sbomscanner.CreateGlobalScanner(coreconfig.SystemProbe(), optional.NewOption(wmeta))
+	sbomScanner, err := sbomscanner.CreateGlobalScanner(pkgconfigsetup.SystemProbe(), optional.NewOption(wmeta))
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (r *Resolver) prepareContextTags() {
 	r.contextTags = append(r.contextTags, fmt.Sprintf("host:%s", r.hostname))
 
 	// merge tags from config
-	for _, tag := range configUtils.GetConfiguredTags(coreconfig.Datadog(), true) {
+	for _, tag := range configUtils.GetConfiguredTags(pkgconfigsetup.Datadog(), true) {
 		if strings.HasPrefix(tag, "host") {
 			continue
 		}

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -13,7 +13,7 @@ import (
 	taggerTelemetry "github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	rootconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -96,12 +96,12 @@ func (t *DefaultResolver) Stop() error {
 // NewResolver returns a new tags resolver
 func NewResolver(config *config.Config, telemetry telemetry.Component) Resolver {
 	if config.RemoteTaggerEnabled {
-		options, err := remote.NodeAgentOptionsForSecurityResolvers(rootconfig.Datadog())
+		options, err := remote.NodeAgentOptionsForSecurityResolvers(pkgconfigsetup.Datadog())
 		if err != nil {
 			log.Errorf("unable to configure the remote tagger: %s", err)
 		} else {
 			return &DefaultResolver{
-				tagger: remote.NewTagger(options, rootconfig.Datadog(), taggerTelemetry.NewStore(telemetry)),
+				tagger: remote.NewTagger(options, pkgconfigsetup.Datadog(), taggerTelemetry.NewStore(telemetry)),
 			}
 		}
 	}

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
@@ -338,7 +338,7 @@ func (adm *ActivityDumpManager) prepareContextTags() {
 	adm.contextTags = append(adm.contextTags, fmt.Sprintf("host:%s", adm.hostname))
 
 	// merge tags from config
-	for _, tag := range configUtils.GetConfiguredTags(coreconfig.Datadog(), true) {
+	for _, tag := range configUtils.GetConfiguredTags(pkgconfigsetup.Datadog(), true) {
 		if strings.HasPrefix(tag, "host") {
 			continue
 		}

--- a/pkg/security/security_profile/dump/remote_storage.go
+++ b/pkg/security/security_profile/dump/remote_storage.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -51,7 +51,7 @@ func NewActivityDumpRemoteStorage() (ActivityDumpStorage, error) {
 	storage := &ActivityDumpRemoteStorage{
 		tooLargeEntities: make(map[tooLargeEntityStatsEntry]*atomic.Uint64),
 		client: &http.Client{
-			Transport: ddhttputil.CreateHTTPTransport(pkgconfig.Datadog()),
+			Transport: ddhttputil.CreateHTTPTransport(pkgconfigsetup.Datadog()),
 		},
 	}
 

--- a/pkg/security/utils/hostname.go
+++ b/pkg/security/utils/hostname.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -60,12 +60,12 @@ func getHostnameFromAgent(ctx context.Context) (string, error) {
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		ipcAddress, err := config.GetIPCAddress()
+		ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
 		if err != nil {
 			return err
 		}
 
-		client, err := grpc.GetDDAgentClient(ctx, ipcAddress, config.GetIPCPort())
+		client, err := grpc.GetDDAgentClient(ctx, ipcAddress, pkgconfigsetup.GetIPCPort())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
replaces most references to pkg/config in various ebpf-platform and agent-security team-owned files to respective submodule (e.g. pkg/config/model, pkg/config/setup, etc).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The majority of functions and variables were already moved to aliases with https://github.com/DataDog/datadog-agent/pull/20034; this change removes obfuscation and makes it clearer what our code is doing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
unit/integration tests should suffice since no code changes are made, just replacing references to aliases to references to the underlying functions/types