### PR TITLE
[SMP] regression detector: bump timeout 1h10s -> 1h10m

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -1,6 +1,6 @@
 single-machine-performance-regression_detector:
   stage: functional_test
-  timeout: 1h10
+  timeout: 1h10m
   rules:
     - !reference [.except_main_or_release_branch]
     - when: on_success


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

After #29644 was merged into `main`, filtering out errors due to 2h01s timeouts attributable to branches that have stale merge-bases with respect to `main`, CI Visibility indicates 6 of 15 errors, at time of writing, are due to 1h10s timeouts. Closer inspection of these errors reveal that SMP Regression Detector jobs are still making good progress. Based on the context of #29644 and the table presented there, I suspect the intended timeout was really 1h10m, so this commit makes that change. We believe the timeout duration increase of 9m50s would have given the Regression Detector enough time to finish running successfully.

As a result of the SMP Regression Detector CI improvements made in timeouts should now be rare; these failures were attributable to searching for merge-base commits that no longer had container images due to a container repo expiration policy. #29679 uses a timestammp heuristic to exit such searches early, rather than continue endlessly until the SMP job timed out.

### Motivation

Avoid spurious timeouts.

### Describe how to test/QA your changes

This change is YAML only, and a GitLab CI-specific setting for timeouts, so I think the only QA that can be done is YAML validation. If the YAML is invalid, the CI pipeline will emit a YAML parsing error.

### Possible Drawbacks / Trade-offs

Jobs may run up to 9m50s longer than they would run under the current settings, but the increase should reduce the likelihood of timing out a job that would have completed successfully, given enough time. (For contrast, #29679 addressed a failure mode in which the job would never have completed successfully, given enough time.)

### Additional Notes

cc: @CelianR, as a heads up.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->