### PR TITLE
[EBPF] Fix TestAttacherSharedLibrary flaky test

### DIFF
--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -821,8 +821,10 @@ func (s *SharedLibrarySuite) TestSingleFile() {
 		func() bool {
 			return methodHasBeenCalledTimes(mockRegistry, "Register", 1)
 		},
-		func() {
-			if cmd != nil && cmd.Process != nil {
+		func(testSuccess bool) {
+			// Only kill the process if the test failed, if it succeeded we want to kill it later
+			// to check if the Unregister call was done correctly
+			if !testSuccess && cmd != nil && cmd.Process != nil {
 				cmd.Process.Kill()
 			}
 		},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Another attempt to fix a flake in `TestAttacherSharedLibrary` by fixing the retry mechanism introduced in [the previous PR](https://github.com/DataDog/datadog-agent/pull/29718). In that PR, the cleanup function is always being called after each retry, which means that we might kill the PID, receive and process that event and _then_ clean the list of received calls in the mock. This PR changes that behavior so that the process is only killed when we have missed the creation event. If it's not missed, we continue as normal.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->