### PR TITLE
Introduce a Regression Detector experiment for metrics+logs

### DIFF
--- a/test/regression/cases/qg_dogstatsd_logs_common/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/qg_dogstatsd_logs_common/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/tmp/smp/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/qg_dogstatsd_logs_common/datadog-agent/datadog.yaml
+++ b/test/regression/cases/qg_dogstatsd_logs_common/datadog-agent/datadog.yaml
@@ -1,4 +1,5 @@
 auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target
@@ -16,3 +17,5 @@ process_config.process_dd_url: http://localhost:9093
 
 telemetry.enabled: true
 telemetry.checks: '*'
+
+dogstatsd_socket: '/tmp/dsd.socket'

--- a/test/regression/cases/qg_dogstatsd_logs_common/experiment.yaml
+++ b/test/regression/cases/qg_dogstatsd_logs_common/experiment.yaml
@@ -1,0 +1,32 @@
+optimization_goal: memory
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+    DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:qg_dogstatsd_logs_common
+
+checks:
+  - name: memory_usage
+    description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
+    bounds:
+      series: total_rss_bytes
+      upper_bound: "700 MiB"

--- a/test/regression/cases/qg_dogstatsd_logs_common/lading/lading.yaml
+++ b/test/regression/cases/qg_dogstatsd_logs_common/lading/lading.yaml
@@ -1,0 +1,66 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 700
+              max: 1400
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 98
+            event: 1
+            service_check: 1
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 1
+            set: 0
+            histogram: 0
+      bytes_per_second: "50 KiB"
+      maximum_prebuild_cache_size_bytes: "50 MiB"
+  - file_gen:
+      logrotate:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        root: "/tmp/smp"
+        concurrent_logs: 1
+        maximum_bytes_per_log: "10MiB"
+        total_rotations: 1
+        max_depth: 1 # flat, all logs are /tmp/smp/12345.log
+        variant: "ascii"
+        bytes_per_second: "100 KiB"
+        maximum_prebuild_cache_size_bytes: "100 MiB"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 0
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
### What does this PR do?

This commit introduces a Regression Detector experiment for a "common" metrics + logs use-case, discussed in more detail
[here](https://datadoghq.atlassian.net/wiki/spaces/SMP/pages/3925672503/Golden+Scenarios#Metrics-%2B-Logs-Only). The ambition is to protect a usual customer use-case and also provide a new Quality Gate on the same, hence the experiment prefix.

### Motivation

CLOSES SMPTNG-480

