### PR TITLE
fix(ownership): Set job ownership for windows

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -146,12 +146,11 @@ new-e2e-discovery*                     @Datadog/universal-service-monitoring
 new-e2e-ndm*                           @DataDog/network-device-monitoring
 new-e2e-npm*                           @DataDog/Networks
 new-e2e-cws*                           @DataDog/agent-security
-new-e2e-windows-agent*                 @DataDog/windows-agent
+new-e2e-windows*                       @DataDog/windows-agent
 new-e2e-orchestrator*                  @DataDog/container-app
 e2e_pre_test*                          @DataDog/agent-devx-loops
 new-e2e-remote-config*                 @DataDog/remote-config
 new-e2e-installer*                     @DataDog/fleet
-new-e2e-windows-service-test           @DataDog/windows-agent
 new-e2e_windows_powershell_module_test @DataDog/windows-kernel-integrations
 
 # Kernel matrix testing

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -146,11 +146,14 @@ new-e2e-discovery*                     @Datadog/universal-service-monitoring
 new-e2e-ndm*                           @DataDog/network-device-monitoring
 new-e2e-npm*                           @DataDog/Networks
 new-e2e-cws*                           @DataDog/agent-security
-new-e2e-windows*                       @DataDog/windows-agent
 new-e2e-orchestrator*                  @DataDog/container-app
 e2e_pre_test*                          @DataDog/agent-devx-loops
 new-e2e-remote-config*                 @DataDog/remote-config
 new-e2e-installer*                     @DataDog/fleet
+new-e2e-installer-windows              @DataDog/windows-agent
+new-e2e-windows*                       @DataDog/windows-agent
+new-e2e-windows-systemprobe            @DataDog/windows-kernel-integrations
+new-e2e-windows-security-agent         @DataDog/windows-kernel-integrations
 new-e2e_windows_powershell_module_test @DataDog/windows-kernel-integrations
 
 # Kernel matrix testing


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set correct ownership

### Motivation
Current job definition
```
.gitlab/JOBOWNERS:149:new-e2e-windows-agent*                 @DataDog/windows-agent
.gitlab/JOBOWNERS:154:new-e2e-windows-service-test           @DataDog/windows-agent
.gitlab/e2e/e2e.yml:150:new-e2e-windows-service-test:
.gitlab/e2e/e2e.yml:164:new-e2e-windows-service-test-nofim:
.gitlab/e2e/e2e.yml:399:new-e2e-windows-systemprobe:
.gitlab/e2e/e2e.yml:412:new-e2e-windows-security-agent:
.gitlab/e2e_install_packages/windows.yml:110:new-e2e-windows-agent-msi-windows-server-a6-x86_64:
.gitlab/e2e_install_packages/windows.yml:132:new-e2e-windows-agent-msi-windows-server-a7-x86_64:
.gitlab/e2e_install_packages/windows.yml:143:new-e2e-windows-agent-domain-tests-a7-x86_64:
.gitlab/e2e_install_packages/windows.yml:162:new-e2e-windows-agent-msi-upgrade-windows-server-a7-x86_64:
```
As a consequence I think we can simplify the job ownership


### Describe how to test/QA your changes
```
inv owners.find-jobowners new-e2e-installer-windows     
@DataDog/windows-agent
inv owners.find-jobowners new-e2e-installer-win    
@DataDog/fleet
inv owners.find-jobowners new-e2e-installer-other
@DataDog/fleet
inv owners.find-jobowners new-e2e-windows-security-agent
@DataDog/windows-kernel-integrations
inv owners.find-jobowners new-e2e-windows-systemprobe   
@DataDog/windows-kernel-integrations
inv owners.find-jobowners new-e2e-windows-sys        
@DataDog/windows-agent
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->