### PR TITLE
Fix CILintersConfig when diff is empty (lint_gitlab_ci job)

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -502,6 +502,11 @@ def gitlab_ci_jobs_needs_rules(_, diff_file=None, config_file=None):
     """
 
     jobs, full_config = get_gitlab_ci_lintable_jobs(diff_file, config_file)
+
+    # No change, info already printed in get_gitlab_ci_lintable_jobs
+    if not full_config:
+        return
+
     ci_linters_config = CILintersConfig(
         lint=True,
         all_jobs=full_config_get_all_leaf_jobs(full_config),
@@ -753,6 +758,11 @@ def gitlab_ci_jobs_owners(_, diff_file=None, config_file=None, path_jobowners='.
     """
 
     jobs, full_config = get_gitlab_ci_lintable_jobs(diff_file, config_file, only_names=True)
+
+    # No change, info already printed in get_gitlab_ci_lintable_jobs
+    if not full_config:
+        return
+
     ci_linters_config = CILintersConfig(
         lint=True,
         all_jobs=full_config_get_all_leaf_jobs(full_config),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

As the CILintersConfig lints the config file, there was an [error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/666417267) when no changes was made to the gitlab jobs.
Fixed it by not building linter config if no changes.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->