### PR TITLE
pkg/trace/config: add 'sqllexer' feature to enable sqllexer obfuscator

### DIFF
--- a/cmd/trace-agent/test/testsuite/traces_test.go
+++ b/cmd/trace-agent/test/testsuite/traces_test.go
@@ -184,6 +184,34 @@ func TestTraces(t *testing.T) {
 		})
 	})
 
+	t.Run("normalize, obfuscate, sqllexer", func(t *testing.T) {
+		if err := r.RunAgent([]byte("apm_config:\r\n  features:[\"sqllexer\"]\r\n")); err != nil {
+			t.Fatal(err)
+		}
+		defer r.KillAgent()
+
+		p := testutil.GeneratePayload(1, &testutil.TraceConfig{
+			MinSpans: 4,
+			Keep:     true,
+		}, nil)
+		for _, span := range p[0] {
+			span.Service = strings.Repeat("a", 200) // Too long
+			span.Name = strings.Repeat("b", 200)    // Too long
+		}
+		p[0][0].Type = "sql"
+		p[0][0].Resource = "SELECT secret FROM users WHERE id = 123"
+		if err := r.Post(p); err != nil {
+			t.Fatal(err)
+		}
+		waitForTrace(t, &r, func(v *pb.AgentPayload) {
+			assert.Equal(t, "SELECT secret FROM users WHERE id = ?", v.TracerPayloads[0].Chunks[0].Spans[0].Resource)
+			for _, s := range v.TracerPayloads[0].Chunks[0].Spans {
+				assert.Len(t, s.Service, 100)
+				assert.Len(t, s.Name, 100)
+			}
+		})
+	})
+
 	t.Run("probabilistic", func(t *testing.T) {
 		if err := r.RunAgent([]byte("apm_config:\r\n  probabilistic_sampler:\r\n    enabled: true\r\n    sampling_percentage: 100\r\n")); err != nil {
 			t.Fatal(err)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1363,7 +1363,7 @@ api_key:
   ## The list of items available under apm_config.features is not guaranteed to persist across versions;
   ## a feature may eventually be promoted to its own configuration option on the agent, or dropped entirely.
   #
-  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sql_cache","enable_otlp_compute_top_level_by_span_kind"]
+  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sql_cache","sqllexer","enable_otlp_compute_top_level_by_span_kind"]
 
   ## @param additional_endpoints - object - optional
   ## @env DD_APM_ADDITIONAL_ENDPOINTS - object - optional

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -119,7 +119,7 @@ type ObfuscationConfig struct {
 
 func obfuscationMode(enabled bool) obfuscate.ObfuscationMode {
 	if enabled {
-		return "obfuscation_only"
+		return obfuscate.ObfuscateOnly
 	}
 	return ""
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -117,6 +117,13 @@ type ObfuscationConfig struct {
 	CreditCards obfuscate.CreditCardsConfig `mapstructure:"credit_cards"`
 }
 
+func obfuscationMode(enabled bool) obfuscate.ObfuscationMode {
+	if enabled {
+		return "obfuscation_only"
+	}
+	return ""
+}
+
 // Export returns an obfuscate.Config matching o.
 func (o *ObfuscationConfig) Export(conf *AgentConfig) obfuscate.Config {
 	return obfuscate.Config{
@@ -126,6 +133,7 @@ func (o *ObfuscationConfig) Export(conf *AgentConfig) obfuscate.Config {
 			KeepSQLAlias:     conf.HasFeature("keep_sql_alias"),
 			DollarQuotedFunc: conf.HasFeature("dollar_quoted_func"),
 			Cache:            conf.HasFeature("sql_cache"),
+			ObfuscationMode:  obfuscationMode(conf.HasFeature("sqllexer")),
 		},
 		ES:                   o.ES,
 		OpenSearch:           o.OpenSearch,

--- a/releasenotes/notes/enable-sqllexer-obfuscation-f0242108ff24efeb.yaml
+++ b/releasenotes/notes/enable-sqllexer-obfuscation-f0242108ff24efeb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+	APM: Add new 'sqllexer' feature flag for the Trace Agent, which enables
+	the sqllexer imprementation of the SQL Obfuscator.

--- a/releasenotes/notes/enable-sqllexer-obfuscation-f0242108ff24efeb.yaml
+++ b/releasenotes/notes/enable-sqllexer-obfuscation-f0242108ff24efeb.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-	APM: Add new 'sqllexer' feature flag for the Trace Agent, which enables
-	the sqllexer imprementation of the SQL Obfuscator.
+        APM: Add new 'sqllexer' feature flag for the Trace Agent, which enables
+        the sqllexer imprementation of the SQL Obfuscator.


### PR DESCRIPTION

### What does this PR do?


This commit adds the feature flag 'sqllexer' which will cause the obfuscator to use sqllexer instead of its usual lexer to obfuscate queries.


### Motivation

The SQL Obfuscator can be configured to use the go sqllexer to obfuscate SQL queries, but this was not exposed in the Trace Agent config.

### Describe how to test/QA your changes

~Run the agent with and without the 'sqllexer' feature while sending SQL queries in traces and validate that they are obfuscated as expected with both configurations.~

~Note, the obfuscation results will differ slightly between the implementations. The important thing is that the queries *are* obfuscated.~

An integration test was added to test this behavior. No manual QA is required.

