### PR TITLE
[usm] add SHOW operation to postgres monitor

### DIFF
--- a/pkg/network/encoding/marshal/usm_postgres.go
+++ b/pkg/network/encoding/marshal/usm_postgres.go
@@ -106,6 +106,8 @@ func toPostgresModelOperation(op postgres.Operation) model.PostgresOperation {
 		return model.PostgresOperation_PostgresAlterOp
 	case postgres.TruncateTableOP:
 		return model.PostgresOperation_PostgresTruncateOp
+	case postgres.ShowOP:
+		return model.PostgresOperation_PostgresShowOp
 	default:
 		return model.PostgresOperation_PostgresUnknownOp
 	}

--- a/pkg/network/encoding/marshal/usm_postgres.go
+++ b/pkg/network/encoding/marshal/usm_postgres.go
@@ -62,7 +62,7 @@ func (e *postgresEncoder) encodeData(connectionData *USMConnectionData[postgres.
 		staticTags |= stats.StaticTags
 		e.postgresAggregationsBuilder.AddAggregations(func(builder *model.DatabaseStatsBuilder) {
 			builder.SetPostgres(func(statsBuilder *model.PostgresStatsBuilder) {
-				statsBuilder.SetTableName(key.TableName)
+				statsBuilder.SetTableName(key.Parameters)
 				statsBuilder.SetOperation(uint64(toPostgresModelOperation(key.Operation)))
 				if latencies := stats.Latencies; latencies != nil {
 					blob, _ := proto.Marshal(latencies.ToProto())

--- a/pkg/network/protocols/postgres/debugging/debugging.go
+++ b/pkg/network/protocols/postgres/debugging/debugging.go
@@ -20,11 +20,11 @@ type address struct {
 	Port uint16
 }
 
-// key represents a (client, server, table name) tuple.
+// key represents a (client, server, parameters: table name or runtime parameter) tuple.
 type key struct {
-	Client    address
-	Server    address
-	TableName string
+	Client     address
+	Server     address
+	Parameters string
 }
 
 // Stats consolidates request count and latency information for a certain status code
@@ -58,7 +58,7 @@ func Postgres(stats map[postgres.Key]*postgres.RequestStat) []RequestSummary {
 				IP:   serverAddr.String(),
 				Port: k.DstPort,
 			},
-			TableName: k.TableName,
+			Parameters: k.Parameters,
 		}
 		if _, ok := resMap[tempKey]; !ok {
 			resMap[tempKey] = make(map[string]Stats)

--- a/pkg/network/protocols/postgres/model_linux.go
+++ b/pkg/network/protocols/postgres/model_linux.go
@@ -26,11 +26,11 @@ import (
 type EventWrapper struct {
 	*ebpf.EbpfEvent
 
-	operationSet bool
-	operation    Operation
-	operandSet   bool
-	operand      string
-	normalizer   *sqllexer.Normalizer
+	operationSet  bool
+	operation     Operation
+	parametersSet bool
+	parameters    string
+	normalizer    *sqllexer.Normalizer
 }
 
 // NewEventWrapper creates a new EventWrapper from an ebpf event.
@@ -73,7 +73,7 @@ func (e *EventWrapper) Operation() Operation {
 	return e.operation
 }
 
-// extractOperand returns the string following the command
+// extractParameters returns the string following the command
 func (e *EventWrapper) extractParameters() string {
 	b := getFragment(&e.Tx)
 	idxStart := bytes.Index(b, []byte(" ")) + 1 // trim operation
@@ -107,16 +107,16 @@ func (e *EventWrapper) extractTableName() string {
 
 // Parameters returns the table name or run-time parameter.
 func (e *EventWrapper) Parameters() string {
-	if !e.operandSet {
+	if !e.parametersSet {
 		if e.operation == ShowOP {
-			e.operand = e.extractParameters()
+			e.parameters = e.extractParameters()
 		} else {
-			e.operand = e.extractTableName()
+			e.parameters = e.extractTableName()
 		}
-		e.operandSet = true
+		e.parametersSet = true
 	}
 
-	return e.operand
+	return e.parameters
 }
 
 // RequestLatency returns the latency of the request in nanoseconds

--- a/pkg/network/protocols/postgres/model_linux.go
+++ b/pkg/network/protocols/postgres/model_linux.go
@@ -76,9 +76,16 @@ func (e *EventWrapper) Operation() Operation {
 // extractParameters returns the string following the command
 func (e *EventWrapper) extractParameters() string {
 	b := getFragment(&e.Tx)
-	idxStart := bytes.Index(b, []byte(" ")) + 1 // trim operation
-	idxEnd := bytes.Index(b, []byte("\x00"))    // trim trailing nulls
-	return string(b[idxStart:idxEnd])
+	idxParam := bytes.IndexByte(b, ' ') // trim the string to a space, it will give the parameter
+	if idxParam == -1 {
+		return ""
+	}
+	idxParam++
+	idxEnd := bytes.IndexByte(b, '\x00') // trim trailing nulls
+	if idxEnd > idxParam {
+		return string(b[idxParam:idxEnd])
+	}
+	return string(b[idxParam:])
 }
 
 var re = regexp.MustCompile(`(?i)if\s+exists`)

--- a/pkg/network/protocols/postgres/model_linux.go
+++ b/pkg/network/protocols/postgres/model_linux.go
@@ -78,12 +78,13 @@ func (e *EventWrapper) extractParameters() string {
 	b := getFragment(&e.Tx)
 	idxParam := bytes.IndexByte(b, ' ') // trim the string to a space, it will give the parameter
 	if idxParam == -1 {
-		return ""
+		return "EMPTY_PARAMETERS"
 	}
 	idxParam++
-	idxEnd := bytes.IndexByte(b, '\x00') // trim trailing nulls
-	if idxEnd > idxParam {
-		return string(b[idxParam:idxEnd])
+
+	idxEnd := bytes.IndexByte(b[idxParam:], '\x00') // trim trailing nulls
+	if idxEnd != -1 {
+		return string(b[idxParam : idxParam+idxEnd])
 	}
 	return string(b[idxParam:])
 }
@@ -115,7 +116,7 @@ func (e *EventWrapper) extractTableName() string {
 // Parameters returns the table name or run-time parameter.
 func (e *EventWrapper) Parameters() string {
 	if !e.parametersSet {
-		if e.operation == ShowOP {
+		if e.operation == ShowOP || e.operation == UnknownOP {
 			e.parameters = e.extractParameters()
 		} else {
 			e.parameters = e.extractTableName()

--- a/pkg/network/protocols/postgres/operations.go
+++ b/pkg/network/protocols/postgres/operations.go
@@ -29,6 +29,8 @@ const (
 	AlterTableOP
 	// TruncateTableOP represents a TRUNCATE operation.
 	TruncateTableOP
+	// ShowOP represents a command SHOW
+	ShowOP
 )
 
 // String returns the string representation of the operation.
@@ -50,6 +52,8 @@ func (op Operation) String() string {
 		return "DELETE"
 	case AlterTableOP:
 		return "ALTER"
+	case ShowOP:
+		return "SHOW"
 	default:
 		return "UNKNOWN"
 	}
@@ -74,6 +78,8 @@ func FromString(op string) Operation {
 		return DeleteTableOP
 	case "ALTER":
 		return AlterTableOP
+	case "SHOW":
+		return ShowOP
 	default:
 		return UnknownOP
 	}

--- a/pkg/network/protocols/postgres/stats_common.go
+++ b/pkg/network/protocols/postgres/stats_common.go
@@ -18,17 +18,17 @@ import (
 
 // Key is an identifier for a group of Postgres transactions
 type Key struct {
-	Operation Operation
-	TableName string
+	Operation  Operation
+	Parameters string
 	types.ConnectionKey
 }
 
 // NewKey creates a new postgres key
-func NewKey(saddr, daddr util.Address, sport, dport uint16, operation Operation, tableName string) Key {
+func NewKey(saddr, daddr util.Address, sport, dport uint16, operation Operation, parameters string) Key {
 	return Key{
 		ConnectionKey: types.NewConnectionKey(saddr, daddr, sport, dport),
 		Operation:     operation,
-		TableName:     tableName,
+		Parameters:    parameters,
 	}
 }
 

--- a/pkg/network/protocols/postgres/statskeeper.go
+++ b/pkg/network/protocols/postgres/statskeeper.go
@@ -37,7 +37,7 @@ func (s *StatKeeper) Process(tx *EventWrapper) {
 
 	key := Key{
 		Operation:     tx.Operation(),
-		TableName:     tx.TableName(),
+		Parameters:    tx.Parameters(),
 		ConnectionKey: tx.ConnTuple(),
 	}
 	requestStats, ok := s.stats[key]

--- a/pkg/network/protocols/postgres/statskeeper_test.go
+++ b/pkg/network/protocols/postgres/statskeeper_test.go
@@ -28,16 +28,16 @@ func TestStatKeeperProcess(t *testing.T) {
 					Response_last_seen: 10,
 				},
 			},
-			operationSet: true,
-			operation:    SelectOP,
-			tableNameSet: true,
-			tableName:    "dummy",
+			operationSet:  true,
+			operation:     SelectOP,
+			parametersSet: true,
+			parameters:    "dummy",
 		})
 	}
 
 	require.Equal(t, 1, len(s.stats))
 	for k, stat := range s.stats {
-		require.Equal(t, "dummy", k.TableName)
+		require.Equal(t, "dummy", k.Parameters)
 		require.Equal(t, SelectOP, k.Operation)
 		require.Equal(t, 20, stat.Count)
 		require.Equal(t, float64(20), stat.Latencies.GetCount())

--- a/pkg/network/protocols/postgres/telemetry.go
+++ b/pkg/network/protocols/postgres/telemetry.go
@@ -156,7 +156,7 @@ func (t *Telemetry) Count(tx *ebpf.EbpfEvent, eventWrapper *EventWrapper) {
 		t.failedOperationExtraction.Add(1)
 		state = operationNotFound
 	}
-	if eventWrapper.TableName() == "UNKNOWN" {
+	if eventWrapper.Parameters() == "UNKNOWN" {
 		t.failedTableNameExtraction.Add(1)
 		if state == operationNotFound {
 			state = tableAndOpNotFound

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -478,7 +478,6 @@ func testDecoding(t *testing.T, isTLS bool) {
 				}, isTLS)
 			},
 		},
-		// This test validates that the SHOW command is currently not supported.
 		{
 			name: "show command",
 			preMonitorSetup: func(t *testing.T, ctx pgTestContext) {

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -497,8 +497,8 @@ func testDecoding(t *testing.T, isTLS bool) {
 			},
 			validation: func(t *testing.T, _ pgTestContext, monitor *Monitor) {
 				validatePostgres(t, monitor, map[string]map[postgres.Operation]int{
-					"UNKNOWN": {
-						postgres.UnknownOP: adjustCount(1),
+					"search_path": {
+						postgres.ShowOP: adjustCount(1),
 					},
 				}, isTLS)
 			},

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -724,10 +724,10 @@ func validatePostgres(t *testing.T, monitor *Monitor, expectedStats map[string]m
 			if hasTLSTag != tls {
 				continue
 			}
-			if _, ok := found[key.TableName]; !ok {
-				found[key.TableName] = make(map[postgres.Operation]int)
+			if _, ok := found[key.Parameters]; !ok {
+				found[key.Parameters] = make(map[postgres.Operation]int)
 			}
-			found[key.TableName][key.Operation] += stats.Count
+			found[key.Parameters][key.Operation] += stats.Count
 		}
 		return reflect.DeepEqual(expectedStats, found)
 	}, time.Second*5, time.Millisecond*100, "Expected to find a %v stats, instead captured %v", &expectedStats, &found)

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -529,7 +529,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 			},
 			validation: func(t *testing.T, _ pgTestContext, monitor *Monitor) {
 				validatePostgres(t, monitor, map[string]map[postgres.Operation]int{
-					"UNKNOWN": {
+					"EMPTY_PARAMETERS": {
 						postgres.UnknownOP: adjustCount(2),
 					},
 					"dummy": {
@@ -730,4 +730,88 @@ func validatePostgres(t *testing.T, monitor *Monitor, expectedStats map[string]m
 		}
 		return reflect.DeepEqual(expectedStats, found)
 	}, time.Second*5, time.Millisecond*100, "Expected to find a %v stats, instead captured %v", &expectedStats, &found)
+}
+
+func (s *postgresProtocolParsingSuite) TestExtractParameters() {
+	t := s.T()
+
+	units := []struct {
+		name     string
+		expected string
+		event    ebpf.EbpfEvent
+	}{
+		{
+			name:     "query_size longer than the actual length of the content",
+			expected: "version and status",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    createFragment([]byte("SHOW version and status")),
+					Original_query_size: 64,
+				},
+			},
+		},
+		{
+			name:     "query_size shorter than the actual length of the content",
+			expected: "param1 param2",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    createFragment([]byte("COMMAND param1 param2 param3")),
+					Original_query_size: 21,
+				},
+			},
+		},
+		{
+			name:     "command has trailing zeros",
+			expected: "param",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    [ebpf.BufferSize]byte{'S', 'O', 'M', 'E', ' ', 'p', 'a', 'r', 'a', 'm', 0, 0, 0},
+					Original_query_size: 13,
+				},
+			},
+		},
+		{
+			name:     "malformed command with wrong query_size",
+			expected: "bc",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    [ebpf.BufferSize]byte{0, 0, 'a', ' ', 'b', 'c', 0, 0, 0},
+					Original_query_size: 12,
+				},
+			},
+		},
+		{
+			name:     "empty content with spaces and nils",
+			expected: "",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    [ebpf.BufferSize]byte{' ', 0, ' ', 0, ' ', 0, 0, 0},
+					Original_query_size: 8,
+				},
+			},
+		},
+		{
+			name:     "content with control codes only",
+			expected: "EMPTY_PARAMETERS",
+			event: ebpf.EbpfEvent{
+				Tx: ebpf.EbpfTx{
+					Request_fragment:    [ebpf.BufferSize]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+					Original_query_size: 10,
+				},
+			},
+		},
+	}
+	for _, unit := range units {
+		t.Run(unit.name, func(t *testing.T) {
+			e := postgres.NewEventWrapper(&unit.event)
+			require.NotNil(t, e)
+			require.Equal(t, unit.expected, e.Parameters())
+		})
+	}
+}
+
+func createFragment(fragment []byte) [ebpf.BufferSize]byte {
+	var b [ebpf.BufferSize]byte
+	copy(b[:], fragment)
+	return b
 }


### PR DESCRIPTION

### What does this PR do?

Postgres monitor processes SHOW command

### Motivation

USM Postgres handler processed a limited number of operations. The Postgres command "SHOW" can consist of 5-10% of all commands and those requires processing. This code adds processing for the SHOW operation (command) and increases USM's accuracy in handling Postgres events.
The USM Postgres resource consisted of an operation and a table name. This code renames the "table_name" structure members to "parameters" because that field is given a broader meaning and is a string of either a table name or SHOW command parameters.

### Describe how to test/QA your changes

Previous tests assumed that the "show" command was not supported and would generate an "unknown" resource. This test has been modified to expect a SHOW resource for the appropriate operation.

### Possible Drawbacks / Trade-offs

### Additional Notes

Repository agent-payload has function PostgresStatsBuilder.SetTableName(). This function should be renamed as it now has a broader meaning and represents any parameters.