### PR TITLE
[serverless] Add readiness check to logs flush

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -419,6 +419,7 @@ func newHTTPPassthroughPipeline(coreConfig model.Reader, eventPlatformReceiver e
 		strategy = sender.NewBatchStrategy(inputChan,
 			senderInput,
 			make(chan struct{}),
+			make(chan struct{}),
 			false,
 			nil,
 			sender.ArraySerializer,

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -418,8 +418,7 @@ func newHTTPPassthroughPipeline(coreConfig model.Reader, eventPlatformReceiver e
 	} else {
 		strategy = sender.NewBatchStrategy(inputChan,
 			senderInput,
-			make(chan struct{}),
-			make(chan struct{}),
+			make(chan *sync.WaitGroup),
 			false,
 			nil,
 			sender.ArraySerializer,

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -171,7 +171,7 @@ func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan cha
 		return
 	}
 
-	if s.serverless {
+	if s.serverless && s.readyWg != nil {
 		// Increment the wait group so the flush doesn't finish until all payloads are sent to all destinations
 		s.flushWg.Add(1)
 		s.readyWg.Done()

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -170,10 +170,12 @@ func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan cha
 		return
 	}
 
-	if s.serverless && s.readyWg != nil {
+	if s.serverless {
 		// Increment the wait group so the flush doesn't finish until all payloads are sent to all destinations
 		s.flushWg.Add(1)
-		s.readyWg.Done()
+		if s.readyWg != nil {
+			s.readyWg.Done()
+		}
 	}
 
 	outputChan <- &message.Payload{

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -7,7 +7,6 @@
 package sender
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -177,7 +176,6 @@ func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan cha
 		s.readyWg.Done()
 	}
 
-	fmt.Println("======================== payload sent to sender ========================")
 	outputChan <- &message.Payload{
 		Messages:      messages,
 		Encoded:       encodedPayload,

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -19,8 +19,9 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
+	s := NewBatchStrategy(input, output, flushChan, strategyChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)
@@ -49,10 +50,11 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 	timerInterval := 100 * time.Millisecond
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, false, nil, LineSerializer, timerInterval, 100, 100, "test", clk, &identityContentType{})
+	s := newBatchStrategyWithClock(input, output, flushChan, strategyChan, false, nil, LineSerializer, timerInterval, 100, 100, "test", clk, &identityContentType{})
 	s.Start()
 
 	for round := 0; round < 3; round++ {
@@ -75,9 +77,10 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", clk, &identityContentType{})
+	s := newBatchStrategyWithClock(input, output, flushChan, strategyChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", clk, &identityContentType{})
 	s.Start()
 
 	message := message.NewMessage([]byte("a"), nil, "", 0)
@@ -101,8 +104,9 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
+	s := NewBatchStrategy(input, output, flushChan, strategyChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
 	s.Start()
 	message := message.NewMessage([]byte{}, nil, "", 0)
 
@@ -123,10 +127,11 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 	// output needs to be buffered so the flush has somewhere to write to without blocking
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", &identityContentType{})
+	strategy := NewBatchStrategy(input, output, flushChan, strategyChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", &identityContentType{})
 	strategy.Start()
 
 	// all of these messages will get buffered
@@ -168,10 +173,11 @@ func TestBatchStrategyFlushChannel(t *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
+	strategyChan := make(chan struct{})
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", &identityContentType{})
+	strategy := NewBatchStrategy(input, output, flushChan, strategyChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", &identityContentType{})
 	strategy.Start()
 
 	// all of these messages will get buffered


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Attempts to fix the panic `sync: WaitGroup is reused before previous Wait has returned`. In AWS Lambda, the panic is caused by the batch strategy calling `wg.Add(1)` after `wg.Wait()` is used in the pipeline. The ready WaitGroup is used to ensure we always increment the flush WaitGroup before `wait()`.

### Motivation
This is a follow up to https://github.com/DataDog/datadog-agent/pull/28601, which did not fix the panic but decreased the frequency in our dogfood apps.

### Describe how to test/QA your changes
I've ran these changes in our serverless self-monitoring/dogfood apps for several days without an issue. QA would follow the same method [here](https://datadoghq.atlassian.net/wiki/spaces/ASC/pages/3497263870/Testing+the+lambda+extension).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->