### PR TITLE
[CWS] do not eval event originating from system-probe itself

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/discarders.h
+++ b/pkg/security/ebpf/c/include/helpers/discarders.h
@@ -283,4 +283,8 @@ int __attribute__((always_inline)) expire_inode_discarders(u32 mount_id, u64 ino
     return 0;
 }
 
+static __attribute__((always_inline)) int is_discarded_by_pid() {
+    return is_runtime_discarded() && is_runtime_request();
+}
+
 #endif

--- a/pkg/security/ebpf/c/include/hooks/bpf.h
+++ b/pkg/security/ebpf/c/include/hooks/bpf.h
@@ -50,6 +50,10 @@ __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cac
 }
 
 HOOK_SYSCALL_ENTRY3(bpf, int, cmd, union bpf_attr __user *, uattr, unsigned int, size) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_BPF);
     struct syscall_cache_t syscall = {
         .policy = policy,

--- a/pkg/security/ebpf/c/include/hooks/chdir.h
+++ b/pkg/security/ebpf/c/include/hooks/chdir.h
@@ -8,6 +8,10 @@
 #include "helpers/syscalls.h"
 
 long __attribute__((always_inline)) trace__sys_chdir(const char *path) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_CHDIR);
     struct syscall_cache_t syscall = {
         .type = EVENT_CHDIR,

--- a/pkg/security/ebpf/c/include/hooks/chmod.h
+++ b/pkg/security/ebpf/c/include/hooks/chmod.h
@@ -7,6 +7,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) trace__sys_chmod(const char *path, umode_t mode) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_CHMOD);
     struct syscall_cache_t syscall = {
         .type = EVENT_CHMOD,

--- a/pkg/security/ebpf/c/include/hooks/chown.h
+++ b/pkg/security/ebpf/c/include/hooks/chown.h
@@ -7,6 +7,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) trace__sys_chown(const char *filename, uid_t user, gid_t group) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_CHOWN);
     struct syscall_cache_t syscall = {
         .type = EVENT_CHOWN,

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -8,6 +8,10 @@
 #include "helpers/syscalls.h"
 
 long __attribute__((always_inline)) trace__sys_mkdir(u8 async, umode_t mode) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_MKDIR);
     struct syscall_cache_t syscall = {
         .type = EVENT_MKDIR,

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -9,6 +9,10 @@
 
 HOOK_ENTRY("vm_mmap_pgoff")
 int hook_vm_mmap_pgoff(ctx_t *ctx) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     u64 len = CTX_PARM3(ctx);
     u64 prot = CTX_PARM4(ctx);
     u64 flags = CTX_PARM5(ctx);

--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -7,6 +7,10 @@
 #include "helpers/syscalls.h"
 
 HOOK_SYSCALL_ENTRY0(mprotect) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_MPROTECT);
     struct syscall_cache_t syscall = {
         .type = EVENT_MPROTECT,

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -11,6 +11,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) trace__sys_openat2(const char *path, u8 async, int flags, umode_t mode, u64 pid_tgid) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_OPEN);
     struct syscall_cache_t syscall = {
         .type = EVENT_OPEN,

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -7,6 +7,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *file, const char *buf, size_t count, enum selinux_source_event_t source_event) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct syscall_cache_t syscall = {
         .type = EVENT_SELINUX,
         .policy = fetch_policy(EVENT_SELINUX),

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -7,6 +7,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_SETXATTR);
     struct syscall_cache_t syscall = {
         .type = EVENT_SETXATTR,

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -6,6 +6,10 @@
 #include "helpers/syscalls.h"
 
 HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     /* TODO: implement the event for pid equal to 0 or -1. */
     if (pid < 1) {
         return 0;

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -9,6 +9,10 @@
 #include "helpers/syscalls.h"
 
 HOOK_SYSCALL_ENTRY0(splice) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_SPLICE);
     struct syscall_cache_t syscall = {
         .type = EVENT_SPLICE,

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -6,6 +6,10 @@
 #include "helpers/syscalls.h"
 
 int __attribute__((always_inline)) trace__sys_utimes(const char *filename) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
     struct policy_t policy = fetch_policy(EVENT_UTIME);
     struct syscall_cache_t syscall = {
         .type = EVENT_UTIME,

--- a/pkg/security/probe/opts_others.go
+++ b/pkg/security/probe/opts_others.go
@@ -3,29 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
+//go:build !linux && !windows
 
 // Package probe holds probe related files
 package probe
-
-import (
-	"github.com/DataDog/datadog-go/v5/statsd"
-)
 
 // Opts defines some probe options
 type Opts struct {
 	// DontDiscardRuntime do not discard the runtime. Mostly used by functional tests
 	DontDiscardRuntime bool
-
-	// StatsdClient to be used for probe stats
-	StatsdClient statsd.ClientInterface
-
-	// this option for test purposes only; should never be true in main code
-	disableProcmon bool
-}
-
-func (o *Opts) normalize() {
-	if o.StatsdClient == nil {
-		o.StatsdClient = &statsd.NoOpClient{}
-	}
 }

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -39,6 +39,7 @@ type PlatformProbe struct {
 // Probe represents the runtime security probe
 type Probe struct {
 	Config *config.Config
+	Opts   Opts
 }
 
 // Origin returns origin

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -807,6 +807,10 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 		emopts.ProbeOpts.TagsResolver = NewFakeResolverDifferentImageNames()
 	}
 
+	if opts.staticOpts.discardRuntime {
+		emopts.ProbeOpts.DontDiscardRuntime = false
+	}
+
 	fxDeps := fxutil.Test[testModuleFxDeps](
 		t,
 		core.MockBundle(),

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -71,6 +71,7 @@ type testOpts struct {
 	enforcementDisarmerExecutableMaxAllowed    int
 	enforcementDisarmerExecutablePeriod        time.Duration
 	eventServerRetention                       time.Duration
+	discardRuntime                             bool
 }
 
 type dynamicTestOpts struct {
@@ -153,5 +154,6 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.enforcementDisarmerExecutableEnabled == opts.enforcementDisarmerExecutableEnabled &&
 		to.enforcementDisarmerExecutableMaxAllowed == opts.enforcementDisarmerExecutableMaxAllowed &&
 		to.enforcementDisarmerExecutablePeriod == opts.enforcementDisarmerExecutablePeriod &&
-		to.eventServerRetention == opts.eventServerRetention
+		to.eventServerRetention == opts.eventServerRetention &&
+		to.discardRuntime == opts.discardRuntime
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

- avoid eval from system-probe event. Fix a regression introduce by https://github.com/DataDog/datadog-agent/pull/28509
- As some event has to be forward from the kernel anyway, like rmdir, unlink, avoid the evaluation userspace side as well.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
