### PR TITLE
Enclose multi_line pattern in non-capturing group

### DIFF
--- a/comp/logs/agent/config/processing_rules.go
+++ b/comp/logs/agent/config/processing_rules.go
@@ -75,7 +75,7 @@ func CompileProcessingRules(rules []*ProcessingRule) error {
 			rule.Regex = re
 			rule.Placeholder = []byte(rule.ReplacePlaceholder)
 		case MultiLine:
-			rule.Regex, err = regexp.Compile("^" + rule.Pattern)
+			rule.Regex, err = regexp.Compile("^(?:" + rule.Pattern + ")")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What does this PR do?
Enclose the `multi_line` pattern between non-capturing group in cases of alternate matching patterns using `|`.

### Motivation
Some users provide multiple patterns that may appear at the start of a log line in one pattern entry

`pattern: error|info` becoming `^error|info` within DD Agent and reads as:
- `^error` -> lines that start with error; and
- `info` -> lines that contain `info`
  - This had unintended result of the `info` pattern being matched anywhere in the log line becoming the start of a log line for aggregation.

A more accurate pattern would have avoided the issue e.g. `pattern: (error|info)` becoming `^(error|info)`. Since DD Agent does not makes use of the matched groups, I opted for a non-capturing group.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->