### PR TITLE
[tagger/entity_id] Replace SplitN with Index to avoid unnecessary allocations

### DIFF
--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -31,24 +31,24 @@ type defaultEntityID string
 
 // GetID implements EntityID#GetID
 func (de defaultEntityID) GetID() string {
-	parts := strings.SplitN(string(de), separator, 2)
+	separatorIndex := strings.Index(string(de), separator)
 
-	if len(parts) != 2 {
+	if separatorIndex == -1 {
 		return ""
 	}
 
-	return parts[1]
+	return string(de[separatorIndex+len(separator):])
 }
 
 // GetPrefix implements EntityID#GetPrefix
 func (de defaultEntityID) GetPrefix() EntityIDPrefix {
-	parts := strings.SplitN(string(de), separator, 2)
+	separatorIndex := strings.Index(string(de), separator)
 
-	if len(parts) != 2 {
+	if separatorIndex == -1 {
 		return ""
 	}
 
-	return EntityIDPrefix(parts[0])
+	return EntityIDPrefix(de[:separatorIndex])
 }
 
 // String implements EntityID#String
@@ -56,7 +56,7 @@ func (de defaultEntityID) String() string {
 	return string(de)
 }
 
-func newDefaultEntityID(id string) EntityID {
+func newDefaultEntityID(id string) defaultEntityID {
 	return defaultEntityID(id)
 }
 


### PR DESCRIPTION
### What does this PR do?

Optimizes a couple of functions in `comp/core/tagger/types/entity_id.go` to avoid unnecessary allocations.

### Describe how to test/QA your changes

No manual test needed. We just need to check the results in the AML team benchmarks.