### PR TITLE
[tagger/collectors/workloadmeta] Use `require` to fail early

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -2446,7 +2447,7 @@ func assertTagInfoEqual(t *testing.T, expected *types.TagInfo, item *types.TagIn
 
 func assertTagInfoListEqual(t *testing.T, expectedUpdates []*types.TagInfo, updates []*types.TagInfo) {
 	t.Helper()
-	assert.Equal(t, len(expectedUpdates), len(updates))
+	require.Equal(t, len(expectedUpdates), len(updates))
 	for i := 0; i < len(expectedUpdates); i++ {
 		assertTagInfoEqual(t, expectedUpdates[i], updates[i])
 	}


### PR DESCRIPTION
### What does this PR do?

Minor improvement in unit tests defined in `comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go`.
Use `require` to compare the length of the arrays to compare, because if the length is different there's no point in comparing them one by one, as it can panic.

### Describe how to test/QA your changes

Nothing. This is just a refactor in a unit test.