### PR TITLE
[CWS] various kitchen cleanup and timeout fixes

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -101,7 +101,10 @@ kitchen_test_security_agent_amazonlinux_x64:
         KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10"
         KITCHEN_CWS_PLATFORM: [docker]
       - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2022-5-15,amazonlinux2023"
+        KITCHEN_OSVERS: "amazonlinux2023"
+        KITCHEN_CWS_PLATFORM: [docker]
+      - KITCHEN_PLATFORM: "amazonlinux"
+        KITCHEN_OSVERS: "amazonlinux2022-5-15"
         KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_test_security_agent_x64_ec2:

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -198,6 +198,7 @@ platforms:
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2
+    max_wait_until_ready: 30
     <% end %>
     <% if sles15 || al2022 || al2023 %>
     # The AWS EC2 driver doesn't recognize Amazon Linux 2022 yet,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR:
- removes the `amazonlinux2023` on host test since it's covered by KMT
- reduce the SSH connection timeout, so that if SSH fails, it fails much faster

The main goal of the ssh timeout reduction is that we are investigating some SSH failures, while we investigate this timeout reduction should help the job fail faster instead of taking >2h 

Example failing job https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/663256745 (that fails much faster than before)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->