### PR TITLE
[ASCII-2387] Remove flake marker in windows e2e test

### DIFF
--- a/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/non_core_agents_sync_win_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
@@ -30,9 +29,6 @@ type configRefreshWindowsSuite struct {
 }
 
 func TestConfigRefreshWindowsSuite(t *testing.T) {
-	// WINA-1014
-	flake.Mark(t)
-
 	t.Parallel()
 	e2e.Run(t, &configRefreshWindowsSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }

--- a/test/new-e2e/tests/agent-shared-components/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-shared-components/secret/secret_win_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	secrets "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/secretsutils"
@@ -27,9 +26,6 @@ type windowsRuntimeSecretSuite struct {
 }
 
 func TestWindowsRuntimeSecretSuite(t *testing.T) {
-	// WINA-1014
-	flake.Mark(t)
-
 	t.Parallel()
 	e2e.Run(t, &windowsRuntimeSecretSuite{}, e2e.WithProvisioner(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),

--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_ec2_win_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
@@ -24,9 +23,6 @@ type windowsHostnameSuite struct {
 }
 
 func TestWindowsHostnameSuite(t *testing.T) {
-	// WINA-1014
-	flake.Mark(t)
-
 	t.Parallel()
 	osOption := awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault))
 	e2e.Run(t, &windowsHostnameSuite{baseHostnameSuite: baseHostnameSuite{osOption: osOption}}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(osOption)))

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_win_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
@@ -28,8 +27,6 @@ type windowsSecretSuite struct {
 }
 
 func TestWindowsSecretSuite(t *testing.T) {
-	// WINA-1014
-	flake.Mark(t)
 	t.Parallel()
 	e2e.Run(t, &windowsSecretSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove the flake marker in Windows e2e tests.

### Motivation
They are marked as flaky due to a bug in the windows agent restart logic.
The framework had a workaround, which was reverted, but now the revert has been reverted so they should be reliable again https://github.com/DataDog/test-infra-definitions/pull/1179.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->