### PR TITLE
logs/tailers: configurable buffer size when tailing a file.

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1490,6 +1490,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 	// maximum time that the unix tailer will hold a log file open after it has been rotated
 	config.BindEnvAndSetDefault("logs_config.close_timeout", 60)
+	// size of buffers used when reading in a file
+	config.BindEnvAndSetDefault("logs_config.file_read_buffer_size", 4096)
 	// maximum time that the windows tailer will hold a log file open, while waiting for
 	// the downstream logs pipeline to be ready to accept more data
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)

--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -45,7 +45,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 // until it is closed or the tailer is stopped.
 func (t *Tailer) read() (int, error) {
 	// keep reading data from file
-	inBuf := make([]byte, 4096)
+	inBuf := make([]byte, t.readBufferSize)
 	n, err := t.osFile.Read(inBuf)
 	if err != nil && err != io.EOF {
 		// an unexpected error occurred, stop the tailor

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -85,7 +85,7 @@ func (t *Tailer) readAvailable() (int, error) {
 			}
 		}
 
-		inBuf := make([]byte, 4096)
+		inBuf := make([]byte, t.readBufferSize)
 		n, err := f.Read(inBuf)
 		bytes += n
 		if n == 0 || err != nil {


### PR DESCRIPTION
### What does this PR do?

Configurable buffer size when tailing files.

### Motivation

Using a better default in the future, with the capacity to stick with the original value (through configuration) if necessary.

### Describe how to test/QA your changes

Configure your agent to collect logs from files and make sure it continue to work.
