### PR TITLE
[SMP] Quality Gates adjustments

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
@@ -28,6 +28,6 @@ checks:
   - name: memory_usage
     description: "Memory usage"
     bounds:
-      series: rss_bytes
+      series: total_rss_bytes
       # The machine has 12GiB free.
       upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -28,6 +28,6 @@ checks:
   - name: memory_usage
     description: "Memory usage"
     bounds:
-      series: rss_bytes
+      series: total_rss_bytes
       # The machine has 12GiB free.
       upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
@@ -28,6 +28,6 @@ checks:
   - name: memory_usage
     description: "Memory usage"
     bounds:
-      series: rss_bytes
+      series: total_rss_bytes
       # The machine has 12GiB free.
       upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
@@ -28,6 +28,6 @@ checks:
   - name: memory_usage
     description: "Memory usage"
     bounds:
-      series: rss_bytes
+      series: total_rss_bytes
       # The machine has 12GiB free.
       upper_bound: 1GiB

--- a/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
@@ -28,6 +28,6 @@ checks:
   - name: memory_usage
     description: "Memory usage"
     bounds:
-      series: rss_bytes
+      series: total_rss_bytes
       # The machine has 12GiB free.
       upper_bound: 1GiB

--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -33,3 +33,7 @@ checks:
     bounds:
       series: total_rss_bytes
       upper_bound: "430.0 MiB"
+
+report_links:
+  - text: "bounds checks dashboard"
+    link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&tpl_var_run-id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -32,4 +32,4 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "465.0 MiB"
+      upper_bound: "430.0 MiB"

--- a/test/regression/cases/idle_all_features/experiment.yaml
+++ b/test/regression/cases/idle_all_features/experiment.yaml
@@ -46,3 +46,7 @@ checks:
     bounds:
       series: total_rss_bytes
       upper_bound: "785.0 MiB"
+
+report_links:
+  - text: "bounds checks dashboard"
+    link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&tpl_var_run-id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/idle_all_features/experiment.yaml
+++ b/test/regression/cases/idle_all_features/experiment.yaml
@@ -40,4 +40,9 @@ target:
     DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
     DD_PROFILING_WAIT_PROFILE: true
 
-
+checks:
+  - name: memory_usage
+    description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
+    bounds:
+      series: total_rss_bytes
+      upper_bound: "785.0 MiB"


### PR DESCRIPTION
### What does this PR do?

Reduce Quality Gate for `idle` experiment, define one for `idle_all_features`, and switch logs experiments to a series pending upcoming support for per-process assertions.

### Motivation

Define and refine bounds for memory use.

### Additional Notes

See recent Quality Gates updates in Slack at #single-machine-performance.