### PR TITLE
Fix external contributor PR job

### DIFF
--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -31,7 +31,6 @@ jobs:
         run: pip install -r requirements.txt -r tasks/requirements.txt
       - name: Set label on external contributor PRs
         run: |
-          gh issue edit "$NUMBER"
           inv -e github.handle-community-pr --repo="$GH_REPO" --pr-id="$NUMBER" --labels="$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the `external-contributor-prs` job which currently always fail, see https://github.com/DataDog/datadog-agent/actions/runs/11157392601/job/31011585168?pr=29744 for example.

### Motivation
Fix the job.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Broken by https://github.com/DataDog/datadog-agent/pull/26928 where I removed half the command to set the milestone instead of all of it.