### PR TITLE
[CI] Remove the macOS Github Actions linter job

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -30,24 +30,6 @@ tests_macos:
     reports:
       junit: "**/junit-out-*.xml"
 
-lint_macos:
-  stage: source_test
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["setup_agent_version"]
-  variables:
-    PYTHON_RUNTIMES: "3"
-  timeout: 6h
-  script:
-    - !reference [.setup_macos_github_app]
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
-    - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
-    - python3 -m pip install -r tasks/libs/requirements-github.txt
-    - inv -e github.trigger-macos --workflow-type "lint" --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
-
 .macos_gitlab:
   variables:
     PYTHON_RUNTIMES: "3"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the macOS GHA job.

### Motivation

- We're getting rate-limited by Github when running lint, tests and build jobs with the current Github plan.
- The lint job already runs on the new macOS Gitlab runners, so we can replace the GHA one.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->