### PR TITLE
replace hardcoded python path

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -132,10 +132,6 @@ build do
     # Retrieving integrations from cache
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
-    # On windows, `ridk enable` puts Ruby's bin on the PATH first, which contains `aws.rb`, but we want the Python one
-    # So include the `aws.cmd` extension on Windows to ensure we select the Python one.
-    # If AWSCLIV2 is installed, we could use `aws.exe` isntead.
-    awscli = if windows_target? then 'aws.cmd' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       shellout! "inv -e agent.get-integrations-from-cache " \
@@ -143,8 +139,7 @@ build do
                 "--branch #{cache_branch || 'main'} " \
                 "--integrations-dir #{windows_safe_path(project_dir)} " \
                 "--target-dir #{cached_wheels_dir} " \
-                "--integrations #{checks_to_install.join(',')} " \
-                "--awscli #{awscli}",
+                "--integrations #{checks_to_install.join(',')}",
                 :cwd => tasks_dir_in
 
       # install all wheels from cache in one pip invocation to speed things up
@@ -221,8 +216,7 @@ build do
                   "--branch #{cache_branch} " \
                   "--integrations-dir #{windows_safe_path(project_dir)} " \
                   "--build-dir #{wheel_build_dir} " \
-                  "--integration #{check} " \
-                  "--awscli #{awscli}",
+                  "--integration #{check}",
                   :cwd => tasks_dir_in
       end
     end

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -132,8 +132,10 @@ build do
     # Retrieving integrations from cache
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
-    # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
-    awscli = if windows_target? then '"c:\Program files\python311\scripts\aws"' else 'aws' end
+    # On windows, `ridk enable` puts Ruby's bin on the PATH first, which contains `aws.rb`, but we want the Python one
+    # So include the `aws.cmd` extension on Windows to ensure we select the Python one.
+    # If AWSCLIV2 is installed, we could use `aws.exe` isntead.
+    awscli = if windows_target? then 'aws.cmd' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       shellout! "inv -e agent.get-integrations-from-cache " \

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -133,10 +133,6 @@ build do
     # Retrieving integrations from cache
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
-    # On windows, `ridk enable` puts Ruby's bin on the PATH first, which contains `aws.rb`, but we want the Python one
-    # So include the `aws.cmd` extension on Windows to ensure we select the Python one.
-    # If AWSCLIV2 is installed, we could use `aws.exe` isntead.
-    awscli = if windows_target? then 'aws.cmd' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       shellout! "inv -e agent.get-integrations-from-cache " \
@@ -144,8 +140,7 @@ build do
                 "--branch #{cache_branch || 'main'} " \
                 "--integrations-dir #{windows_safe_path(project_dir)} " \
                 "--target-dir #{cached_wheels_dir} " \
-                "--integrations #{checks_to_install.join(',')} " \
-                "--awscli #{awscli}",
+                "--integrations #{checks_to_install.join(',')}",
                 :cwd => tasks_dir_in
 
       # install all wheels from cache in one pip invocation to speed things up
@@ -220,8 +215,7 @@ build do
                   "--branch #{cache_branch} " \
                   "--integrations-dir #{windows_safe_path(project_dir)} " \
                   "--build-dir #{wheel_build_dir} " \
-                  "--integration #{check} " \
-                  "--awscli #{awscli}",
+                  "--integration #{check}",
                   :cwd => tasks_dir_in
       end
     end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -133,8 +133,10 @@ build do
     # Retrieving integrations from cache
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
-    # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
-    awscli = if windows_target? then '"c:\Program files\python311\scripts\aws"' else 'aws' end
+    # On windows, `ridk enable` puts Ruby's bin on the PATH first, which contains `aws.rb`, but we want the Python one
+    # So include the `aws.cmd` extension on Windows to ensure we select the Python one.
+    # If AWSCLIV2 is installed, we could use `aws.exe` isntead.
+    awscli = if windows_target? then 'aws.cmd' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       shellout! "inv -e agent.get-integrations-from-cache " \

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -50,7 +50,12 @@ if sys.platform == "win32":
     # This dir contains `aws.rb` which will execute if we just call `aws`,
     # so we need to be explicit about the executable extension/path
     # awscli v1 from Python env
-    AWS_CMD = "aws.cmd"
+    # NOTE: awscli seems to have a bug where running "aws.cmd", quoted, without a full path,
+    #       causes it to fail due to not searching the PATH, so we use shutil.which to looku
+    #       the full path.
+    #       If we remove the user provided awscli args from our invoke tasks
+    #       we could just use `aws.cmd` here and then remove the qoutes from the `ctx.run` calls.
+    AWS_CMD = shutil.which("aws.cmd") or "aws.cmd"
     # TODO: can we use use `aws.exe` from AWSCLIv2? E2E expects v2.
 else:
     AWS_CMD = "aws"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -50,7 +50,7 @@ if sys.platform == "win32":
     # This dir contains `aws.rb` which will execute if we just call `aws`,
     # so we need to be explicit about the executable extension/path
     # NOTE: awscli seems to have a bug where running "aws.cmd", quoted, without a full path,
-    #       causes it to fail due to not searching the PATH, so we use shutil.which to looku
+    #       causes it to fail due to not searching the PATH, so we use shutil.which to lookup
     #       the full path.
     #       If we remove the user provided awscli args from our invoke tasks
     #       we could just use `aws.cmd` here and then remove the qoutes from the `ctx.run` calls.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -49,12 +49,12 @@ if sys.platform == "win32":
     # Our `ridk enable` toolchain puts Ruby's bin dir at the front of the PATH
     # This dir contains `aws.rb` which will execute if we just call `aws`,
     # so we need to be explicit about the executable extension/path
-    # awscli v1 from Python env
     # NOTE: awscli seems to have a bug where running "aws.cmd", quoted, without a full path,
     #       causes it to fail due to not searching the PATH, so we use shutil.which to looku
     #       the full path.
     #       If we remove the user provided awscli args from our invoke tasks
     #       we could just use `aws.cmd` here and then remove the qoutes from the `ctx.run` calls.
+    # aws.cmd -> awscli v1 from Python env
     AWS_CMD = shutil.which("aws.cmd") or "aws.cmd"
     # TODO: can we use use `aws.exe` from AWSCLIv2? E2E expects v2.
 else:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove hardcoded Python path and use `aws.cmd` instead

Move the `aws` vs `aws.cmd` logic from ruby into the invoke task

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1032
Our `ridk enable` toolchain puts Ruby at the front of the PATH, and it includes `aws.rb`, so on Windows running `aws` will run the Ruby AWS SDK instead of the AWS CLI.

Hardcoding the Python PATH creates friction when trying to upgrade the Python version, and when supporting other Python install PATHs.
xref https://github.com/DataDog/datadog-agent-buildimages/pull/692

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs
There are other invoke tasks that do the `aws.cmd` switch, we could consolidate these.

Many places are still using AWSCLIV1 from the Python env/package. But E2E expects AWSCLIV2.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->