### PR TITLE
[SMP] regression detector: move pr comment into new job

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,8 +18,6 @@ single-machine-performance-regression_detector:
       - outputs/regression_signal.json # for debugging, also on S3
       - outputs/bounds_check_signal.json # for debugging, also on S3
       - outputs/junit.xml # for debugging, also on S3
-      - report_as_json_string.txt # for debugging transform to valid JSON string
-      - pr_comment_payload.json  # for debugging PR commenter JSON payload bugs
     when: always
   variables:
     SMP_VERSION: 0.16.0
@@ -126,10 +124,40 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Download auth tool; see
-    # https://github.com/DataDog/dd-source/tree/8f80b7ef031839b0b11b4a70b9067d6142f3dd5b/domains/devex/ci/authanywhere
-    - curl -Lo ./authanywhere binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64
-    - chmod u+x ./authanywhere
+    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
+    # invoke task has additional logic that does not seem to apply well to SMP's
+    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
+    # uploading JUnit XML, so the upload command below respects that convention.
+    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$API_KEY_ORG2")" || exit $?; export DATADOG_API_KEY
+    - datadog-ci junit upload --service datadog-agent outputs/junit.xml
+    # Finally, exit 1 if the job signals a regression else 0.
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+      job result
+      --submission-metadata submission_metadata
+
+# Shamelessly adapted from golang_deps_commenter job config in
+# golang_deps_diff.yml at commit 01da274032e510d617161cf4e264a53292f44e55.
+single-machine-performance-regression_detector-pr-comment:
+  stage: functional_test
+  rules:
+    - !reference [.except_main_or_release_branch]
+    - when: on_success
+  image:
+    name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"
+    entrypoint: [""]  # disable entrypoint script for the pr-commenter image
+  tags: ["arch:amd64"]
+  needs:
+    - job: single-machine-performance-regression_detector
+  artifacts:
+    expire_in: 1 weeks
+    paths:
+      - report_as_json_string.txt # for debugging transform to valid JSON string
+      - pr_comment_payload.json  # for debugging PR commenter JSON payload bugs
+  variables:
+    # Not using the entrypoint script for the pr-commenter image
+    FF_KUBERNETES_HONOR_ENTRYPOINT: false
+  allow_failure: true  # allow_failure here should have same setting as in job above
+  script: # ignore error message about no PR, because it happens for dev branches without PRs
     # We need to transform the Markdown report into a valid JSON string (without
     # quotes) in order to pass a well-formed payload to the PR commenting
     # service. Note that on macOS, the "-z" flag is invalid for `sed` (but
@@ -153,18 +181,22 @@ single-machine-performance-regression_detector:
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
     - |
-      curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+      set +e
+      out=$(curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
           -H "$(./authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
-          -d "${PR_COMMENT_JSON_PAYLOAD}"
-    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
-    # invoke task has additional logic that does not seem to apply well to SMP's
-    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
-    # uploading JUnit XML, so the upload command below respects that convention.
-    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$API_KEY_ORG2")" || exit $?; export DATADOG_API_KEY
-    - datadog-ci junit upload --service datadog-agent outputs/junit.xml
-    # Finally, exit 1 if the job signals a regression else 0.
-    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-      job result
-      --submission-metadata submission_metadata
+          -d "${PR_COMMENT_JSON_PAYLOAD}")
+      exitcode=$?
+      set -e
+      if [ -n "${out}" ]; then
+        if [ $exitcode -eq 0 ]; then
+          echo $out
+        else
+          echo $out >&2
+        fi
+      fi
+      if [ "${out}" != "${out/invalid request: no pr found for this commit}" ]; then
+        exit 0
+      fi
+      exit $exitcode

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -180,10 +180,11 @@ single-machine-performance-regression_detector-pr-comment:
     # Craft an HTTPS request to pr-commenter service to post Markdown report to
     # GitHub, per
     # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
+    # and gracefully handle the case when the commit being tested is not a PR
     - |
       set +e
       out=$(curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
-          -H "$(./authanywhere)" \
+          -H "$(authanywhere)" \
           -H "X-DdOrigin: curl" \
           -X PATCH \
           -d "${PR_COMMENT_JSON_PAYLOAD}")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `single-machine-performance-regression_detector` job's output is a bit untidy due to the operations needed to transform the Regression Detector report from Markdown into JSON-escaped Markdown. This pull request intends to replace #29683 by building on the work done in #29684, essentially transplanting the PR-comment-related commands into a dedicated job in the spirit of #29683. By using the `pr-commenter` container from Developer Experience, we avoid having to download an internal auth tool separately.

### Motivation

Tidier Regression Detector job output, so it's easier to read the raw Markdown in CI output, for use cases where doing so is necessary.

### Describe how to test/QA your changes

When this PR runs in CI, a Regression Detector PR comment should still post. If a PR comment is not posted, this PR is not functioning properly, and should not be merged.

### Possible Drawbacks / Trade-offs

Trades off the drawback of increased complexity for better separation of concerns, tidier output for the Regression Detector job, and a path towards more graceful handling of running the Regression Detector in Agent CI on commits that are not PRs.

### Additional Notes

Replaces and supersedes #29683.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->