### PR TITLE
[ASCII-2294] Add suffix to fstype to avoid using a real type

### DIFF
--- a/pkg/gohai/filesystem/filesystem_nix.go
+++ b/pkg/gohai/filesystem/filesystem_nix.go
@@ -74,9 +74,7 @@ func replaceDev(oldMount, newMount MountInfo) bool {
 }
 
 // getFileSystemInfoWithMounts is an internal method to help testing with test mounts and mocking syscalls
-func getFileSystemInfoWithMounts(initialMounts []*mountinfo.Info, sizeKB, dev fsInfoGetter) ([]MountInfo, error) {
-	mounts := initialMounts
-
+func getFileSystemInfoWithMounts(mounts []*mountinfo.Info, sizeKB, dev fsInfoGetter) ([]MountInfo, error) {
 	devMountInfos := map[uint64]MountInfo{}
 	for _, mount := range mounts {
 		// Skip mounts that seem to be missing data

--- a/pkg/gohai/filesystem/filesystem_nix_test.go
+++ b/pkg/gohai/filesystem/filesystem_nix_test.go
@@ -117,7 +117,6 @@ func TestNixFSTypeFiltering(t *testing.T) {
 			mounts, err := getFileSystemInfoWithMounts(inputMounts, mockFSSizeKB, getMockFSDev())
 			require.NoError(t, err)
 
-			require.Equal(t, len(expectedMounts), len(mounts))
 			assert.ElementsMatch(t, mounts, expectedMounts)
 		})
 	}
@@ -260,8 +259,9 @@ func TestFilterDev(t *testing.T) {
 
 func newTestInputMountinfo(name string) *mountinfo.Info {
 	return &mountinfo.Info{
+		// add suffixes to the name to avoid having an ignored source / type / mountpoint
 		Source:     name + "Source",
-		FSType:     name,
+		FSType:     name + "Type",
 		Mountpoint: name + "MountPoint",
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes a flake in the `TestNixFSTypeFiltering` test.
The test uses randomly generated strings to generate test cases, and it failed due to a random filesystem type unexpectedly being one of the ignored types. This PR adds a suffix to the generated type to avoid collision.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Not have the test flake.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The test was added 13 months ago and failed for the first time now, so pretty unlikely failure.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
