### PR TITLE
Fix flaky container e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -930,9 +930,10 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 	}
 
 	// Record old pod, so we can be sure we are not looking at the incorrect one after deletion
-	oldPods, _ := suite.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+	oldPods, err := suite.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", name).String(),
 	})
+	suite.Require().NoError(err)
 	suite.Require().Len(oldPods.Items, 1)
 	oldPod := oldPods.Items[0]
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -938,7 +938,7 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 	oldPod := oldPods.Items[0]
 
 	// Delete the pod to ensure it is recreated after the admission controller is deployed
-	err := suite.K8sClient.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+	err = suite.K8sClient.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", name).String(),
 	})
 	suite.Require().NoError(err)

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -929,6 +929,13 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 		}, 5*time.Minute, 10*time.Second, "The deployment with name %s in namespace %s does not exist or does not have the auto detected languages annotation", name, namespace)
 	}
 
+	// Record old pod, so we can be sure we are not looking at the incorrect one after deletion
+	oldPods, _ := suite.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", name).String(),
+	})
+	suite.Require().Len(oldPods.Items, 1)
+	oldPod := oldPods.Items[0]
+
 	// Delete the pod to ensure it is recreated after the admission controller is deployed
 	err := suite.K8sClient.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", name).String(),
@@ -948,6 +955,9 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 			return
 		}
 		pod = pods.Items[0]
+		if !assert.NotEqual(c, oldPod.Name, pod.Name) {
+			return
+		}
 	}, 2*time.Minute, 10*time.Second, "Failed to witness the creation of pod with name %s in namespace %s", name, namespace)
 
 	suite.Require().Len(pod.Spec.Containers, 1)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix flaky `TestAdmissionControllerWithoutAPMInjection` test

### Motivation

Tests shouldn't be flaky

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

Case study: [failed test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/648058421)

```
=== RUN   TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    base_test.go:55: START  kindSuite/TestAdmissionControllerWithoutAPMInjection 2024-09-23 13:53:08.999358781 +0000 UTC m=+359.919080680
    k8s_test.go:961: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:961
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_DOGSTATSD_URL"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:964: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:964
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_TRACE_AGENT_URL"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:967: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:967
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_ENTITY_ID"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:968: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:968
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_ENV"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:971: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:971
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_SERVICE"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:974: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:974
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]string{} does not contain "DD_VERSION"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:990: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:990
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string]*v1.HostPathVolumeSource{} does not contain "datadog"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    k8s_test.go:1000: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1000
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:895
        	Error:      	map[string][]string{"kube-api-access-k727h":[]string{"/var/run/secrets/kubernetes.io/serviceaccount"}} does not contain "datadog"
        	Test:       	TestKindSuite/TestAdmissionControllerWithoutAPMInjection
    base_test.go:59: FINISH kindSuite/TestAdmissionControllerWithoutAPMInjection 2024-09-23 13:53:19.0230929 +0000 UTC m=+369.9428[148](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/648058421#L148)02
```

Test started at 13:53:08, finished at 13:53:19, so ran for 11 seconds

According to the k8s event stream:
[Already running pod was killed at 13:53:09](https://dddev.datadoghq.com/event/explorer?query=kube_cluster_name%3Aci-648058421-4670-kind-cluster%20source%3Akubernetes%20%22workload-mutated%2Fmutated%22%20&cols=&event=AgAAAZIfKFGIeI2JlwAAAAAAAAAYAAAAAEFaSWZLSVJRQUFCV3RlRFNaVnp6VUNPVwAAACQAAAAAMDE5MjFmOWMtNzAxOC00ZDZhLWFmZDYtMWJjZGIyYjExZjQ3&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&from_ts=1727099539195&to_ts=1727099635659&live=false)

[New pod was created at 13:53:36](https://dddev.datadoghq.com/event/explorer?query=kube_cluster_name%3Aci-648058421-4670-kind-cluster%20source%3Akubernetes%20%22workload-mutated%2Fmutated%22%20&cols=&event=AgAAAZIfKLsA38qtsAAAAAAAAAAYAAAAAEFaSWZLUG1BQUFDdVdGaXBhTmxJUDRfRgAAACQAAAAAMDE5MjFmOWMtNzAxOC00ZDZhLWFmZDYtMWJjZGIyYjExZjQ3&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&from_ts=1727099539195&to_ts=1727099635659&live=false) (17 seconds after the test finished)

So, based on the timeframe, it can be concluded that the old pod did not finish deleting immediately, and since there is no wait in the test, the old pod was what was used for the rest of the calculations for the test.

This PR should force us to retain the old pod name, and ensure that the new pod name does not match the old one