### PR TITLE
[PROCS-4358][agent][orchestrator] Support scrubbing for quoted args with spaces

### DIFF
--- a/pkg/orchestrator/redact/data_scrubber.go
+++ b/pkg/orchestrator/redact/data_scrubber.go
@@ -107,7 +107,10 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 		}
 	}
 
-	newCmdline := strings.Split(rawCmdline, " ")
+	// Regex tokenizes by capturing non-whitespace terms as tokens EX: "agent --secret" > ["agent", "--secret"]
+	// and non-whitespace terms followed by quotation enclosed subcomponents as tokens EX: "agent --pass="secret house"" > ["agent", "--pass="secret house""]
+	r := regexp.MustCompile(`([^\s"']+("([^"]*)")*('([^']*)')*)`)
+	newCmdline := r.FindAllString(rawCmdline, -1)
 
 	// preprocess, without the preprocessing we would need to strip until whitespaces.
 	// the first index can be skipped because it should be the program name.

--- a/releasenotes/notes/fix-scrubbing-arg-with-spaces-orchestrator-e88651f29cf1120d.yaml
+++ b/releasenotes/notes/fix-scrubbing-arg-with-spaces-orchestrator-e88651f29cf1120d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Orchestrator argument scrubbing to allow scrubbing of quoted arguments.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Allows scrubbing or redacting of quoted arguments.
- Changes tokenization to use Regex instead of `string.Split()` to allow greater flexibility in capturing arguments enclosed by quotes as terms to be scrubbed. 
  - EX: For the string `"process --pass="some thing""`, original behavior would output: `["process", "--pass=\"some", "thing\""]`. The new behavior will be: `["process",  "--pass=\"some thing\""]`.
- Change existing unit tests that tokenize spaces as empty strings (`string.Split()` splits based on single spaces, so it would preserve spaces in consecutive whitespace. On the other hand, the new regex pattern tokenization does not preserve spaces, and would not output spaces or empty strings in the scrubbed output).

### Motivation
https://datadoghq.atlassian.net/browse/PROCS-4358
@DataDog/container-app 

### Describe how to test/QA your changes
- Ran unit tests (all package tests in `data_scrubber_test.go`)
<img width="786" alt="image" src="https://github.com/user-attachments/assets/8e16bfce-0a60-4d60-bd06-4c07d6586bf4">

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This PR's changes is adjacent to the changes in this [PR](https://github.com/DataDog/datadog-agent/pull/29615) that fixes argument scrubbing for Process Agent.