### PR TITLE
Introduce more file to blackhole experiment for logs Agent effort

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
@@ -1,0 +1,26 @@
+generator:
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 8
+        maximum_bytes_per_log: "500MiB"
+        total_rotations: 5
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "10MiB"
+        maximum_prebuild_cache_size_bytes: "300MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 0
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
@@ -1,0 +1,26 @@
+generator:
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 8
+        maximum_bytes_per_log: "500MiB"
+        total_rotations: 5
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "10MiB"
+        maximum_prebuild_cache_size_bytes: "300MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 1000
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
@@ -1,0 +1,26 @@
+generator:
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 8
+        maximum_bytes_per_log: "500MiB"
+        total_rotations: 5
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "10MiB"
+        maximum_prebuild_cache_size_bytes: "300MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 100
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/file_to_blackhole_300ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_300ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
@@ -1,0 +1,26 @@
+generator:
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 8
+        maximum_bytes_per_log: "500MiB"
+        total_rotations: 5
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "10MiB"
+        maximum_prebuild_cache_size_bytes: "300MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 300
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
@@ -1,0 +1,26 @@
+generator:
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 8
+        maximum_bytes_per_log: "500MiB"
+        total_rotations: 5
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "10MiB"
+        maximum_prebuild_cache_size_bytes: "300MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 500
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.23.2
+  version: 0.23.3
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
### What does this PR do?

This commit introduces five new experiments, each a file tailing experiment with one variation: intake latency. 

### Motivation

The intent is to demonstrate that future optimization work to logs Agent is effective even over slow network lines. I have upgraded lading to 0.23.3 which release includes support for a response delay.