### PR TITLE
[tagger/generic_store] Optimize by using specific type instead of interface

### DIFF
--- a/comp/core/tagger/taggerimpl/generic_store/default_store.go
+++ b/comp/core/tagger/taggerimpl/generic_store/default_store.go
@@ -7,7 +7,7 @@ package genericstore
 
 import "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 
-type defaulObjectStore[T any] map[types.EntityID]T
+type defaulObjectStore[T any] map[types.DefaultEntityID]T
 
 func newDefaultObjectStore[T any]() types.ObjectStore[T] {
 	return make(defaulObjectStore[T])
@@ -15,26 +15,24 @@ func newDefaultObjectStore[T any]() types.ObjectStore[T] {
 
 // Get implements ObjectStore#Get
 func (os defaulObjectStore[T]) Get(entityID types.EntityID) (object T, found bool) {
-	obj, found := os[entityID]
+	obj, found := os[entityID.(types.DefaultEntityID)]
 	return obj, found
 }
 
 // GetWithEntityIDStr implements ObjectStore#GetWithEntityIDStr
 func (os defaulObjectStore[T]) GetWithEntityIDStr(id string) (object T, found bool) {
-	// This store is only meant to be used with IDs of type "defaultEntityID"
-	// that's why we can call "NewDefaultEntityIDFromStr"
-	obj, found := os[types.NewDefaultEntityIDFromStr(id)]
+	obj, found := os[types.DefaultEntityID(id)]
 	return obj, found
 }
 
 // Set implements ObjectStore#Set
 func (os defaulObjectStore[T]) Set(entityID types.EntityID, object T) {
-	os[entityID] = object
+	os[entityID.(types.DefaultEntityID)] = object
 }
 
 // Unset implements ObjectStore#Unset
 func (os defaulObjectStore[T]) Unset(entityID types.EntityID) {
-	delete(os, entityID)
+	delete(os, entityID.(types.DefaultEntityID))
 }
 
 // Size implements ObjectStore#Size

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -26,11 +26,11 @@ type EntityID interface {
 	String() string
 }
 
-// defaultEntityID implements EntityID as a plain string id
-type defaultEntityID string
+// DefaultEntityID implements EntityID as a plain string id
+type DefaultEntityID string
 
 // GetID implements EntityID#GetID
-func (de defaultEntityID) GetID() string {
+func (de DefaultEntityID) GetID() string {
 	separatorIndex := strings.Index(string(de), separator)
 
 	if separatorIndex == -1 {
@@ -41,7 +41,7 @@ func (de defaultEntityID) GetID() string {
 }
 
 // GetPrefix implements EntityID#GetPrefix
-func (de defaultEntityID) GetPrefix() EntityIDPrefix {
+func (de DefaultEntityID) GetPrefix() EntityIDPrefix {
 	separatorIndex := strings.Index(string(de), separator)
 
 	if separatorIndex == -1 {
@@ -52,12 +52,12 @@ func (de defaultEntityID) GetPrefix() EntityIDPrefix {
 }
 
 // String implements EntityID#String
-func (de defaultEntityID) String() string {
+func (de DefaultEntityID) String() string {
 	return string(de)
 }
 
-func newDefaultEntityID(id string) defaultEntityID {
-	return defaultEntityID(id)
+func newDefaultEntityID(id string) DefaultEntityID {
+	return DefaultEntityID(id)
 }
 
 // compositeEntityID implements EntityID as a struct of prefix and id


### PR DESCRIPTION
### What does this PR do?

Optimizes the default store used by the tagger.
Instead of using `EntityID` (interface) as the key for the map, it now uses a concrete type (`DefaultEntityID`).

### Describe how to test/QA your changes

Should be covered by unit and e2e tests. We just need to check the AML team benchmarks.
