### PR TITLE
Add non-fx flare providers in component constructor

### DIFF
--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -58,11 +58,15 @@ func TestFlareCreation(t *testing.T) {
 		),
 	)
 
-	assert.Len(t, f.Comp.(*flare).providers, 1)
-	assert.NotNil(t, f.Comp.(*flare).providers[0])
+	assert.GreaterOrEqual(t, len(f.Comp.(*flare).providers), 1)
+	assert.NotContains(t, f.Comp.(*flare).providers, nil)
 }
 
 func TestRunProviders(t *testing.T) {
+	var firstRan atomic.Bool
+	var secondRan atomic.Bool
+	var secondDone atomic.Bool
+
 	deps := fxutil.Test[dependencies](
 		t,
 		fx.Provide(func() log.Component { return logmock.New(t) }),
@@ -79,29 +83,36 @@ func TestRunProviders(t *testing.T) {
 			func() types.FlareCallback { return nil },
 			fx.ResultTags(`group:"flare"`),
 		)),
+		fx.Provide(fx.Annotate(
+			func() types.FlareCallback {
+				return func(_ types.FlareBuilder) error {
+					firstRan.Store(true)
+					return nil
+				}
+			},
+			fx.ResultTags(`group:"flare"`),
+		)),
+		fx.Provide(fx.Annotate(
+			func() types.FlareCallback {
+				return func(_ types.FlareBuilder) error {
+					secondRan.Store(true)
+					time.Sleep(10 * time.Second)
+					secondRan.Store(true)
+					return nil
+				}
+			},
+			fx.ResultTags(`group:"flare"`),
+		)),
 	)
 	deps.Config.Set("flare_provider_timeout", 1, model.SourceAgentRuntime)
 	f := newFlare(deps)
 
-	var firstRan atomic.Bool
-	var secondRan atomic.Bool
-	var secondDone atomic.Bool
-	providers := []types.FlareCallback{
-		func(_ types.FlareBuilder) error {
-			firstRan.Store(true)
-			return nil
-		},
-		func(_ types.FlareBuilder) error {
-			secondRan.Store(true)
-			time.Sleep(10 * time.Second)
-			secondRan.Store(true)
-			return nil
-		},
-	}
-
 	fb, err := helpers.NewFlareBuilder(false)
 	require.NoError(t, err)
-	f.Comp.(*flare).runProviders(fb, providers)
+
+	flare := f.Comp.(*flare)
+	flare.runProviders(fb)
+
 	require.True(t, firstRan.Load())
 	require.True(t, secondRan.Load())
 	require.False(t, secondDone.Load())

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -97,7 +97,7 @@ func TestRunProviders(t *testing.T) {
 				return func(_ types.FlareBuilder) error {
 					secondRan.Store(true)
 					time.Sleep(10 * time.Second)
-					secondRan.Store(true)
+					secondDone.Store(true)
 					return nil
 				}
 			},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Some flare providers are hardcoded in the flare generation process rather than being given with the fx group, either due to the fx migration not being fully done or to avoid circular imports.
This PR adds those providers directly in the component constructor rather than every time the flare is generated.

It also fixes a bug where the extra providers were appended to the map without clone, meaning the providers could be added multiple times when generating several flares.

### Motivation
Make the implementation simpler and fix the bug explained above.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->