### PR TITLE
always remove extracted BTF on deb/rpm rm/upgrade

### DIFF
--- a/omnibus/package-scripts/agent-deb/preinst
+++ b/omnibus/package-scripts/agent-deb/preinst
@@ -42,4 +42,9 @@ if [ -d $TUF_REPO_DIR ]; then
     rm -rf $TUF_REPO_DIR
 fi
 
+# Remove any unpacked BTF files
+find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
+# And remove empty directories
+find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re" -type d -empty -delete || true
+
 exit 0

--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -131,7 +131,10 @@ remove_sysprobe_secagent_files()
     if [ -d "$INSTALL_DIR/run" ]; then
         rmdir "$INSTALL_DIR/run" 2>/dev/null || true
     fi
+}
 
+remove_sysprobe_core_files()
+{
     # Remove any unpacked BTF files
     find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
     # And remove empty directories
@@ -186,6 +189,7 @@ stop_agent
 deregister_agent
 remove_custom_integrations
 remove_py_compiled_files
+remove_sysprobe_core_files
 
 case "$1" in
     remove)

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -93,4 +93,9 @@ if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
     cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
 fi
 
+# Remove any unpacked BTF files
+find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
+# And remove empty directories
+find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re" -type d -empty -delete || true
+
 exit 0

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -115,7 +115,10 @@ remove_sysprobe_secagent_files()
     if [ -d "$INSTALL_DIR/run" ]; then
         rmdir "$INSTALL_DIR/run" 2>/dev/null || true
     fi
+}
 
+remove_sysprobe_core_files()
+{
     # Remove any unpacked BTF files
     find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
     # And remove empty directories
@@ -168,6 +171,7 @@ case "$*" in
 esac
 stop_agent
 deregister_agent
+remove_sysprobe_core_files
 
 case "$*" in
     0)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes extracted `.btf` files on deb/rpm package removal or upgrade.

### Motivation

BTF files are minimized for a specific agent version. Using an old BTF file post-upgrade can cause problems loading eBPF programs.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->