### PR TITLE
[BARX-570] Add retry in windows container build jobs

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -36,9 +36,9 @@
       powershell
       -C C:\mnt\tools\ci\docker-login.ps1
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - powershell -Command "docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
+    - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - docker push ${TARGET_TAG}
+    - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker push ${TARGET_TAG}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker rmi ${TARGET_TAG}
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/tools/ci/retry.ps1
+++ b/tools/ci/retry.ps1
@@ -1,0 +1,24 @@
+#!/usr/bin/env pwsh
+
+if ($args.Length -lt 1) {
+    Write-Host "Usage: $($MyInvocation.InvocationName) <command> [arguments]"
+    Write-Host "The script will execute the provided commands and retry in case of failures"
+    Exit 1
+}
+
+$NB_RETRIES = 5
+
+$commandArgs = $args[1..($args.Length - 1)]
+for ($i = 1; $i -le $NB_RETRIES; $i++) {
+    & $args[0] @commandArgs
+    $errorCode = $LASTEXITCODE
+    if ($errorCode -eq 0) {
+        Exit 0
+    } 
+    Write-Host "Attempt #$i failed with error code $errorCode"
+    if ($i -lt $NB_RETRIES) {
+        Start-Sleep -Seconds ($i * $i)
+    }
+}
+
+Exit $errorCode


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a retry mechanism in windows container build jobs

### Motivation

We observed many transient errors, see attached JIRA card for examples.

### Describe how to test/QA your changes

Run the CI

### Possible Drawbacks / Trade-offs

In case of an actual error, we will retry 5 times.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->