### PR TITLE
Fix rtloader build warning about function prototype

### DIFF
--- a/rtloader/common/builtins/kubeutil.c
+++ b/rtloader/common/builtins/kubeutil.c
@@ -12,7 +12,7 @@
 static cb_get_connection_info_t cb_get_connection_info = NULL;
 
 // forward declarations
-static PyObject *get_connection_info();
+static PyObject *get_connection_info(PyObject *, PyObject *);
 
 static PyMethodDef methods[] = {
     { "get_connection_info", (PyCFunction)get_connection_info, METH_NOARGS, "Get kubelet connection information." },


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix an incorrect prototype warning when building `rtloader`:
```
rtloader/common/builtins/kubeutil.c:15:18: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
static PyObject *get_connection_info();
                 ^
rtloader/common/builtins/kubeutil.c:54:11: note: conflicting prototype is here
PyObject *get_connection_info(PyObject *self, PyObject *args)
          ^
1 warning generated.
```

### Motivation
Not have the warning if it's that easy to fix.

### Describe how to test/QA your changes
Run the following commands before and after the fix to check the warning is fixed.
```
rm -rf rtloader/build
inv rtloader.make
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->