### PR TITLE
[EBPF] Fix problems with maps that use variable-size key types

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -71,7 +71,7 @@ func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, 
 	// of a version comparison because some distros have backported this API), and fallback to
 	// the old method otherwise. The new API is also more efficient because it minimizes the number of allocations.
 	cleaner := mc.cleanWithoutBatches
-	if maps.BatchAPISupported() {
+	if mc.emap.CanUseBatchAPI() {
 		cleaner = mc.cleanWithBatches
 	}
 

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -135,6 +135,10 @@ func (mc *MapCleaner[K, V]) cleanWithBatches(nowTS int64, shouldClean func(nowTS
 		keysToDelete = append(keysToDelete, key)
 	}
 
+	if err := it.Err(); err != nil {
+		log.Errorf("error iterating map=%s: %s", mc.emap, err)
+	}
+
 	var deletionError error
 	if len(keysToDelete) > 0 {
 		deletedCount, deletionError = mc.emap.BatchDelete(keysToDelete)
@@ -177,6 +181,10 @@ func (mc *MapCleaner[K, V]) cleanWithoutBatches(nowTS int64, shouldClean func(no
 			continue
 		}
 		keysToDelete = append(keysToDelete, key)
+	}
+
+	if err := entries.Err(); err != nil {
+		log.Errorf("error iterating map=%s: %s", mc.emap, err)
 	}
 
 	for _, k := range keysToDelete {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR is a followup to https://github.com/DataDog/datadog-agent/pull/29220, changing the code that performs batch updates/deletes to check for support of batch operations for the current map. It also changes the `MapCleaner` code to check for batch support for the specific map being cleaned.

### Motivation

Ensure the proper API is used and make it easier for developers to see why batch operations are not being used.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
