### PR TITLE
Add options to hacky-dev-image-build task to build {process,trace}-agent

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -531,6 +531,13 @@ FROM golang:latest AS dlv
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
+FROM {base_image} AS bash_completion
+
+RUN apt-get update && \
+    apt-get install -y gawk
+
+RUN awk -i inplace '!/^#/ {{uncomment=0}} uncomment {{gsub(/^#/, "")}} /# enable bash completion/ {{uncomment=1}} {{print}}' /etc/bash.bashrc
+
 FROM {base_image}
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -541,6 +548,7 @@ RUN apt-get update && \
 ENV DELVE_PAGER=less
 
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
+COPY --from=bash_completion /etc/bash.bashrc /etc/bash.bashrc
 COPY --from=src /usr/src/datadog-agent {os.getcwd()}
 COPY --from=bin /opt/datadog-agent/bin/agent/agent                                 /opt/datadog-agent/bin/agent/agent
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -497,10 +497,12 @@ def hacky_dev_image_build(
     copy_extra_agents = ""
     if process_agent:
         from tasks.process_agent import build as process_agent_build
+
         process_agent_build(ctx, bundle=False)
         copy_extra_agents += "COPY bin/process-agent/process-agent /opt/datadog-agent/embedded/bin/process-agent\n"
     if trace_agent:
         from tasks.trace_agent import build as trace_agent_build
+
         trace_agent_build(ctx)
         copy_extra_agents += "COPY bin/trace-agent/trace-agent /opt/datadog-agent/embedded/bin/trace-agent\n"
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -454,6 +454,8 @@ def hacky_dev_image_build(
     ctx,
     base_image=None,
     target_image="agent",
+    process_agent=False,
+    trace_agent=False,
     push=False,
     signed_pull=False,
 ):
@@ -491,6 +493,16 @@ def hacky_dev_image_build(
         ctx.run(
             f'perl -0777 -pe \'s|{extracted_python_dir}(/opt/datadog-agent/embedded/lib/python\\d+\\.\\d+/../..)|substr $1."\\0"x length$&,0,length$&|e or die "pattern not found"\' -i dev/lib/libdatadog-agent-three.so'
         )
+
+    copy_extra_agents = ""
+    if process_agent:
+        from tasks.process_agent import build as process_agent_build
+        process_agent_build(ctx, bundle=False)
+        copy_extra_agents += "COPY bin/process-agent/process-agent /opt/datadog-agent/embedded/bin/process-agent\n"
+    if trace_agent:
+        from tasks.trace_agent import build as trace_agent_build
+        trace_agent_build(ctx)
+        copy_extra_agents += "COPY bin/trace-agent/trace-agent /opt/datadog-agent/embedded/bin/trace-agent\n"
 
     with tempfile.NamedTemporaryFile(mode='w') as dockerfile:
         dockerfile.write(
@@ -533,6 +545,7 @@ COPY --from=src /usr/src/datadog-agent {os.getcwd()}
 COPY --from=bin /opt/datadog-agent/bin/agent/agent                                 /opt/datadog-agent/bin/agent/agent
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
+{copy_extra_agents}
 RUN agent          completion bash > /usr/share/bash-completion/completions/agent
 RUN process-agent  completion bash > /usr/share/bash-completion/completions/process-agent
 RUN security-agent completion bash > /usr/share/bash-completion/completions/security-agent


### PR DESCRIPTION
### What does this PR do?

Add `--process-agent` and `--trace-agent` options back to the `agent.hacky-dev-image-build` invoke task to also build the `process-agent` and `trace-agent` and copy them in the docker image.

### Motivation

These options were removed when we migrated to single binary.
But they weren’t added back when the single binary was reverted.

### Describe how to test/QA your changes

Run something like
```
inv agent.hacky-dev-image-build --base-image gcr.io/datadoghq/agent:7.58.0-rc.4 --target-image europe-west3-docker.pkg.dev/datadog-sandbox/lenaic/agent:latest --push --process-agent --trace-agent
```
and validate that the `agent`, `process-agent` and `trace-agent` inside the docker image are your custom ones.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->