### PR TITLE
[CONTP-402] Config component replacing global func in config webhook

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -218,6 +218,7 @@ func start(log log.Component,
 	logReceiver optional.Option[integrations.Component],
 	_ healthprobe.Component,
 	settings settings.Component,
+	datadogConfig config.Component,
 ) error {
 	stopCh := make(chan struct{})
 	validatingStopCh := make(chan struct{})
@@ -471,7 +472,7 @@ func start(log log.Component,
 			ValidatingStopCh:    validatingStopCh,
 		}
 
-		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa)
+		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa, datadogConfig)
 		// Ignore the error if it's related to the validatingwebhookconfigurations.
 		var syncInformerError *apiserver.SyncInformersError
 		if err != nil && !(errors.As(err, &syncInformerError) && syncInformerError.Name == apiserver.ValidatingWebhooksInformer) {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
@@ -52,11 +53,12 @@ func NewController(
 	config Config,
 	wmeta workloadmeta.Component,
 	pa workload.PodPatcher,
+	datadogConfig config.Component,
 ) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa, datadogConfig)
 	}
-	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa)
+	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa, datadogConfig)
 }
 
 // Webhook represents an admission webhook
@@ -88,7 +90,7 @@ type Webhook interface {
 // The reason is that the volume mount for the APM socket added by the configWebhook webhook
 // doesn't always work on Fargate (one of the envs where we use an agent sidecar), and
 // the agent sidecar webhook needs to remove it.
-func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher) []Webhook {
+func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, datadogConfig config.Component) []Webhook {
 	// Note: the auto_instrumentation pod injection filter is used across
 	// multiple mutating webhooks, so we add it as a hard dependency to each
 	// of the components that use it via the injectionFilter parameter.
@@ -108,7 +110,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	// Add Mutating webhooks.
 	if c.config.isMutationEnabled() {
 		mutatingWebhooks = []Webhook{
-			configWebhook.NewWebhook(wmeta, injectionFilter),
+			configWebhook.NewWebhook(wmeta, injectionFilter, datadogConfig),
 			tagsfromlabels.NewWebhook(wmeta, injectionFilter),
 			agentsidecar.NewWebhook(),
 			autoscaling.NewWebhook(pa),

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -24,6 +25,7 @@ import (
 func TestNewController(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
 	factory := informers.NewSharedInformerFactory(client, time.Duration(0))
 
 	// V1
@@ -37,6 +39,7 @@ func TestNewController(t *testing.T) {
 		v1Cfg,
 		wmeta,
 		nil,
+		datadogConfig,
 	)
 
 	assert.IsType(t, &ControllerV1{}, controller)
@@ -52,6 +55,7 @@ func TestNewController(t *testing.T) {
 		v1beta1Cfg,
 		wmeta,
 		nil,
+		datadogConfig,
 	)
 
 	assert.IsType(t, &ControllerV1beta1{}, controller)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -55,6 +56,7 @@ func NewControllerV1(
 	config Config,
 	wmeta workloadmeta.Component,
 	pa workload.PodPatcher,
+	datadogConfig config.Component,
 ) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
@@ -69,7 +71,7 @@ func NewControllerV1(
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.webhooks = controller.generateWebhooks(wmeta, pa)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -941,7 +941,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc()
-			c.webhooks = c.generateWebhooks(wmeta, nil)
+			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1171,6 +1171,7 @@ func newFixtureV1(t *testing.T) *fixtureV1 {
 func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerFactory) {
 	factory := informers.NewSharedInformerFactory(f.client, time.Duration(0))
 	wmeta := fxutil.Test[workloadmeta.Component](f.t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	datadogConfig := fxutil.Test[configComp.Component](f.t, core.MockBundle())
 	return NewControllerV1(
 		f.client,
 		factory.Core().V1().Secrets(),
@@ -1181,6 +1182,7 @@ func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerF
 		v1Cfg,
 		wmeta,
 		nil,
+		datadogConfig,
 	), factory
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -55,6 +56,7 @@ func NewControllerV1beta1(
 	config Config,
 	wmeta workloadmeta.Component,
 	pa workload.PodPatcher,
+	datadogConfig config.Component,
 ) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
@@ -69,7 +71,7 @@ func NewControllerV1beta1(
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
 	controller.isLeaderNotif = isLeaderNotif
-	controller.webhooks = controller.generateWebhooks(wmeta, pa)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -934,7 +934,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc()
-			c.webhooks = c.generateWebhooks(wmeta, nil)
+			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1164,6 +1164,7 @@ func newFixtureV1beta1(t *testing.T) *fixtureV1beta1 {
 func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.SharedInformerFactory) {
 	factory := informers.NewSharedInformerFactory(f.client, time.Duration(0))
 	wmeta := fxutil.Test[workloadmeta.Component](f.t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	datadogConfig := fxutil.Test[configComp.Component](f.t, core.MockBundle())
 	return NewControllerV1beta1(
 		f.client,
 		factory.Core().V1().Secrets(),
@@ -1174,6 +1175,7 @@ func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.Share
 		v1beta1Cfg,
 		wmeta,
 		nil,
+		datadogConfig,
 	), factory
 }
 

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -78,7 +78,8 @@ func TestInjectHostIP(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -89,7 +90,8 @@ func TestInjectService(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "service"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -118,7 +120,8 @@ func TestInjectEntityID(t *testing.T) {
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 				fx.Replace(config.MockParams{Overrides: tt.configOverrides}),
 			)
-			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -305,7 +308,8 @@ func TestInjectSocket(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -332,7 +336,8 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 			Overrides: map[string]interface{}{"admission_controller.inject_config.type_socket_volumes": true},
 		}),
 	)
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -427,7 +432,8 @@ func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
 	}
 
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.True(t, injected)
 	assert.Nil(t, err)
@@ -466,7 +472,8 @@ func TestJSONPatchCorrectness(t *testing.T) {
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 				fx.Replace(config.MockParams{Overrides: tt.overrides}),
 			)
-			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
+			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 			request := admission.Request{
 				Raw:       podJSON,
 				Namespace: "bar",
@@ -496,7 +503,8 @@ func BenchmarkJSONPatch(b *testing.B) {
 	}
 
 	wmeta := fxutil.Test[workloadmeta.Component](b, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter())
+	datadogConfig := fxutil.Test[config.Component](b, core.MockBundle())
+	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
 	podJSON := obj.(*admiv1.AdmissionReview).Request.Object.Raw
 
 	b.ResetTimer()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replace global function to access config instance with the config component as a parameter

### Motivation

We want the agent code base to respect best practices. Tech-debt clean up.

### Describe how to test/QA your changes

N/A.