### PR TITLE
upgrade/downgrade Windows Agent via uninstall -> install

### DIFF
--- a/pkg/fleet/installer/service/msiexec.go
+++ b/pkg/fleet/installer/service/msiexec.go
@@ -10,6 +10,7 @@ package service
 import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"golang.org/x/sys/windows/registry"
 	"os/exec"
 	"path/filepath"
@@ -84,6 +85,7 @@ func processKey(rootPath, key, name string) (*Product, error) {
 // reflect the installed version, and using those installers can lead to undefined behavior (either failure to uninstall,
 // or weird bugs from uninstalling a product with an installer from a different version).
 func removeProduct(productName string) error {
+	log.Debugf("Removing product %s", productName)
 	product, err := findProductCode(productName)
 	if err != nil {
 		return fmt.Errorf("error trying to find product %s: %w", productName, err)
@@ -93,4 +95,12 @@ func removeProduct(productName string) error {
 		return cmd.Run()
 	}
 	return fmt.Errorf("product %s not found", productName)
+}
+
+func isProductInstalled(productName string) bool {
+	product, err := findProductCode(productName)
+	if err != nil {
+		return false
+	}
+	return product != nil
 }

--- a/tasks/winbuildscripts/Generate-OCIPackage.ps1
+++ b/tasks/winbuildscripts/Generate-OCIPackage.ps1
@@ -2,23 +2,19 @@ Param(
     [Parameter(Mandatory=$true,Position=0)]
     [ValidateSet("datadog-agent", "datadog-installer")]
     [String]
-    $package,
-    [Parameter(Mandatory=$false)]
-    [String]
-    $Version
+    $package
 )
 
-if (-not $Version) {
-    $Version = "{0}-1" -f (inv agent.version --url-safe --major-version 7)
-}
 $omnibusOutput = "$($Env:REPO_ROOT)\omnibus\pkg\"
 
 if (-not (Test-Path C:\tools\datadog-package.exe)) {
     Write-Host "Downloading datadog-package.exe"
     (New-Object System.Net.WebClient).DownloadFile("https://dd-agent-omnibus.s3.amazonaws.com/datadog-package.exe", "C:\\tools\\datadog-package.exe")
 }
+$rawAgentVersion = "{0}-1" -f (inv agent.version --url-safe --major-version 7)
+Write-Host "Detected agent version ${rawAgentVersion}"
 
-$packageName = "${package}-${Version}-windows-amd64.oci.tar"
+$packageName = "${package}-${rawAgentVersion}-windows-amd64.oci.tar"
 
 if (Test-Path $omnibusOutput\$packageName) {
     Remove-Item $omnibusOutput\$packageName
@@ -27,9 +23,9 @@ if (Test-Path $omnibusOutput\$packageName) {
 # datadog-package takes a folder as input and will package everything in that, so copy the msi to its own folder
 Remove-Item -Recurse -Force C:\oci-pkg -ErrorAction SilentlyContinue
 New-Item -ItemType Directory C:\oci-pkg
-Copy-Item (Get-ChildItem $omnibusOutput\${package}-${Version}-x86_64.msi).FullName -Destination C:\oci-pkg\${package}-${Version}-x86_64.msi
+Copy-Item (Get-ChildItem $omnibusOutput\${package}-${rawAgentVersion}-x86_64.msi).FullName -Destination C:\oci-pkg\${package}-${rawAgentVersion}-x86_64.msi
 
 # The argument --archive-path ".\omnibus\pkg\datadog-agent-${version}.tar.gz" is currently broken and has no effects
-& C:\tools\datadog-package.exe create --package $package --os windows --arch amd64 --archive --version $Version C:\oci-pkg
+& C:\tools\datadog-package.exe create --package $package --os windows --arch amd64 --archive --version $rawAgentVersion C:\oci-pkg
 
-Move-Item ${package}-${Version}-windows-amd64.tar $omnibusOutput\$packageName
+Move-Item ${package}-${rawAgentVersion}-windows-amd64.tar $omnibusOutput\$packageName

--- a/tasks/winbuildscripts/Generate-OCIPackage.ps1
+++ b/tasks/winbuildscripts/Generate-OCIPackage.ps1
@@ -2,19 +2,23 @@ Param(
     [Parameter(Mandatory=$true,Position=0)]
     [ValidateSet("datadog-agent", "datadog-installer")]
     [String]
-    $package
+    $package,
+    [Parameter(Mandatory=$false)]
+    [String]
+    $Version
 )
 
+if (-not $Version) {
+    $Version = "{0}-1" -f (inv agent.version --url-safe --major-version 7)
+}
 $omnibusOutput = "$($Env:REPO_ROOT)\omnibus\pkg\"
 
 if (-not (Test-Path C:\tools\datadog-package.exe)) {
     Write-Host "Downloading datadog-package.exe"
     (New-Object System.Net.WebClient).DownloadFile("https://dd-agent-omnibus.s3.amazonaws.com/datadog-package.exe", "C:\\tools\\datadog-package.exe")
 }
-$rawAgentVersion = "{0}-1" -f (inv agent.version --url-safe --major-version 7)
-Write-Host "Detected agent version ${rawAgentVersion}"
 
-$packageName = "${package}-${rawAgentVersion}-windows-amd64.oci.tar"
+$packageName = "${package}-${Version}-windows-amd64.oci.tar"
 
 if (Test-Path $omnibusOutput\$packageName) {
     Remove-Item $omnibusOutput\$packageName
@@ -23,9 +27,9 @@ if (Test-Path $omnibusOutput\$packageName) {
 # datadog-package takes a folder as input and will package everything in that, so copy the msi to its own folder
 Remove-Item -Recurse -Force C:\oci-pkg -ErrorAction SilentlyContinue
 New-Item -ItemType Directory C:\oci-pkg
-Copy-Item (Get-ChildItem $omnibusOutput\${package}-${rawAgentVersion}-x86_64.msi).FullName -Destination C:\oci-pkg\${package}-${rawAgentVersion}-x86_64.msi
+Copy-Item (Get-ChildItem $omnibusOutput\${package}-${Version}-x86_64.msi).FullName -Destination C:\oci-pkg\${package}-${Version}-x86_64.msi
 
 # The argument --archive-path ".\omnibus\pkg\datadog-agent-${version}.tar.gz" is currently broken and has no effects
-& C:\tools\datadog-package.exe create --package $package --os windows --arch amd64 --archive --version $rawAgentVersion C:\oci-pkg
+& C:\tools\datadog-package.exe create --package $package --os windows --arch amd64 --archive --version $Version C:\oci-pkg
 
-Move-Item ${package}-${rawAgentVersion}-windows-amd64.tar $omnibusOutput\$packageName
+Move-Item ${package}-${Version}-windows-amd64.tar $omnibusOutput\$packageName


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
When starting/stopping Fleet Automation experiments for the Agent package on Windows, change version by uninstalling the current version, then installing the next version.

### Motivation
support downgrade scenarios
- start experiment to downgrade Agent version
- stop experiment must "rollback" to lower Agent version

https://datadoghq.atlassian.net/browse/WINA-998

### Describe how to test/QA your changes
N/A, has E2E tests for upgrade+stop experiment and downgrade/start-experiment

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
no changelog, unreleased feature