### PR TITLE
[CWS] fix approvers for non open event types

### DIFF
--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -162,7 +162,7 @@ func fimKFiltersGetter(eventType model.EventType, fields []eval.Field) kfiltersG
 			fieldHandled = append(fieldHandled, handled...)
 		}
 
-		kfs, handled, err := getProcessKFilters(model.FileOpenEventType, approvers)
+		kfs, handled, err := getProcessKFilters(eventType, approvers)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/security/probe/kfilters/process.go
+++ b/pkg/security/probe/kfilters/process.go
@@ -62,9 +62,10 @@ func getProcessKFilters(eventType model.EventType, approvers rules.Approvers) ([
 		switch value.Type {
 		case eval.ScalarValueType:
 			kfilters = append(kfilters, &eventMaskEntry{
-				tableName: auidApproversTable,
-				tableKey:  ebpf.Uint32MapItem(value.Value.(int)),
-				eventMask: uint64(1 << (eventType - 1)),
+				approverType: AUIDApproverType,
+				tableName:    auidApproversTable,
+				tableKey:     ebpf.Uint32MapItem(value.Value.(int)),
+				eventMask:    uint64(1 << (eventType - 1)),
 			})
 		case eval.RangeValueType:
 			min, max := value.Value.(rules.RangeFilterValue).Min, value.Value.(rules.RangeFilterValue).Max

--- a/pkg/security/tests/login_uid_test.go
+++ b/pkg/security/tests/login_uid_test.go
@@ -55,12 +55,13 @@ func TestLoginUID(t *testing.T) {
 	}
 	defer dockerInstance.stop()
 
-	t.Run("login-uid-open-test", func(t *testing.T) {
+	t.Run("open", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			args := []string{
-				"-login-uid-open-test",
-				"-login-uid-open-path", "/tmp/test-auid",
-				"-login-uid-open-uid", "1005",
+				"-login-uid-test",
+				"-login-uid-event-type", "open",
+				"-login-uid-path", "/tmp/test-auid",
+				"-login-uid-value", "1005",
 			}
 
 			cmd := dockerInstance.Command(goSyscallTester, args, []string{})
@@ -72,11 +73,13 @@ func TestLoginUID(t *testing.T) {
 		})
 	})
 
-	t.Run("login-uid-exec-test", func(t *testing.T) {
+	t.Run("exec", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			args := []string{
-				"-login-uid-exec-test",
-				"-login-uid-exec-path", goSyscallTester,
+				"-login-uid-test",
+				"-login-uid-event-type", "exec",
+				"-login-uid-path", goSyscallTester,
+				"-login-uid-value", "1005",
 			}
 
 			cmd := dockerInstance.Command(goSyscallTester, args, []string{})

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -42,11 +42,10 @@ var (
 	userSessionExecutable string
 	userSessionOpenPath   string
 	syscallDriftTest      bool
-	loginUIDOpenTest      bool
-	loginUIDOpenPath      string
-	loginUIDOpenUID       int
-	loginUIDExecTest      bool
-	loginUIDExecPath      string
+	loginUIDTest          bool
+	loginUIDPath          string
+	loginUIDEventType     string
+	loginUIDValue         int
 )
 
 //go:embed ebpf_probe.o
@@ -232,35 +231,39 @@ func setSelfLoginUID(uid int) error {
 	return nil
 }
 
-func RunLoginUIDOpenTest() error {
-	if loginUIDOpenUID != -1 {
-		if err := setSelfLoginUID(loginUIDOpenUID); err != nil {
+func RunLoginUIDTest() error {
+	if loginUIDValue != -1 {
+		if err := setSelfLoginUID(loginUIDValue); err != nil {
 			return err
 		}
 	}
 
-	// open test file to trigger an event
-	f, err := os.OpenFile(loginUIDOpenPath, os.O_RDWR|os.O_CREATE, 0755)
-	if err != nil {
-		return fmt.Errorf("couldn't create test-auid file: %v", err)
-	}
-	defer os.Remove(loginUIDOpenPath)
+	switch loginUIDEventType {
+	case "open":
+		// open test file to trigger an event
+		f, err := os.OpenFile(loginUIDPath, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			return fmt.Errorf("couldn't create test-auid file: %v", err)
+		}
+		defer os.Remove(loginUIDPath)
 
-	if err = f.Close(); err != nil {
-		return fmt.Errorf("couldn't close test file: %v", err)
-	}
-	return nil
-}
-
-func RunLoginUIDExecTest() error {
-	if err := setSelfLoginUID(1005); err != nil {
-		return err
-	}
-
-	// exec ls to trigger an execution with auid = 1005
-	cmd := exec.Command(loginUIDExecPath)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("'%s' execution returned an error: %v", loginUIDExecPath, err)
+		if err = f.Close(); err != nil {
+			return fmt.Errorf("couldn't close test file: %v", err)
+		}
+	case "exec":
+		cmd := exec.Command(loginUIDPath)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("'%s' execution returned an error: %v", loginUIDPath, err)
+		}
+	case "unlink":
+		f, err := os.OpenFile(loginUIDPath, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			return fmt.Errorf("couldn't create test-auid file: %v", err)
+		}
+		f.Close()
+		os.Remove(loginUIDPath)
+	default:
+		panic("unknown event type")
 	}
 	return nil
 }
@@ -277,11 +280,10 @@ func main() {
 	flag.BoolVar(&cleanupIMDSTest, "cleanup-imds-test", false, "when set, removes the dummy interface of the IMDS test")
 	flag.BoolVar(&runIMDSTest, "run-imds-test", false, "when set, binds an IMDS server locally and sends a query to it")
 	flag.BoolVar(&syscallDriftTest, "syscall-drift-test", false, "when set, runs the syscall drift test")
-	flag.BoolVar(&loginUIDOpenTest, "login-uid-open-test", false, "when set, runs the login_uid open test")
-	flag.StringVar(&loginUIDOpenPath, "login-uid-open-path", "", "file used for the login_uid open test")
-	flag.IntVar(&loginUIDOpenUID, "login-uid-open-uid", 0, "uid used for the login_uid open test")
-	flag.BoolVar(&loginUIDExecTest, "login-uid-exec-test", false, "when set, runs the login_uid exec test")
-	flag.StringVar(&loginUIDExecPath, "login-uid-exec-path", "", "path to the executable to run during the login_uid exec test")
+	flag.BoolVar(&loginUIDTest, "login-uid-test", false, "when set, runs the login_uid open test")
+	flag.StringVar(&loginUIDPath, "login-uid-path", "", "file used for the login_uid open test")
+	flag.StringVar(&loginUIDEventType, "login-uid-event-type", "", "event type used for the login_uid open test")
+	flag.IntVar(&loginUIDValue, "login-uid-value", 0, "uid used for the login_uid open test")
 
 	flag.Parse()
 
@@ -337,14 +339,8 @@ func main() {
 		}
 	}
 
-	if loginUIDOpenTest {
-		if err := RunLoginUIDOpenTest(); err != nil {
-			panic(err)
-		}
-	}
-
-	if loginUIDExecTest {
-		if err := RunLoginUIDExecTest(); err != nil {
+	if loginUIDTest {
+		if err := RunLoginUIDTest(); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the AUID approvers for non open event types. Before this patch, the policy was correctly pushed but not the approvers themself causing event not to be approved kernel side.

This also fixes the approver metrics for AUID.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->