### PR TITLE
[ASCII-2395] Fix check subcommand Windows e2e test

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
@@ -7,18 +7,25 @@
 package check
 
 import (
+	_ "embed"
 	"fmt"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type baseCheckSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
+
+//go:embed fixtures/hello.yaml
+var customCheckYaml []byte
+
+//go:embed fixtures/hello.py
+var customCheckPython []byte
 
 func (v *baseCheckSuite) TestCheckDisk() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"disk"}))
@@ -43,8 +50,7 @@ func (v *baseCheckSuite) TestCustomCheck() {
 
 func (v *baseCheckSuite) TestCheckRate() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
+	data := parseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 
@@ -59,8 +65,7 @@ func (v *baseCheckSuite) TestCheckTimes() {
 	times := 10
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
 
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
+	data := parseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -7,7 +7,6 @@
 package check
 
 import (
-	_ "embed"
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
@@ -21,12 +20,6 @@ import (
 type linuxCheckSuite struct {
 	baseCheckSuite
 }
-
-//go:embed fixtures/hello.yaml
-var customCheckYaml []byte
-
-//go:embed fixtures/hello.py
-var customCheckPython []byte
 
 func TestLinuxCheckSuite(t *testing.T) {
 	t.Parallel()

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -22,7 +22,6 @@ type windowsCheckSuite struct {
 }
 
 func TestWindowsCheckSuite(t *testing.T) {
-	t.Skip("not working because of the following error: unable to import module 'hello': source code string cannot contain null bytes")
 	t.Parallel()
 	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
@@ -30,5 +29,7 @@ func TestWindowsCheckSuite(t *testing.T) {
 			awshost.WithAgentOptions(
 				agentparams.WithFile("C:/ProgramData/Datadog/conf.d/hello.d/conf.yaml", string(customCheckYaml), true),
 				agentparams.WithFile("C:/ProgramData/Datadog/checks.d/hello.py", string(customCheckPython), true),
-			))))
+			),
+		),
+	))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the "check" subcommand e2e test on Windows. 

### Motivation
It was previously skipped (since 7 months ago), likely due to a framework issue when creating files on Windows.
That bug seems to have been fixed, and only a simple change was required to make the test work as expected.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->