### PR TITLE
Replace Windows system probe socket endpoint localhost:3333 with named pipe \\.\pipe\dd_system_probe.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -460,6 +460,9 @@
 /pkg/process/metadata/parser/*windows*  @DataDog/universal-service-monitoring @DataDog/processes @DataDog/Networks @DataDog/windows-kernel-integrations
 /pkg/process/monitor/                   @DataDog/universal-service-monitoring
 /pkg/process/net/                       @DataDog/universal-service-monitoring @DataDog/processes @DataDog/Networks
+/pkg/process/net/common_windows.go      @DataDog/windows-agent
+/pkg/process/net/windows_pipe.go        @DataDog/windows-kernel-integrations
+/pkg/process/net/windows_pipe_testutil.go     @DataDog/windows-kernel-integrations
 /pkg/proto/datadog/remoteconfig/        @DataDog/remote-config
 /pkg/proto/pbgo/                        # do not notify anyone
 /pkg/proto/pbgo/trace                   @DataDog/agent-apm
@@ -629,6 +632,7 @@
 /tools/ebpf/                            @DataDog/ebpf-platform
 /tools/gdb/                             @DataDog/agent-shared-components
 /tools/go-update/                       @DataDog/agent-shared-components
+/tools/NamedPipeCmd/                    @DataDog/windows-kernel-integrations
 /tools/retry_file_dump/                 @DataDog/agent-metrics-logs
 /tools/windows/                         @DataDog/windows-agent
 /tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl @DataDog/windows-agent @DataDog/documentation

--- a/cmd/agent/subcommands/flare/command_other_test.go
+++ b/cmd/agent/subcommands/flare/command_other_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build !windows
+
+// Package flare implements 'agent flare'.
+package flare
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// NewSystemProbeTestServer starts a new mock server to handle System Probe requests.
+func NewSystemProbeTestServer(_ http.Handler) (*httptest.Server, error) {
+	// Linux still uses a port-based system-probe, it does not need a dedicated system probe server
+	// for the tests.
+	return nil, nil
+}
+
+// InjectConnectionFailures injects a failure in TestReadProfileDataErrors.
+func InjectConnectionFailures(_ model.Config, _ model.Config) {
+}
+
+// CheckExpectedConnectionFailures checks the expected errors after simulated
+// connection failures.
+func CheckExpectedConnectionFailures(c *commandTestSuite, err error) {
+	// System probe by default is disabled and no connection is attempted for it in the test.
+	require.Regexp(c.T(), "^4 errors occurred:\n", err.Error())
+}

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -31,24 +31,38 @@ type commandTestSuite struct {
 	sysprobeSocketPath string
 	tcpServer          *httptest.Server
 	unixServer         *httptest.Server
+	systemProbeServer  *httptest.Server
 }
 
 func (c *commandTestSuite) SetupSuite() {
 	t := c.T()
 	c.sysprobeSocketPath = path.Join(t.TempDir(), "sysprobe.sock")
-	c.tcpServer, c.unixServer = c.getPprofTestServer()
 }
 
-func (c *commandTestSuite) TearDownSuite() {
-	c.tcpServer.Close()
-	if c.unixServer != nil {
-		c.unixServer.Close()
-	}
-}
-
-func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, unixServer *httptest.Server) {
+// startTestServers starts test servers from a clean state to ensure no cache responses are used.
+// This should be called by each test that requires them.
+func (c *commandTestSuite) startTestServers() {
 	t := c.T()
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c.tcpServer, c.unixServer, c.systemProbeServer = c.getPprofTestServer()
+
+	t.Cleanup(func() {
+		if c.tcpServer != nil {
+			c.tcpServer.Close()
+			c.tcpServer = nil
+		}
+		if c.unixServer != nil {
+			c.unixServer.Close()
+			c.unixServer = nil
+		}
+		if c.systemProbeServer != nil {
+			c.systemProbeServer.Close()
+			c.systemProbeServer = nil
+		}
+	})
+}
+
+func newMockHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/debug/pprof/heap":
 			w.Write([]byte("heap_profile"))
@@ -67,17 +81,28 @@ func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, uni
 			w.WriteHeader(500)
 		}
 	})
+}
 
+func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, unixServer *httptest.Server, sysProbeServer *httptest.Server) {
+	var err error
+	t := c.T()
+
+	handler := newMockHandler()
 	tcpServer = httptest.NewServer(handler)
 	if runtime.GOOS == "linux" {
 		unixServer = httptest.NewUnstartedServer(handler)
-		var err error
 		unixServer.Listener, err = net.Listen("unix", c.sysprobeSocketPath)
 		require.NoError(t, err, "could not create listener for unix socket on %s", c.sysprobeSocketPath)
 		unixServer.Start()
 	}
 
-	return tcpServer, unixServer
+	sysProbeServer, err = NewSystemProbeTestServer(handler)
+	require.NoError(c.T(), err, "could not restart system probe server")
+	if sysProbeServer != nil {
+		sysProbeServer.Start()
+	}
+
+	return tcpServer, unixServer, sysProbeServer
 }
 
 func TestCommandTestSuite(t *testing.T) {
@@ -86,6 +111,8 @@ func TestCommandTestSuite(t *testing.T) {
 
 func (c *commandTestSuite) TestReadProfileData() {
 	t := c.T()
+	c.startTestServers()
+
 	u, err := url.Parse(c.tcpServer.URL)
 	require.NoError(t, err)
 	port := u.Port()
@@ -154,6 +181,8 @@ func (c *commandTestSuite) TestReadProfileData() {
 
 func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 	t := c.T()
+	c.startTestServers()
+
 	u, err := url.Parse(c.tcpServer.URL)
 	require.NoError(t, err)
 	port := u.Port()
@@ -217,6 +246,8 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 
 func (c *commandTestSuite) TestReadProfileDataErrors() {
 	t := c.T()
+	c.startTestServers()
+
 	mockConfig := configmock.New(t)
 	// setting Core Agent Expvar port to 0 to ensure failing on fetch (using the default value can lead to
 	// successful request when running next to an Agent)
@@ -226,9 +257,13 @@ func (c *commandTestSuite) TestReadProfileDataErrors() {
 	mockConfig.SetWithoutSource("process_config.enabled", true)
 	mockConfig.SetWithoutSource("process_config.expvar_port", 0)
 
+	mockSysProbeConfig := configmock.NewSystemProbe(t)
+	InjectConnectionFailures(mockSysProbeConfig, mockConfig)
+
 	data, err := readProfileData(10)
+
 	require.Error(t, err)
-	require.Regexp(t, "^4 errors occurred:\n", err.Error())
+	CheckExpectedConnectionFailures(c, err)
 	require.Len(t, data, 0)
 }
 

--- a/cmd/agent/subcommands/flare/command_windows_test.go
+++ b/cmd/agent/subcommands/flare/command_windows_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build windows
+
+// Package flare implements 'agent flare'.
+package flare
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	processNet "github.com/DataDog/datadog-agent/pkg/process/net"
+)
+
+const (
+	// SystemProbeTestPipeName is the test named pipe for system-probe
+	systemProbeTestPipeName = `\\.\pipe\dd_system_probe_flare_test`
+
+	// systemProbeTestPipeSecurityDescriptor has a DACL that allows Everyone access for these tests.
+	systemProbeTestPipeSecurityDescriptor = "D:PAI(A;;FA;;;WD)"
+)
+
+// NewSystemProbeTestServer starts a new mock server to handle System Probe requests.
+func NewSystemProbeTestServer(handler http.Handler) (*httptest.Server, error) {
+	server := httptest.NewUnstartedServer(handler)
+
+	// Override the named pipe path for tests to avoid conflicts with the locally installed Datadog agent.
+	processNet.OverrideSystemProbeNamedPipeConfig(
+		systemProbeTestPipeName,
+		systemProbeTestPipeSecurityDescriptor)
+
+	conn, err := processNet.NewSystemProbeListener("")
+	if err != nil {
+		return nil, err
+	}
+
+	server.Listener = conn.GetListener()
+	return server, nil
+}
+
+// InjectConnectionFailures injects a failure in TestReadProfileDataErrors.
+func InjectConnectionFailures(mockSysProbeConfig model.Config, mockConfig model.Config) {
+	// Explicitly enabled system probe to exercise connections to it.
+	mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
+
+	// Exercise a connection failure for a Windows system probe named pipe client by
+	// making them use a bad path.
+	// The system probe http server must be setup before this override.
+	processNet.OverrideSystemProbeNamedPipeConfig(
+		`\\.\pipe\dd_system_probe_test_bad`,
+		systemProbeTestPipeSecurityDescriptor)
+
+	// The security-agent connection is expected to fail too in this test, but
+	// by enabling system probe, a port will be provided to it (security agent).
+	// Here we make sure the security agent port is a bad one.
+	mockConfig.SetWithoutSource("security_agent.expvar_port", 0)
+}
+
+// CheckExpectedConnectionFailures checks the expected errors after simulated
+// connection failures.
+func CheckExpectedConnectionFailures(c *commandTestSuite, err error) {
+	// In Windows, this test explicitly simulates a system probe connection failure.
+	// We expect the standard socket errors (4) and a named pipe failure for system probe.
+	require.Regexp(c.T(), "^5 errors occurred:\n", err.Error())
+}

--- a/cmd/system-probe/api/client/client.go
+++ b/cmd/system-probe/api/client/client.go
@@ -7,25 +7,10 @@
 package client
 
 import (
-	"context"
-	"net"
 	"net/http"
-	"time"
 )
 
 // Get returns a http client configured to talk to the system-probe
 func Get(socketPath string) *http.Client {
-	return &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConns:    2,
-			IdleConnTimeout: 30 * time.Second,
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial(netType, socketPath)
-			},
-			TLSHandshakeTimeout:   1 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
-			ExpectContinueTimeout: 50 * time.Millisecond,
-		},
-	}
+	return newSystemProbeClient(socketPath)
 }

--- a/cmd/system-probe/api/client/client_linux.go
+++ b/cmd/system-probe/api/client/client_linux.go
@@ -7,6 +7,31 @@
 
 package client
 
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+)
+
 const (
 	netType = "unix"
 )
+
+// newSystemProbeClient returns a http client configured to talk to the system-probe
+// Linux is unable to import pkg/process/net due to size restrictions.
+func newSystemProbeClient(socketPath string) *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:    2,
+			IdleConnTimeout: 30 * time.Second,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial(netType, socketPath)
+			},
+			TLSHandshakeTimeout:   1 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 50 * time.Millisecond,
+		},
+	}
+}

--- a/cmd/system-probe/api/client/client_others.go
+++ b/cmd/system-probe/api/client/client_others.go
@@ -7,6 +7,30 @@
 
 package client
 
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+)
+
 const (
 	netType = "tcp"
 )
+
+// newSystemProbeClient returns a http client configured to talk to the system-probe
+func newSystemProbeClient(socketPath string) *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:    2,
+			IdleConnTimeout: 30 * time.Second,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial(netType, socketPath)
+			},
+			TLSHandshakeTimeout:   1 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 50 * time.Millisecond,
+		},
+	}
+}

--- a/cmd/system-probe/api/client/client_windows.go
+++ b/cmd/system-probe/api/client/client_windows.go
@@ -7,6 +7,15 @@
 
 package client
 
-const (
-	netType = "tcp"
+import (
+	"net/http"
+
+	processNet "github.com/DataDog/datadog-agent/pkg/process/net"
 )
+
+// newSystemProbeClient returns a http client configured to talk to the system-probe
+// This is a simple wrapper around process_net.NewSystemProbeHttpClient because
+// Linux is unable to import pkg/process/net due to size restrictions.
+func newSystemProbeClient(_ string) *http.Client {
+	return processNet.NewSystemProbeClient()
+}

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -27,9 +27,9 @@ import (
 
 // StartServer starts the HTTP and gRPC servers for the system-probe, which registers endpoints from all enabled modules.
 func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmeta workloadmeta.Component, settings settings.Component) error {
-	conn, err := net.NewListener(cfg.SocketAddress)
+	conn, err := net.NewSystemProbeListener(cfg.SocketAddress)
 	if err != nil {
-		return fmt.Errorf("error creating IPC socket: %s", err)
+		return err
 	}
 
 	mux := gorilla.NewRouter()

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -5,6 +5,7 @@
 
 //go:build windows
 
+// Package probe parses Windows crash dumps.
 package probe
 
 /*

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
@@ -8,7 +8,6 @@
 package wincrashdetect
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 
@@ -24,18 +23,31 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 
-	//process_net "github.com/DataDog/datadog-agent/pkg/process/net"
+	process_net "github.com/DataDog/datadog-agent/pkg/process/net"
 
 	"golang.org/x/sys/windows/registry"
 )
 
+const (
+	// SystemProbeTestPipeName is the test named pipe for system-probe
+	systemProbeTestPipeName = `\\.\pipe\dd_system_probe_wincrash_test`
+
+	// systemProbeTestPipeSecurityDescriptor has a DACL that allows Everyone access for these tests.
+	systemProbeTestPipeSecurityDescriptor = "D:PAI(A;;FA;;;WD)"
+)
+
 func createSystemProbeListener() (l net.Listener, close func()) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	process_net.OverrideSystemProbeNamedPipeConfig(
+		systemProbeTestPipeName,
+		systemProbeTestPipeSecurityDescriptor)
+
+	// No socket address. Windows uses a fixed name pipe
+	conn, err := process_net.NewSystemProbeListener("")
 	if err != nil {
 		panic(err)
 	}
-	return l, func() {
-		_ = l.Close()
+	return conn.GetListener(), func() {
+		_ = conn.GetListener().Close()
 	}
 }
 
@@ -69,8 +81,8 @@ func TestWinCrashReporting(t *testing.T) {
 	}
 	defer server.Close()
 
-	sock := fmt.Sprintf("localhost:%d", listener.Addr().(*net.TCPAddr).Port)
-	pkgconfigsetup.SystemProbe().SetWithoutSource("system_probe_config.sysprobe_socket", sock)
+	// no socket address is set in config for Windows since system probe
+	// utilizes a fixed named pipe.
 
 	/*
 	 * the underlying system probe connector is a singleton.  Therefore, we can't set up different

--- a/pkg/languagedetection/detector_linux_test.go
+++ b/pkg/languagedetection/detector_linux_test.go
@@ -29,7 +29,7 @@ func startTestUnixServer(t *testing.T, handler http.Handler) string {
 	t.Helper()
 
 	socketPath := path.Join(t.TempDir(), "test.sock")
-	listener, err := net.NewListener(socketPath)
+	listener, err := net.NewSystemProbeListener(socketPath)
 	require.NoError(t, err)
 	t.Cleanup(listener.Stop)
 

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -312,41 +312,6 @@ func (r *RemoteSysProbeUtil) Register(clientID string) error {
 	return nil
 }
 
-func newSystemProbe(path string) *RemoteSysProbeUtil {
-	return &RemoteSysProbeUtil{
-		path: path,
-		httpClient: http.Client{
-			Timeout: 10 * time.Second,
-			Transport: &http.Transport{
-				MaxIdleConns:    2,
-				IdleConnTimeout: 30 * time.Second,
-				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial(netType, path)
-				},
-				TLSHandshakeTimeout:   1 * time.Second,
-				ResponseHeaderTimeout: 5 * time.Second,
-				ExpectContinueTimeout: 50 * time.Millisecond,
-			},
-		},
-		pprofClient: http.Client{
-			Transport: &http.Transport{
-				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial(netType, path)
-				},
-			},
-		},
-		tracerouteClient: http.Client{
-			// no timeout set here, the expected usage of this client
-			// is that the caller will set a timeout on each request
-			Transport: &http.Transport{
-				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial(netType, path)
-				},
-			},
-		},
-	}
-}
-
 //nolint:revive // TODO(PROC) Fix revive linter
 func (r *RemoteSysProbeUtil) DetectLanguage(pids []int32) ([]languagemodels.Language, error) {
 	procs := make([]*languagepb.Process, len(pids))

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -8,8 +8,12 @@
 package net
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"time"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 )
@@ -39,4 +43,40 @@ func CheckPath(path string) error {
 		return fmt.Errorf("socket path does not exist: %v", err)
 	}
 	return nil
+}
+
+// newSystemProbe creates a group of clients to interact with system-probe.
+func newSystemProbe(path string) *RemoteSysProbeUtil {
+	return &RemoteSysProbeUtil{
+		path: path,
+		httpClient: http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:    2,
+				IdleConnTimeout: 30 * time.Second,
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial(netType, path)
+				},
+				TLSHandshakeTimeout:   1 * time.Second,
+				ResponseHeaderTimeout: 5 * time.Second,
+				ExpectContinueTimeout: 50 * time.Millisecond,
+			},
+		},
+		pprofClient: http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial(netType, path)
+				},
+			},
+		},
+		tracerouteClient: http.Client{
+			// no timeout set here, the expected usage of this client
+			// is that the caller will set a timeout on each request
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial(netType, path)
+				},
+			},
+		},
+	}
 }

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -8,7 +8,11 @@
 package net
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 )
@@ -29,6 +33,17 @@ const (
 	procStatsURL = "http://localhost:3333/" + string(sysconfig.ProcessModule) + "stats"
 	// pingURL is not used in windows, the value is added to avoid compilation error in windows
 	pingURL = "http://localhost:3333/" + string(sysconfig.PingModule) + "/ping/"
+
+	// SystemProbePipeName is the production named pipe for system probe
+	SystemProbePipeName = `\\.\pipe\dd_system_probe`
+
+	// systemProbeMaxIdleConns sets the maximum number of idle named pipe connections.
+	systemProbeMaxIdleConns = 2
+
+	// systemProbeIdleConnTimeout is the time a named pipe connection is held up idle before being closed.
+	// This should be small since connections are local, to close them as soon as they are done,
+	// and to quickly service new pending connections.
+	systemProbeIdleConnTimeout = 5 * time.Second
 )
 
 // CheckPath is used to make sure the globalSocketPath has been set before attempting to connect
@@ -37,4 +52,49 @@ func CheckPath(path string) error {
 		return fmt.Errorf("socket path is empty")
 	}
 	return nil
+}
+
+// NewSystemProbeClient returns a http client configured to talk to the system-probe
+func NewSystemProbeClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:    systemProbeMaxIdleConns,
+			IdleConnTimeout: systemProbeIdleConnTimeout,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return DialSystemProbe()
+			},
+			TLSHandshakeTimeout:   1 * time.Second,
+			ResponseHeaderTimeout: 2 * time.Second,
+			ExpectContinueTimeout: 50 * time.Millisecond,
+		},
+	}
+}
+
+// newSystemProbe creates a group of clients to interact with system-probe.
+func newSystemProbe(path string) *RemoteSysProbeUtil {
+	return &RemoteSysProbeUtil{
+		path:       path,
+		httpClient: *NewSystemProbeClient(),
+		pprofClient: http.Client{
+			Transport: &http.Transport{
+				MaxIdleConns:    systemProbeMaxIdleConns,
+				IdleConnTimeout: systemProbeIdleConnTimeout,
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return DialSystemProbe()
+				},
+			},
+		},
+		tracerouteClient: http.Client{
+			// no timeout set here, the expected usage of this client
+			// is that the caller will set a timeout on each request
+			Transport: &http.Transport{
+				MaxIdleConns:    systemProbeMaxIdleConns,
+				IdleConnTimeout: systemProbeIdleConnTimeout,
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return DialSystemProbe()
+				},
+			},
+		},
+	}
 }

--- a/pkg/process/net/uds.go
+++ b/pkg/process/net/uds.go
@@ -22,8 +22,8 @@ type UDSListener struct {
 	socketPath string
 }
 
-// NewListener returns an idle UDSListener
-func NewListener(socketAddr string) (*UDSListener, error) {
+// newSocketListener creates a Unix Domain Socket Listener
+func newSocketListener(socketAddr string) (*UDSListener, error) {
 	if len(socketAddr) == 0 {
 		return nil, fmt.Errorf("uds: empty socket path provided")
 	}
@@ -71,6 +71,16 @@ func NewListener(socketAddr string) (*UDSListener, error) {
 
 	log.Debugf("uds: %s successfully initialized", conn.Addr())
 	return listener, nil
+}
+
+// NewSystemProbeListener returns an idle UDSListener
+func NewSystemProbeListener(socketAddr string) (*UDSListener, error) {
+	var listener, err = newSocketListener(socketAddr)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IPC socket: %s", err)
+	}
+
+	return listener, err
 }
 
 // GetListener will return the underlying Conn's net.Listener

--- a/pkg/process/net/uds_test.go
+++ b/pkg/process/net/uds_test.go
@@ -25,7 +25,7 @@ func testSocketExistsNewUDSListener(t *testing.T, socketPath string) {
 	assert.NoError(t, err)
 
 	// Create a new socket using UDSListener
-	l, err := NewListener(socketPath)
+	l, err := NewSystemProbeListener(socketPath)
 	require.NoError(t, err)
 
 	l.Stop()
@@ -38,12 +38,12 @@ func testSocketExistsAsRegularFileNewUDSListener(t *testing.T, socketPath string
 	defer f.Close()
 
 	// Create a new socket using UDSListener
-	_, err = NewListener(socketPath)
+	_, err = NewSystemProbeListener(socketPath)
 	require.Error(t, err)
 }
 
 func testWorkingNewUDSListener(t *testing.T, socketPath string) {
-	s, err := NewListener(socketPath)
+	s, err := NewSystemProbeListener(socketPath)
 	require.NoError(t, err)
 	defer s.Stop()
 

--- a/pkg/process/net/windows_pipe.go
+++ b/pkg/process/net/windows_pipe.go
@@ -8,7 +8,26 @@
 package net
 
 import (
+	"fmt"
 	"net"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/Microsoft/go-winio"
+)
+
+const (
+	// Buffer sizes for the system probe named pipe.
+	// The sizes are advisory, Windows can adjust them, but should be small enough to preserve
+	// the nonpaged pool.
+	namedPipeInputBufferSize  = int32(4096)
+	namedPipeOutputBufferSize = int32(4096)
+
+	// DACL for the system probe named pipe.
+	// SE_DACL_PROTECTED (P), SE_DACL_AUTO_INHERITED (AI)
+	// Allow Everyone (WD)
+	// nolint:revive // TODO: Hardened DACL and ensure the datadogagent run-as user is allowed.
+	namedPipeSecurityDescriptor = "D:PAI(A;;FA;;;WD)"
 )
 
 // WindowsPipeListener for communicating with Probe
@@ -17,10 +36,36 @@ type WindowsPipeListener struct {
 	pipePath string
 }
 
-// NewListener sets up a TCP listener for now, will eventually be a named pipe
-func NewListener(socketAddr string) (*WindowsPipeListener, error) {
-	l, err := net.Listen("tcp", socketAddr)
-	return &WindowsPipeListener{l, "path"}, err
+// systemProbePipeName is the effective named pipe path for system probe
+var systemProbePipeName = SystemProbePipeName
+
+// systemProbePipSecurityDescriptor has the effective DACL for the system probe named pipe.
+var systemProbePipSecurityDescriptor = namedPipeSecurityDescriptor
+
+// newPipeListener creates a standardized named pipe server and with hardened ACL
+func newPipeListener(namedPipeName string) (net.Listener, error) {
+	// The DACL must allow the run-as user of datadogagent.
+	config := winio.PipeConfig{
+		SecurityDescriptor: systemProbePipSecurityDescriptor,
+		InputBufferSize:    namedPipeInputBufferSize,
+		OutputBufferSize:   namedPipeOutputBufferSize,
+	}
+
+	// winio specifies virtually unlimited number of named pipe instances but is limited by
+	// the nonpaged pool.
+	return winio.ListenPipe(namedPipeName, &config)
+}
+
+// NewSystemProbeListener sets up a named pipe listener for the system probe service.
+func NewSystemProbeListener(_ string) (*WindowsPipeListener, error) {
+	// socketAddr not used
+
+	namedPipe, err := newPipeListener(systemProbePipeName)
+	if err != nil {
+		return nil, fmt.Errorf("error named pipe %s : %s", systemProbePipeName, err)
+	}
+
+	return &WindowsPipeListener{namedPipe, systemProbePipeName}, nil
 }
 
 // GetListener will return underlying Listener's conn
@@ -31,4 +76,23 @@ func (wp *WindowsPipeListener) GetListener() net.Listener {
 // Stop closes the WindowsPipeListener connection and stops listening
 func (wp *WindowsPipeListener) Stop() {
 	wp.conn.Close()
+}
+
+// DialSystemProbe connects to the system-probe service endpoint
+func DialSystemProbe() (net.Conn, error) {
+	// Go clients do not immediately close (named pipe) connections when done,
+	// they keep connections idle for a while.  Make sure the idle time
+	// is not too high and the timeout is generous enough for pending connections.
+	var timeout = time.Duration(30 * time.Second)
+
+	namedPipe, err := winio.DialPipe(systemProbePipeName, &timeout)
+	if err != nil {
+		// This important error may not get reported upstream, making connection failures
+		// very difficult to diagnose. Explicitly log the error here too for diagnostics.
+		var namedPipeErr = fmt.Errorf("error connecting to named pipe %s : %s", systemProbePipeName, err)
+		log.Errorf("%s", namedPipeErr.Error())
+		return nil, namedPipeErr
+	}
+
+	return namedPipe, nil
 }

--- a/pkg/process/net/windows_pipe_testutil.go
+++ b/pkg/process/net/windows_pipe_testutil.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && windows
+
+package net
+
+// OverrideSystemProbeNamedPipeConfig sets the active named pipe path and its DACL for
+// System Probe connections.
+// This is used by tests only to avoid conflicts with an existing locally installed Datadog agent.
+func OverrideSystemProbeNamedPipeConfig(path string, securityDescriptor string) {
+	if path != "" {
+		systemProbePipeName = path
+	}
+
+	if securityDescriptor != "" {
+		systemProbePipSecurityDescriptor = securityDescriptor
+	}
+}

--- a/releasenotes/notes/windows_sysprobe_socket_to_pipe-089738b8f07a56ad.yaml
+++ b/releasenotes/notes/windows_sysprobe_socket_to_pipe-089738b8f07a56ad.yaml
@@ -1,0 +1,7 @@
+other:
+  - |
+    On Windows, the TCP socket transport mechanism for system probe
+    communications has been replaced with a named pipe.
+    This deprecates the system_probe_config.sysprobe_socket configuration
+    entry for Windows.
+    The new fixed named pipe path is \\.\pipe\dd_system_probe.

--- a/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
@@ -295,6 +295,9 @@ func (v *apmvmSuite) TestUSMAutoTaggingSuite() {
 	testExe := path.Join("c:", "users", "administrator", "littleget.exe")
 	vm.CopyFile("usmtest/littleget.exe", testExe)
 
+	pipeExe := path.Join("c:", "users", "administrator", "NamedPipeCmd.exe")
+	vm.CopyFile("usmtest/NamedPipeCmd.exe", pipeExe)
+
 	pscommand := "%s -TargetHost localhost -TargetPort %s -TargetPath %s -ExpectedClientTags %s -ExpectedServerTags %s -ConnExe %s"
 
 	for _, test := range usmTaggingTests {

--- a/test/new-e2e/tests/sysprobe-functional/usmtest/test_tags.ps1
+++ b/test/new-e2e/tests/sysprobe-functional/usmtest/test_tags.ps1
@@ -30,7 +30,11 @@ function make-connectionrequest {
 }
 
 function get-connectionsendpoint {
-    $payload = ((iwr -UseBasicParsing -DisableKeepAlive http://localhost:3333/network_tracer/connections).content | ConvertFrom-Json)
+    $payload = (.\NamedPipeCmd.exe -method GET -path /network_tracer/connections -quiet) | convertfrom-json
+    if (! $?){
+        Write-Host -ForegroundColor Red "Failed to get connection list"
+        exit 1
+    }
     return $payload
 }
 

--- a/tools/NamedPipeCmd/main.go
+++ b/tools/NamedPipeCmd/main.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build windows
+
+// Package namedpipecmd is the entrypoint for the NamedPipeCmd tool
+package namedpipecmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	winio "github.com/Microsoft/go-winio"
+)
+
+var (
+	quiet = flag.Bool("quiet", false, "Only return the exit code on failure, or the JSON output on success")
+)
+
+func exitWithError(err error) {
+	fmt.Printf("\nError: %s\n", err.Error())
+	os.Exit(1)
+}
+
+func exitWithErrorCode(err int) {
+	fmt.Printf("Error: %d\n", err)
+	os.Exit(err)
+}
+
+func fprintf(format string, a ...interface{}) {
+	if !*quiet {
+		fmt.Printf(format, a...)
+	}
+}
+
+func main() {
+
+	method := flag.String("method", "", "GET or POST")
+	path := flag.String("path", "", "URI path")
+	//payload := flag.String(payload, "", "POST payload")
+	flag.Parse()
+
+	// This should match SystemProbeProductionPipeName in
+	// "github.com/DataDog/datadog-agent/pkg/process/net"
+	pipePath := `\\.\pipe\dd_system_probe`
+	fmt.Printf("Connecting to named pipe %s ... ", pipePath)
+
+	// The Go wrapper for named pipes does not expose buffer size for the client.
+	// It seems the client named pipe is fixed with 4K bytes for its buffer.
+	pipeClient, err := winio.DialPipe(pipePath, nil)
+	if err != nil {
+		exitWithError(err)
+		return
+	}
+
+	fprintf("connected")
+
+	defer func() {
+		fprintf("\nClosing named pipe...\n")
+		pipeClient.Close()
+
+	}()
+
+	// The HTTP client still needs the URL as part of the request even though
+	// the underlying transport is a named pipe.
+	method := os.Args[1]
+	uriPath := os.Args[2]
+	url := "http://localhost" + uriPath
+
+	if (*method != "GET") && (*method != "POST") {
+		fprintf("Invalid HTTP method: %s\n", *method)
+		os.Exit(1)
+	}
+
+	// This HTTP client handles formatting and chunked messages.
+	fmt.Printf("Creating HTTP client. ")
+	httpClient := http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:    2,
+			IdleConnTimeout: 30 * time.Second,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return pipeClient, nil
+			},
+			TLSHandshakeTimeout:   1 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 50 * time.Millisecond,
+		},
+	}
+
+	fprintf("Setting up options. ")
+
+	options := &util.ReqOptions{Conn: 1}
+	if options.Authtoken == "" {
+		options.Authtoken = util.GetAuthToken()
+	}
+
+	if options.Ctx == nil {
+		options.Ctx = context.Background()
+	}
+
+	fprintf("Creating request. \n")
+
+	req, err := http.NewRequestWithContext(options.Ctx, *method, url, nil)
+	if err != nil {
+		exitWithError(err)
+	}
+
+	// Set required headers.
+	req.Header.Set("User-Agent", "namedpipecmd/1.1")
+	req.Header.Set("Accept-Encoding", "gzip")
+	if options.Conn == 1 {
+		req.Close = true
+	}
+
+	fprintf("Sending HTTP request...\n")
+
+	result, err := httpClient.Do(req)
+	if err != nil {
+		exitWithError(err)
+	}
+
+	body, err := io.ReadAll(result.Body)
+	result.Body.Close()
+	if err != nil {
+		exitWithError(err)
+	}
+
+	fprintf("Received %d bytes. Status %d\n", len(body), result.StatusCode)
+
+	fmt.Printf("\n---------------------------------------\n\n")
+	fmt.Printf("%s\n", body)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR revives the previous reverted change, where it failed on the full-test pass.  The problem was that the default (null) DACL of the named pipe did not allow ddagentuser to access the named pipe and queries with "datadogagent.exe -status" failed. 

Updates on top of the previous PR:
- The named pipe DACL now allows Everyone at the present, maintaining access parity with the previous open socket.
- HTTP clients for system probe have been refactored and split per OS to allow better tuning of connection parameters (e.g. idle connections).  The clients previously held up the named pipe connections for 30 seconds after being done, before finally closing them.
- The test utility override function now accepts a named pipe path and a DACL.  Once the production named pipe has a hardened DACL (future work), the tests need to override the DACL in order to run.
- Explicit logging of client named pipe connection failures. The root error is never propagated up for visibility. Without explicit logging, a lot of time is wasted searching for the failures.

----
Original description:

This PR replaces the Windows system probe socket endpoint on default port 3333 with a fixed named pipe \\.\pipe\dd_system_probe.
The API where the system probe listener was created was renamed from net.GetListener to net.GetSystemProbeListener for better readability and auditing.
As an effect of this change, the Flare tests and a few others tests have been adjusted.
Source code has been included that builds a simple named pipe client tool, that allows manual CLI communication with the system probe named pipe server.
The port config for system probe on Windows (system_probe_config.sysprobe_socket) will be no-opt and will still remain unchanged for other OS platforms.

### Motivation
See: https://docs.google.com/document/d/1EJJ899nfXwXBU76-f69S6XP5vp1-q2tb0hUHbDbCwfA/edit

### Describe how to test/QA your changes
CI
Manually use named pipe client tool to query system probe server endpoint.
Manually step through process agent code when pinging system probe endpoint.
Manually verified console output without debugger when process agent connects to system probe.
Manually ran "datadadogagent.exe -status" against a running datadog agent service.
aws-vault exec sso-agent-sandbox-account-admin -- inv new-e2e-tests.run --targets=./tests/process --run=TestWindowsTestSuite
aws-vault exec sso-agent-sandbox-account-admin -- inv -e pipeline.run --here

### Possible Drawbacks / Trade-offs
The named pipe allows access for everyone, which maintains parity with todays open socket and run-as user for datadogagent. A future task will harden the named pipe.
Since the named pipe path is fixed, it is possible for local experiments/tests to cause named pipe path collisions. As workaround, these local experiments should temporarily use a different named pipe path.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
System probe for Linux and other platforms retain the original socket based communication.
There has never been a single system-probe client implementation; there are multiple, spread through out the source.
The Linux system-probe client in cmd/system-probe/api/client cannot import pkg/process/net; it increases the dependency size and dogstatsd size test will fail.
