### PR TITLE
Draft: async Windows crash reporting

### DIFF
--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -23,6 +23,7 @@ import (
 
 // allow us to change for testing
 var readfn = doReadCrashDump
+var parseCrashDump = parseWinCrashDump
 
 type logCallbackContext struct {
 	loglines       []string
@@ -107,14 +108,14 @@ func doReadCrashDump(filename string, ctx *logCallbackContext, exterr *uint32) e
 	return nil
 }
 
-func parseCrashDump(wcs *WinCrashStatus) {
+func parseWinCrashDump(wcs *WinCrashStatus) {
 	var ctx logCallbackContext
 	var extendedError uint32
 
 	err := readfn(wcs.FileName, &ctx, &extendedError)
 
 	if err != nil {
-		wcs.Success = false
+		wcs.StatusCode = WinCrashStatusCodeFailed
 		wcs.ErrString = fmt.Sprintf("Failed to load crash dump file %v %x", err, extendedError)
 		log.Errorf("Failed to open crash dump %s: %v %x", wcs.FileName, err, extendedError)
 		return
@@ -122,7 +123,7 @@ func parseCrashDump(wcs *WinCrashStatus) {
 
 	if len(ctx.loglines) < 2 {
 		wcs.ErrString = fmt.Sprintf("Invalid crash dump file %s", wcs.FileName)
-		wcs.Success = false
+		wcs.StatusCode = WinCrashStatusCodeFailed
 		return
 	}
 
@@ -190,5 +191,5 @@ func parseCrashDump(wcs *WinCrashStatus) {
 		wcs.Offender = callsite
 		break
 	}
-	wcs.Success = true
+	wcs.StatusCode = WinCrashStatusCodeSuccess
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -51,12 +51,11 @@ func TestCrashParser(t *testing.T) {
 		FileName: "testdata/crashsample1.txt",
 	}
 	// first read in the sample data
-
-	readfn = testCrashReader
+	OverrideCrashDumpReader(testCrashReader)
 
 	parseCrashDump(wcs)
 
-	assert.True(t, wcs.Success)
+	assert.Equal(t, wcs.StatusCode, WinCrashStatusCodeSuccess)
 	assert.Empty(t, wcs.ErrString)
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")
@@ -72,11 +71,11 @@ func TestCrashParserWithLineSplits(t *testing.T) {
 	}
 	// first read in the sample data
 
-	readfn = testCrashReaderWithLineSplits
+	OverrideCrashDumpReader(testCrashReaderWithLineSplits)
 
 	parseCrashDump(wcs)
 
-	assert.True(t, wcs.Success)
+	assert.Equal(t, wcs.StatusCode, WinCrashStatusCodeSuccess)
 	assert.Empty(t, wcs.ErrString)
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -29,10 +29,26 @@ const (
 	DumpTypeAutomatic    = int(7) // automatic
 )
 
+const (
+	// WinCrashStatusCodeUnknown indicates an invalid or corrupted code.
+	WinCrashStatusCodeUnknown = int(-1)
+
+	// WinCrashStatusCodeSuccess indicates that crash dump processing succeeded
+	// or no crash dump was found.
+	WinCrashStatusCodeSuccess = int(0)
+
+	// WinCrashStatusCodeBusy indicates that crash dump processing is still busy
+	// and no result is yet available.
+	WinCrashStatusCodeBusy = int(1)
+
+	// WinCrashStatusCodeFailed indicates that crash dump processing failed or had an error.
+	WinCrashStatusCodeFailed = int(2)
+)
+
 // WinCrashStatus defines all of the information returned from the system
 // probe to the caller
 type WinCrashStatus struct {
-	Success    bool   `json:"success"`
+	StatusCode int    `json:"statuscode"`
 	ErrString  string `json:"errstring"`
 	FileName   string `json:"filename"`
 	Type       int    `json:"dumptype"`

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && windows
+
+package probe
+
+type readCrashDumpType func(filename string, ctx *logCallbackContext, _ *uint32) error
+type parseCrashDumpType func(wcs *WinCrashStatus)
+
+// SetCachedSettings sets the settings used for tests without reading the Registry.
+func (p *WinCrashProbe) SetCachedSettings(wcs *WinCrashStatus) {
+	p.status = wcs
+}
+
+// OverrideCrashDumpReader relpaces the crash dump reading function for tests.
+func OverrideCrashDumpReader(customCrashReader readCrashDumpType) {
+	readfn = customCrashReader
+}
+
+// OverrideCrashDumpParser relpaces the crash dump parsing function for tests.
+func OverrideCrashDumpParser(customParseCrashDump parseCrashDumpType) {
+	parseCrashDump = customParseCrashDump
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -11,38 +11,128 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"golang.org/x/sys/windows/registry"
 )
 
+type probeState uint32
+
+const (
+	// Idle indicates that the probe is waiting for a request
+	idle probeState = iota
+
+	// Busy indicates that the probe is currently processing a crash dump
+	busy
+
+	// Completed indicates that the probe finished processing a crash dump.
+	completed
+
+	// Failed indicates that the probe failed to process a crash dump.
+	failed
+)
+
 // WinCrashProbe has no stored state.
 type WinCrashProbe struct {
+	state  probeState
+	status *WinCrashStatus
+	mu     sync.Mutex
 }
 
 // NewWinCrashProbe returns an initialized WinCrashProbe
 func NewWinCrashProbe(_ *sysconfigtypes.Config) (*WinCrashProbe, error) {
-	return &WinCrashProbe{}, nil
+	return &WinCrashProbe{
+		state:  idle,
+		status: nil,
+	}, nil
+}
+
+// Handles crash dump parsing in a separate thread since this may take very long.
+func (p *WinCrashProbe) parseCrashDumpAsync() {
+	if p.status == nil {
+		p.state = failed
+		return
+	}
+
+	parseCrashDump(p.status)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.state = completed
 }
 
 // Get returns the current crash, if any
 func (p *WinCrashProbe) Get() *WinCrashStatus {
 	wcs := &WinCrashStatus{}
 
-	err := wcs.getCurrentCrashSettings()
-	if err != nil {
-		wcs.ErrString = err.Error()
-		wcs.Success = false
-		return wcs
-	}
+	// Nothing in this method should take long.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
-	if len(wcs.FileName) == 0 {
-		// no filename means no crash dump
-		wcs.Success = true // we succeeded
-		return wcs
+	switch p.state {
+	case idle:
+		if p.status == nil {
+			// This is a new request.
+			err := wcs.getCurrentCrashSettings()
+			if err != nil {
+				wcs.ErrString = err.Error()
+				wcs.StatusCode = WinCrashStatusCodeFailed
+			}
+		} else {
+			// Use cached settings.
+			wcs.FileName = p.status.FileName
+			wcs.Type = p.status.Type
+			wcs.StatusCode = p.status.StatusCode
+			wcs.ErrString = p.status.ErrString
+		}
+
+		// Transition to the next state.
+		if wcs.StatusCode == WinCrashStatusCodeFailed {
+			// Only try once and cache the failure.
+			p.status = wcs
+			p.state = failed
+		} else if len(wcs.FileName) == 0 {
+			// No filename means no crash dump
+			p.status = wcs
+			p.state = completed
+			wcs.StatusCode = WinCrashStatusCodeSuccess
+		} else {
+			// Kick off the crash dump processing asynchronously.
+			// The crash dump may be very large and we should not block for a response.
+			p.state = busy
+			wcs.StatusCode = WinCrashStatusCodeBusy
+
+			// Make a new copy of the wcs for async processing while returning "Busy"
+			// for the current response.
+			p.status = &WinCrashStatus{
+				FileName: wcs.FileName,
+				Type:     wcs.Type,
+			}
+
+			go p.parseCrashDumpAsync()
+		}
+
+	case busy:
+		// The crash dump processing is not done yet. Reply busy.
+		if p.status != nil {
+			wcs.FileName = p.status.FileName
+			wcs.Type = p.status.Type
+		}
+		wcs.StatusCode = WinCrashStatusCodeBusy
+
+	case failed:
+		fallthrough
+	case completed:
+		// The crash dump processing was done, return the result.
+		if p.status != nil {
+			// This result is cached for all subsequent queries.
+			wcs = p.status
+		} else {
+			wcs.StatusCode = WinCrashStatusCodeFailed
+		}
 	}
-	parseCrashDump(wcs)
 
 	return wcs
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
@@ -10,11 +10,10 @@ package wincrashdetect
 import (
 	"net"
 	"net/http"
-
-	//"strings"
+	"sync"
 	"testing"
+	"time"
 
-	//"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
@@ -108,7 +107,7 @@ func TestWinCrashReporting(t *testing.T) {
 
 		// set the return value handled in the check handler above
 		p = &probe.WinCrashStatus{
-			Success: true,
+			StatusCode: probe.WinCrashStatusCodeSuccess,
 		}
 
 		check := newCheck()
@@ -128,7 +127,7 @@ func TestWinCrashReporting(t *testing.T) {
 		testSetup(t)
 		defer testCleanup()
 		p = &probe.WinCrashStatus{
-			Success:    true,
+			StatusCode: probe.WinCrashStatusCodeSuccess,
 			FileName:   `c:\windows\memory.dmp`,
 			Type:       probe.DumpTypeAutomatic,
 			DateString: `Fri Jun 30 15:33:05.086 2023 (UTC - 7:00)`,
@@ -199,5 +198,161 @@ func TestWinCrashReporting(t *testing.T) {
 		mock.AssertNumberOfCalls(t, "Rate", 0)
 		mock.AssertNumberOfCalls(t, "Event", 2)
 		mock.AssertNumberOfCalls(t, "Commit", 2)
+	})
+}
+
+func TestCrashReportingStates(t *testing.T) {
+	var crashStatus *probe.WinCrashStatus
+
+	listener, closefunc := createSystemProbeListener()
+	defer closefunc()
+
+	pkgconfigsetup.InitSystemProbeConfig(pkgconfigsetup.SystemProbe())
+
+	mux := http.NewServeMux()
+	server := http.Server{
+		Handler: mux,
+	}
+	defer server.Close()
+
+	cp, err := probe.NewWinCrashProbe(nil)
+	assert.NotNil(t, cp)
+	assert.Nil(t, err)
+
+	wg := sync.WaitGroup{}
+
+	// This will artificially delay the "parsing" to ensure the first check gets a "busy" status.
+	delayedCrashDumpParser := func(wcs *probe.WinCrashStatus) {
+		time.Sleep(4 * time.Second)
+
+		wcs.StatusCode = crashStatus.StatusCode
+		wcs.ErrString = crashStatus.ErrString
+		wcs.DateString = crashStatus.DateString
+		wcs.Offender = crashStatus.Offender
+		wcs.BugCheck = crashStatus.BugCheck
+
+		// Signal that the artificial delay is done.
+		wg.Done()
+	}
+
+	// This ensures that no crash dump parsing should happen.
+	noCrashDumpParser := func(_ *probe.WinCrashStatus) {
+		assert.FailNow(t, "Should not parse")
+	}
+
+	mux.Handle("/windows_crash_detection/check", http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		results := cp.Get()
+		utils.WriteAsJSON(rw, results)
+	}))
+	mux.Handle("/debug/stats", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	}))
+	go server.Serve(listener)
+
+	t.Run("test reporting a crash with a busy intermediate state", func(t *testing.T) {
+		testSetup(t)
+		defer testCleanup()
+
+		check := newCheck()
+		crashCheck := check.(*WinCrashDetect)
+		mock := mocksender.NewMockSender(crashCheck.ID())
+		err := crashCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "")
+		assert.NoError(t, err)
+
+		crashStatus = &probe.WinCrashStatus{
+			StatusCode: probe.WinCrashStatusCodeSuccess,
+			FileName:   `c:\windows\memory.dmp`,
+			Type:       probe.DumpTypeAutomatic,
+			DateString: `Fri Jun 30 15:33:05.086 2023 (UTC - 7:00)`,
+			Offender:   `somedriver.sys`,
+			BugCheck:   "0x00000007",
+		}
+
+		// Test the 2-check response from crash reporting.
+		cp.SetCachedSettings(crashStatus)
+		probe.OverrideCrashDumpParser(delayedCrashDumpParser)
+
+		// First run should be "busy" and not return an event yet.
+		wg.Add(1)
+		err = crashCheck.Run()
+		assert.Nil(t, err)
+		mock.AssertNumberOfCalls(t, "Gauge", 0)
+		mock.AssertNumberOfCalls(t, "Rate", 0)
+		mock.AssertNumberOfCalls(t, "Event", 0)
+		mock.AssertNumberOfCalls(t, "Commit", 0)
+
+		// Wait for the artificial delay to finish, plus a small time buffer.
+		wg.Wait()
+		time.Sleep(4 * time.Second)
+
+		expected := event.Event{
+			Priority:       event.PriorityNormal,
+			SourceTypeName: CheckName,
+			EventType:      CheckName,
+			AlertType:      event.AlertTypeError,
+			Title:          formatTitle(crashStatus),
+			Text:           formatText(crashStatus),
+		}
+
+		mock.On("Event", expected).Return().Times(1)
+		mock.On("Commit").Return().Times(1)
+
+		// The result should be available now.
+		err = crashCheck.Run()
+		assert.Nil(t, err)
+		mock.AssertNumberOfCalls(t, "Gauge", 0)
+		mock.AssertNumberOfCalls(t, "Rate", 0)
+		mock.AssertNumberOfCalls(t, "Event", 1)
+		mock.AssertNumberOfCalls(t, "Commit", 1)
+	})
+
+	t.Run("test that no crash is reported", func(t *testing.T) {
+		testSetup(t)
+		defer testCleanup()
+
+		check := newCheck()
+		crashCheck := check.(*WinCrashDetect)
+		mock := mocksender.NewMockSender(crashCheck.ID())
+		err := crashCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "")
+		assert.NoError(t, err)
+
+		noCrashStatus := &probe.WinCrashStatus{
+			StatusCode: probe.WinCrashStatusCodeSuccess,
+			FileName:   "",
+		}
+
+		// Test finding no crashes. The response should be immediate.
+		cp.SetCachedSettings(noCrashStatus)
+		probe.OverrideCrashDumpParser(noCrashDumpParser)
+		err = crashCheck.Run()
+		assert.Nil(t, err)
+		mock.AssertNumberOfCalls(t, "Gauge", 0)
+		mock.AssertNumberOfCalls(t, "Rate", 0)
+		mock.AssertNumberOfCalls(t, "Event", 0)
+		mock.AssertNumberOfCalls(t, "Commit", 0)
+	})
+
+	t.Run("test failure on reading crash settings", func(t *testing.T) {
+		testSetup(t)
+		defer testCleanup()
+
+		check := newCheck()
+		crashCheck := check.(*WinCrashDetect)
+		mock := mocksender.NewMockSender(crashCheck.ID())
+		err := crashCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "")
+		assert.NoError(t, err)
+
+		failedStatus := &probe.WinCrashStatus{
+			StatusCode: probe.WinCrashStatusCodeFailed,
+			ErrString:  "Mocked failure",
+		}
+
+		// Test having a failure reading setings. The response should be immediate.
+		cp.SetCachedSettings(failedStatus)
+		probe.OverrideCrashDumpParser(noCrashDumpParser)
+		err = crashCheck.Run()
+		assert.NotNil(t, err)
+		mock.AssertNumberOfCalls(t, "Rate", 0)
+		mock.AssertNumberOfCalls(t, "Event", 0)
+		mock.AssertNumberOfCalls(t, "Commit", 0)
 	})
 }

--- a/pkg/util/crashreport/crashreport.go
+++ b/pkg/util/crashreport/crashreport.go
@@ -115,6 +115,13 @@ func (wcr *WinCrashReporter) CheckForCrash() (*probe.WinCrashStatus, error) {
 	if !ok {
 		return nil, fmt.Errorf("Raw data has incorrect type")
 	}
+
+	// Crash dump processing is not done yet, nothing to send at the moment. Try later.
+	if crash.StatusCode == probe.WinCrashStatusCodeBusy {
+		log.Infof("Crash dump processing is busy")
+		return nil, nil
+	}
+
 	/*
 	 * originally did this with a sync.once.  The problem is the check is run prior to the
 	 * system probe being successfully started.  This is OK; we just need to detect the BSOD
@@ -124,7 +131,7 @@ func (wcr *WinCrashReporter) CheckForCrash() (*probe.WinCrashStatus, error) {
 	 * we don't need to run any more
 	 */
 	wcr.hasRunOnce = true
-	if !crash.Success {
+	if crash.StatusCode == probe.WinCrashStatusCodeFailed {
 		return nil, fmt.Errorf("Error getting crash data %s", crash.ErrString)
 	}
 


### PR DESCRIPTION
### What does this PR do?
This is a draft of changes to make Windows crash reports asynchronous.

### Motivation
Crash dumps may be very large (example: 128 GB) and it may take a while for the Windows Windbg subsystem to process the dump.   The queries for crash reports (from agent to system probe) will often timeout before the processing completes. This makes the queries return a "BUSY" status while the crash dump is still being process, and eventually report the result once the processing is done.

### Describe how to test/QA your changes
Using the following query: NamedPipeCmd.exe -method GET -path /windows_crash_detection/check -quiet
-Manually queried system probe for a crash dump in a VM.
-Artificially added a 1 minute sleep in the crash dump processing to verify "BUSY" status and eventual success.

### Possible Drawbacks / Trade-offs

### Additional Notes
