### PR TITLE
Make gitlab ci linters do not fail fast

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -109,4 +109,3 @@ job-owners:
     - unit_tests_notify
     - update_rc_build_links
     - validate_modules
-    - a

--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -109,3 +109,4 @@ job-owners:
     - unit_tests_notify
     - update_rc_build_links
     - validate_modules
+    - a

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -62,8 +62,10 @@ lint_gitlab_ci:
     - !reference [.compute_gitlab_ci_config_rules]
     - !reference [.on_gitlab_changes_or_mergequeue_or_main]
   script:
-    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml
-    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml
+    - status=0
+    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml; if [ $? -ne 0 ]; then status=1; fi
+    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml; if [ $? -ne 0 ]; then status=1; fi
+    - exit $status
 
 lint_gitlab_ci_jobs_codeowners:
   stage: .pre

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -65,7 +65,11 @@ lint_gitlab_ci:
     - status=0
     - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml || status=1; true
     - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml || status=1; true
-    - exit $status
+    - |
+      if [ $status != 0 ]; then
+        echo "At least one linter failed, exiting..." >& 2
+        exit $status
+      fi
 
 lint_gitlab_ci_jobs_codeowners:
   stage: .pre

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -63,8 +63,8 @@ lint_gitlab_ci:
     - !reference [.on_gitlab_changes_or_mergequeue_or_main]
   script:
     - status=0
-    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml; if [ $? -ne 0 ]; then status=1; fi
-    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml; if [ $? -ne 0 ]; then status=1; fi
+    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml || status=1; true
+    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml || status=1; true
     - exit $status
 
 lint_gitlab_ci_jobs_codeowners:

--- a/.gitlab/.pre/gitlab_configuration.yml
+++ b/.gitlab/.pre/gitlab_configuration.yml
@@ -63,8 +63,8 @@ lint_gitlab_ci:
     - !reference [.on_gitlab_changes_or_mergequeue_or_main]
   script:
     - status=0
-    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml || status=1; true
-    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml || status=1; true
+    - inv -e linter.gitlab-ci-jobs-needs-rules --config-file artifacts/after.gitlab-ci.yml || status=1
+    - inv -e linter.gitlab-ci-jobs-owners --config-file artifacts/after.gitlab-ci.yml || status=1
     - |
       if [ $status != 0 ]; then
         echo "At least one linter failed, exiting..." >& 2


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This executes linters and then exit if one of them fail, all linters are always executed

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->