### PR TITLE
[CWS] do not use event category to select parsing/serializer

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -698,13 +698,6 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		return utils.NetNSPathFromPid(event.PIDContext.Pid)
 	})
 
-	if model.GetEventTypeCategory(eventType.String()) == model.NetworkCategory {
-		if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {
-			seclog.Errorf("failed to decode Network Context")
-		}
-		offset += read
-	}
-
 	// handle exec and fork before process context resolution as they modify the process context resolution
 	switch eventType {
 	case model.ForkEventType:
@@ -1000,6 +993,11 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		}
 		p.pushNewTCClassifierRequest(event.VethPair.PeerDevice)
 	case model.DNSEventType:
+		if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {
+			seclog.Errorf("failed to decode Network Context")
+		}
+		offset += read
+
 		if _, err = event.DNS.UnmarshalBinary(data[offset:]); err != nil {
 			if errors.Is(err, model.ErrDNSNameMalformatted) {
 				seclog.Debugf("failed to validate DNS event: %s", event.DNS.Name)
@@ -1012,6 +1010,11 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			return
 		}
 	case model.IMDSEventType:
+		if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {
+			seclog.Errorf("failed to decode Network Context")
+		}
+		offset += read
+
 		if _, err = event.IMDS.UnmarshalBinary(data[offset:]); err != nil {
 			// it's very possible we can't parse the IMDS body, as such let's put it as debug for now
 			seclog.Debugf("failed to decode IMDS event: %s (offset %d, len %d)", err, offset, len(data))

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -43,7 +43,6 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 	case "exec", "signal", "exit", "fork", "syscalls":
 		return ProcessCategory
 	case "bpf", "selinux", "mmap", "mprotect", "ptrace", "load_module", "unload_module", "bind":
-		// TODO(will): "bind" is in this category because answering "NetworkCategory" would insert a network section in the serializer.
 		return KernelCategory
 	case "dns", "imds":
 		return NetworkCategory

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -105,6 +105,11 @@ type NetworkContext struct {
 	Size        uint32        `field:"size"`        // SECLDoc[size] Definition:`Size in bytes of the network packet`
 }
 
+// IsZero returns if there is a network context
+func (nc *NetworkContext) IsZero() bool {
+	return nc.Size == 0
+}
+
 // SpanContext describes a span context
 type SpanContext struct {
 	SpanID  uint64          `field:"-"`

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1142,7 +1142,7 @@ func NewEventSerializer(event *model.Event, opts *eval.Opts) *EventSerializer {
 	}
 	s.Async = event.FieldHandlers.ResolveAsync(event)
 
-	if s.Category == model.NetworkCategory {
+	if !event.NetworkContext.IsZero() {
 		s.NetworkContextSerializer = newNetworkContextSerializer(event)
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Do not rely on the event category to parse or to serialize network context. The category should be only used to disable certain rules according the CWS features. 

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->