### PR TITLE
Fix gitlab-ci-jobs-codeowners linter to match only gitlab files

### DIFF
--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -73,4 +73,4 @@ lint_gitlab_ci_jobs_codeowners:
   rules:
     - !reference [.on_gitlab_changes]
   script:
-    - inv -e linter.gitlab-ci-jobs-codeowners
+    - inv -e linter.gitlab-ci-jobs-codeowners --all-files

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 from collections import defaultdict
+from fnmatch import fnmatch
 from glob import glob
 
 import yaml
@@ -817,11 +818,13 @@ def _gitlab_ci_jobs_codeowners_lint(path_codeowners, modified_yml_files, gitlab_
 def gitlab_ci_jobs_codeowners(ctx, path_codeowners='.github/CODEOWNERS', all_files=False):
     """Verifies that added / modified job files are defined within CODEOWNERS."""
 
+    target_files = '.gitlab/**/*.yml'
+
     if all_files:
-        modified_yml_files = glob('.gitlab/**/*.yml', recursive=True)
+        modified_yml_files = glob(target_files, recursive=True)
     else:
         modified_yml_files = get_file_modifications(ctx, added=True, modified=True, only_names=True)
-        modified_yml_files = [path for path in modified_yml_files if path.endswith('.yml')]
+        modified_yml_files = [path for path in modified_yml_files if fnmatch(path, target_files)]
 
     if not modified_yml_files:
         print(f'{color_message("Info", Color.BLUE)}: No added / modified job files, skipping lint')

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -818,13 +818,11 @@ def _gitlab_ci_jobs_codeowners_lint(path_codeowners, modified_yml_files, gitlab_
 def gitlab_ci_jobs_codeowners(ctx, path_codeowners='.github/CODEOWNERS', all_files=False):
     """Verifies that added / modified job files are defined within CODEOWNERS."""
 
-    target_files = '.gitlab/**/*.yml'
-
     if all_files:
-        modified_yml_files = glob(target_files, recursive=True)
+        modified_yml_files = glob('.gitlab/**/*.yml', recursive=True)
     else:
         modified_yml_files = get_file_modifications(ctx, added=True, modified=True, only_names=True)
-        modified_yml_files = [path for path in modified_yml_files if fnmatch(path, target_files)]
+        modified_yml_files = [path for path in modified_yml_files if fnmatch(path, '.gitlab/**.yml')]
 
     if not modified_yml_files:
         print(f'{color_message("Info", Color.BLUE)}: No added / modified job files, skipping lint')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

1. The linter matches only gitlab files (when checking for modified files)
2. All gitlab files are checked within the job

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->