### PR TITLE
[PROCS-4304] Add `process_config.run_in_core_agent` to config template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1492,7 +1492,7 @@ api_key:
     ## @param enabled - boolean - optional - default: false
     ## Enables process/container collection on the core Agent instead of the process Agent.
     # enabled: false
-  {{ end -}}
+  {{ end }}
 
   ## @param process_collection - custom object - optional
   ## Specifies settings for collecting processes.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1485,12 +1485,14 @@ api_key:
 #
 # process_config:
 
+  {{- if (eq .OS "linux")}}
   ## @param run_in_core_agent - custom object - optional
-  ## Specifies which agent collects process and/or container information.
+  ## Specifies which agent collects process and/or container information (Linux only).
   # run_in_core_agent:
     ## @param enabled - boolean - optional - default: false
     ## Enables process/container collection on the core agent instead of the process agent.
     # enabled: false
+  {{ end -}}
 
   ## @param process_collection - custom object - optional
   ## Specifies settings for collecting processes.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1485,6 +1485,13 @@ api_key:
 #
 # process_config:
 
+  ## @param run_in_core_agent - custom object - optional
+  ## Specifies which agent collects process and/or container information.
+  # run_in_core_agent:
+    ## @param enabled - boolean - optional - default: false
+    ## Enables process/container collection on the core agent instead of the process agent.
+    # enabled: false
+
   ## @param process_collection - custom object - optional
   ## Specifies settings for collecting processes.
   # process_collection:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1487,10 +1487,10 @@ api_key:
 
   {{- if (eq .OS "linux")}}
   ## @param run_in_core_agent - custom object - optional
-  ## Specifies which agent collects process and/or container information (Linux only).
+  ## Controls whether the process Agent or core Agent collects process and/or container information (Linux only).
   # run_in_core_agent:
     ## @param enabled - boolean - optional - default: false
-    ## Enables process/container collection on the core agent instead of the process agent.
+    ## Enables process/container collection on the core Agent instead of the process Agent.
     # enabled: false
   {{ end -}}
 

--- a/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
+++ b/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Add ability to run process/container collection on the core agent. This is controlled
+    Add ability to run process/container collection on the core agent (Linux only). This is controlled
     by the `process_config.run_in_core_agent.enabled` config in datadog.yaml.

--- a/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
+++ b/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Add ability to run process/container collection on the core agent (Linux only). This is controlled
-    by the `process_config.run_in_core_agent.enabled` config in datadog.yaml.
+    Add ability to run process/container collection on the core Agent (Linux only). This is controlled
+    by the `process_config.run_in_core_agent.enabled` option in datadog.yaml.

--- a/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
+++ b/releasenotes/notes/add-run-in-core-agent-to-template-e6c2c3134d2fb17d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add ability to run process/container collection on the core agent. This is controlled
+    by the `process_config.run_in_core_agent.enabled` config in datadog.yaml.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds `process_config.run_in_core_agent` to the config template. Support for the underlying feature has been added in previous releases.

### Motivation
PROCS-4304

### Describe how to test/QA your changes
Validated through fresh agent install that the template appears correctly.
Linux:
```
$ cat /etc/datadog-agent/datadog.yaml.example
######################################
## Process Collection Configuration ##
######################################

## @param process_config - custom object - optional
## Enter specific configurations for your Process data collection.
## Uncomment this parameter and the one below to enable them.
## See https://docs.datadoghq.com/graphing/infrastructure/process/
#
# process_config:
  ## @param run_in_core_agent - custom object - optional
  ## Controls whether the process Agent or core Agent collects process and/or container information (Linux only).
  # run_in_core_agent:
    ## @param enabled - boolean - optional - default: false
    ## Enables process/container collection on the core Agent instead of the process Agent.
    # enabled: false
```
Windows
```
$ vim C:\ProgramData\Datadog\datadog.yaml.example
######################################
## Process Collection Configuration ##
######################################

## @param process_config - custom object - optional
## Enter specific configurations for your Process data collection.
## Uncomment this parameter and the one below to enable them.
## See https://docs.datadoghq.com/graphing/infrastructure/process/
#
# process_config:

  ## @param process_collection - custom object - optional
  ## Specifies settings for collecting processes.
  # process_collection:
    ## @param enabled - boolean - optional - default: false
    ## Enables collection of information about running processes.
    # enabled: false
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->