### PR TITLE
Add systemd headers to our build system

### DIFF
--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -65,6 +65,8 @@ else
   # creates required build directories
   dependency 'preparation'
 
+  dependency "systemd" if linux_target?
+
   # Datadog agent
   dependency 'datadog-iot-agent'
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -65,8 +65,6 @@ else
   # creates required build directories
   dependency 'preparation'
 
-  dependency "systemd" if linux_target?
-
   # Datadog agent
   dependency 'datadog-iot-agent'
 

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -13,3 +13,5 @@ end
 if with_python_runtime? "3"
   dependency 'datadog-agent-integrations-py3-dependencies'
 end
+
+dependency "systemd"

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -14,4 +14,4 @@ if with_python_runtime? "3"
   dependency 'datadog-agent-integrations-py3-dependencies'
 end
 
-dependency "systemd"
+dependency "systemd" if linux_target?

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -37,6 +37,7 @@ build do
   else
     major_version_arg = "$MAJOR_VERSION"
     py_runtimes_arg = "$PY_RUNTIMES"
+    env['CGO_CFLAGS'] = "-I#{install_dir}/embedded/include"
   end
 
   if linux_target?

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -11,6 +11,8 @@ name 'datadog-iot-agent'
 source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 
+dependency "systemd" if linux_target?
+
 build do
   license :project_license
 

--- a/omnibus/config/software/systemd.rb
+++ b/omnibus/config/software/systemd.rb
@@ -32,8 +32,6 @@ source url: "https://github.com/systemd/systemd/archive/refs/tags/v#{version}.ta
 relative_path "#{name}-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
   # We only need the headers for coreos/go-systemd, and building
   # libsystemd itself would be fairly complicated as our toolchain doesn't
   # default include `/usr/include` in its default include path, while systemd

--- a/omnibus/config/software/systemd.rb
+++ b/omnibus/config/software/systemd.rb
@@ -1,0 +1,42 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "systemd"
+default_version "253"
+
+license "GPLv2"
+license "LGPL-2.1"
+license_file "LICENSE.GPL2"
+license_file "LICENSE.LGPL2.1"
+skip_transitive_dependency_licensing true
+
+version("253") { source sha256: "acbd86d42ebc2b443722cb469ad215a140f504689c7a9133ecf91b235275a491" }
+
+ship_source_offer true
+
+source url: "https://github.com/systemd/systemd/archive/refs/tags/v#{version}.tar.gz"
+
+relative_path "#{name}-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  env["CFLAGS"] << " -fPIC"
+
+  configure "", env: env
+
+  make "-j #{workers}", env: env
+  make "install", env: env
+end

--- a/omnibus/config/software/systemd.rb
+++ b/omnibus/config/software/systemd.rb
@@ -33,10 +33,11 @@ relative_path "#{name}-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env["CFLAGS"] << " -fPIC"
 
-  configure "", env: env
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  # We only need the headers for coreos/go-systemd, and building
+  # libsystemd itself would be fairly complicated as our toolchain doesn't
+  # default include `/usr/include` in its default include path, while systemd
+  # definitely need files in /usr/include/sys to build.
+  mkdir "#{install_dir}/embedded/include/systemd"
+  copy "src/systemd/*.h", "#{install_dir}/embedded/include/systemd/"
 end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a recipe to provide systemd headers

### Motivation

We need those to build, and as such we should provide a recipe to provide those.
They currently are shipped in the build images, which is not the correct location for a source dependency. We need to be able to see those as a regular dependency and easily change the version we use.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->