### PR TITLE
[CWS] Fix case of ineffective AD snapshot

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -690,14 +690,9 @@ func (pces *processCacheEntrySearcher) SearchTracedProcessCacheEntry(entry *mode
 	// compute the list of ancestors, we need to start inserting them from the root
 	ancestors := []*model.ProcessCacheEntry{entry}
 	parent := pces.getNextAncestorBinaryOrArgv0(&entry.ProcessContext)
-	var nextAncestor *model.ProcessCacheEntry
-	if parent != nil {
-		nextAncestor = pces.getNextAncestorBinaryOrArgv0(&parent.ProcessContext)
-	}
-	for nextAncestor != nil && pces.ad.MatchesSelector(entry) && activity_tree.IsValidRootNodeForAncestor(&parent.ProcessContext, nextAncestor) {
+	for parent != nil && pces.ad.MatchesSelector(entry) {
 		ancestors = append(ancestors, parent)
-		parent = nextAncestor
-		nextAncestor = pces.getNextAncestorBinaryOrArgv0(&parent.ProcessContext)
+		parent = pces.getNextAncestorBinaryOrArgv0(&parent.ProcessContext)
 	}
 	slices.Reverse(ancestors)
 
@@ -705,8 +700,8 @@ func (pces *processCacheEntrySearcher) SearchTracedProcessCacheEntry(entry *mode
 	for _, parent = range ancestors {
 		node, _, err := pces.ad.ActivityTree.CreateProcessNode(parent, imageTag, activity_tree.Snapshot, false, pces.adm.resolvers)
 		if err != nil {
-			// if one of the parents wasn't inserted, leave now
-			break
+			// try to insert the other ancestors as we might find a valid root node in the lineage
+			continue
 		}
 		if node != nil {
 			// This step is important to populate the kernel space "traced_pids" map. Some traced event types use this

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -700,8 +700,8 @@ func (pces *processCacheEntrySearcher) SearchTracedProcessCacheEntry(entry *mode
 	for _, parent = range ancestors {
 		node, _, err := pces.ad.ActivityTree.CreateProcessNode(parent, imageTag, activity_tree.Snapshot, false, pces.adm.resolvers)
 		if err != nil {
-			// if one of the parents wasn't inserted, leave now
-			break
+			// try to insert the other ancestors as we might find a valid root node in the lineage
+			continue
 		}
 		if node != nil {
 			// This step is important to populate the kernel space "traced_pids" map. Some traced event types use this

--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -196,7 +196,7 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 				activeTypes = append(activeTypes, model.FileOpenEventType)
 			}
 			if !isEventTypesStringSlicesEqual(activeTypes, presentEventTypes) {
-				t.Fatalf("Dump's event types don't match: expected[%v] vs observed[%v]", activeEventTypes, presentEventTypes)
+				t.Fatalf("Dump's event types don't match: expected[%v] vs observed[%v]", activeTypes, presentEventTypes)
 			}
 			dump = nextDump
 		})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the following bug when doing the snapshot of an activity dump :
- Container `ABC` starts, the process for this container has PID `123`
- system-probe captures both the execution of runc and the container's entrypoint
- At this point the process cache entry for PID `123` points to the container's entrypoint, with its parent being runc
-  The AD snapshot starts
    - Walks processes within the process cache and finds the container entrypoint
    - Creates a process lineage from PID 1 (host) to the container's entrypoint (which includes the runc entry)
    - Attempts to insert all processes in the lineage
        - All insertions of non containerized processes are skipped and do not result in any error
        - The insertion of the runc entry results in an error because runc isn't a valid root process node
        - This causes an early return and the container's entrypoint is never added to the AD snapshot and results in the AD snapshot to have no effect
 
The fix simply continues looping through the lineage to insert any valid root node. 

### Motivation

This fixes the `TestActivityDumpsLoadControllerEventTypes/none` functional test which exhibits this issue.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->