### PR TITLE
[usm] remove unneeded slice allocation from `(*EventWrapper).Operation`

### DIFF
--- a/pkg/network/protocols/postgres/model_linux.go
+++ b/pkg/network/protocols/postgres/model_linux.go
@@ -72,7 +72,8 @@ func getFragment(e *ebpf.EbpfTx) []byte {
 // Operation returns the operation of the query (SELECT, INSERT, UPDATE, DROP, etc.)
 func (e *EventWrapper) Operation() Operation {
 	if !e.operationSet {
-		e.operation = FromString(string(bytes.SplitN(getFragment(&e.Tx), []byte(" "), 2)[0]))
+		op, _, _ := bytes.Cut(getFragment(&e.Tx), []byte(" "))
+		e.operation = FromString(string(op))
 		e.operationSet = true
 	}
 	return e.operation


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[Profile showing this function allocating a non-negligable amount of memory](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe%20version%3A_7_59_0_rc.1__147c1a8085_&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AgAAAZKAtUNePkOq0AAAAAAAAAAYAAAAAEFaS0F0VVBIQUFCbTU3bkM4UlMzY2dBQQAAACQAAAAAMDE5MjgwYjktYTQ0Zi00ZDMzLTg1YjItMGUyM2I3ZTZhOTVk&my_code=disabled&op_filter=ignore_from%28function%3A%22%28%2AEventWrapper%29.extractTableName%22%29&profile_type=alloc-size&profileId=AZKAtUPHAABm57nC8RS3cgAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1728734842330&to_ts=1728738442330&live=false).

The usage of `bytes.SplitN` in this function allocates a slice, of which we only take the first value. The usage of `bytes.Cut` will do the same things but directly return the sub-slice matching this first value, without any allocation.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->