### PR TITLE
Return success from `RemoveAgent` when the Agent MSI/Product is not installed

### DIFF
--- a/pkg/fleet/installer/service/datadog_agent_windows.go
+++ b/pkg/fleet/installer/service/datadog_agent_windows.go
@@ -100,7 +100,10 @@ func RemoveAgent(ctx context.Context) (err error) {
 		}
 		span.Finish(tracer.WithError(err))
 	}()
-	err = removeProduct("Datadog Agent")
+	// Don't return an error if the Agent is already not installed.
+	// returning an error here will prevent the package from being removed
+	// from the local repository.
+	err = removeAgentIfInstalled(ctx)
 	return err
 }
 

--- a/pkg/fleet/installer/service/datadog_agent_windows.go
+++ b/pkg/fleet/installer/service/datadog_agent_windows.go
@@ -31,7 +31,7 @@ func SetupAgent(ctx context.Context, args []string) (err error) {
 		span.Finish(tracer.WithError(err))
 	}()
 	// Make sure there are no Agent already installed
-	_ = removeProduct("Datadog Agent")
+	_ = removeAgentIfInstalled(ctx)
 	err = installAgentPackage("stable", args)
 	return err
 }
@@ -91,20 +91,10 @@ func PromoteAgentExperiment(_ context.Context) error {
 
 // RemoveAgent stops and removes the agent
 func RemoveAgent(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_agent")
-	defer func() {
-		if err != nil {
-			// removal failed, this should rarely happen.
-			// Rollback might have restored the Agent, but we can't be sure.
-			log.Errorf("Failed to remove agent: %s", err)
-		}
-		span.Finish(tracer.WithError(err))
-	}()
 	// Don't return an error if the Agent is already not installed.
 	// returning an error here will prevent the package from being removed
 	// from the local repository.
-	err = removeAgentIfInstalled(ctx)
-	return err
+	return removeAgentIfInstalled(ctx)
 }
 
 // ConfigureAgent noop
@@ -121,9 +111,18 @@ func installAgentPackage(target string, args []string) error {
 	return nil
 }
 
-func removeAgentIfInstalled(ctx context.Context) error {
+func removeAgentIfInstalled(ctx context.Context) (err error) {
 	if isProductInstalled("Datadog Agent") {
-		err := RemoveAgent(ctx)
+		span, _ := tracer.StartSpanFromContext(ctx, "remove_agent")
+		defer func() {
+			if err != nil {
+				// removal failed, this should rarely happen.
+				// Rollback might have restored the Agent, but we can't be sure.
+				log.Errorf("Failed to remove agent: %s", err)
+			}
+			span.Finish(tracer.WithError(err))
+		}()
+		err := removeProduct("Datadog Agent")
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -61,6 +61,7 @@ type BaseInstallerSuite struct {
 	currentAgentVersion    agentVersion.Version
 	stableInstallerVersion PackageVersion
 	stableAgentVersion     PackageVersion
+	outputDir              string
 }
 
 // Installer the Datadog Installer for testing.
@@ -115,10 +116,11 @@ func (s *BaseInstallerSuite) SetupSuite() {
 func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
 
-	outputDir, err := runner.GetTestOutputDir(runner.GetProfile(), s.T())
+	var err error
+	s.outputDir, err = runner.GetTestOutputDir(runner.GetProfile(), s.T())
 	s.Require().NoError(err, "should get output dir")
-	s.T().Logf("Output dir: %s", outputDir)
-	s.installer = NewDatadogInstaller(s.Env(), outputDir)
+	s.T().Logf("Output dir: %s", s.outputDir)
+	s.installer = NewDatadogInstaller(s.Env(), s.outputDir)
 }
 
 // Require instantiates a suiteAssertions for the current suite.
@@ -131,4 +133,8 @@ func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 // on the Windows Datadog installer `BaseInstallerSuite` object.
 func (s *BaseInstallerSuite) Require() *suiteasserts.SuiteAssertions {
 	return suiteasserts.New(s.BaseSuite.Require(), s)
+}
+
+func (s *BaseInstallerSuite) OutputDir() string {
+	return s.outputDir
 }

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -135,6 +135,7 @@ func (s *BaseInstallerSuite) Require() *suiteasserts.SuiteAssertions {
 	return suiteasserts.New(s.BaseSuite.Require(), s)
 }
 
+// OutputDir returns the output directory for the test
 func (s *BaseInstallerSuite) OutputDir() string {
 	return s.outputDir
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Return success from `RemoveAgent` when the Agent MSI/Product is not installed.

### Motivation
It was preventing `installer remove datadog-agent` from removing the Agent package from the repository. And `installer install datadog-agent` would fail since its "already installed".

### Describe how to test/QA your changes
N/A, E2E test installs the agent package, removes with the MSI, then removes the agent package

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`installer remove datadog-agent` will still throw an error if the Agent package is not in the repository

no changelog, unreleased feature