### PR TITLE
fix invalid bpf_memcpy in http2 TLS parsing

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -337,4 +337,4 @@ notify_ebpf_complexity_changes:
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
   script:
-    - inv -e ebpf.generate-complexity-summary-for-pr --branch-name $CI_COMMIT_REF_NAME
+    - inv -e ebpf.generate-complexity-summary-for-pr

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -337,4 +337,4 @@ notify_ebpf_complexity_changes:
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
   script:
-    - inv -e ebpf.generate-complexity-summary-for-pr
+    - inv -e ebpf.generate-complexity-summary-for-pr --branch-name $CI_COMMIT_REF_NAME

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -137,8 +137,8 @@ static __always_inline void handle_end_of_stream(http2_stream_t *current_stream,
     const __u32 zero = 0;
     http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
     if (event) {
-        bpf_memcpy(&event->tuple, &http2_stream_key_template->tup, sizeof(conn_tuple_t));
-        bpf_memcpy(&event->stream, current_stream, sizeof(http2_stream_t));
+        event->tuple = http2_stream_key_template->tup;
+        event->stream = *current_stream;
         // enqueue
         http2_batch_enqueue(event);
     }

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -6,7 +6,7 @@ import shutil
 from tasks.github_tasks import pr_commenter
 from tasks.kmt import download_complexity_data
 from tasks.libs.ciproviders.github_api import GithubAPI
-from tasks.libs.common.git import get_commit_sha, get_current_branch, get_common_ancestor
+from tasks.libs.common.git import get_commit_sha, get_common_ancestor, get_current_branch
 from tasks.libs.types.arch import Arch
 
 try:
@@ -20,11 +20,10 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from invoke.context import Context
 from invoke.exceptions import Exit
-from invoke.runners import Result
 from invoke.tasks import task
 
 if TYPE_CHECKING:

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -6,7 +6,7 @@ import shutil
 from tasks.github_tasks import pr_commenter
 from tasks.kmt import download_complexity_data
 from tasks.libs.ciproviders.github_api import GithubAPI
-from tasks.libs.common.git import get_commit_sha, get_current_branch
+from tasks.libs.common.git import get_commit_sha, get_current_branch, get_common_ancestor
 from tasks.libs.types.arch import Arch
 
 try:
@@ -689,13 +689,16 @@ def generate_complexity_summary_for_pr(
     if tabulate is None:
         raise Exit("tabulate is required to print the complexity summary")
 
+    if branch_name is None:
+        branch_name = os.getenv("CI_COMMIT_REF_NAME") or get_current_branch(ctx)
+        commit_sha = os.getenv("CI_COMMIT_SHA") or get_commit_sha(ctx)
+    else:
+        commit_sha = get_commit_sha(ctx, branch_name)
+
     pr_comment_head = 'eBPF complexity changes'
     github = GithubAPI()
     prs = list(github.get_pr_for_branch(branch_name))
     has_prs = len(prs) > 0
-
-    if branch_name is None:
-        branch_name = get_current_branch(ctx)
 
     if base_branch is None:
         if len(prs) == 0:
@@ -729,9 +732,7 @@ def generate_complexity_summary_for_pr(
         return
 
     # We have files, now get files for the main branch
-    common_ancestor = cast(
-        Result, ctx.run(f"git merge-base {branch_name} origin/{base_branch}", hide=True)
-    ).stdout.strip()
+    common_ancestor = get_common_ancestor(ctx, commit_sha, f"origin/{base_branch}")
     main_branch_complexity_path = Path("/tmp/verifier-complexity-main")
     print(f"Downloading complexity data for {base_branch} branch (commit {common_ancestor})...")
     download_complexity_data(ctx, common_ancestor, main_branch_complexity_path)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

fix invalid bpf_memcpy in http2 TLS parsing

### Motivation

`bpf_memcpy` was generating invalid pointer arithmetic for these lines, by changing the base pointer.

before:
```
;     case 48: jmp_48: __it_mob(d, s, 64);
    6763:	79 a1 40 ff 00 00 00 00	r1 = *(u64 *)(r10 - 192)
    6764:	79 11 00 00 00 00 00 00	r1 = *(u64 *)(r1 + 0)
    6765:	7b 16 28 00 00 00 00 00	*(u64 *)(r6 + 40) = r1
;     case 40: jmp_40: __it_mob(d, s, 64);
    6766:	79 a1 48 ff 00 00 00 00	r1 = *(u64 *)(r10 - 184)
    6767:	79 11 00 00 00 00 00 00	r1 = *(u64 *)(r1 + 0)
    6768:	7b 16 20 00 00 00 00 00	*(u64 *)(r6 + 32) = r1
;     case 32: jmp_32: __it_mob(d, s, 64);
    6769:	79 a1 50 ff 00 00 00 00	r1 = *(u64 *)(r10 - 176)
    6770:	79 11 00 00 00 00 00 00	r1 = *(u64 *)(r1 + 0)
    6771:	7b 16 18 00 00 00 00 00	*(u64 *)(r6 + 24) = r1
```

after:
```
12401:	r1 = *(u64 *)(r2 + 40)
12402:	*(u64 *)(r6 + 40) = r1
12403:	r1 = *(u64 *)(r2 + 32)
12404:	*(u64 *)(r6 + 32) = r1
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This compiler bug is fixed in later clang/LLVM versions, but we are fixing other regressions before we can upgrade.