### PR TITLE
[CWS] increase test timeout in KMT tests to 45min

### DIFF
--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -65,7 +65,7 @@ var timeouts = map[*regexp.Regexp]time.Duration{
 	regexp.MustCompile("pkg/network/tracer$"):         55 * time.Minute,
 	regexp.MustCompile("pkg/network/usm$"):            55 * time.Minute,
 	regexp.MustCompile("pkg/network/usm/tests$"):      20 * time.Minute,
-	regexp.MustCompile("pkg/security.*"):              30 * time.Minute,
+	regexp.MustCompile("pkg/security.*"):              45 * time.Minute,
 }
 
 func getTimeout(pkg string) time.Duration {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`kmt_run_secagent_tests_x64: [opensuse_15.3, all_tests] ` has started to randomly fail with timeout errors, always in one of the last tests. This PR increases the timeout for security tests to fix this kind of issues.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->