### PR TITLE
Fix bugs introduced in KMT

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -424,6 +424,7 @@ The format of the profile is a json list of objects representing a vm. For each 
 - IP
 - architecture
 - name
+- ssh_user
 
 An example of an alien VMs profile:
 ```json
@@ -432,7 +433,8 @@ An example of an alien VMs profile:
         "ssh_key_path": "/home/user/.ssh/some-key.id_rsa",
         "ip": "xxx.yyy.aaa.bbb",
         "arch": "x86",
-        "name": "ubuntu-gcp"
+        "name": "ubuntu-gcp",
+        "ssh_user": "ubuntu"
     }
 ]
 ```

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -146,7 +146,9 @@ class LibvirtDomain:
 
         info(f"[+] Copying (HOST: {source}) => (VM: {target})...")
 
-        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {source} {self.user}@{self.ip}:{target}"
+        run = (
+            self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {source} {self.user}@{self.ip}:{target}"
+        )
         res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
         if res:
             info(f"[+] Copied (HOST: {source}) => (VM: {target})")
@@ -161,7 +163,9 @@ class LibvirtDomain:
         exclude: PathOrStr | None = None,
         verbose: bool = False,
     ):
-        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {self.user}@{self.ip}:{source} {target}"
+        run = (
+            self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {self.user}@{self.ip}:{source} {target}"
+        )
         res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
         if res:
             info(f"[+] (VM: {source}) => (HOST: {target})")

--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -102,6 +102,7 @@ class LibvirtDomain:
         ssh_key_path: str | None,
         arch: KMTArchNameOrLocal | None,
         instance: HostInstance,
+        user: str = "root",
     ):
         self.ip = ip
         self.name = domain_id
@@ -110,6 +111,7 @@ class LibvirtDomain:
         self.ssh_key = ssh_key_path
         self.instance = instance
         self.arch = arch
+        self.user = user
 
     def run_cmd(self, ctx: Context, cmd: str, allow_fail=False, verbose=False, timeout_sec=None):
         if timeout_sec is not None:
@@ -117,7 +119,8 @@ class LibvirtDomain:
         else:
             extra_opts = SSH_MULTIPLEX_OPTIONS
 
-        run = f"ssh {ssh_options_command(extra_opts)} -o IdentitiesOnly=yes -i {self.ssh_key} root@{self.ip} {{proxy_cmd}} '{cmd}'"
+        cmd = f"sudo bash -c \"{cmd}\"" if self.user != "root" else cmd
+        run = f"ssh {ssh_options_command(extra_opts)} -o IdentitiesOnly=yes -i {self.ssh_key} {self.user}@{self.ip} {{proxy_cmd}} '{cmd}'"
         return self.instance.runner.run_cmd(ctx, self.instance, run, allow_fail, verbose)
 
     def _get_rsync_base(self, exclude: PathOrStr | None, verbose=False) -> str:
@@ -126,8 +129,9 @@ class LibvirtDomain:
             exclude_arg = f"--exclude '{exclude}'"
 
         verbose_arg = "-vP" if verbose else ""
+        sudo = "--rsync-path=\"sudo rsync\"" if self.user != "root" else ""
 
-        return f"rsync {verbose_arg} -e \"ssh {ssh_options_command({'IdentitiesOnly': 'yes'} | SSH_MULTIPLEX_OPTIONS)} {{proxy_cmd}} -i {self.ssh_key}\" -p -rt --exclude='.git*' {exclude_arg} --filter=':- .gitignore'"
+        return f"rsync {sudo} {verbose_arg} -e \"ssh {ssh_options_command({'IdentitiesOnly': 'yes'} | SSH_MULTIPLEX_OPTIONS)} {{proxy_cmd}} -i {self.ssh_key}\" -p -rt --exclude='.git*' {exclude_arg} --filter=':- .gitignore'"
 
     def copy(
         self,
@@ -142,7 +146,7 @@ class LibvirtDomain:
 
         info(f"[+] Copying (HOST: {source}) => (VM: {target})...")
 
-        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {source} root@{self.ip}:{target}"
+        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {source} {self.user}@{self.ip}:{target}"
         res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
         if res:
             info(f"[+] Copied (HOST: {source}) => (VM: {target})")
@@ -157,7 +161,7 @@ class LibvirtDomain:
         exclude: PathOrStr | None = None,
         verbose: bool = False,
     ):
-        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" root@{self.ip}:{source} {target}"
+        run = self._get_rsync_base(exclude, verbose=ctx.config.run["echo"]) + f" {self.user}@{self.ip}:{source} {target}"
         res = self.instance.runner.run_cmd(ctx, self.instance, run, False, verbose)
         if res:
             info(f"[+] (VM: {source}) => (HOST: {target})")
@@ -233,6 +237,9 @@ def build_alien_infrastructure(alien_vms: Path) -> dict[KMTArchNameOrLocal, Host
     # want to bypass the ssh proxying stuff when running commands and copying things
     instance = HostInstance("local", "local", None)
     for vm in profile:
+        ssh_user = "root"
+        if "ssh_user" in vm:
+            ssh_user = vm["ssh_user"]
         instance.add_microvm(
             LibvirtDomain(
                 vm["ip"],
@@ -242,6 +249,7 @@ def build_alien_infrastructure(alien_vms: Path) -> dict[KMTArchNameOrLocal, Host
                 vm["ssh_key_path"],
                 vm["arch"],
                 instance,
+                ssh_user,
             )
         )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
This PR fixes two issues in KMT:
1. https://github.com/DataDog/datadog-agent/pull/29338 introduced an invalid check, and lacked support for working with VMs, where the ssh key is not owned by the root user in the target VM.
2. kmt.build task did not copy over cross-arch clang-bpf and llc-bpf, causing runtime compilation to fail.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
