### PR TITLE
Fix race in aggregator expvars

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -74,14 +74,12 @@ func (s *Stats) copy() *Stats {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	stats := &Stats{
+	return &Stats{
 		Flushes:    s.Flushes,
 		FlushIndex: s.FlushIndex,
 		LastFlush:  s.LastFlush,
 		Name:       s.Name,
 	}
-	copy(stats.Flushes[:], s.Flushes[:])
-	return stats
 }
 
 func newFlushTimeStats(name string) {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -730,3 +730,24 @@ func createAggrDeps(t *testing.T) aggregatorDeps {
 		Demultiplexer: InitAndStartAgentDemultiplexerForTest(deps, opts, ""),
 	}
 }
+
+func TestStatsCopy(t *testing.T) {
+	// Flushes    [32]int64 // circular buffer of recent flushes stat
+	// FlushIndex int       // last flush position in circular buffer
+	// LastFlush  int64     // most recent flush stat, provided for convenience
+	// Name       string
+
+	stats := &Stats{
+		Flushes:    [32]int64{1, 2, 3},
+		FlushIndex: 2,
+		LastFlush:  1,
+		Name:       "name",
+	}
+	stats.Flushes[31] = 32
+
+	statsCopy := stats.copy()
+	assert.Equal(t, stats.Flushes, statsCopy.Flushes)
+	assert.Equal(t, stats.FlushIndex, statsCopy.FlushIndex)
+	assert.Equal(t, stats.LastFlush, statsCopy.LastFlush)
+	assert.Equal(t, stats.Name, statsCopy.Name)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix a race in the aggregator stats expvar. 

The global stats maps `flushTimeStats` and `flushCountStats` are returned in `expvar.Func`, meaning they can be unmarshalled at any moment (eg. when getting a status or a flare), but their `Stats` values are also modified at any given time.
The `Stats` struct has a lock but the `expvar` just marshals the struct without locking anything.
Cloning the `Stats` struct while holding the lock in the `expvar.Func` fixes the race.

### Motivation
Not have races in the agent.

### Describe how to test/QA your changes
Tested manually that I could not reproduce the race.
Testing in an automated way that there is no race is pretty much impossible.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Found the race by building the agent with the race detector enabled and creating a flare from it.