### PR TITLE
Add back hostname_force_config_as_canonical.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -270,6 +270,7 @@
 /docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
 
 /docs/public/components/                                     @DataDog/documentation @DataDog/agent-shared-components
+/docs/public/hostname/                                       @DataDog/documentation @DataDog/agent-shared-components
 /docs/public/architecture/dogstatsd/                         @DataDog/documentation @DataDog/agent-metrics-logs
 /docs/public/guidelines/deprecated-components-documentation/ @DataDog/documentation @DataDog/agent-shared-components
 

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -17,5 +17,5 @@ If this warning is logged, you have the following options:
 
 Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` is accepted as the canonical hostname in-app:
 
-- for new hosts, enabling this option works immediately
+- For new hosts, enabling this option works immediately.
 - for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -8,7 +8,7 @@ More information about what a canonical hostname is can be found at [How does Da
 To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
 `Hostname '<HOSTNAME>' defined in configuration are not used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical`
 
-If this warning is logged, you can either:
+If this warning is logged, you have the following options:
 
 - if you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
 - if you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -1,0 +1,21 @@
+# Config-provided hostname starting with `ip-` or `domu`
+
+## Description of the issue
+
+In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
+More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
+
+To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
+`Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical`
+
+If this warning is logged, you can either:
+
+- if you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
+- if you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below
+
+## Allowing Agent in-app hostnames to start with `ip-` or `domu`
+
+Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app:
+
+- for new hosts, enabling this option will work immediately
+- for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -17,5 +17,5 @@ If this warning is logged, you have the following options:
 
 Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` is accepted as the canonical hostname in-app:
 
-- for new hosts, enabling this option will work immediately
+- for new hosts, enabling this option works immediately
 - for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -18,4 +18,4 @@ If this warning is logged, you have the following options:
 Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` is accepted as the canonical hostname in-app:
 
 - For new hosts, enabling this option works immediately.
-- for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.
+- For hosts that already report to Datadog, after enabling this option, contact Datadog support at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -15,7 +15,7 @@ If this warning is logged, you have the following options:
 
 ## Allowing Agent in-app hostnames to start with `ip-` or `domu`
 
-Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app:
+Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` is accepted as the canonical hostname in-app:
 
 - for new hosts, enabling this option will work immediately
 - for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -6,7 +6,7 @@ In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
 To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
-`Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical`
+`Hostname '<HOSTNAME>' defined in configuration are not used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical`
 
 If this warning is logged, you can either:
 

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -2,7 +2,7 @@
 
 ## Description of the issue
 
-In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
+In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even if it is a valid hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
 To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -10,7 +10,7 @@ To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agen
 
 If this warning is logged, you have the following options:
 
-- if you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
+- If you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
 - if you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below
 
 ## Allowing Agent in-app hostnames to start with `ip-` or `domu`

--- a/docs/public/hostname/hostname_force_config_as_canonical.md
+++ b/docs/public/hostname/hostname_force_config_as_canonical.md
@@ -11,7 +11,7 @@ To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agen
 If this warning is logged, you have the following options:
 
 - If you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
-- if you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below
+- If you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below
 
 ## Allowing Agent in-app hostnames to start with `ip-` or `domu`
 


### PR DESCRIPTION
<!--
https://datadoghq.atlassian.net/browse/ASCII-2406
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add back `hostname_force_config_as_canonical.md` which was removed by https://github.com/DataDog/datadog-agent/pull/26037.

### Motivation
The file is referenced by https://dtdg.co/agent-hostname-force-config-as-canonical (currently dead, will update once this is merged), the link is printed by the agent when specific hostname issues occur in order to help users.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Copy pasted the file from its [last version](https://github.com/DataDog/datadog-agent/blob/40f9f7916c78dd13705e4248276a5779d8ec8ab6/docs%2Fagent%2Fhostname_force_config_as_canonical.md).