### PR TITLE
[gitlab] run e2e tests on changes to flakes.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -796,6 +796,7 @@ workflow:
       paths:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
+        - flakes.yaml
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .on_e2e_or_windows_installer_changes:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Run all e2e tests when `flakes.yaml` changes

### Motivation

We recently broke `main` on an attempt to remove `TestECSSuite` from `flakes.yaml`, as the test did not run on the PR's CI and did not prevent its merge.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

This will force all tests to run on changes to `flakes.yaml`, even if we change something related to one single test. We might review this in the future, or drop support for `flakes.yaml` and have only flakes marking in tests.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->