### PR TITLE
Split compute and display gitlab ci config / diff ACIX-423

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 ---
 include:
   - .gitlab/.pre/cancel-prev-pipelines.yml
-  - .gitlab/.pre/test_gitlab_configuration.yml
+  - .gitlab/.pre/gitlab_configuration.yml
   - .gitlab/benchmarks/include.yml
   - .gitlab/binary_build/include.yml
   - .gitlab/check_deploy/check_deploy.yml

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -23,7 +23,7 @@ test_gitlab_compare_to:
     - pip install -r tasks/requirements.txt
     - inv pipeline.compare-to-itself
 
-# TODO: Rename the source file to gitlab_config.yml
+# Computes and uploads the GitLab CI configuration diff as an artifact
 compute_gitlab_ci_config:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -25,10 +25,10 @@ test_gitlab_compare_to:
 
 # Computes and uploads the GitLab CI configuration diff as an artifact
 compute_gitlab_ci_config:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
   needs: []
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   rules:
     - if: $CI_PIPELINE_SOURCE != "push"
       when: never

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -47,16 +47,3 @@ compute_gitlab_ci_config:
     paths:
       - artifacts/
     expire_in: 1 day
-
-test_compute_gitlab_ci_config:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  stage: .pre
-  needs: [compute_gitlab_ci_config]
-  dependencies: [compute_gitlab_ci_config]
-  tags: ["arch:amd64"]
-  rules:
-    - if: $CI_PIPELINE_SOURCE != "push"
-      when: never
-    - when: on_success
-  script:
-    - inv -e gitlab.print-gitlab-ci-diff

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -29,9 +29,9 @@ compute_gitlab_ci_config:
   stage: .pre
   needs: []
   tags: ["arch:amd64"]
-  rules:
-    - if: $CI_PIPELINE_SOURCE != "push"
-      when: never
+  # rules:
+  #   - if: $CI_PIPELINE_SOURCE != "push"
+  #     when: never
   before_script:
     # Get main history
     - git fetch origin main
@@ -52,8 +52,8 @@ test_compute_gitlab_ci_config:
   stage: .pre
   needs: [compute_gitlab_ci_config]
   tags: ["arch:amd64"]
-  rules:
-    - if: $CI_PIPELINE_SOURCE != "push"
-      when: never
+  # rules:
+  #   - if: $CI_PIPELINE_SOURCE != "push"
+  #     when: never
   script:
     - inv -e gitlab.print-gitlab-ci-diff

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -24,9 +24,9 @@ test_gitlab_compare_to:
     - inv pipeline.compare-to-itself
 
 # TODO: Rename the source file to gitlab_config.yml
-gitlab_ci_changes:
+compute_gitlab_ci_config:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  stage: notify
+  stage: .pre
   needs: []
   tags: ["arch:amd64"]
   rules:
@@ -39,4 +39,21 @@ gitlab_ci_changes:
     - git checkout -
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
-    - inv -e gitlab.compute-gitlab-ci-config
+    - mkdir -p artifacts
+    - inv -e gitlab.compute-gitlab-ci-config --before-file before.gitlab-ci.yml --after-file after.gitlab-ci.yml --diff-file diff.gitlab-ci.yml
+  artifacts:
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 1 day
+
+test_compute_gitlab_ci_config:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  stage: .pre
+  needs: [compute_gitlab_ci_config]
+  tags: ["arch:amd64"]
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "push"
+      when: never
+  script:
+    - inv -e gitlab.print-gitlab-ci-diff

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -22,3 +22,21 @@ test_gitlab_compare_to:
     - !reference [.setup_agent_github_app]
     - pip install -r tasks/requirements.txt
     - inv pipeline.compare-to-itself
+
+# TODO: Rename the source file to gitlab_config.yml
+gitlab_ci_changes:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  stage: notify
+  needs: []
+  tags: ["arch:amd64"]
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "push"
+      when: never
+  before_script:
+    # Get main history
+    - git fetch origin main
+    - git checkout main
+    - git checkout -
+  script:
+    - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
+    - inv -e gitlab.compute-gitlab-ci-config

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -29,9 +29,10 @@ compute_gitlab_ci_config:
   stage: .pre
   needs: []
   tags: ["arch:amd64"]
-  # rules:
-  #   - if: $CI_PIPELINE_SOURCE != "push"
-  #     when: never
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "push"
+      when: never
+    - when: on_success
   before_script:
     # Get main history
     - git fetch origin main
@@ -51,9 +52,11 @@ test_compute_gitlab_ci_config:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: .pre
   needs: [compute_gitlab_ci_config]
+  dependencies: [compute_gitlab_ci_config]
   tags: ["arch:amd64"]
-  # rules:
-  #   - if: $CI_PIPELINE_SOURCE != "push"
-  #     when: never
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "push"
+      when: never
+    - when: on_success
   script:
     - inv -e gitlab.print-gitlab-ci-diff

--- a/.gitlab/.pre/test_gitlab_configuration.yml
+++ b/.gitlab/.pre/test_gitlab_configuration.yml
@@ -41,7 +41,7 @@ compute_gitlab_ci_config:
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
     - mkdir -p artifacts
-    - inv -e gitlab.compute-gitlab-ci-config --before-file before.gitlab-ci.yml --after-file after.gitlab-ci.yml --diff-file diff.gitlab-ci.yml
+    - inv -e gitlab.compute-gitlab-ci-config --before-file artifacts/before.gitlab-ci.yml --after-file artifacts/after.gitlab-ci.yml --diff-file artifacts/diff.gitlab-ci.yml
   artifacts:
     when: always
     paths:

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -159,14 +159,14 @@ notify_failure_summary_daily:
 
 close_failing_tests_stale_issues:
   stage: notify
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   rules:
     # Daily
     - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
       when: never
     - !reference [.on_deploy_nightly_repo_branch_always]
   needs: []
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   script:
     - weekday="$(date --utc '+%A')"
     # Weekly on Friday

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -111,7 +111,7 @@ notify_gitlab_ci_changes:
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
-    - inv -e notify.gitlab-ci-diff --pr-comment
+    - inv -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment
 
 .failure_summary_job:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -92,7 +92,6 @@ notify_gitlab_ci_changes:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: notify
   needs: [compute_gitlab_ci_config]
-  dependencies: [compute_gitlab_ci_config]
   tags: ["arch:amd64"]
   rules:
     - if: $CI_PIPELINE_SOURCE != "push"

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -91,7 +91,8 @@ notify_github:
 notify_gitlab_ci_changes:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: notify
-  needs: []
+  needs: [compute_gitlab_ci_config]
+  dependencies: [compute_gitlab_ci_config]
   tags: ["arch:amd64"]
   rules:
     - if: $CI_PIPELINE_SOURCE != "push"

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -102,11 +102,6 @@ notify_gitlab_ci_changes:
           - .gitlab-ci.yml
           - .gitlab/**/*.yml
         compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
-  before_script:
-    # Get main history
-    - git fetch origin main
-    - git checkout main
-    - git checkout -
   script:
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - !reference [.setup_agent_github_app]

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -320,6 +320,8 @@ def compute_gitlab_ci_config(
 ):
     """
     Will compute the Gitlab CI full configuration for the current commit and the base commit and will compute the diff between them.
+
+    The diff can be loaded using `MultiGitlabCIDiff.from_dict`.
     """
 
     before_config, after_config, diff = compute_gitlab_ci_config_diff(ctx, before, after)

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -297,7 +297,7 @@ def compute_gitlab_ci_config_diff(ctx, before: str, after: str):
 
     # The before commit is the LCA commit between before and after
     before = before or DEFAULT_BRANCH
-    before = get_common_ancestor(before, after or "HEAD")
+    before = get_common_ancestor(ctx, before, after or "HEAD")
 
     print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
     after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
@@ -305,7 +305,7 @@ def compute_gitlab_ci_config_diff(ctx, before: str, after: str):
     print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
     before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
 
-    diff = MultiGitlabCIDiff(before_config, after_config)
+    diff = MultiGitlabCIDiff.from_contents(before_config, after_config)
 
     return before_config, after_config, diff
 

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -342,7 +342,7 @@ def print_gitlab_ci_diff(ctx):
     """
     Print the diff of the Gitlab CI configuration between the current commit and the base commit.
     """
-    with open('/tmp/diff.gitlab-ci.yml') as f:
+    with open('artifacts/diff.gitlab-ci.yml') as f:
         diff = MultiGitlabCIDiff.from_dict(yaml.safe_load(f))
 
     print(diff.display(cli=True))

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -288,7 +288,7 @@ def print_entry_points(ctx):
 def compute_gitlab_ci_config_diff(ctx, before: str, after: str):
     """
     Computes the full configs and the diff between two git references.
-    The base commit where after is compared to is the LCA commit between before and after.
+    The "after reference" is compared to the Lowest Common Ancestor (LCA) commit of "before reference" and "after reference".
     """
 
     before_name = before or "merge base"

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -334,7 +334,7 @@ def compute_gitlab_ci_config(
 
     print('Writing', diff_file)
     with open(diff_file, 'w') as f:
-        f.write(yaml.safe_dump(diff.todict()))
+        f.write(yaml.safe_dump(diff.to_dict()))
 
 
 @task
@@ -342,7 +342,7 @@ def print_gitlab_ci_diff(ctx):
     """
     Print the diff of the Gitlab CI configuration between the current commit and the base commit.
     """
-    with open('artifacts/diff.gitlab-ci.yml') as f:
-        diff = MultiGitlabCIDiff(yaml.safe_load(f))
+    with open('/tmp/diff.gitlab-ci.yml') as f:
+        diff = MultiGitlabCIDiff.from_dict(yaml.safe_load(f))
 
     print(diff.display(cli=True))

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -281,3 +281,154 @@ def print_entry_points(ctx):
     print(len(entry_points), 'entry points:')
     for entry_point, config in entry_points.items():
         print(f'- {color_message(entry_point, Color.BOLD)} ({len(config)} components)')
+
+
+from tasks.libs.ciproviders.gitlab_api import (
+    MultiGitlabCIDiff,
+)
+from tasks.libs.common.constants import DEFAULT_BRANCH
+
+
+@task
+def compute_gitlab_ci_config(
+    ctx,
+    before: str | None = None,
+    after: str | None = None,
+    before_file: str = 'before.gitlab-ci.yml',
+    after_file: str = 'after.gitlab-ci.yml',
+    diff_file: str = 'diff.gitlab-ci.yml',
+):
+    """
+    Will compute the Gitlab CI full configuration for the current commit and the base commit and will compute the diff between them.
+    """
+
+    with open('/tmp/diff.yml') as f:
+        diff = MultiGitlabCIDiff.fromdict(yaml.safe_load(f))
+    print(diff.display(cli=True))
+    exit()
+
+    before_name = before or "merge base"
+    after_name = after or "local files"
+
+    # The before commit is the LCA commit between before and after
+    before = before or DEFAULT_BRANCH
+    before = ctx.run(f'git merge-base {before} {after or "HEAD"}', hide=True).stdout.strip()
+
+    print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
+    after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
+
+    print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
+    before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
+
+    print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
+    after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
+
+    print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
+    before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
+
+    diff = MultiGitlabCIDiff(before_config, after_config)
+
+    print('Writing', before_file)
+    with open(before_file, 'w') as f:
+        f.write(yaml.safe_dump(before_config))
+
+    print('Writing', after_file)
+    with open(after_file, 'w') as f:
+        f.write(yaml.safe_dump(after_config))
+
+    print('Writing', diff_file)
+    with open(diff_file, 'w') as f:
+        f.write(yaml.safe_dump(diff.todict()))
+
+
+def gitlab_ci_diff(ctx, before: str | None = None, after: str | None = None, pr_comment: bool = False):
+    """
+    Creates a diff from two gitlab-ci configurations.
+
+    - before: Git ref without new changes, None for default branch
+    - after: Git ref with new changes, None for current local configuration
+    - pr_comment: If True, post the diff as a comment in the PR
+    - NOTE: This requires a full api token access level to the repository
+    """
+
+    from tasks.libs.ciproviders.github_api import GithubAPI
+
+    pr_comment_head = 'Gitlab CI Configuration Changes'
+    if pr_comment:
+        github = GithubAPI()
+
+        if (
+            "CI_COMMIT_BRANCH" not in os.environ
+            or len(list(github.get_pr_for_branch(os.environ["CI_COMMIT_BRANCH"]))) != 1
+        ):
+            print(
+                color_message("Warning: No PR found for current branch, skipping message", Color.ORANGE),
+                file=sys.stderr,
+            )
+            pr_comment = False
+
+    if pr_comment:
+        job_url = os.environ['CI_JOB_URL']
+
+    try:
+        before_name = before or "merge base"
+        after_name = after or "local files"
+
+        # The before commit is the LCA commit between before and after
+        before = before or DEFAULT_BRANCH
+        before = ctx.run(f'git merge-base {before} {after or "HEAD"}', hide=True).stdout.strip()
+
+        print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
+        after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
+
+        print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
+        before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
+
+        diff = MultiGitlabCIDiff(before_config, after_config)
+
+        if not diff:
+            print(color_message("No changes in the gitlab-ci configuration", Color.GREEN))
+
+            # Remove comment if no changes
+            if pr_comment:
+                pr_commenter(ctx, pr_comment_head, delete=True, force_delete=True)
+
+            return
+
+        # Display diff
+        print('\nGitlab CI configuration diff:')
+        with gitlab_section('Gitlab CI configuration diff'):
+            print(diff.display(cli=True))
+
+        if pr_comment:
+            print('\nSending / updating PR comment')
+            comment = diff.display(cli=False, job_url=job_url)
+            try:
+                pr_commenter(ctx, pr_comment_head, comment)
+            except Exception:
+                # Comment too large
+                print(color_message('Warning: Failed to send full diff, sending only changes summary', Color.ORANGE))
+
+                comment_summary = diff.display(cli=False, job_url=job_url, only_summary=True)
+                try:
+                    pr_commenter(ctx, pr_comment_head, comment_summary)
+                except Exception:
+                    print(color_message('Warning: Failed to send summary diff, sending only job link', Color.ORANGE))
+
+                    pr_commenter(
+                        ctx,
+                        pr_comment_head,
+                        f'Cannot send only summary message, see the [job log]({job_url}) for details',
+                    )
+
+            print(color_message('Sent / updated PR comment', Color.GREEN))
+    except Exception:
+        if pr_comment:
+            # Send message
+            pr_commenter(
+                ctx,
+                pr_comment_head,
+                f':warning: *Failed to display Gitlab CI configuration changes, see the [job log]({job_url}) for details.*',
+            )
+
+        raise

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -29,6 +29,7 @@ from tasks.libs.civisibility import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import DEFAULT_BRANCH
+from tasks.libs.common.git import get_common_ancestor
 from tasks.libs.common.utils import experimental
 
 
@@ -296,7 +297,7 @@ def compute_gitlab_ci_config_diff(ctx, before: str, after: str):
 
     # The before commit is the LCA commit between before and after
     before = before or DEFAULT_BRANCH
-    before = ctx.run(f'git merge-base {before} {after or "HEAD"}', hide=True).stdout.strip()
+    before = get_common_ancestor(before, after or "HEAD")
 
     print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
     after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
@@ -320,8 +321,6 @@ def compute_gitlab_ci_config(
 ):
     """
     Will compute the Gitlab CI full configuration for the current commit and the base commit and will compute the diff between them.
-
-    The diff can be loaded using `MultiGitlabCIDiff.from_dict`.
     """
 
     before_config, after_config, diff = compute_gitlab_ci_config_diff(ctx, before, after)

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -406,7 +406,7 @@ class MultiGitlabCIDiff:
         else:
             self.before = dict(before)
             self.after = dict(after)
-            self.diffs: list[MultiGitlabCIDiff.MultiDiff] = []
+            self.diffs = []
             self.make_diff()
 
     def __bool__(self) -> bool:

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -364,6 +364,27 @@ class GitlabCIDiff:
 
         return '\n'.join(res)
 
+    def iter_jobs(self, added=True, modified=True, removed=False):
+        """
+        Will iterate over all jobs in all files for the given states
+
+        Returns a tuple of (job_name, contents, state)
+
+        Note that the contents is the contents after modification or before removal
+        """
+
+        if added:
+            for job in self.added:
+                yield job, self.after[job], 'added'
+
+        if modified:
+            for job in self.modified:
+                yield job, self.after[job], 'modified'
+
+        if removed:
+            for job in self.removed:
+                yield job, self.before[job], 'removed'
+
 
 class MultiGitlabCIDiff:
     @dataclass
@@ -484,6 +505,19 @@ class MultiGitlabCIDiff:
             res.append(self.diffs[-1].diff.footnote(job_url))
 
         return '\n'.join(res)
+
+    def iter_jobs(self, added=True, modified=True, removed=False):
+        """
+        Will iterate over all jobs in all files for the given states
+
+        Returns a tuple of (entry_point, job_name, contents, state)
+
+        Note that the contents is the contents after modification or before removal
+        """
+
+        for diff in self.diffs:
+            for job, contents, state in diff.diff.iter_jobs(added=added, modified=modified, removed=removed):
+                yield diff.entry_point, job, contents, state
 
 
 class ReferenceTag(yaml.YAMLObject):

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -142,7 +142,7 @@ class GitlabCIDiff:
     def __bool__(self) -> bool:
         return bool(self.added or self.removed or self.modified or self.renamed)
 
-    def todict(self) -> dict:
+    def to_dict(self) -> dict:
         return {
             'before': self.before,
             'after': self.after,
@@ -155,7 +155,7 @@ class GitlabCIDiff:
         }
 
     @staticmethod
-    def fromdict(data: dict) -> GitlabCIDiff:
+    def from_dict(data: dict) -> GitlabCIDiff:
         return GitlabCIDiff(dict_initialization=data)
 
     def make_diff(self):
@@ -374,18 +374,18 @@ class MultiGitlabCIDiff:
         is_added: bool
         is_removed: bool
 
-        def todict(self) -> dict:
+        def to_dict(self) -> dict:
             return {
                 'entry_point': self.entry_point,
-                'diff': self.diff.todict(),
+                'diff': self.diff.to_dict(),
                 'is_added': self.is_added,
                 'is_removed': self.is_removed,
             }
 
         @staticmethod
-        def fromdict(data: dict) -> MultiGitlabCIDiff.MultiDiff:
+        def from_dict(data: dict) -> MultiGitlabCIDiff.MultiDiff:
             return MultiGitlabCIDiff.MultiDiff(
-                data['entry_point'], GitlabCIDiff.fromdict(data['diff']), data['is_added'], data['is_removed']
+                data['entry_point'], GitlabCIDiff.from_dict(data['diff']), data['is_added'], data['is_removed']
             )
 
     def __init__(
@@ -402,7 +402,7 @@ class MultiGitlabCIDiff:
         if dict_initialization:
             self.before = dict_initialization['before']
             self.after = dict_initialization['after']
-            self.diffs = [MultiGitlabCIDiff.MultiDiff.fromdict(d) for d in dict_initialization['diffs']]
+            self.diffs = [MultiGitlabCIDiff.MultiDiff.from_dict(d) for d in dict_initialization['diffs']]
         else:
             self.before = dict(before)
             self.after = dict(after)
@@ -412,11 +412,11 @@ class MultiGitlabCIDiff:
     def __bool__(self) -> bool:
         return bool(self.diffs)
 
-    def todict(self) -> dict:
-        return {'before': self.before, 'after': self.after, 'diffs': [diff.todict() for diff in self.diffs]}
+    def to_dict(self) -> dict:
+        return {'before': self.before, 'after': self.after, 'diffs': [diff.to_dict() for diff in self.diffs]}
 
     @staticmethod
-    def fromdict(data: dict) -> MultiGitlabCIDiff:
+    def from_dict(data: dict) -> MultiGitlabCIDiff:
         return MultiGitlabCIDiff(dict_initialization=data)
 
     def make_diff(self):

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -18,6 +18,7 @@ from gitlab.v4.objects import Project, ProjectCommit, ProjectPipeline
 from invoke.exceptions import Exit
 
 from tasks.libs.common.color import Color, color_message
+from tasks.libs.common.constants import DEFAULT_BRANCH
 from tasks.libs.common.git import get_common_ancestor, get_current_branch
 from tasks.libs.common.utils import retry_function
 
@@ -386,7 +387,7 @@ class GitlabCIDiff:
 
         Returns a tuple of (job_name, contents, state)
 
-        Note that the contents is the contents after modification or before removal
+        Note that the contents of the job is the contents after modification if modified or before removal if removed
         """
 
         if added:
@@ -1160,3 +1161,27 @@ def gitlab_configuration_is_modified(ctx):
             return True
 
     return False
+
+
+def compute_gitlab_ci_config_diff(ctx, before: str, after: str):
+    """
+    Computes the full configs and the diff between two git references.
+    The "after reference" is compared to the Lowest Common Ancestor (LCA) commit of "before reference" and "after reference".
+    """
+
+    before_name = before or "merge base"
+    after_name = after or "local files"
+
+    # The before commit is the LCA commit between before and after
+    before = before or DEFAULT_BRANCH
+    before = get_common_ancestor(ctx, before, after or "HEAD")
+
+    print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
+    after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
+
+    print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
+    before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
+
+    diff = MultiGitlabCIDiff.from_contents(before_config, after_config)
+
+    return before_config, after_config, diff

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -54,8 +54,8 @@ def get_current_branch(ctx) -> str:
     return ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
 
 
-def get_common_ancestor(ctx, branch) -> str:
-    return ctx.run(f"git merge-base {branch} main", hide=True).stdout.strip()
+def get_common_ancestor(ctx, branch, base=DEFAULT_BRANCH) -> str:
+    return ctx.run(f"git merge-base {branch} {base}", hide=True).stdout.strip()
 
 
 def check_uncommitted_changes(ctx):

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -10,12 +10,11 @@ from invoke.exceptions import Exit
 
 import tasks.libs.notify.unit_tests as unit_tests_utils
 from tasks.github_tasks import pr_commenter
+from tasks.gitlab_helpers import compute_gitlab_ci_config_diff
 from tasks.libs.ciproviders.gitlab_api import (
     MultiGitlabCIDiff,
-    get_all_gitlab_ci_configurations,
 )
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.constants import DEFAULT_BRANCH
 from tasks.libs.common.datadog_api import send_metrics
 from tasks.libs.common.utils import gitlab_section
 from tasks.libs.notify import alerts, failure_summary, pipeline_status
@@ -138,7 +137,9 @@ def unit_tests(ctx, pipeline_id, pipeline_url, branch_name, dry_run=False):
 
 
 @task
-def gitlab_ci_diff(ctx, before: str | None = None, after: str | None = None, pr_comment: bool = False):
+def gitlab_ci_diff(
+    ctx, before: str | None = None, after: str | None = None, pr_comment: bool = False, from_diff: str | None = None
+):
     """
     Creates a diff from two gitlab-ci configurations.
 
@@ -168,20 +169,10 @@ def gitlab_ci_diff(ctx, before: str | None = None, after: str | None = None, pr_
         job_url = os.environ['CI_JOB_URL']
 
     try:
-        before_name = before or "merge base"
-        after_name = after or "local files"
-
-        # The before commit is the LCA commit between before and after
-        before = before or DEFAULT_BRANCH
-        before = ctx.run(f'git merge-base {before} {after or "HEAD"}', hide=True).stdout.strip()
-
-        print(f'Getting after changes config ({color_message(after_name, Color.BOLD)})')
-        after_config = get_all_gitlab_ci_configurations(ctx, git_ref=after, clean_configs=True)
-
-        print(f'Getting before changes config ({color_message(before_name, Color.BOLD)})')
-        before_config = get_all_gitlab_ci_configurations(ctx, git_ref=before, clean_configs=True)
-
-        diff = MultiGitlabCIDiff(before_config, after_config)
+        if from_diff:
+            diff = MultiGitlabCIDiff.from_dict(from_diff)
+        else:
+            _, _, diff = compute_gitlab_ci_config_diff(ctx, before, after)
 
         if not diff:
             print(color_message("No changes in the gitlab-ci configuration", Color.GREEN))

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -5,6 +5,7 @@ import re
 import sys
 from datetime import timedelta
 
+import yaml
 from invoke import Context, task
 from invoke.exceptions import Exit
 
@@ -170,7 +171,9 @@ def gitlab_ci_diff(
 
     try:
         if from_diff:
-            diff = MultiGitlabCIDiff.from_dict(from_diff)
+            with open(from_diff) as f:
+                diff_data = yaml.safe_load(f)
+            diff = MultiGitlabCIDiff.from_dict(diff_data)
         else:
             _, _, diff = compute_gitlab_ci_config_diff(ctx, before, after)
 

--- a/tasks/unit_tests/gitlab_api_tests.py
+++ b/tasks/unit_tests/gitlab_api_tests.py
@@ -171,7 +171,7 @@ class TestGitlabCiDiff(unittest.TestCase):
                 'script': 'echo "???"',
             },
         }
-        diff = GitlabCIDiff(before, after)
+        diff = GitlabCIDiff.from_contents(before, after)
         self.assertSetEqual(diff.modified, {'job1'})
         self.assertSetEqual(set(diff.modified_diffs.keys()), {'job1'})
         self.assertSetEqual(diff.removed, {'job4'})
@@ -215,7 +215,7 @@ class TestGitlabCiDiff(unittest.TestCase):
                 'script': 'echo "???"',
             },
         }
-        diff = MultiGitlabCIDiff({'file': before}, {'file': after})
+        diff = MultiGitlabCIDiff.from_contents({'file': before}, {'file': after})
         dict_diff = diff.to_dict()
         diff_from_dict = MultiGitlabCIDiff.from_dict(dict_diff)
 

--- a/tasks/unit_tests/gitlab_api_tests.py
+++ b/tasks/unit_tests/gitlab_api_tests.py
@@ -6,6 +6,7 @@ from invoke import MockContext, Result
 
 from tasks.libs.ciproviders.gitlab_api import (
     GitlabCIDiff,
+    MultiGitlabCIDiff,
     clean_gitlab_ci_configuration,
     expand_matrix_jobs,
     filter_gitlab_ci_configuration,
@@ -176,6 +177,49 @@ class TestGitlabCiDiff(unittest.TestCase):
         self.assertSetEqual(diff.removed, {'job4'})
         self.assertSetEqual(diff.added, {'job5'})
         self.assertSetEqual(diff.renamed, {('job2', 'job2_renamed')})
+
+    def test_serialization(self):
+        before = {
+            'job1': {
+                'script': [
+                    'echo "hello"',
+                    'echo "hello?"',
+                    'echo "hello!"',
+                ]
+            },
+            'job2': {
+                'script': 'echo "world"',
+            },
+            'job3': {
+                'script': 'echo "!"',
+            },
+            'job4': {
+                'script': 'echo "?"',
+            },
+        }
+        after = {
+            'job1': {
+                'script': [
+                    'echo "hello"',
+                    'echo "bonjour?"',
+                    'echo "hello!"',
+                ]
+            },
+            'job2_renamed': {
+                'script': 'echo "world"',
+            },
+            'job3': {
+                'script': 'echo "!"',
+            },
+            'job5': {
+                'script': 'echo "???"',
+            },
+        }
+        diff = MultiGitlabCIDiff({'file': before}, {'file': after})
+        dict_diff = diff.to_dict()
+        diff_from_dict = MultiGitlabCIDiff.from_dict(dict_diff)
+
+        self.assertDictEqual(diff_from_dict.before, diff.before)
 
 
 class TestRetrieveAllPaths(unittest.TestCase):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Preparing ACIX-423

Currently, only the gitlab diff commenter is using the diff but soon more jobs such as linters will use it as well (cf ACIX-423).
Split into two stages the job as computing the diff is costly.

Added serialization functions and an `iter_jobs` method to iterate easily through all jobs of a diff.

> [!NOTE]
> I used arm64 runners as recommended for the new / modified jobs

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->