### PR TITLE
add minimal test for otel agent BYOC Docker build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -570,6 +570,7 @@
 /test/benchmarks/                       @DataDog/agent-metrics-logs
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
 /test/integration/                      @DataDog/container-integrations
+/test/integration/docker/otel_agent_build_tests.py @DataDog/opentelemetry
 /test/integration/serverless            @DataDog/serverless @Datadog/serverless-aws
 /test/integration/serverless_perf       @DataDog/serverless @Datadog/serverless-aws
 /test/kitchen/                          @DataDog/agent-devx-loops

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -122,6 +122,8 @@ trigger_auto_staging_release           @DataDog/agent-delivery
 
 # Integration test
 integration_tests_windows*    @DataDog/windows-agent
+integration_tests_otel        @DataDog/opentelemetry
+docker_image_build_otel       @DataDog/opentelemetry
 
 # Functional test
 kitchen_*_system_probe_windows*                @DataDog/windows-kernel-integrations

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -21,3 +21,31 @@ integration_tests_otel:
     - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
       when: never
     - when: always
+
+
+docker_image_build_otel:  
+  stage: integration_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  needs: ["go_deps","integration_tests_otel"]
+  tags: ["runner:docker"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - mkdir -p /tmp/otel-ci
+    - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
+    - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
+  script:
+    - cd /tmp/otel-ci
+    - docker build -f Dockerfile.agent-otel -t agent-byoc:latest
+    - cd
+    - OT_AGENT_IMAGE_NAME=agent-byoc OT_AGENT_TAG=latest python3 ./test/integration/docker/otel_agent_build_test.py
+    # - docker run --entrypoint otel-agent agent-byoc version
+  rules:
+    - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
+      when: never
+    - when: always

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -34,6 +34,13 @@ docker_image_build_otel:
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
     - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
     - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
+    - wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O
+      /usr/bin/yq && chmod +x /usr/bin/yq
+    - export OTELCOL_VERSION=v$(/usr/bin/yq r /tmp/otel-ci/manifest.yaml dist.otelcol_version)
+    - /usr/bin/yq w -i /tmp/otel-ci/manifest.yaml "receivers[+] gomod"  
+      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver ${OTELCOL_VERSION}"
+    - /usr/bin/yq w -i /tmp/otel-ci/manifest.yaml "processors[+] gomod" 
+      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor ${OTELCOL_VERSION}"
   script:
     - docker build -t agent-byoc:latest -f /tmp/otel-ci/Dockerfile.agent-otel /tmp/otel-ci
     - OT_AGENT_IMAGE_NAME=agent-byoc OT_AGENT_TAG=latest python3 /tmp/otel-ci/otel_agent_build_tests.py

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -35,7 +35,7 @@ docker_image_build_otel:
     - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
     - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
     - wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O
-      yq && chmod +x /usr/bin/yq
+      /usr/bin/yq && chmod +x /usr/bin/yq
     - export OTELCOL_VERSION=v$(/usr/bin/yq r /tmp/otel-ci/manifest.yaml dist.otelcol_version)
     - yq w -i /tmp/otel-ci/manifest.yaml "receivers[+] gomod" 
       "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver ${OTELCOL_VERSION}"

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -34,12 +34,12 @@ docker_image_build_otel:
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
     - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
     - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
-    - wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O
-      /usr/bin/yq && chmod +x /usr/bin/yq
+    - wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O
+      yq && chmod +x /usr/bin/yq
     - export OTELCOL_VERSION=v$(/usr/bin/yq r /tmp/otel-ci/manifest.yaml dist.otelcol_version)
-    - /usr/bin/yq w -i /tmp/otel-ci/manifest.yaml "receivers[+] gomod"  
+    - yq w -i /tmp/otel-ci/manifest.yaml "receivers[+] gomod" 
       "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver ${OTELCOL_VERSION}"
-    - /usr/bin/yq w -i /tmp/otel-ci/manifest.yaml "processors[+] gomod" 
+    - yq w -i /tmp/otel-ci/manifest.yaml "processors[+] gomod" 
       "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor ${OTELCOL_VERSION}"
   script:
     - docker build -t agent-byoc:latest -f /tmp/otel-ci/Dockerfile.agent-otel /tmp/otel-ci

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -33,9 +33,10 @@ docker_image_build_otel:
     - mkdir -p /tmp/otel-ci
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
     - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
+    - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
   script:
     - docker build -t agent-byoc:latest -f /tmp/otel-ci/Dockerfile.agent-otel /tmp/otel-ci
-    - OT_AGENT_IMAGE_NAME=agent-byoc OT_AGENT_TAG=latest python3 ./test/integration/docker/otel_agent_build_test.py
+    - OT_AGENT_IMAGE_NAME=agent-byoc OT_AGENT_TAG=latest python3 /tmp/otel-ci/otel_agent_build_tests.py
   rules:
     - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
       when: never

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -34,11 +34,8 @@ docker_image_build_otel:
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
     - cp Dockerfiles/agent-ot/Dockerfile.agent-otel /tmp/otel-ci/
   script:
-    - cd /tmp/otel-ci
-    - docker build -f Dockerfile.agent-otel -t agent-byoc:latest
-    - cd
+    - docker build -t agent-byoc:latest -f /tmp/otel-ci/Dockerfile.agent-otel /tmp/otel-ci
     - OT_AGENT_IMAGE_NAME=agent-byoc OT_AGENT_TAG=latest python3 ./test/integration/docker/otel_agent_build_test.py
-    # - docker run --entrypoint otel-agent agent-byoc version
   rules:
     - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
       when: never

--- a/test/integration/docker/otel_agent_build_tests.py
+++ b/test/integration/docker/otel_agent_build_tests.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+import docker
+
+
+def setUpModule():
+    global client
+    client = docker.from_env()
+
+
+class OtelAgentBuildTest(unittest.TestCase):
+    """contains setup and tests for otel agent build. Must be invoked directly
+    by 'inv otel-agent.test-image-build' so that necessary image is built and
+    environment variables are set"""
+
+    def setUp(self):
+        self.assertIsNotNone(os.environ.get('OT_AGENT_IMAGE_NAME'), "OT_AGENT_IMAGE_NAME envvar needed")
+        self.image_name = os.environ.get('OT_AGENT_IMAGE_NAME')
+        self.assertIsNotNone(os.environ.get('OT_AGENT_TAG'), "OT_AGENT_TAG envvar needed")
+        self.tag = os.environ.get('OT_AGENT_TAG')
+        # self.assertIsNotNone(os.environ.get('EXPECTED_VERSION'), "EXPECTED_VERSION envvar needed")
+        # self.expected_version = os.environ.get('EXPECTED_VERSION')
+
+    def test_otel_agent_docker_image(self):
+        version_output = client.containers.run(
+            f'{self.image_name}:{self.tag}', entrypoint='otel-agent', command='version'
+        )
+        self.assertIn("otel-agent", version_output.decode('utf-8'))
+        # TODO: replace with expected version code when https://github.com/DataDog/datadog-agent/pull/29334
+        # is merged to otel beta branch
+        # self.assertIn(f"otel-agent {self.expected_version}", version_output.decode('utf-8'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds `docker_image_build_otel` integration test to build and run the OTel Agent Bring Your Own Collector (BYOC) Docker image, verifying that a "version" command passed to the otel-agent entrypoint succeeds

### Motivation
Closes [OTEL-1989](https://datadoghq.atlassian.net/browse/OTEL-1989)

### Describe how to test/QA your changes
Run integration_tests stage of gitlab CI, see passing job here: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/662106364

### Possible Drawbacks / Trade-offs
Runs a static command in `otel.yml`, could expand tests and functionality in the future by making the test call an invoke command

### Additional Notes
Also adds updates to JOBOWNERS and CODEOWNERS file to reflect OTEL team ownership of OTEL-related test files.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[OTEL-1989]: https://datadoghq.atlassian.net/browse/OTEL-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ