### PR TITLE
Check PrepareFilePath errors in remote-config flare provider

### DIFF
--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -95,13 +95,19 @@ func hashRCTargets(raw []byte) []byte {
 }
 
 func getRemoteConfigDB(fb flaretypes.FlareBuilder) error {
-	dstPath, _ := fb.PrepareFilePath("remote-config.db")
-	tempPath, _ := fb.PrepareFilePath("remote-config.temp.db")
+	dstPath, err := fb.PrepareFilePath("remote-config.db")
+	if err != nil {
+		return err
+	}
+	tempPath, err := fb.PrepareFilePath("remote-config.temp.db")
+	if err != nil {
+		return err
+	}
 	srcPath := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "remote-config.db")
 
 	// Copies the db so it avoids bbolt from being locked
 	// Also avoid concurrent modifications
-	err := util.CopyFileAll(srcPath, tempPath)
+	err = util.CopyFileAll(srcPath, tempPath)
 	// Delete the db at the end to avoid having target files content
 	defer os.Remove(tempPath)
 	if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Check errors returned by `PrepareFilePath` in remote-config flare provider.

### Motivation
The function can fail, in which case the returned path should not be used.
I noticed the following error log and tracked the error down to this.
```
pkg/flare/archive.go:116 in CompleteFlare) | Could not export remote-config state: rename ./3129576775 : no such file or directory
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->