### PR TITLE
[CWS] disable runtime compilation in functional tests

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1878,8 +1878,6 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		"DD_TRACE_PIPE_NAME":                       {},
 		"DD_TRACE_TRANSPORT":                       {},
 		"DD_VERSION":                               {},
-		// this variable is used by CWS functional tests
-		"DD_TESTS_RUNTIME_COMPILED": {},
 		// this variable is used by the Kubernetes leader election mechanism
 		"DD_POD_NAME": {},
 		// this variable is used by tracers

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -71,8 +71,6 @@ system_probe_config:
 
 event_monitoring_config:
   socket: /tmp/test-event-monitor.sock
-  runtime_compilation:
-    enabled: true
   remote_tagger: false
   custom_sensitive_words:
     - "*custom*"

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -791,17 +791,6 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 		return nil, fmt.Errorf("failed to init module: %w", err)
 	}
 
-	kv, _ := kernel.NewKernelVersion()
-
-	var isRuntimeCompiled bool
-	if p, ok := testMod.eventMonitor.Probe.PlatformProbe.(*sprobe.EBPFProbe); ok {
-		isRuntimeCompiled = p.IsRuntimeCompiled()
-	}
-
-	if os.Getenv("DD_TESTS_RUNTIME_COMPILED") == "1" && secconfig.Probe.RuntimeCompilationEnabled && !isRuntimeCompiled && !kv.IsSuseKernel() {
-		return nil, errors.New("failed to runtime compile module")
-	}
-
 	if opts.staticOpts.preStartCallback != nil {
 		opts.staticOpts.preStartCallback(testMod)
 	}

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -122,9 +122,7 @@ describe "security-agent" do
   case cws_platform
   when "host"
     context 'functional tests running directly on host' do
-      env = {
-        "DD_TESTS_RUNTIME_COMPILED"=>"1",
-      }
+      env = {}
       include_examples "passes", "host", env
     end
   when "host-fentry"
@@ -150,7 +148,6 @@ describe "security-agent" do
     context 'activity dump functional test running on dedicated node' do
       env = {
         "DEDICATED_ACTIVITY_DUMP_NODE"=>"1",
-        "DD_TESTS_RUNTIME_COMPILED"=>"1",
       }
       include_examples "passes", "ad", env
     end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

runtime compilation is disabled for CWS/event monitor by default. In order to have functional tests matching more closely what is shipped to clients, this PR disables runtime compilation in tests.

N.B: runtime compilation is still tested through the `TestOctogonConstants` test which still checks that rc is able to provide constants

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->