### PR TITLE
remove stale unit test

### DIFF
--- a/pkg/util/containers/entity_test.go
+++ b/pkg/util/containers/entity_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 )
 
 func TestBuildEntityName(t *testing.T) {
@@ -31,23 +29,6 @@ func TestBuildEntityName(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.expected), func(t *testing.T) {
 			out := BuildEntityName(tc.runtime, tc.cID)
-			assert.Equal(t, tc.expected, out)
-		})
-	}
-}
-
-func TestBuildTaggerEntityName(t *testing.T) {
-	for nb, tc := range []struct {
-		cID      string
-		expected string
-	}{
-		// Empty
-		{"", "container_id://"},
-		// Empty runtime
-		{"5bef08742407ef", "container_id://5bef08742407ef"},
-	} {
-		t.Run(fmt.Sprintf("case %d: %s", nb, tc.expected), func(t *testing.T) {
-			out := types.NewEntityID(types.ContainerID, tc.cID).String()
 			assert.Equal(t, tc.expected, out)
 		})
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

See title. 

### Motivation

The removed unit test was testing the function [BuildTaggerEntityName](https://github.com/DataDog/datadog-agent/blob/e3501142eef52cfbde578bd94ecb6a06d25571b5/pkg/util/containers/entity.go#L30-L36) which is now removed, so no need for the unit test anymore. 

### Describe how to test/QA your changes

No need for qa. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->