### PR TITLE
feat(fetch_secret): Add the capacity to call vault in the script

### DIFF
--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -3,19 +3,24 @@
 retry_count=0
 max_retries=10
 parameter_name="$1"
+parameter_field="$2"
 
 set +x
 
 while [[ $retry_count -lt $max_retries ]]; do
-    result=$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> awsErrorFile)
-    error=$(<awsErrorFile)
+    if [ -n "$parameter_field" ]; then
+        result=$(vault kv get -field="${parameter_field}" kv/k8s/gitlab-runner/datadog-agent/"${parameter_name}" 2> errorFile)
+    else
+        result=$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)
+    fi
+    error=$(<errorFile)
     if [ -n "$result" ]; then
         echo "$result"
         exit 0
     fi
     if [[ "$error" =~ "Unable to locate credentials" ]]; then
         # See 5th row in https://docs.google.com/spreadsheets/d/1JvdN0N-RdNEeOJKmW_ByjBsr726E3ZocCKU8QoYchAc
-        >&2 echo "Permanent error: unable to locate AWS credentials, not retrying"
+        >&2 echo "Permanent error: unable to locate credentials, not retrying"
         exit 42
     fi
     retry_count=$((retry_count+1))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
Add the possibility to call `vault` instead of `aws ssm` on the `fetch_secret` wrapper of the CI

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[JIRA](https://datadoghq.atlassian.net/browse/ACIX-354) - Security [recommendation](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3826647944/Secure+Storage+and+Handling+of+Secrets#In-GitLab) is to use `vault`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I propose to use the same script to ease the transision

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
