### PR TITLE
[AMLII-2064] Fix TestInitialLogsExceedTotalUsageMultipleFiles Flaky Test

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -258,7 +258,7 @@ func (s *Launcher) getLeastRecentlyModifiedFile() *fileInfo {
 	var leastRecentlyModifiedFile *fileInfo
 
 	for _, fileInfo := range s.integrationToFile {
-		if fileInfo.lastModified.Before(leastRecentlyModifiedTime) {
+		if fileInfo.lastModified.Before(leastRecentlyModifiedTime) || fileInfo.lastModified.Equal(leastRecentlyModifiedTime) {
 			leastRecentlyModifiedFile = fileInfo
 			leastRecentlyModifiedTime = fileInfo.lastModified
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds another condition in the check for `getLeastRecentlyModifiedFile` that allows it to select a file that has been created at the same time as `time.Now()`. This should fix flakiness in tests where files might have been created at the same time as the function runs, causing `getLeastRecentlyModifiedFile()` to return `nil`.

### Motivation

Flaky test

### Describe how to test/QA your changes

Make sure all the tests pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->