### PR TITLE
Remove from merge queue lint_macos_gitlab_amd64

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -109,6 +109,9 @@ tests_macos:
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
   tags: ["macos:monterey-amd64", "specific:true"]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
 
 lint_macos_gitlab_arm64:
   extends: .lint_macos_gitlab


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This removes `lint_macos_gitlab_amd64` from the merge queue since it is flaky with new macos runners (example [1](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/656906929), [2](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/655221562))

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->