### PR TITLE
Add DD_PING_ENABLED to config_template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1899,6 +1899,7 @@ api_key:
 
 # ping:
   ## @param enabled - boolean - optional - default: false
+  ## @env DD_PING_ENABLED - boolean - optional - default: false
   ## Set to true to enable the Ping Module of the System Probe
   #
   # enabled: false


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Adds `DD_PING_ENABLED` environmental variable to example `datadog.yaml` file 

### Motivation

* To guide users enabling Ping for SNMP check in containerized environments

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->