### PR TITLE
retry omnibus code signing

### DIFF
--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -57,7 +57,6 @@ module Omnibus
         end.join(" ")
     
         status = shellout(cmd)
-        
         if status.exitstatus != 0
           log.warn(self.class.name) do
             <<-EOH.strip
@@ -72,20 +71,17 @@ module Omnibus
               #{status.stderr}
             EOH
           end
-    
-          # Retry logic: raise error after 3 attempts
-          if attempts < max_retries
-            log.info(self.class.name) { "Retrying signing #{file} (Attempt #{attempts + 1})" }
-            sleep(delay)
-            retry
-          else
-            raise "Failed to sign with dd-wcs after #{max_retries} attempts"
-          end
+          raise "Failed to sign with dd-wcs"
         else
           log.info(self.class.name) { "Successfully signed #{file} after #{attempts} attempt(s)" }
         end
       rescue => e
-        log.error(self.class.name) { "Error during signing: #{e.message}" }
+        # Retry logic: raise error after 3 attempts
+        if attempts < max_retries
+          log.info(self.class.name) { "Retrying signing #{file} (Attempt #{attempts + 1})" }
+          sleep(delay)
+          retry
+        end
         raise "Failed to sign with dd-wcs: #{e.message}"
       end
     end

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -82,7 +82,7 @@ module Omnibus
           sleep(delay)
           retry
         end
-        raise "Failed to sign with dd-wcs: #{e.message}"
+        raise "Failed to sign with dd-wcs"
       end
     end
 

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -42,7 +42,7 @@ module Omnibus
     def ddwcssign(file)
       log.info(self.class.name) { "Signing #{file}" }
 
-      # Signing is inherently flaky as the signing server may not be available
+      # Signing is inherently flaky as the timestamp server may not be available
       # retry a few times
       max_retries = 3
       attempts = 0

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -46,6 +46,7 @@ module Omnibus
       # retry a few times
       max_retries = 3
       attempts = 0
+      delay = 2
     
       begin
         attempts += 1
@@ -75,7 +76,7 @@ module Omnibus
           # Retry logic: raise error after 3 attempts
           if attempts < max_retries
             log.info(self.class.name) { "Retrying signing #{file} (Attempt #{attempts + 1})" }
-            sleep(2) # Add a small delay before retrying (optional)
+            sleep(delay)
             retry
           else
             raise "Failed to sign with dd-wcs after #{max_retries} attempts"

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -41,26 +41,51 @@ module Omnibus
 
     def ddwcssign(file)
       log.info(self.class.name) { "Signing #{file}" }
-      cmd = Array.new.tap do |arr|
+
+      # Signing is inherently flaky as the signing server may not be available
+      # retry a few times
+      max_retries = 3
+      attempts = 0
+    
+      begin
+        attempts += 1
+        cmd = Array.new.tap do |arr|
           arr << "dd-wcs"
           arr << "sign"
           arr << "\"#{file}\""
-      end.join(" ")
-      status = shellout(cmd)
-      if status.exitstatus != 0
-        log.warn(self.class.name) do
-        <<-EOH.strip
-          Failed to sign with dd-wcs
-
-          STDOUT
-          ------
-          #{status.stdout}
-
-          STDERR
-          ------
-          #{status.stderr}
-        EOH
+        end.join(" ")
+    
+        status = shellout(cmd)
+        
+        if status.exitstatus != 0
+          log.warn(self.class.name) do
+            <<-EOH.strip
+              Failed to sign with dd-wcs (Attempt #{attempts} of #{max_retries})
+    
+              STDOUT
+              ------
+              #{status.stdout}
+    
+              STDERR
+              ------
+              #{status.stderr}
+            EOH
+          end
+    
+          # Retry logic: raise error after 3 attempts
+          if attempts < max_retries
+            log.info(self.class.name) { "Retrying signing #{file} (Attempt #{attempts + 1})" }
+            sleep(2) # Add a small delay before retrying (optional)
+            retry
+          else
+            raise "Failed to sign with dd-wcs after #{max_retries} attempts"
+          end
+        else
+          log.info(self.class.name) { "Successfully signed #{file} after #{attempts} attempt(s)" }
         end
+      rescue => e
+        log.error(self.class.name) { "Error during signing: #{e.message}" }
+        raise "Failed to sign with dd-wcs: #{e.message}"
       end
     end
 

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -82,7 +82,7 @@ module Omnibus
           sleep(delay)
           retry
         end
-        raise "Failed to sign with dd-wcs"
+        raise "Failed to sign with dd-wcs: #{e.message}"
       end
     end
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add retry loop to code signing in omnibus build

If all retries fail, raise the error to fail the build and job.

### Motivation
signing can flake, for example if the timestamp server isn't responding

failure can be detected since https://github.com/DataDog/windows-code-signer/pull/21, so we can fail the build instead of failing later in the tests

### Describe how to test/QA your changes
N/A. build job should succeed and E2E tests should validate signing.

### Possible Drawbacks / Trade-offs
would be neat for `dd-wcs` to have a `--retry` option so we don't have to implement a retry loop everywhere we use it.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->