### PR TITLE
fix(fetch_secret): Transfer the exit code in windows context

### DIFF
--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -12,6 +12,7 @@ publish_choco_7_x64:
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:CHOCOLATEY_API_KEY" -tempFile "$tmpfile")
+    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - $chocolateyApiKey=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"

--- a/.gitlab/choco_deploy/choco_deploy.yml
+++ b/.gitlab/choco_deploy/choco_deploy.yml
@@ -12,8 +12,7 @@ publish_choco_7_x64:
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:CHOCOLATEY_API_KEY" -tempFile "$tmpfile")
-    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - $chocolateyApiKey=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"
   script:

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -34,7 +34,7 @@
       -v "$(Get-Location):C:\mnt"
       -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       powershell
-      -C C:\mnt\tools\ci\docker-login.ps1
+      -File C:\mnt\tools\ci\docker-login.ps1
     - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -35,6 +35,7 @@
       -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       powershell
       -C C:\mnt\tools\ci\docker-login.ps1
+    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -35,8 +35,7 @@
       -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       powershell
       -File C:\mnt\tools\ci\docker-login.ps1
-    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker push ${TARGET_TAG}"

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -12,8 +12,7 @@ publish_winget_7_x64:
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:WINGET_PAT" -tempFile "$tmpfile")
-    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - $wingetPat=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"
   script:

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -12,6 +12,7 @@ publish_winget_7_x64:
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:WINGET_PAT" -tempFile "$tmpfile")
+    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - $wingetPat=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -9,6 +9,7 @@
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -tempFile "$tmpfile")
+    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - $vcpkgBlobSaSUrl=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -9,8 +9,7 @@
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -tempFile "$tmpfile")
-    - If ($lastExitCode -eq "42") { exit "$lastExitCode" }
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - $vcpkgBlobSaSUrl=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"
   script:

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -46,7 +46,7 @@
       -e COVERAGE_CACHE_FLAG="${COVERAGE_CACHE_FLAG}"
       486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       c:\mnt\tasks\winbuildscripts\unittests.bat
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
   variables:
     TEST_OUTPUT_FILE: test_output.json
   artifacts:

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -15,7 +15,15 @@ xcopy /e/s/h/q c:\mnt\*.*
 call %TEST_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %TEST_ROOT%\datadog-agent modcache
 call %TEST_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %TEST_ROOT%\datadog-agent modcache_tools
 
-Powershell -C "%TEST_ROOT%\datadog-agent\tasks\winbuildscripts\unittests.ps1" || exit /b 2
+Powershell -File "%TEST_ROOT%\datadog-agent\tasks\winbuildscripts\unittests.ps1"
+if %ERRORLEVEL% neq 0 (
+    if %ERRORLEVEL% == 42 (
+        echo "Issue with aws, need job restart"
+        exit /b 42
+    ) else (
+        exit /b 2
+    )
+)
 
 goto :EOF
 

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -17,12 +17,7 @@ call %TEST_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %TEST_
 
 Powershell -File "%TEST_ROOT%\datadog-agent\tasks\winbuildscripts\unittests.ps1"
 if %ERRORLEVEL% neq 0 (
-    if %ERRORLEVEL% == 42 (
-        echo "Issue with aws, need job restart"
-        exit /b 42
-    ) else (
-        exit /b 2
-    )
+    exit /b %ERRORLEVEL%
 )
 
 goto :EOF

--- a/tools/ci/docker-login.ps1
+++ b/tools/ci/docker-login.ps1
@@ -10,13 +10,13 @@ $tmpfile = [System.IO.Path]::GetTempFileName()
 & "C:\mnt\tools\ci\fetch_secret.ps1" -parameterName "$Env:DOCKER_REGISTRY_LOGIN" -tempFile "$tmpfile"
 If ($lastExitCode -ne "0") {
     Write-Host "Previous command returned $lastExitCode"
-    exit $lastExitCode
+    exit "$lastExitCode"
 }
 $DOCKER_REGISTRY_LOGIN = $(cat "$tmpfile")
 & "C:\mnt\tools\ci\fetch_secret.ps1" -parameterName "$Env:DOCKER_REGISTRY_PWD" -tempFile "$tmpfile"
 If ($lastExitCode -ne "0") {
     Write-Host "Previous command returned $lastExitCode"
-    exit $lastExitCode
+    exit "$lastExitCode"
 }
 $DOCKER_REGISTRY_PWD = $(cat "$tmpfile")
 Remove-Item "$tmpfile"

--- a/tools/ci/docker-login.ps1
+++ b/tools/ci/docker-login.ps1
@@ -9,12 +9,14 @@ If ($lastExitCode -ne "0") {
 $tmpfile = [System.IO.Path]::GetTempFileName()
 & "C:\mnt\tools\ci\fetch_secret.ps1" -parameterName "$Env:DOCKER_REGISTRY_LOGIN" -tempFile "$tmpfile"
 If ($lastExitCode -ne "0") {
-    throw "Previous command returned $lastExitCode"
+    Write-Host "Previous command returned $lastExitCode"
+    exit $lastExitCode
 }
 $DOCKER_REGISTRY_LOGIN = $(cat "$tmpfile")
 & "C:\mnt\tools\ci\fetch_secret.ps1" -parameterName "$Env:DOCKER_REGISTRY_PWD" -tempFile "$tmpfile"
 If ($lastExitCode -ne "0") {
-    throw "Previous command returned $lastExitCode"
+    Write-Host "Previous command returned $lastExitCode"
+    exit $lastExitCode
 }
 $DOCKER_REGISTRY_PWD = $(cat "$tmpfile")
 Remove-Item "$tmpfile"


### PR DESCRIPTION
### What does this PR do?
Currently when facing an `Unable to locate` credential issue on windows we are not using the `retry:exit_codes`. To do so we need to transfer the $lastExitCode up to the Gitlab script

### Motivation
Have an automatic retry in [this situation ](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/668540879)

### Describe how to test/QA your changes
Tested the basics of calling `powershell` to get the correct exit code:
```
PS C:\Users\Administrator> powershell -C .\fail.ps1
PS C:\Users\Administrator> Write-Host $lastexitcode
1
PS C:\Users\Administrator> powershell -File .\fail.ps1
PS C:\Users\Administrator> Write-Host $lastexitcode
42
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->