### PR TITLE
config.BindEnv requires a key argument

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -108,7 +108,7 @@ type Setup interface {
 	SetFs(fs afero.Fs)
 
 	SetEnvPrefix(in string)
-	BindEnv(input ...string)
+	BindEnv(key string, envvars ...string)
 	SetEnvKeyReplacer(r *strings.Replacer)
 
 	// The following helpers allow a type to be enforce when parsing environment variables. Most of them exists to

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -536,17 +536,17 @@ func (c *safeConfig) mergeWithEnvPrefix(key string) string {
 }
 
 // BindEnv wraps Viper for concurrent access, and adds tracking of the configurable env vars
-func (c *safeConfig) BindEnv(input ...string) {
+func (c *safeConfig) BindEnv(key string, envvars ...string) {
 	c.Lock()
 	defer c.Unlock()
 	var envKeys []string
 
 	// If one input is given, viper derives an env key from it; otherwise, all inputs after
 	// the first are literal env vars.
-	if len(input) == 1 {
-		envKeys = []string{c.mergeWithEnvPrefix(input[0])}
+	if len(envvars) == 0 {
+		envKeys = []string{c.mergeWithEnvPrefix(key)}
 	} else {
-		envKeys = input[1:]
+		envKeys = envvars
 	}
 
 	for _, key := range envKeys {
@@ -557,8 +557,8 @@ func (c *safeConfig) BindEnv(input ...string) {
 		c.configEnvVars[key] = struct{}{}
 	}
 
-	_ = c.configSources[SourceEnvVar].BindEnv(input...)
-	_ = c.Viper.BindEnv(input...)
+	_ = c.configSources[SourceEnvVar].BindEnv(append([]string{key}, envvars...)...)
+	_ = c.Viper.BindEnv(append([]string{key}, envvars...)...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access
@@ -825,9 +825,9 @@ func (c *safeConfig) GetEnvVars() []string {
 }
 
 // BindEnvAndSetDefault implements the Config interface
-func (c *safeConfig) BindEnvAndSetDefault(key string, val interface{}, env ...string) {
+func (c *safeConfig) BindEnvAndSetDefault(key string, val interface{}, envvars ...string) {
 	c.SetDefault(key, val)
-	c.BindEnv(append([]string{key}, env...)...) //nolint:errcheck
+	c.BindEnv(key, envvars...) //nolint:errcheck
 }
 
 func (c *safeConfig) Warnings() *Warnings {

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -557,8 +557,9 @@ func (c *safeConfig) BindEnv(key string, envvars ...string) {
 		c.configEnvVars[key] = struct{}{}
 	}
 
-	_ = c.configSources[SourceEnvVar].BindEnv(append([]string{key}, envvars...)...)
-	_ = c.Viper.BindEnv(append([]string{key}, envvars...)...)
+	newKeys := append([]string{key}, envvars...)
+	_ = c.configSources[SourceEnvVar].BindEnv(newKeys...)
+	_ = c.Viper.BindEnv(newKeys...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -513,8 +513,9 @@ func (c *safeConfig) BindEnv(key string, envvars ...string) {
 		c.configEnvVars[key] = struct{}{}
 	}
 
-	_ = c.configSources[model.SourceEnvVar].BindEnv(append([]string{key}, envvars...)...)
-	_ = c.Viper.BindEnv(append([]string{key}, envvars...)...)
+	newKeys := append([]string{key}, envvars...)
+	_ = c.configSources[model.SourceEnvVar].BindEnv(newKeys...)
+	_ = c.Viper.BindEnv(newKeys...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -492,17 +492,17 @@ func (c *safeConfig) mergeWithEnvPrefix(key string) string {
 }
 
 // BindEnv wraps Viper for concurrent access, and adds tracking of the configurable env vars
-func (c *safeConfig) BindEnv(input ...string) {
+func (c *safeConfig) BindEnv(key string, envvars ...string) {
 	c.Lock()
 	defer c.Unlock()
 	var envKeys []string
 
 	// If one input is given, viper derives an env key from it; otherwise, all inputs after
 	// the first are literal env vars.
-	if len(input) == 1 {
-		envKeys = []string{c.mergeWithEnvPrefix(input[0])}
+	if len(envvars) == 0 {
+		envKeys = []string{c.mergeWithEnvPrefix(key)}
 	} else {
-		envKeys = input[1:]
+		envKeys = envvars
 	}
 
 	for _, key := range envKeys {
@@ -513,8 +513,8 @@ func (c *safeConfig) BindEnv(input ...string) {
 		c.configEnvVars[key] = struct{}{}
 	}
 
-	_ = c.configSources[model.SourceEnvVar].BindEnv(input...)
-	_ = c.Viper.BindEnv(input...)
+	_ = c.configSources[model.SourceEnvVar].BindEnv(append([]string{key}, envvars...)...)
+	_ = c.Viper.BindEnv(append([]string{key}, envvars...)...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access
@@ -781,9 +781,9 @@ func (c *safeConfig) GetEnvVars() []string {
 }
 
 // BindEnvAndSetDefault implements the Config interface
-func (c *safeConfig) BindEnvAndSetDefault(key string, val interface{}, env ...string) {
+func (c *safeConfig) BindEnvAndSetDefault(key string, val interface{}, envvars ...string) {
 	c.SetDefault(key, val)
-	c.BindEnv(append([]string{key}, env...)...) //nolint:errcheck
+	c.BindEnv(key, envvars...) //nolint:errcheck
 }
 
 func (c *safeConfig) Warnings() *model.Warnings {

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -212,9 +212,9 @@ func (t *teeConfig) SetEnvPrefix(in string) {
 }
 
 // BindEnv wraps Viper for concurrent access, and adds tracking of the configurable env vars
-func (t *teeConfig) BindEnv(input ...string) {
-	t.baseline.BindEnv(input...)
-	t.compare.BindEnv(input...)
+func (t *teeConfig) BindEnv(key string, envvars ...string) {
+	t.baseline.BindEnv(key, envvars...)
+	t.compare.BindEnv(key, envvars...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access


### PR DESCRIPTION
### What does this PR do?

Require at least 1 key argument to `config.BindEnv`

### Motivation

Cleanup the config API a bit. This method `config.BindEnv` won't work properly without a key argument, might as well enforce that with the compiler.

### Describe how to test/QA your changes

No functional changes.

### Possible Drawbacks / Trade-offs

### Additional Notes
