### PR TITLE
Update lading load generator to 0.23.2

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.23.0
+  version: 0.23.2
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
### Motivation

Release notes [here](https://github.com/DataDog/lading/releases/tag/v0.23.2).
