### PR TITLE
[NTWK-557] Fix NPM sendpage probes in openSUSE 15rc6

### DIFF
--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -27,7 +27,7 @@ func hasTCPSendPage(kv kernel.Version) bool {
 		return len(missing) == 0
 	}
 
-	log.Warnf("error verifying tcp_sendpage presence, falling back to v6.5 check: %s", err)
+	log.Debugf("unable to determine whether tcp_sendpage exists, using kernel version instead: %s", err)
 
 	kv650 := kernel.VersionCode(6, 5, 0)
 	return kv < kv650

--- a/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
+++ b/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
@@ -2,4 +2,4 @@
 ---
 fixes:
   - |
-    Fixed issue with OpenSUSE 15 RC 6 where the eBPF tracer wouldn't to start due to a failed validation of the tcp_sendpage probe.
+    Fixed issue with openSUSE 15 RC 6 where the eBPF tracer wouldn't to start due to a failed validation of the tcp_sendpage probe.

--- a/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
+++ b/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
@@ -1,0 +1,5 @@
+
+---
+fixes:
+  - |
+    Fixed issue with OpenSUSE 15 RC 6 where the eBPF tracer wouldn't to start due to a failed validation of the tcp_sendpage probe.

--- a/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
+++ b/releasenotes/notes/fix-opensuse-15rc6-sendpage-11ba41034deaa721.yaml
@@ -2,4 +2,4 @@
 ---
 fixes:
   - |
-    Fixed issue with openSUSE 15 RC 6 where the eBPF tracer wouldn't to start due to a failed validation of the tcp_sendpage probe.
+    Fixed issue with openSUSE 15 RC 6 where the eBPF tracer wouldn't start due to a failed validation of the ``tcp_sendpage`` probe.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes an issue with openSUSE 15 RC 6 where the eBPF tracer wouldn't to start due to a failed validation of the tcp_sendpage probe.

### Motivation

Discovered via inbound issue from customer.

### Describe how to test/QA your changes

Install the RPM for this branch in an openSUSE VM and start up system-probe via `sudo /opt/datadog-agent/embedded/bin/system-probe run`. It should not yield the error related to tcp_sendpage anymore.

In addition, I ran the KMT alien tests on openSUSE via the following: (sles15rc6.json is the alien config pointing to SSH for the VM)
```
inv -e kmt.test --packages=./pkg/network/tracer --run TestTracerSuite/prebuilt/TestTCPRTT --alien-vms=/Users/stuart.geipel/Documents/aliens/sles15rc6.json
```
With this change, everything but `TestTracerSuite/prebuilt/TestTCPRTT` passes which is an unrelated flake of offset guessing in prebuilt.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->