### PR TITLE
Auto multiline v2 improve telemetry 

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1512,7 +1512,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.tokenizer_max_input_bytes", 60)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_max_size", 20)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.pattern_table_match_threshold", 0.75)
-	config.BindEnvAndSetDefault("logs_config.tag_auto_multi_line_logs", false)
+	// Add a tag to logs that are multiline aggregated
+	config.BindEnvAndSetDefault("logs_config.tag_multi_line_logs", false)
 	// Add a tag to logs that are truncated by the agent
 	config.BindEnvAndSetDefault("logs_config.tag_truncated_logs", false)
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
 type bucket struct {
@@ -61,27 +61,25 @@ func (b *bucket) flush() *message.Message {
 	copy(content, data)
 
 	msg := message.NewRawMessage(content, b.message.Status, b.originalDataLen, b.message.ParsingExtra.Timestamp)
-	tlmTags := []string{}
+	tlmTags := []string{"false", "single_line"}
 
 	if b.lineCount > 1 {
 		msg.ParsingExtra.IsMultiLine = true
-		tlmTags = append(tlmTags, "line_type:multi_line")
+		tlmTags[1] = "multi_line"
 		if b.tagMultiLineLogs {
-			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.AutoMultiLineTag)
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.MultiLineSourceTag("auto_multiline"))
 		}
-	} else {
-		tlmTags = append(tlmTags, "line_type:single_line")
 	}
 
 	if b.truncated {
 		msg.ParsingExtra.IsTruncated = true
-		tlmTags = append(tlmTags, "truncated:true")
+		tlmTags[0] = "true"
 		if b.tagTruncatedLogs {
-			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedTag)
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("auto_multiline"))
 		}
 	}
 
-	telemetry.GetStatsTelemetryProvider().Count("datadog.logs_agent.auto_multi_line_aggregator.flush", 1, tlmTags)
+	metrics.TlmAutoMultilineAggregatorFlush.Inc(tlmTags...)
 	return msg
 }
 
@@ -135,7 +133,6 @@ func (a *Aggregator) Aggregate(msg *message.Message, label Label) {
 	// If `startGroup` - flush the bucket.
 	if label == startGroup {
 		a.multiLineMatchInfo.Add(1)
-		telemetry.GetStatsTelemetryProvider().Count("datadog.logs_agent.auto_multi_line_aggregator.multiline_matches", 1, []string{""})
 		a.Flush()
 	}
 
@@ -149,7 +146,6 @@ func (a *Aggregator) Aggregate(msg *message.Message, label Label) {
 
 	if !a.bucket.isEmpty() {
 		a.linesCombinedInfo.Add(1)
-		telemetry.GetStatsTelemetryProvider().Count("datadog.logs_agent.auto_multi_line_aggregator.lines_combined", 1, []string{""})
 	}
 
 	a.bucket.add(msg)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -133,12 +133,12 @@ func TestTagTruncatedLogs(t *testing.T) {
 
 	msg := <-outputChan
 	assert.True(t, msg.ParsingExtra.IsTruncated)
-	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedTag})
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
 	assertMessageContent(t, msg, "1234567890...TRUNCATED...")
 
 	msg = <-outputChan
 	assert.True(t, msg.ParsingExtra.IsTruncated)
-	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedTag})
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
 	assertMessageContent(t, msg, "...TRUNCATED...1")
 
 	msg = <-outputChan
@@ -159,7 +159,7 @@ func TestTagMultiLineLogs(t *testing.T) {
 	msg := <-outputChan
 	assert.True(t, msg.ParsingExtra.IsMultiLine)
 	assert.True(t, msg.ParsingExtra.IsTruncated)
-	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.AutoMultiLineTag})
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.MultiLineSourceTag("auto_multiline")})
 	assertMessageContent(t, msg, "12345\\n67890...TRUNCATED...")
 
 	msg = <-outputChan

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -52,7 +52,7 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 			maxContentSize,
 			flushTimeout,
 			pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs"),
-			pkgconfigsetup.Datadog().GetBool("logs_config.tag_auto_multi_line_logs"),
+			pkgconfigsetup.Datadog().GetBool("logs_config.tag_multi_line_logs"),
 			tailerInfo),
 	}
 }

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -111,7 +111,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 				// Save the pattern again for the next rotation
 				detectedPattern.Set(multiLinePattern)
 
-				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, true, tailerInfo, "legacy_multi_line")
+				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, true, tailerInfo, "legacy_auto_multi_line")
 				syncSourceInfo(source, lh)
 				lineHandler = lh
 			} else {

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -92,7 +92,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 	var lineHandler LineHandler
 	for _, rule := range source.Config().ProcessingRules {
 		if rule.Type == config.MultiLine {
-			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, false, tailerInfo)
+			lh := NewMultiLineHandler(outputFn, rule.Regex, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, false, tailerInfo, "multi_line")
 			syncSourceInfo(source, lh)
 			lineHandler = lh
 		}
@@ -111,7 +111,7 @@ func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Par
 				// Save the pattern again for the next rotation
 				detectedPattern.Set(multiLinePattern)
 
-				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, true, tailerInfo)
+				lh := NewMultiLineHandler(outputFn, multiLinePattern, config.AggregationTimeout(pkgconfigsetup.Datadog()), maxContentSize, true, tailerInfo, "legacy_multi_line")
 				syncSourceInfo(source, lh)
 				lineHandler = lh
 			} else {

--- a/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
@@ -207,7 +207,7 @@ func (h *LegacyAutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) 
 	h.singleLineHandler = nil
 
 	// Build and start a multiline-handler
-	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true, h.tailerInfo)
+	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true, h.tailerInfo, "legacy_multi_line")
 	h.source.RegisterInfo(h.multiLineHandler.countInfo)
 	h.source.RegisterInfo(h.multiLineHandler.linesCombinedInfo)
 	// stay with the multiline handler

--- a/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
@@ -207,7 +207,7 @@ func (h *LegacyAutoMultilineHandler) switchToMultilineHandler(r *regexp.Regexp) 
 	h.singleLineHandler = nil
 
 	// Build and start a multiline-handler
-	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true, h.tailerInfo, "legacy_multi_line")
+	h.multiLineHandler = NewMultiLineHandler(h.outputFn, r, h.flushTimeout, h.lineLimit, true, h.tailerInfo, "legacy_auto_multi_line")
 	h.source.RegisterInfo(h.multiLineHandler.countInfo)
 	h.source.RegisterInfo(h.multiLineHandler.linesCombinedInfo)
 	// stay with the multiline handler

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -57,7 +57,7 @@ func benchmarkMultiLineHandler(b *testing.B, logs int, line string) {
 		messages[i] = getDummyMessageWithLF(fmt.Sprintf("%s %d", line, i))
 	}
 
-	h := NewMultiLineHandler(func(*message.Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100, false, status.NewInfoRegistry())
+	h := NewMultiLineHandler(func(*message.Message) {}, regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`), 1000*time.Millisecond, 100, false, status.NewInfoRegistry(), "")
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -96,7 +96,7 @@ func TestTrimSingleLine(t *testing.T) {
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 20, false, status.NewInfoRegistry())
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 20, false, status.NewInfoRegistry(), "")
 
 	var output *message.Message
 
@@ -187,7 +187,7 @@ func TestMultiLineHandler(t *testing.T) {
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry(), "")
 
 	var output *message.Message
 
@@ -216,7 +216,7 @@ func TestTrimMultiLine(t *testing.T) {
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry(), "")
 
 	h.process(getDummyMessage(""))
 
@@ -245,7 +245,7 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	re := regexp.MustCompile(`[0-9]+\.`)
 	outputFn, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry())
+	h := NewMultiLineHandler(outputFn, re, 250*time.Millisecond, 100, false, status.NewInfoRegistry(), "")
 
 	h.process(getDummyMessage("1.third line"))
 	h.process(getDummyMessage("fourth line"))

--- a/pkg/logs/internal/decoder/single_line_handler.go
+++ b/pkg/logs/internal/decoder/single_line_handler.go
@@ -39,7 +39,7 @@ func (h *SingleLineHandler) flush() {
 
 func addTruncatedTag(msg *message.Message) {
 	if pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs") {
-		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedTag)
+		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
 	}
 }
 

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -362,5 +362,5 @@ func TruncatedReasonTag(reason string) string {
 
 // MultiLineSourceTag returns a tag for multiline logs.
 func MultiLineSourceTag(source string) string {
-	return fmt.Sprintf("auto_multiline:%s", source)
+	return fmt.Sprintf("multiline:%s", source)
 }

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -354,3 +354,13 @@ func (m *Message) Tags() []string {
 func (m *Message) TagsToString() string {
 	return m.Origin.TagsToString(m.ProcessingTags)
 }
+
+// TruncatedReasonTag returns a tag with the reason for truncation.
+func TruncatedReasonTag(reason string) string {
+	return fmt.Sprintf("truncated:%s", reason)
+}
+
+// MultiLineSourceTag returns a tag for multiline logs.
+func MultiLineSourceTag(source string) string {
+	return fmt.Sprintf("auto_multiline:%s", source)
+}

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -71,6 +71,9 @@ var (
 	//nolint:revive // TODO(AML) Fix revive linter
 	TlmDestinationHttpRespByStatusAndUrl = telemetry.NewCounter("logs", "destination_http_resp", []string{"status_code", "url"}, "Count of http responses by status code and destination url")
 
+	// TlmAutoMultilineAggregatorFlush Count of each line flushed from the auto mulitline aggregator.
+	TlmAutoMultilineAggregatorFlush = telemetry.NewCounter("logs", "auto_multi_line_aggregator_flush", []string{"truncated", "line_type"}, "Count of each line flushed from the auto mulitline aggregator")
+
 	// TlmLogsDiscardedFromSDSBuffer how many messages were dropped when waiting for an SDS configuration because the buffer is full
 	TlmLogsDiscardedFromSDSBuffer = telemetry.NewCounter("logs", "sds__dropped_from_buffer", nil, "Count of messages dropped from the buffer while waiting for an SDS configuration")
 )

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -380,7 +380,7 @@ func (suite *TailerTestSuite) TestTruncatedTag() {
 
 	msg := <-suite.outputChan
 	tags := msg.Tags()
-	suite.Contains(tags, message.TruncatedTag)
+	suite.Contains(tags, message.TruncatedReasonTag("single_line"))
 }
 
 func (suite *TailerTestSuite) TestMutliLineAutoDetect() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Remove default stats telemetry in favor of regular telemetry counters. 
- add a `reason` value to the truncated tag to easily differentiate between different types of truncated logs
- add a `source` value to the `multiline` tag to easily differentiate the source of the multiline aggregation 
- rename config `logs_config.tag_auto_multi_line_logs` -> `logs_config.tag_multi_line_logs` to better describe it's new behavior (this config was not publicly documented and tied behind the experimental flag so it's safe to change) 


### Motivation

### Describe how to test/QA your changes

1. in `datadog.yaml`
```
logs_config:
    experimental_auto_multi_line_detection: true
    max_message_size_bytes: 20
    tag_multi_line_logs: true
    tag_truncated_logs: true
```

2. send any logs (longer than 20 bytes)
3. they should have a truncated tag, 
4. remove the `max_message_size_bytes` setting
5. send multiline logs

```
2024-08-13 17:22:24 INFO Main main Some log line 149
2024-08-13 17:22:24 INFO Main main Some log line 150
2024-08-13 17:22:24 SEVERE Main main Exception occur
java.lang.Exception: boom
	at Main.funcd(Main.java:50)
	at Main.funcc(Main.java:49)
	at Main.funcb(Main.java:48)
	at Main.funca(Main.java:47)
	at Main.main(Main.java:29)
2024-08-13 17:22:24 INFO Main main Some log line 151
2024-08-13 17:22:24 INFO Main main Some log line 152
```

6. Confirm they have an `multiline:auto_multiline` tag. 
7. spot check the agent telemetry page for the `auto_multi_line_aggregator_flush` metrics. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
[](https://datadoghq.atlassian.net/browse/AMLII-2038)