### PR TITLE
[gitlab] Fix go_deps cache keys

### DIFF
--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -31,6 +31,7 @@
       POLICY: pull
   retry: 2
 
+# HACK: If you change the behavior of this job, change the `cache:key:prefix` value to invalidate the cache
 go_deps:
   extends: .cache
   variables:
@@ -48,15 +49,16 @@ go_deps:
     paths:
       - $CI_PROJECT_DIR/modcache.tar.xz
   cache:
-    # The `cache:key:files` only accepts up to two path ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
+    # The `cache:key:files` only accepts up to two paths ([docs](https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles)).
     # Ideally, we should also include the https://github.com/DataDog/datadog-agent/blob/main/.custom-gcl.yml file to
     # avoid issues if a plugin is added in one PR and enabled in another. However, we decided to accept this limitation
     # because the probability for this to happen is very low and go mod files are modified frequently so the risk of
     # failing a job because of a network issue when building the custom binary is very low, but still exists.
+    # We should also include the file this job is defined in to invalicate the cache when this job is modified.
     - key:
         files:
-          - \**/go.mod
-          - .gitlab/deps_fetch/deps_fetch.yml
+          - go.mod
+          - ./**/go.mod
         prefix: "go_deps_modcache"
       paths:
         - modcache.tar.xz


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates the `go_deps` cache keys to depend explicitly on the `go.mod` file. The previous attempt did not work, causing the cache to not update on changes to the root `go.mod` file, ultimately causing the cache to be outdated.

This caused jobs to start downloading dependencies again, increasing the risk of failures.

### Motivation

Temporary fix to make the cache behave closer to what we need.

The limitations explained in comments still apply: if the `.gitlab/deps_fetch/deps_fetch.yml` or `.custom-gcl.yml` files change, we should invalidate the cache, but we can't. We prefer making sure we invalidate the cache on `go.mod` changes because this is a more frequent operation.

### Describe how to test/QA your changes

Check that the `go_deps` job in the pipeline changed its cache key.

### Possible Drawbacks / Trade-offs

See job comments.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->