### PR TITLE
use strings.Cut instead of strings.Split in NewEntityIDFromString

### DIFF
--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -102,11 +102,14 @@ func NewEntityID(prefix EntityIDPrefix, id string) EntityID {
 // NewEntityIDFromString constructs EntityID from a plain string id
 func NewEntityIDFromString(plainStringID string) (EntityID, error) {
 	if taggerutils.ShouldUseCompositeStore() {
-		if !strings.Contains(plainStringID, separator) {
+
+		prefix, id, found := strings.Cut(plainStringID, separator)
+
+		if !found {
 			return nil, fmt.Errorf("unsupported tagger entity id format %q, correct format is `{prefix}://{id}`", plainStringID)
 		}
-		parts := strings.Split(plainStringID, separator)
-		return newCompositeEntityID(EntityIDPrefix(parts[0]), parts[1]), nil
+
+		return newCompositeEntityID(EntityIDPrefix(prefix), id), nil
 	}
 	return newDefaultEntityID(plainStringID), nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR replaces strings.Split by strings.Cut in NewEntityIDFromString in order to initialise a composite entity id from a string.

### Motivation

Optimise CPU usage and avoid regression.

CPU impact visible in APM Profiles:
![image](https://github.com/user-attachments/assets/99154bc4-5e06-4329-bc48-f262f0fc3a71)


### Describe how to test/QA your changes
No need for QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->