### PR TITLE
feat(secret): Prevent useless usage of Gitlab token

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -541,6 +541,7 @@ generate-flakes-finder-pipeline:
     - !reference [.on_deploy_nightly_repo_branch]
     - !reference [.manual]
   needs:
+    - compute_gitlab_ci_config
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64
     - deploy_rpm_testing-a7_arm64

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -557,7 +557,6 @@ generate-flakes-finder-pipeline:
     - qa_agent_ot
   tags: ["arch:amd64"]
   script:
-    - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_FULL_API_TOKEN) || exit $?; export GITLAB_TOKEN
     - inv -e testwasher.generate-flake-finder-pipeline
   artifacts:
     paths:

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -134,7 +134,7 @@ def generate_flake_finder_pipeline(ctx, n=3):
     """
 
     # Read gitlab config
-    config = resolve_gitlab_ci_configuration(ctx, ".gitlab-ci.yml")
+    config = resolve_gitlab_ci_configuration(ctx, ".gitlab-ci.yml", with_lint=False)
 
     # Lets keep only variables and jobs with flake finder variable
     kept_job = {}

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 from collections import defaultdict
 
 import yaml
-from invoke import task
+from invoke import Exit, task
 
 from tasks.libs.ciproviders.gitlab_api import (
     resolve_gitlab_ci_configuration,
@@ -128,13 +129,21 @@ class TestWasher:
 
 
 @task
-def generate_flake_finder_pipeline(ctx, n=3):
+def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
     """
     Generate a child pipeline where jobs marked with SHOULD_RUN_IN_FLAKES_FINDER are run n times
     """
-
-    # Read gitlab config
-    config = resolve_gitlab_ci_configuration(ctx, ".gitlab-ci.yml", with_lint=False)
+    if generate_config:
+        # Read gitlab config
+        config = resolve_gitlab_ci_configuration(ctx, ".gitlab-ci.yml")
+    else:
+        # Read gitlab config, which is computed and stored in compute_gitlab_ci_config job
+        if not os.path.exists("artifacts/after.gitlab-ci.yml"):
+            raise Exit(
+                "The configuration is not stored as artifact. Please ensure you ran the compute_gitlab_ci_config job, or set generate_config to True"
+            )
+        with open("artifacts/after.gitlab-ci.yml") as f:
+            config = yaml.safe_load(f)[".gitlab-ci.yml"]
 
     # Lets keep only variables and jobs with flake finder variable
     kept_job = {}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent usage of Gitlab token when it's not necessary

### Motivation
Less usage of secrets

### Describe how to test/QA your changes
```
inv testwasher.generate-flake-finder-pipeline -g
mkdir artifacts
inv -e gitlab.compute-gitlab-ci-config --before-file artifacts/before.gitlab-ci.yml --after-file artifacts/after.gitlab-ci.yml --diff-file artifacts/diff.gitlab-ci.yml
inv testwasher.generate-flake-finder-pipeline
```
The compare the generated content. Some spurious `-` are removed with the new behaviour, and the execution of the testwasher generation is instantaneous.

### Possible Drawbacks / Trade-offs
I had to add the `  - !reference [.on_deploy_nightly_repo_branch]` condition to generate the `compute_gitlab_ci_config` when it's necessary for the `generate_testwasher` job.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->