### PR TITLE
fix(installer): Support leftover /opt/datadog-agent dir

### DIFF
--- a/test/new-e2e/tests/installer/package_agent_test.go
+++ b/test/new-e2e/tests/installer/package_agent_test.go
@@ -423,6 +423,18 @@ func (s *packageAgentSuite) TestUpgrade_DisabledAgentDebRPM_to_OCI() {
 	s.host.Run("sudo systemctl show datadog-agent -p ExecStart | grep /opt/datadog-packages")
 }
 
+func (s *packageAgentSuite) TestInstallWithLeftoverDebDir() {
+	// create /opt/datadog-agent to simulate a disabled agent
+	s.host.Run("sudo mkdir -p /opt/datadog-agent")
+
+	// install OCI agent
+	s.RunInstallScript(envForceInstall("datadog-agent"))
+
+	state := s.host.State()
+	s.assertUnits(state, false)
+	s.host.Run("sudo systemctl show datadog-agent -p ExecStart | grep /opt/datadog-packages")
+}
+
 func (s *packageAgentSuite) purgeAgentDebInstall() {
 	pkgManager := s.host.GetPkgManager()
 	switch pkgManager {


### PR DESCRIPTION
### What does this PR do?
Don't fail when disabling a unit that is already disabled or doesn't exist

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->