### PR TITLE
product version logging and error handling

### DIFF
--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -75,7 +75,9 @@ namespace Datadog.AgentCustomActions
             var upgradeDetected = _session["WIX_UPGRADE_DETECTED"];
             if (!string.IsNullOrEmpty(upgradeDetected)) // This is an upgrade, conditionally set rollback flags.
             {
+                _session.Log($"WIX_UPGRADE_DETECTED: {_session["WIX_UPGRADE_DETECTED"]}");
                 var versionString = _nativeMethods.GetVersionString(upgradeDetected);
+                _session.Log($"versionString: {versionString}");
                 // Using Version class
                 // https://learn.microsoft.com/en-us/dotnet/api/system.version?view=net-8.0
                 var currentVersion = new Version(versionString);

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -934,7 +934,7 @@ namespace Datadog.CustomActions.Native
             if (err != ReturnCodes.NO_ERROR)
             {
                 throw new Exception($"Failed to get version string for product {product}",
-                                       new Win32Exception((int)err));
+                    new Win32Exception((int)err));
             }
 
             return builder.ToString();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -930,7 +930,12 @@ namespace Datadog.CustomActions.Native
             var len = 512;
             var builder = new System.Text.StringBuilder(len);
 
-            MsiGetProductInfo(product, "VersionString", builder, ref len);
+            var err = (ReturnCodes)MsiGetProductInfo(product, "VersionString", builder, ref len);
+            if (err != ReturnCodes.NO_ERROR)
+            {
+                throw new Exception($"Failed to get version string for product {product}",
+                                       new Win32Exception((int)err));
+            }
 
             return builder.ToString();
         }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add additional logging and error handling

### Motivation
https://datadoghq.atlassian.net/browse/WINA-674
better logging/error message for when  [MsiGetProductInfo](https://learn.microsoft.com/en-us/windows/win32/api/msi/nf-msi-msigetproductinfoa) fails, e.g. in rare case when two products are stuck/installed simultaneously

Error of `MsiGetProductInfo` was ignored so `GetVersionString` was returning an uninitialized buffer string, which `Version.Version` of course failed to parse.

### Describe how to test/QA your changes
E2E tests cover happy paths, details unknown for rare case mentioned above

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Example error when `MsiGetProductInfo` fails
```
CA: 17:53:00: ReadInstallState. Error reading install state: System.Exception: Failed to get version string for product {5071E877-08D6-4B59-8A3E-E9E87B451111} ---> System.ComponentModel.Win32Exception: Unknown property
```