### PR TITLE
Avoid full copy of logs auditor map when possible

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -133,8 +133,7 @@ func (a *RegistryAuditor) Channel() chan *message.Payload {
 // GetOffset returns the last committed offset for a given identifier,
 // returns an empty string if it does not exist.
 func (a *RegistryAuditor) GetOffset(identifier string) string {
-	r := a.readOnlyRegistryCopy()
-	entry, exists := r[identifier]
+	entry, exists := a.readOnlyRegistryEntryCopy(identifier)
 	if !exists {
 		return ""
 	}
@@ -144,8 +143,7 @@ func (a *RegistryAuditor) GetOffset(identifier string) string {
 // GetTailingMode returns the last committed offset for a given identifier,
 // returns an empty string if it does not exist.
 func (a *RegistryAuditor) GetTailingMode(identifier string) string {
-	r := a.readOnlyRegistryCopy()
-	entry, exists := r[identifier]
+	entry, exists := a.readOnlyRegistryEntryCopy(identifier)
 	if !exists {
 		return ""
 	}
@@ -263,6 +261,16 @@ func (a *RegistryAuditor) readOnlyRegistryCopy() map[string]RegistryEntry {
 		r[path] = *entry
 	}
 	return r
+}
+
+func (a *RegistryAuditor) readOnlyRegistryEntryCopy(identifier string) (RegistryEntry, bool) {
+	a.registryMutex.Lock()
+	defer a.registryMutex.Unlock()
+	entry, exists := a.registry[identifier]
+	if !exists {
+		return RegistryEntry{}, false
+	}
+	return *entry, true
 }
 
 // flushRegistry writes on disk the registry at the given path


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Avoid making a full copy of the logs auditor map when a single entry is needed. 

### Motivation
Minimize memory usage and allocations.

I'm looking into a support case where a profile diff over 30 seconds shows ~12MB of memory allocated by `readOnlyRegistryCopy` called by `GetOffset` (most memory used in the diff).
Getting the entry directly should avoid that. 
![image](https://github.com/user-attachments/assets/0aca0648-a8bc-4f68-8d02-629e8f623072)


### Describe how to test/QA your changes
CI should catch any functional issue.
There should be no functional change.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->