### PR TITLE
do not recalculate global entity id as string on each call

### DIFF
--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -39,8 +39,14 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 }
 
 var globalEntityID = types.NewEntityID("internal", "global-entity-id")
+var globalEntityIDString = globalEntityID.String()
 
 // GetGlobalEntityID returns the entity ID that holds global tags
 func GetGlobalEntityID() types.EntityID {
 	return globalEntityID
+}
+
+// GetGlobalEntityIDString returns, in a plain string format, the entity ID that holds global tags
+func GetGlobalEntityIDString() string {
+	return globalEntityIDString
 }

--- a/comp/core/tagger/taggerimpl/local/fake_tagger.go
+++ b/comp/core/tagger/taggerimpl/local/fake_tagger.go
@@ -57,7 +57,7 @@ func (f *FakeTagger) SetTags(entityID string, source string, low, orch, high, st
 
 // SetGlobalTags allows to set tags in store for the global entity
 func (f *FakeTagger) SetGlobalTags(low, orch, high, std []string) {
-	f.SetTags(common.GetGlobalEntityID().String(), "static", low, orch, high, std)
+	f.SetTags(common.GetGlobalEntityIDString(), "static", low, orch, high, std)
 }
 
 // SetTagsFromInfo allows to set tags from list of TagInfo
@@ -112,7 +112,7 @@ func (f *FakeTagger) Tag(entityID string, cardinality types.TagCardinality) ([]s
 
 // GlobalTags fake implementation
 func (f *FakeTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return f.Tag(common.GetGlobalEntityID().String(), cardinality)
+	return f.Tag(common.GetGlobalEntityIDString(), cardinality)
 }
 
 // AccumulateTagsFor fake implementation

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -338,14 +338,14 @@ func (t *TaggerClient) AgentTags(cardinality types.TagCardinality) ([]string, er
 func (t *TaggerClient) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
 	t.mux.RLock()
 	if t.captureTagger != nil {
-		tags, err := t.captureTagger.Tag(taggercommon.GetGlobalEntityID().String(), cardinality)
+		tags, err := t.captureTagger.Tag(taggercommon.GetGlobalEntityIDString(), cardinality)
 		if err == nil && len(tags) > 0 {
 			t.mux.RUnlock()
 			return tags, nil
 		}
 	}
 	t.mux.RUnlock()
-	return t.defaultTagger.Tag(taggercommon.GetGlobalEntityID().String(), cardinality)
+	return t.defaultTagger.Tag(taggercommon.GetGlobalEntityIDString(), cardinality)
 }
 
 // globalTagBuilder queries global tags that should apply to all data coming
@@ -353,7 +353,7 @@ func (t *TaggerClient) GlobalTags(cardinality types.TagCardinality) ([]string, e
 func (t *TaggerClient) globalTagBuilder(cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
 	t.mux.RLock()
 	if t.captureTagger != nil {
-		err := t.captureTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityID().String(), cardinality, tb)
+		err := t.captureTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityIDString(), cardinality, tb)
 
 		if err == nil {
 			t.mux.RUnlock()
@@ -361,7 +361,7 @@ func (t *TaggerClient) globalTagBuilder(cardinality types.TagCardinality, tb tag
 		}
 	}
 	t.mux.RUnlock()
-	return t.defaultTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityID().String(), cardinality, tb)
+	return t.defaultTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityIDString(), cardinality, tb)
 }
 
 // List the content of the defaulTagger


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR performs an optimisation by avoiding calculating global tagger entity id as string on each call.
This change calculates the id as a string only once, and returns the string on each call.

### Motivation

Optimise CPU usage and avoid regression.

CPU impact visible in APM Profiles:

![image](https://github.com/user-attachments/assets/2d9ec0fa-98b4-4079-ac84-cc9c0f7d7422)


### Describe how to test/QA your changes

No need for QA, we already have E2E and unit tests.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->