### PR TITLE
Remove MetricsExcluded check in Unschedule call

### DIFF
--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -80,7 +80,6 @@ func InitCheckScheduler(collector optional.Option[collector.Component], senderMa
 
 // Schedule schedules configs to checks
 func (s *CheckScheduler) Schedule(configs []integration.Config) {
-
 	if coll, ok := s.collector.Get(); ok {
 		checks := s.GetChecksFromConfigs(configs, true)
 		for _, c := range checks {
@@ -99,8 +98,8 @@ func (s *CheckScheduler) Schedule(configs []integration.Config) {
 // Unschedule unschedules checks matching configs
 func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 	for _, config := range configs {
-		if !config.IsCheckConfig() || config.HasFilter(containers.MetricsFilter) {
-			// skip non check and excluded configs.
+		if !config.IsCheckConfig() {
+			// skip non check
 			continue
 		}
 		// unschedule all the possible checks corresponding to this config

--- a/releasenotes/notes/fix-check-unscheduling-98598e4a139e8120.yaml
+++ b/releasenotes/notes/fix-check-unscheduling-98598e4a139e8120.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing a bug introduced in 7.55 where in some specific scenarios, checks associated with a deleted container or POD would keep running until the Agent is restarted.


### PR DESCRIPTION
### What does this PR do?

Fixing an issue where "zombie" checks could appear since `7.55`. The issue is revealed by the work done on making calls to Scheduler async from AD decisions, but is actually not coming from the introduced code.

The issue appears only when we get a `Set` event in WLM with `ContainerState: !Running` before getting an `Unset` event. It seems to appear much more frequently on containers that are slow to terminate.

The issue happens because we currently send a new `Service` with `metricsExcluded: true` instead of just removing the service entirely if the container is not running anymore. Then the `CheckScheduler` checks this flag in the `Unschedule` call, skipping the deletion of an otherwise known check.

This check does not seem to serve any purpose in the `Unschedule` call (as opposed to the `Schedule` one) as a known check id should be removed regardless. Unknown/already deleted will just be skipped.

### Motivation

Bugfix.

### Describe how to test/QA your changes

The bug is not easily reproducible, but manual testing was already done for this.

### Possible Drawbacks / Trade-offs

### Additional Notes

More context in this [ticket](https://datadoghq.atlassian.net/browse/CONTP-426)