### PR TITLE
[SMP] smp: stop timeouts due to stale merge-bases

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -86,6 +86,7 @@ single-machine-performance-regression_detector:
               echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
               exit 1
           fi
+          echo "Commit ${BASELINE_SHA} is recent enough"
           echo "Checking if image exists for commit ${BASELINE_SHA}..."
       done
     - echo "Image exists for commit ${BASELINE_SHA}"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -57,8 +57,37 @@ single-machine-performance-regression_detector:
     - chmod +x smp
     - BASELINE_SHA="${SMP_MERGE_BASE}"
     - echo "Computing baseline..."
+    - echo "Checking if commit ${BASELINE_SHA} is recent enough..."
+    # Compute four days before now as UNIX timestamp in order to test against SMP ECR expiration policy;
+    # add an hour as a small correction factor to overestimate time needed for SMP to query and pull the
+    # image so we don't end up with a hard-to-diagnose bug in which the image expires after checking its
+    # age in CI, but before SMP pulls the image.
+    - FOUR_DAYS_BEFORE_NOW=$(date --date="-4 days +1 hour" "+%s")
+    # Compute UNIX timestamp of potential baseline SHA
+    - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
+    # If baseline SHA is older than expiration policy, exit with an error
+    - | # Only 1st line of multiline command echoes, which reduces debuggability, so multiline commands are a maintenance tradeoff
+      if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
+      then
+          echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+          exit 1
+      fi
+    - echo "Commit ${BASELINE_SHA} is recent enough"
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
-    - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
+    - |
+      while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]
+      do
+          echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"
+          BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^)
+          echo "Checking if commit ${BASELINE_SHA} is recent enough..."
+          BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
+          if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
+          then
+              echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+              exit 1
+          fi
+          echo "Checking if image exists for commit ${BASELINE_SHA}..."
+      done
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"
     - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This pull request improves CI operation by checking whether each commit used in querying SMP's ECR is recent enough that the image has not expired from SMP's ECR. If the ECR query commit is not recent enough, then the CI step exits with an error message and an exit code of 1. The error message is intended to be informative and suggest a way to fix the error, but may need feedback to improve it.

Technically, the time that should be checked is that the image is no more than 4 days old at the point SMP queries the image. We cannot know precisely when that will happen, so we check whether an image is no more than 4 days minus 1 hour old instead. The "minus 1 hour" portion is an overestimate of the time it would take for SMP to pull the image, and guards against a pathological, hard-to-diagnose bug in which the shell command commit timestamp test passes, yet the image expires out of ECR before SMP can pull it. This buffer of an hour could be tweaked if a more precise estimate is needed; for now, the extra engineering effort required for such an estimate does not seem worthwhile.

### Motivation

If the Regression Detector tests a PR with a merge-base more than 4 days old, then the container image for the merge-base commit that SMP would use as a baseline has expired from SMP's ECR. That container image's absence would eventually cause a GitLab CI timeout, but timing out in this situation is not useful -- it wastes time, wastes compute, and provides no insight to users as to the cause of the timeout error. A significant fraction of SMP CI errors are timeouts, likely due to this mechanism; see https://github.com/DataDog/datadog-agent/pull/29644 for statistics that circumstantially support this assertion.

### Describe how to test/QA your changes

See if CI passes, in order to check shell syntax. Beyond that, we won't see the effects on CI quality of service until a day or so after merging because we would need to aggregate a large-enough collection of PRs to determine whether the CI duration for runs with SMP CI errors has decreased.

### Possible Drawbacks / Trade-offs

Aside from the typical issue of "there's more code, so more things can go wrong", the major maintainability versus debuggability tradeoff arises via the use of YAML multiline block syntax. Using this syntax means that [only the first line of a block will be echoed](https://docs.gitlab.com/ee/ci/yaml/script.html#split-long-commands) in job output. If only the first line of a block is echoed, debugging those commands becomes more challenging because a developer has to be aware of this behavior and must figure out which block corresponds to the echoed command. The block syntax does improve readability of the code by breaking up obnoxiously long lines. (I introduced those lines, and appreciate the maintainers' patience.)

### Additional Notes

Could be of interest to Agent DevX, given https://github.com/DataDog/datadog-agent/pull/29644?

Addresses SMPTNG-468.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->