### PR TITLE
[gitlab] Retrieve go modules cache in integration_tests_otel

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -6,8 +6,9 @@ integration_tests_otel:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: []
+  needs: ["go_deps"]
   script:
+    - !reference [.retrieve_linux_go_deps]
     - inv check-otel-build
     - inv check-otel-module-versions
   rules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a step in the `integration_tests_otel` job that fetches the go dependencies cache: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/646429075

### Motivation

Avoids unnecessary dependency downloads in CI jobs, which are prone to failure.

### Describe how to test/QA your changes

Check the `integration_tests_otel` job: it should succeed, and not download dependencies.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The `integration_tests_otel` job still downloads 4 dependencies after this change. This is due to an issue in the caching logic itself, that is missing some dependencies. This will be fixed in a separate PR.