### PR TITLE
Enforce regression detector must pass on PRs

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -17,7 +17,7 @@ single-machine-performance-regression_detector:
       - outputs/report.html # for debugging, also on S3
     when: always
   variables:
-    SMP_VERSION: 0.16.0
+    SMP_VERSION: 0.17.2
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main
@@ -25,10 +25,7 @@ single-machine-performance-regression_detector:
   # with the SHA of the merge base from main. It's solved in Vector by
   # building Vector twice for each Regression Detector run.
   #
-  # We allow failure for now. _Unfortunately_ this also means that if the
-  # Regression Detector finds a performance issue with a PR it will not be
-  # flagged.
-  allow_failure: true
+  allow_failure: false
   script:
     # Ensure output files exist for artifact downloads step
     - mkdir outputs # Also needed for smp job sync step


### PR DESCRIPTION
### What does this PR do?

Enforces that each PR must pass correctly execute and pass Regression Detector testing.

### Motivation

Prevent regressions.

### Describe how to test/QA your changes

n/a

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->