### PR TITLE
(fleet) wait for the catalog to subscribe to tasks

### DIFF
--- a/pkg/fleet/daemon/remote_config.go
+++ b/pkg/fleet/daemon/remote_config.go
@@ -36,7 +36,7 @@ func newRemoteConfig(rcFetcher client.ConfigFetcher) (*remoteConfig, error) {
 	client, err := client.NewClient(
 		rcFetcher,
 		client.WithUpdater(),
-		client.WithProducts(state.ProductUpdaterCatalogDD, state.ProductUpdaterTask),
+		client.WithProducts(state.ProductUpdaterCatalogDD),
 		client.WithoutTufVerification(),
 	)
 	if err != nil {


### PR DESCRIPTION
This PR makes the installer wait for a catalog to be received before subscribe, fixing a race where the first task might be received before the catalog is applied.
