### PR TITLE
[CWS] fix race between probe closing and `pushNewTCClassifierRequest`

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1430,6 +1430,9 @@ func (err QueuedNetworkDeviceError) Error() string {
 
 func (p *EBPFProbe) pushNewTCClassifierRequest(device model.NetDevice) {
 	select {
+	case <-p.ctx.Done():
+		// the probe is stopping, do not push the new tc classifier request
+		return
 	case p.newTCNetDevices <- device:
 		// do nothing
 	default:


### PR DESCRIPTION
### What does this PR do?

A potential race condition was reported to us [in this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/636360914).

```
=== RUN   TestNoAWSIMDSv1Response
1726090798963821553 [Info] stopping Runtime Security Agent telemetry
==================
WARNING: DATA RACE
Read at 0x00c003665210 by goroutine 1738:
  runtime.chansend1()
      /usr/local/go/src/runtime/chan.go:146 +0x2c
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).pushNewTCClassifierRequest()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1432 +0x54f4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:983 +0x547c
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent-fm()
      <autogenerated>:1 +0x54
  github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.NewOrderedPerfMap.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:111 +0xf0
  github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*reOrdererHeap).dequeue()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:144 +0x548
  github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*ReOrderer).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:234 +0x310
  github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*OrderedPerfMap).Start.gowrap2()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:79 +0x40
Previous write at 0x00c003665210 by goroutine 1766:
  runtime.recvDirect()
      /usr/local/go/src/runtime/chan.go:348 +0x7c
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Close()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1400 +0x58
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Close()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:188 +0x1ac
  github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Close()
      /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:183 +0x180
  github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).cleanup()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:1030 +0x1590
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModuleWithOnDemandProbes()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:770 +0x1564
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:648 +0x718
  github.com/DataDog/datadog-agent/pkg/security/tests.TestNoAWSIMDSv1Response()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/imds_test.go:227 +0x684
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x40
Goroutine 1738 (running) created at:
  github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*OrderedPerfMap).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:79 +0x1a4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:372 +0xb4
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:159 +0x16c
  github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:141 +0x458
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModuleWithOnDemandProbes()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:881 +0x2ae0
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:648 +0x720
  github.com/DataDog/datadog-agent/pkg/security/tests.TestAWSIMDSv1Request()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/imds_test.go:73 +0x684
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x40
Goroutine 1766 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1742 +0x5e4
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2161 +0x80
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x180
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2159 +0x6e0
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2027 +0xb74
  github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:26 +0xa4
  main.main()
      _testmain.go:359 +0x294
==================
panic: send on closed channel
goroutine 1697 [running]:
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).pushNewTCClassifierRequest(...)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1432
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent(0xc00261f188, 0x2, {0xc002476d20, 0xc4, 0x1c4})
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:983 +0x54f8
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.NewOrderedPerfMap.func1(0xc003d19440)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:111 +0xf4
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*reOrdererHeap).dequeue(0xc0002efe20, 0xc00265dba8, 0x3b, 0xc003117a58, 0xc003117a30)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:144 +0x54c
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*ReOrderer).Start(0xc003117a00, 0xc00261f3c0)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:234 +0x314
created by github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*OrderedPerfMap).Start in goroutine 1648
	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:79 +0x1a8
FAIL pkg/security.TestNoAWSIMDSv1Response (779.50s)
```

This PR fixes the issue by ensuring we check if the probe is closing in the select.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
