### PR TITLE
[CI] Set `DD_ENV` to `prod` when uploading junit to Test Visibility on the macOS runners

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -64,6 +64,7 @@ tests_macos:
         - $EXTERNAL_LINKS_PATH
 
 .upload_junit_source:
+  - export DD_ENV=prod
   - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
 
 .upload_coverage:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR sets `DD_ENV` to `prod` when uploading JUnit to Test Visibility on the macOS runners

### Motivation

It's currently sent with `DD_ENV` set to `None` separating the reports from the other OS' tests.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->