### PR TITLE
[CONTP-403] Configure agent sidecar mutator to use config component

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -112,7 +112,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 		mutatingWebhooks = []Webhook{
 			configWebhook.NewWebhook(wmeta, injectionFilter, datadogConfig),
 			tagsfromlabels.NewWebhook(wmeta, injectionFilter),
-			agentsidecar.NewWebhook(),
+			agentsidecar.NewWebhook(datadogConfig),
 			autoscaling.NewWebhook(pa),
 		}
 		webhooks = append(webhooks, mutatingWebhooks...)

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -137,7 +137,7 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 		podUpdated = true
 	}
 
-	updated, err := applyProviderOverrides(pod)
+	updated, err := applyProviderOverrides(pod, w.datadogConfig)
 	if err != nil {
 		log.Errorf("Failed to apply provider overrides: %v", err)
 		return podUpdated, errors.New(metrics.InvalidInput)
@@ -148,7 +148,7 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	// highest override-priority. They only apply to the agent sidecar container.
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == agentSidecarContainerName {
-			updated, err = applyProfileOverrides(&pod.Spec.Containers[i])
+			updated, err = applyProfileOverrides(&pod.Spec.Containers[i], w.datadogConfig)
 			if err != nil {
 				log.Errorf("Failed to apply profile overrides: %v", err)
 				return podUpdated, errors.New(metrics.InvalidInput)
@@ -257,7 +257,7 @@ func labelSelectors(datadogConfig config.Component) (namespaceSelector, objectSe
 	selectorsJSON := datadogConfig.GetString("admission_controller.agent_sidecar.selectors")
 
 	// Get sidecar profiles
-	_, err := loadSidecarProfiles()
+	_, err := loadSidecarProfiles(datadogConfig)
 	if err != nil {
 		log.Errorf("encountered issue when loading sidecar profiles: %s", err)
 		return nil, nil

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -52,23 +53,25 @@ type Webhook struct {
 	namespaceSelector *metav1.LabelSelector
 	objectSelector    *metav1.LabelSelector
 	containerRegistry string
+	datadogConfig     config.Component
 }
 
 // NewWebhook returns a new Webhook
-func NewWebhook() *Webhook {
-	nsSelector, objSelector := labelSelectors()
+func NewWebhook(datadogConfig config.Component) *Webhook {
+	nsSelector, objSelector := labelSelectors(datadogConfig)
 
 	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.agent_sidecar.container_registry")
 
 	return &Webhook{
 		name:              webhookName,
-		isEnabled:         pkgconfigsetup.Datadog().GetBool("admission_controller.agent_sidecar.enabled"),
-		endpoint:          pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.endpoint"),
+		isEnabled:         datadogConfig.GetBool("admission_controller.agent_sidecar.enabled"),
+		endpoint:          datadogConfig.GetString("admission_controller.agent_sidecar.endpoint"),
 		resources:         []string{"pods"},
 		operations:        []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		namespaceSelector: nsSelector,
 		objectSelector:    objSelector,
 		containerRegistry: containerRegistry,
+		datadogConfig:     datadogConfig,
 	}
 }
 
@@ -129,7 +132,7 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	podUpdated := false
 
 	if !agentSidecarExists {
-		agentSidecarContainer := getDefaultSidecarTemplate(w.containerRegistry)
+		agentSidecarContainer := getDefaultSidecarTemplate(w.containerRegistry, w.datadogConfig)
 		pod.Spec.Containers = append(pod.Spec.Containers, *agentSidecarContainer)
 		podUpdated = true
 	}
@@ -158,14 +161,14 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	return podUpdated, nil
 }
 
-func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {
+func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Component) *corev1.Container {
 	ddSite := os.Getenv("DD_SITE")
 	if ddSite == "" {
 		ddSite = pkgconfigsetup.DefaultSite
 	}
 
-	imageName := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.image_name")
-	imageTag := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.image_tag")
+	imageName := datadogConfig.GetString("admission_controller.agent_sidecar.image_name")
+	imageTag := datadogConfig.GetString("admission_controller.agent_sidecar.image_tag")
 
 	agentContainer := &corev1.Container{
 		Env: []corev1.EnvVar{
@@ -199,7 +202,7 @@ func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {
 			},
 			{
 				Name:  "DD_LANGUAGE_DETECTION_ENABLED",
-				Value: strconv.FormatBool(pkgconfigsetup.Datadog().GetBool("language_detection.enabled") && pkgconfigsetup.Datadog().GetBool("language_detection.reporting.enabled")),
+				Value: strconv.FormatBool(datadogConfig.GetBool("language_detection.enabled") && datadogConfig.GetBool("language_detection.reporting.enabled")),
 			},
 		},
 		Image:           fmt.Sprintf("%s/%s:%s", containerRegistry, imageName, imageTag),
@@ -217,11 +220,11 @@ func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {
 		},
 	}
 
-	clusterAgentEnabled := pkgconfigsetup.Datadog().GetBool("admission_controller.agent_sidecar.cluster_agent.enabled")
+	clusterAgentEnabled := datadogConfig.GetBool("admission_controller.agent_sidecar.cluster_agent.enabled")
 
 	if clusterAgentEnabled {
-		clusterAgentCmdPort := pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")
-		clusterAgentServiceName := pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name")
+		clusterAgentCmdPort := datadogConfig.GetInt("cluster_agent.cmd_port")
+		clusterAgentServiceName := datadogConfig.GetString("cluster_agent.kubernetes_service_name")
 
 		_, _ = withEnvOverrides(agentContainer, corev1.EnvVar{
 			Name:  "DD_CLUSTER_AGENT_ENABLED",
@@ -249,9 +252,9 @@ func getDefaultSidecarTemplate(containerRegistry string) *corev1.Container {
 }
 
 // labelSelectors returns the mutating webhooks object selectors based on the configuration
-func labelSelectors() (namespaceSelector, objectSelector *metav1.LabelSelector) {
+func labelSelectors(datadogConfig config.Component) (namespaceSelector, objectSelector *metav1.LabelSelector) {
 	// Read and parse selectors
-	selectorsJSON := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.selectors")
+	selectorsJSON := datadogConfig.GetString("admission_controller.agent_sidecar.selectors")
 
 	// Get sidecar profiles
 	_, err := loadSidecarProfiles()
@@ -273,7 +276,7 @@ func labelSelectors() (namespaceSelector, objectSelector *metav1.LabelSelector) 
 		return nil, nil
 	}
 
-	provider := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.provider")
+	provider := datadogConfig.GetString("admission_controller.agent_sidecar.provider")
 	if !providerIsSupported(provider) {
 		log.Errorf("agent sidecar provider is not supported: %v", provider)
 		return nil, nil

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/profiles.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/profiles.go
@@ -13,7 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 ////////////////////////////////
@@ -32,9 +32,9 @@ type ProfileOverride struct {
 // loadSidecarProfiles returns the profile overrides provided by the user
 // It returns an error in case of miss-configuration or in case more than
 // one profile is configured
-func loadSidecarProfiles() ([]ProfileOverride, error) {
+func loadSidecarProfiles(datadogConfig config.Component) ([]ProfileOverride, error) {
 	// Read and parse profiles
-	profilesJSON := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.profiles")
+	profilesJSON := datadogConfig.GetString("admission_controller.agent_sidecar.profiles")
 
 	var profiles []ProfileOverride
 
@@ -52,12 +52,12 @@ func loadSidecarProfiles() ([]ProfileOverride, error) {
 
 // applyProfileOverrides applies the profile overrides to the container. It
 // returns a boolean that indicates if the container was mutated
-func applyProfileOverrides(container *corev1.Container) (bool, error) {
+func applyProfileOverrides(container *corev1.Container, datadogConfig config.Component) (bool, error) {
 	if container == nil {
 		return false, fmt.Errorf("can't apply profile overrides to nil containers")
 	}
 
-	profiles, err := loadSidecarProfiles()
+	profiles, err := loadSidecarProfiles(datadogConfig)
 
 	if err != nil {
 		return false, err

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
@@ -117,7 +117,7 @@ func TestLoadSidecarProfiles(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
-			profiles, err := loadSidecarProfiles()
+			profiles, err := loadSidecarProfiles(mockConfig)
 
 			if test.expectError {
 				assert.Error(tt, err)
@@ -361,7 +361,7 @@ func TestApplyProfileOverrides(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
-			mutated, err := applyProfileOverrides(test.baseContainer)
+			mutated, err := applyProfileOverrides(test.baseContainer, mockConfig)
 
 			assert.Equal(tt, test.expectMutated, mutated)
 

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
@@ -13,9 +13,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
@@ -55,8 +55,8 @@ func providerIsSupported(provider string) bool {
 
 // applyProviderOverrides applies the necessary overrides for the provider
 // configured. It returns a boolean that indicates if the pod was mutated.
-func applyProviderOverrides(pod *corev1.Pod) (bool, error) {
-	provider := pkgconfigsetup.Datadog().GetString("admission_controller.agent_sidecar.provider")
+func applyProviderOverrides(pod *corev1.Pod, datadogConfig config.Component) (bool, error) {
+	provider := datadogConfig.GetString("admission_controller.agent_sidecar.provider")
 
 	if !providerIsSupported(provider) {
 		return false, fmt.Errorf("unsupported provider: %v", provider)

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -416,7 +416,7 @@ func TestApplyProviderOverrides(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
-			mutated, err := applyProviderOverrides(test.basePod)
+			mutated, err := applyProviderOverrides(test.basePod, mockConfig)
 
 			if test.expectError {
 				assert.Error(tt, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Configures the agent sidecar mutator in the admission controller to use the Config Component instead of a global function call to the config.

### Motivation

Tech-debt clean up. We want to use components to simplify dependencies.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A