### PR TITLE
fix(linter): Do not import codeowners globally

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -8,7 +8,6 @@ from fnmatch import fnmatch
 from glob import glob
 
 import yaml
-from codeowners import CodeOwners
 from invoke import Exit, task
 
 from tasks.build_tags import compute_build_tags_for_flavor
@@ -817,6 +816,7 @@ def _gitlab_ci_jobs_codeowners_lint(path_codeowners, modified_yml_files, gitlab_
 @task
 def gitlab_ci_jobs_codeowners(ctx, path_codeowners='.github/CODEOWNERS', all_files=False):
     """Verifies that added / modified job files are defined within CODEOWNERS."""
+    from codeowners import CodeOwners
 
     if all_files:
         modified_yml_files = glob('.gitlab/**/*.yml', recursive=True)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
fix(linter): Do not import codeowners globally

### Motivation
#incident-31371 Import codeowners locally to prevent [failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/667121269) on jobs using the `btf-gen` image

### Describe how to test/QA your changes
Job passed on the pipeline
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/667295219
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/667295218

### Possible Drawbacks / Trade-offs

### Additional Notes
Could have used [this](https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/owners/parsing.py#L7) method. Needs some quiet time as it's not strictly equivalent, will do this as follow-up
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->