### PR TITLE
[CWS] Filter out non filesystem files when doing AD snapshot

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -69,6 +69,10 @@ func (pn *ProcessNode) snapshotAllFiles(p *process.Process, stats *Stats, newEve
 		seclog.Warnf("error while listing files (pid: %v): %s", p.Pid, err)
 	}
 
+	fileFDs = slices.DeleteFunc(fileFDs, func(fd process.OpenFilesStat) bool {
+		return !strings.HasPrefix(fd.Path, "/")
+	})
+
 	var (
 		isSampling = false
 		preAlloc   = len(fileFDs)

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -69,6 +69,8 @@ func (pn *ProcessNode) snapshotAllFiles(p *process.Process, stats *Stats, newEve
 		seclog.Warnf("error while listing files (pid: %v): %s", p.Pid, err)
 	}
 
+	// filter out fd corresponding to anon inodes, pipes, sockets, etc. when snapshotting process opened files
+	// the goal is to avoid sampling opened files for processes that mostly open files not present on the filesystem
 	fileFDs = slices.DeleteFunc(fileFDs, func(fd process.OpenFilesStat) bool {
 		return !strings.HasPrefix(fd.Path, "/")
 	})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Filter out fd corresponding to anon inodes, pipes, sockets, etc. when snapshotting process opened files. 

### Motivation

The goal is to avoid sampling opened files for processes that mostly open files not present on the filesystem.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->