### PR TITLE
[Backport 7.58.x] [tagger/entity_id] Replace SplitN with Index to avoid unnecessary allocations

### DIFF
--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -31,24 +31,24 @@ type defaultEntityID string
 
 // GetID implements EntityID#GetID
 func (de defaultEntityID) GetID() string {
-	parts := strings.SplitN(string(de), separator, 2)
+	separatorIndex := strings.Index(string(de), separator)
 
-	if len(parts) != 2 {
+	if separatorIndex == -1 {
 		return ""
 	}
 
-	return parts[1]
+	return string(de[separatorIndex+len(separator):])
 }
 
 // GetPrefix implements EntityID#GetPrefix
 func (de defaultEntityID) GetPrefix() EntityIDPrefix {
-	parts := strings.SplitN(string(de), separator, 2)
+	separatorIndex := strings.Index(string(de), separator)
 
-	if len(parts) != 2 {
+	if separatorIndex == -1 {
 		return ""
 	}
 
-	return EntityIDPrefix(parts[0])
+	return EntityIDPrefix(de[:separatorIndex])
 }
 
 // String implements EntityID#String
@@ -56,7 +56,7 @@ func (de defaultEntityID) String() string {
 	return string(de)
 }
 
-func newDefaultEntityID(id string) EntityID {
+func newDefaultEntityID(id string) defaultEntityID {
 	return defaultEntityID(id)
 }
 


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/DataDog/datadog-agent/pull/29625
