### PR TITLE
[gitlab] Improve go modules cache accuracy and speed

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -4,15 +4,15 @@
 # to reuse them in further jobs that need them.
 
 .retrieve_linux_go_deps:
-  - mkdir -p $GOPATH/pkg/mod && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache.tar.xz
 
 .retrieve_linux_go_tools_deps:
-  - mkdir -p $GOPATH/pkg/mod && tar xJf modcache_tools.tar.xz -C $GOPATH/pkg/mod
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_tools.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache_tools.tar.xz
 
 .retrieve_linux_go_e2e_deps:
-  - mkdir -p $GOPATH/pkg/mod && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache_e2e.tar.xz
 
 .cache:
@@ -42,7 +42,7 @@ go_deps:
     - if [ -f modcache.tar.xz  ]; then exit 0; fi
     - inv -e deps --verbose
     - inv -e install-tools
-    - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache.tar.xz .
+    - cd $GOPATH/pkg/mod/cache/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache.tar.xz .
   artifacts:
     expire_in: 1 day
     paths:
@@ -66,7 +66,7 @@ go_tools_deps:
   script:
     - if [ -f modcache_tools.tar.xz  ]; then exit 0; fi
     - inv -e install-tools
-    - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_tools.tar.xz .
+    - cd $GOPATH/pkg/mod/cache/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_tools.tar.xz .
   artifacts:
     expire_in: 1 day
     paths:
@@ -85,7 +85,7 @@ go_e2e_deps:
   script:
     - if [ -f modcache_e2e.tar.xz  ]; then exit 0; fi
     - inv -e new-e2e-tests.deps
-    - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_e2e.tar.xz .
+    - cd $GOPATH/pkg/mod/cache/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_e2e.tar.xz .
   artifacts:
     expire_in: 1 day
     paths:

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -57,7 +57,7 @@ go_deps:
         files:
           - \**/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_deps_v2"
+        prefix: "go_deps_modcache"
       paths:
         - modcache.tar.xz
 
@@ -76,7 +76,7 @@ go_tools_deps:
         files:
           - ./**/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_tools_deps_v2"
+        prefix: "go_tools_deps_modcache"
       paths:
         - modcache_tools.tar.xz
 
@@ -95,6 +95,6 @@ go_e2e_deps:
         files:
           - ./test/new-e2e/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_e2e_deps_v2"
+        prefix: "go_e2e_deps_modcache"
       paths:
         - modcache_e2e.tar.xz

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -57,7 +57,7 @@ go_deps:
         files:
           - \**/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_deps"
+        prefix: "go_deps_v2"
       paths:
         - modcache.tar.xz
 
@@ -76,7 +76,7 @@ go_tools_deps:
         files:
           - ./**/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_tools_deps"
+        prefix: "go_tools_deps_v2"
       paths:
         - modcache_tools.tar.xz
 
@@ -95,6 +95,6 @@ go_e2e_deps:
         files:
           - ./test/new-e2e/go.mod
           - .gitlab/deps_fetch/deps_fetch.yml
-        prefix: "go_e2e_deps"
+        prefix: "go_e2e_deps_v2"
       paths:
         - modcache_e2e.tar.xz

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -11,8 +11,10 @@ if TYPE_CHECKING:
 
 def download_go_dependencies(ctx: Context, paths: list[str], verbose: bool = False, max_retry: int = 3):
     print("downloading dependencies")
-    with timed("go mod download"):
+    with timed("go mod download && go mod tidy"):
         verbosity = ' -x' if verbose else ''
         for path in paths:
             with ctx.cd(path):
-                run_command_with_retry(ctx, f"go mod download{verbosity}", max_retry=max_retry)
+                run_command_with_retry(
+                    ctx, f"go mod download{verbosity} && go mod tidy{verbosity}", max_retry=max_retry
+                )

--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -33,7 +33,7 @@ if exist %MODCACHE_XZ_FILE% (
     REM This shouldn't have any negative impact: since modules are
     REM stored per version and hash, files that get replaced will
     REM get replaced by the same files
-    Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE% -aoa -bt"
+    Powershell -C "7z x %MODCACHE_TAR_FILE% -o%GOMODCACHE%\cache -aoa -bt"
     @echo Modcache extracted
 ) else (
     @echo %MODCACHE_XZ_FILE% not found, dependencies will be downloaded


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR does two updates to the go modules cache step used in CI:
- it fixes an issue where not all dependencies needed by modules would be downloaded. Doing `go mod download` is not guaranteed to fetch all dependencies, a `go mod tidy` is also needed.
- it improves the size, and therefore speed, of cache extraction operations, by only keeping the go download cache in `$GOPATH/pkg/mod/cache` (see the Additional Notes section for details on why).

### Motivation

Make sure the go module cache is accurate, and that its use is as fast as possible.

### Describe how to test/QA your changes

Verify that the pipeline logs contain as few `go: downloading` log lines as possible, as shown in [this query](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22go%3A%20downloading%22%20%40ci.pipeline.id%3A44901316&agg_m=count&agg_m_source=base&agg_q=%40ci.job.name&agg_q_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=paused&saved-view-id=2873694&storage=flex_tier&stream_sort=desc&top_n=100&top_o=top&viz=timeseries&x_missing=true&from_ts=1727092912530&to_ts=1727098580000&live=false).
The only exceptions are:
- the cache jobs themselves,
- jobs not cached yet (`lint_licenses`, `integration_tests_otel`, macOS Gitlab jobs, OCI jobs) that are tackled in separate PRs,
- `go_mod_tidy_check`, which still has 2 downloads happening, that will need to be investigated in a follow-up.

### Possible Drawbacks / Trade-offs

From my experiments and observations above, I believe caching `$GOPATH/pkg/mod/cache` is enough, but I might be wrong and we'll be seeing downloads happen. To verify this, we can add a monitor on pipeline logs verifying the absence of `go: downloading` log lines (except for jobs on which this is expected).
It is also possible, but thought to be unlikely, that some downloads happen in places whose output is suppressed, which would evade this monitor.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The go modules cache is made of two parts:
- `$GOPATH/pkg/mod` contains the source code of go dependencies
- `$GOPATH/pkg/mod/cache` contains an index of the downloaded go dependencies, as well as the source code of go dependencies in zipped form.

When a go operation that needs a go dependency is done (`go mod tidy`, `go build`, etc.), the following scenarios can happen:
- a dependency is present in extracted form in `$GOPATH/pkg/mod`, and is present in zipped form in `$GOPATH/pkg/mod/cache`: go does nothing
- a dependency *is* present in extracted form in `$GOPATH/pkg/mod`, but *is not* present in zipped form in `$GOPATH/pkg/mod/cache`: go downloads the dependency, and extracts it (same as if the dependency was not present to begin with)
- a dependency *is not* present in extracted form in `$GOPATH/pkg/mod`, but *is* present in zipped form in `$GOPATH/pkg/mod/cache`: go extracts the dependency's zip.
- a dependency *is not* present in extracted form in `$GOPATH/pkg/mod`, and *is not* present in zipped form in `$GOPATH/pkg/mod/cache`: go downloads the dependency, and extracts it.

By archiving the whole `$GOPATH/pkg/mod` directory, we were therefore caching all dependencies twice, and we were extracting _all_ dependencies of the repository every time, even when they are not needed.
By only archiving the `$GOPATH/pkg/mod/cache` directory, the cache archive is smaller (~50% of its original size), extracts way faster, especially on Windows which does not like having to deal with lots of small files (the cache archive is only a couple of zipped files and index files, instead of the whole list of source files). Since the dependencies are only extracted if a `go` command needs to, resulting in slightly faster jobs across the board.