### PR TITLE
[CWS] Use the wrapped program exit code to exit the ptracer

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -205,10 +205,11 @@ func Command() []*cobra.Command {
 				return nil
 			}
 			exitCode, err := ptracer.Wrap(args, os.Environ(), params.ProbeAddr, opts)
-			if exitCode != 0 {
-				os.Exit(exitCode)
+			if err != nil {
+				return err
 			}
-			return err
+			os.Exit(exitCode)
+			return err // fake return
 		},
 	}
 

--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -204,7 +204,11 @@ func Command() []*cobra.Command {
 
 				return nil
 			}
-			return ptracer.Wrap(args, os.Environ(), params.ProbeAddr, opts)
+			exitCode, err := ptracer.Wrap(args, os.Environ(), params.ProbeAddr, opts)
+			if exitCode != 0 {
+				os.Exit(exitCode)
+			}
+			return err
 		},
 	}
 

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -146,7 +146,7 @@ func preTestsHook() {
 			Debug:           true,
 		}
 
-		err := ptracer.Wrap(args, envs, constants.DefaultEBPFLessProbeAddr, opts)
+		_, err := ptracer.Wrap(args, envs, constants.DefaultEBPFLessProbeAddr, opts)
 		if err != nil {
 			fmt.Printf("unable to trace [%v]: %s", args, err)
 			os.Exit(-1)


### PR DESCRIPTION
### What does this PR do?

Now when a wrapped program exit with an exit code, the wrapper use it to exit too

### Motivation

A customer noticed its wrapped container always exited with 0 even if the container cmd failed. This will allow to let the user retrieve the correct exit code of its workload

### Describe how to test/QA your changes

`sudo ./bin/cws-instrumentation/cws-instrumentation trace --probe-addr="" --verbose --debug -- cat /tmp/foo ; echo $?`
should print 0 if /tmp/foo exists

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->