### PR TITLE
[USMON-1254] usm: postgres: Remove redundant regex replacement

### DIFF
--- a/pkg/network/protocols/postgres/model_linux.go
+++ b/pkg/network/protocols/postgres/model_linux.go
@@ -10,7 +10,6 @@ package postgres
 import (
 	"bytes"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/DataDog/go-sqllexer"
@@ -24,6 +23,10 @@ import (
 const (
 	// EmptyParameters represents the case where the non-empty query has no parameters
 	EmptyParameters = "EMPTY_PARAMETERS"
+)
+
+var (
+	postgresDBMS = sqllexer.WithDBMS(sqllexer.DBMSPostgres)
 )
 
 // EventWrapper wraps an ebpf event and provides additional methods to extract information from it.
@@ -98,17 +101,10 @@ func (e *EventWrapper) extractParameters() string {
 	return string(b[idxParam:])
 }
 
-var re = regexp.MustCompile(`(?i)if\s+exists`)
-
 // extractTableName extracts the table name from the query.
 func (e *EventWrapper) extractTableName() string {
-	fragment := string(getFragment(&e.Tx))
-	// Temp solution for the fact that ObfuscateSQLString does not support "IF EXISTS" or "if exists", so we remove
-	// it from the fragment if found.
-	fragment = re.ReplaceAllString(fragment, "")
-
 	// Normalize the query without obfuscating it.
-	_, statementMetadata, err := e.normalizer.Normalize(fragment, sqllexer.WithDBMS(sqllexer.DBMSPostgres))
+	_, statementMetadata, err := e.normalizer.Normalize(string(getFragment(&e.Tx)), postgresDBMS)
 	if err != nil {
 		log.Debugf("unable to normalize due to: %s", err)
 		return "UNKNOWN"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes redundant call to regex that scans every captured query in order to omit "IF EXISTS".

### Motivation

* A leftover from the original PR.
* Removed as Normalizer handles 'IF EXISTS'.
* Improves 25% in runtime, bytes and allocations

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

Before
```
BenchmarkExtractTableName-16    	  950824	      1221 ns/op	     327 B/op	      13 allocs/op
```

After
```
BenchmarkExtractTableName-16    	 1506913	       933.9 ns/op	     256 B/op	      10 allocs/op
```

Summary - ~24% improvement in every aspect

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->