### PR TITLE
[system-probe] Allow specifying eBPF compiler

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -369,6 +369,7 @@ def build_functional_tests(
     debug=False,
     skip_object_files=False,
     syscall_tester_compiler='clang',
+    ebpf_compiler='clang',
 ):
     if not is_windows:
         if not skip_object_files:
@@ -379,6 +380,7 @@ def build_functional_tests(
                 kernel_release=kernel_release,
                 debug=debug,
                 bundle_ebpf=bundle_ebpf,
+                ebpf_compiler=ebpf_compiler,
             )
         build_embed_syscall_tester(ctx, compiler=syscall_tester_compiler)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1508,7 +1508,9 @@ def build_cws_object_files(
 
 
 @task
-def object_files(ctx, kernel_release=None, with_unit_test=False, arch: str = CURRENT_ARCH, ebpf_compiler: str = 'clang'):
+def object_files(
+    ctx, kernel_release=None, with_unit_test=False, arch: str = CURRENT_ARCH, ebpf_compiler: str = 'clang'
+):
     build_object_files(
         ctx, kernel_release=kernel_release, with_unit_test=with_unit_test, arch=arch, ebpf_compiler=ebpf_compiler
     )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow only using the downloaded compiler instead of the local one.

### Motivation

Using newest versions of clang make the compilation fail because of incompatibility with the LLVM 12 and LLVM15 compiled artefacts.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->