### PR TITLE
[windows] Fix cmd/otel-agent/config.TestBadDDConfigFile test

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -183,7 +182,7 @@ func (suite *ConfigTestSuite) TestBadDDConfigFile() {
 	ddFileName := "testdata/doesnotexists.yaml"
 	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
 
-	assert.True(t, errors.Is(err, fs.ErrNotExist))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func (suite *ConfigTestSuite) TestBadLogLevel() {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -184,6 +185,13 @@ func (suite *ConfigTestSuite) TestBadDDConfigFile() {
 	expectedError := fmt.Sprintf(
 		"open %s: no such file or directory\nopen %s: no such file or directory",
 		ddFileName, ddFileName)
+
+	if runtime.GOOS == "windows" {
+		expectedError = fmt.Sprintf(
+			"open %s: The system cannot find the file specified.\nopen %s: The system cannot find the file specified.",
+			ddFileName, ddFileName)
+	}
+
 	assert.ErrorContains(t, err, expectedError)
 }
 

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -7,9 +7,10 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -182,17 +183,7 @@ func (suite *ConfigTestSuite) TestBadDDConfigFile() {
 	ddFileName := "testdata/doesnotexists.yaml"
 	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
 
-	expectedError := fmt.Sprintf(
-		"open %s: no such file or directory\nopen %s: no such file or directory",
-		ddFileName, ddFileName)
-
-	if runtime.GOOS == "windows" {
-		expectedError = fmt.Sprintf(
-			"open %s: The system cannot find the file specified.\nopen %s: The system cannot find the file specified.",
-			ddFileName, ddFileName)
-	}
-
-	assert.ErrorContains(t, err, expectedError)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func (suite *ConfigTestSuite) TestBadLogLevel() {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `cmd/otel-agent/config.TestBadDDConfigFile` test to handle Windows cases.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix the test on Windows. It was failing because the test was expecting a very specific error string that was only true on Linux / macOS. `assert.ErrorIs(t, err, fs.ErrNotExist)` is an OS-agnostic way to catch file not found errors, and is preferred here.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a
