### PR TITLE
[cloudproviders/azure] Handle case of resource groups with underscores

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -45,15 +45,18 @@ type metadata struct {
 }
 
 func (metadata metadata) GetFromStyle(style string) (string, error) {
+	// The resource group name can contain "_" characters, which is not a valid
+	// character for a hostname.
+	parsedResourceGroupName := strings.ReplaceAll(metadata.ResourceGroupName, "_", "-")
 	switch style {
 	case "vmid":
 		return metadata.VMID, nil
 	case "name":
 		return metadata.Name, nil
 	case "name_and_resource_group":
-		return fmt.Sprintf("%s.%s", metadata.Name, metadata.ResourceGroupName), nil
+		return fmt.Sprintf("%s.%s", metadata.Name, parsedResourceGroupName), nil
 	case "full":
-		return fmt.Sprintf("%s.%s.%s", metadata.Name, metadata.ResourceGroupName, metadata.SubscriptionID), nil
+		return fmt.Sprintf("%s.%s.%s", metadata.Name, parsedResourceGroupName, metadata.SubscriptionID), nil
 	case "os_computer_name":
 		return strings.ToLower(metadata.OsProfile.ComputerName), nil
 	default:

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -185,7 +185,7 @@ func TestGetHostnameKubernetesTag(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{
 			"name": "vm-name",
-			"resourceGroupName": "my-resource-group",
+			"resourceGroupName": "MC_some-resource-group_some-cluster_westus2",
 			"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
 			"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
 			"osProfile": {"computerName":"node-name-A"},
@@ -202,8 +202,8 @@ func TestGetHostnameKubernetesTag(t *testing.T) {
 		{"os", "node-name-a", false}, // use osProfile.computerName when running in AKS
 		{"vmid", "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d", false},
 		{"name", "vm-name", false},
-		{"name_and_resource_group", "vm-name.my-resource-group", false},
-		{"full", "vm-name.my-resource-group.2370ac56-5683-45f8-a2d4-d1054292facb", false},
+		{"name_and_resource_group", "vm-name.MC-some-resource-group-some-cluster-westus2", false},
+		{"full", "vm-name.MC-some-resource-group-some-cluster-westus2.2370ac56-5683-45f8-a2d4-d1054292facb", false},
 		{"invalid", "", true},
 	}
 

--- a/releasenotes/notes/azure-resource-name-with-underscores-08404617cf0fadfc.yaml
+++ b/releasenotes/notes/azure-resource-name-with-underscores-08404617cf0fadfc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes wrong hostname resolution in Azure when ``azure_hostname_style`` is set to ``name_and_resouce_group`` or ``full``.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in Azure hostname resolution.

At least on AKS, resource group names can have underscores. They follow the format "MC_resourcegroup_clustername_zone".

The resource group name is included when building the hostname if the "style" option (`azure_hostname_style`) is set to `name_and_resource_group` or `full`. However, "_" is not allowed in hostnames and needs to be replaced. We didn't have a unit test for this scenario.

### Describe how to test/QA your changes

Skip. New case added in unit test should be enough.