### PR TITLE
[CONTP-390] Allow user to set the cardinality of a check in the check configuration

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/common_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/common_test.go
@@ -54,6 +54,11 @@ func (s *dummyService) GetTags() ([]string, error) {
 	return nil, nil
 }
 
+// GetTagsWithCardinality returns the tags for this service
+func (s *dummyService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid return a dummy pid
 func (s *dummyService) GetPid(context.Context) (int, error) {
 	return s.Pid, nil

--- a/comp/core/autodiscovery/common/utils/annotations.go
+++ b/comp/core/autodiscovery/common/utils/annotations.go
@@ -23,6 +23,7 @@ const (
 	logsConfigPath          = "logs"
 	checksPath              = "checks"
 	checkIDPath             = "check.id"
+	checkTagCardinality     = "check_tag_cardinality"
 )
 
 // ExtractTemplatesFromMap looks for autodiscovery configurations in a given
@@ -76,7 +77,10 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 	}
 	// ParseBool returns `true` only on success cases
 	ignoreAdTags, _ := strconv.ParseBool(input[prefix+ignoreAutodiscoveryTags])
-	return BuildTemplates(key, checkNames, initConfigs, instances, ignoreAdTags), nil
+
+	cardinality := input[prefix+checkTagCardinality]
+
+	return BuildTemplates(key, checkNames, initConfigs, instances, ignoreAdTags, cardinality), nil
 }
 
 // extractLogsTemplatesFromMap returns the logs configuration from a given map,
@@ -166,8 +170,8 @@ func ParseJSONValue(value string) ([][]integration.Data, error) {
 
 // BuildTemplates returns check configurations configured according to the
 // passed in AD identifier, check names, init, instance configs and their
-// `ignoreAutoDiscoveryTags` field.
-func BuildTemplates(adID string, checkNames []string, initConfigs, instances [][]integration.Data, ignoreAutodiscoveryTags bool) []integration.Config {
+// `ignoreAutoDiscoveryTags`, `CheckTagCardinality` fields.
+func BuildTemplates(adID string, checkNames []string, initConfigs, instances [][]integration.Data, ignoreAutodiscoveryTags bool, checkCard string) []integration.Config {
 	templates := make([]integration.Config, 0)
 
 	// sanity checks
@@ -192,6 +196,7 @@ func BuildTemplates(adID string, checkNames []string, initConfigs, instances [][
 				Instances:               []integration.Data{instance},
 				ADIdentifiers:           []string{adID},
 				IgnoreAutodiscoveryTags: ignoreAutodiscoveryTags,
+				CheckTagCardinality:     checkCard,
 			})
 		}
 	}

--- a/comp/core/autodiscovery/common/utils/pod_annotations.go
+++ b/comp/core/autodiscovery/common/utils/pod_annotations.go
@@ -60,6 +60,7 @@ func parseChecksJSON(adIdentifier string, checksJSON string) ([]integration.Conf
 		Instances               []interface{}   `json:"instances"`
 		Logs                    json.RawMessage `json:"logs"`
 		IgnoreAutodiscoveryTags bool            `json:"ignore_autodiscovery_tags"`
+		CheckTagCardinality     string          `json:"check_tag_cardinality"`
 	}
 
 	err := json.Unmarshal([]byte(checksJSON), &namedChecks)
@@ -83,6 +84,8 @@ func parseChecksJSON(adIdentifier string, checksJSON string) ([]integration.Conf
 			ADIdentifiers:           []string{adIdentifier},
 			IgnoreAutodiscoveryTags: config.IgnoreAutodiscoveryTags,
 		}
+
+		c.CheckTagCardinality = config.CheckTagCardinality
 
 		if len(config.Logs) > 0 {
 			c.LogsConfig = integration.Data(config.Logs)

--- a/comp/core/autodiscovery/common/utils/pod_annotations_test.go
+++ b/comp/core/autodiscovery/common/utils/pod_annotations_test.go
@@ -138,6 +138,32 @@ func TestExtractTemplatesFromAnnotations(t *testing.T) {
 			},
 		},
 		{
+			name: "Nominal case with two templates and check tag cardinality",
+			annotations: map[string]string{
+				"ad.datadoghq.com/foobar.check_names":           "[\"apache\",\"http_check\"]",
+				"ad.datadoghq.com/foobar.init_configs":          "[{},{}]",
+				"ad.datadoghq.com/foobar.instances":             "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"},{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}]",
+				"ad.datadoghq.com/foobar.check_tag_cardinality": "low",
+			},
+			adIdentifier: "foobar",
+			output: []integration.Config{
+				{
+					Name:                "apache",
+					Instances:           []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:          integration.Data("{}"),
+					ADIdentifiers:       []string{adID},
+					CheckTagCardinality: "low",
+				},
+				{
+					Name:                "http_check",
+					Instances:           []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:          integration.Data("{}"),
+					ADIdentifiers:       []string{adID},
+					CheckTagCardinality: "low",
+				},
+			},
+		},
+		{
 			name: "Take one, ignore one",
 			annotations: map[string]string{
 				"ad.datadoghq.com/foobar.check_names":  "[\"apache\"]",

--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -93,7 +93,13 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, errors.New("unable to resolve, service not ready")
 	}
 
-	tags, err := svc.GetTags()
+	var tags []string
+	var err error
+	if tpl.CheckTagCardinality != "" {
+		tags, err = svc.GetTagsWithCardinality(tpl.CheckTagCardinality)
+	} else {
+		tags, err = svc.GetTags()
+	}
 	if err != nil {
 		return resolvedConfig, fmt.Errorf("couldn't get tags for service '%s', err: %w", svc.GetServiceID(), err)
 	}

--- a/comp/core/autodiscovery/configresolver/configresolver_test.go
+++ b/comp/core/autodiscovery/configresolver/configresolver_test.go
@@ -62,6 +62,11 @@ func (s *dummyService) GetTags() ([]string, error) {
 	return []string{"foo:bar"}, nil
 }
 
+// GetTagsWithCardinality returns the tags for this service
+func (s *dummyService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid return a dummy pid
 func (s *dummyService) GetPid(context.Context) (int, error) {
 	return s.Pid, nil

--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -97,6 +97,9 @@ type Config struct {
 	// IgnoreAutodiscoveryTags is used to ignore tags coming from autodiscovery
 	IgnoreAutodiscoveryTags bool `json:"ignore_autodiscovery_tags"` // (include in digest: true)
 
+	// CheckTagCardinality is used to override the default tag cardinality in the agent configuration
+	CheckTagCardinality string `json:"check_tag_cardinality"` // (include in digest: false)
+
 	// MetricsExcluded is whether metrics collection is disabled (set by
 	// container listeners only)
 	MetricsExcluded bool `json:"metrics_excluded"` // (include in digest: false)

--- a/comp/core/autodiscovery/listeners/cloudfoundry.go
+++ b/comp/core/autodiscovery/listeners/cloudfoundry.go
@@ -234,6 +234,11 @@ func (s *CloudFoundryService) GetTags() ([]string, error) {
 	return s.tags, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality. Not supported in CF
+func (s *CloudFoundryService) GetTagsWithCardinality(cardinality string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid returns nil and an error because pids are currently not supported in CF
 func (s *CloudFoundryService) GetPid(context.Context) (int, error) {
 	return -1, ErrNotSupported

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -239,6 +239,11 @@ func (d *DBMAuroraService) GetTags() ([]string, error) {
 	return []string{}, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality. Not supported in DBMAuroraService
+func (d *DBMAuroraService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return d.GetTags()
+}
+
 // GetPid returns nil and an error because pids are currently not supported
 func (d *DBMAuroraService) GetPid(context.Context) (int, error) {
 	return -1, ErrNotSupported

--- a/comp/core/autodiscovery/listeners/environment.go
+++ b/comp/core/autodiscovery/listeners/environment.go
@@ -109,6 +109,11 @@ func (s *EnvironmentService) GetTags() ([]string, error) {
 	return nil, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality. Not supported in EnvironmentService
+func (s *EnvironmentService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid inspect the container and return its pid
 // Not relevant in this listener
 func (s *EnvironmentService) GetPid(context.Context) (int, error) {

--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -487,6 +487,11 @@ func (s *KubeEndpointService) GetTags() ([]string, error) {
 	return s.tags, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality.
+func (s *KubeEndpointService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetHostname returns nil and an error because port is not supported in Kubelet
 func (s *KubeEndpointService) GetHostname(context.Context) (string, error) {
 	return "", ErrNotSupported

--- a/comp/core/autodiscovery/listeners/kube_services.go
+++ b/comp/core/autodiscovery/listeners/kube_services.go
@@ -368,6 +368,11 @@ func (s *KubeServiceService) GetTags() ([]string, error) {
 	return s.tags, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality.
+func (s *KubeServiceService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetHostname returns nil and an error because port is not supported in Kubelet
 func (s *KubeServiceService) GetHostname(context.Context) (string, error) {
 	return "", ErrNotSupported

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -90,6 +91,16 @@ func (s *service) GetPorts(_ context.Context) ([]ContainerPort, error) {
 // GetTags returns the tags associated with the service.
 func (s *service) GetTags() ([]string, error) {
 	return tagger.Tag(taggercommon.BuildTaggerEntityID(s.entity.GetID()).String(), tagger.ChecksCardinality())
+}
+
+// GetTagsWithCardinality returns the tags with given cardinality.
+func (s *service) GetTagsWithCardinality(cardinality string) ([]string, error) {
+	checkCard, err := types.StringToTagCardinality(cardinality)
+	if err == nil {
+		return tagger.Tag(taggercommon.BuildTaggerEntityID(s.entity.GetID()).String(), checkCard)
+	}
+	log.Warnf("error converting cardinality %s to TagCardinality: %v", cardinality, err)
+	return s.GetTags()
 }
 
 // GetPid returns the process ID of the service.

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -357,6 +357,11 @@ func (s *SNMPService) GetTags() ([]string, error) {
 	return []string{}, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality.
+func (s *SNMPService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid returns nil and an error because pids are currently not supported
 func (s *SNMPService) GetPid(context.Context) (int, error) {
 	return -1, ErrNotSupported

--- a/comp/core/autodiscovery/listeners/staticconfig.go
+++ b/comp/core/autodiscovery/listeners/staticconfig.go
@@ -92,6 +92,11 @@ func (s *StaticConfigService) GetTags() ([]string, error) {
 	return nil, nil
 }
 
+// GetTagsWithCardinality returns the tags with given cardinality.
+func (s *StaticConfigService) GetTagsWithCardinality(_ string) ([]string, error) {
+	return s.GetTags()
+}
+
 // GetPid inspect the container and return its pid
 // Not relevant in this listener
 func (s *StaticConfigService) GetPid(context.Context) (int, error) {

--- a/comp/core/autodiscovery/listeners/types.go
+++ b/comp/core/autodiscovery/listeners/types.go
@@ -25,17 +25,18 @@ type ContainerPort struct {
 // It should be matched with a check template by the ConfigResolver using the
 // ADIdentifiers field.
 type Service interface {
-	Equal(Service) bool                                  // compare two services
-	GetServiceID() string                                // unique service name
-	GetADIdentifiers(context.Context) ([]string, error)  // identifiers on which templates will be matched
-	GetHosts(context.Context) (map[string]string, error) // network --> IP address
-	GetPorts(context.Context) ([]ContainerPort, error)   // network ports
-	GetTags() ([]string, error)                          // tags
-	GetPid(context.Context) (int, error)                 // process identifier
-	GetHostname(context.Context) (string, error)         // hostname.domainname for the entity
-	IsReady(context.Context) bool                        // is the service ready
-	HasFilter(containers.FilterType) bool                // whether the service is excluded by metrics or logs exclusion config
-	GetExtraConfig(string) (string, error)               // Extra configuration values
+	Equal(Service) bool                                          // compare two services
+	GetServiceID() string                                        // unique service name
+	GetADIdentifiers(context.Context) ([]string, error)          // identifiers on which templates will be matched
+	GetHosts(context.Context) (map[string]string, error)         // network --> IP address
+	GetPorts(context.Context) ([]ContainerPort, error)           // network ports
+	GetTags() ([]string, error)                                  // tags
+	GetTagsWithCardinality(cardinality string) ([]string, error) // tags with given cardinality
+	GetPid(context.Context) (int, error)                         // process identifier
+	GetHostname(context.Context) (string, error)                 // hostname.domainname for the entity
+	IsReady(context.Context) bool                                // is the service ready
+	HasFilter(containers.FilterType) bool                        // whether the service is excluded by metrics or logs exclusion config
+	GetExtraConfig(string) (string, error)                       // Extra configuration values
 
 	// FilterTemplates filters the templates which will be resolved against
 	// this service, in a map keyed by template digest.

--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -35,6 +35,7 @@ type configFormat struct {
 	Instances               []integration.RawMap
 	DockerImages            []string `yaml:"docker_images"`             // Only imported for deprecation warning
 	IgnoreAutodiscoveryTags bool     `yaml:"ignore_autodiscovery_tags"` // Use to ignore tags coming from autodiscovery
+	CheckTagCardinality     string   `yaml:"check_tag_cardinality"`     // Use to set the tag cardinality override for the check
 }
 
 type configPkg struct {
@@ -429,6 +430,9 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 
 	// Copy ignore_autodiscovery_tags parameter
 	conf.IgnoreAutodiscoveryTags = cf.IgnoreAutodiscoveryTags
+
+	// Copy check_tag_cardinality parameter
+	conf.CheckTagCardinality = cf.CheckTagCardinality
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {

--- a/comp/core/autodiscovery/providers/consul.go
+++ b/comp/core/autodiscovery/providers/consul.go
@@ -237,7 +237,7 @@ func (p *ConsulConfigProvider) getTemplates(ctx context.Context, key string) []i
 		log.Errorf("Failed to retrieve instances at %s. Error: %s", instanceKey, err)
 		return templates
 	}
-	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false)
+	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false, "")
 }
 
 // getValue returns value, error

--- a/comp/core/autodiscovery/providers/etcd.go
+++ b/comp/core/autodiscovery/providers/etcd.go
@@ -124,7 +124,7 @@ func (p *EtcdConfigProvider) getTemplates(ctx context.Context, key string) []int
 		return nil
 	}
 
-	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false)
+	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false, "")
 }
 
 // getEtcdValue retrieves content from etcd

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -297,6 +297,7 @@ func endpointChecksFromTemplate(tpl integration.Config, ep *v1.Endpoints) []inte
 				Provider:                names.KubeEndpointsFile,
 				Source:                  tpl.Source,
 				IgnoreAutodiscoveryTags: tpl.IgnoreAutodiscoveryTags,
+				CheckTagCardinality:     tpl.CheckTagCardinality,
 			}
 
 			utils.ResolveEndpointConfigAuto(config, ep.Subsets[i].Addresses[j])

--- a/comp/core/autodiscovery/providers/zookeeper.go
+++ b/comp/core/autodiscovery/providers/zookeeper.go
@@ -198,7 +198,7 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []integration.Config 
 		return nil
 	}
 
-	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false)
+	return utils.BuildTemplates(key, checkNames, initConfigs, instances, false, "")
 }
 
 func (z *ZookeeperConfigProvider) getJSONValue(key string) ([][]integration.Data, error) {

--- a/releasenotes/notes/autodiscovery-add-check_tag_cardinality-2dae869a081bb4e5.yaml
+++ b/releasenotes/notes/autodiscovery-add-check_tag_cardinality-2dae869a081bb4e5.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Add `check_tag_cardinality` parameter config check.
+
+    By default `check_tag_cardinality` is not set which doesn't change the behavior of the checks.
+    Once it is set in pod annotaions, it overrides the cardinality value provided in the base agent configuration.
+    Example of usage:
+    ```yaml
+    ad.datadoghq.com/redis.checks: |
+      {
+        "redisdb": {
+          "check_tag_cardinality": "high", 
+          "instances": [
+            {
+              "host": "%%host%%",
+              "port": "6379"
+            }
+          ]
+        }
+      }
+    ```


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add check_tag_cardinality option in the check configuration. And if the user sets it, it overrides the value provided in the agent configuration.
See difference below

The cardinality is passed into this [function](https://github.com/DataDog/datadog-agent/pull/29984/files#diff-12faee531601d8cc7d46d720be825018e508b3d116d25a7051cb4daccf95b9f2R99) in configresolver
```
	if tpl.CheckTagCardinality != "" {
		tags, err = svc.GetTagsWithCardinality(tpl.CheckTagCardinality)
	} 
```

### Motivation
This will allow user to configure the cardinality of check instance (configured with a Pod annotation) directly inside the annotation check config. 

### Describe how to test/QA your changes
deploy dummy app
```
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
  namespace: workload-redis-test
  labels:
    app: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
        service: redis
        team: container-integrations
        chart_name: redis_chart
      annotations:
        ad.datadoghq.com/redis.checks: |
          {
            "redisdb": {
              "init_config": {},
              "check_tag_cardinality": "low",
              "instances": [
                {
                  "host": "%%host%%",
                  "port": "6379"
                }
              ]
            }
          }
        ad.datadoghq.com/redis.logs: '[{"type": "docker","image": "redis","service": "redis","source": "redis"}]'
        ad.datadoghq.com/tags: '{redis_port: "REDIS_VERSION_%%env_REDIS_VERSION%%"}'
    spec:
      containers:
        - name: redis
          image: redis:latest
          resources:
            limits:
              cpu: 2000m
              memory: 64Mi
            requests:
              cpu: 1000m
              memory: 64Mi
---
apiVersion: v1
kind: Service
metadata:
  name: redis
  namespace: workload-redis-test
  labels:
    app: redis
spec:
  selector:
    app: redis
  ports:
    - name: redis
      port: 6379
      targetPort: 6379
```
Compare config
"check_tag_cardinality": "low" vs
"check_tag_cardinality": "high",
<img width="1683" alt="Screenshot 2024-10-10 at 4 23 13 PM" src="https://github.com/user-attachments/assets/23a642fe-ad6c-4999-806a-5fa8c04a7fba">

Container name is high cardinality tag. 

Also run `agent configcheck | grep redis -C 15`

high
```
=== redisdb check ===
Configuration provider: kubernetes-container-allinone
Configuration source: container:containerd://5157e690ea25a4386c855b1208d10b0bca42b2e6561bd90ad30fdeadfebb6fe4
Config for instance ID: redisdb:52cac392cc9736a1
host: 10.244.0.69
port: "6379"
tags:
- container_id:5157e690ea25a4386c855b1208d10b0bca42b2e6561bd90ad30fdeadfebb6fe4
- container_name:redis
- display_container_name:redis_redis-7fbdd8797c-dszpj
- image_id:********@sha256:11a62e03dc70b18fe3e18532f751dcb941a6432920bf4cfbf37e36a13ed48711
- image_name:us-east4-docker.pkg.dev/datadog-sandbox/mztest/redis
- image_tag:latest
- kube_container_name:redis
- kube_deployment:redis
- kube_namespace:workload-redis-test
- kube_ownerref_kind:replicaset
- kube_ownerref_name:redis-7fbdd8797c
- kube_qos:Burstable
- kube_replica_set:redis-7fbdd8797c
- kube_service:redis
- pod_name:redis-7fbdd8797c-dszpj
- pod_phase:running
- short_image:redis
```

low
```
Config for instance ID: redisdb:f54e4b63528529bf
host: 10.244.0.70
port: "6379"
tags:
- image_id:********@sha256:11a62e03dc70b18fe3e18532f751dcb941a6432920bf4cfbf37e36a13ed48711
- image_name:us-east4-docker.pkg.dev/datadog-sandbox/mztest/redis
- image_tag:latest
- kube_container_name:redis
- kube_deployment:redis
- kube_namespace:workload-redis-test
- kube_ownerref_kind:replicaset
- kube_qos:Burstable
- kube_replica_set:redis-5b49bb7567
- kube_service:redis
- pod_phase:running
- short_image:redis
```


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->