### PR TITLE
Fix fx related issues for agenttelemetry improvements

### DIFF
--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -267,19 +267,8 @@ This command print the security-agent metadata payload. This payload is used by 
 		},
 	}
 
-	showPayloadCommand.AddCommand(payloadV5Cmd)
-	showPayloadCommand.AddCommand(payloadGohaiCmd)
-	showPayloadCommand.AddCommand(payloadInventoriesAgentCmd)
-	showPayloadCommand.AddCommand(payloadInventoriesHostCmd)
-	showPayloadCommand.AddCommand(payloadInventoriesOtelCmd)
-	showPayloadCommand.AddCommand(payloadInventoriesChecksCmd)
-	showPayloadCommand.AddCommand(payloadInventoriesPkgSigningCmd)
-	showPayloadCommand.AddCommand(payloadSystemProbeCmd)
-	showPayloadCommand.AddCommand(payloadSecurityAgentCmd)
-	diagnoseCommand.AddCommand(showPayloadCommand)
-
 	showAgentTelemetryCommand := &cobra.Command{
-		Use:   "show-telemetry",
+		Use:   "agent-telemetry",
 		Short: "Print agent telemetry payloads sent by the agent.",
 		Long:  `.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -290,7 +279,18 @@ This command print the security-agent metadata payload. This payload is used by 
 			)
 		},
 	}
-	diagnoseCommand.AddCommand(showAgentTelemetryCommand)
+
+	showPayloadCommand.AddCommand(payloadV5Cmd)
+	showPayloadCommand.AddCommand(payloadGohaiCmd)
+	showPayloadCommand.AddCommand(payloadInventoriesAgentCmd)
+	showPayloadCommand.AddCommand(payloadInventoriesHostCmd)
+	showPayloadCommand.AddCommand(payloadInventoriesOtelCmd)
+	showPayloadCommand.AddCommand(payloadInventoriesChecksCmd)
+	showPayloadCommand.AddCommand(payloadInventoriesPkgSigningCmd)
+	showPayloadCommand.AddCommand(payloadSystemProbeCmd)
+	showPayloadCommand.AddCommand(payloadSecurityAgentCmd)
+	showPayloadCommand.AddCommand(showAgentTelemetryCommand)
+	diagnoseCommand.AddCommand(showPayloadCommand)
 
 	return []*cobra.Command{diagnoseCommand}
 }

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -121,7 +121,7 @@ func TestShowAgentTelemetryCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"diagnose", "show-metadata", "agent-telemetry"},
 		printPayload,
-		func(_ core.BundleParams, secretParams secrets.Params) {
-			require.Equal(t, false, secretParams.Enabled)
+		func(payload payloadName) {
+			require.Equal(t, payloadName("agent-telemetry"), payload)
 		})
 }

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -115,3 +115,13 @@ func TestShowMetadataSecurityAgentCommand(t *testing.T) {
 			require.Equal(t, false, secretParams.Enabled)
 		})
 }
+
+func TestShowAgentTelemetryCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"diagnose", "show-metadata", "agent-telemetry"},
+		printPayload,
+		func(_ core.BundleParams, secretParams secrets.Params) {
+			require.Equal(t, false, secretParams.Enabled)
+		})
+}

--- a/comp/core/agenttelemetry/fx/fx.go
+++ b/comp/core/agenttelemetry/fx/fx.go
@@ -7,11 +7,17 @@
 package fx
 
 import (
+	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
 	agenttelemetryimpl "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // Module defines the fx options for this component
 func Module() fxutil.Module {
-	return agenttelemetryimpl.Module()
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			agenttelemetryimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[agenttelemetry.Component](),
+	)
 }

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -48,6 +48,7 @@ type atel struct {
 	cancel    context.CancelFunc
 }
 
+// Provides defines the output of the agenttelemetry component
 type Provides struct {
 	compdef.Out
 
@@ -55,6 +56,7 @@ type Provides struct {
 	Endpoint api.AgentEndpointProvider
 }
 
+// Requires declares the input types to the constructor
 type Requires struct {
 	compdef.In
 
@@ -135,6 +137,7 @@ func createAtel(
 	}
 }
 
+// NewComponent creates a new agent telemetry component.
 func NewComponent(deps Requires) Provides {
 	a := createAtel(
 		deps.Config,

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -554,6 +554,7 @@ func TestTwoProfilesOnTheSameScheduleGenerateSinglePayload(t *testing.T) {
 
 	// Single payload whcich has sub-payloads for each metric
 	requestType, ok := payload["request_type"]
+	assert.True(t, ok)
 	assert.Equal(t, "agent-metrics", requestType)
 	metricsPayload, ok := payload["payload"].(map[string]interface{})
 	assert.True(t, ok)
@@ -600,6 +601,7 @@ func TestOneProfileWithOneMetricMultipleContextsGenerateTwoPayloads(t *testing.T
 
 	// One payloads each has the same metric (different tags)
 	requestType, ok := payload["request_type"]
+	assert.True(t, ok)
 	assert.Equal(t, "message-batch", requestType)
 	metricPayloads, ok := payload["payload"].([]interface{})
 	assert.True(t, ok)
@@ -608,6 +610,7 @@ func TestOneProfileWithOneMetricMultipleContextsGenerateTwoPayloads(t *testing.T
 	// 2 metrics
 	// 1-st
 	payload1, ok := metricPayloads[0].(map[string]interface{})
+	assert.True(t, ok)
 	requestType1, ok := payload1["request_type"]
 	assert.True(t, ok)
 	assert.Equal(t, "agent-metrics", requestType1)
@@ -621,6 +624,7 @@ func TestOneProfileWithOneMetricMultipleContextsGenerateTwoPayloads(t *testing.T
 
 	// 2-nd
 	payload2, ok := metricPayloads[1].(map[string]interface{})
+	assert.True(t, ok)
 	requestType2, ok := payload2["request_type"]
 	assert.True(t, ok)
 	assert.Equal(t, "agent-metrics", requestType2)
@@ -672,6 +676,7 @@ func TestOneProfileWithTwoMetricGenerateSinglePayloads(t *testing.T) {
 
 	// Single payload whcich has sub-payloads for each metric
 	requestType, ok := payload["request_type"]
+	assert.True(t, ok)
 	assert.Equal(t, "agent-metrics", requestType)
 	metricsPayload, ok := payload["payload"].(map[string]interface{})
 	assert.True(t, ok)


### PR DESCRIPTION
### What does this PR do?

- Fix the `Fx` related issues and linter. make sure the `agenttelemetry` follow the latest component framework guidance. Add a test for the new command 
- Make the new command follow the same pattern as the other to show display metadata. `agent diagnose show-metadata agent-telemetrty`
- Ensure that if the agent telemetry feature is disable, calling the command `agent diagnose show-metadata agent-telemetrty` do not panic
- Fix a few linters issues 

### Motivation

Help @iglendd get the agenttelemetry improvements [PR](https://github.com/DataDog/datadog-agent/pull/29770) merged 😄 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->