### PR TITLE
[SMP] regression detector: curl request to pr-commenter

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -21,6 +21,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.16.0
+    VAULT_ADDR: "https://vault.us1.ddbuild.io"
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main
@@ -124,16 +125,15 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Download auth tool; see
-    # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
-    - curl -Lo authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
-    - chmod u+x authanywhere
+    # In conjunction with setting VAULT_ADDR, a wild guess at Vault setup based on
+    # https://github.com/DataDog/dd-sdk-flutter/blob/e744cca56783b70d847592c08c5b8c342a38eb1f/.gitlab-ci.yml
+    - vault login -method=aws -no-print
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
     - |
       curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
-          -H "Authorization: $(./authanywhere)" \
+          -H "Authorization: $(vault read -field=token identity/oidc/token/rapid-eee-ci-interfaces)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
           -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}'

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -128,7 +128,8 @@ single-machine-performance-regression_detector:
     # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
     - curl -Lo authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
     - chmod u+x authanywhere
-    # Craft an HTTPS request to pr-commenter service, per
+    # Craft an HTTPS request to pr-commenter service to post Markdown report to
+    # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
     - |
       curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
@@ -136,9 +137,6 @@ single-machine-performance-regression_detector:
           -H "X-DdOrigin: curl" \
           -X PATCH \
           -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}'
-    - !reference [.install_pr_commenter]
-    # Post HTML report to GitHub
-    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector"
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -23,7 +23,6 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.16.0
-    VAULT_ADDR: "https://vault.us1.ddbuild.io"
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main
@@ -139,8 +138,8 @@ single-machine-performance-regression_detector:
     # option with `sed` because that option treats its input as
     # NUL-character-separated (i.e., '\0'-separated, the zero-byte character),
     # so `sed` does not interpret its input as newline-delimited. We also need
-    # escape double quotes to distinguish literal quotes in the report from the
-    # double quotes that delimit the value of the "message" field in the
+    # to escape double quotes to distinguish literal quotes in the report from
+    # the double quotes that delimit the value of the "message" field in the
     # payload.
     - cat outputs/report.md | sed -z 's/\n/\\n/g' | sed -z 's/"/\\"/g' > report_as_json_string.txt
     - cat report_as_json_string.txt
@@ -149,7 +148,7 @@ single-machine-performance-regression_detector:
     # help debugging.
     - PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message":"'"$(cat report_as_json_string.txt)"'"}'
     - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}"
-    - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
+    - printf "%s\n" "${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -137,7 +137,7 @@ single-machine-performance-regression_detector:
           -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}'
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat outputs/report.md)"'"}'
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -125,8 +125,6 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # In conjunction with setting VAULT_ADDR, a wild guess at Vault setup
-    - vault login -method=oidc -no-print
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -142,7 +142,7 @@ single-machine-performance-regression_detector:
     # escape double quotes to distinguish literal quotes in the report from the
     # double quotes that delimit the value of the "message" field in the
     # payload.
-    - cat outputs/report.md | sed -z 's/\n/\\n/g' | sed -z 's/"/\"/g' > report_as_json_string.txt
+    - cat outputs/report.md | sed -z 's/\n/\\n/g' | sed -z 's/"/\\"/g' > report_as_json_string.txt
     - cat report_as_json_string.txt
     # Transforming the Markdown report to a valid JSON string is easy to foul
     # up, so to make debugging easier, we store the payload in a variable to

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,6 +18,7 @@ single-machine-performance-regression_detector:
       - outputs/regression_signal.json # for debugging, also on S3
       - outputs/bounds_check_signal.json # for debugging, also on S3
       - outputs/junit.xml # for debugging, also on S3
+      - report_as_json_string.txt # for debugging transform to valid JSON string
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -129,21 +130,24 @@ single-machine-performance-regression_detector:
     # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
     - curl -Lo ./authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
     - chmod u+x ./authanywhere
+    # We need to transform the Markdown report into a valid JSON string (without
+    # quotes) in order to pass a well-formed payload to the PR commenting
+    # service. Note that on macOS, the "-z" flag is invalid for `sed` (but
+    # should be fine for GNU `sed`). We need to use `sed` to escape newlines
+    # because JSON does not permit (raw) newlines in strings. We use the "-z"
+    # option with `sed` because that option treats its input as
+    # NUL-character-separated (i.e., '\0'-separated, the zero-byte character),
+    # so `sed` does not interpret its input as newline-delimited.
+    - cat outputs/report.md | sed -z 's/\n/\\n/g' > report_as_json_string.txt
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
-    # Note that on macOS, the "-z" flag is invalid for `sed` (but should be fine
-    # for GNU `sed`). We need to use `sed` to escape newlines because JSON does
-    # not permit (raw) newlines in strings. We use the "-z" option with `sed`
-    # because that option treats its input as NUL-character-separated (i.e.,
-    # '\0'-separated, the zero-byte character), so `sed` does not interpret its
-    # input as newline-delimited.
     - |
       curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
           -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat outputs/report.md | sed -z 's/\n/\\n/g')"'"}'
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat report_as_json_string.txt)"'"}'
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -144,9 +144,9 @@ single-machine-performance-regression_detector:
     # Transforming the Markdown report to a valid JSON string is easy to foul
     # up, so to make debugging easier, we store the payload in a variable to
     # help debugging.
-    - export PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat report_as_json_string.txt)"'"}'
-    - printf "%s\n" "PR comment JSON payload: ${PR_COMMENT_JSON_PAYLOAD}"
-    - printf "%s\n" "PR comment JSON payload: ${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
+    - export PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message":"'"$(cat report_as_json_string.txt)"'"}'
+    - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}"
+    - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -144,7 +144,7 @@ single-machine-performance-regression_detector:
     # Transforming the Markdown report to a valid JSON string is easy to foul
     # up, so to make debugging easier, we store the payload in a variable to
     # help debugging.
-    - export PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message":"'"$(cat report_as_json_string.txt)"'"}'
+    - PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message":"'"$(cat report_as_json_string.txt)"'"}'
     - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}"
     - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
     # Craft an HTTPS request to pr-commenter service to post Markdown report to

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -125,12 +125,16 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Download auth tool; see
+    # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
+    - curl -Lo ./authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
+    - chmod u+x ./authanywhere
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
     - |
       curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
-          -H "Authorization: $(vault read -field=token identity/oidc/token/rapid-eee-ci-interfaces)" \
+          -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
           -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}'

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -132,12 +132,18 @@ single-machine-performance-regression_detector:
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
+    # Note that on macOS, the "-z" flag is invalid for `sed` (but should be fine
+    # for GNU `sed`). We need to use `sed` to escape newlines because JSON does
+    # not permit (raw) newlines in strings. We use the "-z" option with `sed`
+    # because that option treats its input as NUL-character-separated (i.e.,
+    # '\0'-separated, the zero-byte character), so `sed` does not interpret its
+    # input as newline-delimited.
     - |
       curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
           -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat outputs/report.md)"'"}'
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat outputs/report.md | sed -z 's/\n/\\n/g')"'"}'
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -19,6 +19,7 @@ single-machine-performance-regression_detector:
       - outputs/bounds_check_signal.json # for debugging, also on S3
       - outputs/junit.xml # for debugging, also on S3
       - report_as_json_string.txt # for debugging transform to valid JSON string
+      - pr_comment_payload.json  # for debugging PR commenter JSON payload bugs
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -139,6 +140,13 @@ single-machine-performance-regression_detector:
     # NUL-character-separated (i.e., '\0'-separated, the zero-byte character),
     # so `sed` does not interpret its input as newline-delimited.
     - cat outputs/report.md | sed -z 's/\n/\\n/g' > report_as_json_string.txt
+    - cat report_as_json_string.txt
+    # Transforming the Markdown report to a valid JSON string is easy to foul
+    # up, so to make debugging easier, we store the payload in a variable to
+    # help debugging.
+    - export PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat report_as_json_string.txt)"'"}'
+    - printf "%s\n" "PR comment JSON payload: ${PR_COMMENT_JSON_PAYLOAD}"
+    - printf "%s\n" "PR comment JSON payload: ${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
@@ -147,7 +155,7 @@ single-machine-performance-regression_detector:
           -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Regression Detector", "message": "'"$(cat report_as_json_string.txt)"'"}'
+          -d "${PR_COMMENT_JSON_PAYLOAD}"
     # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -125,9 +125,8 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # In conjunction with setting VAULT_ADDR, a wild guess at Vault setup based on
-    # https://github.com/DataDog/dd-sdk-flutter/blob/e744cca56783b70d847592c08c5b8c342a38eb1f/.gitlab-ci.yml
-    - vault login -method=aws -no-print
+    # In conjunction with setting VAULT_ADDR, a wild guess at Vault setup
+    - vault login -method=oidc -no-print
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -138,8 +138,11 @@ single-machine-performance-regression_detector:
     # because JSON does not permit (raw) newlines in strings. We use the "-z"
     # option with `sed` because that option treats its input as
     # NUL-character-separated (i.e., '\0'-separated, the zero-byte character),
-    # so `sed` does not interpret its input as newline-delimited.
-    - cat outputs/report.md | sed -z 's/\n/\\n/g' > report_as_json_string.txt
+    # so `sed` does not interpret its input as newline-delimited. We also need
+    # escape double quotes to distinguish literal quotes in the report from the
+    # double quotes that delimit the value of the "message" field in the
+    # payload.
+    - cat outputs/report.md | sed -z 's/\n/\\n/g' | sed -z 's/"/\"/g' > report_as_json_string.txt
     - cat report_as_json_string.txt
     # Transforming the Markdown report to a valid JSON string is easy to foul
     # up, so to make debugging easier, we store the payload in a variable to

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -124,6 +124,18 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Download auth tool; see
+    # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
+    - curl -Lo authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
+    - chmod u+x authanywhere
+    # Craft an HTTPS request to pr-commenter service, per
+    # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
+    - |
+      curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+          -H "Authorization: $(./authanywhere)" \
+          -H "X-DdOrigin: curl" \
+          -X PATCH \
+          -d '{"org":"DataDog", "repo":"datadog-agent", "commit":'"${CI_COMMIT_SHA}"', "header":"Regression Detector", "message":'"$(cat outputs/report.md)"'}'
     - !reference [.install_pr_commenter]
     # Post HTML report to GitHub
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

This commit changes the command that posts a Regression Detector PR comment from a `pr-commenter` CLI call to a `curl`ed HTTPS request to PR commenter service.

### Motivation

I couldn't get #29683 to work, so this PR is supposed to accomplish the same aims as that PR -- replace `pr-commenter` binary calls with use of a PR commenter service -- to cut down on Regression Detector job errors in Agent CI. As noted in that other PR, authentication is where previous replacement efforts were blocked. Use of an internal auth tool hopefully unblocks this replacement effort.

### Describe how to test/QA your changes

In theory, if this change succeeds, we will see a Regression Detector PR comment in the comment thread of this PR.

### Possible Drawbacks / Trade-offs

In theory, replacing use of the devtools pr-commenter binary with Datadog's pr-commenter service should reduce Regression Detector job failures due to pull request commenting.

The main drawback I see with the approach in this PR is that a hand-written `curl` request is error prone, and tightly couples the CI job to the PR comment service request API. The shell syntax required is also difficult to read, but the mix of single and double quotes seemed preferable to alternatives that require escaping.

### Additional Notes

If this PR is merged, #29683 should be closed. If #29683 is merged, this PR should be closed. Both this PR and #29683 accomplish the same aim, so there should be no need to merge both.

Changes to PR commenting are scoped to Regression Detector CI jobs to limit both risk and scope. This limitation should limit development costs: it's easier to debug one targeted, uncertain change than several such changes. However, the pr-commenter binary appears to be used by other Agent CI jobs. If the approach in this PR succeeds, migrating other uses of that binary to the pr-commenter service may be worth pursuing in subsequent PRs for consistency and tidiness.

Completes SMPTNG-471.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->