### PR TITLE
[AMLII-2108] Manually set file mod time so scanIntialFiles detects them correctly

### DIFF
--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -8,7 +8,6 @@ package integration
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 type LauncherTestSuite struct {
@@ -43,10 +41,6 @@ type LauncherTestSuite struct {
 }
 
 func (suite *LauncherTestSuite) SetupTest() {
-	if runtime.GOOS == "windows" {
-		flake.Mark(suite.T())
-	}
-
 	suite.pipelineProvider = mock.NewMockProvider()
 	suite.outputChan = suite.pipelineProvider.NextPipelineChan()
 	suite.integrationsComp = integrationsmock.Mock()

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -399,8 +399,9 @@ func (suite *LauncherTestSuite) TestSentLogExceedsTotalUsage() {
 	// scanInitialFiles function to detect them in a deterministic manner
 	modTime := time.Now()
 	accessTime := time.Now()
-	os.Chtimes(fileWithPath2, accessTime, modTime)
-	os.Chtimes(fileWithPath3, accessTime, modTime.Add(1*time.Minute))
+	os.Chtimes(fileWithPath1, accessTime, modTime.Add(-2*time.Minute))
+	os.Chtimes(fileWithPath2, accessTime, modTime.Add(-1*time.Minute))
+	os.Chtimes(fileWithPath3, accessTime, modTime)
 
 	suite.s.Start(nil, nil, nil, nil)
 

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -385,19 +386,27 @@ func (suite *LauncherTestSuite) TestSentLogExceedsTotalUsage() {
 	suite.s.combinedUsageMax = 3 * 1024 * 1024
 
 	// Given 3 files exist
-	filename1 := "sample_integration1_123.log"
-	filename2 := "sample_integration2_123.log"
-	filename3 := "sample_integration3_123.log"
-	files := [3]string{filename1, filename2, filename3}
+	fileWithPath1 := filepath.Join(suite.s.runPath, "sample_integration1_123.log")
+	fileWithPath2 := filepath.Join(suite.s.runPath, "sample_integration2_123.log")
+	fileWithPath3 := filepath.Join(suite.s.runPath, "sample_integration3_123.log")
+	fileNames := [3]string{fileWithPath1, fileWithPath2, fileWithPath3}
 
 	//  And I write 1Mb to each file in seq order
 	dataOneMB := make([]byte, 1*1024*1024)
-	for _, filename := range files {
-		file, err := os.Create(filepath.Join(suite.s.runPath, filename))
+	for _, fileWithPath := range fileNames {
+		file, err := os.Create(fileWithPath)
 		require.NoError(suite.T(), err)
 		_, _ = file.Write(dataOneMB)
 		_ = file.Close()
 	}
+
+	// If the files have the same timestamp, scanInitialFiles will detect them in
+	// random order. Setting their modified time manually allows the
+	// scanInitialFiles function to detect them in a deterministic manner
+	modTime := time.Now()
+	accessTime := time.Now()
+	os.Chtimes(fileWithPath2, accessTime, modTime)
+	os.Chtimes(fileWithPath3, accessTime, modTime.Add(1*time.Minute))
 
 	suite.s.Start(nil, nil, nil, nil)
 
@@ -410,8 +419,8 @@ func (suite *LauncherTestSuite) TestSentLogExceedsTotalUsage() {
 	suite.s.receiveLogs(integrationLog)
 
 	var actualSize int64
-	for _, filename := range files {
-		file, err := os.Stat(filepath.Join(suite.s.runPath, filename))
+	for _, fileWithPath := range fileNames {
+		file, err := os.Stat(fileWithPath)
 		require.Nil(suite.T(), err)
 		actualSize += file.Size()
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates `TestSentLogExceedsTotalUsage` to manually set the individual files' mod times so that the `scanInitialFiles` function can detect them deterministically. Previously, the files were created (and modified) with the exact same timestamp, so `scanInitialFiles` would detect them in a random order, leading to flakiness. This change guarantees that won't happen.

### Motivation

Fixing flaky test.

### Describe how to test/QA your changes

N/A

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->