### PR TITLE
[ASCII-2217] List agent open files in flares on Windows

### DIFF
--- a/pkg/util/lsof/lsof_linux_test.go
+++ b/pkg/util/lsof/lsof_linux_test.go
@@ -7,7 +7,6 @@ package lsof
 
 import (
 	"errors"
-	"io/fs"
 	"os"
 	"syscall"
 	"testing"
@@ -466,33 +465,6 @@ func TestMmapFD(t *testing.T) {
 			assert.Equal(t, tc.expected, res)
 		})
 	}
-}
-
-type mockFileInfo struct {
-	modTime time.Time
-	mode    fs.FileMode
-	name    string
-	size    int64
-	sys     any
-}
-
-func (m *mockFileInfo) IsDir() bool {
-	return m.mode.IsDir()
-}
-func (m *mockFileInfo) ModTime() time.Time {
-	return m.modTime
-}
-func (m *mockFileInfo) Mode() fs.FileMode {
-	return m.mode
-}
-func (m *mockFileInfo) Name() string {
-	return m.name
-}
-func (m *mockFileInfo) Size() int64 {
-	return m.size
-}
-func (m *mockFileInfo) Sys() any {
-	return m.sys
 }
 
 func TestModeTypeToString(t *testing.T) {

--- a/pkg/util/lsof/lsof_windows.go
+++ b/pkg/util/lsof/lsof_windows.go
@@ -5,6 +5,102 @@
 
 package lsof
 
-func openFiles(_ int) (Files, error) {
-	return nil, ErrNotImplemented
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func openFiles(pid int) (Files, error) {
+	handle, err := windows.OpenProcess(windows.STANDARD_RIGHTS_ALL|windows.SPECIFIC_RIGHTS_ALL, false, uint32(pid))
+	if err != nil {
+		return nil, err
+	}
+
+	ofl := &openFilesLister{
+		windows.EnumProcessModules,
+		windows.GetModuleFileNameEx,
+		os.Stat,
+	}
+
+	files, err := ofl.getDLLFiles(handle)
+
+	return files, err
+}
+
+type openFilesLister struct {
+	EnumProcessModules  func(windows.Handle, *windows.Handle, uint32, *uint32) error
+	GetModuleFileNameEx func(windows.Handle, windows.Handle, *uint16, uint32) error
+	Stat                func(string) (os.FileInfo, error)
+}
+
+// getDLLFiles returns the list of File for the DLLs opened by the process
+func (ofl *openFilesLister) getDLLFiles(process windows.Handle) (Files, error) {
+	hModules, err := ofl.listOpenDLL(process)
+	if err != nil {
+		return nil, err
+	}
+
+	var files Files
+	for _, hModule := range hModules {
+		file, err := ofl.getDLLFile(process, hModule)
+		if err != nil {
+			continue
+		}
+		files = append(files, file)
+	}
+
+	return files, nil
+}
+
+func (ofl *openFilesLister) getDLLFile(process windows.Handle, hModule windows.Handle) (File, error) {
+	// get DLL file path
+	modPath, err := ofl.getModulePath(process, hModule)
+	if err != nil {
+		return File{}, err
+	}
+
+	// try to get some permissions and file size
+	filePerms := "<unknown>"
+	var fileSize int64 = -1
+	fileInfo, err := ofl.Stat(modPath)
+	if err == nil {
+		fileSize = fileInfo.Size()
+		filePerms = fileInfo.Mode().Perm().String()
+	}
+
+	file := File{
+		Fd:       fmt.Sprintf("%d", hModule),
+		Type:     "DLL",
+		FilePerm: filePerms,
+		Size:     fileSize,
+		Name:     modPath,
+	}
+	return file, nil
+}
+
+// listOpenDLL returns the list of DLLs opened by the process
+func (ofl *openFilesLister) listOpenDLL(process windows.Handle) ([]windows.Handle, error) {
+	var hModules [1024]windows.Handle
+	var cbNeeded uint32
+
+	if err := ofl.EnumProcessModules(process, &hModules[0], uint32(unsafe.Sizeof(hModules)), &cbNeeded); err != nil {
+		return nil, err
+	}
+
+	nModules := int(cbNeeded / uint32(unsafe.Sizeof(hModules[0])))
+	return hModules[:nModules], nil
+}
+
+// getModulePath returns the path to the given module
+func (ofl *openFilesLister) getModulePath(process windows.Handle, module windows.Handle) (string, error) {
+	var modName [windows.MAX_PATH]uint16
+	if err := ofl.GetModuleFileNameEx(process, module, &modName[0], windows.MAX_PATH); err != nil {
+		return "", err
+	}
+
+	modPath := windows.UTF16ToString(modName[:])
+	return modPath, nil
 }

--- a/pkg/util/lsof/lsof_windows_test.go
+++ b/pkg/util/lsof/lsof_windows_test.go
@@ -1,0 +1,255 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lsof
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"testing"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+	"golang.org/x/sys/windows"
+)
+
+func TestOpenFiles(t *testing.T) {
+	pid := os.Getpid()
+
+	files, err := openFiles(pid)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+}
+
+func TestGetDLLFiles(t *testing.T) {
+	var procHandle windows.Handle = 42
+	modules := []windows.Handle{1, 2, 3}
+	paths := map[windows.Handle]string{
+		1: "C:/some/path",
+		2: "C:/some/other/path",
+	}
+	stats := map[string]fs.FileInfo{
+		paths[1]: &mockFileInfo{
+			mode: 0400,
+			size: 10,
+		},
+	}
+
+	ofl := &openFilesLister{
+		EnumProcessModules: func(proc windows.Handle, handles *windows.Handle, _ uint32, size *uint32) error {
+			require.EqualValues(t, procHandle, proc)
+
+			copySliceToBuff(modules, handles)
+			*size = uint32(len(modules)) * uint32(unsafe.Sizeof(procHandle))
+			return nil
+		},
+		GetModuleFileNameEx: func(process, module windows.Handle, buff *uint16, _ uint32) error {
+			require.Equal(t, procHandle, process)
+			require.Contains(t, modules, module)
+
+			path, ok := paths[module]
+			if ok {
+				writeStringToUTF16Buffer(path, buff)
+				return nil
+			}
+
+			return errors.New("some error")
+		},
+		Stat: func(s string) (os.FileInfo, error) {
+			require.Contains(t, maps.Values(paths), s)
+			stat, ok := stats[s]
+			if ok {
+				return stat, nil
+			}
+			return nil, errors.New("some error")
+		},
+	}
+
+	expected := Files{
+		{
+			Fd:       "1",
+			Type:     "DLL",
+			FilePerm: "-r--------",
+			Size:     10,
+			Name:     "C:/some/path",
+		},
+		{
+			Fd:       "2",
+			Type:     "DLL",
+			FilePerm: "<unknown>",
+			Size:     -1,
+			Name:     "C:/some/other/path",
+		},
+	}
+
+	files, err := ofl.getDLLFiles(procHandle)
+	require.NoError(t, err)
+	require.ElementsMatch(t, expected, files)
+}
+
+func TestGetDLLFilesError(t *testing.T) {
+	expectedErr := errors.New("some error")
+	ofl := &openFilesLister{
+		EnumProcessModules: func(_ windows.Handle, _ *windows.Handle, _ uint32, _ *uint32) error {
+			return expectedErr
+		},
+	}
+	_, err := ofl.getDLLFiles(0)
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestGetDLLFile(t *testing.T) {
+	t.Run("success with stat", func(t *testing.T) {
+		var expectedProc windows.Handle = 42
+		var expectedModule windows.Handle = 43
+		var expectedSize int64 = 10
+		path := "C:/some/path"
+
+		ofl := &openFilesLister{
+			GetModuleFileNameEx: func(process, module windows.Handle, buff *uint16, _ uint32) error {
+				require.Equal(t, expectedProc, process)
+				require.Equal(t, expectedModule, module)
+				writeStringToUTF16Buffer(path, buff)
+				return nil
+			},
+			Stat: func(s string) (os.FileInfo, error) {
+				require.Equal(t, path, s)
+				return &mockFileInfo{
+					mode: 0400,
+					size: expectedSize,
+				}, nil
+			},
+		}
+		file, err := ofl.getDLLFile(expectedProc, expectedModule)
+		require.NoError(t, err)
+		expected := File{
+			Fd:       fmt.Sprintf("%d", expectedModule),
+			FilePerm: "-r--------",
+			Name:     path,
+			Size:     expectedSize,
+			Type:     "DLL",
+		}
+		require.Equal(t, expected, file)
+	})
+
+	t.Run("success without stat", func(t *testing.T) {
+		someError := errors.New("some error")
+		path := "C:/some/path"
+		ofl := &openFilesLister{
+			GetModuleFileNameEx: func(_, _ windows.Handle, buff *uint16, _ uint32) error {
+				writeStringToUTF16Buffer(path, buff)
+				return nil
+			},
+			Stat: func(s string) (os.FileInfo, error) {
+				require.Equal(t, path, s)
+				return nil, someError
+			},
+		}
+
+		file, err := ofl.getDLLFile(42, 43)
+		require.NoError(t, err)
+		assert.EqualValues(t, -1, file.Size)
+		assert.Equal(t, "<unknown>", file.FilePerm)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		someError := errors.New("some error")
+		ofl := &openFilesLister{
+			GetModuleFileNameEx: func(_, _ windows.Handle, _ *uint16, _ uint32) error {
+				return someError
+			},
+		}
+		_, err := ofl.getDLLFile(42, 43)
+		require.ErrorIs(t, err, someError)
+	})
+}
+
+func TestListOpenDLL(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var procHandle windows.Handle = 42
+		expected := []windows.Handle{1, 2}
+
+		ofl := &openFilesLister{
+			EnumProcessModules: func(proc windows.Handle, handles *windows.Handle, _ uint32, size *uint32) error {
+				require.EqualValues(t, procHandle, proc)
+
+				copySliceToBuff(expected, handles)
+				*size = uint32(len(expected)) * uint32(unsafe.Sizeof(procHandle))
+				return nil
+			},
+		}
+		handles, err := ofl.listOpenDLL(procHandle)
+		require.NoError(t, err)
+		require.Equal(t, expected, handles)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		someError := errors.New("some error")
+
+		ofl := &openFilesLister{
+			EnumProcessModules: func(_ windows.Handle, _ *windows.Handle, _ uint32, _ *uint32) error {
+				return someError
+			},
+		}
+		_, err := ofl.listOpenDLL(0)
+		require.ErrorIs(t, err, someError)
+	})
+}
+
+func TestGetModulePath(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var expectedProc windows.Handle = 42
+		var expectedModule windows.Handle = 43
+		name := "C:/some/path"
+
+		ofl := &openFilesLister{
+			GetModuleFileNameEx: func(proc windows.Handle, module windows.Handle, buff *uint16, _ uint32) error {
+				require.Equal(t, expectedProc, proc)
+				require.Equal(t, expectedModule, module)
+				writeStringToUTF16Buffer(name, buff)
+				return nil
+			},
+		}
+
+		path, err := ofl.getModulePath(expectedProc, expectedModule)
+		require.NoError(t, err)
+		require.Equal(t, name, path)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		someError := errors.New("some error")
+		ofl := &openFilesLister{
+			GetModuleFileNameEx: func(_ windows.Handle, _ windows.Handle, _ *uint16, _ uint32) error {
+				return someError
+			},
+		}
+
+		_, err := ofl.getModulePath(0, 0)
+		require.ErrorIs(t, err, someError)
+	})
+}
+
+// this function assumes the buffer is big enough
+func copySliceToBuff[T any](elems []T, buff *T) {
+	if len(elems) == 0 {
+		return
+	}
+
+	for i, v := range elems {
+		*(*T)(unsafe.Pointer(uintptr(unsafe.Pointer(buff)) + uintptr(i)*unsafe.Sizeof(elems[0]))) = v
+	}
+}
+
+// this function assumes the buffer is big enough
+func writeStringToUTF16Buffer(str string, buff *uint16) {
+	nameUTF16Encoded := utf16.Encode([]rune(str))
+	copySliceToBuff(nameUTF16Encoded, buff)
+}

--- a/pkg/util/lsof/test_utils.go
+++ b/pkg/util/lsof/test_utils.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test && (linux || windows)
+
+package lsof
+
+import (
+	"io/fs"
+	"time"
+)
+
+type mockFileInfo struct {
+	modTime time.Time
+	mode    fs.FileMode
+	name    string
+	size    int64
+	sys     any
+}
+
+func (m *mockFileInfo) IsDir() bool {
+	return m.mode.IsDir()
+}
+func (m *mockFileInfo) ModTime() time.Time {
+	return m.modTime
+}
+func (m *mockFileInfo) Mode() fs.FileMode {
+	return m.mode
+}
+func (m *mockFileInfo) Name() string {
+	return m.name
+}
+func (m *mockFileInfo) Size() int64 {
+	return m.size
+}
+func (m *mockFileInfo) Sys() any {
+	return m.sys
+}

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_files.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_files.go
@@ -37,6 +37,7 @@ var nonLocalFlareFiles = []string{
 	"process-agent_tagger-list.json",
 	"tagger-list.json",
 	"workload-list.log",
+	"agent_open_files.txt",
 }
 
 // defaultLogFiles contains all the log files that are created with a default installation
@@ -85,9 +86,7 @@ var windowsFiles = []string{
 }
 
 // linuxFiles contains files that are specific to Linux
-var linuxFiles = []string{
-	"agent_open_files.txt",
-}
+var linuxFiles = []string{}
 
 var profilingFiles = []string{
 	"profiles/core-1st-heap.pprof",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Implement a basic version of listing DLLs opened by the agent process in flares on Windows, similar to https://github.com/DataDog/datadog-agent/pull/28584 on Linux.

### Motivation
Help with debugging support cases.

### Describe how to test/QA your changes
Logic is covered by unit tests, and an e2e test ensures the file is properly generated on an actual Windows VM.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This PR only implements listing DLLs, it does not list opened regular files or network connections as this is much trickier and I couldn't find a way to implement it natively (without running a binary and parsing the output).