### PR TITLE
(fleet) part 1 - add setup command

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -51,7 +51,7 @@ func Commands(_ *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{
 		bootstrapCommand(),
 		installCommand(),
-		installDefaultCommand(),
+		setupCommand(),
 		removeCommand(),
 		installExperimentCommand(),
 		removeExperimentCommand(),
@@ -217,14 +217,14 @@ func bootstrapCommand() *cobra.Command {
 	return cmd
 }
 
-func installDefaultCommand() *cobra.Command {
+func setupCommand() *cobra.Command {
 	var timeout time.Duration
 	cmd := &cobra.Command{
-		Use:     "install-default",
+		Use:     "setup",
 		Hidden:  true,
 		GroupID: "installer",
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
-			b := newBootstraperCmd("install-default")
+			b := newBootstraperCmd("setup")
 			defer func() { b.Stop(err) }()
 			ctx, cancel := context.WithTimeout(b.ctx, timeout)
 			defer cancel()

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -51,6 +51,7 @@ func Commands(_ *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{
 		bootstrapCommand(),
 		installCommand(),
+		installDefaultCommand(),
 		removeCommand(),
 		installExperimentCommand(),
 		removeExperimentCommand(),
@@ -210,6 +211,24 @@ func bootstrapCommand() *cobra.Command {
 			ctx, cancel := context.WithTimeout(b.ctx, timeout)
 			defer cancel()
 			return bootstraper.Bootstrap(ctx, b.env)
+		},
+	}
+	cmd.Flags().DurationVarP(&timeout, "timeout", "T", 3*time.Minute, "timeout to bootstrap with")
+	return cmd
+}
+
+func installDefaultCommand() *cobra.Command {
+	var timeout time.Duration
+	cmd := &cobra.Command{
+		Use:     "install-default",
+		Short:   "Install and setup the default packages.",
+		GroupID: "installer",
+		RunE: func(_ *cobra.Command, _ []string) (err error) {
+			b := newBootstraperCmd("install-default")
+			defer func() { b.Stop(err) }()
+			ctx, cancel := context.WithTimeout(b.ctx, timeout)
+			defer cancel()
+			return bootstraper.InstallDefaultPackages(ctx, b.env)
 		},
 	}
 	cmd.Flags().DurationVarP(&timeout, "timeout", "T", 3*time.Minute, "timeout to bootstrap with")

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -221,7 +221,7 @@ func installDefaultCommand() *cobra.Command {
 	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:     "install-default",
-		Short:   "Install and setup the default packages.",
+		Hidden:  true,
 		GroupID: "installer",
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			b := newBootstraperCmd("install-default")

--- a/pkg/fleet/bootstraper/bootstraper.go
+++ b/pkg/fleet/bootstraper/bootstraper.go
@@ -32,7 +32,11 @@ func Bootstrap(ctx context.Context, env *env.Env) error {
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap the installer: %w", err)
 	}
+	return InstallDefaultPackages(ctx, env)
+}
 
+// InstallDefaultPackages installs the default packages.
+func InstallDefaultPackages(ctx context.Context, env *env.Env) error {
 	cmd := exec.NewInstallerExec(env, exec.StableInstallerPath)
 	defaultPackages, err := cmd.DefaultPackages(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently the bootstrapper has to run multiple commands on the installer to run the default setup.

This PR aims to ease this constraint by making the bootstrapper just install the installer + execute a single command on it. 

**Plan**
To avoid the risk of an incompatible bootstrapper & installer in the wild, 2 PRs + releases will be needed
1. release new command on the installer
2. re-release with the bootstrapper using this command