### PR TITLE
[CWS] Add status to kill action report

### DIFF
--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -24,7 +24,7 @@ const (
 	// KillActionStatusPerformed indicates the kill action was performed
 	KillActionStatusPerformed KillActionStatus = "performed"
 	// KillActionStatusRuleDisarmed indicates the kill action was skipped because the rule was disarmed
-	KillActionStatusRuleDisarmed KillActionStatus = "rule_dismarmed"
+	KillActionStatusRuleDisarmed KillActionStatus = "rule_disarmed"
 )
 
 // KillActionReport defines a kill action reports

--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -38,10 +38,10 @@ type KillActionReport struct {
 	DetectedAt   time.Time
 	KilledAt     time.Time
 	ExitedAt     time.Time
-	DisarmerType disarmerType
+	DisarmerType string
 
 	// internal
-	pid      uint32
+	Pid      uint32
 	resolved bool
 	rule     *rules.Rule
 }
@@ -80,7 +80,7 @@ func (k *KillActionReport) ToJSON() ([]byte, error) {
 		Signal:       k.Signal,
 		Scope:        k.Scope,
 		Status:       string(k.Status),
-		DisarmerType: string(k.DisarmerType),
+		DisarmerType: k.DisarmerType,
 		CreatedAt:    utils.NewEasyjsonTime(k.CreatedAt),
 		DetectedAt:   utils.NewEasyjsonTime(k.DetectedAt),
 		KilledAt:     utils.NewEasyjsonTimeIfNotZero(k.KilledAt),

--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -17,19 +17,31 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
+// KillActionStatus defines the status of a kill action
+type KillActionStatus string
+
+const (
+	// KillActionStatusPerformed indicates the kill action was performed
+	KillActionStatusPerformed KillActionStatus = "performed"
+	// KillActionStatusRuleDisarmed indicates the kill action was skipped because the rule was disarmed
+	KillActionStatusRuleDisarmed KillActionStatus = "rule_dismarmed"
+)
+
 // KillActionReport defines a kill action reports
 type KillActionReport struct {
 	sync.RWMutex
 
-	Signal     string
-	Scope      string
-	Pid        uint32
-	CreatedAt  time.Time
-	DetectedAt time.Time
-	KilledAt   time.Time
-	ExitedAt   time.Time
+	Signal       string
+	Scope        string
+	Status       KillActionStatus
+	CreatedAt    time.Time
+	DetectedAt   time.Time
+	KilledAt     time.Time
+	ExitedAt     time.Time
+	DisarmerType disarmerType
 
 	// internal
+	pid      uint32
 	resolved bool
 	rule     *rules.Rule
 }
@@ -37,14 +49,16 @@ type KillActionReport struct {
 // JKillActionReport used to serialize date
 // easyjson:json
 type JKillActionReport struct {
-	Type       string              `json:"type"`
-	Signal     string              `json:"signal"`
-	Scope      string              `json:"scope"`
-	CreatedAt  utils.EasyjsonTime  `json:"created_at"`
-	DetectedAt utils.EasyjsonTime  `json:"detected_at"`
-	KilledAt   utils.EasyjsonTime  `json:"killed_at"`
-	ExitedAt   *utils.EasyjsonTime `json:"exited_at,omitempty"`
-	TTR        string              `json:"ttr,omitempty"`
+	Type         string              `json:"type"`
+	Signal       string              `json:"signal"`
+	Scope        string              `json:"scope"`
+	Status       string              `json:"status"`
+	DisarmerType string              `json:"disarmer_type,omitempty"`
+	CreatedAt    utils.EasyjsonTime  `json:"created_at"`
+	DetectedAt   utils.EasyjsonTime  `json:"detected_at"`
+	KilledAt     *utils.EasyjsonTime `json:"killed_at,omitempty"`
+	ExitedAt     *utils.EasyjsonTime `json:"exited_at,omitempty"`
+	TTR          string              `json:"ttr,omitempty"`
 }
 
 // IsResolved return if the action is resolved
@@ -53,7 +67,7 @@ func (k *KillActionReport) IsResolved() bool {
 	defer k.RUnlock()
 
 	// for sigkill wait for exit
-	return k.Signal != "SIGKILL" || k.resolved
+	return k.Signal != "SIGKILL" || k.resolved || k.Status == KillActionStatusRuleDisarmed
 }
 
 // ToJSON marshal the action
@@ -62,13 +76,15 @@ func (k *KillActionReport) ToJSON() ([]byte, error) {
 	defer k.RUnlock()
 
 	jk := JKillActionReport{
-		Type:       rules.KillAction,
-		Signal:     k.Signal,
-		Scope:      k.Scope,
-		CreatedAt:  utils.NewEasyjsonTime(k.CreatedAt),
-		DetectedAt: utils.NewEasyjsonTime(k.DetectedAt),
-		KilledAt:   utils.NewEasyjsonTime(k.KilledAt),
-		ExitedAt:   utils.NewEasyjsonTimeIfNotZero(k.ExitedAt),
+		Type:         rules.KillAction,
+		Signal:       k.Signal,
+		Scope:        k.Scope,
+		Status:       string(k.Status),
+		DisarmerType: string(k.DisarmerType),
+		CreatedAt:    utils.NewEasyjsonTime(k.CreatedAt),
+		DetectedAt:   utils.NewEasyjsonTime(k.DetectedAt),
+		KilledAt:     utils.NewEasyjsonTimeIfNotZero(k.KilledAt),
+		ExitedAt:     utils.NewEasyjsonTimeIfNotZero(k.ExitedAt),
 	}
 
 	if !k.ExitedAt.IsZero() {

--- a/pkg/security/probe/actions_easyjson.go
+++ b/pkg/security/probe/actions_easyjson.go
@@ -43,6 +43,10 @@ func easyjsonB97b45a3DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 			out.Signal = string(in.String())
 		case "scope":
 			out.Scope = string(in.String())
+		case "status":
+			out.Status = string(in.String())
+		case "disarmer_type":
+			out.DisarmerType = string(in.String())
 		case "created_at":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.CreatedAt).UnmarshalJSON(data))
@@ -52,8 +56,16 @@ func easyjsonB97b45a3DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 				in.AddError((out.DetectedAt).UnmarshalJSON(data))
 			}
 		case "killed_at":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.KilledAt).UnmarshalJSON(data))
+			if in.IsNull() {
+				in.Skip()
+				out.KilledAt = nil
+			} else {
+				if out.KilledAt == nil {
+					out.KilledAt = new(utils.EasyjsonTime)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.KilledAt).UnmarshalJSON(data))
+				}
 			}
 		case "exited_at":
 			if in.IsNull() {
@@ -99,6 +111,16 @@ func easyjsonB97b45a3EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 		out.String(string(in.Scope))
 	}
 	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix)
+		out.String(string(in.Status))
+	}
+	if in.DisarmerType != "" {
+		const prefix string = ",\"disarmer_type\":"
+		out.RawString(prefix)
+		out.String(string(in.DisarmerType))
+	}
+	{
 		const prefix string = ",\"created_at\":"
 		out.RawString(prefix)
 		(in.CreatedAt).MarshalEasyJSON(out)
@@ -108,10 +130,10 @@ func easyjsonB97b45a3EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 		out.RawString(prefix)
 		(in.DetectedAt).MarshalEasyJSON(out)
 	}
-	{
+	if in.KilledAt != nil {
 		const prefix string = ",\"killed_at\":"
 		out.RawString(prefix)
-		(in.KilledAt).MarshalEasyJSON(out)
+		(*in.KilledAt).MarshalEasyJSON(out)
 	}
 	if in.ExitedAt != nil {
 		const prefix string = ",\"exited_at\":"

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -127,7 +127,7 @@ func (p *ProcessKiller) HandleProcessExited(event *model.Event) {
 		report.Lock()
 		defer report.Unlock()
 
-		if report.pid == event.ProcessContext.Pid {
+		if report.Pid == event.ProcessContext.Pid {
 			report.ExitedAt = event.ProcessContext.ExitTime
 			report.resolved = true
 			return true
@@ -196,10 +196,10 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 				Scope:        scope,
 				Signal:       kill.Signal,
 				Status:       KillActionStatusRuleDisarmed,
-				DisarmerType: dt,
+				DisarmerType: string(dt),
 				CreatedAt:    ev.ProcessContext.ExecTime,
 				DetectedAt:   ev.ResolveEventTime(),
-				pid:          ev.ProcessContext.Pid,
+				Pid:          ev.ProcessContext.Pid,
 				rule:         rule,
 			})
 		}
@@ -273,7 +273,7 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 		CreatedAt:  ev.ProcessContext.ExecTime,
 		DetectedAt: ev.ResolveEventTime(),
 		KilledAt:   killedAt,
-		pid:        ev.ProcessContext.Pid,
+		Pid:        ev.ProcessContext.Pid,
 		rule:       rule,
 	}
 	ev.ActionReports = append(ev.ActionReports, report)
@@ -455,8 +455,8 @@ const (
 type disarmerType string
 
 const (
-	containerDisarmerType  = disarmerType("container")
-	executableDisarmerType = disarmerType("executable")
+	containerDisarmerType  disarmerType = "container"
+	executableDisarmerType disarmerType = "executable"
 )
 
 type ruleDisarmer struct {

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -127,6 +127,9 @@ func TestActionKill(t *testing.T) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.signal == 'SIGUSR2')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+					t.Errorf("element not found %s => %v", string(msg.Data), err)
+				}
 			})
 
 			return nil
@@ -180,6 +183,9 @@ func TestActionKill(t *testing.T) {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.exited_at =~ /20.*/)]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+					t.Errorf("element not found %s => %v", string(msg.Data), err)
+				}
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 			})
@@ -331,6 +337,9 @@ func TestActionKillRuleSpecific(t *testing.T) {
 			if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.exited_at =~ /20.*/)]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 				t.Errorf("element not found %s => %v", string(msg.Data), err)
 			}
+			if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+				t.Errorf("element not found %s => %v", string(msg.Data), err)
+			}
 		})
 
 		return nil
@@ -399,6 +408,9 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.exited_at =~ /20.*/)]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+					t.Errorf("element not found %s => %v", string(msg.Data), err)
+				}
 			})
 
 			return nil
@@ -406,7 +418,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 		assert.NoError(t, err)
 	}
 
-	testKillActionIgnored := func(t *testing.T, ruleID string, cmdFunc func(context.Context)) {
+	testKillActionDisarmed := func(t *testing.T, ruleID string, cmdFunc func(context.Context)) {
 		test.msgSender.flush()
 		err := test.GetEventSent(t, func() error {
 			cmdFunc(nil)
@@ -426,8 +438,11 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 			validateMessageSchema(t, string(msg.Data))
 
 			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
-				if _, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions`); err == nil {
-					t.Errorf("unexpected rule action %s", string(msg.Data))
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.signal == 'SIGKILL')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+					t.Errorf("element not found %s => %v", string(msg.Data), err)
+				}
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'rule_disarmed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 			})
 
@@ -448,7 +463,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 		}
 
 		// test that another executable disarms the kill action
-		testKillActionIgnored(t, "kill_action_disarm_executable", func(_ context.Context) {
+		testKillActionDisarmed(t, "kill_action_disarm_executable", func(_ context.Context) {
 			cmd := exec.Command(sleep, "1")
 			cmd.Env = []string{"TARGETTOKILL=1"}
 			_ = cmd.Run()
@@ -487,7 +502,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 		defer newDockerInstance.stop()
 
 		// test that another container disarms the kill action
-		testKillActionIgnored(t, "kill_action_disarm_container", func(_ context.Context) {
+		testKillActionDisarmed(t, "kill_action_disarm_container", func(_ context.Context) {
 			cmd := newDockerInstance.Command("env", []string{"-i", "-", "TARGETTOKILL=1", "sleep", "1"}, []string{})
 			_ = cmd.Run()
 		})

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -447,7 +447,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 			})
 		}
 
-		// test that another executable dismars the kill action
+		// test that another executable disarms the kill action
 		testKillActionIgnored(t, "kill_action_disarm_executable", func(_ context.Context) {
 			cmd := exec.Command(sleep, "1")
 			cmd.Env = []string{"TARGETTOKILL=1"}
@@ -486,7 +486,7 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 		}
 		defer newDockerInstance.stop()
 
-		// test that another container dismars the kill action
+		// test that another container disarms the kill action
 		testKillActionIgnored(t, "kill_action_disarm_container", func(_ context.Context) {
 			cmd := newDockerInstance.Command("env", []string{"-i", "-", "TARGETTOKILL=1", "sleep", "1"}, []string{})
 			_ = cmd.Run()

--- a/pkg/security/tests/schemas/kill.schema.json
+++ b/pkg/security/tests/schemas/kill.schema.json
@@ -33,29 +33,55 @@
             "properties": {
                 "signal": {
                     "const": "SIGKILL"
+                },
+                "status": {
+                    "const": "performed"
                 }
             },
             "required": [
                 "type",
                 "signal",
+                "scope",
+                "status",
                 "created_at",
                 "detected_at",
                 "killed_at",
-                "exited_at"
+                "exited_at",
+                "ttr"
             ]
         },
         {
             "properties": {
                 "signal": {
                     "const": "SIGUSR2"
+                },
+                "status": {
+                    "const": "performed"
                 }
             },
             "required": [
                 "type",
                 "signal",
+                "scope",
+                "status",
                 "created_at",
                 "detected_at",
                 "killed_at"
+            ]
+        },
+        {
+            "properties": {
+                "status": {
+                    "const": "rule_disarmed"
+                }
+            },
+            "required": [
+                "type",
+                "signal",
+                "scope",
+                "status",
+                "created_at",
+                "detected_at"
             ]
         }
     ]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new `status` field to kill action reports.
This field can either be set to:
- `performed` if the kill action was effectively carried out.
- `rule_disarmed` if the action was skipped because the corresponding rule was disarmed.
In this case, another `disarmer_type` field is added to indicate the kind of disarmer that caused the rule to be disarmed (either `executable` or `container`). 

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->