### PR TITLE
[ASCII-2054] Adding check presence of Agent check's metadata in datadog-agent status command output

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/status/fixtures/custom_check.py
+++ b/test/new-e2e/tests/agent-subcommands/status/fixtures/custom_check.py
@@ -1,0 +1,6 @@
+from checks import AgentCheck
+
+
+class HelloCheck(AgentCheck):
+    def check(self, instance):
+        self.set_metadata('custom_metadata_key', 'custom_metadata_value')

--- a/test/new-e2e/tests/agent-subcommands/status/fixtures/custom_check.yaml
+++ b/test/new-e2e/tests/agent-subcommands/status/fixtures/custom_check.yaml
@@ -1,0 +1,3 @@
+init_config:
+instances:
+  [{}]

--- a/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
@@ -107,16 +107,6 @@ func (v *baseStatusSuite) TestDefaultInstallStatus() {
 			shouldBePresent: false,
 		},
 		{
-			name:            "Collector",
-			shouldBePresent: true,
-			shouldContain: []string{"Instance ID:", "[OK]",
-				// Following lines check the presence of checks metadata
-				"metadata:",
-				"custom_metadata_key: custom_metadata_value",
-			},
-			shouldNotContain: []string{"Errors"},
-		},
-		{
 			name:            "Compliance",
 			shouldBePresent: false,
 		},

--- a/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
@@ -6,6 +6,7 @@
 package status
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 	"time"
@@ -16,6 +17,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+//go:embed fixtures/custom_check.yaml
+var customCheckYaml []byte
+
+//go:embed fixtures/custom_check.py
+var customCheckPython []byte
 
 type baseStatusSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -100,9 +107,13 @@ func (v *baseStatusSuite) TestDefaultInstallStatus() {
 			shouldBePresent: false,
 		},
 		{
-			name:             "Collector",
-			shouldBePresent:  true,
-			shouldContain:    []string{"Instance ID:", "[OK]"},
+			name:            "Collector",
+			shouldBePresent: true,
+			shouldContain: []string{"Instance ID:", "[OK]",
+				// Following lines check the presence of checks metadata
+				"metadata:",
+				"custom_metadata_key: custom_metadata_value",
+			},
 			shouldNotContain: []string{"Errors"},
 		},
 		{

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -22,7 +22,10 @@ type linuxStatusSuite struct {
 
 func TestLinuxStatusSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
+	e2e.Run(t, &linuxStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(
+		agentparams.WithFile("/etc/datadog-agent/conf.d/custom_check.yaml", string(customCheckYaml), true),
+		agentparams.WithFile("/etc/datadog-agent/checks.d/custom_check.py", string(customCheckPython), true),
+	))))
 }
 
 func (v *linuxStatusSuite) TestStatusHostname() {

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -29,27 +29,29 @@ func (v *linuxStatusSuite) TestStatusHostname() {
 	metadata := client.NewEC2Metadata(v.T(), v.Env().RemoteHost.Host, v.Env().RemoteHost.OSFamily)
 	resourceID := metadata.Get("instance-id")
 
-	status := v.Env().Agent.Client.Status()
-
-	expected := expectedSection{
-		name:            `Hostname`,
-		shouldBePresent: true,
-		shouldContain:   []string{fmt.Sprintf("hostname: %v", resourceID), "hostname provider: aws"},
+	expectedSections := []expectedSection{
+		{
+			name:            `Hostname`,
+			shouldBePresent: true,
+			shouldContain:   []string{fmt.Sprintf("hostname: %v", resourceID), "hostname provider: aws"},
+		},
 	}
 
-	verifySectionContent(v.T(), status.Content, expected)
+	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }
 
 func (v *linuxStatusSuite) TestFIPSProxyStatus() {
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig("fips.enabled: true"))))
 
-	expectedSection := expectedSection{
-		name:            `Agent \(.*\)`,
-		shouldBePresent: true,
-		shouldContain:   []string{"FIPS proxy"},
+	expectedSections := []expectedSection{
+		{
+			name:            `Agent \(.*\)`,
+			shouldBePresent: true,
+			shouldContain:   []string{"FIPS proxy"},
+		},
 	}
-	status := v.Env().Agent.Client.Status()
-	verifySectionContent(v.T(), status.Content, expectedSection)
+
+	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }
 
 // This test asserts the presence of metadata sent by Python checks in the status subcommand output.
@@ -59,15 +61,16 @@ func (v *linuxStatusSuite) TestChecksMetadataUnix() {
 		agentparams.WithFile("/etc/datadog-agent/checks.d/custom_check.py", string(customCheckPython), true),
 	)))
 
-	section := expectedSection{
-		name:            "Collector",
-		shouldBePresent: true,
-		shouldContain: []string{"Instance ID:", "[OK]",
-			"metadata:",
-			"custom_metadata_key: custom_metadata_value",
+	expectedSections := []expectedSection{
+		{
+			name:            "Collector",
+			shouldBePresent: true,
+			shouldContain: []string{"Instance ID:", "[OK]",
+				"metadata:",
+				"custom_metadata_key: custom_metadata_value",
+			},
 		},
 	}
 
-	status := v.Env().Agent.Client.Status()
-	verifySectionContent(v.T(), status.Content, section)
+	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -24,11 +24,7 @@ type windowsStatusSuite struct {
 
 func TestWindowsStatusSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &windowsStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
-		awshost.WithAgentOptions(
-			agentparams.WithFile("C:/ProgramData/Datadog/conf.d/custom_check.d/conf.yaml", string(customCheckYaml), true),
-			agentparams.WithFile("C:/ProgramData/Datadog/checks.d/custom_check.py", string(customCheckPython), true),
-		))))
+	e2e.Run(t, &windowsStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }
 
 func (v *windowsStatusSuite) TestStatusHostname() {

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -44,10 +44,12 @@ func (v *windowsStatusSuite) TestStatusHostname() {
 
 // This test asserts the presence of metadata sent by Python checks in the status subcommand output.
 func (v *windowsStatusSuite) TestChecksMetadataWindows() {
-	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(
-		agentparams.WithFile("C:/ProgramData/Datadog/conf.d/custom_check.d/conf.yaml", string(customCheckYaml), true),
-		agentparams.WithFile("C:/ProgramData/Datadog/checks.d/custom_check.py", string(customCheckPython), true),
-	)))
+	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+		awshost.WithAgentOptions(
+			agentparams.WithFile("C:/ProgramData/Datadog/conf.d/custom_check.d/conf.yaml", string(customCheckYaml), true),
+			agentparams.WithFile("C:/ProgramData/Datadog/checks.d/custom_check.py", string(customCheckPython), true),
+		)))
 
 	section := expectedSection{
 		name:            "Collector",

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -31,15 +31,15 @@ func (v *windowsStatusSuite) TestStatusHostname() {
 	metadata := client.NewEC2Metadata(v.T(), v.Env().RemoteHost.Host, v.Env().RemoteHost.OSFamily)
 	resourceID := metadata.Get("instance-id")
 
-	status := v.Env().Agent.Client.Status()
-
-	expected := expectedSection{
-		name:            `Hostname`,
-		shouldBePresent: true,
-		shouldContain:   []string{fmt.Sprintf("instance-id: %v", resourceID), "hostname provider: os"},
+	expectedSections := []expectedSection{
+		{
+			name:            `Hostname`,
+			shouldBePresent: true,
+			shouldContain:   []string{fmt.Sprintf("instance-id: %v", resourceID), "hostname provider: os"},
+		},
 	}
 
-	verifySectionContent(v.T(), status.Content, expected)
+	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }
 
 // This test asserts the presence of metadata sent by Python checks in the status subcommand output.
@@ -51,16 +51,17 @@ func (v *windowsStatusSuite) TestChecksMetadataWindows() {
 			agentparams.WithFile("C:/ProgramData/Datadog/checks.d/custom_check.py", string(customCheckPython), true),
 		)))
 
-	section := expectedSection{
-		name:            "Collector",
-		shouldBePresent: true,
-		shouldContain: []string{"Instance ID:", "[OK]",
-			// Following lines check the presence of checks metadata
-			"metadata:",
-			"custom_metadata_key: custom_metadata_value",
+	expectedSections := []expectedSection{
+		{
+			name:            "Collector",
+			shouldBePresent: true,
+			shouldContain: []string{"Instance ID:", "[OK]",
+				// Following lines check the presence of checks metadata
+				"metadata:",
+				"custom_metadata_key: custom_metadata_value",
+			},
 		},
 	}
 
-	status := v.Env().Agent.Client.Status()
-	verifySectionContent(v.T(), status.Content, section)
+	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
@@ -23,7 +24,11 @@ type windowsStatusSuite struct {
 
 func TestWindowsStatusSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &windowsStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
+	e2e.Run(t, &windowsStatusSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+		awshost.WithAgentOptions(
+			agentparams.WithFile("C:/ProgramData/Datadog/conf.d/custom_check.d/conf.yaml", string(customCheckYaml), true),
+			agentparams.WithFile("C:/ProgramData/Datadog/checks.d/custom_check.py", string(customCheckPython), true),
+		))))
 }
 
 func (v *windowsStatusSuite) TestStatusHostname() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do ?
This PR adds check presence of Agent check's metadata in `datadog-agent status`command output.

### Motivation
Agent check's metadata was missing between version `7.51` and `7.56`.
This regression was fixed in this PR: #27801

### Describe how to test/QA your changes
This PR only update an e2e test.