### PR TITLE
Set `direction:undefined` unless flow type is NetFlow v9

### DIFF
--- a/comp/netflow/flowaggregator/buildpayload.go
+++ b/comp/netflow/flowaggregator/buildpayload.go
@@ -19,7 +19,7 @@ func buildPayload(aggFlow *common.Flow, hostname string, flushTime time.Time) pa
 		FlushTimestamp: flushTime.UnixMilli(),
 		FlowType:       string(aggFlow.FlowType),
 		SamplingRate:   aggFlow.SamplingRate,
-		Direction:      format.Direction(aggFlow.Direction),
+		Direction:      format.Direction(aggFlow.Direction, aggFlow.FlowType),
 		Device: payload.Device{
 			Namespace: aggFlow.Namespace,
 		},

--- a/comp/netflow/format/direction.go
+++ b/comp/netflow/format/direction.go
@@ -5,8 +5,14 @@
 
 package format
 
+import "github.com/DataDog/datadog-agent/comp/netflow/common"
+
 // Direction remaps direction from 0 or 1 to respectively ingress or egress.
-func Direction(direction uint32) string {
+func Direction(direction uint32, flowType common.FlowType) string {
+	// See https://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9.html#:~:text=4%20is%20assumed.-,DIRECTION,-61
+	if flowType != common.TypeNetFlow9 {
+		return "undefined"
+	}
 	if direction == 1 {
 		return "egress"
 	}

--- a/comp/netflow/format/direction_test.go
+++ b/comp/netflow/format/direction_test.go
@@ -8,11 +8,15 @@ package format
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDirection(t *testing.T) {
-	assert.Equal(t, "ingress", Direction(uint32(0)))
-	assert.Equal(t, "egress", Direction(uint32(1)))
-	assert.Equal(t, "ingress", Direction(uint32(99))) // invalid direction will default to ingress
+	assert.Equal(t, "ingress", Direction(uint32(0), common.TypeNetFlow9))
+	assert.Equal(t, "egress", Direction(uint32(1), common.TypeNetFlow9))
+	assert.Equal(t, "undefined", Direction(uint32(99), common.TypeNetFlow9))
+	assert.Equal(t, "undefined", Direction(uint32(0), common.TypeNetFlow5))
+	assert.Equal(t, "undefined", Direction(uint32(1), common.TypeNetFlow5))
+	assert.Equal(t, "undefined", Direction(uint32(99), common.TypeNetFlow5))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set `direction:undefined` unless flow type is NetFlow v9.

### Motivation

`netsampler/goflow2 v1.3.3` maps [DIRECTION](https://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9.html#:~:text=4%20is%20assumed.-,DIRECTION,-61) to `FlowDirection`, [code](https://github.com/netsampler/goflow2/blob/v1.3.3/producer/producer_nf.go#L426-L427).

- IPFIX has [biflowDirection information element](https://datatracker.ietf.org/doc/html/rfc5103#section-6.3), but not have direction. Should we have a new tag like `biflowdirection:xxx`?
  - arbitrary
  - initiator
  - reverseInitiator
  - perimeter
- [NetFlow v5](https://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html) doesn't have direction information. 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->