### PR TITLE
Fix ssh key in configmap for GCP

### DIFF
--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -12,6 +12,7 @@ import (
 	commonconfig "github.com/DataDog/test-infra-definitions/common/config"
 	infraaws "github.com/DataDog/test-infra-definitions/resources/aws"
 	infraazure "github.com/DataDog/test-infra-definitions/resources/azure"
+	infragcp "github.com/DataDog/test-infra-definitions/resources/gcp"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 
@@ -49,6 +50,13 @@ const (
 	AzurePrivateKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infraazure.DDInfraDefaultPrivateKeyPath
 	// AzurePrivateKeyPassword pulumi config paramater name
 	AzurePrivateKeyPassword = commonconfig.DDInfraConfigNamespace + ":" + infraazure.DDInfraDefaultPrivateKeyPassword
+
+	// GCPPublicKeyPath pulumi config paramater name
+	GCPPublicKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infragcp.DDInfraDefaultPublicKeyPath
+	// GCPPrivateKeyPath pulumi config paramater name
+	GCPPrivateKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infragcp.DDInfraDefaultPrivateKeyPath
+	// GCPPrivateKeyPassword pulumi config paramater name
+	GCPPrivateKeyPassword = commonconfig.DDInfraConfigNamespace + ":" + infragcp.DDInfraDefaultPrivateKeyPassword
 )
 
 // ConfigMap type alias to auto.ConfigMap
@@ -111,8 +119,8 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	cm.Set(InfraEnvironmentVariables, profile.EnvironmentNames(), false)
 	params := map[parameters.StoreKey][]string{
 		parameters.KeyPairName:        {AWSKeyPairName},
-		parameters.PublicKeyPath:      {AWSPublicKeyPath, AzurePublicKeyPath},
-		parameters.PrivateKeyPath:     {AWSPrivateKeyPath, AzurePrivateKeyPath},
+		parameters.PublicKeyPath:      {AWSPublicKeyPath, AzurePublicKeyPath, GCPPublicKeyPath},
+		parameters.PrivateKeyPath:     {AWSPrivateKeyPath, AzurePrivateKeyPath, GCPPrivateKeyPath},
 		parameters.ExtraResourcesTags: {InfraExtraResourcesTags},
 		parameters.PipelineID:         {AgentPipelineID},
 		parameters.CommitSHA:          {AgentCommitSHA},
@@ -132,7 +140,7 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	secretParams := map[parameters.StoreKey][]string{
 		parameters.APIKey:             {AgentAPIKey},
 		parameters.APPKey:             {AgentAPPKey},
-		parameters.PrivateKeyPassword: {AWSPrivateKeyPassword, AzurePrivateKeyPassword},
+		parameters.PrivateKeyPassword: {AWSPrivateKeyPassword, AzurePrivateKeyPassword, GCPPrivateKeyPassword},
 	}
 
 	for storeKey, configMapKeys := range secretParams {

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -42,6 +42,9 @@ func Test_BuildStackParameters(t *testing.T) {
 		"ddinfra:az/defaultPublicKeyPath":       auto.ConfigValue{Value: "public_key_path", Secret: false},
 		"ddinfra:az/defaultPrivateKeyPath":      auto.ConfigValue{Value: "private_key_path", Secret: false},
 		"ddinfra:az/defaultPrivateKeyPassword":  auto.ConfigValue{Value: "private_key_password", Secret: true},
+		"ddinfra:gcp/defaultPublicKeyPath":      auto.ConfigValue{Value: "public_key_path", Secret: false},
+		"ddinfra:gcp/defaultPrivateKeyPath":     auto.ConfigValue{Value: "private_key_path", Secret: false},
+		"ddinfra:gcp/defaultPrivateKeyPassword": auto.ConfigValue{Value: "private_key_password", Secret: true},
 		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 		"ddagent:commit_sha":                    auto.ConfigValue{Value: "commit_sha", Secret: false},
 	}, configMap)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix GCP e2e tests by passing ssh key information in the configmap

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

I do not like the current local behavior, because we can only retrieve the ssh information that we have in the `aws` section and we use them to run tests on Azure and GCP which is not what should be expected by the user. I will work on a follow-up PR to refactor that

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->