### PR TITLE
[CWS] make `forkExec` nosplit, so that it's not preemptible before the exec

### DIFF
--- a/pkg/security/ptracer/exec.go
+++ b/pkg/security/ptracer/exec.go
@@ -118,7 +118,5 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 }
 
 func exit(errno syscall.Errno) {
-	for {
-		_, _, _ = syscall.RawSyscall(syscall.SYS_EXIT, uintptr(errno), 0, 0)
-	}
+	_, _, _ = syscall.RawSyscall(syscall.SYS_EXIT, uintptr(errno), 0, 0)
 }

--- a/pkg/security/ptracer/exec.go
+++ b/pkg/security/ptracer/exec.go
@@ -24,7 +24,6 @@ func runtimeAfterFork()
 func runtimeAfterForkInChild()
 
 //go:norace
-//go:nosplit
 func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *syscall.SockFprog) (int, error) {
 	argv0p, err := syscall.BytePtrFromString(argv0)
 	if err != nil {
@@ -41,6 +40,20 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 		return 0, err
 	}
 
+	pid, errno := forkExec1(argv0p, argvp, envvp, creds, prog)
+	if errno != 0 {
+		exit(errno)
+	}
+
+	return pid, nil
+}
+
+// forkExec1 does the actual forking and execing, it should have the smallest possible stack to not overflow
+// because of the `nosplit`
+//
+//go:norace
+//go:nosplit
+func forkExec1(argv0 *byte, argv []*byte, envv []*byte, creds Creds, prog *syscall.SockFprog) (int, syscall.Errno) {
 	syscall.ForkLock.Lock()
 
 	// no more go runtime calls
@@ -52,11 +65,7 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 		runtimeAfterFork()
 
 		syscall.ForkLock.Unlock()
-
-		if errno != 0 {
-			return int(pid), errno
-		}
-		return int(pid), nil
+		return int(pid), errno
 	}
 
 	// in the child, no more go runtime calls
@@ -64,17 +73,17 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 
 	pid, _, errno = syscall.RawSyscall(syscall.SYS_GETPID, 0, 0, 0)
 	if errno != 0 {
-		exit(errno)
+		return 0, errno
 	}
 
 	_, _, errno = syscall.RawSyscall(syscall.SYS_PTRACE, uintptr(syscall.PTRACE_TRACEME), 0, 0)
 	if errno != 0 {
-		exit(errno)
+		return 0, errno
 	}
 
 	_, _, errno = syscall.RawSyscall6(syscall.SYS_PRCTL, unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0, 0)
 	if errno != 0 {
-		exit(errno)
+		return 0, errno
 	}
 
 	const (
@@ -85,19 +94,19 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 	if prog != nil {
 		_, _, errno = syscall.RawSyscall(unix.SYS_SECCOMP, mode, tsync, uintptr(unsafe.Pointer(prog)))
 		if errno != 0 {
-			exit(errno)
+			return 0, errno
 		}
 	}
 
 	_, _, errno = syscall.RawSyscall(syscall.SYS_KILL, pid, uintptr(syscall.SIGSTOP), 0)
 	if errno != 0 {
-		exit(errno)
+		return 0, errno
 	}
 
 	if creds.GID != nil {
 		_, _, errno = syscall.RawSyscall(syscall.SYS_SETGID, uintptr(*creds.GID), 0, 0)
 		if errno != 0 {
-			exit(errno)
+			return 0, errno
 		}
 
 	}
@@ -105,19 +114,16 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 	if creds.UID != nil {
 		_, _, errno = syscall.RawSyscall(syscall.SYS_SETUID, uintptr(*creds.UID), 0, 0)
 		if errno != 0 {
-			exit(errno)
+			return 0, errno
 		}
 	}
 
 	_, _, errno = syscall.RawSyscall(syscall.SYS_EXECVE,
-		uintptr(unsafe.Pointer(argv0p)),
-		uintptr(unsafe.Pointer(&argvp[0])),
-		uintptr(unsafe.Pointer(&envvp[0])))
-	if errno != 0 {
-		exit(errno)
-	}
+		uintptr(unsafe.Pointer(argv0)),
+		uintptr(unsafe.Pointer(&argv[0])),
+		uintptr(unsafe.Pointer(&envv[0])))
 
-	return 0, err
+	return 0, errno
 }
 
 func exit(errno syscall.Errno) {

--- a/pkg/security/ptracer/exec.go
+++ b/pkg/security/ptracer/exec.go
@@ -54,9 +54,9 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 		syscall.ForkLock.Unlock()
 
 		if errno != 0 {
-			err = errno
+			return int(pid), errno
 		}
-		return int(pid), err
+		return int(pid), nil
 	}
 
 	// in the child, no more go runtime calls
@@ -109,10 +109,13 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 		}
 	}
 
-	_, _, err = syscall.RawSyscall(syscall.SYS_EXECVE,
+	_, _, errno = syscall.RawSyscall(syscall.SYS_EXECVE,
 		uintptr(unsafe.Pointer(argv0p)),
 		uintptr(unsafe.Pointer(&argvp[0])),
 		uintptr(unsafe.Pointer(&envvp[0])))
+	if errno != 0 {
+		exit(errno)
+	}
 
 	return 0, err
 }

--- a/pkg/security/ptracer/exec.go
+++ b/pkg/security/ptracer/exec.go
@@ -23,8 +23,9 @@ func runtimeAfterFork()
 //go:linkname runtimeAfterForkInChild syscall.runtime_AfterForkInChild
 func runtimeAfterForkInChild()
 
-//go:norace
 //nolint:unused
+//go:norace
+//go:nosplit
 func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *syscall.SockFprog) (int, error) {
 	argv0p, err := syscall.BytePtrFromString(argv0)
 	if err != nil {

--- a/pkg/security/ptracer/exec.go
+++ b/pkg/security/ptracer/exec.go
@@ -23,7 +23,6 @@ func runtimeAfterFork()
 //go:linkname runtimeAfterForkInChild syscall.runtime_AfterForkInChild
 func runtimeAfterForkInChild()
 
-//nolint:unused
 //go:norace
 //go:nosplit
 func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *syscall.SockFprog) (int, error) {
@@ -118,7 +117,6 @@ func forkExec(argv0 string, argv []string, envv []string, creds Creds, prog *sys
 	return 0, err
 }
 
-//nolint:unused
 func exit(errno syscall.Errno) {
 	for {
 		_, _, _ = syscall.RawSyscall(syscall.SYS_EXIT, uintptr(errno), 0, 0)


### PR DESCRIPTION
### What does this PR do?

Small PR adding `nosplit` to forkExec. This ensure that this function is not preempted, especially not by a stack growth request from the runtime. This should prevent some issues with crashing between the fork and the exec like:
```
$ /cws-instrumentation-volume/cws-instrumentation trace --async -- ./scratch.sh 
fatal error: stack growth after fork

runtime stack:
runtime.throw(¨0x76d3ac?, 0x0?¼)
	/usr/local/go/src/runtime/panic.go:1023 +0x5c fp=0x7ffe0cad3d88 sp=0x7ffe0cad3d58 pc=0x43bf7c
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:966 +0xbe7 fp=0x7ffe0cad3f38 sp=0x7ffe0cad3d88 pc=0x457da7
runtime.morestack()
	/usr/local/go/src/runtime/asm_amd64.s:616 +0x7a fp=0x7ffe0cad3f40 sp=0x7ffe0cad3f38 pc=0x46f67a

goroutine 1 gp=0xc0000061c0 m=0 mp=0xa30f20 running, locked to thread¦:
runtime.convT64(0x8?)
	/usr/local/go/src/runtime/iface.go:378 +0x59 fp=0xc00010f898 sp=0xc00010f890 pc=0x40ef59
github.com/DataDog/datadog-agent/pkg/security/ptracer.forkExec(¨0xc000012580?, 0x18?¼, ¨0xc0001994d0, 0x1, 0x3¼, ¨0xc0000163c0, 0x1d, 0x1d¼, ¨0x0, 0x0¼, ...)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/exec.go:112 +0x305 fp=0xc00010f948 sp=0xc00010f898 pc=0x697085
github.com/DataDog/datadog-agent/pkg/security/ptracer.(*CWSPtracerCtx).NewTracer(0xc0001946e0)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/ptracer.go:565 +0x13d fp=0xc00010fa78 sp=0xc00010f948 pc=0x6a63dd
github.com/DataDog/datadog-agent/pkg/security/ptracer.Wrap(¨0xc0001994d0?, 0x0?, 0x0?¼, ¨0xc0000163c0?, 0x0?, 0x0?¼, ¨0x769423?, 0x0?¼, ¨¨0x0, 0x0¼, ...¼)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ptracer/cws.go:430 +0x7c fp=0xc00010fb10 sp=0xc00010fa78 pc=0x69699c
github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/tracecmd.Command.func1(0xc0000ee800?, ¨0xc0001994d0, 0x1, 0x3¼)
	/go/src/github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/tracecmd/trace.go:207 +0x39d fp=0xc00010fc68 sp=0xc00010fb10 pc=0x6af75d
github.com/spf13/cobra.(*Command).execute(0xc0001a4908, ¨0xc000199440, 0x3, 0x3¼)
	/go/pkg/mod/github.com/spf13/cobra¾v1.8.1/command.go:985 +0xaca fp=0xc00010fdf0 sp=0xc00010fc68 pc=0x5bb2ca
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001a4008)
	/go/pkg/mod/github.com/spf13/cobra¾v1.8.1/command.go:1117 +0x3ff fp=0xc00010fec8 sp=0xc00010fdf0 pc=0x5bbb9f
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra¾v1.8.1/command.go:1041
github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run(0xc0001a4008)
	/go/src/github.com/DataDog/datadog-agent/cmd/internal/runcmd/runcmd.go:27 +0x25 fp=0xc00010ff08 sp=0xc00010fec8 pc=0x6b0f25
main.main()
	/go/src/github.com/DataDog/datadog-agent/cmd/cws-instrumentation/main_linux.go:20 +0x65 fp=0xc00010ff50 sp=0xc00010ff08 pc=0x6b11c5
runtime.main()
	/usr/local/go/src/runtime/proc.go:271 +0x29d fp=0xc00010ffe0 sp=0xc00010ff50 pc=0x43ea3d
runtime.goexit(¨¼)
	/usr/local/go/src/runtime/asm_amd64.s:1695 +0x1 fp=0xc00010ffe8 sp=0xc00010ffe0 pc=0x4713a1
```

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->