### PR TITLE
omnibus: fix python build when using a non default compiler

### DIFF
--- a/omnibus/config/patches/python2/0001-disable-multiarch.patch
+++ b/omnibus/config/patches/python2/0001-disable-multiarch.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2024-08-02 16:54:59.662444071 +0200
++++ b/setup.py	2024-08-02 16:55:29.130442616 +0200
+@@ -506,7 +506,7 @@
+             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+         if cross_compiling:
+             self.add_gcc_paths()
+-        self.add_multiarch_paths()
++        #self.add_multiarch_paths()
+
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.

--- a/omnibus/config/patches/python3/0001-disable-multiarch.patch
+++ b/omnibus/config/patches/python3/0001-disable-multiarch.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2023-11-30 18:22:54.926361916 +0100
++++ b/setup.py	2023-11-30 18:23:22.022400406 +0100
+@@ -852,7 +852,7 @@
+         # only change this for cross builds for 3.3, issues on Mageia
+         if CROSS_COMPILING:
+             self.add_cross_compiling_paths()
+-        self.add_multiarch_paths()
++        # self.add_multiarch_paths()
+         self.add_ldflags_cppflags()
+
+     def init_inc_lib_dirs(self):

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -55,6 +55,7 @@ if ohai["platform"] != "windows"
 
     patch :source => "avoid-allocating-thunks-in-ctypes.patch" if linux_target?
     patch :source => "fix-platform-ubuntu.diff" if linux_target?
+    patch :source => "0001-disable-multiarch.patch" if linux_target?
     # security patches backported by the debian community
     # see: http://deb.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-6.diff.gz
     patch :source => "python2.7_2.7.18-cve-2019-20907.diff" unless windows_target?

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -40,6 +40,8 @@ if ohai["platform"] != "windows"
     # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
+    patch source: "0001-disable-multiarch.patch" if linux_target?
+
     env = with_standard_compiler_flags(with_embedded_path)
     # Force different defaults for the "optimization settings"
     # This removes the debug symbol generation and doesn't enable all warnings


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove python's setup for multiarch which causes build failures when using a non default toolchain

### Motivation

Python's add_multiarch_paths will systematically add /usr/include and similar paths to CFLAGS, causing mismatches when using a non default compiler which does not rely on /usr/include

We're hitting this problem when we try to build the agent using a custom toolchain that target an arbitrary version of glibc

### Describe how to test/QA your changes

The build should be green, and the regular tests passing

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->