### PR TITLE
Allow developers to target "alien" VMs with KMT build tasks

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -414,3 +414,34 @@ This will show several tables, skipping the cases where all jobs/tests passed to
 - For each component (security-agent or system-probe) and vmset (e.g., in system-probe we have `only_tracersuite` and `no_tracersuite` test sets) it will show the jobs that failed and why (e.g., if the job failed due to an infra or a test failure).
 - Again, for each component and vmset, it will show which tests failed in a table showing in which distros/archs they failed (tests and distros that did not have any failures will not be shown).
 - For each job that failed due to infra reasons, it will show a summary with quick detection of possible boot causes (e.g., it will show if the VM did not reach the login prompt, or if it didn't get an IP address, etc).
+
+## Alien VMs
+The KMT tasks provided here allow developers to run the system-probe build process, and tests setup exactly as in the CI. As such it can be useful to use these tasks to package system-probe and target VMs outside the purview of KMT. For this we can provide a profile representing these "alien" vms, and the invoke tasks will
+correctly package system-probe and share with the provided VMs as if they were launch by KMT. This can be useful when a developer wants to use these tasks with local VMs launch with VMware, parallels, etc, or remote VMs launch in ec2 or gcp.
+
+The format of the profile is a json list of objects representing a vm. For each VM the following information is required:
+- ssh_key_path
+- IP
+- architecture
+- name
+
+An example of an alien VMs profile:
+```json
+[
+    {
+        "ssh_key_path": "/home/user/.ssh/some-key.id_rsa",
+        "ip": "xxx.yyy.aaa.bbb",
+        "arch": "x86",
+        "name": "ubuntu-gcp"
+    }
+]
+```
+
+To target these alien profiles use the `--alien-vms` flag to provide the path to this profile file.
+```
+inv -e kmt.build --alien-vms=/tmp/alien.profile
+```
+
+```
+inv -e kmt.test --packages=./pkg/ebpf --run=TestLockRanges/Hashmap --alien-vms=./alien.profile
+```

--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -416,7 +416,7 @@ This will show several tables, skipping the cases where all jobs/tests passed to
 - For each job that failed due to infra reasons, it will show a summary with quick detection of possible boot causes (e.g., it will show if the VM did not reach the login prompt, or if it didn't get an IP address, etc).
 
 ## Alien VMs
-The KMT tasks provided here allow developers to run the system-probe build process, and tests setup exactly as in the CI. As such it can be useful to use these tasks to package system-probe and target VMs outside the purview of KMT. For this we can provide a profile representing these "alien" vms, and the invoke tasks will
+The KMT tasks provided here allow developers to run the system-probe build process, and test setup exactly as in the CI. As such it can be useful to use these tasks to package system-probe and target VMs outside the purview of KMT. For this we can provide a profile representing these "alien" vms, and the invoke tasks will
 correctly package system-probe and share with the provided VMs as if they were launch by KMT. This can be useful when a developer wants to use these tasks with local VMs launch with VMware, parallels, etc, or remote VMs launch in ec2 or gcp.
 
 The format of the profile is a json list of objects representing a vm. For each VM the following information is required:

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -13,7 +13,7 @@ from tasks.kernel_matrix_testing.kmt_os import get_kmt_os
 from tasks.kernel_matrix_testing.tool import Exit, error, info
 
 if TYPE_CHECKING:
-    from tasks.kernel_matrix_testing.types import Arch, KMTArchNameOrLocal, PathOrStr, SSHKey, StackOutput
+    from tasks.kernel_matrix_testing.types import KMTArchNameOrLocal, PathOrStr, SSHKey, StackOutput
 
 # Common SSH options for all SSH commands
 SSH_OPTIONS = {
@@ -217,10 +217,12 @@ class AlienVMInfo(TypedDict):
     name: str
     arch: str
 
+
 AlienInfrastructure = list[AlienVMInfo]
 
+
 def build_alien_infrastructure(alien_vms: Path) -> dict[KMTArchNameOrLocal, HostInstance]:
-    with open(alien_vms, 'r') as f:
+    with open(alien_vms) as f:
         profile: AlienInfrastructure = json.load(f)
 
     # lets pretend all VMs are present locally even if they are not, because we just
@@ -229,11 +231,18 @@ def build_alien_infrastructure(alien_vms: Path) -> dict[KMTArchNameOrLocal, Host
     for vm in profile:
         instance.add_microvm(
             LibvirtDomain(
-                vm["ip"], "", "", [], vm["ssh_key_path"], vm["arch"], instance,
+                vm["ip"],
+                "",
+                "",
+                [],
+                vm["ssh_key_path"],
+                vm["arch"],
+                instance,
             )
         )
 
     return {"local": instance}
+
 
 def get_ssh_key_name(pubkey: Path) -> str | None:
     parts = pubkey.read_text().split()

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -701,7 +701,7 @@ def prepare(
 
     assert len(domains) > 0, err_msg
 
-    _prepare(ctx, component, stack, arch, packages, verbose, ci, compile_only, domains=domains)
+    _prepare(ctx, stack, component, arch, packages, verbose, ci, compile_only, domains=domains)
 
 
 def _prepare(

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -681,15 +681,6 @@ def prepare(
     ci=False,
     compile_only=False,
 ):
-    if ci:
-        domains = None
-        stack = "ci"
-        return _prepare(ctx, stack, component, arch, packages, verbose, ci, compile_only)
-
-    if alien_vms is not None:
-        err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
-    else:
-        err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
     arch_obj = Arch.from_str(arch)
     if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
@@ -697,6 +688,15 @@ def prepare(
             f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
         )
 
+    if ci:
+        domains = None
+        stack = "ci"
+        return _prepare(ctx, stack, component, arch_obj, packages, verbose, ci, compile_only)
+
+    if alien_vms is not None:
+        err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
+    else:
+        err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
     stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
     domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
     assert len(domains) > 0, err_msg

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -681,24 +681,24 @@ def prepare(
     ci=False,
     compile_only=False,
 ):
-    arch_obj = Arch.from_str(arch)
-    if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
-        raise Exit(
-            f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
-        )
-
-    if not ci:
-        stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
-        domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
-    else:
+    if ci:
         domains = None
         stack = "ci"
+        return _prepare(ctx, stack, component, arch, packages, verbose, ci, compile_only)
 
     if alien_vms is not None:
         err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
     else:
         err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
+    arch_obj = Arch.from_str(arch)
+    if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
+        raise Exit(
+            f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
+        )
+
+    stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
+    domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
     assert len(domains) > 0, err_msg
 
     _prepare(ctx, stack, component, arch, packages, verbose, ci, compile_only, domains=domains)

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -700,7 +700,7 @@ def prepare(
     else:
         err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
-    assert len(domains) > 0, f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
+    assert len(domains) > 0, err_msg
 
     _prepare(ctx, component, domains, stack, arch, packages, verbose, ci, compile_only)
 
@@ -1131,7 +1131,7 @@ def test(
     else:
         err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
-    assert len(domains) > 0, f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
+    assert len(domains) > 0, err_msg
 
     info("[+] Detected architectures in target VMs: " + ", ".join(map(str, used_archs)))
 

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -681,7 +681,6 @@ def prepare(
     ci=False,
     compile_only=False,
 ):
-
     arch_obj = Arch.from_str(arch)
     if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
         raise Exit(

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -30,8 +30,8 @@ from tasks.kernel_matrix_testing.infra import (
     SSH_OPTIONS,
     HostInstance,
     LibvirtDomain,
-    build_infrastructure,
     build_alien_infrastructure,
+    build_infrastructure,
     ensure_key_in_ec2,
     get_ssh_agent_key_names,
     get_ssh_key_name,
@@ -693,7 +693,6 @@ def prepare(
         )
 
     domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
-    used_archs = get_archs_in_domains(domains)
 
     if alien_vms is not None:
         err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
@@ -710,7 +709,7 @@ def _prepare(
     stack: str,
     component: Component,
     domains: list[LibvirtDomain],
-    arch_obj:  Arch,
+    arch_obj: Arch,
     packages=None,
     verbose=True,
     ci=False,
@@ -1061,6 +1060,7 @@ def images_matching_ci(_: Context, domains: list[LibvirtDomain]):
 
     return len(not_matches) == 0
 
+
 def get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms):
     def _get_infrastructure(ctx, stack, ssh_key, vms, alien_vms):
         if alien_vms:
@@ -1088,6 +1088,7 @@ def get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms):
         if ask("Some VMs do not match version in CI. Continue anyway [y/N]") != "y":
             return
     return domains
+
 
 @task(
     help={
@@ -1220,6 +1221,7 @@ def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
         stack
     ), f"Stack {stack} does not exist. Please create with 'inv kmt.create-stack --stack=<name>'"
     return stack
+
 
 @task(
     help={

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -31,6 +31,7 @@ from tasks.kernel_matrix_testing.infra import (
     HostInstance,
     LibvirtDomain,
     build_infrastructure,
+    build_alien_infrastructure,
     ensure_key_in_ec2,
     get_ssh_agent_key_names,
     get_ssh_key_name,
@@ -458,7 +459,7 @@ def filter_target_domains(vms: str, infra: dict[KMTArchNameOrLocal, HostInstance
 def get_archs_in_domains(domains: Iterable[LibvirtDomain]) -> set[Arch]:
     archs: set[Arch] = set()
     for d in domains:
-        archs.add(Arch.from_str(d.instance.arch))
+        archs.add(Arch.from_str(d.arch))
     return archs
 
 
@@ -620,10 +621,8 @@ def ninja_copy_ebpf_files(
 @task
 def kmt_secagent_prepare(
     ctx: Context,
-    vms: str | None = None,
     stack: str | None = None,
     arch: Arch | str = "local",
-    ssh_key: str | None = None,
     packages: str | None = None,
     verbose: bool = True,
     ci: bool = True,
@@ -673,6 +672,7 @@ def prepare(
     ctx: Context,
     component: Component,
     vms: str | None = None,
+    alien_vms: str | None = None,
     stack: str | None = None,
     arch: str | Arch = "local",
     ssh_key: str | None = None,
@@ -682,10 +682,7 @@ def prepare(
     compile_only=False,
 ):
     if not ci:
-        stack = check_and_get_stack(stack)
-        assert stacks.stack_exists(
-            stack
-        ), f"Stack {stack} does not exist. Please create with 'inv kmt.create-stack --stack=<name>'"
+        stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
     else:
         stack = "ci"
 
@@ -695,6 +692,30 @@ def prepare(
             f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
         )
 
+    domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
+    used_archs = get_archs_in_domains(domains)
+
+    if alien_vms is not None:
+        err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
+    else:
+        err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
+
+    assert len(domains) > 0, f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
+
+    _prepare(ctx, component, domains, stack, arch, packages, verbose, ci, compile_only)
+
+
+def _prepare(
+    ctx: Context,
+    stack: str,
+    component: Component,
+    domains: list[LibvirtDomain],
+    arch_obj:  Arch,
+    packages=None,
+    verbose=True,
+    ci=False,
+    compile_only=False,
+):
     if not ci:
         cc = get_compiler(ctx)
 
@@ -710,7 +731,7 @@ def prepare(
     info(f"[+] Compiling artifacts for {arch_obj}, component = {component}")
     if component == "security-agent":
         if ci:
-            kmt_secagent_prepare(ctx, vms, stack, arch_obj, ssh_key, packages, verbose, ci)
+            kmt_secagent_prepare(ctx, stack, arch_obj, packages, verbose, ci)
         else:
             cc.exec(
                 f"git config --global --add safe.directory {CONTAINER_AGENT_PATH} && inv {inv_echo} kmt.kmt-secagent-prepare --stack={stack} {pkgs} --arch={arch_obj.name}",
@@ -765,14 +786,7 @@ def prepare(
     if ci or compile_only:
         return
 
-    if vms is None or vms == "":
-        raise Exit("No vms specified to sync with")
-
-    ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
-    infra = build_infrastructure(stack, ssh_key_obj)
-    domains = filter_target_domains(vms, infra, arch_obj)
-
-    info(f"[+] Preparing VMs {vms} in stack {stack} for {arch}")
+    info(f"[+] Preparing VMs in stack {stack} for {arch_obj}")
 
     target_instances: list[HostInstance] = []
     for d in domains:
@@ -1047,6 +1061,33 @@ def images_matching_ci(_: Context, domains: list[LibvirtDomain]):
 
     return len(not_matches) == 0
 
+def get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms):
+    def _get_infrastructure(ctx, stack, ssh_key, vms, alien_vms):
+        if alien_vms:
+            alien_vms_path = Path(alien_vms)
+            if not alien_vms_path.exists():
+                raise Exit(f"No alien VMs profile found @ {alien_vms_path}")
+            return build_alien_infrastructure(alien_vms_path)
+
+        if vms is None:
+            vms = ",".join(stacks.get_all_vms_in_stack(stack))
+            info(f"[+] running tests on all vms in stack {stack}: vms={vms}")
+
+        ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
+        return build_infrastructure(stack, ssh_key_obj)
+
+    if vms is not None and alien_vms is not None:
+        raise Exit("target VMs can be either KMT VMs or alien VMs, not both")
+
+    infra = _get_infrastructure(ctx, stack, ssh_key, vms, alien_vms)
+    if alien_vms is not None:
+        return infra["local"].microvms
+
+    domains = filter_target_domains(vms, infra, arch_obj)
+    if not images_matching_ci(ctx, domains):
+        if ask("Some VMs do not match version in CI. Continue anyway [y/N]") != "y":
+            return
+    return domains
 
 @task(
     help={
@@ -1068,6 +1109,7 @@ def test(
     ctx: Context,
     component: str = "system-probe",
     vms: str | None = None,
+    alien_vms: str | None = None,
     stack: str | None = None,
     packages=None,
     run: str | None = None,
@@ -1080,23 +1122,14 @@ def test(
     test_extra_arguments=None,
     test_extra_env=None,
 ):
-    stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(
-        stack
-    ), f"Stack {stack} does not exist. Please create with 'inv kmt.create-stack --stack=<name>'"
-
-    if vms is None:
-        vms = ",".join(stacks.get_all_vms_in_stack(stack))
-        info(f"[+] Running tests on all VMs in stack {stack}: vms={vms}")
-
-    ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
-    infra = build_infrastructure(stack, ssh_key_obj)
-    domains = filter_target_domains(vms, infra)
+    stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
+    domains = get_target_domains(ctx, stack, ssh_key, None, vms, alien_vms)
     used_archs = get_archs_in_domains(domains)
 
-    if not images_matching_ci(ctx, domains):
-        if ask("Some VMs do not match version in CI. Continue anyway [y/N]") != "y":
-            return
+    if alien_vms is not None:
+        err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
+    else:
+        err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
     assert len(domains) > 0, f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
@@ -1105,7 +1138,7 @@ def test(
     if not quick:
         for arch in used_archs:
             info(f"[+] Preparing {component} for {arch}")
-            prepare(ctx, component, stack=stack, vms=vms, packages=packages, ssh_key=ssh_key, arch=arch)
+            _prepare(ctx, stack, component, domains, arch, packages=packages, verbose=verbose)
 
     if run is not None and packages is None:
         raise Exit("Package must be provided when specifying test")
@@ -1175,6 +1208,19 @@ def build_layout(ctx, domains, layout: str, verbose: bool):
             d.run_cmd(ctx, cmd, verbose)
 
 
+def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
+    if alien_vms is not None and vms is None:
+        stack = check_and_get_stack("alien-stack")
+        if not stacks.stack_exists(stack):
+            stacks.create_stack(ctx, stack)
+        return stack
+
+    stack = check_and_get_stack(stack)
+    assert stacks.stack_exists(
+        stack
+    ), f"Stack {stack} does not exist. Please create with 'inv kmt.create-stack --stack=<name>'"
+    return stack
+
 @task(
     help={
         "vms": "Comma seperated list of vms to target when running tests",
@@ -1189,6 +1235,7 @@ def build_layout(ctx, domains, layout: str, verbose: bool):
 def build(
     ctx: Context,
     vms: str | None = None,
+    alien_vms: str | None = None,
     stack: str | None = None,
     ssh_key: str | None = None,
     verbose=True,
@@ -1198,10 +1245,7 @@ def build(
     compile_only=False,
     override_agent=False,
 ):
-    stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(
-        stack
-    ), f"Stack {stack} does not exist. Please create with 'inv kmt.create-stack --stack=<name>'"
+    stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
 
     if arch is None:
         arch = "local"
@@ -1225,20 +1269,15 @@ def build(
     if compile_only:
         return
 
-    if vms is None:
-        vms = ",".join(stacks.get_all_vms_in_stack(stack))
-
     assert os.path.exists(layout), f"File {layout} does not exist"
 
-    ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
-    infra = build_infrastructure(stack, ssh_key_obj)
-    domains = filter_target_domains(vms, infra, arch_obj)
+    domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
+    if alien_vms is not None:
+        err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
+    else:
+        err_msg = f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
 
-    if not images_matching_ci(ctx, domains):
-        if ask("Some VMs do not match version in CI. Continue anyway [y/N]") != "y":
-            return
-
-    assert len(domains) > 0, f"no vms found from list {vms}. Run `inv -e kmt.status` to see all VMs in current stack"
+    assert len(domains) > 0, err_msg
 
     build_layout(ctx, domains, layout, verbose)
     for d in domains:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1076,9 +1076,6 @@ def get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms):
         ssh_key_obj = try_get_ssh_key(ctx, ssh_key)
         return build_infrastructure(stack, ssh_key_obj)
 
-    if vms is not None and alien_vms is not None:
-        raise Exit("target VMs can be either KMT VMs or alien VMs, not both")
-
     infra = _get_infrastructure(ctx, stack, ssh_key, vms, alien_vms)
     if alien_vms is not None:
         return infra["local"].microvms
@@ -1210,6 +1207,8 @@ def build_layout(ctx, domains, layout: str, verbose: bool):
 
 
 def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
+    assert vms is not None and alien_vms is not None, "target VMs can be either KMT VMs or alien VMs, not both"
+
     if alien_vms is not None and vms is None:
         stack = check_and_get_stack("alien-stack")
         if not stacks.stack_exists(stack):

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -683,7 +683,9 @@ def prepare(
 ):
     if not ci:
         stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
+        domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
     else:
+        domains = None
         stack = "ci"
 
     arch_obj = Arch.from_str(arch)
@@ -692,8 +694,6 @@ def prepare(
             f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
         )
 
-    domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
-
     if alien_vms is not None:
         err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
     else:
@@ -701,19 +701,19 @@ def prepare(
 
     assert len(domains) > 0, err_msg
 
-    _prepare(ctx, component, domains, stack, arch, packages, verbose, ci, compile_only)
+    _prepare(ctx, component, stack, arch, packages, verbose, ci, compile_only, domains=domains)
 
 
 def _prepare(
     ctx: Context,
     stack: str,
     component: Component,
-    domains: list[LibvirtDomain],
     arch_obj: Arch,
     packages=None,
     verbose=True,
     ci=False,
     compile_only=False,
+    domains: list[LibvirtDomain] | None = None
 ):
     if not ci:
         cc = get_compiler(ctx)
@@ -1139,7 +1139,7 @@ def test(
     if not quick:
         for arch in used_archs:
             info(f"[+] Preparing {component} for {arch}")
-            _prepare(ctx, stack, component, domains, arch, packages=packages, verbose=verbose)
+            _prepare(ctx, stack, component, arch, packages=packages, verbose=verbose, domains=domains)
 
     if run is not None and packages is None:
         raise Exit("Package must be provided when specifying test")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -681,18 +681,18 @@ def prepare(
     ci=False,
     compile_only=False,
 ):
+    arch_obj = Arch.from_str(arch)
+    if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
+        raise Exit(
+            f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
+        )
+
     if not ci:
         stack = get_kmt_or_alien_stack(ctx, stack, vms, alien_vms)
         domains = get_target_domains(ctx, stack, ssh_key, arch_obj, vms, alien_vms)
     else:
         domains = None
         stack = "ci"
-
-    arch_obj = Arch.from_str(arch)
-    if arch_obj.kmt_arch not in KMT_SUPPORTED_ARCHS:
-        raise Exit(
-            f"Architecture {arch} (inferred {arch_obj}) is not supported. Supported architectures are amd64 and arm64"
-        )
 
     if alien_vms is not None:
         err_msg = f"no alient VMs discovered from provided profile {alien_vms}."
@@ -713,7 +713,7 @@ def _prepare(
     verbose=True,
     ci=False,
     compile_only=False,
-    domains: list[LibvirtDomain] | None = None
+    domains: list[LibvirtDomain] | None = None,
 ):
     if not ci:
         cc = get_compiler(ctx)

--- a/tasks/libs/types/arch.py
+++ b/tasks/libs/types/arch.py
@@ -136,7 +136,7 @@ ARCH_AMD64 = Arch(
     kmt_arch="x86_64",
     windows_arch="x64",
     ci_arch="x64",
-    spellings={"amd64", "x86_64", "x64", "x86-64"},
+    spellings={"amd64", "x86_64", "x64", "x86-64", "x86"},
 )
 
 ALL_ARCHS = [ARCH_AMD64, ARCH_ARM64]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR allows developers to use the KMT build tasks to target VMs launch outside the purview of KMT. These can be local VMs launched with Parallels, VMWare, etc, or remote VMs launched in EC2 or GCP, etc.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The KMT build tasks allow a user to build and test system-probe exactly like the CI, locally. This new feature now allows developers to share the build/test packages with any VM even if it is not launch with KMT.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
