### PR TITLE
usm: Move SoWatcher tests to FileRegistry and EbpfProgram

### DIFF
--- a/pkg/network/usm/sharedlibraries/ebpf_test.go
+++ b/pkg/network/usm/sharedlibraries/ebpf_test.go
@@ -8,15 +8,20 @@
 package sharedlibraries
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
@@ -249,6 +254,302 @@ func (s *EbpfProgramSuite) TestMultipleProgramsReceiveMultipleLibsetEvents() {
 
 	require.Equal(t, fooPathCuda, receivedEventCuda.String())
 	require.Equal(t, commandCuda.Process.Pid, int(receivedEventCuda.Pid))
+}
+
+func TestIgnoreOpenedForWrite(t *testing.T) {
+	tests := []struct {
+		syscallType string
+		skipFunc    func(t *testing.T)
+	}{
+		{
+			syscallType: "open",
+		},
+		{
+			syscallType: "openat",
+		},
+		{
+			syscallType: "openat2",
+			skipFunc: func(t *testing.T) {
+				if !sysOpenAt2Supported() {
+					t.Skip("openat2 not supported")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.syscallType, func(t *testing.T) {
+			if tt.skipFunc != nil {
+				tt.skipFunc(t)
+			}
+			// Since we want to detect that the write _hasn't_ been detected, verify the
+			// read too to try to ensure that test isn't broken and failing to detect
+			// the write due to some bug in the test itself.
+			readPath, _ := createTempTestFile(t, "read-foo-libssl.so")
+			writePath, _ := createTempTestFile(t, "write-foo-libssl.so")
+
+			cfg := ebpf.NewConfig()
+			require.NotNil(t, cfg)
+
+			progSsl := GetEBPFProgram(cfg)
+			require.NotNil(t, progSsl)
+			t.Cleanup(progSsl.Stop)
+
+			require.NoError(t, progSsl.InitWithLibsets(LibsetCrypto))
+
+			var receivedEventMutex sync.Mutex
+			var receivedEvents []LibPath
+			callback := func(path LibPath) {
+				receivedEventMutex.Lock()
+				defer receivedEventMutex.Unlock()
+				receivedEvents = append(receivedEvents, path)
+			}
+
+			unsub, err := progSsl.Subscribe(callback, LibsetCrypto)
+			require.NoError(t, err)
+			t.Cleanup(unsub)
+
+			how := unix.OpenHow{Mode: 0644}
+			how.Flags = syscall.O_CREAT | syscall.O_WRONLY
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				how.Flags = syscall.O_CREAT | syscall.O_RDONLY
+				fd, err := open(unix.AT_FDCWD, readPath, &how, tt.syscallType)
+				require.NoError(c, err)
+				require.NoError(c, syscall.Close(fd))
+
+				how.Flags = syscall.O_CREAT | syscall.O_WRONLY
+				fd, err = open(unix.AT_FDCWD, writePath, &how, tt.syscallType)
+				require.NoError(c, err)
+				require.NoError(c, syscall.Close(fd))
+
+				// Sleep to ensure that the event is received
+				time.Sleep(10 * time.Millisecond)
+
+				receivedEventMutex.Lock()
+				defer receivedEventMutex.Unlock()
+
+				assert.Greater(c, len(receivedEvents), 0, "no events received")
+
+				containsReadPath, containsWritePath := false, false
+				for _, event := range receivedEvents {
+					if event.String() == readPath {
+						containsReadPath = true
+					} else if event.String() == writePath {
+						containsWritePath = true
+					}
+				}
+
+				assert.True(c, containsReadPath, "expected event to be received for read path")
+				assert.False(c, containsWritePath, "expected event to not be received for write path")
+
+				// Reset the received events to avoid false positives on the next iteration
+				receivedEvents = nil
+			}, time.Second*3, 100*time.Millisecond)
+		})
+	}
+}
+
+// open abstracts open, openat, and openat2
+func open(dirfd int, pathname string, how *unix.OpenHow, syscallType string) (int, error) {
+	switch syscallType {
+	case "open":
+		return unix.Open(pathname, int(how.Flags), uint32(how.Mode))
+	case "openat":
+		return unix.Openat(dirfd, pathname, int(how.Flags), uint32(how.Mode))
+	case "openat2":
+		return unix.Openat2(dirfd, pathname, how)
+	default:
+		return -1, fmt.Errorf("unsupported syscall type: %s", syscallType)
+	}
+}
+
+func TestLongPathsIgnored(t *testing.T) {
+	const (
+		fileName             = "foo-libssl.so"
+		nullTerminatorLength = len("\x00")
+	)
+
+	padLength := LibPathMaxSize - len(fileName) - len(t.TempDir()) - len("_") - len(string(filepath.Separator)) - nullTerminatorLength
+	fooPath1, _ := createTempTestFile(t, strings.Repeat("a", padLength)+"_"+fileName)
+	// fooPath2 is longer than the limit we have, thus it will be ignored.
+	fooPath2, _ := createTempTestFile(t, strings.Repeat("a", padLength+1)+"_"+fileName)
+
+	cfg := ebpf.NewConfig()
+	require.NotNil(t, cfg)
+
+	progSsl := GetEBPFProgram(cfg)
+	require.NotNil(t, progSsl)
+	t.Cleanup(progSsl.Stop)
+
+	require.NoError(t, progSsl.InitWithLibsets(LibsetCrypto))
+
+	var receivedEventMutex sync.Mutex
+	var receivedEvents []LibPath
+	callback := func(path LibPath) {
+		receivedEventMutex.Lock()
+		defer receivedEventMutex.Unlock()
+		receivedEvents = append(receivedEvents, path)
+	}
+
+	unsub, err := progSsl.Subscribe(callback, LibsetCrypto)
+	require.NoError(t, err)
+	t.Cleanup(unsub)
+
+	// create files
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if command1 != nil && command1.Process != nil {
+			command1.Process.Kill()
+		}
+	})
+	command2, err := fileopener.OpenFromAnotherProcess(t, fooPath2)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if command2 != nil && command2.Process != nil {
+			command2.Process.Kill()
+		}
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		receivedEventMutex.Lock()
+		defer receivedEventMutex.Unlock()
+
+		assert.Greater(t, len(receivedEvents), 0, "no events received")
+		containsFooPath1, containsFooPath2 := false, false
+		for _, event := range receivedEvents {
+			if event.String() == fooPath1 {
+				containsFooPath1 = true
+			} else if event.String() == fooPath2 {
+				containsFooPath2 = true
+			}
+		}
+
+		assert.True(c, containsFooPath1, "expected event to be received for fooPath1")
+		assert.False(c, containsFooPath2, "expected event to not be received for fooPath2")
+
+		// Reset the received events to avoid false positives on the next iteration
+		receivedEvents = nil
+	}, time.Second*3, 100*time.Millisecond)
+}
+
+func zeroPages(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
+}
+
+// This test ensures that the shared library watcher correctly identifies and processes the first file path in memory,
+// even when a second path is present, particularly in scenarios where the first path crosses a memory page boundary.
+// The goal is to verify that the presence of the second path does not inadvertently cause the watcher to send to the
+// user mode the first path. Before each iteration, the memory-mapped pages are zeroed to ensure consistent and isolated
+// test conditions.
+func TestValidPathExistsInTheMemory(t *testing.T) {
+	pageSize := os.Getpagesize()
+
+	// We want to allocate two contiguous pages and ensure that the address
+	// after the two pages is inaccessible. So allocate 3 pages and change the
+	// protection of the last one with mprotect(2). If we only map two pages the
+	// kernel may merge this mmaping with another existing mapping after it.
+	data, err := syscall.Mmap(-1, 0, 3*pageSize, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = syscall.Munmap(data) })
+
+	err = syscall.Mprotect(data[2*pageSize:], 0)
+	require.NoError(t, err)
+	// Truncate the size so that the range loop on it in zeroPages() does not
+	// access the memory we've disabled access to.
+	data = data[:2*pageSize]
+
+	dummyPath, _ := createTempTestFile(t, "dummy.text")
+	soPath, _ := createTempTestFile(t, "foo-libssl.so")
+
+	tests := []struct {
+		name       string
+		writePaths func(data []byte, textFilePath, soPath string) int
+	}{
+		{
+			// Paths are written consecutively in memory, without crossing a page boundary.
+			name: "sanity",
+			writePaths: func(data []byte, textFilePath, soPath string) int {
+				copy(data, textFilePath)
+				data[len(textFilePath)] = 0 // Null-terminate the first path
+				copy(data[len(textFilePath)+1:], soPath)
+
+				return 0
+			},
+		},
+		{
+			// Paths are written consecutively in memory, at the end of a page.
+			name: "end of a page",
+			writePaths: func(data []byte, textFilePath, soPath string) int {
+				offset := 2*pageSize - len(textFilePath) - 1 - len(soPath) - 1
+				copy(data[offset:], textFilePath)
+				data[offset+len(textFilePath)] = 0 // Null-terminate the first path
+				copy(data[offset+len(textFilePath)+1:], soPath)
+				data[offset+len(textFilePath)+1+len(soPath)] = 0 // Null-terminate the second path
+
+				return offset
+			},
+		},
+		{
+			// The first path is written at the end of the first page, and the second path is written at the beginning
+			// of the second page.
+			name: "cross pages",
+			writePaths: func(data []byte, textFilePath, soPath string) int {
+				// Ensure the first path ends near the end of the first page, crossing into the second page
+				offset := pageSize - len(textFilePath) - 1
+				copy(data[offset:], textFilePath)
+				data[offset+len(textFilePath)] = 0 // Null-terminate the first path
+				copy(data[pageSize:], soPath)
+
+				return offset
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zeroPages(data)
+
+			// Ensure the first path ends near the end of the first page, crossing into the second page
+			offset := tt.writePaths(data, dummyPath, soPath)
+
+			cfg := ebpf.NewConfig()
+			require.NotNil(t, cfg)
+
+			progSsl := GetEBPFProgram(cfg)
+			require.NotNil(t, progSsl)
+			t.Cleanup(progSsl.Stop)
+
+			require.NoError(t, progSsl.InitWithLibsets(LibsetCrypto))
+
+			var receivedEventMutex sync.Mutex
+			var receivedEvents []LibPath
+			callback := func(path LibPath) {
+				receivedEventMutex.Lock()
+				defer receivedEventMutex.Unlock()
+				receivedEvents = append(receivedEvents, path)
+			}
+
+			unsub, err := progSsl.Subscribe(callback, LibsetCrypto)
+			require.NoError(t, err)
+			t.Cleanup(unsub)
+
+			pathPtr := uintptr(unsafe.Pointer(&data[offset]))
+			dirfd := int(unix.AT_FDCWD)
+			fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, uintptr(dirfd), pathPtr, uintptr(os.O_RDONLY), 0644, 0, 0)
+			require.Zero(t, errno)
+			t.Cleanup(func() { _ = syscall.Close(int(fd)) })
+
+			// Since we want to verify that the write _hasn't_ been detected, we need to try it multiple times
+			// to avoid race conditions.
+			for i := 0; i < 10; i++ {
+				time.Sleep(100 * time.Millisecond)
+				// the 'watcher.libHits' counter is incremented before rule matching and may be > 0, do not check it.
+				assert.Empty(t, receivedEvents)
+			}
+		})
+	}
 }
 
 func createTempTestFile(t *testing.T, name string) (string, utils.PathIdentifier) {

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -8,10 +8,12 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -386,6 +388,128 @@ func TestRelativeFilePathInCallbackArgument(t *testing.T) {
 	// that would `Clean` the path, removing the relative components.
 	expectedPath := filepath.Join(r.procRoot, strconv.Itoa(pid), "cwd") + string(filepath.Separator) + relpath
 	assert.Equal(t, expectedPath, capturedPath)
+}
+
+func TestSameInodeRegression(t *testing.T) {
+	var capturedPath string
+	callback := func(f FilePath) error {
+		capturedPath = f.HostPath
+		return nil
+	}
+
+	fooPath1, fooPathID1 := createTempTestFile(t, "a-foo-libssl.so")
+	fooPath2 := filepath.Join(t.TempDir(), "b-foo-libssl.so")
+
+	require.NoError(t, os.Link(fooPath1, fooPath2))
+
+	fooPathID2, err := NewPathIdentifier(fooPath2)
+	require.NoError(t, err)
+	require.Equal(t, fooPathID1, fooPathID2)
+
+	cmd, err := testutil.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	require.NoError(t, err)
+	pid := cmd.Process.Pid
+
+	// Ensure that we only get the first path in the callback
+	r := newFileRegistry()
+	require.NoError(t, r.Register(fooPath1, uint32(pid), callback, callback))
+	require.True(t, strings.HasSuffix(capturedPath, fooPath1))
+	require.ErrorIs(t, r.Register(fooPath2, uint32(pid), callback, callback), ErrPathIsAlreadyRegistered)
+	require.True(t, strings.HasSuffix(capturedPath, fooPath1))
+
+	// Check that closing the file descriptor unregisters the path
+	require.NoError(t, r.Unregister(uint32(pid)))
+	require.Empty(t, r.GetRegisteredProcesses())
+}
+
+func TestNoLeaks(t *testing.T) {
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
+	pid1, pid2 := uint32(1), uint32(2)
+
+	registerRecorder := new(CallbackRecorder)
+	unregisterRecorder := &CallbackRecorder{
+		ReturnError: errors.New("fake unregisterCB error"),
+	}
+
+	registerCB := registerRecorder.Callback()
+	unregisterCB := unregisterRecorder.Callback()
+
+	registry := newFileRegistry()
+
+	// Simulate a process that opens two files
+	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB))
+	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB))
+
+	// Checking register callback was executed once for each library
+	// and that we're tracking the two command PIDs
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID2))
+	require.Contains(t, registry.GetRegisteredProcesses(), pid1)
+
+	// Now open the first file from another process
+	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB), ErrPathIsAlreadyRegistered)
+
+	// Check that no more callbacks were executed, but we're tracking two PIDs now
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID2))
+	require.Contains(t, registry.GetRegisteredProcesses(), pid1)
+	require.Contains(t, registry.GetRegisteredProcesses(), pid2)
+
+	// Now close the first process
+	require.NoError(t, registry.Unregister(pid1))
+
+	// Checking that the unregisteredCB was executed only for pathID2
+	require.Equal(t, 0, unregisterRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID2))
+
+	// Close the second process
+	require.NoError(t, registry.Unregister(pid2))
+
+	// Checking that the unregisteredCB was executed for both pathIDs
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID2))
+
+	// Check there are no more processes registered
+	require.Empty(t, registry.GetRegisteredProcesses())
+}
+
+func TestAlreadyHoldingReferences(t *testing.T) {
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
+	pid1, pid2 := uint32(1), uint32(2)
+
+	registerRecorder := new(CallbackRecorder)
+	unregisterRecorder := new(CallbackRecorder)
+	registerCB := registerRecorder.Callback()
+	unregisterCB := unregisterRecorder.Callback()
+
+	registry := newFileRegistry()
+	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB))
+	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB))
+	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB), ErrPathIsAlreadyRegistered)
+
+	// Checking register callback was executed once for each library
+	// and that we're tracking the two command PIDs
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID2))
+	require.Contains(t, registry.GetRegisteredProcesses(), pid1)
+	require.Contains(t, registry.GetRegisteredProcesses(), pid2)
+
+	require.NoError(t, registry.Unregister(pid1))
+	require.Equal(t, 0, unregisterRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID2))
+	require.NotContains(t, registry.GetRegisteredProcesses(), pid1)
+	require.Contains(t, registry.GetRegisteredProcesses(), pid2)
+
+	require.NoError(t, registry.Unregister(pid2))
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID1))
+	require.Equal(t, 1, unregisterRecorder.CallsForPathID(fooPathID2))
+	require.NotContains(t, registry.GetRegisteredProcesses(), pid1)
+	require.NotContains(t, registry.GetRegisteredProcesses(), pid2)
+
+	// Check there are no more processes registered
+	require.Empty(t, registry.GetRegisteredProcesses())
 }
 
 func createTempTestFile(t *testing.T, name string) (string, PathIdentifier) {

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -412,9 +412,9 @@ func TestSameInodeRegression(t *testing.T) {
 
 	// Ensure that we only get the first path in the callback
 	r := newFileRegistry()
-	require.NoError(t, r.Register(fooPath1, uint32(pid), callback, callback))
+	require.NoError(t, r.Register(fooPath1, uint32(pid), callback, callback, IgnoreCB))
 	require.True(t, strings.HasSuffix(capturedPath, fooPath1))
-	require.ErrorIs(t, r.Register(fooPath2, uint32(pid), callback, callback), ErrPathIsAlreadyRegistered)
+	require.ErrorIs(t, r.Register(fooPath2, uint32(pid), callback, callback, IgnoreCB), ErrPathIsAlreadyRegistered)
 	require.True(t, strings.HasSuffix(capturedPath, fooPath1))
 
 	// Check that closing the file descriptor unregisters the path
@@ -438,8 +438,8 @@ func TestNoLeaks(t *testing.T) {
 	registry := newFileRegistry()
 
 	// Simulate a process that opens two files
-	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB))
-	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB))
+	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB, IgnoreCB))
+	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB, IgnoreCB))
 
 	// Checking register callback was executed once for each library
 	// and that we're tracking the two command PIDs
@@ -448,7 +448,7 @@ func TestNoLeaks(t *testing.T) {
 	require.Contains(t, registry.GetRegisteredProcesses(), pid1)
 
 	// Now open the first file from another process
-	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB), ErrPathIsAlreadyRegistered)
+	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB, IgnoreCB), ErrPathIsAlreadyRegistered)
 
 	// Check that no more callbacks were executed, but we're tracking two PIDs now
 	require.Equal(t, 1, registerRecorder.CallsForPathID(fooPathID1))

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -425,7 +425,14 @@ func TestSameInodeRegression(t *testing.T) {
 func TestNoLeaks(t *testing.T) {
 	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
 	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
-	pid1, pid2 := uint32(1), uint32(2)
+
+	cmd1, err := testutil.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
+	pid1 := uint32(cmd1.Process.Pid)
+
+	cmd2, err := testutil.OpenFromAnotherProcess(t, fooPath2)
+	require.NoError(t, err)
+	pid2 := uint32(cmd2.Process.Pid)
 
 	registerRecorder := new(CallbackRecorder)
 	unregisterRecorder := &CallbackRecorder{
@@ -477,7 +484,14 @@ func TestNoLeaks(t *testing.T) {
 func TestAlreadyHoldingReferences(t *testing.T) {
 	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
 	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
-	pid1, pid2 := uint32(1), uint32(2)
+
+	cmd1, err := testutil.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
+	pid1 := uint32(cmd1.Process.Pid)
+
+	cmd2, err := testutil.OpenFromAnotherProcess(t, fooPath2)
+	require.NoError(t, err)
+	pid2 := uint32(cmd2.Process.Pid)
 
 	registerRecorder := new(CallbackRecorder)
 	unregisterRecorder := new(CallbackRecorder)

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -485,9 +485,9 @@ func TestAlreadyHoldingReferences(t *testing.T) {
 	unregisterCB := unregisterRecorder.Callback()
 
 	registry := newFileRegistry()
-	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB))
-	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB))
-	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB), ErrPathIsAlreadyRegistered)
+	require.NoError(t, registry.Register(fooPath1, pid1, registerCB, unregisterCB, IgnoreCB))
+	require.NoError(t, registry.Register(fooPath2, pid1, registerCB, unregisterCB, IgnoreCB))
+	require.ErrorIs(t, registry.Register(fooPath1, pid2, registerCB, unregisterCB, IgnoreCB), ErrPathIsAlreadyRegistered)
 
 	// Checking register callback was executed once for each library
 	// and that we're tracking the two command PIDs


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds tests that were present in `watcher_test.go` and were removed in #37124 that could be kept as they were mostly testing behaviour of either the `FileRegistry` or the `EbpfProgram` types. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Keep test coverage.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Tests passing in CI.
