### PR TITLE
only allow CO-RE macros in COMPILE_CORE build mode

### DIFF
--- a/pkg/ebpf/c/bpf_core_read.h
+++ b/pkg/ebpf/c/bpf_core_read.h
@@ -482,7 +482,7 @@ enum bpf_enum_value_kind {
 	__r;								    \
 })
 
-#ifdef COMPILE_RUNTIME
+#ifndef COMPILE_CORE
 
 #undef BPF_CORE_READ
 #define BPF_CORE_READ BPF_PROBE_READ


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

only allow CO-RE macros in COMPILE_CORE build mode

### Motivation

If you used `BPF_CORE_READ`/`BPF_CORE_READ_INTO` macros, it would add the `__builtin_preserve_access_index` attribute under the hood. This causes a compiler fatal error when building in prebuilt mode because it cannot deal with the intrinsic.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->