### PR TITLE
(fleet) add a best effort to get the API key to telemetry

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -164,11 +166,40 @@ func newBootstraperCmd(operation string) *bootstraperCmd {
 	}
 }
 
-func newTelemetry(env *env.Env) *telemetry.Telemetry {
-	if env.APIKey == "" {
-		return nil
+type telemetryConfigFields struct {
+	APIKey string `yaml:"api_key"`
+	Site   string `yaml:"site"`
+}
+
+// telemetryConfig is a best effort to get the API key / site from `datadog.yaml`.
+func telemetryConfig() telemetryConfigFields {
+	configPath := "/etc/datadog-agent/datadog.yaml"
+	if runtime.GOOS == "windows" {
+		configPath = "C:\\ProgramData\\Datadog\\datadog.yaml"
 	}
-	t, err := telemetry.NewTelemetry(env, "datadog-installer")
+	rawConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		return telemetryConfigFields{}
+	}
+	var config telemetryConfigFields
+	err = yaml.Unmarshal(rawConfig, &config)
+	if err != nil {
+		return telemetryConfigFields{}
+	}
+	return config
+}
+
+func newTelemetry(env *env.Env) *telemetry.Telemetry {
+	config := telemetryConfig()
+	apiKey := env.APIKey
+	if apiKey == "" {
+		apiKey = config.APIKey
+	}
+	site := env.Site
+	if site == "" {
+		site = config.Site
+	}
+	t, err := telemetry.NewTelemetry(apiKey, site, "datadog-installer")
 	if err != nil {
 		fmt.Printf("failed to initialize telemetry: %v\n", err)
 		return nil

--- a/comp/updater/telemetry/telemetryimpl/telemetry.go
+++ b/comp/updater/telemetry/telemetryimpl/telemetry.go
@@ -31,7 +31,8 @@ func Module() fxutil.Module {
 }
 
 func newTelemetry(deps dependencies) (telemetry.Component, error) {
-	telemetry, err := fleettelemetry.NewTelemetry(env.FromConfig(deps.Config), "datadog-installer")
+	env := env.FromConfig(deps.Config)
+	telemetry, err := fleettelemetry.NewTelemetry(env.APIKey, env.Site, "datadog-installer")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/internaltelemetry"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -55,15 +54,15 @@ type Telemetry struct {
 }
 
 // NewTelemetry creates a new telemetry instance
-func NewTelemetry(env *env.Env, service string) (*Telemetry, error) {
+func NewTelemetry(apiKey string, site string, service string) (*Telemetry, error) {
 	endpoint := &traceconfig.Endpoint{
-		Host:   fmt.Sprintf("https://%s.%s", telemetrySubdomain, strings.TrimSpace(env.Site)),
-		APIKey: env.APIKey,
+		Host:   fmt.Sprintf("https://%s.%s", telemetrySubdomain, strings.TrimSpace(site)),
+		APIKey: apiKey,
 	}
 	listener := newTelemetryListener()
 	t := &Telemetry{
-		telemetryClient: internaltelemetry.NewClient(http.DefaultClient, []*traceconfig.Endpoint{endpoint}, service, env.Site == "datad0g.com"),
-		site:            env.Site,
+		telemetryClient: internaltelemetry.NewClient(http.DefaultClient, []*traceconfig.Endpoint{endpoint}, service, site == "datad0g.com"),
+		site:            site,
 		service:         service,
 		listener:        listener,
 		server:          &http.Server{},


### PR DESCRIPTION
This PR adds a naive config read in the telemetry of the installer to attempt to get an api_key from the datadog.yaml when one isn't passed as env.
