### PR TITLE
[CWS] Log errors when stopping the `eventmonitor` module

### DIFF
--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -11,7 +11,6 @@ package eventmonitor
 import (
 	"context"
 	"fmt"
-	"net"
 	"slices"
 	"sync"
 	"time"
@@ -55,7 +54,6 @@ type EventMonitor struct {
 	cancelFnc      context.CancelFunc
 	sendStatsChan  chan chan bool
 	eventConsumers []EventConsumerInterface
-	netListener    net.Listener
 	wg             sync.WaitGroup
 }
 
@@ -107,8 +105,6 @@ func (m *EventMonitor) Start() error {
 	if err != nil {
 		return fmt.Errorf("unable to register event monitoring module: %w", err)
 	}
-
-	m.netListener = ln
 
 	m.wg.Add(1)
 	go func() {
@@ -167,12 +163,6 @@ func (m *EventMonitor) Close() {
 
 	if m.GRPCServer != nil {
 		m.GRPCServer.Stop()
-	}
-
-	if m.netListener != nil {
-		if err := m.netListener.Close(); err != nil {
-			seclog.Errorf("failed to close event montior socket: %v", err)
-		}
 	}
 
 	if err := m.cleanup(); err != nil {

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -170,16 +170,22 @@ func (m *EventMonitor) Close() {
 	}
 
 	if m.netListener != nil {
-		m.netListener.Close()
+		if err := m.netListener.Close(); err != nil {
+			seclog.Errorf("failed to close event montior socket: %v", err)
+		}
 	}
 
-	m.cleanup()
+	if err := m.cleanup(); err != nil {
+		seclog.Errorf("failed to cleanup event monitor: %v", err)
+	}
 
 	m.cancelFnc()
 	m.wg.Wait()
 
 	// all the go routines should be stopped now we can safely call close the probe and remove the eBPF programs
-	m.Probe.Close()
+	if err := m.Probe.Close(); err != nil {
+		seclog.Errorf("failed to close event monitor probe: %v", err)
+	}
 }
 
 // SendStats send stats

--- a/pkg/eventmonitor/eventmonitor_linux.go
+++ b/pkg/eventmonitor/eventmonitor_linux.go
@@ -26,10 +26,15 @@ func (m *EventMonitor) getListener() (net.Listener, error) {
 
 func (m *EventMonitor) init() error {
 	// force socket cleanup of previous socket not cleanup
-	os.Remove(m.Config.SocketPath)
+	if err := os.Remove(m.Config.SocketPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	return nil
 }
 
-func (m *EventMonitor) cleanup() {
-	os.Remove(m.Config.SocketPath)
+func (m *EventMonitor) cleanup() error {
+	if err := os.Remove(m.Config.SocketPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }

--- a/pkg/eventmonitor/eventmonitor_windows.go
+++ b/pkg/eventmonitor/eventmonitor_windows.go
@@ -19,4 +19,6 @@ func (m *EventMonitor) init() error {
 	return nil
 }
 
-func (m *EventMonitor) cleanup() {}
+func (m *EventMonitor) cleanup() error {
+	return nil
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Starts logging errors occuring when the eventmonitor module is stopped
- Avoids closing the eventmonitor gRPC socket twice (as the gRPC server is already closing it when stopped)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->