### PR TITLE
move sysprobe config fetcher into subpackage

### DIFF
--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	fetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	sysprobeConfigFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -60,7 +61,7 @@ var (
 	fetchSecurityConfig    = configFetcher.SecurityAgentConfig
 	fetchProcessConfig     = func(cfg model.Reader) (string, error) { return configFetcher.ProcessAgentConfig(cfg, true) }
 	fetchTraceConfig       = configFetcher.TraceAgentConfig
-	fetchSystemProbeConfig = configFetcher.SystemProbeConfig
+	fetchSystemProbeConfig = sysprobeConfigFetcher.SystemProbeConfig
 )
 
 type agentMetadata map[string]interface{}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	sysprobeConfigFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -456,7 +457,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	}
 
 	defer func() {
-		fetchSystemProbeConfig = configFetcher.SystemProbeConfig
+		fetchSystemProbeConfig = sysprobeConfigFetcher.SystemProbeConfig
 	}()
 	fetchSystemProbeConfig = func(config pkgconfigmodel.Reader) (string, error) {
 		// test that the system-probe config was passed and not the agent config

--- a/comp/metadata/systemprobe/impl/system_probe.go
+++ b/comp/metadata/systemprobe/impl/system_probe.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	systemprobemetadata "github.com/DataDog/datadog-agent/comp/metadata/systemprobe/def"
-	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"

--- a/comp/metadata/systemprobe/impl/system_probe_test.go
+++ b/comp/metadata/systemprobe/impl/system_probe_test.go
@@ -24,7 +24,7 @@ import (
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
-	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	serializermock "github.com/DataDog/datadog-agent/pkg/serializer/mocks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
@@ -106,20 +105,4 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "process-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 
 	return client.FullConfig()
-}
-
-// SystemProbeConfig fetch the configuration from the system-probe process by querying its API
-func SystemProbeConfig(config config.Reader) (string, error) {
-	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
-
-	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
-	return c.FullConfig()
-}
-
-// SystemProbeConfigBySource fetch the all configuration layers from the system-probe process by querying its API
-func SystemProbeConfigBySource(config config.Reader) (string, error) {
-	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
-
-	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
-	return c.FullConfigBySource()
 }

--- a/pkg/config/fetcher/sysprobe/from_sysprobe.go
+++ b/pkg/config/fetcher/sysprobe/from_sysprobe.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package sysprobe is a collection of high level helpers to pull the configuration from system-probe.
+// Is it separated from the other helpers in the parent package to avoid unnecessary imports in processes
+// that have no need to directly communicate with system-probe.
+package sysprobe
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+)
+
+// SystemProbeConfig fetch the configuration from the system-probe process by querying its API
+func SystemProbeConfig(config config.Reader) (string, error) {
+	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
+
+	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
+	return c.FullConfig()
+}
+
+// SystemProbeConfigBySource fetch the all configuration layers from the system-probe process by querying its API
+func SystemProbeConfigBySource(config config.Reader) (string, error) {
+	hc := client.Get(config.GetString("system_probe_config.sysprobe_socket"))
+
+	c := settingshttp.NewClient(hc, "http://localhost/config", "system-probe", settingshttp.NewHTTPClientOptions(util.CloseConnection))
+	return c.FullConfigBySource()
+}

--- a/pkg/config/fetcher/sysprobe/from_sysprobe.go
+++ b/pkg/config/fetcher/sysprobe/from_sysprobe.go
@@ -4,7 +4,7 @@
 // Copyright 2024-present Datadog, Inc.
 
 // Package sysprobe is a collection of high level helpers to pull the configuration from system-probe.
-// Is it separated from the other helpers in the parent package to avoid unnecessary imports in processes
+// It is separated from the other helpers in the parent package to avoid unnecessary imports in processes
 // that have no need to directly communicate with system-probe.
 package sysprobe
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moves the system-probe config fetcher helpers into a subpackage.

### Motivation

To avoid unnecessary imports in processes that have no need to directly communicate with system-probe.
See https://github.com/DataDog/datadog-agent/pull/29530#issuecomment-2372584808 for an example of this import explosion.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->