### PR TITLE
[CONTINT-4418] Add Tag for 422 Unprocessable Entity Error

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -92,8 +92,8 @@ func isRateLimitError(err error) bool {
 	return strings.Contains(err.Error(), "429 Too Many Requests")
 }
 
-// isUnprocessableContentError is a helper function that checks if the received error is an unprocessable content error
-func isUnprocessableContentError(err error) bool {
+// isUnprocessableEntityError is a helper function that checks if the received error is an unprocessable entity error
+func isUnprocessableEntityError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -116,8 +116,8 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 	if err != nil {
 		if isRateLimitError(err) {
 			ddRequests.Inc("rate_limit_error", le.JoinLeaderValue)
-		} else if isUnprocessableContentError(err) {
-			ddRequests.Inc("unprocessable_content_error", le.JoinLeaderValue)
+		} else if isUnprocessableEntityError(err) {
+			ddRequests.Inc("unprocessable_entity_error", le.JoinLeaderValue)
 		} else {
 			ddRequests.Inc("error", le.JoinLeaderValue)
 		}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -92,6 +92,14 @@ func isRateLimitError(err error) bool {
 	return strings.Contains(err.Error(), "429 Too Many Requests")
 }
 
+// isUnprocessableContentError is a helper function that checks if the received error is an unprocessable content error
+func isUnprocessableContentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "422 Unprocessable Entity")
+}
+
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
 func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Duration) (map[string]Point, error) {
@@ -108,6 +116,8 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 	if err != nil {
 		if isRateLimitError(err) {
 			ddRequests.Inc("rate_limit_error", le.JoinLeaderValue)
+		} else if isUnprocessableContentError(err) {
+			ddRequests.Inc("unprocessable_content_error", le.JoinLeaderValue)
 		} else {
 			ddRequests.Inc("error", le.JoinLeaderValue)
 		}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
@@ -303,3 +303,39 @@ func TestIsRateLimitError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUnprocessableEntityError(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		err                   error
+		isUnprocessableEntity bool
+	}{
+		{
+			name:                  "nil error",
+			err:                   nil,
+			isUnprocessableEntity: false,
+		},
+		{
+			name:                  "empty error",
+			err:                   errors.New(""),
+			isUnprocessableEntity: false,
+		},
+		{
+			name:                  "unprocessable entity error",
+			err:                   errors.New("422 Unprocessable Entity"),
+			isUnprocessableEntity: true,
+		},
+		{
+			name:                  "unprocessable entity error variant",
+			err:                   errors.New("API error 422 Unprocessable Entity: "),
+			isUnprocessableEntity: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, isUnprocessableEntityError(test.err), test.isUnprocessableEntity)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Replaces the generic `error` tag with `unprocessable_entity_error` when `422 Unprocessable Entity` errors are returned by the API in the external metric query. Tag is added to the metric `datadog.cluster_agent.datadog.requests`

### Motivation

Improve visualization and debugging for this error. Allows users to count and identify 422 errors.

### Additional Notes



### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

I was unable to simulate a `422 Unprocessable Entity` error after trying numerous queries. [Info on 422 Unprocessable Entity errors](https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-422-status-code/)
However, I temporarily changed `strings.Contains(err.Error(), "422 Unprocessable Entity")` to `strings.Contains(err.Error(), "400 Bad Request")` to verify the tag is added as expected:

I deployed the agent and a DatadogMetric configured as follows:
```
---
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: nginx
spec:
  query: ""
...
---
```
The empty query throws a `400 Bad Request` error. The `status` tag of `datadog.cluster_agent.datadog.requests` on ddev was set to `unprocessable_entity_error`.