### PR TITLE
[clusteragent] Add support for PHP injection (SSI) in kubernetes

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -302,10 +302,14 @@ func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) *libInfoLanguag
 	}
 }
 
-// getAllLatestLibraries returns all supported by APM Instrumentation tracing libraries
-func (w *Webhook) getAllLatestLibraries() []libInfo {
+// getAllLatestDefaultLibraries returns all supported by APM Instrumentation tracing libraries
+// that should be enabled by default
+func (w *Webhook) getAllLatestDefaultLibraries() []libInfo {
 	var libsToInject []libInfo
 	for _, lang := range supportedLanguages {
+		if !lang.isEnabledByDefault() {
+			continue
+		}
 		libsToInject = append(libsToInject, lang.defaultLibInfo(w.config.containerRegistry, ""))
 	}
 
@@ -430,7 +434,7 @@ func (w *Webhook) extractLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 	}
 
 	if extracted.source.isSingleStep() {
-		return extracted.withLibs(w.getAllLatestLibraries())
+		return extracted.withLibs(w.getAllLatestDefaultLibraries())
 	}
 
 	// Get libraries to inject for Remote Instrumentation
@@ -444,7 +448,7 @@ func (w *Webhook) extractLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 			log.Warnf("Ignoring version %q. To inject all libs, the only supported version is latest for now", version)
 		}
 
-		return extracted.withLibs(w.getAllLatestLibraries())
+		return extracted.withLibs(w.getAllLatestDefaultLibraries())
 	}
 
 	return extractedPodLibInfo{}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -675,10 +675,6 @@ func TestExtractLibInfo(t *testing.T) {
 			lang:  "ruby",
 			image: "registry/dd-lib-ruby-init:v2",
 		},
-		{
-			lang:  "php",
-			image: "registry/dd-lib-php-init:v1",
-		},
 	}
 
 	var mockConfig model.Config
@@ -1766,7 +1762,6 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 		"ruby":   "v2",
 		"dotnet": "v3",
 		"js":     "v5",
-		"php":    "v1",
 	}
 
 	defaultLibrariesFor := func(languages ...string) map[string]string {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -654,7 +654,7 @@ func assertLibReq(t *testing.T, pod *corev1.Pod, lang language, image, envKey, e
 
 func TestExtractLibInfo(t *testing.T) {
 	// TODO: Add new entry when a new language is supported
-	allLatestLibs := []libInfo{
+	allLatestDefaultLibs := []libInfo{
 		{
 			lang:  "java",
 			image: "registry/dd-lib-java-init:v1",
@@ -826,14 +826,14 @@ func TestExtractLibInfo(t *testing.T) {
 			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "latest"),
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(true),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 		},
 		{
 			name:                 "all with mutate_unlabelled off",
 			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "latest"),
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(false),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -852,7 +852,7 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(true),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -862,7 +862,7 @@ func TestExtractLibInfo(t *testing.T) {
 			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "latest"),
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(false),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -881,7 +881,7 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(true),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -891,7 +891,7 @@ func TestExtractLibInfo(t *testing.T) {
 			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "latest"),
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(false),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -910,7 +910,7 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 			containerRegistry:    "registry",
 			expectedPodEligible:  pointer.Ptr(true),
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", false)
 			},
@@ -937,14 +937,14 @@ func TestExtractLibInfo(t *testing.T) {
 			name:                 "all with unsupported version",
 			pod:                  common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.version", "unsupported"),
 			containerRegistry:    "registry",
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig:          func() { mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", false) },
 		},
 		{
 			name:                 "single step instrumentation with no pinned versions",
 			pod:                  common.FakePodWithNamespaceAndLabel("ns", "", ""),
 			containerRegistry:    "registry",
-			expectedLibsToInject: allLatestLibs,
+			expectedLibsToInject: allLatestDefaultLibs,
 			setupConfig:          func() { mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true) },
 		},
 		{
@@ -995,6 +995,17 @@ func TestExtractLibInfo(t *testing.T) {
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("apm_config.instrumentation.lib_versions", map[string]string{"java": "v1.20.0"})
 				mockConfig.SetWithoutSource("admission_controller.mutate_unlabelled", true)
+			},
+		},
+		{
+			name:              "php (opt-in)",
+			pod:               common.FakePodWithAnnotation("admission.datadoghq.com/php-lib.version", "v1"),
+			containerRegistry: "registry",
+			expectedLibsToInject: []libInfo{
+				{
+					lang:  "php",
+					image: "registry/dd-lib-php-init:v1",
+				},
 			},
 		},
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -675,6 +675,10 @@ func TestExtractLibInfo(t *testing.T) {
 			lang:  "ruby",
 			image: "registry/dd-lib-ruby-init:v2",
 		},
+		{
+			lang:  "php",
+			image: "registry/dd-lib-php-init:v1",
+		},
 	}
 
 	var mockConfig model.Config
@@ -1762,6 +1766,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 		"ruby":   "v2",
 		"dotnet": "v3",
 		"js":     "v5",
+		"php":    "v1",
 	}
 
 	defaultLibrariesFor := func(languages ...string) map[string]string {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -101,6 +101,7 @@ var supportedLanguages = []language{
 	python,
 	dotnet,
 	ruby,
+	php, // PHP only works with injection v2, no environment variables are set in any case
 }
 
 func (l language) isSupported() bool {
@@ -117,7 +118,7 @@ var languageVersions = map[language]string{
 	python: "v2", // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
-	php:    "v2", // https://datadoghq.atlassian.net/browse/APMON-1128
+	php:    "v1", // https://datadoghq.atlassian.net/browse/APMON-1128
 }
 
 func (l language) defaultLibVersion() string {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -108,6 +108,10 @@ func (l language) isSupported() bool {
 	return slices.Contains(supportedLanguages, l)
 }
 
+func (l language) isEnabledByDefault() bool {
+	return l != "php"
+}
+
 // languageVersions defines the major library versions we consider "default" for each
 // supported language. If not set, we will default to "latest", see defaultLibVersion.
 //

--- a/releasenotes/notes/ssi-php-k8s-a5beff276151f2d4.yaml
+++ b/releasenotes/notes/ssi-php-k8s-a5beff276151f2d4.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for PHP Single Step Instrumentation in Kubernetes

--- a/releasenotes/notes/ssi-php-k8s-a5beff276151f2d4.yaml
+++ b/releasenotes/notes/ssi-php-k8s-a5beff276151f2d4.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add support for PHP Single Step Instrumentation in Kubernetes
+    Add support for PHP Single Step Instrumentation in Kubernetes (not enabled by default)


### PR DESCRIPTION
### What does this PR do?

Alternative to https://github.com/DataDog/datadog-agent/pull/28078 for https://datadoghq.atlassian.net/browse/INPLAT-178

Notes:
- PHP only works with injection v2, no environment variables are set in any case. v1 should just do nothing.
- PHP should not be enabled by default if not present in [the yaml configuration file](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetes)
- ~~It is NOT tested. Can someone help me testing with a real cluster?~~ tested with minikube

### Motivation

### Describe how to test/QA your changes

Tested with the following configuration in `datadog-values.yml`:
```
datadog:
 # ...

 apm:
   instrumentation:
      enabled: true
      libVersions:
         php: "1"
```

and a PHP application:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: php-nextcloud
  labels:
    app: php-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: php-app
  template:
    metadata:
      labels:
        app: php-app
    spec:
      containers:
      - name: app
        image: nextcloud
        env:
          - name: DD_INJECT_FORCE
            value: "true" # because JIT is enabled on the nextcloud image
        readinessProbe:
          timeoutSeconds: 1
          successThreshold: 1
          failureThreshold: 1
          httpGet:
            host:
            scheme: HTTP
            path: /
            port: 80
          initialDelaySeconds: 30
          periodSeconds: 1
        ports:
          - containerPort: 80
            protocol: TCP

```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->