### PR TITLE
[CONS-6540] Better look for image name in podman DB

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/podman/podman.go
+++ b/comp/core/workloadmeta/collectors/internal/podman/podman.go
@@ -161,7 +161,11 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		log.Warnf("Could not get env vars for container %s", containerID)
 	}
 
-	image, err := workloadmeta.NewContainerImage(container.Config.ContainerRootFSConfig.RootfsImageID, container.Config.RawImageName)
+	imageName := container.Config.RawImageName
+	if imageName == "" {
+		imageName = container.Config.RootfsImageName
+	}
+	image, err := workloadmeta.NewContainerImage(container.Config.ContainerRootFSConfig.RootfsImageID, imageName)
 	if err != nil {
 		log.Warnf("Could not get image for container %s", containerID)
 	}

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -204,6 +204,10 @@ type ContainerRootFSConfig struct {
 	// based on an image with this ID.
 	// This conflicts with Rootfs.
 	RootfsImageID string `json:"rootfsImageID,omitempty"`
+	// RootfsImageName is the (normalized) name of the image used to create
+	// the container. If the container was created from a Rootfs, this will
+	// be empty.
+	RootfsImageName string `json:"rootfsImageName,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix cases where the agent couldn’t find the container image name with podman.

### Additional Notes

In the customer support case, the `image_name` tag missing from all data and wasn’t even visible in workload meta.
An analysis of the podman DB showed that the `RawImageName` field where the agent was looking at was empty:
```
sqlite3 -readonly /var/lib/containers/storage/db.sql 'SELECT ContainerConfig.JSON FROM ContainerConfig;' | jq .RawImageName
null
null
null
null
[…]
```

Yet, the `podman` CLI was able to find the image name of the containers from the same DB file:
```
podman ps --format '{{ .ID }}' | while read -r ctr; do sudo podman inspect "$ctr" | jq '.[] | .ImageName'; done
"docker.io/moby/buildkit:buildx-stable-1"
"docker.io/library/redis:6.0.5"
"docker.io/minio/minio:RELEASE.2023-01-20T02-05-44Z"
"docker.io/library/mysql:8.0.26"
[…]
```

And the only field where those image names could be found in the podman DB is in the `rootfsImageName` field:
```
sqlite3 -readonly /tmp/db.sql 'SELECT ContainerConfig.JSON FROM ContainerConfig;' | jq | grep docker.io
  "rootfsImageName": "docker.io/moby/buildkit:buildx-stable-1",
  "rootfsImageName": "docker.io/library/redis:6.0.5",
  "rootfsImageName": "docker.io/minio/minio:RELEASE.2023-01-20T02-05-44Z",
  "rootfsImageName": "docker.io/library/mysql:8.0.26",
[…]
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
