### PR TITLE
Installer support app-armor on injector install

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -153,6 +153,9 @@ func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := setupAppArmor(ctx); err != nil {
+		return err
+	}
 
 	// Create mandatory dirs
 	err = os.Mkdir("/var/log/datadog/dotnet", 0777)
@@ -239,6 +242,8 @@ func (a *apmInjectorInstaller) Uninstrument(ctx context.Context) error {
 		dockerErr := a.uninstrumentDocker(ctx)
 		errs = append(errs, dockerErr)
 	}
+	appArmorErr := removeAppArmor(ctx)
+	errs = append(errs, appArmorErr)
 
 	return multierr.Combine(errs...)
 }

--- a/pkg/fleet/installer/service/app_armor.go
+++ b/pkg/fleet/installer/service/app_armor.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package service provides a way to interact with os services
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+const (
+	appArmorConfigPath = "/etc/apparmor.d/abstractions/base.d"
+	appArmorProfile    = `/opt/datadog-packages/** rix,
+/proc/@{pid}/** rix,`
+)
+
+var datadogProfilePath = filepath.Join(appArmorConfigPath, "datadog")
+
+func setupAppArmor(ctx context.Context) (err error) {
+	_, err = exec.LookPath("aa-status")
+	if err != nil {
+		// no-op if apparmor is not installed
+		return nil
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, "setup_app_armor")
+	defer func() { span.Finish(tracer.WithError(err)) }()
+	if err = os.MkdirAll(appArmorConfigPath, 0755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", appArmorConfigPath, err)
+	}
+	// unfortunately this isn't an atomic change. All files in that directory can be interpreted
+	// and I did not implement finding a safe directory to write to in the same partition, to run an atomic move.
+	// This shouldn't be a problem as we reload app armor right after writing the file.
+	if err = os.WriteFile(datadogProfilePath, []byte(appArmorProfile), 0644); err != nil {
+		return err
+	}
+	if err = reloadAppArmor(); err != nil {
+		if rollbackErr := os.Remove(datadogProfilePath); rollbackErr != nil {
+			log.Warnf("failed to remove apparmor profile: %v", rollbackErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func removeAppArmor(ctx context.Context) (err error) {
+	_, err = os.Stat(datadogProfilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	span, _ := tracer.StartSpanFromContext(ctx, "remove_app_armor")
+	defer span.Finish(tracer.WithError(err))
+	if err = os.Remove(datadogProfilePath); err != nil {
+		return err
+	}
+	return reloadAppArmor()
+}
+
+func reloadAppArmor() error {
+	if !isAppArmorRunning() {
+		return nil
+	}
+	if running, err := isSystemdRunning(); err != nil {
+		return err
+	} else if running {
+		return exec.Command("systemctl", "reload", "apparmor").Run()
+	}
+	return exec.Command("service", "apparmor", "reload").Run()
+}
+
+func isAppArmorRunning() bool {
+	data, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "Y"
+}


### PR DESCRIPTION
### What does this PR do?
AppArmor can enforce shared library locations, making runtime linker trigger an error: due to not finding the injector shared library.

In particular this happens by default on `dhclient` on unbutu and debian! Even if the dhclient runs successfully, a caller on reboot of dhclient fails instanciating DHCP due to stderr being filled, (this caller was not identified but the trigger of the stderr was)

```
$ sudo dhclient
ERROR: ld.so: object '/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
```

Making a special datadog rule that allows the injector to parse /proc/self + ensure that the launcher can be read
result:
```
sudo DD_APM_INSTRUMENTATION_DEBUG=true /usr/sbin/dhclient; echo $?
[datadog_preload_hook] debug flag set, running injection
[datadog_preload_hook] executing /opt/datadog-packages/datadog-apm-inject/0.21.0/inject/process
{"level":"debug","ts":1727794169.4597325,"caller":"process/main.go:122","msg":"starting process"}
{"level":"debug","ts":1727794169.4604414,"caller":"preload_go/inject.go:64","msg":"arguments","inFilename":"/usr/sbin/dhclient","libc":"glibc:2.36","envs":["DD_APM_INSTRUMENTATION_DEBUG=true"]}
{"level":"debug","ts":1727794169.4605951,"caller":"preload_go/inject.go:68","msg":"not injecting; on deny list","reason":"executable full path match"}
{"level":"debug","ts":1727794169.460635,"caller":"process/main.go:159","msg":"exiting process"}
[datadog_preload_hook] done waiting!
RTNETLINK answers: File exists
0
```

### Investigation details

AppArmor was caught by checking with strace. Somehow dhclient misses the authorisation to read a world readable file! And this after the execve of dhclient, making AppArmor a potential culprit.
```
$ sudo DD_APM_INSTRUMENTATION_DEBUG=true strace dhclient
______________strace intercepted
[datadog_preload_hook] debug flag set, running injection
[datadog_preload_hook] executing /opt/datadog-packages/datadog-apm-inject/0.21.0-dev.b0d6e40.glci656490395.gadbecaea/inject/process
{"level":"debug","ts":1727773024.6590946,"caller":"process/main.go:122","msg":"starting process"}
{"level":"debug","ts":1727773024.6594894,"caller":"preload_go/inject.go:64","msg":"arguments","inFilename":"/usr/bin/strace","libc":"glibc:2.36","envs":["DD_APM_INSTRUMENTATION_DEBUG=true"]}
{"level":"debug","ts":1727773024.659572,"caller":"preload_go/inject.go:68","msg":"not injecting; on deny list","reason":"executable full path match"}
{"level":"debug","ts":1727773024.6596227,"caller":"process/main.go:159","msg":"exiting process"}
[datadog_preload_hook] done waiting!
______________dhclient execve (runtime linker syscalls)
execve("/usr/sbin/dhclient", ["dhclient"], 0x7fff009f40a0 /* 20 vars */) = 0
brk(NULL)                               = 0x55c81be39000
mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fe2111c7000
access("/etc/ld.so.preload", R_OK)      = 0
openat(AT_FDCWD, "/etc/ld.so.preload", O_RDONLY|O_CLOEXEC) = 3
newfstatat(3, "", {st_mode=S_IFREG|0644, st_size=75, ...}, AT_EMPTY_PATH) = 0
mmap(NULL, 75, PROT_READ|PROT_WRITE, MAP_PRIVATE, 3, 0) = 0x7fe2111c6000
close(3)                                = 0
openat(AT_FDCWD, "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so", O_RDONLY|O_CLOEXEC) = -1 EACCES (Permission denied)
```

### dhclient rules
```
$ sudo cat sudo vim /etc/apparmor.d/sbin.dhclient
...
  #include <abstractions/base>
...
```
Below we see restrictions on shared library, ld.so.preload is present! which means that injector entrypoint is caught. But the datadog injector is not reachable and requires a dedicated rule
```
$ sudo cat /etc/apparmor.d/abstractions/base
....
  # ld.so.cache and ld are used to load shared libraries; they are best
  # available everywhere
  @{etc_ro}/ld.so.cache               mr,
  @{etc_ro}/ld.so.conf                r,
  @{etc_ro}/ld.so.conf.d/{,*.conf}    r,
  @{etc_ro}/ld.so.preload             r,
  ...
```