### PR TITLE
AMLII-2042: Moving assertions around to make the error more obvious w…

### DIFF
--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/utils/file_tailing_utils.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/utils/file_tailing_utils.go
@@ -33,6 +33,13 @@ const WindowsLogsFolderPath = "C:\\logs\\e2e_test_logs"
 
 type ddtags []string
 
+const (
+	// WaitFor Time to wait for file tailing utils
+	WaitFor = 2 * time.Minute
+	// Tick how many seconds each ticket should take
+	Tick = 10 * time.Second
+)
+
 // LogsTestSuite is an interface for the log agent test suite.
 type LogsTestSuite interface {
 	T() *testing.T
@@ -92,7 +99,7 @@ func AppendLog(ls LogsTestSuite, logFileName, content string, recurrence int) {
 		if strings.Contains(output, content) {
 			t.Logf("Finished generating %s log, log file's content is now: \n '%s' \n", osStr, output)
 		}
-	}, 2*time.Minute, 10*time.Second)
+	}, WaitFor, Tick)
 }
 
 // CheckLogFilePresence verifies the presence or absence of a log file path
@@ -165,7 +172,7 @@ func CheckLogsExpected(t *testing.T, fakeIntake *components.FakeIntake, service,
 				}
 			}
 		}
-	}, 2*time.Minute, 10*time.Second)
+	}, WaitFor, Tick)
 }
 
 // CheckLogsNotExpected verifies the absence of unexpected logs.
@@ -180,7 +187,7 @@ func CheckLogsNotExpected(t *testing.T, fakeIntake *components.FakeIntake, servi
 				t.Logf("No logs from service: '%s' with content: '%s' collected as expected", service, content)
 			}
 		}
-	}, 2*time.Minute, 10*time.Second)
+	}, WaitFor, Tick)
 }
 
 // CleanUp cleans up any existing log files (only useful when running dev mode/local runs).
@@ -220,7 +227,7 @@ func CleanUp(ls LogsTestSuite) {
 			if assert.NoErrorf(c, err, "Having issue cleaning up log files, retrying... %s", output) {
 				t.Log("Successfully cleaned up log files.")
 			}
-		}, 1*time.Minute, 10*time.Second)
+		}, 1*time.Minute, Tick)
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -228,7 +235,7 @@ func CleanUp(ls LogsTestSuite) {
 		if assert.NoErrorf(c, err, "Having issue flushing server and resetting aggregators, retrying...") {
 			t.Log("Successfully flushed server and reset aggregators.")
 		}
-	}, 1*time.Minute, 10*time.Second)
+	}, 1*time.Minute, Tick)
 }
 
 // prettyPrintLog pretty prints a log entry.


### PR DESCRIPTION

### What does this PR do?

Moves some of the assertions around so that it is more obvious which one is timing out.

### Motivation

To reduce the number of flaky tests.