### PR TITLE
[E2E] Retry Agent MSI download

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/aws/smithy-go v1.20.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/charmbracelet/bubbles v0.18.0 // indirect
 	github.com/charmbracelet/bubbletea v0.25.0 // indirect

--- a/test/new-e2e/tests/security-agent-functional/security_agent_test.go
+++ b/test/new-e2e/tests/security-agent-functional/security_agent_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
-	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
@@ -76,13 +75,7 @@ func (v *vmSuite) TestSystemProbeCWSSuite() {
 	// install the agent (just so we can get the driver(s) installed)
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
 	require.NoError(t, err)
-	remoteMSIPath, err := windowsCommon.GetTemporaryFile(vm)
-	require.NoError(t, err)
-	t.Logf("Getting install package %s...", agentPackage.URL)
-	err = windowsCommon.PutOrDownloadFile(vm, agentPackage.URL, remoteMSIPath)
-	require.NoError(t, err)
-
-	err = windowsCommon.InstallMSI(vm, remoteMSIPath, "", "")
+	_, err = windowsAgent.InstallAgent(vm, windowsAgent.WithPackage(agentPackage))
 	t.Log("Install complete")
 	require.NoError(t, err)
 

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
-	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	componentsos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
@@ -106,13 +105,7 @@ func (v *vmSuite) TestSystemProbeNPMSuite() {
 	// install the agent (just so we can get the driver(s) installed)
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
 	require.NoError(t, err)
-	remoteMSIPath, err := windowsCommon.GetTemporaryFile(vm)
-	require.NoError(t, err)
-	t.Logf("Getting install package %s...", agentPackage.URL)
-	err = windowsCommon.PutOrDownloadFile(vm, agentPackage.URL, remoteMSIPath)
-	require.NoError(t, err)
-
-	err = windowsCommon.InstallMSI(vm, remoteMSIPath, "", "")
+	_, err = windowsAgent.InstallAgent(vm, windowsAgent.WithPackage(agentPackage))
 	t.Log("Install complete")
 	require.NoError(t, err)
 

--- a/test/new-e2e/tests/windows/common/agent/agent.go
+++ b/test/new-e2e/tests/windows/common/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
@@ -20,6 +21,7 @@ import (
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	infraCommon "github.com/DataDog/test-infra-definitions/common"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,13 +74,23 @@ func InstallAgent(host *components.RemoteHost, options ...InstallAgentOption) (s
 		p.LocalInstallLogFile = filepath.Join(os.TempDir(), "install.log")
 	}
 
+	downloadBackOff := p.DownloadMSIBackOff
+	if downloadBackOff == nil {
+		// 5s, 7s, 11s, 17s, 25s, 38s, 60s, 60s...for up to 5 minutes
+		downloadBackOff = backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(5*time.Second),
+			backoff.WithMaxInterval(60*time.Second),
+			backoff.WithMaxElapsedTime(5*time.Minute),
+		)
+	}
+
 	args := p.toArgs()
 
 	remoteMSIPath, err := windowsCommon.GetTemporaryFile(host)
 	if err != nil {
 		return "", err
 	}
-	err = windowsCommon.PutOrDownloadFile(host, p.Package.URL, remoteMSIPath)
+	err = windowsCommon.PutOrDownloadFileWithRetry(host, p.Package.URL, remoteMSIPath, downloadBackOff)
 	if err != nil {
 		return "", err
 	}

--- a/test/new-e2e/tests/windows/common/agent/agent_install_params.go
+++ b/test/new-e2e/tests/windows/common/agent/agent_install_params.go
@@ -13,11 +13,15 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams/msi"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 // InstallAgentParams are the parameters used for installing the Agent using msiexec.
 type InstallAgentParams struct {
-	Package *Package
+	Package            *Package
+	DownloadMSIBackOff backoff.BackOff
+
 	// Path on local test runner to save the MSI install log
 	LocalInstallLogFile string
 
@@ -142,6 +146,14 @@ func WithLastStablePackage() InstallAgentOption {
 			return err
 		}
 		i.Package = lastStablePackage
+		return nil
+	}
+}
+
+// WithDownloadMSIBackoff specifies the backoff strategy for downloading the MSI.
+func WithDownloadMSIBackoff(backoff backoff.BackOff) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.DownloadMSIBackOff = backoff
 		return nil
 	}
 }

--- a/test/new-e2e/tests/windows/common/network.go
+++ b/test/new-e2e/tests/windows/common/network.go
@@ -82,20 +82,8 @@ func ListBoundPorts(host *components.RemoteHost) ([]*BoundPort, error) {
 // If the URL is a local file, it will be uploaded to the VM.
 // If the URL is a remote file, it will be downloaded from the VM
 func PutOrDownloadFile(host *components.RemoteHost, url string, destination string) error {
-	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		return DownloadFile(host, url, destination)
-	}
-
-	if strings.HasPrefix(url, "file://") {
-		// URL is a local file
-		localPath := strings.TrimPrefix(url, "file://")
-		host.CopyFile(localPath, destination)
-		return nil
-	}
-
-	// just assume it's a local file
-	host.CopyFile(url, destination)
-	return nil
+	// no retry
+	return PutOrDownloadFileWithRetry(host, url, destination, &backoff.StopBackOff{})
 }
 
 // PutOrDownloadFileWithRetry is similar to PutOrDownloadFile but retries on download failure,

--- a/test/new-e2e/tests/windows/install-test/npm_test.go
+++ b/test/new-e2e/tests/windows/install-test/npm_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
@@ -111,8 +110,6 @@ func (s *testNPMInstallWithAddLocalSuite) TestNPMInstallWithAddLocal() {
 //
 // Old name: Scenario 10
 func TestNPMUpgradeFromBeta(t *testing.T) {
-	// incident-30584
-	flake.Mark(t)
 	s := &testNPMUpgradeFromBeta{}
 	s.previousVersion = "7.23.2-beta1-1"
 	s.url = "https://ddagent-windows-unstable.s3.amazonaws.com/datadog-agent-7.23.2-beta1-1-x86_64.msi"

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	servicetest "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test"
@@ -24,8 +23,6 @@ import (
 
 // TestUpgrade tests upgrading the agent from LAST_STABLE_VERSION to WINDOWS_AGENT_VERSION
 func TestUpgrade(t *testing.T) {
-	// incident-30584
-	flake.Mark(t)
 	s := &testUpgradeSuite{}
 	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
 	require.NoError(t, err, "should get last stable agent package from env")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a retry mechanism to downloading the Agent MSI during MSI E2E tests.

Retries for up to 5 minutes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WINA-809

reverts https://github.com/DataDog/datadog-agent/pull/29323

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Does not apply to Agent E2E tests using test-infra to install the Agent

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
N/A, test change