### PR TITLE
[clusteragent/autoscaling] Fix flaky DCA target test

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -281,10 +281,16 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 				Owner: datadoghq.DatadogPodAutoscalerLocalOwner,
 			}
 
+			// Create object in store
 			dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-dca", 1, testTime, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
 			f.InformerObjects = append(f.InformerObjects, dpa)
 			f.Objects = append(f.Objects, dpaTyped)
 
+			f.RunControllerSync(true, id)
+			_, found := f.store.Get(id)
+			assert.True(t, found)
+
+			// Test that object gets updated with correct error status
 			expectedDPAError := &datadoghq.DatadogPodAutoscaler{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DatadogPodAutoscaler",
@@ -348,7 +354,6 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 			}
 			expectedUnstructuredError, err := autoscaling.ToUnstructured(expectedDPAError)
 			assert.NoError(t, err)
-			f.RunControllerSync(true, id)
 
 			f.ExpectUpdateStatusAction(expectedUnstructuredError)
 			f.RunControllerSync(true, id)

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -283,6 +283,7 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 
 			dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-dca", 1, testTime, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
 			f.InformerObjects = append(f.InformerObjects, dpa)
+			f.Objects = append(f.Objects, dpaTyped)
 
 			expectedDPAError := &datadoghq.DatadogPodAutoscaler{
 				TypeMeta: metav1.TypeMeta{
@@ -348,9 +349,6 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 			expectedUnstructuredError, err := autoscaling.ToUnstructured(expectedDPAError)
 			assert.NoError(t, err)
 			f.RunControllerSync(true, id)
-
-			f.Objects = append(f.Objects, dpaTyped)
-			f.Actions = nil
 
 			f.ExpectUpdateStatusAction(expectedUnstructuredError)
 			f.RunControllerSync(true, id)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Check that DPA is added to store before continuing to test that the proper error status is set.

### Motivation

This test has flaked a few times. The error seems to be caused by the object not being found "in kubernetes". This moves the call to add the object to `f.Objects` earlier, better matching the logic used in the `TestLeaderCreateDeleteLocal` test. 

### Describe how to test/QA your changes

Check that test does not flake.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It has been quite difficult to test this change as I am not able to reproduce the same failure locally, so not 100% sure this will fix the flake but probably a change we would want to make anyway.