### PR TITLE
fix(fleet): Unflake ansible tests

### DIFF
--- a/test/new-e2e/tests/installer/all_packages_test.go
+++ b/test/new-e2e/tests/installer/all_packages_test.go
@@ -116,10 +116,6 @@ func TestPackages(t *testing.T) {
 					flake.Mark(t)
 				}
 
-				// FIXME: Ansible tests are flaky on multiple tests/os
-				if method == InstallMethodAnsible {
-					flake.Mark(t)
-				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),


### PR DESCRIPTION
### What does this PR do?
Unmarks ansible tests as flaky as [they were green all week](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.job.name%3A%22new-e2e-installer-ansible%22%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&colorBy=meta%5B%27ci.stage.name%27%5D&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=trace&fromUser=true&index=cipipeline&start=1725545554901&end=1726150354901&paused=false)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
