### PR TITLE
[SMP] regression detector: use pr-commenter service

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -141,7 +141,7 @@ single-machine-performance-regression_detector-commenter:
   rules:
     - !reference [.except_main_or_release_branch]
   image:
-    name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2"
+    name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"
     entrypoint: [""]  # disable entrypoint script for the pr-commenter image
   tags: ["runner:docker"]
   needs:
@@ -150,9 +150,16 @@ single-machine-performance-regression_detector-commenter:
   allow_failure: true  # allow_failure here should have same setting as in job above
   script: # ignore error message about no PR, because it happens for dev branches without PRs
     - echo "${CI_COMMIT_REF_NAME}"
+    # Craft an HTTPS request to pr-commenter service to post Markdown report to
+    # GitHub, per
+    # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
     - |
       set +e
-      out=$(pr-commenter --for-pr="${CI_COMMIT_REF_NAME}" --header="Regression Detector" --infile outputs/report.md 2>&1)
+      out=$(curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+          -H "Authorization: $(authanywhere)" \
+          -H "X-DdOrigin: curl" \
+          -X PATCH \
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}')
       exitcode=$?
       set -e
       if [ -n "${out}" ]; then

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -147,6 +147,7 @@ single-machine-performance-regression_detector-commenter:
   needs:
     - job: single-machine-performance-regression_detector
       artifacts: true  # overrides default behavior that does not download artifacts
+  allow_failure: true  # allow_failure here should have same setting as in job above
   script: # ignore error message about no PR, because it happens for dev branches without PRs
     - echo "${CI_COMMIT_REF_NAME}"
     - |

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -123,9 +123,6 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    - !reference [.install_pr_commenter]
-    # Post HTML report to GitHub
-    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector"
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
@@ -136,3 +133,34 @@ single-machine-performance-regression_detector:
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result
       --submission-metadata submission_metadata
+
+# Shamelessly adapted from golang_deps_commenter job config in
+# golang_deps_diff.yml at commit 01da274032e510d617161cf4e264a53292f44e55.
+single-machine-performance-regression_detector-commenter:
+  stage: functional_test
+  rules:
+    - !reference [.except_main_or_release_branch]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
+  tags: ["arch:amd64"]
+  needs: ["single-machine-performance-regression_detector"]
+  variables:
+    # Not using the entrypoint script for the pr-commenter image
+    FF_KUBERNETES_HONOR_ENTRYPOINT: false
+  script: # ignore error message about no PR, because it happens for dev branches without PRs
+    - echo "${CI_COMMIT_REF_NAME}"
+    - |
+      set +e
+      out=$(pr-commenter --for-pr="${CI_COMMIT_REF_NAME}" --header="Regression Detector" --infile outputs/report.md 2>&1)
+      exitcode=$?
+      set -e
+      if [ -n "${out}" ]; then
+        if [ $exitcode -eq 0 ]; then
+          echo $out
+        else
+          echo $out >&2
+        fi
+      fi
+      if [ "${out}" != "${out/invalid request: no pr found for this commit}" ]; then
+        exit 0
+      fi
+      exit $exitcode

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -159,7 +159,7 @@ single-machine-performance-regression_detector-commenter:
           -H "Authorization: $(authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}')
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat outputs/report.md)"'"}')
       exitcode=$?
       set -e
       if [ -n "${out}" ]; then

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -140,12 +140,13 @@ single-machine-performance-regression_detector-commenter:
   stage: functional_test
   rules:
     - !reference [.except_main_or_release_branch]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
-  tags: ["arch:amd64"]
-  needs: ["single-machine-performance-regression_detector"]
-  variables:
-    # Not using the entrypoint script for the pr-commenter image
-    FF_KUBERNETES_HONOR_ENTRYPOINT: false
+  image:
+    name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2"
+    entrypoint: [""]  # disable entrypoint script for the pr-commenter image
+  tags: ["arch:amd64", "runner:docker"]
+  needs:
+    - job: single-machine-performance-regression_detector
+      artifacts: true  # overrides default behavior that does not download artifacts
   script: # ignore error message about no PR, because it happens for dev branches without PRs
     - echo "${CI_COMMIT_REF_NAME}"
     - |

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -143,7 +143,7 @@ single-machine-performance-regression_detector-commenter:
   image:
     name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2"
     entrypoint: [""]  # disable entrypoint script for the pr-commenter image
-  tags: ["arch:amd64", "runner:docker"]
+  tags: ["runner:docker"]
   needs:
     - job: single-machine-performance-regression_detector
       artifacts: true  # overrides default behavior that does not download artifacts


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit splits the `single-machine-performance-regression_detector` Agent CI job config into two jobs: one with the same name, and another called `single-machine-performance-regression_detector-commenter`.

The first of these two jobs contains all of the commands in the existing `single-machine-performance-regression_detector` job, except for installing the `pr-commenter` binary discussed above, and `pr-commenter`-related commands.

The second of these two jobs is scoped to posting Regression Detector PR comments using a container that includes `pr-commenter`.

### Motivation

Use of the `pr-commenter` binary from Datadog's devtools repo seems to be deprecated in favor of using an internal `pr-commenter` service. Regression Detector jobs in Agent CI sometimes emit errors in the PR commenting step and the maintainers of both that binary and that service suggested using the service instead. 

Previous SMP attempts to migrate from the `pr-commenter` binary to a `pr-commenter` service have been blocked because we were unable to figure out how to provide the necessary authentication for that service. I believe that the `pr-commenter` container includes a mechanism for authentication that should unblock this migration. However, if testing reveals that this approach fails due to lack of authentication, an alternative approach may be necessary.

### Describe how to test/QA your changes

In theory, if this change succeeds, we will see a Regression Detector PR comment in the comment thread of this PR.

### Possible Drawbacks / Trade-offs

In theory, replacing use of the devtools `pr-commenter` binary with Datadog's `pr-commenter` service should reduce Regression Detector job failures due to pull request commenting. The tradeoff here is the complexity of introducing an additional job that runs on a different container image, and it's unclear to me at time of pull request submission how this change will impact debugging job failures in the future.

An alternative, fallback approach would use a certain internal binary for authentication. That approach would not require a separate CI job running in a different container image, but it would require constructing an HTTP POST request with knowledge of the request fields required by the `pr-commenter` service. This requirement would tightly couple such an approach to modifications of `pr-commenter` service request messages, which seems undesirable from a maintenance perspective without some API stability policy. To the best of my knowledge, no such policy exists, but the `pr-commenter` command provided by the `pr-commenter` container preserves the CLI of the deprecated `pr-commenter` binary, and suggests that the CLI has a stronger implicit stability policy than that of the service's HTTP endpoint.

### Additional Notes

Changes to PR commenting are scoped to Regression Detector CI jobs to limit both risk and scope. This limitation should reduce development costs: it's easier to debug one targeted, uncertain change than several such changes. However, the `pr-commenter` binary appears to be used by other Agent CI jobs. If the approach in this PR succeeds, migrating other uses of that binary to the `pr-commenter` service may be worth pursuing in subsequent PRs for consistency and tidiness.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->