### PR TITLE
Remove Unmarshal and UnmarshalExact method from the config API

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -23,6 +23,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/config/model => ../../../../../../pkg/config/model
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel => ../../../../../../pkg/config/nodetreemodel
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../../../../../../pkg/config/setup
+	github.com/DataDog/datadog-agent/pkg/config/structure => ../../../../../../pkg/config/structure
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../../../../../../pkg/config/teeconfig
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../../../pkg/config/utils
 	github.com/DataDog/datadog-agent/pkg/metrics => ../../../../../../pkg/metrics
@@ -108,6 +109,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -603,7 +603,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.56.2
 	github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/def v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl v0.0.0-00010101000000-000000000000
-	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.60.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths v0.0.0-00010101000000-000000000000
 	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/errdefs v0.1.0

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -142,8 +142,6 @@ type Setup interface {
 // some misc functions, that should likely be split into another interface
 type Compound interface {
 	UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error
-	Unmarshal(rawVal interface{}) error
-	UnmarshalExact(rawVal interface{}) error
 
 	ReadInConfig() error
 	ReadConfig(in io.Reader) error

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -579,20 +579,6 @@ func (c *safeConfig) UnmarshalKey(key string, rawVal interface{}, opts ...viper.
 	return c.Viper.UnmarshalKey(key, rawVal, opts...)
 }
 
-// Unmarshal wraps Viper for concurrent access
-func (c *safeConfig) Unmarshal(rawVal interface{}) error {
-	c.RLock()
-	defer c.RUnlock()
-	return c.Viper.Unmarshal(rawVal)
-}
-
-// UnmarshalExact wraps Viper for concurrent access
-func (c *safeConfig) UnmarshalExact(rawVal interface{}) error {
-	c.RLock()
-	defer c.RUnlock()
-	return c.Viper.UnmarshalExact(rawVal)
-}
-
 // ReadInConfig wraps Viper for concurrent access
 func (c *safeConfig) ReadInConfig() error {
 	c.Lock()

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -535,24 +535,11 @@ func (c *safeConfig) UnmarshalKey(key string, rawVal interface{}, opts ...viper.
 	return c.Viper.UnmarshalKey(key, rawVal, opts...)
 }
 
-// Unmarshal wraps Viper for concurrent access
-func (c *safeConfig) Unmarshal(rawVal interface{}) error {
-	c.RLock()
-	defer c.RUnlock()
-	return c.Viper.Unmarshal(rawVal)
-}
-
-// UnmarshalExact wraps Viper for concurrent access
-func (c *safeConfig) UnmarshalExact(rawVal interface{}) error {
-	c.RLock()
-	defer c.RUnlock()
-	return c.Viper.UnmarshalExact(rawVal)
-}
-
 // ReadInConfig wraps Viper for concurrent access
 func (c *safeConfig) ReadInConfig() error {
 	c.Lock()
 	defer c.Unlock()
+
 	// ReadInConfig reset configuration with the main config file
 	err := errors.Join(c.Viper.ReadInConfig(), c.configSources[model.SourceFile].ReadInConfig())
 	if err != nil {

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -228,16 +228,6 @@ func (t *teeConfig) UnmarshalKey(key string, rawVal interface{}, opts ...viper.D
 	return t.baseline.UnmarshalKey(key, rawVal, opts...)
 }
 
-// Unmarshal wraps Viper for concurrent access
-func (t *teeConfig) Unmarshal(rawVal interface{}) error {
-	return t.baseline.Unmarshal(rawVal)
-}
-
-// UnmarshalExact wraps Viper for concurrent access
-func (t *teeConfig) UnmarshalExact(rawVal interface{}) error {
-	return t.baseline.UnmarshalExact(rawVal)
-}
-
 // ReadInConfig wraps Viper for concurrent access
 func (t *teeConfig) ReadInConfig() error {
 	err1 := t.baseline.ReadInConfig()

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -12,11 +12,12 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../aggregator/ckey/
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../pkg/collector/check/defaults
 	github.com/DataDog/datadog-agent/pkg/config/env => ../../pkg/config/env
-	github.com/DataDog/datadog-agent/pkg/config/mock => ../../pkg/config/mock
+	github.com/DataDog/datadog-agent/pkg/config/mock => ../config/mock
 	github.com/DataDog/datadog-agent/pkg/config/model => ../config/model/
-	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel => ../../pkg/config/nodetreemodel
-	github.com/DataDog/datadog-agent/pkg/config/setup => ../../pkg/config/setup
-	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../../pkg/config/teeconfig
+	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel => ../config/nodetreemodel
+	github.com/DataDog/datadog-agent/pkg/config/setup => ../config/setup
+	github.com/DataDog/datadog-agent/pkg/config/structure => ../config/structure
+	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../config/teeconfig
 	github.com/DataDog/datadog-agent/pkg/tagger/types => ../../pkg/tagger/types
 	github.com/DataDog/datadog-agent/pkg/tagset => ../tagset/
 	github.com/DataDog/datadog-agent/pkg/telemetry => ../telemetry/
@@ -40,6 +41,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.1
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/tagset v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.56.0-rc.3

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -16,13 +16,11 @@ import (
 )
 
 func TestHistogramConf(t *testing.T) {
-	h := histogramPercentilesConfig{Percentiles: []string{"0.95", "0.96", "0.28", "0.57", "0.58"}}
-	assert.Equal(t, []int{95, 96, 28, 57, 58}, h.percentiles())
+	assert.Equal(t, []int{95, 96, 28, 57, 58}, parsePercentiles([]string{"0.95", "0.96", "0.28", "0.57", "0.58"}))
 }
 
 func TestHistogramConfError(t *testing.T) {
-	h := histogramPercentilesConfig{Percentiles: []string{"0.95", "test", "0.12test", "0.22", "200", "-50"}}
-	assert.Equal(t, []int{95, 22}, h.percentiles())
+	assert.Equal(t, []int{95, 22}, parsePercentiles([]string{"0.95", "test", "0.12test", "0.22", "200", "-50"}))
 }
 
 func TestConfigureDefault(t *testing.T) {

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -24,6 +24,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/config/model => ../config/model
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel => ../../pkg/config/nodetreemodel
 	github.com/DataDog/datadog-agent/pkg/config/setup => ../config/setup/
+	github.com/DataDog/datadog-agent/pkg/config/structure => ../../pkg/config/structure
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../../pkg/config/teeconfig
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../config/utils/
 	github.com/DataDog/datadog-agent/pkg/metrics => ../metrics/
@@ -98,6 +99,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.60.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3 // indirect


### PR DESCRIPTION
### What does this PR do?
Remove Unmarshal and UnmarshalExact method from the config API.

This helps reduce the API of the config which will simplify the replacement of viper.

### Describe how to test/QA your changes

Running the CI is enough.