### PR TITLE
fix lock contention asset names

### DIFF
--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -337,7 +337,7 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 		collectionSpec.Maps["lock_stat"].MaxEntries = ranges
 		collectionSpec.Maps["ranges"].MaxEntries = ranges
 
-		// Ideally we would want this to be the max number of proccesses allowed
+		// Ideally we would want this to be the max number of processes allowed
 		// by the kernel, however verifier constraints force us to choose a smaller
 		// value. This value has been experimentally determined to pass the verifier.
 		collectionSpec.Maps["tstamp"].MaxEntries = 16384
@@ -365,7 +365,7 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 			if errors.As(err, &ve) {
 				return fmt.Errorf("verfier error loading collection: %s\n%+v", err, ve)
 			}
-			return fmt.Errorf("failed to load objects: %w", err)
+			return fmt.Errorf("failed to load objects (%d ranges): %w", l.ranges, err)
 		}
 
 		return nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `bytecode/build/co-re/` prefix from the CO-RE asset names.

### Motivation

The telemetry was including the prefixes.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

Removed string constants that were only used in a single place

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->