### PR TITLE
[SMP]: upload Regression Detector JUnit XML to Test Visibility

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -17,9 +17,6 @@ single-machine-performance-regression_detector:
       - outputs/regression_signal.json # for debugging, also on S3
       - outputs/bounds_check_signal.json # for debugging, also on S3
       - outputs/junit.xml # for debugging, also on S3
-      - tags.txt # for debugging datadog-ci junit.xml uploads
-      - job_env.txt # for debugging datadog-ci junit.xml uploads
-      - junit-*.tgz # for debugging datadog-ci junit.xml uploads
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -99,27 +96,12 @@ single-machine-performance-regression_detector:
     - !reference [.install_pr_commenter]
     # Post HTML report to GitHub
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector"
-    # Upload JUnit XML via Agent's internal tooling; see
-    # datadog-agent/tasks/libs/common/junit_upload_core.py for details,
-    # specifically the produce_junit_tar function
-    ## For simplicity in setting up the tarball, put the JUnit XML in the
-    ## current working directory.
-    - cp outputs/junit.xml junit.xml
-    ## This block of 2 lines reverse engineers the "tags.txt" part of JUnit XML
-    ## metadata added to JUnit tarballs by invoke. Runners are x86_64 and always
-    ## run Linux; this information may change in the future.
-    - touch tags.txt
-    - printf "%s" '--tags os.architecture:x86_64 --tags os.platform:linux ' >> tags.txt
-    ## This block of 3 lines reverse engineers the "job_env.txt" part of JUnit
-    ## XML metadata added to JUnit tarballs by invoke.
-    - touch job_env.txt
-    - echo "CI_JOB_URL=${CI_JOB_URL}" >> job_env.txt
-    - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> job_env.txt
-    ## datadog-agent tooling expects a gzipped tarball with filename matching
-    ## the pattern "junit-*.tgz" for uploads, so this command creates one.
-    - tar czvf "junit-${CI_JOB_ID}.tgz" junit.xml tags.txt job_env.txt
-    ## Call the JUnit XML uploader in Agent tooling.
-    #- "${CI_PROJECT_DIR}/tools/ci/junit_upload.sh" ## TODO(geoffrey.oxberry@datadoghq.com): Uncomment this line later
+    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
+    # invoke task has additional logic that does not seem to apply well to SMP's
+    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
+    # uploading JUnit XML, so the upload command below respects that convention.
+    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$API_KEY_ORG2")" || exit $?; export DATADOG_API_KEY
+    - datadog-ci junit upload --service datadog-agent outputs/junit.xml
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -16,7 +16,6 @@ single-machine-performance-regression_detector:
       - outputs/report.md # for debugging, also on S3
       - outputs/regression_signal.json # for debugging, also on S3
       - outputs/bounds_check_signal.json # for debugging, also on S3
-      - outputs/output_metadata.json
       - outputs/junit.xml # for debugging, also on S3
       - tags.txt # for debugging datadog-ci junit.xml uploads
       - job_env.txt # for debugging datadog-ci junit.xml uploads

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -14,6 +14,13 @@ single-machine-performance-regression_detector:
       - submission_metadata # for provenance, debugging
       - ${CI_COMMIT_SHA}-baseline_sha # for provenance, debugging
       - outputs/report.md # for debugging, also on S3
+      - outputs/regression_signal.json # for debugging, also on S3
+      - outputs/bounds_check_signal.json # for debugging, also on S3
+      - outputs/output_metadata.json
+      - outputs/junit.xml # for debugging, also on S3
+      - tags.txt # for debugging datadog-ci junit.xml uploads
+      - job_env.txt # for debugging datadog-ci junit.xml uploads
+      - junit-*.tgz # for debugging datadog-ci junit.xml uploads
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -93,6 +100,27 @@ single-machine-performance-regression_detector:
     - !reference [.install_pr_commenter]
     # Post HTML report to GitHub
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector"
+    # Upload JUnit XML via Agent's internal tooling; see
+    # datadog-agent/tasks/libs/common/junit_upload_core.py for details,
+    # specifically the produce_junit_tar function
+    ## For simplicity in setting up the tarball, put the JUnit XML in the
+    ## current working directory.
+    - cp outputs/junit.xml junit.xml
+    ## This block of 2 lines reverse engineers the "tags.txt" part of JUnit XML
+    ## metadata added to JUnit tarballs by invoke. Runners are x86_64 and always
+    ## run Linux; this information may change in the future.
+    - touch tags.txt
+    - printf "--tags os.architecture:x86_64 --tags os.platform:linux " >> tags.txt
+    ## This block of 3 lines reverse engineers the "job_env.txt" part of JUnit
+    ## XML metadata added to JUnit tarballs by invoke.
+    - touch job_env.txt
+    - echo "CI_JOB_URL=${CI_JOB_URL}" >> job_env.txt
+    - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> job_env.txt
+    ## datadog-agent tooling expects a gzipped tarball with filename matching
+    ## the pattern "junit-*.tgz" for uploads, so this command creates one.
+    - tar czvf "junit-${CI_JOB_ID}.tgz" junit.xml tags.txt job_env.txt
+    ## Call the JUnit XML uploader in Agent tooling.
+    #- "${CI_PROJECT_DIR}/tools/ci/junit_upload.sh" ## TODO(geoffrey.oxberry@datadoghq.com): Uncomment this line later
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -110,7 +110,7 @@ single-machine-performance-regression_detector:
     ## metadata added to JUnit tarballs by invoke. Runners are x86_64 and always
     ## run Linux; this information may change in the future.
     - touch tags.txt
-    - printf '--tags os.architecture:x86_64 --tags os.platform:linux ' >> tags.txt
+    - printf "%s" '--tags os.architecture:x86_64 --tags os.platform:linux ' >> tags.txt
     ## This block of 3 lines reverse engineers the "job_env.txt" part of JUnit
     ## XML metadata added to JUnit tarballs by invoke.
     - touch job_env.txt

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -14,7 +14,6 @@ single-machine-performance-regression_detector:
       - submission_metadata # for provenance, debugging
       - ${CI_COMMIT_SHA}-baseline_sha # for provenance, debugging
       - outputs/report.md # for debugging, also on S3
-      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -33,7 +32,6 @@ single-machine-performance-regression_detector:
     # Ensure output files exist for artifact downloads step
     - mkdir outputs # Also needed for smp job sync step
     - touch outputs/report.md # Will be emitted by smp job sync
-    - touch outputs/report.html # Will be emitted by smp job sync
     # Compute merge base of current commit and `main`
     - git fetch origin
     - SMP_BASE_BRANCH=$(inv release.get-release-json-value base_branch)

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -110,7 +110,7 @@ single-machine-performance-regression_detector:
     ## metadata added to JUnit tarballs by invoke. Runners are x86_64 and always
     ## run Linux; this information may change in the future.
     - touch tags.txt
-    - printf "--tags os.architecture:x86_64 --tags os.platform:linux " >> tags.txt
+    - printf '--tags os.architecture:x86_64 --tags os.platform:linux ' >> tags.txt
     ## This block of 3 lines reverse engineers the "job_env.txt" part of JUnit
     ## XML metadata added to JUnit tarballs by invoke.
     - touch job_env.txt


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds tooling to upload Regression Detector JUnit XML reports to Datadog Test Visibility.

### Motivation

Make it easier to search Regression Detector results in Datadog.

### Describe how to test/QA your changes

Still working on that.

### Possible Drawbacks / Trade-offs

Adds more commands to the Regression Detector's GitLab task, so more can go wrong.

### Additional Notes

I've tried adding metadata to the JUnit XML via some additional text files to mimic what `invoke` does to build JUnit gzipped tarballs. Unsure if this attempt will work.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->