### PR TITLE
[omnibus] Make system-probe binary builds use the GOMODCACHE env

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -152,9 +152,9 @@ build do
   if sysprobe_support
     if not bundled_agents.include? "system-probe"
       if windows_target?
-        command "invoke -e system-probe.build"
+        command "invoke -e system-probe.build", env: env
       elsif linux_target?
-        command "invoke -e system-probe.build-sysprobe-binary --install-path=#{install_dir} --no-bundle"
+        command "invoke -e system-probe.build-sysprobe-binary --install-path=#{install_dir} --no-bundle", env: env
       end
     end
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates the `system-probe` binary build commands in the `datadog-agent.rb` software definition to pass the `env` hash.

This hash sets a number of environment variables (like `GOPATH`, `LDFLAGS`, `CGO_CFLAGS`, `CGO_LDFLAGS`, `GOMODCACHE`).

The `GOMODCACHE` one in particular is important, as it allows the command to reuse the go dependency cache that we prepare in the `go_deps` job. This helps avoid the total number of dependency downloads done from third-parties in the CI.

Since the `system-probe` binary build commands did not have this variable set, they were re-downloading their go dependencies. This sometimes caused download errors ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/665024290)), making CI fail.

### Motivation

Avoid unnecessary dependency downloads in CI.

### Describe how to test/QA your changes

Full successful pipeline run.

### Possible Drawbacks / Trade-offs

I could have passed only the `GOMODCACHE` variable to the commands to be extra safe. However, since all other go build commands in the software definition already pass the full `env` hash, I prefer having a uniform way of running all of them.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a