### PR TITLE
fix: fix slice init length

### DIFF
--- a/comp/api/api/apiimpl/grpc.go
+++ b/comp/api/api/apiimpl/grpc.go
@@ -109,7 +109,7 @@ func (s *serverSecure) DogstatsdSetTaggerState(_ context.Context, req *pb.Tagger
 	if taggerReplay == nil {
 		return &pb.TaggerStateResponse{Loaded: false}, fmt.Errorf("unable to instantiate state")
 	}
-	state := make([]taggerTypes.Entity, len(req.State))
+	state := make([]taggerTypes.Entity, 0, len(req.State))
 
 	// better stores these as the native type
 	for id, entity := range req.State {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The intention here should be to initialize a slice with a capacity of len(req.State) rather than initializing the length of this slice. 

The only demo: https://go.dev/play/p/q1BcVCmvidW



### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->