### PR TITLE
Auto Multiline V2 - Fix double truncation bug

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -43,8 +43,10 @@ func (b *bucket) isEmpty() bool {
 }
 
 func (b *bucket) truncate() {
-	b.buffer.Write(message.TruncatedFlag)
-	b.truncated = true
+	if !b.truncated {
+		b.buffer.Write(message.TruncatedFlag)
+		b.truncated = true
+	}
 }
 
 func (b *bucket) flush() *message.Message {

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -43,10 +43,8 @@ func (b *bucket) isEmpty() bool {
 }
 
 func (b *bucket) truncate() {
-	if !b.truncated {
-		b.buffer.Write(message.TruncatedFlag)
-		b.truncated = true
-	}
+	b.buffer.Write(message.TruncatedFlag)
+	b.truncated = true
 }
 
 func (b *bucket) flush() *message.Message {
@@ -140,7 +138,7 @@ func (a *Aggregator) Aggregate(msg *message.Message, label Label) {
 
 	// At this point we either have `startGroup` with an empty bucket or `aggregate` with a non-empty bucket
 	// so we add the message to the bucket or flush if the bucket will overflow the max content size.
-	if msg.RawDataLen+a.bucket.buffer.Len() > a.maxContentSize {
+	if msg.RawDataLen+a.bucket.buffer.Len() > a.maxContentSize && !a.bucket.isEmpty() {
 		a.bucket.truncate() // Truncate the end of the current bucket
 		a.Flush()
 		a.bucket.truncate() // Truncate the start of the next bucket

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -129,7 +129,8 @@ func TestTagTruncatedLogs(t *testing.T) {
 
 	ag.Aggregate(newMessage("1234567890"), startGroup)
 	ag.Aggregate(newMessage("12345678901"), aggregate) // Causes overflow, truncate and flush
-	ag.Aggregate(newMessage("2"), aggregate)
+	ag.Aggregate(newMessage("12345"), aggregate)
+	ag.Aggregate(newMessage("6789"), aggregate)
 	ag.Aggregate(newMessage("3"), noAggregate)
 
 	msg := <-outputChan
@@ -145,7 +146,12 @@ func TestTagTruncatedLogs(t *testing.T) {
 	msg = <-outputChan
 	assert.True(t, msg.ParsingExtra.IsTruncated)
 	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
-	assertMessageContent(t, msg, "...TRUNCATED...2")
+	assertMessageContent(t, msg, "...TRUNCATED...12345...TRUNCATED...")
+
+	msg = <-outputChan
+	assert.True(t, msg.ParsingExtra.IsTruncated)
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
+	assertMessageContent(t, msg, "...TRUNCATED...6789")
 
 	msg = <-outputChan
 	assert.False(t, msg.ParsingExtra.IsTruncated)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -128,8 +128,9 @@ func TestTagTruncatedLogs(t *testing.T) {
 	ag := NewAggregator(outputFn, 10, time.Duration(1*time.Second), true, false, status.NewInfoRegistry())
 
 	ag.Aggregate(newMessage("1234567890"), startGroup)
-	ag.Aggregate(newMessage("1"), aggregate) // Causes overflow, truncate and flush
-	ag.Aggregate(newMessage("2"), noAggregate)
+	ag.Aggregate(newMessage("12345678901"), aggregate) // Causes overflow, truncate and flush
+	ag.Aggregate(newMessage("2"), aggregate)
+	ag.Aggregate(newMessage("3"), noAggregate)
 
 	msg := <-outputChan
 	assert.True(t, msg.ParsingExtra.IsTruncated)
@@ -139,12 +140,17 @@ func TestTagTruncatedLogs(t *testing.T) {
 	msg = <-outputChan
 	assert.True(t, msg.ParsingExtra.IsTruncated)
 	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
-	assertMessageContent(t, msg, "...TRUNCATED...1")
+	assertMessageContent(t, msg, "...TRUNCATED...12345678901...TRUNCATED...")
+
+	msg = <-outputChan
+	assert.True(t, msg.ParsingExtra.IsTruncated)
+	assert.Equal(t, msg.ParsingExtra.Tags, []string{message.TruncatedReasonTag("auto_multiline")})
+	assertMessageContent(t, msg, "...TRUNCATED...2")
 
 	msg = <-outputChan
 	assert.False(t, msg.ParsingExtra.IsTruncated)
 	assert.Empty(t, msg.ParsingExtra.Tags)
-	assertMessageContent(t, msg, "2")
+	assertMessageContent(t, msg, "3")
 }
 
 func TestTagMultiLineLogs(t *testing.T) {
@@ -175,7 +181,7 @@ func TestTagMultiLineLogs(t *testing.T) {
 	assertMessageContent(t, msg, "2")
 }
 
-func TestTruncatedFlagIsOnlyAddedOnce(t *testing.T) {
+func TestStartGruopIsNotTruncatedWithoutAggreagation(t *testing.T) {
 	outputChan, outputFn := makeHandler()
 	ag := NewAggregator(outputFn, 5, time.Duration(1*time.Second), false, true, status.NewInfoRegistry())
 
@@ -184,5 +190,5 @@ func TestTruncatedFlagIsOnlyAddedOnce(t *testing.T) {
 	ag.Aggregate(newMessage(""), startGroup)
 
 	msg := <-outputChan
-	assertMessageContent(t, msg, "...TRUNCATED...123456")
+	assertMessageContent(t, msg, "123456")
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -174,3 +174,15 @@ func TestTagMultiLineLogs(t *testing.T) {
 	assert.Empty(t, msg.ParsingExtra.Tags)
 	assertMessageContent(t, msg, "2")
 }
+
+func TestTruncatedFlagIsOnlyAddedOnce(t *testing.T) {
+	outputChan, outputFn := makeHandler()
+	ag := NewAggregator(outputFn, 5, time.Duration(1*time.Second), false, true, status.NewInfoRegistry())
+
+	ag.Aggregate(newMessage("123456"), startGroup)
+	// Force a flush
+	ag.Aggregate(newMessage(""), startGroup)
+
+	msg := <-outputChan
+	assertMessageContent(t, msg, "...TRUNCATED...123456")
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix an edge case bug where if a log is larger than the max message size, and it gets assigned a `startGroup` label, The truncation flag gets applied twice.

ex: `...TRUNCATED......TRUNCATED...log message`

In this situation, the truncation should only be applied to the end of the message if it gets aggregated with a future log. 
This PR fixes the truncation behavior and ads UT coverage for these cases. 

### Motivation

Fix bug. 

### Describe how to test/QA your changes

Covered by UT. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->