### PR TITLE
feat(linter.gitlab-ci): Prevent double call to lint api during `linter.gitlab-ci` task

### DIFF
--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -15,10 +15,10 @@ from invoke.exceptions import Exit
 from tasks.kernel_matrix_testing.ci import get_kmt_dashboard_links
 from tasks.libs.ciproviders.gitlab_api import (
     get_all_gitlab_ci_configurations,
-    get_full_gitlab_ci_configuration,
     get_gitlab_ci_configuration,
     get_gitlab_repo,
     print_gitlab_ci_configuration,
+    resolve_gitlab_ci_configuration,
 )
 from tasks.libs.civisibility import (
     get_pipeline_link_to_job_id,
@@ -173,7 +173,7 @@ def gen_config_subset(ctx, jobs, dry_run=False, force=False):
     if not force and not dry_run and ctx.run('git status -s .gitlab-ci.yml', hide='stdout').stdout.strip():
         raise Exit(color_message('The .gitlab-ci.yml file should not be modified as it will be overwritten', Color.RED))
 
-    config = get_full_gitlab_ci_configuration(ctx, '.gitlab-ci.yml')
+    config = resolve_gitlab_ci_configuration(ctx, '.gitlab-ci.yml')
 
     jobs = [j for j in jobs.split(',') if j] + jobs_to_keep
     required = set()
@@ -242,7 +242,7 @@ def print_ci(
     keep_special_objects: bool = False,
     expand_matrix: bool = False,
     git_ref: str | None = None,
-    ignore_errors: bool = False,
+    with_lint: bool = True,
 ):
     """
     Prints the full gitlab ci configuration.
@@ -251,7 +251,7 @@ def print_ci(
     - clean: Apply post processing to make output more readable (remove extends, flatten lists of lists...)
     - keep_special_objects: If True, do not filter out special objects (variables, stages etc.)
     - expand_matrix: Will expand matrix jobs into multiple jobs
-    - ignore_errors: If True, ignore errors in the gitlab configuration (only process yaml)
+    - with_lint: If False, do not lint the configuration
     - git_ref: If provided, use this git reference to fetch the configuration
     - NOTE: This requires a full api token access level to the repository
     """
@@ -262,7 +262,7 @@ def print_ci(
         clean=clean,
         expand_matrix=expand_matrix,
         git_ref=git_ref,
-        ignore_errors=ignore_errors,
+        with_lint=with_lint,
         keep_special_objects=keep_special_objects,
     )
 

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -8,7 +8,7 @@ import yaml
 from invoke import task
 
 from tasks.libs.ciproviders.gitlab_api import (
-    get_full_gitlab_ci_configuration,
+    resolve_gitlab_ci_configuration,
 )
 from tasks.libs.common.utils import gitlab_section
 from tasks.test_core import ModuleTestResult
@@ -180,7 +180,7 @@ def generate_flake_finder_pipeline(ctx, n=3):
     """
 
     # Read gitlab config
-    config = get_full_gitlab_ci_configuration(ctx, ".gitlab-ci.yml")
+    config = resolve_gitlab_ci_configuration(ctx, ".gitlab-ci.yml")
 
     # Lets keep only variables and jobs with flake finder variable
     kept_job = {}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent double call to [lint](https://docs.gitlab.com/ee/api/lint.html) api during `linter.gitlab-ci` task

### Motivation
The call to lint api with our config takes 15~20s. As the `linter.gitlab-ci` task is in the `pre-commit` push, it was really painful to wait that much. 

### Describe how to test/QA your changes
Local run of the task:
before
```
[0:00:00.492194]info: Fetching Gitlab CI configurations...
[0:00:20.994323]> Testing .gitlab-ci.yml...
info: We will test 1 contexts
Test gitlab configuration with context:  [('BUCKET_BRANCH', 'nightly'), ('CI_COMMIT_BRANCH', 'main'), ('CI_COMMIT_TAG', ''), ('CI_PIPELINE_SOURCE', 'pipeline'), ('DEPLOY_AGENT', 'true'), ('RUN_ALL_BUILDS', 'true'), ('RUN_E2E_TESTS', 'auto'), ('RUN_KMT_TESTS', 'on'), ('RUN_UNIT_TESTS', 'on'), ('TESTING_CLEANUP', 'true')]
.gitlab-ci.yml config is valid
[0:00:33.298568]> Testing .gitlab/deploy_containers/deploy_containers_a7.yml...
.gitlab/deploy_containers/deploy_containers_a7.yml config is valid
[0:00:33.874816]end
```
after
```
[0:00:00.000002]info: Fetching Gitlab CI configurations...
[0:00:02.166166]> Testing .gitlab-ci.yml...
info: We will test 1 contexts
Test gitlab configuration with context:  [('BUCKET_BRANCH', 'nightly'), ('CI_COMMIT_BRANCH', 'main'), ('CI_COMMIT_TAG', ''), ('CI_PIPELINE_SOURCE', 'pipeline'), ('DEPLOY_AGENT', 'true'), ('RUN_ALL_BUILDS', 'true'), ('RUN_E2E_TESTS', 'auto'), ('RUN_KMT_TESTS', 'on'), ('RUN_UNIT_TESTS', 'on'), ('TESTING_CLEANUP', 'true')]
.gitlab-ci.yml config is valid
[0:00:22.311904]> Testing .gitlab/deploy_containers/deploy_containers_a7.yml...
.gitlab/deploy_containers/deploy_containers_a7.yml config is valid
[0:00:23.777173]end
```

### Possible Drawbacks / Trade-offs
I changed the `ignore_errors` to `with_linter` because `ignore_errors` was not used in the current_code. Thus I automatically consider I should check errors if I call the linter

### Additional Notes
I've done some refactoring because I felt:
- reading code is really hard with method definitions within other methods
- all the names were really similar, I've tried to find more explicit names, but it's maybe not better, don't hesitate to react

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->