### PR TITLE
Fix duplicate tags in TCP/UDP logs

### DIFF
--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -110,7 +110,6 @@ func (t *Tailer) readForever() {
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
 				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, sourceHostTag)
 			}
-			fmt.Println("wacktest", msg.ParsingExtra.Tags)
 			t.decoder.InputChan <- msg
 		}
 	}

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -98,8 +98,7 @@ func (t *Tailer) readForever() {
 				log.Warnf("Couldn't read message from connection: %v", err)
 				return
 			}
-			copiedTags := make([]string, len(t.source.Config.Tags))
-			copy(copiedTags, t.source.Config.Tags)
+			msg := decoder.NewInput(data)
 			if ipAddress != "" && pkgconfigsetup.Datadog().GetBool("logs_config.use_sourcehost_tag") {
 				lastColonIndex := strings.LastIndex(ipAddress, ":")
 				var ipAddressWithoutPort string
@@ -109,10 +108,9 @@ func (t *Tailer) readForever() {
 					ipAddressWithoutPort = ipAddress
 				}
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
-				copiedTags = append(copiedTags, sourceHostTag)
+				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, sourceHostTag)
 			}
-			msg := decoder.NewInput(data)
-			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, copiedTags...)
+
 			t.decoder.InputChan <- msg
 		}
 	}

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -110,7 +110,7 @@ func (t *Tailer) readForever() {
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
 				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, sourceHostTag)
 			}
-
+			fmt.Println("wacktest", msg.ParsingExtra.Tags)
 			t.decoder.InputChan <- msg
 		}
 	}

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -58,20 +58,20 @@ func TestReadShouldFailWithError(t *testing.T) {
 	tailer.Stop()
 }
 
-func TestDuplicateTags(t *testing.T) {
+func TestAvoidDuplicateTags(t *testing.T) {
 	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
-	// Create a log source with a sample configuration, if needed
-	logSource := sources.NewLogSource("test-source", &config.LogsConfig{})
+	logsConfig := &config.LogsConfig{
+		Tags: []string{"wack:tag", "test:tag2"},
+	}
+	logSource := sources.NewLogSource("test-source", logsConfig)
 
-	// Define the read function to append tags to the message
 	read := func(tailer *Tailer) ([]byte, string, error) {
 		inBuf := make([]byte, 4096)
 		n, err := tailer.Conn.Read(inBuf)
 		if err != nil {
 			return nil, "", err
 		}
-		// Append tags to the message based on your logic
 		return inBuf[:n], "", nil
 	}
 
@@ -80,25 +80,12 @@ func TestDuplicateTags(t *testing.T) {
 
 	var msg *message.Message
 
-	// should receive and decode one message
 	w.Write([]byte("foo\n"))
 	msg = <-msgChan
-	// Adding tags to the message
-	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag1")
-	assert.Equal(t, "foo", string(msg.GetContent()))
-	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag1")
 
-	// should receive and decode two messages
-	w.Write([]byte("bar\nboo\n"))
-	msg = <-msgChan
-	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag2")
-	assert.Equal(t, "bar", string(msg.GetContent()))
-	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag2")
-
-	msg = <-msgChan
-	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag3")
-	assert.Equal(t, "boo", string(msg.GetContent()))
-	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag3")
+	// Getting tags from Origin adds tags from the log config, we want to ensure that the tags
+	// are not added before that
+	assert.Equal(t, msg.Tags(), []string{})
 
 	tailer.Stop()
 }

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -58,7 +58,7 @@ func TestReadShouldFailWithError(t *testing.T) {
 	tailer.Stop()
 }
 
-func TestAvoidDuplicateTags(t *testing.T) {
+func TestDuplicateTags(t *testing.T) {
 	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
 	logsConfig := &config.LogsConfig{
@@ -73,8 +73,6 @@ func TestAvoidDuplicateTags(t *testing.T) {
 
 	w.Write([]byte("foo\n"))
 	msg = <-msgChan
-	// Getting tags from Origin adds tags from the log config, we want to ensure that the tags
-	// are not added before that
 	assert.Equal(t, []string{"test:tag"}, msg.Tags())
 
 	tailer.Stop()

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -65,16 +66,6 @@ func TestSourceHostTag(t *testing.T) {
 		Tags: []string{"test:tag"},
 	}
 
-	mockIPAddress := "192.168.1.100:8080"
-	readWithIP := func(tailer *Tailer) ([]byte, string, error) {
-		inBuf := make([]byte, 4096)
-		n, err := tailer.Conn.Read(inBuf)
-		if err != nil {
-			return nil, "", err
-		}
-		return inBuf[:n], mockIPAddress, nil
-	}
-
 	logSource := sources.NewLogSource("test-source", logsConfig)
 	tailer := NewTailer(logSource, r, msgChan, readWithIP)
 	tailer.Start()
@@ -86,6 +77,31 @@ func TestSourceHostTag(t *testing.T) {
 	tailer.Stop()
 }
 
+func TestSourceHostTagFlagDisabled(t *testing.T) {
+	// Set the config flag for source_host tag to false
+	pkgconfigsetup.Datadog().BindEnvAndSetDefault("logs_config.use_sourcehost_tag", false)
+
+	// Set up test components
+	msgChan := make(chan *message.Message)
+	r, w := net.Pipe()
+	logsConfig := &config.LogsConfig{
+		Tags: []string{"test:tag"},
+	}
+
+	logSource := sources.NewLogSource("test-source", logsConfig)
+	tailer := NewTailer(logSource, r, msgChan, readWithIP)
+	tailer.Start()
+
+	var msg *message.Message
+	w.Write([]byte("foo\n"))
+	msg = <-msgChan
+
+	// Assert that only the original tag is present (source_host tag should not be added)
+	assert.Equal(t, []string{"test:tag"}, msg.Tags(), "source_host tag should not be added when flag is disabled")
+
+	tailer.Stop()
+}
+
 func read(tailer *Tailer) ([]byte, string, error) {
 	inBuf := make([]byte, 4096)
 	n, err := tailer.Conn.Read(inBuf)
@@ -93,4 +109,14 @@ func read(tailer *Tailer) ([]byte, string, error) {
 		return nil, "", err
 	}
 	return inBuf[:n], "", nil
+}
+
+func readWithIP(tailer *Tailer) ([]byte, string, error) {
+	inBuf := make([]byte, 4096)
+	n, err := tailer.Conn.Read(inBuf)
+	if err != nil {
+		return nil, "", err
+	}
+	mockIPAddress := "192.168.1.100:8080"
+	return inBuf[:n], mockIPAddress, nil
 }

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -62,18 +62,9 @@ func TestAvoidDuplicateTags(t *testing.T) {
 	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
 	logsConfig := &config.LogsConfig{
-		Tags: []string{"wack:tag", "test:tag2"},
+		Tags: []string{"test:tag"},
 	}
 	logSource := sources.NewLogSource("test-source", logsConfig)
-
-	read := func(tailer *Tailer) ([]byte, string, error) {
-		inBuf := make([]byte, 4096)
-		n, err := tailer.Conn.Read(inBuf)
-		if err != nil {
-			return nil, "", err
-		}
-		return inBuf[:n], "", nil
-	}
 
 	tailer := NewTailer(logSource, r, msgChan, read)
 	tailer.Start()
@@ -82,10 +73,9 @@ func TestAvoidDuplicateTags(t *testing.T) {
 
 	w.Write([]byte("foo\n"))
 	msg = <-msgChan
-
 	// Getting tags from Origin adds tags from the log config, we want to ensure that the tags
 	// are not added before that
-	assert.Equal(t, msg.Tags(), []string{})
+	assert.Equal(t, []string{"test:tag"}, msg.Tags())
 
 	tailer.Stop()
 }

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -58,6 +58,51 @@ func TestReadShouldFailWithError(t *testing.T) {
 	tailer.Stop()
 }
 
+func TestDuplicateTags(t *testing.T) {
+	msgChan := make(chan *message.Message)
+	r, w := net.Pipe()
+	// Create a log source with a sample configuration, if needed
+	logSource := sources.NewLogSource("test-source", &config.LogsConfig{})
+
+	// Define the read function to append tags to the message
+	read := func(tailer *Tailer) ([]byte, string, error) {
+		inBuf := make([]byte, 4096)
+		n, err := tailer.Conn.Read(inBuf)
+		if err != nil {
+			return nil, "", err
+		}
+		// Append tags to the message based on your logic
+		return inBuf[:n], "", nil
+	}
+
+	tailer := NewTailer(logSource, r, msgChan, read)
+	tailer.Start()
+
+	var msg *message.Message
+
+	// should receive and decode one message
+	w.Write([]byte("foo\n"))
+	msg = <-msgChan
+	// Adding tags to the message
+	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag1")
+	assert.Equal(t, "foo", string(msg.GetContent()))
+	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag1")
+
+	// should receive and decode two messages
+	w.Write([]byte("bar\nboo\n"))
+	msg = <-msgChan
+	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag2")
+	assert.Equal(t, "bar", string(msg.GetContent()))
+	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag2")
+
+	msg = <-msgChan
+	msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "test_tag:tag3")
+	assert.Equal(t, "boo", string(msg.GetContent()))
+	assert.Contains(t, msg.ParsingExtra.Tags, "test_tag:tag3")
+
+	tailer.Stop()
+}
+
 func read(tailer *Tailer) ([]byte, string, error) {
 	inBuf := make([]byte, 4096)
 	n, err := tailer.Conn.Read(inBuf)

--- a/releasenotes/notes/fix-duplicate-tags-e97e8eeb6492235f.yaml
+++ b/releasenotes/notes/fix-duplicate-tags-e97e8eeb6492235f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix duplicate tags in UDP/TCP logs.
+

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/listener/listener_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/listener/listener_test.go
@@ -115,4 +115,5 @@ func assertLogsReceived(
 
 	t.Logf("stdout:\n\n%s\n\nstderr:\n\n%s", stdout, stderr)
 	utils.CheckLogsExpected(t, fakeIntake, "test-app", "bob", []string{sourceHostTag})
+	utils.CheckNoDuplicateTags(t, fakeIntake, "test-app", "bob")
 }

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/listener/listener_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/listener/listener_test.go
@@ -115,5 +115,4 @@ func assertLogsReceived(
 
 	t.Logf("stdout:\n\n%s\n\nstderr:\n\n%s", stdout, stderr)
 	utils.CheckLogsExpected(t, fakeIntake, "test-app", "bob", []string{sourceHostTag})
-	utils.CheckNoDuplicateTags(t, fakeIntake, "test-app", "bob")
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes bug where duplicate tags occur in UDP/TCP logs

### Motivation
[Issue](https://datadoghq.atlassian.net/browse/AGENT-12428)
### Describe how to test/QA your changes

Inside `conf.yaml`, add the following
Create the file if needed `dev/dist/conf.d/test.d/conf.yaml`

```
logs:
  - type: udp
    port: 10518
    service: "test_app"
    source: "test_app_src"
    tags:
      - "name:integrationtag"

```
Inside Datadog.yaml, enable logs and have tags as well
```
logs_enabled: true
tags:
  - "name:hosttag"
```

Run the agent
`./bin/agent/agent run -c bin/agent/dist/datadog.yaml
`
In a different terminal, get the logs from the agent
`./bin/agent/agent stream-logs -c bin/agent/dist/datadog.yaml
`
In a different terminal, send logs to the agent
`echo -n "this is my log" | nc -u -w 1 127.0.0.1 10518
`
Ensure that the tags are not duplicated in the terminal that gets the logs

Different QA steps are also provided in the [ticket](https://datadoghq.atlassian.net/browse/AGENT-12428) if needed

