### PR TITLE
[CI] Add the `go deps` cache to `lint_macos_gitlab*` and `tests_macos_gitlab*`

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -4,7 +4,6 @@
 # to reuse them in further jobs that need them.
 
 .retrieve_linux_go_deps:
-  - echo $GOPATH/pkg/mod/cache
   - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache.tar.xz
 
@@ -47,7 +46,7 @@ go_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - modcache.tar.xz
+      - $CI_PROJECT_DIR/modcache.tar.xz
   cache:
     # The `cache:key:files` only accepts up to two path ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
     # Ideally, we should also include the https://github.com/DataDog/datadog-agent/blob/main/.custom-gcl.yml file to
@@ -60,7 +59,7 @@ go_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_deps_modcache"
       paths:
-        - modcache.tar.xz
+        - $CI_PROJECT_DIR/modcache.tar.xz
 
 go_tools_deps:
   extends: .cache
@@ -71,7 +70,7 @@ go_tools_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - modcache_tools.tar.xz
+      - $CI_PROJECT_DIR/modcache_tools.tar.xz
   cache:
     - key:
         files:
@@ -79,7 +78,7 @@ go_tools_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_tools_deps_modcache"
       paths:
-        - modcache_tools.tar.xz
+        - $CI_PROJECT_DIR/modcache_tools.tar.xz
 
 go_e2e_deps:
   extends: .cache
@@ -90,7 +89,7 @@ go_e2e_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - modcache_e2e.tar.xz
+      - $CI_PROJECT_DIR/modcache_e2e.tar.xz
   cache:
     - key:
         files:
@@ -98,4 +97,4 @@ go_e2e_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_e2e_deps_modcache"
       paths:
-        - modcache_e2e.tar.xz
+        - $CI_PROJECT_DIR/modcache_e2e.tar.xz

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -59,7 +59,7 @@ go_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_deps_modcache"
       paths:
-        - $CI_PROJECT_DIR/modcache.tar.xz
+        - modcache.tar.xz
 
 go_tools_deps:
   extends: .cache
@@ -78,7 +78,7 @@ go_tools_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_tools_deps_modcache"
       paths:
-        - $CI_PROJECT_DIR/modcache_tools.tar.xz
+        - modcache_tools.tar.xz
 
 go_e2e_deps:
   extends: .cache
@@ -97,4 +97,4 @@ go_e2e_deps:
           - .gitlab/deps_fetch/deps_fetch.yml
         prefix: "go_e2e_deps_modcache"
       paths:
-        - $CI_PROJECT_DIR/modcache_e2e.tar.xz
+        - modcache_e2e.tar.xz

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -40,7 +40,6 @@ go_deps:
   script:
     # If the cache already contains the dependencies, don't redownload them
     # but still provide the artifact that's expected for the other jobs to run
-    - echo $CI_PROJECT_DIR/modcache.tar.xz
     - if [ -f modcache.tar.xz  ]; then exit 0; fi
     - inv -e deps --verbose
     - inv -e install-tools
@@ -48,7 +47,7 @@ go_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache.tar.xz
+      - modcache.tar.xz
   cache:
     # The `cache:key:files` only accepts up to two path ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
     # Ideally, we should also include the https://github.com/DataDog/datadog-agent/blob/main/.custom-gcl.yml file to
@@ -72,7 +71,7 @@ go_tools_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache_tools.tar.xz
+      - modcache_tools.tar.xz
   cache:
     - key:
         files:
@@ -91,7 +90,7 @@ go_e2e_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache_e2e.tar.xz
+      - modcache_e2e.tar.xz
   cache:
     - key:
         files:

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -40,6 +40,7 @@ go_deps:
   script:
     # If the cache already contains the dependencies, don't redownload them
     # but still provide the artifact that's expected for the other jobs to run
+    - echo $CI_PROJECT_DIR/modcache.tar.xz
     - if [ -f modcache.tar.xz  ]; then exit 0; fi
     - inv -e deps --verbose
     - inv -e install-tools

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -4,6 +4,7 @@
 # to reuse them in further jobs that need them.
 
 .retrieve_linux_go_deps:
+  - echo $GOPATH/pkg/mod/cache
   - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache.tar.xz
 

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -86,6 +86,7 @@ lint_macos:
   extends: .macos_gitlab
   needs: ["go_deps", "go_tools_deps"]
   script:
+    - echo $GOPATH
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e linter.go --cpus 12 --timeout 60
@@ -100,6 +101,7 @@ lint_macos:
   variables:
     TEST_OUTPUT_FILE: test_output.json
   script:
+    - echo $GOPATH
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -84,7 +84,7 @@ lint_macos:
   stage: source_test
   allow_failure: true
   extends: .macos_gitlab
-  needs: ["setup_agent_version"]
+  needs: ["go_deps", "go_tools_deps"]
   script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
@@ -96,10 +96,12 @@ lint_macos:
   rules:
     !reference [.manual]
   extends: .macos_gitlab
-  needs: ["setup_agent_version"]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     TEST_OUTPUT_FILE: test_output.json
   script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -86,6 +86,8 @@ lint_macos:
   extends: .macos_gitlab
   needs: ["setup_agent_version"]
   script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - inv -e linter.go --cpus 12 --timeout 60
 
 .tests_macos_gitlab:

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -86,7 +86,6 @@ lint_macos:
   extends: .macos_gitlab
   needs: ["go_deps", "go_tools_deps"]
   script:
-    - echo $GOPATH
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e linter.go --cpus 12 --timeout 60
@@ -101,8 +100,6 @@ lint_macos:
   variables:
     TEST_OUTPUT_FILE: test_output.json
   script:
-    - echo $GOPATH
-    - echo $CI_PROJECT_DIR/modcache.tar.xz
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -77,8 +77,6 @@ lint_macos:
     - pyenv rehash
     - inv -e rtloader.make --python-runtimes $PYTHON_RUNTIMES
     - inv -e rtloader.install
-    - inv -e install-tools
-    - inv -e deps
 
 .lint_macos_gitlab:
   stage: source_test

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -102,6 +102,7 @@ lint_macos:
     TEST_OUTPUT_FILE: test_output.json
   script:
     - echo $GOPATH
+    - echo $CI_PROJECT_DIR/modcache.tar.xz
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR uses the `go deps` cache for the `lint_macos_gitlab*` and `tests_macos_gitlab*` jobs.

### Motivation

- Avoid having network error in the jobs
- Save CI Time

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-420

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->