### PR TITLE
[network path] Add reverse_dns_hostname field

### DIFF
--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -57,7 +57,7 @@ type NetworkPathDestination struct {
 	IPAddress          string `json:"ip_address"`
 	Port               uint16 `json:"port"`
 	Service            string `json:"service,omitempty"`
-	ReverseDnsHostname string `json:"reverse_dns_hostname"`
+	ReverseDNSHostname string `json:"reverse_dns_hostname,omitempty"`
 }
 
 // NetworkPath encapsulates data that defines a

--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -33,9 +33,13 @@ const (
 // NetworkPathHop encapsulates the data for a single
 // hop within a path
 type NetworkPathHop struct {
-	TTL       int     `json:"ttl"`
-	IPAddress string  `json:"ip_address"`
-	Hostname  string  `json:"hostname,omitempty"`
+	TTL       int    `json:"ttl"`
+	IPAddress string `json:"ip_address"`
+
+	// hostname is the reverse DNS of the ip_address
+	// TODO (separate PR): we might want to rename it to reverse_dns_hostname for consistency with destination.reverse_dns_hostname
+	Hostname string `json:"hostname,omitempty"`
+
 	RTT       float64 `json:"rtt,omitempty"`
 	Reachable bool    `json:"reachable"`
 }

--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -53,10 +53,11 @@ type NetworkPathSource struct {
 // NetworkPathDestination encapsulates information
 // about the destination of a path
 type NetworkPathDestination struct {
-	Hostname  string `json:"hostname"`
-	IPAddress string `json:"ip_address"`
-	Port      uint16 `json:"port"`
-	Service   string `json:"service,omitempty"`
+	Hostname           string `json:"hostname"`
+	IPAddress          string `json:"ip_address"`
+	Port               uint16 `json:"port"`
+	Service            string `json:"service,omitempty"`
+	ReverseDnsHostname string `json:"reverse_dns_hostname"`
 }
 
 // NetworkPath encapsulates data that defines a

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -238,7 +238,7 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 			Hostname:           destinationHost,
 			Port:               destinationPort,
 			IPAddress:          destinationIP.String(),
-			ReverseDNSHostname: getReverseDnsForIP(destinationIP),
+			ReverseDNSHostname: getReverseDNSForIP(destinationIP),
 		},
 	}
 
@@ -302,7 +302,7 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 			Hostname:           destinationHost,
 			Port:               destinationPort,
 			IPAddress:          destinationIP.String(),
-			ReverseDNSHostname: getReverseDnsForIP(destinationIP),
+			ReverseDNSHostname: getReverseDNSForIP(destinationIP),
 		},
 	}
 

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -235,9 +235,10 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 			NetworkID: r.networkID,
 		},
 		Destination: payload.NetworkPathDestination{
-			Hostname:  getDestinationHostname(destinationHost),
-			Port:      destinationPort,
-			IPAddress: destinationIP.String(),
+			Hostname:           destinationHost,
+			ReverseDnsHostname: getReverseDnsForDestination(destinationHost),
+			Port:               destinationPort,
+			IPAddress:          destinationIP.String(),
 		},
 	}
 
@@ -298,9 +299,10 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 			NetworkID: r.networkID,
 		},
 		Destination: payload.NetworkPathDestination{
-			Hostname:  getDestinationHostname(destinationHost),
-			Port:      destinationPort,
-			IPAddress: destinationIP.String(),
+			Hostname:           destinationHost,
+			ReverseDnsHostname: getReverseDnsForDestination(destinationHost),
+			Port:               destinationPort,
+			IPAddress:          destinationIP.String(),
 		},
 	}
 

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -236,9 +236,9 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 		},
 		Destination: payload.NetworkPathDestination{
 			Hostname:           destinationHost,
-			ReverseDnsHostname: getReverseDnsForDestination(destinationHost),
 			Port:               destinationPort,
 			IPAddress:          destinationIP.String(),
+			ReverseDNSHostname: getReverseDnsForIP(destinationIP),
 		},
 	}
 
@@ -300,9 +300,9 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 		},
 		Destination: payload.NetworkPathDestination{
 			Hostname:           destinationHost,
-			ReverseDnsHostname: getReverseDnsForDestination(destinationHost),
 			Port:               destinationPort,
 			IPAddress:          destinationIP.String(),
+			ReverseDNSHostname: getReverseDnsForIP(destinationIP),
 		},
 	}
 

--- a/pkg/networkpath/traceroute/utils.go
+++ b/pkg/networkpath/traceroute/utils.go
@@ -15,7 +15,7 @@ import (
 
 var lookupAddrFn = net.DefaultResolver.LookupAddr
 
-func getReverseDnsForIP(destIP net.IP) string {
+func getReverseDNSForIP(destIP net.IP) string {
 	if destIP == nil {
 		return ""
 	}

--- a/pkg/networkpath/traceroute/utils.go
+++ b/pkg/networkpath/traceroute/utils.go
@@ -15,17 +15,14 @@ import (
 
 var lookupAddrFn = net.DefaultResolver.LookupAddr
 
-// getDestinationHostname tries to convert the input destinationHost to hostname.
+// getReverseDnsForDestination tries to convert the input destinationHost to hostname.
 // When input destinationHost is an IP, a reverse DNS call is made to convert it into a hostname.
-func getDestinationHostname(destinationHost string) string {
+func getReverseDnsForDestination(destinationHost string) string {
 	destIP := net.ParseIP(destinationHost)
 	if destIP != nil {
-		reverseDNSHostname := getHostname(destinationHost)
-		if reverseDNSHostname != "" {
-			return reverseDNSHostname
-		}
+		return getHostname(destinationHost)
 	}
-	return destinationHost
+	return ""
 }
 
 func getHostname(ipAddr string) string {

--- a/pkg/networkpath/traceroute/utils.go
+++ b/pkg/networkpath/traceroute/utils.go
@@ -15,14 +15,11 @@ import (
 
 var lookupAddrFn = net.DefaultResolver.LookupAddr
 
-// getReverseDnsForDestination tries to convert the input destinationHost to hostname.
-// When input destinationHost is an IP, a reverse DNS call is made to convert it into a hostname.
-func getReverseDnsForDestination(destinationHost string) string {
-	destIP := net.ParseIP(destinationHost)
-	if destIP != nil {
-		return getHostname(destinationHost)
+func getReverseDnsForIP(destIP net.IP) string {
+	if destIP == nil {
+		return ""
 	}
-	return ""
+	return getHostname(destIP.String())
 }
 
 func getHostname(ipAddr string) string {

--- a/pkg/networkpath/traceroute/utils_test.go
+++ b/pkg/networkpath/traceroute/utils_test.go
@@ -21,8 +21,8 @@ func Test_getReverseDnsForIP(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "domain-a.com", getReverseDnsForIP(net.ParseIP("1.2.3.4")))
-		assert.Equal(t, "", getReverseDnsForIP(nil))
+		assert.Equal(t, "domain-a.com", getReverseDNSForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", getReverseDNSForIP(nil))
 	})
 	t.Run("reverse dns lookup failure", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
@@ -30,8 +30,8 @@ func Test_getReverseDnsForIP(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "1.2.3.4", getReverseDnsForIP(net.ParseIP("1.2.3.4")))
-		assert.Equal(t, "", getReverseDnsForIP(nil))
+		assert.Equal(t, "1.2.3.4", getReverseDNSForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", getReverseDNSForIP(nil))
 	})
 }
 

--- a/pkg/networkpath/traceroute/utils_test.go
+++ b/pkg/networkpath/traceroute/utils_test.go
@@ -21,8 +21,8 @@ func Test_getDestinationHostname(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "domain-a.com", getDestinationHostname("1.2.3.4"))
-		assert.Equal(t, "not-an-ip", getDestinationHostname("not-an-ip"))
+		assert.Equal(t, "domain-a.com", getReverseDnsForDestination("1.2.3.4"))
+		assert.Equal(t, "", getReverseDnsForDestination("not-an-ip"))
 	})
 	t.Run("reverse dns lookup failure", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
@@ -30,8 +30,8 @@ func Test_getDestinationHostname(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "1.2.3.4", getDestinationHostname("1.2.3.4"))
-		assert.Equal(t, "not-an-ip", getDestinationHostname("not-an-ip"))
+		assert.Equal(t, "1.2.3.4", getReverseDnsForDestination("1.2.3.4"))
+		assert.Equal(t, "", getReverseDnsForDestination("not-an-ip"))
 	})
 }
 

--- a/pkg/networkpath/traceroute/utils_test.go
+++ b/pkg/networkpath/traceroute/utils_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_getDestinationHostname(t *testing.T) {
+func Test_getReverseDnsForIP(t *testing.T) {
 	t.Run("reverse dns lookup successful", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
 			return []string{"domain-a.com", "domain-b.com"}, nil
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "domain-a.com", getReverseDnsForDestination("1.2.3.4"))
-		assert.Equal(t, "", getReverseDnsForDestination("not-an-ip"))
+		assert.Equal(t, "domain-a.com", getReverseDnsForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", getReverseDnsForIP(nil))
 	})
 	t.Run("reverse dns lookup failure", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
@@ -30,8 +30,8 @@ func Test_getDestinationHostname(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "1.2.3.4", getReverseDnsForDestination("1.2.3.4"))
-		assert.Equal(t, "", getReverseDnsForDestination("not-an-ip"))
+		assert.Equal(t, "1.2.3.4", getReverseDnsForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", getReverseDnsForIP(nil))
 	})
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[network path] Add reverse_dns_hostname field

Naming: using `reverse_dns_hostname` field name for consistency with netflow https://github.com/DataDog/datadog-agent/blob/b6a59f4fb6e2ee418f4e18b58d75cd30093e42a5/comp/netflow/payload/payload.go#L27

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->