### PR TITLE
usm: go-tls: Restore full support in golang 1.23

### DIFF
--- a/pkg/network/go/goid/goid_offset.go
+++ b/pkg/network/go/goid/goid_offset.go
@@ -17,11 +17,17 @@ var MinGoVersion = goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}
 func GetGoroutineIDOffset(version goversion.GoVersion, goarch string) (uint64, error) {
 	switch goarch {
 	case "amd64":
+		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 23, Rev: 0}) {
+			return 0xa0, nil
+		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return 0x98, nil
 		}
 		return 0, fmt.Errorf("unsupported version go%d.%d.%d (min supported: go%d.%d.%d)", version.Major, version.Minor, version.Rev, 1, 13, 0)
 	case "arm64":
+		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 23, Rev: 0}) {
+			return 0xa0, nil
+		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return 0x98, nil
 		}

--- a/releasenotes/notes/usm-go-tls-support-golang-1-23-34e08c2f5a627b95.yaml
+++ b/releasenotes/notes/usm-go-tls-support-golang-1-23-34e08c2f5a627b95.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix USM's GO-TLS support for Golang 1.23


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updated go-tls code base with the correct offset of `goroutineid` for golang 1.23

Changes introduced by `inv -e system-probe.generate-lookup-tables`

### Motivation

Restore support for golang 1.23

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->