### PR TITLE
Make sure we do not create flake finder if e2e tests are disabled

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -480,6 +480,7 @@ generate-flakes-finder-pipeline:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: e2e
   rules:
+    - !reference [.except_disable_e2e_tests]
     - !reference [.on_deploy_nightly_repo_branch]
     - !reference [.manual]
   needs:
@@ -509,6 +510,7 @@ trigger-flakes-finder:
   stage: e2e
   needs: [generate-flakes-finder-pipeline]
   rules:
+    - !reference [.except_disable_e2e_tests]
     - !reference [.on_deploy_nightly_repo_branch]
     - !reference [.manual]
   variables:

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -764,7 +764,7 @@ def generate_gitlab_full_configuration(
 
     # Override some variables with a dedicated context
     if context:
-        full_configuration['variables'] = full_configuration.get('variables', {}).update(context)
+        full_configuration.get('variables', {}).update(context)
     if compare_to:
         for value in full_configuration.values():
             if (
@@ -896,6 +896,15 @@ def get_preset_contexts(required_tests):
         ("CI_PIPELINE_SOURCE", ["pipeline"]),  # ["trigger", "pipeline", "schedule"]
         ("DDR_WORKFLOW_ID", ["true"]),
     ]
+    integrations_core_contexts = [
+        ("RELEASE_VERSION_6", ["nightly"]),
+        ("RELEASE_VERSION_7", ["nightly-a7"]),
+        ("BUCKET_BRANCH", ["dev"]),
+        ("DEPLOY_AGENT", ["false"]),
+        ("INTEGRATIONS_CORE_VERSION", ["foo/bar"]),
+        ("RUN_KITCHEN_TESTS", ["false"]),
+        ("RUN_E2E_TESTS", ["off"]),
+    ]
     all_contexts = []
     for test in required_tests:
         if test in ["all", "main"]:
@@ -906,6 +915,8 @@ def get_preset_contexts(required_tests):
             generate_contexts(mq_contexts, [], all_contexts)
         if test in ["all", "conductor"]:
             generate_contexts(conductor_contexts, [], all_contexts)
+        if test in ["all", "ntegrations"]:
+            generate_contexts(integrations_core_contexts, [], all_contexts)
     return all_contexts
 
 

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -915,7 +915,7 @@ def get_preset_contexts(required_tests):
             generate_contexts(mq_contexts, [], all_contexts)
         if test in ["all", "conductor"]:
             generate_contexts(conductor_contexts, [], all_contexts)
-        if test in ["all", "ntegrations"]:
+        if test in ["all", "integrations"]:
             generate_contexts(integrations_core_contexts, [], all_contexts)
     return all_contexts
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Disable flake finder pipeline when e2e tests are disabled. Otherwise the pipeline can end in a [weird](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/45200140) state because some jobs are not generated when the e2e tests are disabled.
As such adds a new configuration test case to the `linter.gitlab-ci` task with the appropriate fix.

### Motivation
Do not fail to generate the pipeline when [called from](https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/652438972) `integrations-core`

### Describe how to test/QA your changes
1. Pushed the new test case on a dedicated branch and validate the test is [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/652744510)
2. Cherry-picked this test on current branch and validated [it passes](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/652754507)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->