### PR TITLE
fix(fleet): Fix misleading error

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -103,7 +103,7 @@ func (d *Downloader) Download(ctx context.Context, packageURL string) (*Download
 		return nil, fmt.Errorf("unsupported package URL scheme: %s", url.Scheme)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("could not download package from %s: %w", packageURL, err)
+		return nil, fmt.Errorf("could not download package: %w", err)
 	}
 	manifest, err := image.Manifest()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
When you override a repo & there's an error pulling the error is misleading. The following error shouldn't mention gcr.io.
```
failed to bootstrap the installer: failed to download installer: failed to download installer package: could not download package from oci://gcr.io/datadoghq/installer-package:latest: could not download image: Get "https://my.fake.repo/v2/": dial tcp: lookup my.fake.repo on XX.XX.XX.XX:53: no such host
```

This PR removes it from the error.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->