### PR TITLE
remove usage of `strings.SplitN` in `entity_id.go`

### DIFF
--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -31,24 +31,20 @@ type defaultEntityID string
 
 // GetID implements EntityID#GetID
 func (de defaultEntityID) GetID() string {
-	parts := strings.SplitN(string(de), separator, 2)
-
-	if len(parts) != 2 {
+	_, id, found := strings.Cut(string(de), separator)
+	if !found {
 		return ""
 	}
-
-	return parts[1]
+	return id
 }
 
 // GetPrefix implements EntityID#GetPrefix
 func (de defaultEntityID) GetPrefix() EntityIDPrefix {
-	parts := strings.SplitN(string(de), separator, 2)
-
-	if len(parts) != 2 {
+	prefix, _, found := strings.Cut(string(de), separator)
+	if !found {
 		return ""
 	}
-
-	return EntityIDPrefix(parts[0])
+	return EntityIDPrefix(prefix)
 }
 
 // String implements EntityID#String


### PR DESCRIPTION
### What does this PR do?

`strings.SplitN` will allocate (the underlying storage for the returned slice), and the `GetID` function can be in the hot path. To reduce allocation (and also reduce CPU usage related to those allocations), this PR replaces the `strings.SplitN(_, _, 2)` by `strings.Cut`.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->