### PR TITLE
[agent] Support scrubbing for quoted args with spaces

### DIFF
--- a/pkg/process/procutil/data_scrubber.go
+++ b/pkg/process/procutil/data_scrubber.go
@@ -102,7 +102,7 @@ func CompileStringsToRegex(words []string) []DataScrubberPattern {
 			continue
 		}
 
-		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=|:)(?P<value>(\"([^\"]*)\")+|('([^']*)')+|[^\\s]*)"
+		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=|:)(?P<value>(\"([^\"]*)\")|('([^']*)')|[^\\s]*)"
 		r, err := regexp.Compile(pattern)
 		if err == nil {
 			compiledRegexps = append(compiledRegexps, DataScrubberPattern{

--- a/pkg/process/procutil/data_scrubber.go
+++ b/pkg/process/procutil/data_scrubber.go
@@ -102,7 +102,7 @@ func CompileStringsToRegex(words []string) []DataScrubberPattern {
 			continue
 		}
 
-		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=|:)(?P<value>[^\\s]*)"
+		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=|:)(?P<value>(\"([^\"]*)\")+|('([^']*)')+|[^\\s]*)"
 		r, err := regexp.Compile(pattern)
 		if err == nil {
 			compiledRegexps = append(compiledRegexps, DataScrubberPattern{

--- a/pkg/process/procutil/data_scrubber_test.go
+++ b/pkg/process/procutil/data_scrubber_test.go
@@ -62,6 +62,9 @@ type testProcess struct {
 
 func setupSensitiveCmdlines() []testCase {
 	return []testCase{
+		{[]string{"process --password=\"Data Source another_password=12345\""}, []string{"process", "--password=********"}},
+		{[]string{"process --password=\"Data Source\""}, []string{"process", "--password=********"}},
+		{[]string{"process --password:'Data Source another_pass=12345'"}, []string{"process", "--password:********"}},
 		{[]string{"agent", "password", "-token", "1234"}, []string{"agent", "password", "********", "1234"}},
 		{[]string{"agent", "-password", "1234"}, []string{"agent", "-password", "********"}},
 		{[]string{"agent --password > /password/secret; agent --password echo >> /etc"}, []string{"agent", "--password", "********", "/password/secret;", "agent", "--password", "********", ">>", "/etc"}},

--- a/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
+++ b/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix Process Agent argument scrubbing to account for spaces in quotes arguments.
+    Fix Process Agent argument scrubbing to account for spaces in quoted arguments.

--- a/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
+++ b/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Process Agent argument scrubbing to account for spaces in quotes arguments.

--- a/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
+++ b/releasenotes/notes/fix-scrubbing-arg-with-spaces-7d4372e6cf865856.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix Process Agent argument scrubbing to account for spaces in quoted arguments.
+    Fix Process Agent argument scrubbing to allow scrubbing of quoted arguments.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Changes regex pattern for matching sensitive words to scrub, by capturing additional groups as values in the `key-delimiter-value` pattern. 
  - New values that can be captured as arguments to scrub include single and double quote enclosed values. EX: `"process --pass="some thing"" > ["process", "=pass=******"]`

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4358

### Describe how to test/QA your changes
-Ran unit tests (all package tests in `data_scrubber_test.go`)
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b03875fa-9696-45ec-9207-f930721d5d7f">


### Possible Drawbacks / Trade-offs

### Additional Notes
Affected teams:
@DataDog/processes
@DataDog/agent-security 
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->