### PR TITLE
Clarify OpenSSL update on changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -391,7 +391,7 @@ Deprecation Notes
 Security Notes
 --------------
 
-- Updating OpenSSL to 3.0.14 to address CVE-2024-4741.
+- Updating OpenSSL to 3.0.14 to address CVE-2024-4741 (on Linux and macOS).
 
 
 .. _Release Notes_7.56.0_Bug Fixes:


### PR DESCRIPTION
### What does this PR do?

Clarifies that OpenSSL only got updated on Linux and macOS (not on Windows).

### Motivation

The release notes are misleading for Windows users, as the version of OpenSSL is updated differently.

### Additional Notes

Once merged I will be follow this up by updating the release notes on GitHub to match.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
