### PR TITLE
(fleet) add a bootstraper-only build

### DIFF
--- a/cmd/installer/main_bootstraper.go
+++ b/cmd/installer/main_bootstraper.go
@@ -3,19 +3,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//go:build !bootstraper
+//go:build bootstraper
 
 // Package main implements 'installer'.
 package main
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-agent/cmd/installer/command"
-	"github.com/DataDog/datadog-agent/cmd/installer/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/installer/subcommands/installer"
+	"github.com/DataDog/datadog-agent/cmd/installer/user"
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 )
 
 func main() {
-	os.Exit(runcmd.Run(command.MakeCommand(subcommands.InstallerSubcommands())))
+	if !user.IsRoot() {
+		fmt.Fprintln(os.Stderr, "This command requires root privileges.")
+		os.Exit(1)
+	}
+	cmd := installer.BootstrapCommand()
+	cmd.SilenceUsage = true
+	os.Exit(runcmd.Run(cmd))
 }

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -46,6 +46,11 @@ const (
 	envAgentDistChannel            = "DD_AGENT_DIST_CHANNEL"
 )
 
+// BootstrapCommand returns the bootstrap command.
+func BootstrapCommand() *cobra.Command {
+	return bootstrapCommand()
+}
+
 // Commands returns the installer subcommands.
 func Commands(_ *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{
@@ -158,7 +163,6 @@ func newBootstraperCmd(operation string) *bootstraperCmd {
 
 func newTelemetry(env *env.Env) *telemetry.Telemetry {
 	if env.APIKey == "" {
-		fmt.Printf("telemetry disabled: missing DD_API_KEY\n")
 		return nil
 	}
 	t, err := telemetry.NewTelemetry(env, "datadog-installer")

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -19,6 +19,7 @@ MAJOR_VERSION = '7'
 @task
 def build(
     ctx,
+    bootstraper=False,
     rebuild=False,
     race=False,
     install_path=None,
@@ -47,18 +48,23 @@ def build(
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
     build_tags = get_build_tags(build_include, build_exclude)
+    if bootstraper:
+        build_tags.append("bootstraper")
 
     strip_flags = "" if no_strip_binary else "-s -w"
     race_opt = "-race" if race else ""
     build_type = "-a" if rebuild else ""
     go_build_tags = " ".join(build_tags)
-    updater_bin = os.path.join(BIN_PATH, bin_name("installer"))
+    installer_bin_name = "installer"
+    if bootstraper:
+        installer_bin_name = "bootstraper"
+    installer_bin = os.path.join(BIN_PATH, bin_name(installer_bin_name))
 
     if no_cgo:
         env["CGO_ENABLED"] = "0"
 
     cmd = f"go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
-    cmd += f"-o {updater_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags} {strip_flags}\" {REPO_PATH}/cmd/installer"
+    cmd += f"-o {installer_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags} {strip_flags}\" {REPO_PATH}/cmd/installer"
 
     ctx.run(cmd, env=env)
 


### PR DESCRIPTION
This PR adds a way to build the installer as a bootstraper only.
