### PR TITLE
[OTEL-2101] Make datadog exporter optional in otel agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -59,8 +60,14 @@ var logLevelReverseMap = func(src map[string]logLevel) map[logLevel]string {
 	return reverse
 }(logLevelMap)
 
+// ErrNoDDExporter indicates there is no Datadog exporter in the configs
+var ErrNoDDExporter = fmt.Errorf("no datadog exporter found")
+
 // NewConfigComponent creates a new config component from the given URIs
 func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (config.Component, error) {
+	if len(uris) == 0 {
+		return nil, errors.New("no URIs provided for configs")
+	}
 	// Load the configuration from the fileName
 	rs := confmap.ResolverSettings{
 		URIs: uris,
@@ -220,7 +227,7 @@ func getDDExporterConfig(cfg *confmap.Conf) (*datadogexporter.Config, error) {
 		}
 	}
 	if len(configs) == 0 {
-		return nil, fmt.Errorf("no datadog exporter found")
+		return nil, ErrNoDDExporter
 	}
 	// Check if we have multiple datadog exporters
 	// We only support one exporter for now

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -29,6 +29,11 @@ func (suite *ConfigTestSuite) SetupTest() {
 	pkgconfigsetup.SetDatadog(datadog)
 }
 
+func TestNoURIsProvided(t *testing.T) {
+	_, err := NewConfigComponent(context.Background(), "", []string{})
+	assert.Error(t, err, "no URIs provided for configs")
+}
+
 func (suite *ConfigTestSuite) TestAgentConfig() {
 	t := suite.T()
 	fileName := "testdata/config.yaml"

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -93,6 +93,9 @@ func (o *orchestratorinterfaceimpl) Reset() {
 
 func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, opts ...fx.Option) error {
 	acfg, err := agentConfig.NewConfigComponent(context.Background(), params.CoreConfPath, params.ConfPaths)
+	if err != nil && err != agentConfig.ErrNoDDExporter {
+		return err
+	}
 	if err == agentConfig.ErrNoDDExporter {
 		return fxutil.Run(
 			fx.Provide(func() []string {
@@ -104,8 +107,6 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 			fx.Invoke(func(_ collectordef.Component) {
 			}),
 		)
-	} else if err != nil {
-		return err
 	}
 
 	return fxutil.Run(

--- a/cmd/otel-agent/subcommands/run/command_test.go
+++ b/cmd/otel-agent/subcommands/run/command_test.go
@@ -15,10 +15,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestFxRun(t *testing.T) {
+func TestFxRun_WithDatadogExporter(t *testing.T) {
 	fxutil.TestRun(t, func() error {
 		ctx := context.Background()
-		cliParams := &subcommands.GlobalParams{}
-		return runOTelAgentCommand(ctx, cliParams)
+		params := &subcommands.GlobalParams{
+			ConfPaths: []string{"test_config.yaml"},
+		}
+		return runOTelAgentCommand(ctx, params)
+	})
+}
+
+func TestFxRun_NoDatadogExporter(t *testing.T) {
+	fxutil.TestRun(t, func() error {
+		ctx := context.Background()
+		params := &subcommands.GlobalParams{
+			ConfPaths: []string{"test_config_no_dd.yaml"},
+		}
+		return runOTelAgentCommand(ctx, params)
 	})
 }

--- a/cmd/otel-agent/subcommands/run/test_config.yaml
+++ b/cmd/otel-agent/subcommands/run/test_config.yaml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+      grpc:
+        endpoint: "localhost:4317"
+
+exporters:
+  datadog:
+    api:
+      key: "abc"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [datadog]
+  telemetry:
+    metrics:
+      address: 127.0.0.1:8888

--- a/cmd/otel-agent/subcommands/run/test_config_no_dd.yaml
+++ b/cmd/otel-agent/subcommands/run/test_config_no_dd.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+      grpc:
+        endpoint: "localhost:4317"
+
+exporters:
+  debug:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+  telemetry:
+    metrics:
+      address: 127.0.0.1:8888

--- a/comp/otelcol/collector/fx/fx.go
+++ b/comp/otelcol/collector/fx/fx.go
@@ -25,3 +25,13 @@ func Module() fxutil.Module {
 		fxutil.ProvideOptional[collector.Component](),
 	)
 }
+
+// ModuleNoAgent for OTel Agent with no Agent functionalities
+func ModuleNoAgent() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			collectorimpl.NewComponentNoAgent,
+		),
+		fxutil.ProvideOptional[collector.Component](),
+	)
+}


### PR DESCRIPTION
### What does this PR do?

Removes a restriction on must have DD exporter in OTel agent config. If there is no DD exporter in the config, starts the OTel agent without Agent functionalities

### Motivation

Resolves customer feedback from private beta

### Describe how to test/QA your changes

Start an otel agent with no DD exporter in the config, and verify otel agent still works properly.

```
receivers:
  hostmetrics:
    scrapers:
      load:
      memory:

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    metrics/sys:
      receivers: [hostmetrics]
      exporters: [debug]
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->