### PR TITLE
[CWS] restore mmaped files as regular files for activity dump load controller

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -50,8 +50,6 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 	// snapshot files
 	if owner.IsEventTypeValid(model.FileOpenEventType) {
 		pn.snapshotAllFiles(p, stats, newEvent, reducer)
-	} else {
-		pn.snapshotMemoryMappedFiles(p, stats, newEvent, reducer)
 	}
 
 	// snapshot sockets
@@ -107,16 +105,6 @@ func (pn *ProcessNode) snapshotAllFiles(p *process.Process, stats *Stats, newEve
 	}
 
 	pn.addFiles(files, stats, newEvent, reducer)
-}
-
-func (pn *ProcessNode) snapshotMemoryMappedFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
-	// list the mmaped files of the process
-	mmapedFiles, err := getMemoryMappedFiles(p.Pid, pn.Process.FileEvent.PathnameStr)
-	if err != nil {
-		seclog.Warnf("error while listing memory maps (pid: %v): %s", p.Pid, err)
-	}
-
-	pn.addFiles(mmapedFiles, stats, newEvent, reducer)
 }
 
 func (pn *ProcessNode) addFiles(files []string, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {

--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 	"time"
 
@@ -186,14 +185,6 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 			presentEventTypes, err := test.extractAllDumpEventTypes(dump)
 			if err != nil {
 				t.Fatal(err)
-			}
-			activeTypes := make([]model.EventType, len(activeEventTypes))
-			for i, eventType := range activeEventTypes {
-				activeTypes[i] = eventType
-			}
-			if !slices.Contains(activeTypes, model.FileOpenEventType) {
-				// add open to the list of expected event types because mmaped files being present in the dump
-				activeTypes = append(activeTypes, model.FileOpenEventType)
 			}
 			if !isEventTypesStringSlicesEqual(activeTypes, presentEventTypes) {
 				t.Fatalf("Dump's event types don't match: expected[%v] vs observed[%v]", activeTypes, presentEventTypes)

--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -186,8 +186,8 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !isEventTypesStringSlicesEqual(activeTypes, presentEventTypes) {
-				t.Fatalf("Dump's event types don't match: expected[%v] vs observed[%v]", activeTypes, presentEventTypes)
+			if !isEventTypesStringSlicesEqual(activeEventTypes, presentEventTypes) {
+				t.Fatalf("Dump's event types don't match: expected[%v] vs observed[%v]", activeEventTypes, presentEventTypes)
 			}
 			dump = nextDump
 		})


### PR DESCRIPTION
### What does this PR do?

A special case was introduced to always force mmaped files to be part of any dumps, which drift from the initial behavior of activity dump load controller and defeat a bit its purpose (we can imagine a DB like service which could use intensively mmap until it triggers the load controller).

Today files are included by default, so mmaped libraries will be part of any initial dump, even if they'll be absent on the subsequent load-controlled ones (if a workload is very, very noisy), the libs used by the workload will still be present on the first dump.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->