### PR TITLE
use same build tags for KMT test package expansion

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -872,12 +872,12 @@ def build_run_config(run: str | None, packages: list[str]):
     return c
 
 
-def build_target_packages(filter_packages):
-    all_packages = go_package_dirs(TEST_PACKAGES_LIST, [NPM_TAG, BPF_TAG])
-    if filter_packages == []:
+def build_target_packages(filter_packages: list[str], build_tags: list[str]):
+    all_packages = go_package_dirs(TEST_PACKAGES_LIST, build_tags)
+    if not filter_packages:
         return all_packages
 
-    filter_packages = [os.path.relpath(p) for p in go_package_dirs(filter_packages, [NPM_TAG, BPF_TAG])]
+    filter_packages = [os.path.relpath(p) for p in go_package_dirs(filter_packages, build_tags)]
     return [pkg for pkg in all_packages if os.path.relpath(pkg) in filter_packages]
 
 
@@ -887,9 +887,8 @@ def build_object_files(ctx, fp, arch: Arch):
     ctx.run(f"ninja -d explain -f {fp}")
 
 
-def compute_package_dependencies(ctx: Context, packages: list[str]) -> dict[str, set[str]]:
+def compute_package_dependencies(ctx: Context, packages: list[str], build_tags: list[str]) -> dict[str, set[str]]:
     dd_pkg_name = "github.com/DataDog/datadog-agent/"
-    build_tags = get_sysprobe_buildtags(False, False)
     pkg_deps: dict[str, set[str]] = defaultdict(set)
 
     packages_list = " ".join(packages)
@@ -923,7 +922,6 @@ def kmt_sysprobe_prepare(
     ctx: Context,
     arch: str | Arch,
     stack: str | None = None,
-    kernel_release: str | None = None,
     packages=None,
     extra_arguments: str | None = None,
     ci: bool = False,
@@ -956,8 +954,9 @@ def kmt_sysprobe_prepare(
     build_object_files(ctx, f"{kmt_paths.arch_dir}/kmt-object-files.ninja", arch)
 
     info("[+] Computing Go dependencies for test packages...")
-    target_packages = build_target_packages(filter_pkgs)
-    pkg_deps = compute_package_dependencies(ctx, target_packages)
+    build_tags = get_sysprobe_buildtags(False, False)
+    target_packages = build_target_packages(filter_pkgs, build_tags)
+    pkg_deps = compute_package_dependencies(ctx, target_packages, build_tags)
 
     info("[+] Generating build instructions..")
     with open(nf_path, 'w') as ninja_file:
@@ -976,6 +975,7 @@ def kmt_sysprobe_prepare(
         ninja_build_dependencies(ctx, nw, kmt_paths, go_path, arch)
         ninja_copy_ebpf_files(nw, "system-probe", kmt_paths, arch)
 
+        build_tags = get_sysprobe_buildtags(False, False)
         for pkg in target_packages:
             pkg_name = os.path.relpath(pkg, os.getcwd())
             target_path = os.path.join(kmt_paths.sysprobe_tests, pkg_name)
@@ -983,7 +983,7 @@ def kmt_sysprobe_prepare(
             variables = {
                 "env": env_str,
                 "go": go_path,
-                "build_tags": get_sysprobe_buildtags(False, False),
+                "build_tags": build_tags,
             }
             timeout = get_test_timeout(os.path.relpath(pkg, os.getcwd()))
             if timeout:
@@ -1015,9 +1015,9 @@ def kmt_sysprobe_prepare(
                     rule="copyfiles",
                 )
 
-        # handle testutils and testdata seperately since they are
+        # handle testutils and testdata separately since they are
         # shared across packages
-        target_pkgs = build_target_packages([])
+        target_pkgs = build_target_packages([], build_tags)
         for pkg in target_pkgs:
             target_path = os.path.join(kmt_paths.sysprobe_tests, os.path.relpath(pkg, os.getcwd()))
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -845,7 +845,6 @@ def go_package_dirs(packages, build_tags):
     This handles the ellipsis notation (eg. ./pkg/ebpf/...)
     """
 
-    target_packages = []
     format_arg = '{{ .Dir }}'
     buildtags_arg = ",".join(build_tags)
     packages_arg = " ".join(packages)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

KMT package expansion was not using the same build tags (notably missing `test`) as the actual build process. 

### Motivation

It would miss a package with only tests in a file with the `test` build tag.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->