### PR TITLE
[CONTP-403] Store config values for sidecar mutator

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -53,7 +53,16 @@ type Webhook struct {
 	namespaceSelector *metav1.LabelSelector
 	objectSelector    *metav1.LabelSelector
 	containerRegistry string
-	datadogConfig     config.Component
+
+	profilesJSON                 string
+	provider                     string
+	imageName                    string
+	imageTag                     string
+	isLangDetectEnabled          bool
+	isLangDetectReportingEnabled bool
+	isClusterAgentEnabled        bool
+	clusterAgentCmdPort          int
+	clusterAgentServiceName      string
 }
 
 // NewWebhook returns a new Webhook
@@ -71,7 +80,16 @@ func NewWebhook(datadogConfig config.Component) *Webhook {
 		namespaceSelector: nsSelector,
 		objectSelector:    objSelector,
 		containerRegistry: containerRegistry,
-		datadogConfig:     datadogConfig,
+
+		profilesJSON:                 datadogConfig.GetString("admission_controller.agent_sidecar.profiles"),
+		provider:                     datadogConfig.GetString("admission_controller.agent_sidecar.provider"),
+		imageName:                    datadogConfig.GetString("admission_controller.agent_sidecar.image_name"),
+		imageTag:                     datadogConfig.GetString("admission_controller.agent_sidecar.image_tag"),
+		clusterAgentServiceName:      datadogConfig.GetString("cluster_agent.kubernetes_service_name"),
+		clusterAgentCmdPort:          datadogConfig.GetInt("cluster_agent.cmd_port"),
+		isClusterAgentEnabled:        datadogConfig.GetBool("admission_controller.agent_sidecar.cluster_agent.enabled"),
+		isLangDetectEnabled:          datadogConfig.GetBool("language_detection.enabled"),
+		isLangDetectReportingEnabled: datadogConfig.GetBool("language_detection.reporting.enabled"),
 	}
 }
 
@@ -132,12 +150,12 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	podUpdated := false
 
 	if !agentSidecarExists {
-		agentSidecarContainer := getDefaultSidecarTemplate(w.containerRegistry, w.datadogConfig)
+		agentSidecarContainer := w.getDefaultSidecarTemplate()
 		pod.Spec.Containers = append(pod.Spec.Containers, *agentSidecarContainer)
 		podUpdated = true
 	}
 
-	updated, err := applyProviderOverrides(pod, w.datadogConfig)
+	updated, err := applyProviderOverrides(pod, w.provider)
 	if err != nil {
 		log.Errorf("Failed to apply provider overrides: %v", err)
 		return podUpdated, errors.New(metrics.InvalidInput)
@@ -148,7 +166,7 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	// highest override-priority. They only apply to the agent sidecar container.
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == agentSidecarContainerName {
-			updated, err = applyProfileOverrides(&pod.Spec.Containers[i], w.datadogConfig)
+			updated, err = applyProfileOverrides(&pod.Spec.Containers[i], w.profilesJSON)
 			if err != nil {
 				log.Errorf("Failed to apply profile overrides: %v", err)
 				return podUpdated, errors.New(metrics.InvalidInput)
@@ -161,14 +179,11 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, _ string, _ dynamic.Interf
 	return podUpdated, nil
 }
 
-func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Component) *corev1.Container {
+func (w *Webhook) getDefaultSidecarTemplate() *corev1.Container {
 	ddSite := os.Getenv("DD_SITE")
 	if ddSite == "" {
 		ddSite = pkgconfigsetup.DefaultSite
 	}
-
-	imageName := datadogConfig.GetString("admission_controller.agent_sidecar.image_name")
-	imageTag := datadogConfig.GetString("admission_controller.agent_sidecar.image_tag")
 
 	agentContainer := &corev1.Container{
 		Env: []corev1.EnvVar{
@@ -202,10 +217,10 @@ func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Co
 			},
 			{
 				Name:  "DD_LANGUAGE_DETECTION_ENABLED",
-				Value: strconv.FormatBool(datadogConfig.GetBool("language_detection.enabled") && datadogConfig.GetBool("language_detection.reporting.enabled")),
+				Value: strconv.FormatBool(w.isLangDetectEnabled && w.isLangDetectReportingEnabled),
 			},
 		},
-		Image:           fmt.Sprintf("%s/%s:%s", containerRegistry, imageName, imageTag),
+		Image:           fmt.Sprintf("%s/%s:%s", w.containerRegistry, w.imageName, w.imageTag),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            agentSidecarContainerName,
 		Resources: corev1.ResourceRequirements{
@@ -220,11 +235,7 @@ func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Co
 		},
 	}
 
-	clusterAgentEnabled := datadogConfig.GetBool("admission_controller.agent_sidecar.cluster_agent.enabled")
-
-	if clusterAgentEnabled {
-		clusterAgentCmdPort := datadogConfig.GetInt("cluster_agent.cmd_port")
-		clusterAgentServiceName := datadogConfig.GetString("cluster_agent.kubernetes_service_name")
+	if w.isClusterAgentEnabled {
 
 		_, _ = withEnvOverrides(agentContainer, corev1.EnvVar{
 			Name:  "DD_CLUSTER_AGENT_ENABLED",
@@ -241,7 +252,7 @@ func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Co
 			},
 		}, corev1.EnvVar{
 			Name:  "DD_CLUSTER_AGENT_URL",
-			Value: fmt.Sprintf("https://%s.%s.svc.cluster.local:%v", clusterAgentServiceName, apiCommon.GetMyNamespace(), clusterAgentCmdPort),
+			Value: fmt.Sprintf("https://%s.%s.svc.cluster.local:%v", w.clusterAgentServiceName, apiCommon.GetMyNamespace(), w.clusterAgentCmdPort),
 		}, corev1.EnvVar{
 			Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
 			Value: "true",
@@ -255,9 +266,10 @@ func getDefaultSidecarTemplate(containerRegistry string, datadogConfig config.Co
 func labelSelectors(datadogConfig config.Component) (namespaceSelector, objectSelector *metav1.LabelSelector) {
 	// Read and parse selectors
 	selectorsJSON := datadogConfig.GetString("admission_controller.agent_sidecar.selectors")
+	profilesJSON := datadogConfig.GetString("admission_controller.agent_sidecar.profiles")
 
 	// Get sidecar profiles
-	_, err := loadSidecarProfiles(datadogConfig)
+	_, err := loadSidecarProfiles(profilesJSON)
 	if err != nil {
 		log.Errorf("encountered issue when loading sidecar profiles: %s", err)
 		return nil, nil

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -54,6 +54,9 @@ type Webhook struct {
 	objectSelector    *metav1.LabelSelector
 	containerRegistry string
 
+	// These fields store datadog agent config parameters
+	// to avoid calling the config resolution each time the webhook
+	// receives requests because the resolution is CPU expensive.
 	profilesJSON                 string
 	provider                     string
 	imageName                    string

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/profiles.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/profiles.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 ////////////////////////////////
@@ -32,10 +30,8 @@ type ProfileOverride struct {
 // loadSidecarProfiles returns the profile overrides provided by the user
 // It returns an error in case of miss-configuration or in case more than
 // one profile is configured
-func loadSidecarProfiles(datadogConfig config.Component) ([]ProfileOverride, error) {
+func loadSidecarProfiles(profilesJSON string) ([]ProfileOverride, error) {
 	// Read and parse profiles
-	profilesJSON := datadogConfig.GetString("admission_controller.agent_sidecar.profiles")
-
 	var profiles []ProfileOverride
 
 	err := json.Unmarshal([]byte(profilesJSON), &profiles)
@@ -52,12 +48,12 @@ func loadSidecarProfiles(datadogConfig config.Component) ([]ProfileOverride, err
 
 // applyProfileOverrides applies the profile overrides to the container. It
 // returns a boolean that indicates if the container was mutated
-func applyProfileOverrides(container *corev1.Container, datadogConfig config.Component) (bool, error) {
+func applyProfileOverrides(container *corev1.Container, profilesJSON string) (bool, error) {
 	if container == nil {
 		return false, fmt.Errorf("can't apply profile overrides to nil containers")
 	}
 
-	profiles, err := loadSidecarProfiles(datadogConfig)
+	profiles, err := loadSidecarProfiles(profilesJSON)
 
 	if err != nil {
 		return false, err

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestLoadSidecarProfiles(t *testing.T) {
-	// mockConfig := configmock.New(t)
-
 	tests := []struct {
 		name             string
 		profilesJSON     string
@@ -114,7 +112,6 @@ func TestLoadSidecarProfiles(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
 			profiles, err := loadSidecarProfiles(test.profilesJSON)
 
 			if test.expectError {
@@ -136,8 +133,6 @@ func TestLoadSidecarProfiles(t *testing.T) {
 }
 
 func TestApplyProfileOverrides(t *testing.T) {
-	// mockConfig := configmock.New(t)
-
 	tests := []struct {
 		name              string
 		profilesJSON      string
@@ -358,7 +353,6 @@ func TestApplyProfileOverrides(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
 			mutated, err := applyProfileOverrides(test.baseContainer, test.profilesJSON)
 
 			assert.Equal(tt, test.expectMutated, mutated)

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/profiles_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestLoadSidecarProfiles(t *testing.T) {
-	mockConfig := configmock.New(t)
+	// mockConfig := configmock.New(t)
 
 	tests := []struct {
 		name             string
@@ -116,8 +114,8 @@ func TestLoadSidecarProfiles(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
-			profiles, err := loadSidecarProfiles(mockConfig)
+			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
+			profiles, err := loadSidecarProfiles(test.profilesJSON)
 
 			if test.expectError {
 				assert.Error(tt, err)
@@ -138,7 +136,7 @@ func TestLoadSidecarProfiles(t *testing.T) {
 }
 
 func TestApplyProfileOverrides(t *testing.T) {
-	mockConfig := configmock.New(t)
+	// mockConfig := configmock.New(t)
 
 	tests := []struct {
 		name              string
@@ -360,8 +358,8 @@ func TestApplyProfileOverrides(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
-			mutated, err := applyProfileOverrides(test.baseContainer, mockConfig)
+			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.profiles", test.profilesJSON)
+			mutated, err := applyProfileOverrides(test.baseContainer, test.profilesJSON)
 
 			assert.Equal(tt, test.expectMutated, mutated)
 

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers.go
@@ -13,7 +13,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
@@ -55,8 +54,7 @@ func providerIsSupported(provider string) bool {
 
 // applyProviderOverrides applies the necessary overrides for the provider
 // configured. It returns a boolean that indicates if the pod was mutated.
-func applyProviderOverrides(pod *corev1.Pod, datadogConfig config.Component) (bool, error) {
-	provider := datadogConfig.GetString("admission_controller.agent_sidecar.provider")
+func applyProviderOverrides(pod *corev1.Pod, provider string) (bool, error) {
 
 	if !providerIsSupported(provider) {
 		return false, fmt.Errorf("unsupported provider: %v", provider)

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestProviderIsSupported(t *testing.T) {
-
 	tests := []struct {
 		name              string
 		provider          string
@@ -57,8 +56,6 @@ func TestProviderIsSupported(t *testing.T) {
 }
 
 func TestApplyProviderOverrides(t *testing.T) {
-	// mockConfig := configmock.New(t)
-
 	tests := []struct {
 		name                     string
 		provider                 string
@@ -414,7 +411,6 @@ func TestApplyProviderOverrides(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
 			mutated, err := applyProviderOverrides(test.basePod, test.provider)
 
 			if test.expectError {

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/providers_test.go
@@ -17,7 +17,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
@@ -58,7 +57,7 @@ func TestProviderIsSupported(t *testing.T) {
 }
 
 func TestApplyProviderOverrides(t *testing.T) {
-	mockConfig := configmock.New(t)
+	// mockConfig := configmock.New(t)
 
 	tests := []struct {
 		name                     string
@@ -415,8 +414,8 @@ func TestApplyProviderOverrides(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
-			mutated, err := applyProviderOverrides(test.basePod, mockConfig)
+			// mockConfig.SetWithoutSource("admission_controller.agent_sidecar.provider", test.provider)
+			mutated, err := applyProviderOverrides(test.basePod, test.provider)
 
 			if test.expectError {
 				assert.Error(tt, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Follow up to [last PR](https://github.com/DataDog/datadog-agent/pull/29881), by storing relevant config values in struct.

### Motivation

Currently, the config mutator is storing a pointer to the datadogConfig and fetching values as needed. Unfortunately, caching does not work with the config component so we are storing the relevant values in the webhook struct instead.

### Describe how to test/QA your changes

Unit tests should be fine.