### PR TITLE
Install tools in the `deps_fetch` job to get `golangci-lint` dependencies

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -41,6 +41,7 @@ go_deps:
     # but still provide the artifact that's expected for the other jobs to run
     - if [ -f modcache.tar.xz  ]; then exit 0; fi
     - inv -e deps --verbose
+    - inv -e install-tools
     - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache.tar.xz .
   artifacts:
     expire_in: 1 day
@@ -49,8 +50,8 @@ go_deps:
   cache:
     - key:
         files:
-          - go.mod
-          - ./**/go.mod
+          - \**/go.mod
+          - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_deps"
       paths:
         - modcache.tar.xz
@@ -59,7 +60,7 @@ go_tools_deps:
   extends: .cache
   script:
     - if [ -f modcache_tools.tar.xz  ]; then exit 0; fi
-    - inv -e download-tools
+    - inv -e install-tools
     - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_tools.tar.xz .
   artifacts:
     expire_in: 1 day
@@ -69,6 +70,7 @@ go_tools_deps:
     - key:
         files:
           - ./**/go.mod
+          - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_tools_deps"
       paths:
         - modcache_tools.tar.xz
@@ -87,6 +89,7 @@ go_e2e_deps:
     - key:
         files:
           - ./test/new-e2e/go.mod
+          - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_e2e_deps"
       paths:
         - modcache_e2e.tar.xz

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -48,6 +48,11 @@ go_deps:
     paths:
       - $CI_PROJECT_DIR/modcache.tar.xz
   cache:
+    # The `cache:key:files` only accepts up to two path ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
+    # Ideally, we should also include the https://github.com/DataDog/datadog-agent/blob/main/.custom-gcl.yml file to
+    # avoid issues if a plugin is added in one PR and enabled in another. However, we decided to accept this limitation
+    # because the probability for this to happen is very low and go mod files are modified frequently so the risk of
+    # failing a job because of a network issue when building the custom binary is very low, but still exists.
     - key:
         files:
           - \**/go.mod

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from invoke import Context, Exit, task
 
 from tasks.libs.ciproviders.github_api import GithubAPI
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.go import download_go_dependencies
 from tasks.libs.common.retry import run_command_with_retry
 from tasks.libs.common.utils import bin_name, environ, gitlab_section
@@ -41,6 +42,7 @@ TOOLS = {
 @task
 def download_tools(ctx):
     """Download all Go tools for testing."""
+    print(color_message("This command is deprecated, please use `install-tools` instead", Color.ORANGE))
     with environ({'GO111MODULE': 'on'}):
         download_go_dependencies(ctx, paths=list(TOOLS.keys()))
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -43,7 +43,6 @@ def setup(ctx, vscode=False):
         check_python_version,
         check_go_version,
         update_python_dependencies,
-        download_go_tools,
         install_go_tools,
         install_protoc,
         enable_pre_commit,
@@ -257,19 +256,3 @@ def install_protoc(ctx) -> SetupResult:
         status = Status.FAIL
 
     return SetupResult("Install protoc", status, message)
-
-
-def download_go_tools(ctx) -> SetupResult:
-    print(color_message("Downloading go tools...", Color.BLUE))
-    status = Status.OK
-    message = ""
-
-    try:
-        from tasks import download_tools
-
-        download_tools(ctx)
-    except Exception as e:
-        message = f'Download Go tools failed: {e}'
-        status = Status.FAIL
-
-    return SetupResult("Download Go tools", status, message)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Install tools in the `deps_fetch` job to get `golangci-lint` dependencies

### Motivation

We know build a custom version of golangci-lint which is built in the specific lint jobs. When the custom binary is built, we download some more golangci-lint dependencies. This step could fail with because of network issues we we should also cache them. Example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/644884804

> [!WARNING]  
> The `cache:key:files` only accepts up to two path ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)). Ideally, we should also include the https://github.com/DataDog/datadog-agent/blob/main/.custom-gcl.yml file to avoid issues if a plugin is added in one PR and enabled in another. However, we decided to accept this limitation because the probability for this to happen is very low and go mod files are modified frequently so the risk of failing a job because of a network issue when building the custom binary is very low, but still exists.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- https://datadoghq.atlassian.net/browse/ACIX-433
- The `download-tools` task is done as part of the `install-tools` task and was needed only in the CI so we can now deprecate it and remove it later

#incident-30779