### PR TITLE
ebpfcheck: make sure we do not do expensive task if logger is not tracing

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/features"
@@ -305,9 +306,11 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 		stats.Programs = append(stats.Programs, ps)
 	}
 
-	log.Tracef("found %d programs", len(stats.Programs))
-	for _, ps := range stats.Programs {
-		log.Tracef("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("found %d programs", len(stats.Programs))
+		for _, ps := range stats.Programs {
+			log.Tracef("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

Those `log.Trace` calls can be quite expensive (slice of arguments for the variadic call, iteration over `stats.Programs`). The goal of this PR is to add a check for the log level before even doing the `log.Trace` calls, in order to skip this altogether if we won't need it anyway.

[Interesting profile where I saw this](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe%20version%3A_7_59_0_rc.1__147c1a8085_%20&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AgAAAZKAtUNePkOq0AAAAAAAAAAYAAAAAEFaS0F0VVBIQUFCbTU3bkM4UlMzY2dBQQAAACQAAAAAMDE5MjgwYjktYTQ0Zi00ZDMzLTg1YjItMGUyM2I3ZTZhOTVk&my_code=disabled&op_filter=ignore_from%28function%3A%22%28%2AEventWrapper%29.extractTableName%22%29&profile_type=alloc-size&profileId=AZKAtUPHAABm57nC8RS3cgAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&zoom=1952190238&from_ts=1728734842330&to_ts=1728738442330&live=false)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->