### PR TITLE
logs/sds: custom build 7.58.x+sds excluded keywords

### DIFF
--- a/pkg/logs/sds/rules.go
+++ b/pkg/logs/sds/rules.go
@@ -50,7 +50,9 @@ type StandardRulesConfig struct {
 // StandardRulesDefaults contains consts defaults information for
 // standard rules.
 type StandardRulesDefaults struct {
-	IncludedKeywordsCharCount uint32 `json:"included_keywords_char_count"`
+	IncludedKeywordsCharCount uint32   `json:"included_keywords_char_count"`
+	ExcludedKeywordsCharCount uint32   `json:"excluded_keywords_char_count"`
+	ExcludedKeywords          []string `json:"excluded_keywords"`
 }
 
 // RuleConfig of rule as sent by the Remote Configuration.
@@ -67,8 +69,9 @@ type RuleConfig struct {
 
 // ProximityKeywords definition in RC config.
 type ProximityKeywords struct {
-	Keywords       []string `json:"keywords"`
-	CharacterCount uint32   `json:"character_count"`
+	Keywords               []string `json:"keywords"`
+	CharacterCount         uint32   `json:"character_count"`
+	UseRecommendedKeywords bool     `json:"use_recommended_keywords"`
 }
 
 // RuleDefinition definition in RC config.

--- a/pkg/logs/sds/scanner_test.go
+++ b/pkg/logs/sds/scanner_test.go
@@ -572,6 +572,12 @@ func TestCloseCycleScan(t *testing.T) {
 func TestInterpretRC(t *testing.T) {
 	require := require.New(t)
 
+	defaults := StandardRulesDefaults{
+		IncludedKeywordsCharCount: 10,
+		ExcludedKeywordsCharCount: 10,
+		ExcludedKeywords:          []string{"trace-id"},
+	}
+
 	stdRc := StandardRuleConfig{
 		ID:          "0",
 		Name:        "Zero",
@@ -593,9 +599,12 @@ func TestInterpretRC(t *testing.T) {
 			Type:        matchActionRCRedact,
 			Placeholder: "[redacted]",
 		},
+		IncludedKeywords: ProximityKeywords{
+			UseRecommendedKeywords: true,
+		},
 	}
 
-	rule, err := interpretRCRule(rc, stdRc, StandardRulesDefaults{})
+	rule, err := interpretRCRule(rc, stdRc, defaults)
 	require.NoError(err)
 	rxRule, ok := rule.(sds.RegexRuleConfig)
 	require.True(ok)
@@ -611,7 +620,7 @@ func TestInterpretRC(t *testing.T) {
 		RequiredCapabilities: []string{RCSecondaryValidationLuhnChecksum},
 	})
 
-	rule, err = interpretRCRule(rc, stdRc, StandardRulesDefaults{})
+	rule, err = interpretRCRule(rc, stdRc, defaults)
 	require.NoError(err)
 	rxRule, ok = rule.(sds.RegexRuleConfig)
 	require.True(ok)
@@ -641,7 +650,7 @@ func TestInterpretRC(t *testing.T) {
 		},
 	}
 
-	rule, err = interpretRCRule(rc, stdRc, StandardRulesDefaults{})
+	rule, err = interpretRCRule(rc, stdRc, defaults)
 	require.NoError(err)
 	rxRule, ok = rule.(sds.RegexRuleConfig)
 	require.True(ok)
@@ -650,8 +659,11 @@ func TestInterpretRC(t *testing.T) {
 	require.Equal(rxRule.Pattern, "second pattern")
 	require.Equal(rxRule.SecondaryValidator, sds.LuhnChecksum)
 
+	// included keywords
+	// -----------------
+
 	// make sure we use the keywords proximity feature if any's configured
-	// in the std rule definition 	stdRc.Definitions = []StandardRuleDefinition{
+	// in the std rule definition
 	stdRc.Definitions = []StandardRuleDefinition{
 		{
 			Version:                 2,
@@ -666,7 +678,7 @@ func TestInterpretRC(t *testing.T) {
 		},
 	}
 
-	rule, err = interpretRCRule(rc, stdRc, StandardRulesDefaults{IncludedKeywordsCharCount: 10})
+	rule, err = interpretRCRule(rc, stdRc, defaults)
 	require.NoError(err)
 	rxRule, ok = rule.(sds.RegexRuleConfig)
 	require.True(ok)
@@ -681,11 +693,12 @@ func TestInterpretRC(t *testing.T) {
 	// make sure we use the user provided information first
 	// even if there is some in the std rule
 	rc.IncludedKeywords = ProximityKeywords{
-		Keywords:       []string{"custom"},
-		CharacterCount: 42,
+		Keywords:               []string{"custom"},
+		CharacterCount:         42,
+		UseRecommendedKeywords: false,
 	}
 
-	rule, err = interpretRCRule(rc, stdRc, StandardRulesDefaults{IncludedKeywordsCharCount: 10})
+	rule, err = interpretRCRule(rc, stdRc, defaults)
 	require.NoError(err)
 	rxRule, ok = rule.(sds.RegexRuleConfig)
 	require.True(ok)
@@ -696,4 +709,42 @@ func TestInterpretRC(t *testing.T) {
 	require.NotNil(rxRule.ProximityKeywords)
 	require.Equal(rxRule.ProximityKeywords.LookAheadCharacterCount, uint32(42))
 	require.Equal(rxRule.ProximityKeywords.IncludedKeywords, []string{"custom"})
+
+	// excluded keywords
+	// -----------------
+
+	// make sure we use the user provided information first
+	// even if there is some in the std rule
+	rc.IncludedKeywords = ProximityKeywords{
+		Keywords:               nil,
+		CharacterCount:         0,
+		UseRecommendedKeywords: false,
+	}
+
+	// make sure we use the keywords proximity feature if any's configured
+	// in the std rule definition, here the excluded keywords one
+	stdRc.Definitions = []StandardRuleDefinition{
+		{
+			Version:              2,
+			Pattern:              "second pattern",
+			RequiredCapabilities: []string{RCSecondaryValidationLuhnChecksum},
+		},
+		{
+			Version:              1,
+			Pattern:              "first pattern",
+			RequiredCapabilities: nil,
+		},
+	}
+
+	rule, err = interpretRCRule(rc, stdRc, defaults)
+	require.NoError(err)
+	rxRule, ok = rule.(sds.RegexRuleConfig)
+	require.True(ok)
+
+	require.Equal(rxRule.Id, "Zero")
+	require.Equal(rxRule.Pattern, "second pattern")
+	require.Equal(rxRule.SecondaryValidator, sds.LuhnChecksum)
+	require.NotNil(rxRule.ProximityKeywords)
+	require.Equal(rxRule.ProximityKeywords.LookAheadCharacterCount, uint32(10))
+	require.Equal(rxRule.ProximityKeywords.ExcludedKeywords, []string{"trace-id"})
 }


### PR DESCRIPTION
### What does this PR do?

Custom build of a 7.58.x version of the Agent with:
* SDS excluded keywords support
* Improved performance telemetry of the SDS scanner
