### PR TITLE
[EBPF] Remove unnecesary boolean return value in attacher

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -746,12 +746,9 @@ func (ua *UprobeAttacher) attachToBinary(fpath utils.FilePath, matchingRules []*
 		return fmt.Errorf("error computing symbols to request for rules %+v: %w", matchingRules, err)
 	}
 
-	inspectResult, isAttachable, err := ua.inspector.Inspect(fpath, symbolsToRequest)
+	inspectResult, err := ua.inspector.Inspect(fpath, symbolsToRequest)
 	if err != nil {
 		return fmt.Errorf("error inspecting %s: %w", fpath.HostPath, err)
-	}
-	if !isAttachable {
-		return fmt.Errorf("incompatible binary %s", fpath.HostPath)
 	}
 
 	uid := getUID(fpath.ID)

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -450,7 +450,7 @@ func TestAttachToBinaryAndDetach(t *testing.T) {
 
 	// Tell the inspector to return a simple symbol
 	symbolToAttach := bininspect.FunctionMetadata{EntryLocation: 0x1234}
-	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, true, nil)
+	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, nil)
 	inspector.On("Cleanup", mock.Anything).Return(nil)
 
 	// Tell the manager to return no probe when finding an existing one
@@ -511,7 +511,7 @@ func TestAttachToBinaryAtReturnLocation(t *testing.T) {
 
 	// Tell the inspector to return a simple symbol
 	symbolToAttach := bininspect.FunctionMetadata{EntryLocation: 0x1234, ReturnLocations: []uint64{0x0, 0x1}}
-	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, true, nil)
+	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, nil)
 
 	// Tell the manager to return no probe when finding an existing one
 	var nilProbe *manager.Probe // we can't just pass nil directly, if we do that the mock cannot convert it to *manager.Probe
@@ -593,7 +593,7 @@ func TestAttachToLibrariesOfPid(t *testing.T) {
 
 	// Tell the inspector to return a simple symbol
 	symbolToAttach := bininspect.FunctionMetadata{EntryLocation: 0x1234}
-	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, true, nil)
+	inspector.On("Inspect", target, mock.Anything).Return(map[string]bininspect.FunctionMetadata{"SSL_connect": symbolToAttach}, nil)
 
 	// Tell the manager to return no probe when finding an existing one
 	var nilProbe *manager.Probe // we can't just pass nil directly, if we do that the mock cannot convert it to *manager.Probe

--- a/pkg/ebpf/uprobes/inspector_test.go
+++ b/pkg/ebpf/uprobes/inspector_test.go
@@ -36,28 +36,25 @@ func TestNativeBinarySymbolRetrieval(t *testing.T) {
 	inspector := &NativeBinaryInspector{}
 
 	t.Run("MandatoryAllExist", func(tt *testing.T) {
-		result, compat, err := inspector.Inspect(fpath, allMandatoryExisting)
+		result, err := inspector.Inspect(fpath, allMandatoryExisting)
 		require.NoError(tt, err)
-		require.True(tt, compat)
 		require.ElementsMatch(tt, []string{"SSL_connect"}, maps.Keys(result))
 	})
 
 	t.Run("BestEffortAllExist", func(tt *testing.T) {
-		result, compat, err := inspector.Inspect(fpath, allBestEffortExisting)
+		result, err := inspector.Inspect(fpath, allBestEffortExisting)
 		require.NoError(tt, err)
-		require.True(tt, compat)
 		require.ElementsMatch(tt, []string{"SSL_connect"}, maps.Keys(result))
 	})
 
 	t.Run("BestEffortDontExist", func(tt *testing.T) {
-		result, compat, err := inspector.Inspect(fpath, mandatoryExistBestEffortDont)
+		result, err := inspector.Inspect(fpath, mandatoryExistBestEffortDont)
 		require.NoError(tt, err)
-		require.True(tt, compat)
 		require.ElementsMatch(tt, []string{"SSL_connect"}, maps.Keys(result))
 	})
 
 	t.Run("SomeMandatoryDontExist", func(tt *testing.T) {
-		_, _, err := inspector.Inspect(fpath, mandatoryNonExisting)
+		_, err := inspector.Inspect(fpath, mandatoryNonExisting)
 		require.Error(tt, err, "should have failed to find mandatory symbols")
 	})
 }

--- a/pkg/ebpf/uprobes/testutil.go
+++ b/pkg/ebpf/uprobes/testutil.go
@@ -84,9 +84,9 @@ type MockBinaryInspector struct {
 }
 
 // Inspect is a mock implementation of the BinaryInspector.Inspect method.
-func (m *MockBinaryInspector) Inspect(fpath utils.FilePath, requests []SymbolRequest) (map[string]bininspect.FunctionMetadata, bool, error) {
+func (m *MockBinaryInspector) Inspect(fpath utils.FilePath, requests []SymbolRequest) (map[string]bininspect.FunctionMetadata, error) {
 	args := m.Called(fpath, requests)
-	return args.Get(0).(map[string]bininspect.FunctionMetadata), args.Bool(1), args.Error(2)
+	return args.Get(0).(map[string]bininspect.FunctionMetadata), args.Error(1)
 }
 
 // Cleanup is a mock implementation of the BinaryInspector.Cleanup method.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

A minor refactor of the `Inspect` method in the uprobe attacher code, removing a redundant return value.

### Motivation

Related discussion: https://github.com/DataDog/datadog-agent/pull/29309#discussion_r1791132259

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->