### PR TITLE
[EBPF] Do not initialize process monitor in uprobe-attacher

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -178,9 +178,6 @@ type AttacherConfig struct {
 	// PerformInitialScan defines if the attacher should perform an initial scan of the processes before starting the monitor
 	PerformInitialScan bool
 
-	// ProcessMonitorEventStream defines whether the process monitor is using the event stream
-	ProcessMonitorEventStream bool
-
 	// EnableDetailedLogging makes the attacher log why it's attaching or not attaching to a process
 	// This is useful for debugging purposes, do not enable in production.
 	EnableDetailedLogging bool
@@ -383,11 +380,6 @@ func (ua *UprobeAttacher) handlesExecutables() bool {
 func (ua *UprobeAttacher) Start() error {
 	var cleanupExec, cleanupExit func()
 	procMonitor := monitor.GetProcessMonitor()
-	err := procMonitor.Initialize(ua.config.ProcessMonitorEventStream)
-	if err != nil {
-		return fmt.Errorf("error initializing process monitor: %w", err)
-	}
-
 	if ua.handlesExecutables() {
 		cleanupExec = procMonitor.SubscribeExec(ua.handleProcessStart)
 	}

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -176,6 +176,8 @@ type AttacherConfig struct {
 	EbpfConfig *ebpf.Config
 
 	// PerformInitialScan defines if the attacher should perform an initial scan of the processes before starting the monitor
+	// Note that if processMonitor is being used (i.e., rules are targeting executables), the ProcessMonitor itself
+	// will perform an initial scan in its Initialize method.
 	PerformInitialScan bool
 
 	// EnableDetailedLogging makes the attacher log why it's attaching or not attaching to a process

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -273,13 +273,14 @@ func TestMonitor(t *testing.T) {
 		return
 	}
 
+	launchProcessMonitor(t, false)
+
 	config := AttacherConfig{
 		Rules: []*AttachRule{{
 			LibraryNameRegex: regexp.MustCompile(`libssl.so`),
 			Targets:          AttachToExecutable | AttachToSharedLibraries,
 		}},
-		ProcessMonitorEventStream: false,
-		EbpfConfig:                ebpfCfg,
+		EbpfConfig: ebpfCfg,
 	}
 	ua, err := NewUprobeAttacher("mock", config, &MockManager{}, nil, nil)
 	require.NoError(t, err)
@@ -653,6 +654,8 @@ func TestUprobeAttacher(t *testing.T) {
 		t.Skip("Kernel version does not support shared libraries")
 		return
 	}
+
+	launchProcessMonitor(t, false)
 
 	buf, err := bytecode.GetReader(ebpfCfg.BPFDir, "uprobe_attacher-test.o")
 	require.NoError(t, err)

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -41,6 +42,10 @@ func TestProbeCanReceiveEvents(t *testing.T) {
 	if kver < minimumKernelVersion {
 		t.Skipf("minimum kernel version %s not met, read %s", minimumKernelVersion, kver)
 	}
+
+	procMon := monitor.GetProcessMonitor()
+	require.NotNil(t, procMon)
+	require.NoError(t, procMon.Initialize(false))
 
 	cfg := NewConfig()
 	cfg.InitialProcessSync = false

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -125,7 +125,6 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) (*nodeJSMonitor, e
 		EbpfConfig:                     &c.Config,
 		ExcludeTargets:                 uprobes.ExcludeSelf | uprobes.ExcludeInternal | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
 		EnablePeriodicScanNewProcesses: true,
-		ProcessMonitorEventStream:      c.EnableUSMEventStream,
 	}
 
 	attacher, err := uprobes.NewUprobeAttacher(nodeJsAttacherName, attachCfg, mgr, uprobes.NopOnAttachCallback, &uprobes.NativeBinaryInspector{})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the call to `ProcessMonitor.Initialize` in the uprobe attacher to retain previous behavior, as the process monitor is initialized outside by USM after all protocol monitors have been started. This behavior change was causing certain USM protocols to not attach to all the process existing in the system.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->