### PR TITLE
[EBPF] Use uint64 instead of uintptr in CGo types

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -44,9 +44,9 @@ func main() {
 	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(` + strings.Join(int8variableNames, "|") + `)(\s+)\[(\d+)\]u?int8`)
 	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
-	// Convert generated pointers to CGo structs to uintptr
+	// Convert generated pointers to CGo structs to uint64
 	convertPointerToUint64Regex := regexp.MustCompile(`\*_Ctype_struct_(\w+)`)
-	b = convertPointerToUint64Regex.ReplaceAll(b, []byte("uintptr"))
+	b = convertPointerToUint64Regex.ReplaceAll(b, []byte("uint64"))
 
 	b, err = format.Source(b)
 	if err != nil {

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -77,12 +77,12 @@ type PIDFD struct {
 	Fd  uint32
 }
 type UDPRecvSock struct {
-	Sk  uintptr
-	Msg uintptr
+	Sk  uint64
+	Msg uint64
 }
 type BindSyscallArgs struct {
-	Addr uintptr
-	Sk   uintptr
+	Addr uint64
+	Sk   uint64
 }
 type ProtocolStack struct {
 	Api         uint8


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR is a followup to https://github.com/DataDog/datadog-agent/pull/29221, changing the uintptr to uint64 as Go still considers uintptr a variable-size type.

### Motivation

Avoid problems when generated types are structs with pointers inside, as the calls to `binary.Read/Write` used in some APIs (batch map APIs mainly) cannot deal with them correctly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
