### PR TITLE
[gitlab] fixing failed before_script variable expansion

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -98,6 +98,7 @@ deploy_containers-a7_internal-rc:
 deploy_containers-ot:
   extends: .deploy_containers-a7-base-ot
   before_script:
+    - source /root/.bashrc
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Unfortunately variable expansion in gitlab will not work if the `before_script` is in the same job, hence why we need to resort to an additional hidden job.

This was called out, and rightfully so, in the review to #29215. Unfortunately the refactor suggested actually broke the beta releases for the reason mentioned above. This was later fixed in branch `7.57.x-otel-beta-v1` and this is a backport of that fix.  

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix version resolving for OTel beta images.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Gitlab jobs are hard to follow due to this kind of unexpected behavior with the YAML templating, merging and its run-time resolution, etc. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
This has been tested in `7.57.x-otel-beta-v1`, producing the right versions with the correct version tags. If you're so inclined, running the manual jobs and publishing an `otel` image with this code should succeed.
