### PR TITLE
[NETPATH-314] Fix Traceroute Latency

### DIFF
--- a/releasenotes/notes/network-path-latency-fix-575efe1aa26c250b.yaml
+++ b/releasenotes/notes/network-path-latency-fix-575efe1aa26c250b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix an issue where TCP traceroute latency was not being calculated correctly.
+    Fixes an issue where TCP traceroute latency was not being calculated correctly.

--- a/releasenotes/notes/network-path-latency-fix-575efe1aa26c250b.yaml
+++ b/releasenotes/notes/network-path-latency-fix-575efe1aa26c250b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue where TCP traceroute latency was not being calculated correctly.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Moves the timestamp that determines when a response is received to right after the packet is taken from the wire, before we parse it.

### Motivation
Latency is currently always 100ms because we wait for both listeners to return before taking a time measurement which is incorrect.

### Describe how to test/QA your changes
Run the agent with traceroute enabled for a TCP endpoint. When you look at the logs, or in the UI, the RTT/latency should be incremental and not be stuck at 100ms/hop RTT or 50ms

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->