### PR TITLE
[windows][usm] fix bug in filename evaluation

### DIFF
--- a/pkg/network/events/monitor_windows.go
+++ b/pkg/network/events/monitor_windows.go
@@ -62,7 +62,7 @@ func getAPMTags(already map[string]struct{}, filename string) []*intern.Value {
 
 	tags := make([]*intern.Value, 0, 3)
 	// see if there's an app.config in the directory
-	appConfig := filepath.Join(dir, "app.config")
+	appConfig := filename + ".config"
 	ddJSON := filepath.Join(dir, "datadog.json")
 	if _, err := os.Stat(appConfig); err == nil {
 
@@ -74,7 +74,7 @@ func getAPMTags(already map[string]struct{}, filename string) []*intern.Value {
 			}
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		log.Warnf("Error reading app.config: %v", err)
+		log.Warnf("Error reading app.config: %s %v", appConfig, err)
 	}
 	if len(already) == len(envFilter) {
 		// we've seen all we need, no point in looking in datadog.json

--- a/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
@@ -217,7 +217,7 @@ func setupTest(vm *components.RemoteHost, test usmTaggingTest) error {
 	testRoot := path.Join("c:", "users", "administrator")
 
 	clientJSONFile := path.Join(testRoot, "datadog.json")
-	clientAppConfig := path.Join(testRoot, "app.config")
+	clientAppConfig := path.Join(testRoot, "littleget.exe.config")
 
 	removeIfExists(vm, clientJSONFile)
 	removeIfExists(vm, clientAppConfig)


### PR DESCRIPTION
During testing & discussion, it was discovered that there was a misunderstanding in the name of the `app.config` file.  While generally referred to as `app.config`, the filename is actually `<app.exe>.config`.  This PR fixes the filename evaluation.

### What does this PR do?


### Motivation

Parse the right file to get USM tag names

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Updated tests included in PR