### PR TITLE
[NPM] Set `CsmEnabled` in agent payload from `runtime_security_config.enabled`

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -121,8 +121,9 @@ func load() (*types.Config, error) {
 	npmEnabled := cfg.GetBool(netNS("enabled"))
 	usmEnabled := cfg.GetBool(smNS("enabled"))
 	ccmEnabled := cfg.GetBool(ccmNS("enabled"))
+	csmEnabled := cfg.GetBool(secNS("enabled"))
 
-	if npmEnabled || usmEnabled || ccmEnabled {
+	if npmEnabled || usmEnabled || ccmEnabled || csmEnabled {
 		c.EnabledModules[NetworkTracerModule] = struct{}{}
 	}
 	if cfg.GetBool(spNS("enable_tcp_queue_length")) {

--- a/cmd/system-probe/config/config_linux_test.go
+++ b/cmd/system-probe/config/config_linux_test.go
@@ -73,17 +73,25 @@ func TestEventStreamEnabledForSupportedKernelsLinux(t *testing.T) {
 
 func TestNPMEnabled(t *testing.T) {
 	tests := []struct {
-		npm, usm, ccm bool
-		npmEnabled    bool
+		npm, usm, ccm, csm bool
+		npmEnabled         bool
 	}{
-		{false, false, false, false},
-		{false, false, true, true},
-		{false, true, false, true},
-		{false, true, true, true},
-		{true, false, false, true},
-		{true, false, true, true},
-		{true, true, false, true},
-		{true, true, true, true},
+		{false, false, false, false, false},
+		{false, false, true, false, true},
+		{false, true, false, false, true},
+		{false, true, true, false, true},
+		{true, false, false, false, true},
+		{true, false, true, false, true},
+		{true, true, false, false, true},
+		{true, true, true, false, true},
+		{false, false, false, true, true},
+		{false, false, true, true, true},
+		{false, true, false, true, true},
+		{false, true, true, true, true},
+		{true, false, false, true, true},
+		{true, false, true, true, true},
+		{true, true, false, true, true},
+		{true, true, true, true, true},
 	}
 
 	mock.NewSystemProbe(t)
@@ -92,6 +100,7 @@ func TestNPMEnabled(t *testing.T) {
 			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(te.npm))
 			t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", strconv.FormatBool(te.usm))
 			t.Setenv("DD_CCM_NETWORK_CONFIG_ENABLED", strconv.FormatBool(te.ccm))
+			t.Setenv("DD_RUNTIME_SECURITY_CONFIG_ENABLED", strconv.FormatBool(te.csm))
 			cfg, err := New("", "")
 			require.NoError(t, err)
 			assert.Equal(t, te.npmEnabled, cfg.ModuleIsEnabled(NetworkTracerModule), "unexpected network tracer module enablement: npm: %v, usm: %v, ccm: %v", te.npm, te.usm, te.ccm)

--- a/pkg/network/encoding/marshal/modeler.go
+++ b/pkg/network/encoding/marshal/modeler.go
@@ -67,6 +67,7 @@ func (c *ConnectionsModeler) modelConnections(builder *model.ConnectionsBuilder,
 			NpmEnabled: pkgconfigsetup.SystemProbe().GetBool("network_config.enabled"),
 			UsmEnabled: pkgconfigsetup.SystemProbe().GetBool("service_monitoring_config.enabled"),
 			CcmEnabled: pkgconfigsetup.SystemProbe().GetBool("ccm_network_config.enabled"),
+			CsmEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.enabled"),
 		}
 	})
 
@@ -86,6 +87,7 @@ func (c *ConnectionsModeler) modelConnections(builder *model.ConnectionsBuilder,
 		w.SetNpmEnabled(agentCfg.NpmEnabled)
 		w.SetUsmEnabled(agentCfg.UsmEnabled)
 		w.SetCcmEnabled(agentCfg.CcmEnabled)
+		w.SetCsmEnabled(agentCfg.CsmEnabled)
 	})
 	for _, d := range c.dnsFormatter.Domains() {
 		builder.AddDomains(d)

--- a/pkg/network/encoding/marshal/modeler_test.go
+++ b/pkg/network/encoding/marshal/modeler_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package marshal
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+func TestConnectionModelerAgentConfiguration(t *testing.T) {
+	tests := []struct {
+		npm, usm, ccm, csm bool
+	}{
+		{false, false, false, false},
+		{false, false, true, false},
+		{false, true, false, false},
+		{false, true, true, false},
+		{true, false, false, false},
+		{true, false, true, false},
+		{true, true, false, false},
+		{true, true, true, false},
+		{false, false, false, true},
+		{false, false, true, true},
+		{false, true, false, true},
+		{false, true, true, true},
+		{true, false, false, true},
+		{true, false, true, true},
+		{true, true, false, true},
+		{true, true, true, true},
+	}
+
+	for _, te := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(te.npm))
+			t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", strconv.FormatBool(te.usm))
+			t.Setenv("DD_CCM_NETWORK_CONFIG_ENABLED", strconv.FormatBool(te.ccm))
+			t.Setenv("DD_RUNTIME_SECURITY_CONFIG_ENABLED", strconv.FormatBool(te.csm))
+			mock.NewSystemProbe(t)
+			cfgOnce = sync.Once{}
+			conns := &network.Connections{}
+			mod := NewConnectionsModeler(conns)
+			streamer := NewProtoTestStreamer[*model.Connections]()
+			builder := model.NewConnectionsBuilder(streamer)
+			expected := &model.AgentConfiguration{
+				CcmEnabled: te.ccm,
+				CsmEnabled: te.csm,
+				UsmEnabled: te.usm,
+				NpmEnabled: te.npm,
+			}
+
+			mod.modelConnections(builder, conns)
+
+			actual := streamer.Unwrap(t, &model.Connections{})
+			assert.Equal(t, expected, actual.AgentConfiguration)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Sets the `CsmEnabled` field in the agent payload to the value of `runtime_security_config.enabled` from the system-probe config. Also enables the network_tracer module if `runtime_security_config.enabled` is `true`.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->