### PR TITLE
[otel-agent] report and build with proper versioning

### DIFF
--- a/cmd/otel-agent/main.go
+++ b/cmd/otel-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/command"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	_ "github.com/DataDog/datadog-agent/pkg/version"
 )
 
 func main() {

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -55,6 +55,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	_ "github.com/DataDog/datadog-agent/pkg/version"
 
 	"go.uber.org/fx"
 )

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -55,7 +55,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	_ "github.com/DataDog/datadog-agent/pkg/version"
 
 	"go.uber.org/fx"
 )

--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -10,6 +10,8 @@ package collectorimpl
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
@@ -143,7 +145,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	set := otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{
 			Version:     "v0.104.0",
-			Command:     "otel-agent",
+			Command:     filepath.Base(os.Args[0]),
 			Description: "Datadog Agent OpenTelemetry Collector",
 		},
 		LoggingOptions: options,

--- a/comp/otelcol/ddflareextension/impl/extension.go
+++ b/comp/otelcol/ddflareextension/impl/extension.go
@@ -20,6 +20,7 @@ import (
 
 	extensionDef "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/def"
 	"github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl/internal/metadata"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // Type exports the internal metadata type for easy reference
@@ -202,7 +203,7 @@ func (ext *ddExtension) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	resp := extensionDef.Response{
 		BuildInfoResponse: extensionDef.BuildInfoResponse{
-			AgentVersion:     ext.info.Version,
+			AgentVersion:     version.AgentVersion,
 			AgentCommand:     ext.info.Command,
 			AgentDesc:        ext.info.Description,
 			ExtensionVersion: ext.info.Version,

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -110,6 +110,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/api v0.56.2
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.0
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.0
+	github.com/DataDog/datadog-agent/pkg/version v0.57.0
 	github.com/gorilla/mux v1.8.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.104.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.104.0
@@ -234,7 +235,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/tagger v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.56.2 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.26.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.5.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect

--- a/go.mod
+++ b/go.mod
@@ -704,7 +704,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/testutil v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.0
-	github.com/DataDog/datadog-agent/pkg/version v0.56.2
+	github.com/DataDog/datadog-agent/pkg/version v0.57.0
 	github.com/DataDog/go-libddwaf/v3 v3.3.0
 	github.com/DataDog/go-sqllexer v0.0.14
 	github.com/Datadog/dublin-traceroute v0.0.1

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -4,7 +4,7 @@ import shutil
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.libs.common.utils import REPO_PATH, bin_name
+from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
 
 BIN_NAME = "otel-agent"
 CFG_NAME = "otel-config.yaml"
@@ -25,8 +25,9 @@ def build(ctx):
 
     env = {"GO111MODULE": "on"}
     build_tags = ['otlp']
+    ldflags = get_version_ldflags(ctx, major_version='7')
 
-    cmd = f"go build -mod=mod -tags=\"{' '.join(build_tags)}\" -o {BIN_PATH} {REPO_PATH}/cmd/otel-agent"
+    cmd = f"go build -mod=mod -tags=\"{' '.join(build_tags)}\" -ldflags=\"{ldflags}\" -o {BIN_PATH} {REPO_PATH}/cmd/otel-agent"
 
     ctx.run(cmd, env=env)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR attempts to introduce proper versioning for the `otel-agent`. The goal is that `otel-agent` and `agent` are aligned with the respective `pkg/version` versioning pattern. We also still need to understand what OTel Collector version is being used (currently reported in BuildInfo as `v0.104.0`) and submitted in the `metadata` as the extension version).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Proper version tracking for the `otel-agent` and the OTel Collector internals moving forward. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
We may want to add additional fields to the OTel metadata payload. We may need to discern between:
- `otel-agent` version
- `extension` version
- `collector component` version

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
- OTel metadata payloads in the app should reflect the updated versioning.
- `otel-agent version` and `agent version` commands should reflect the same version.

