### PR TITLE
[CWS] add cleanup loop, removing persisted dumps that are no longer needed

### DIFF
--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -196,6 +197,9 @@ func LoadProtoFromFile(filepath string) (*proto.SecurityProfile, error) {
 	if err = pp.UnmarshalVT(raw); err != nil {
 		return nil, fmt.Errorf("couldn't decode protobuf profile: %w", err)
 	}
+
+	seclog.Errorf("profile loaded from %s (%d bytes) => %s:%s", filepath, len(raw), pp.Selector.ImageName, pp.Selector.ImageTag)
+
 	return pp, nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

This PR adds a new cleanup goroutine, that will remove the unneeded activity dumps from the directory managed by the directory provider.

The basic rule used is that if there is a real profile (i.e. tag == "*") for a given image name, a dump (tag != "*") is not needed (and we already have the logic to not even load it).

The main goal is to drastically cut on the amount of calls to `LoadProfile` that are done, reducing clearly the amount of allocations (obviously since we load way less profiles).
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
