### PR TITLE
[AMLII-2060] Add more robust error handling for files

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -197,7 +197,7 @@ func (s *Launcher) receiveLogs(log integrations.IntegrationLog) {
 	for s.combinedUsageSize+logSize > s.combinedUsageMax {
 		leastRecentlyModifiedFile := s.getLeastRecentlyModifiedFile()
 		if leastRecentlyModifiedFile == nil {
-			ddLog.Warn("getLeastRecentlyModifiedFile returned nil, skipping writing log to file.")
+			ddLog.Warn("Could not determine least recently modified file, skipping writing log to file.")
 			return
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds more robust error handling for files where settings are improperly set or read incorrectly.

### Motivation

Previous changes induced a panic in the agent when `integrations_logs_disk_ratio` was read or set improperly, this change mitigates that.

### Describe how to test/QA your changes

Since this is a fix, just maake sure the agent runs correctly and all tests pass.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->