### PR TITLE
[CWS-2861] Add rule actions metric 

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -39,6 +39,12 @@ var (
 	// Tags: rule_id
 	MetricRulesSuppressed = newRuntimeMetric(".rules.suppressed")
 
+	// Rule action metrics
+
+	// MetricRuleActionPerformed is the name of the metric used to count actions performed after a rule was matched
+	// Tags: rule_id, action_name
+	MetricRuleActionPerformed = newRuntimeMetric(".rules.action_performed")
+
 	// Syscall monitoring metrics
 
 	// MetricSyscalls is the name of the metric used to count each syscall executed on the host

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -339,9 +339,6 @@ var (
 
 	// Enforcement metrics
 
-	// MetricEnforcementKillActionPerformed is the name of the metric used to report that a kill action was performed
-	// Tags: rule_id
-	MetricEnforcementKillActionPerformed = newRuntimeMetric(".enforcement.kill_action_performed")
 	// MetricEnforcementProcessKilled is the name of the metric used to report the number of processes killed
 	// Tags: rule_id
 	MetricEnforcementProcessKilled = newRuntimeMetric(".enforcement.process_killed")

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -104,6 +104,11 @@ type CustomEventHandler interface {
 // DiscarderPushedCallback describe the callback used to retrieve pushed discarders information
 type DiscarderPushedCallback func(eventType string, event *model.Event, field string)
 
+type actionStatsTags struct {
+	ruleID     rules.RuleID
+	actionName rules.ActionName
+}
+
 // Probe represents the runtime security eBPF probe in charge of
 // setting up the required kProbes and decoding events sent from the kernel
 type Probe struct {
@@ -126,14 +131,19 @@ type Probe struct {
 	eventHandlers       [model.MaxAllEventType][]EventHandler
 	eventConsumers      [model.MaxAllEventType][]*EventConsumer
 	customEventHandlers [model.MaxAllEventType][]CustomEventHandler
+
+	// stats
+	ruleActionStatsLock sync.RWMutex
+	ruleActionStats     map[actionStatsTags]*atomic.Int64
 }
 
 func newProbe(config *config.Config, opts Opts) *Probe {
 	return &Probe{
-		Opts:         opts,
-		Config:       config,
-		StatsdClient: opts.StatsdClient,
-		scrubber:     newProcScrubber(config.Probe.CustomSensitiveWords),
+		Opts:            opts,
+		Config:          config,
+		StatsdClient:    opts.StatsdClient,
+		scrubber:        newProcScrubber(config.Probe.CustomSensitiveWords),
+		ruleActionStats: make(map[actionStatsTags]*atomic.Int64),
 	}
 }
 
@@ -180,6 +190,20 @@ func (p *Probe) SendStats() error {
 	if err := p.sendConsumerStats(); err != nil {
 		return err
 	}
+
+	p.ruleActionStatsLock.RLock()
+	for tags, counter := range p.ruleActionStats {
+		count := counter.Swap(0)
+		if count > 0 {
+			tags := []string{
+				fmt.Sprintf("rule_id:%s", tags.ruleID),
+				fmt.Sprintf("action_name:%s", tags.actionName),
+			}
+			_ = p.StatsdClient.Count(metrics.MetricRuleActionPerformed, count, tags, 1.0)
+		}
+	}
+	p.ruleActionStatsLock.RUnlock()
+
 	return p.PlatformProbe.SendStats()
 }
 
@@ -204,6 +228,9 @@ func (p *Probe) FlushDiscarders() error {
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
 func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
+	p.ruleActionStatsLock.Lock()
+	clear(p.ruleActionStats)
+	p.ruleActionStatsLock.Unlock()
 	return p.PlatformProbe.ApplyRuleSet(rs)
 }
 
@@ -364,6 +391,24 @@ func (p *Probe) GetService(ev *model.Event) string {
 	return p.Config.RuntimeSecurity.HostServiceName
 }
 
+func (p *Probe) onRuleActionPerformed(rule *rules.Rule, action *rules.ActionDefinition) {
+	p.ruleActionStatsLock.Lock()
+	defer p.ruleActionStatsLock.Unlock()
+
+	tags := actionStatsTags{
+		ruleID:     rule.ID,
+		actionName: action.Name(),
+	}
+
+	var counter *atomic.Int64
+	if counter = p.ruleActionStats[tags]; counter == nil {
+		counter = atomic.NewInt64(1)
+		p.ruleActionStats[tags] = counter
+	} else {
+		counter.Inc()
+	}
+}
+
 // NewRuleSet returns a new ruleset
 func (p *Probe) NewRuleSet(eventTypeEnabled map[eval.EventType]bool) *rules.RuleSet {
 	ruleOpts, evalOpts := rules.NewBothOpts(eventTypeEnabled)
@@ -371,6 +416,7 @@ func (p *Probe) NewRuleSet(eventTypeEnabled map[eval.EventType]bool) *rules.Rule
 	ruleOpts.WithReservedRuleIDs(events.AllCustomRuleIDs())
 	ruleOpts.WithSupportedDiscarders(SupportedDiscarders)
 	ruleOpts.WithSupportedMultiDiscarder(SupportedMultiDiscarder)
+	ruleOpts.WithRuleActionPerformedCb(p.onRuleActionPerformed)
 
 	eventCtor := func() eval.Event {
 		return p.PlatformProbe.NewEvent()

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -601,11 +601,15 @@ func (p *EBPFLessProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
+			if p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
-			})
+			}) {
+				p.probe.onRuleActionPerformed(rule, action.Def)
+			}
 		case action.Def.Hash != nil:
-			p.fileHasher.HashAndReport(rule, ev)
+			if p.fileHasher.HashAndReport(rule, ev) {
+				p.probe.onRuleActionPerformed(rule, action.Def)
+			}
 		}
 	}
 }

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1362,9 +1362,11 @@ func (p *WindowsProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				return
 			}
 
-			p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
+			if p.processKiller.KillAndReport(action.Def.Kill.Scope, action.Def.Kill.Signal, rule, ev, func(pid uint32, sig uint32) error {
 				return p.processKiller.KillFromUserspace(pid, sig, ev)
-			})
+			}) {
+				p.probe.onRuleActionPerformed(rule, action.Def)
+			}
 		}
 	}
 }

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -53,7 +53,6 @@ type ProcessKiller struct {
 }
 
 type processKillerStats struct {
-	actionPerformed int64
 	processesKilled int64
 }
 
@@ -241,7 +240,6 @@ func (p *ProcessKiller) KillAndReport(scope string, signal string, rule *rules.R
 		stats = &processKillerStats{}
 		p.perRuleStats[rule.ID] = stats
 	}
-	stats.actionPerformed++
 	stats.processesKilled += processesKilled
 	p.perRuleStatsLock.Unlock()
 
@@ -279,11 +277,6 @@ func (p *ProcessKiller) SendStats(statsd statsd.ClientInterface) {
 	for ruleID, stats := range p.perRuleStats {
 		ruleIDTag := []string{
 			"rule_id:" + string(ruleID),
-		}
-
-		if stats.actionPerformed > 0 {
-			_ = statsd.Count(metrics.MetricEnforcementKillActionPerformed, stats.actionPerformed, ruleIDTag, 1)
-			stats.actionPerformed = 0
 		}
 
 		if stats.processesKilled > 0 {

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -20,6 +20,9 @@ type VariableProvider interface {
 // VariableProviderFactory describes a function called to instantiate a variable provider
 type VariableProviderFactory func() VariableProvider
 
+// RuleActionPerformedCb describes the callback function called after a rule action is performed
+type RuleActionPerformedCb func(r *Rule, action *ActionDefinition)
+
 // Opts defines rules set options
 type Opts struct {
 	SupportedDiscarders      map[eval.Field]bool
@@ -28,6 +31,7 @@ type Opts struct {
 	EventTypeEnabled         map[eval.EventType]bool
 	StateScopes              map[Scope]VariableProviderFactory
 	Logger                   log.Logger
+	ruleActionPerformedCb    RuleActionPerformedCb
 }
 
 // WithSupportedDiscarders set supported discarders
@@ -63,6 +67,12 @@ func (o *Opts) WithLogger(logger log.Logger) *Opts {
 // WithStateScopes set state scopes
 func (o *Opts) WithStateScopes(stateScopes map[Scope]VariableProviderFactory) *Opts {
 	o.StateScopes = stateScopes
+	return o
+}
+
+// WithRuleActionPerformedCb sets the rule action performed callback
+func (o *Opts) WithRuleActionPerformedCb(cb RuleActionPerformedCb) *Opts {
+	o.ruleActionPerformedCb = cb
 	return o
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -552,6 +552,11 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 					}
 				}
 			}
+
+			if rs.opts.ruleActionPerformedCb != nil {
+				rs.opts.ruleActionPerformedCb(rule, action.Def)
+			}
+
 		}
 	}
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -514,14 +514,14 @@ func (rs *RuleSet) IsDiscarder(event eval.Event, field eval.Field) (bool, error)
 	return IsDiscarder(ctx, field, bucket.rules)
 }
 
-func (rs *RuleSet) runRuleActions(_ eval.Event, ctx *eval.Context, rule *Rule) error {
+func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) error {
 	for _, action := range rule.PolicyRule.Actions {
 		if !action.IsAccepted(ctx) {
 			continue
 		}
 
 		switch {
-		// action.Kill has to handled by a ruleset listener
+		// other actions are handled by ruleset listeners
 		case action.Def.Set != nil:
 			name := string(action.Def.Set.Scope)
 			if name != "" {
@@ -586,8 +586,8 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 					rs.logger.Tracef("Rule `%s` matches with event `%s`\n", rule.ID, event)
 				}
 
-				if err := rs.runRuleActions(event, ctx, rule); err != nil {
-					rs.logger.Errorf("Error while executing rule actions: %s", err)
+				if err := rs.runSetActions(event, ctx, rule); err != nil {
+					rs.logger.Errorf("Error while executing Set actions: %s", err)
 				}
 
 				rs.NotifyRuleMatch(rule, event)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Adds a new `datadog.runtime_security.rules.action_performed` metric used to count actions performed after a rule matched. The metric is tagged with the `rule_id` and the `action_name`
- Removes the `datadog.runtime_security.enforcement.kill_action_performed` metric that now becomes redundant with the new metric

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->