### PR TITLE
[E2E] forward exit code to `host.Execute`

### DIFF
--- a/test/new-e2e/examples/vm_with_file_operations_test.go
+++ b/test/new-e2e/examples/vm_with_file_operations_test.go
@@ -6,6 +6,7 @@
 package examples
 
 import (
+	"golang.org/x/crypto/ssh"
 	"io/fs"
 	"testing"
 
@@ -14,6 +15,8 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type vmSuiteWithFileOperations struct {
@@ -22,8 +25,70 @@ type vmSuiteWithFileOperations struct {
 
 // TestVMSuiteWithFileOperations runs tests for the VM interface to ensure its implementation is correct.
 func TestVMSuiteWithFileOperations(t *testing.T) {
-	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))))}
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))))}
 	e2e.Run(t, &vmSuiteWithFileOperations{}, suiteParams...)
+}
+
+func assertExitCodeEqual(t *testing.T, err error, expected int, msgAndArgs ...interface{}) {
+	t.Helper()
+	var exitErr *ssh.ExitError
+	assert.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, expected, exitErr.ExitStatus(), msgAndArgs)
+}
+
+// TestCommandResults tests that commands return output or errors in the expected way
+func (v *vmSuiteWithFileOperations) TestCommandResults() {
+	vm := v.Env().RemoteHost
+
+	// successful command should return the output
+	out, err := vm.Execute("echo hello")
+	v.Assert().NoError(err)
+	v.Assert().Contains(out, "hello")
+
+	// invalid commands should return an error
+	_, err = vm.Execute("not-a-command")
+	v.Assert().Error(err, "invalid command should return an error")
+
+	if vm.OSFamily == os.WindowsFamily {
+		v.testWindowsCommandResults()
+	}
+}
+
+func (v *vmSuiteWithFileOperations) testWindowsCommandResults() {
+	vm := v.Env().RemoteHost
+
+	// invalid commands should return an error
+	_, err := vm.Execute("not-a-command")
+	v.Assert().Error(err, "invalid command should return an error")
+	assertExitCodeEqual(v.T(), err, 1, "generic poewrshell error should return exit code 1")
+
+	// native commands should return the exit status
+	_, err = vm.Execute("cmd.exe /c exit 2")
+	v.Assert().Error(err, "native command failure should return an error")
+	assertExitCodeEqual(v.T(), err, 2, "specific exit code should be returned")
+
+	// a failing native command should continue to execute the rest of the command
+	// and the result should be from the lsat command
+	out, err := vm.Execute("cmd.exe /c exit 2; echo hello")
+	v.Assert().NoError(err, "result should come from the last command")
+	v.Assert().Contains(out, "hello", "native command failure should continue to execute the rest of the command")
+
+	// Execute should auto-set $ErrorActionPreference to 'Stop', so
+	// a failing PowerShell cmdlet should fail immediately and not
+	// execute the rest of the command, so the output should not contain "hello"
+	out, err = vm.Execute(`Write-Error 'error'; echo he""llo`)
+	v.Assert().Error(err, "Execute should add ErrorActionPreference='Stop' to stop command execution on error")
+	v.Assert().NotContains(err.Error(), "hello")
+	v.Assert().NotContains(out, "hello")
+	assertExitCodeEqual(v.T(), err, 1, "failing PowerShell cmdlet should return exit code 1")
+
+	// Execute should auto-set $ErrorActionPreference to 'Stop', so subcommands return an error
+	_, err = vm.Execute(`(Get-Service -Name 'not-a-service').Status`)
+	v.Assert().Error(err, "Execute should add ErrorActionPreference='Stop' to stop subcommand execution on error")
+	assertExitCodeEqual(v.T(), err, 1, "failing PowerShell cmdlet should return exit code 1")
+	// Sanity check default 'Continue' behavior does not return an error
+	_, err = vm.Execute(`$ErrorActionPreference='Continue'; (Get-Service -Name 'not-a-service').Status`)
+	v.Assert().NoError(err, "explicit ErrorActionPreference='Continue' should ignore subcommand error")
 }
 
 func (v *vmSuiteWithFileOperations) TestFileOperations() {

--- a/test/new-e2e/examples/vm_with_file_operations_test.go
+++ b/test/new-e2e/examples/vm_with_file_operations_test.go
@@ -49,6 +49,11 @@ func (v *vmSuiteWithFileOperations) TestCommandResults() {
 	_, err = vm.Execute("not-a-command")
 	v.Assert().Error(err, "invalid command should return an error")
 
+	// specific exit code should be returned
+	_, err = vm.Execute("exit 2")
+	v.Assert().Error(err, "non-zero exit code should return an error")
+	assertExitCodeEqual(v.T(), err, 2, "specific exit code should be returned")
+
 	if vm.OSFamily == os.WindowsFamily {
 		v.testWindowsCommandResults()
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -40,7 +40,7 @@ const (
 	sshMaxRetries    = 20
 )
 
-type buildCommandFn func(host *Host, command string, envVars EnvVar) string
+type buildCommandFn func(command string, envVars EnvVar) string
 
 type convertPathSeparatorFn func(string) string
 
@@ -122,7 +122,7 @@ func (h *Host) Execute(command string, options ...ExecuteOption) (string, error)
 	if err != nil {
 		return "", err
 	}
-	command = h.buildCommand(h, command, params.EnvVariables)
+	command = h.buildCommand(command, params.EnvVariables)
 	return h.executeAndReconnectOnError(command)
 }
 
@@ -487,7 +487,7 @@ func buildCommandFactory(osFamily oscomp.Family) buildCommandFn {
 	return buildCommandOnLinuxAndMacOS
 }
 
-func buildCommandOnWindows(h *Host, command string, envVar EnvVar) string {
+func buildCommandOnWindows(command string, envVar EnvVar) string {
 	cmd := ""
 
 	// Set $ErrorActionPreference to 'Stop' to cause PowerShell to stop on an error instead
@@ -531,7 +531,7 @@ func buildCommandOnWindows(h *Host, command string, envVar EnvVar) string {
 	return cmd
 }
 
-func buildCommandOnLinuxAndMacOS(_ *Host, command string, envVar EnvVar) string {
+func buildCommandOnLinuxAndMacOS(command string, envVar EnvVar) string {
 	cmd := ""
 	for envName, envValue := range envVar {
 		cmd += fmt.Sprintf("%s='%s' ", envName, envValue)

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -507,14 +507,7 @@ func buildCommandOnWindows(h *Host, command string, envVar EnvVar) string {
 	// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#erroractionpreference
 	cmd += "$ErrorActionPreference='Stop'; "
 
-	envVarSave := map[string]string{}
 	for envName, envValue := range envVar {
-		previousEnvVar, err := h.executeAndReconnectOnError(fmt.Sprintf("$env:%s", envName))
-		if err != nil || previousEnvVar == "" {
-			previousEnvVar = "null"
-		}
-		envVarSave[envName] = previousEnvVar
-
 		cmd += fmt.Sprintf("$env:%s='%s'; ", envName, envValue)
 	}
 	// By default, powershell will just exit with 0 or 1, so we call exit to preserve


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use `exit $LASTEXITCODE` to set the PowerShell/command exit code when running commands with `host.Execute`.

Removes the env var clearing after the command. Each `host.Execute` call creates a new PowerShell session, so there will be no leakage or cross contamination between commands.

### Motivation
E2E tests should be able to examine the exit code of commands.

Continuation of https://github.com/DataDog/datadog-agent/pull/28291, which had a similar effect only for PowerShell cmdlets.

By default PowerShell only returns 0 or 1, you have to call `exit` for a custom error code.

The env var reset commands were hiding errors. Since they run after the caller provided command, they reset/clear the error state, causing `host.Execute` to always return success for commands run with env vars.

### Describe how to test/QA your changes
N/A, test change
testcase added
```
go test -v ./examples --run TestVMSuiteWithFileOperations/TestCommandResults
```

### Possible Drawbacks / Trade-offs
Test case added to `examples` folder. is there a better place for them (and the file operation tests)?

Does not add detailed test cases for Linux platforms

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->