### PR TITLE
[tagger] Reduce allocations caused by passing an EntityID around

### DIFF
--- a/comp/core/tagger/taggerimpl/generic_store/composite_store.go
+++ b/comp/core/tagger/taggerimpl/generic_store/composite_store.go
@@ -32,6 +32,16 @@ func (os *compositeObjectStore[T]) Get(entityID types.EntityID) (object T, found
 	return
 }
 
+// GetWithEntityIDStr implements ObjectStore#GetWithEntityIDStr
+func (os *compositeObjectStore[T]) GetWithEntityIDStr(id string) (object T, found bool) {
+	entityID, err := types.NewEntityIDFromString(id)
+	if err != nil {
+		return
+	}
+
+	return os.Get(entityID)
+}
+
 // Set implements ObjectStore#Set
 func (os *compositeObjectStore[T]) Set(entityID types.EntityID, object T) {
 	prefix := entityID.GetPrefix()

--- a/comp/core/tagger/taggerimpl/generic_store/default_store.go
+++ b/comp/core/tagger/taggerimpl/generic_store/default_store.go
@@ -19,6 +19,14 @@ func (os defaulObjectStore[T]) Get(entityID types.EntityID) (object T, found boo
 	return obj, found
 }
 
+// GetWithEntityIDStr implements ObjectStore#GetWithEntityIDStr
+func (os defaulObjectStore[T]) GetWithEntityIDStr(id string) (object T, found bool) {
+	// This store is only meant to be used with IDs of type "defaultEntityID"
+	// that's why we can call "NewDefaultEntityIDFromStr"
+	obj, found := os[types.NewDefaultEntityIDFromStr(id)]
+	return obj, found
+}
+
 // Set implements ObjectStore#Set
 func (os defaulObjectStore[T]) Set(entityID types.EntityID, object T) {
 	os[entityID] = object

--- a/comp/core/tagger/taggerimpl/generic_store/store_test.go
+++ b/comp/core/tagger/taggerimpl/generic_store/store_test.go
@@ -75,6 +75,44 @@ func TestObjectStore_GetSet(t *testing.T) {
 	test(t, true)
 }
 
+func TestObjectStore_GetWithEntityIDStr(t *testing.T) {
+	test := func(t *testing.T, isComposite bool) {
+		cfg := configmock.New(t)
+		cfg.SetWithoutSource("tagger.tagstore_use_composite_entity_id", isComposite)
+
+		store := NewObjectStore[any](cfg)
+
+		id := types.NewEntityID("prefix", "id")
+		idStr := id.String()
+		// getting a non-existent item
+		obj, found := store.GetWithEntityIDStr(idStr)
+		assert.Nil(t, obj)
+		assert.Falsef(t, found, "item should not be found in store")
+
+		// set item
+		store.Set(id, struct{}{})
+
+		// getting item
+		obj, found = store.GetWithEntityIDStr(idStr)
+		assert.NotNil(t, obj)
+		assert.Truef(t, found, "item should be found in store")
+
+		// unsetting item
+		store.Unset(id)
+
+		// getting a non-existent item
+		obj, found = store.GetWithEntityIDStr(idStr)
+		assert.Nil(t, obj)
+		assert.Falsef(t, found, "item should not be found in store")
+	}
+
+	// default store
+	test(t, false)
+
+	// composite store
+	test(t, true)
+}
+
 func TestObjectStore_Size(t *testing.T) {
 
 	test := func(t *testing.T, isComposite bool) {

--- a/comp/core/tagger/taggerimpl/local/tagger.go
+++ b/comp/core/tagger/taggerimpl/local/tagger.go
@@ -75,13 +75,13 @@ func (t *Tagger) Stop() error {
 }
 
 // getTags returns a read only list of tags for a given entity.
-func (t *Tagger) getTags(entityID types.EntityID, cardinality types.TagCardinality) (tagset.HashedTags, error) {
-	if entityID.GetID() == "" {
+func (t *Tagger) getTags(entityID string, cardinality types.TagCardinality) (tagset.HashedTags, error) {
+	if entityID == "" {
 		t.telemetryStore.QueriesByCardinality(cardinality).EmptyEntityID.Inc()
 		return tagset.HashedTags{}, fmt.Errorf("empty entity ID")
 	}
 
-	cachedTags := t.tagStore.LookupHashed(entityID, cardinality)
+	cachedTags := t.tagStore.LookupHashedWithEntityStr(entityID, cardinality)
 
 	t.telemetryStore.QueriesByCardinality(cardinality).Success.Inc()
 	return cachedTags, nil
@@ -89,16 +89,14 @@ func (t *Tagger) getTags(entityID types.EntityID, cardinality types.TagCardinali
 
 // AccumulateTagsFor appends tags for a given entity from the tagger to the TagsAccumulator
 func (t *Tagger) AccumulateTagsFor(entityID string, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
-	id, _ := types.NewEntityIDFromString(entityID)
-	tags, err := t.getTags(id, cardinality)
+	tags, err := t.getTags(entityID, cardinality)
 	tb.AppendHashed(tags)
 	return err
 }
 
 // Tag returns a copy of the tags for a given entity
 func (t *Tagger) Tag(entityID string, cardinality types.TagCardinality) ([]string, error) {
-	id, _ := types.NewEntityIDFromString(entityID)
-	tags, err := t.getTags(id, cardinality)
+	tags, err := t.getTags(entityID, cardinality)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/tagger/taggerimpl/local/tagger_test.go
+++ b/comp/core/tagger/taggerimpl/local/tagger_test.go
@@ -27,8 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestTagBuilder(t *testing.T) {
-
+func TestAccumulateTagsFor(t *testing.T) {
 	entityID := types.NewEntityID("", "entity_name")
 
 	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
@@ -64,4 +63,51 @@ func TestTagBuilder(t *testing.T) {
 	err := tagger.AccumulateTagsFor(entityID.String(), types.HighCardinality, tb)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"high", "low1", "low2"}, tb.Get())
+}
+
+func TestTag(t *testing.T) {
+	entityID := types.NewEntityID(types.ContainerID, "123")
+	entityIDStr := entityID.String()
+
+	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Supply(config.Params{}),
+		fx.Supply(log.Params{}),
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		config.MockModule(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+	telemetryStore := taggerTelemetry.NewStore(tel)
+	cfg := configmock.New(t)
+	tagger := NewTagger(cfg, store, telemetryStore)
+
+	tagger.tagStore.ProcessTagInfo([]*types.TagInfo{
+		{
+			EntityID:             entityID,
+			Source:               "stream",
+			LowCardTags:          []string{"low1"},
+			OrchestratorCardTags: []string{"orchestrator1"},
+			HighCardTags:         []string{"high1"},
+		},
+		{
+			EntityID:             entityID,
+			Source:               "pull",
+			LowCardTags:          []string{"low2"},
+			OrchestratorCardTags: []string{"orchestrator2"},
+			HighCardTags:         []string{"high2"},
+		},
+	})
+
+	lowCardTags, err := tagger.Tag(entityIDStr, types.LowCardinality)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"low1", "low2"}, lowCardTags)
+
+	orchestratorCardTags, err := tagger.Tag(entityIDStr, types.OrchestratorCardinality)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"low1", "low2", "orchestrator1", "orchestrator2"}, orchestratorCardTags)
+
+	highCardTags, err := tagger.Tag(entityIDStr, types.HighCardinality)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"low1", "low2", "orchestrator1", "orchestrator2", "high1", "high2"}, highCardTags)
 }

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore.go
@@ -259,6 +259,22 @@ func (s *TagStore) LookupHashed(entityID types.EntityID, cardinality types.TagCa
 	return storedTags.getHashedTags(cardinality)
 }
 
+// LookupHashedWithEntityStr is the same as LookupHashed but takes a string as input.
+// This function is needed only for performance reasons. It functions like
+// LookupHashed, but accepts a string instead of an EntityID. This reduces the
+// allocations that occur when an EntityID is passed as a parameter.
+func (s *TagStore) LookupHashedWithEntityStr(entityID string, cardinality types.TagCardinality) tagset.HashedTags {
+	s.RLock()
+	defer s.RUnlock()
+
+	storedTags, present := s.store.GetWithEntityIDStr(entityID)
+
+	if !present {
+		return tagset.HashedTags{}
+	}
+	return storedTags.getHashedTags(cardinality)
+}
+
 // Lookup gets tags from the store and returns them concatenated in a string slice.
 func (s *TagStore) Lookup(entityID types.EntityID, cardinality types.TagCardinality) []string {
 	return s.LookupHashed(entityID, cardinality).Get()

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
@@ -96,6 +96,37 @@ func (s *StoreTestSuite) TestLookup() {
 	assert.Len(s.T(), tagsOrch, 3)
 }
 
+func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
+	entityID := types.NewEntityID(types.ContainerID, "test")
+	entityIDStr := entityID.String()
+	s.tagstore.ProcessTagInfo([]*types.TagInfo{
+		{
+			Source:       "source1",
+			EntityID:     entityID,
+			LowCardTags:  []string{"low1"},
+			HighCardTags: []string{"high1"},
+		},
+		{
+			Source:      "source2",
+			EntityID:    entityID,
+			LowCardTags: []string{"low2"},
+		},
+		{
+			Source:               "source3",
+			EntityID:             entityID,
+			OrchestratorCardTags: []string{"orchestrator1"},
+		},
+	})
+
+	tagsLow := s.tagstore.LookupHashedWithEntityStr(entityIDStr, types.LowCardinality)
+	tagsOrch := s.tagstore.LookupHashedWithEntityStr(entityIDStr, types.OrchestratorCardinality)
+	tagsHigh := s.tagstore.LookupHashedWithEntityStr(entityIDStr, types.HighCardinality)
+
+	assert.ElementsMatch(s.T(), tagsLow.Get(), []string{"low1", "low2"})
+	assert.ElementsMatch(s.T(), tagsOrch.Get(), []string{"low1", "low2", "orchestrator1"})
+	assert.ElementsMatch(s.T(), tagsHigh.Get(), []string{"low1", "low2", "orchestrator1", "high1"})
+}
+
 func (s *StoreTestSuite) TestLookupStandard() {
 	entityID := types.NewEntityID("", "test")
 

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -111,6 +111,11 @@ func NewEntityIDFromString(plainStringID string) (EntityID, error) {
 	return newDefaultEntityID(plainStringID), nil
 }
 
+// NewDefaultEntityIDFromStr constructs a default EntityID from a plain string id
+func NewDefaultEntityIDFromStr(plainStringID string) EntityID {
+	return newDefaultEntityID(plainStringID)
+}
+
 const (
 	// ContainerID is the prefix `container_id`
 	ContainerID EntityIDPrefix = "container_id"

--- a/comp/core/tagger/types/entity_id_test.go
+++ b/comp/core/tagger/types/entity_id_test.go
@@ -71,3 +71,10 @@ func TestDefaultEntityID_GetPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestNewDefaultEntityIDFromStr(t *testing.T) {
+	str := "container_id://1234"
+	entityID := NewDefaultEntityIDFromStr(str)
+	assert.Equal(t, ContainerID, entityID.GetPrefix())
+	assert.Equal(t, "1234", entityID.GetID())
+}

--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -22,6 +22,13 @@ type ApplyFunc[V any] func(EntityID, V)
 type ObjectStore[V any] interface {
 	// Get returns an object with the specified entity ID if it exists in the store
 	Get(EntityID) (V, bool)
+	// GetWithEntityIDStr returns an object with the specified entity ID if it
+	// exists in the store.
+	// This function is needed only for performance reasons. It functions like
+	// Get, but accepts a string instead of an EntityID, creating the EntityID
+	// internally. This reduces the allocations that occur when an EntityID is
+	// passed as a parameter.
+	GetWithEntityIDStr(string) (V, bool)
 	// Set sets a given entityID to a given object in the store
 	Set(EntityID, V)
 	// Unset unsets a given entityID in the store


### PR DESCRIPTION
### What does this PR do?

Optimizes CPU usage in the tagger by reducing heap allocations caused by passing `EntityID` objects as parameters.
This is a problem that was detected by AML benchmarks.
This only focuses on the default tagger store. In future PRs we'll probably need similar optimizations for the "composite" one.

### Describe how to test/QA your changes

The changes here are covered by unit and integration tests. We just need to check that AML benchmarks show an improvement.
