### PR TITLE
ec2 client credential init fix for AWS IRSA

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -97,7 +98,7 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	// except when a more specific role (e.g. task role in ECS) does not have
 	// EC2:DescribeTags permission, but a more general role (e.g. instance role)
 	// does have it.
-	tags, err := getTagsWithCreds(ctx, instanceIdentity, nil)
+	tags, err := getTagsWithCreds(ctx, instanceIdentity, ec2Cconnection(ctx, instanceIdentity.Region, nil))
 	if err == nil {
 		return tags, nil
 	}
@@ -111,14 +112,25 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	}
 
 	awsCreds := credentials.NewStaticCredentialsProvider(iamParams.AccessKeyID, iamParams.SecretAccessKey, iamParams.Token)
-	return getTagsWithCreds(ctx, instanceIdentity, awsCreds)
+	return getTagsWithCreds(ctx, instanceIdentity, ec2Cconnection(ctx, instanceIdentity.Region, awsCreds))
 }
 
-func getTagsWithCreds(ctx context.Context, instanceIdentity *EC2Identity, awsCreds aws.CredentialsProvider) ([]string, error) {
-	connection := ec2.New(ec2.Options{
-		Region:      instanceIdentity.Region,
-		Credentials: awsCreds,
-	})
+type ec2ClientInterface interface {
+	DescribeTags(ctx context.Context, params *ec2.DescribeTagsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error)
+}
+
+// ec2Cconnection creates an ec2 client with the given region and credentials
+func ec2Cconnection(ctx context.Context, region string, awsCreds aws.CredentialsProvider) ec2ClientInterface {
+	// using aws config to read the build in credentials to set up the ec2 client.
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region), config.WithCredentialsProvider(awsCreds))
+	if err != nil {
+		log.Warnf("unable to get aws configurations: %s", err)
+		return nil
+	}
+	return ec2.NewFromConfig(cfg)
+}
+
+func getTagsWithCreds(ctx context.Context, instanceIdentity *EC2Identity, connection ec2ClientInterface) ([]string, error) {
 
 	// We want to use 'ec2_metadata_timeout' here instead of current context. 'ctx' comes from the agent main and will
 	// only be canceled if the agent is stopped. The default timeout for the AWS SDK is 1 minutes (20s timeout with

--- a/releasenotes/notes/ec2-cred-fix-9326728a245381e7.yaml
+++ b/releasenotes/notes/ec2-cred-fix-9326728a245381e7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Modifies the initialisation of the AWS EC2 client to use the AWS configuration package.
+    This change enables support for built-in credentials such as AWS IAM Roles for Service Accounts (IRSA).

--- a/releasenotes/notes/ec2-cred-fix-9326728a245381e7.yaml
+++ b/releasenotes/notes/ec2-cred-fix-9326728a245381e7.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Modifies the initialisation of the AWS EC2 client to use the AWS configuration package.
-    This change enables support for built-in credentials such as AWS IAM Roles for Service Accounts (IRSA).
+    Modifies the initialization of the Amazon EC2 client to use the AWS configuration package.
+    This change enables support for built-in credentials, such as AWS IAM Roles for Service Accounts (IRSA).


### PR DESCRIPTION
### What does this PR do?
This PR modifies the initialisation of the AWS EC2 client to use the AWS configuration package. This change enables support for built-in credentials such as AWS IAM Roles for Service Accounts (IRSA). The current use of ec2.New() does not work with IRSA, and although not tested, a similar issue likely occurs with EKS Pod Identity as well.

When a pod is assigned an IRSA with the correct permissions to perform DescribeTags, it encounters an error and logs the following message:

```
(pkg/util/ec2/ec2_tags.go:104 in fetchEc2TagsFromAPI) | unable to get tags using default credentials (falling back to instance role): operation error EC2: DescribeTags, https response error StatusCode: 400, RequestID: 1234-1234-1234, api error MissingParameter: The request must contain the parameter AWSAccessKeyId
```
fixes [issue 29916](https://github.com/DataDog/datadog-agent/issues/29916)

### Motivation
We are currently running the Datadog Agent pod in AWS EKS and are aiming to clean up the instance role by eliminating unnecessary permissions attached to it. Datadog is one of many services that currently use the instance role for the ec2:DescribeTags permission, and we would like to switch to using the IRSA-assigned role.

After extensive debugging and tracing, we discovered that when the pod is assigned an IRSA token but the instance is running IMDSv2, it fails to use IRSA and always falls back to using the instance role.

### Describe how to test/QA your changes
1. create a new EKS node and instance role that does not allow ec2:describeTags.
2. create a new AWS IAM Rolewith ec2:describeTags, and attach this to datadog-agent using IRSA
3. deploy datadog-agent with config.yaml (or using configMap) like this 
collect_ec2_tags: true
collect_ec2_tags_use_imds: true
ec2_prefer_imdsv2: true
4. start the datadog-agent and verify the role gets used, and tags are collected using the IRSA role.

### Possible Drawbacks / Trade-offs
none

### Additional Notes
none