### PR TITLE
auto-instrumentation: increase default memory request to 100Mi

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -41,7 +41,7 @@ const (
 	// defaultMilliCPURequest defines default milli cpu request number.
 	defaultMilliCPURequest int64 = 50 // 0.05 core
 	// defaultMemoryRequest defines default memory request size.
-	defaultMemoryRequest int64 = 20 * 1024 * 1024 // 20 MB
+	defaultMemoryRequest int64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
 
 	webhookName = "lib_injection"
 )

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1098,7 +1098,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			lang:    java,
 			wantErr: false,
 			wantCPU: "50m",
-			wantMem: "20Mi",
+			wantMem: "100Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
 		{
@@ -1121,7 +1121,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			lang:    java,
 			wantErr: false,
 			wantCPU: "200m",
-			wantMem: "20Mi",
+			wantMem: "100Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
 		{
@@ -1143,7 +1143,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			lang:    java,
 			wantErr: true,
 			wantCPU: "50m",
-			wantMem: "20Mi",
+			wantMem: "100Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
 		{
@@ -1153,7 +1153,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			lang:    java,
 			wantErr: false,
 			wantCPU: "50m",
-			wantMem: "20Mi",
+			wantMem: "100Mi",
 			secCtx: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Add:  []corev1.Capability{"NET_ADMIN", "SYS_TIME"},
@@ -1191,7 +1191,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			lang:    java,
 			wantErr: false,
 			wantCPU: "50m",
-			wantMem: "20Mi",
+			wantMem: "100Mi",
 			secCtx: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},

--- a/releasenotes/notes/auto-instrumentation-fix-memory-request-8391bb2d06ac6990.yaml
+++ b/releasenotes/notes/auto-instrumentation-fix-memory-request-8391bb2d06ac6990.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix OOM error with cluster agent auto instrumentation by increasing default memory request from 20Mi to 100Mi.


### PR DESCRIPTION
### What does this PR do?

Increases the default memory request for the auto instrumentation container from 20Mi to 100Mi.

100Mi is closer to the recommended [minimum memory requirements](https://wiki.alpinelinux.org/wiki/Requirements) for Alpine.

### Motivation

https://datadoghq.atlassian.net/browse/APMON-1472

Right now the containers may get OOM Killed when copying lib injection files from the lib injection container to the application container. This memory usage comes from the `cp` command's usage of `sendfile` and is correlated to the total number of files being copied.

From @levan-m:

> From my perspective, making this change in Agent is cleaner. Memory increase will be tied to a specific Agent version upgrade. On the other hand, Operator config may change while Agent version is pinned (or vice versa). This could create a situation where Operator overrides default value in future Agent versions, or sets higher limit on older installations which work fine with 20mb.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Testing limits manually.

Before:

```bash
$ docker run -it --rm  --memory=20Mib --memory-swap=20Mib -v "$(pwd):/out" gcr.io/datadoghq/dd-lib-python-init:2.12 /datadog-init/copy-lib.sh /out/
Killed
```

After:

```bash
$ docker run -it --rm  --memory=100Mib --memory-swap=100Mib -v "$(pwd):/out" gcr.io/datadoghq/dd-lib-python-init:2.12 /datadog-init/copy-lib.sh /out/
```


This change can also be validated by manually updating the cluster agent configuation:


Manually setting the resource request:

```yaml
datadog:
 apiKey: <API-KEY>
 site: datadoghq.com
 tags:
      - env:<ENV>
 apm:
   instrumentation:
      enabled: true
      libVersions:
         java: "1"
         dotnet: "3"
         python: "2"
         js: "5"
         ruby: "2"
clusterAgent:
  env:
    - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY
      value: 100Mi
```

Using a custom built image with the changes:

```yaml
datadog:
 apiKey: <API-KEY>
 site: datadoghq.com
 tags:
      - env:<ENV>
 apm:
   instrumentation:
      enabled: true
      libVersions:
         java: "1"
         dotnet: "3"
         python: "2"
         js: "5"
         ruby: "2"
clusterAgent:
   image:
     name: <user>/cluster_agent
     tag: master
     repository: docker.io/<user>/cluster_agent
     doNotCheckTag: true
```

```bash
helm upgrade datadog-agent -f datadog-values.yml datadog/datadog
```


Sample app configuration:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kyle-django-app
  labels:
    app: python-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: python-app
  template:
    metadata:
      labels:
        app: python-app
    spec:
      containers:
      - name: app
        image: ddkverhoog/django-helloworld:v1.0.1
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
        readinessProbe:
          timeoutSeconds: 1
          successThreshold: 1
          failureThreshold: 1
          httpGet:
            host:
            scheme: HTTP
            path: /
            port: 18080
          initialDelaySeconds: 30
          periodSeconds: 1
        ports:
          - containerPort: 18080
            protocol: TCP
```