### PR TITLE
[CWS] fix a race in the policy loaded

### DIFF
--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -112,12 +112,13 @@ func (p *PolicyLoader) notifyListeners() {
 
 // Close stops the loader
 func (p *PolicyLoader) Close() {
-	p.RLock()
-	defer p.RUnlock()
+	p.Lock()
+	defer p.Unlock()
 
 	for _, ch := range p.listeners {
 		close(ch)
 	}
+	p.listeners = p.listeners[:0]
 
 	p.debouncer.Stop()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

fix a race with the `Close` and the `notifyListeners` functions while accessing the chan. The is a way that the `debouncer` can call the `notifyListeners` after the chan being close. This PR ensure that there is no more `listerners` after the `Close` function so that we don't send event on a closed chan.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->