### PR TITLE
Add gitlab-ci linters to a pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
     - id: gitlab-configuration
       name: gitlab-configuration
       description: test the gitlab configuration on main
-      entry: 'inv linter.gitlab-ci -t main'
+      entry: 'inv pre-commit.gitlab-config-prepush'
       language: system
       require_serial: true
       files: .*gitlab.*\.yml$


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

> [!NOTE]
> The pre-push takes 34s and was taking 16s before

This adds a prepush hook to run all the long gitlab ci linters

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->