### PR TITLE
[CWS/CSPM] make sure the SECL rule filter is created only once in compliance module

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -133,6 +133,26 @@ func xccdfEnabled() bool {
 	return pkgconfigsetup.Datadog().GetBool("compliance_config.xccdf.enabled") || pkgconfigsetup.Datadog().GetBool("compliance_config.host_benchmarks.enabled")
 }
 
+var (
+	defaultSECLRuleFilterLock sync.Mutex
+	defaultSECLRuleFilter     *secl.SECLRuleFilter
+)
+
+func getDefaultSECLRuleFilter() (*secl.SECLRuleFilter, error) {
+	defaultSECLRuleFilterLock.Lock()
+	defer defaultSECLRuleFilterLock.Unlock()
+
+	if defaultSECLRuleFilter == nil {
+		ruleFilterModel, err := rules.NewRuleFilterModel(nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create default SECL rule filter: %w", err)
+		}
+		defaultSECLRuleFilter = secl.NewSECLRuleFilter(ruleFilterModel)
+	}
+
+	return defaultSECLRuleFilter, nil
+}
+
 // DefaultRuleFilter implements the default filtering of benchmarks' rules. It
 // will exclude rules based on the evaluation context / environment running
 // the benchmark.
@@ -150,12 +170,12 @@ func DefaultRuleFilter(r *Rule) bool {
 		return false
 	}
 	if len(r.Filters) > 0 {
-		ruleFilterModel, err := rules.NewRuleFilterModel(nil, "")
+		seclRuleFilter, err := getDefaultSECLRuleFilter()
 		if err != nil {
-			log.Errorf("failed to apply rule filters: %v", err)
+			log.Errorf("failed to apply rule filters: %s", err)
 			return false
 		}
-		seclRuleFilter := secl.NewSECLRuleFilter(ruleFilterModel)
+
 		accepted, err := seclRuleFilter.IsRuleAccepted(&secl.RuleDefinition{
 			Filters: r.Filters,
 		})

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -82,17 +82,13 @@ func (r *AgentVersionFilter) IsMacroAccepted(macro *MacroDefinition) (bool, erro
 // SECLRuleFilter defines a SECL rule filter
 type SECLRuleFilter struct {
 	model          eval.Model
-	context        *eval.Context
 	parsingContext *ast.ParsingContext
 }
 
 // NewSECLRuleFilter returns a new agent version based rule filter
 func NewSECLRuleFilter(model eval.Model) *SECLRuleFilter {
 	return &SECLRuleFilter{
-		model: model,
-		context: &eval.Context{
-			Event: model.NewEvent(),
-		},
+		model:          model,
 		parsingContext: ast.NewParsingContext(),
 	}
 }
@@ -105,6 +101,12 @@ func mergeFilterExpressions(filters []string) (expression string) {
 		expression += "(" + filter + ")"
 	}
 	return
+}
+
+func (r *SECLRuleFilter) newEvalContext() eval.Context {
+	return eval.Context{
+		Event: r.model.NewEvent(),
+	}
 }
 
 // IsRuleAccepted checks whether the rule is accepted
@@ -128,7 +130,8 @@ func (r *SECLRuleFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 		return false, err
 	}
 
-	return evaluator.Eval(r.context), nil
+	ctx := r.newEvalContext()
+	return evaluator.Eval(&ctx), nil
 }
 
 // IsMacroAccepted checks whether the macro is accepted
@@ -148,5 +151,6 @@ func (r *SECLRuleFilter) IsMacroAccepted(macro *MacroDefinition) (bool, error) {
 		return false, err
 	}
 
-	return evaluator.Eval(r.context), nil
+	ctx := r.newEvalContext()
+	return evaluator.Eval(&ctx), nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[Example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asecurity-agent%20kube_cluster_name%3Astripe%20version%3A_7_60_0_devel_git.136.89132af_89132af611_%20&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AgAAAZKGaXi-cZEozAAAAAAAAAAYAAAAAEFaS0dhWHNoQUFDZE4xVTFFWXRENkFBQQAAACQAAAAAMDE5Mjg2N2EtNzgzNC00ZWFlLTk3OWMtZTdmNTYyNjQ2ODZl&my_code=disabled&profile_type=alloc-size&profileId=AZKGaXshAACdN1U1EYtD6AAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&zoom=1067442512&from_ts=1728831694027&to_ts=1728835294027&live=false) showing the big memory allocation caused by this function being called repetitivly, and re-allocating a new parsing context each time.

This PR makes sure the SECL rule filter model and evaluator are created only once, and re-used as needed.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->