### PR TITLE
[CWS] Add the possibility to build system-probe statically

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -139,7 +139,7 @@ SECURITY_AGENT_TAGS = {
 SERVERLESS_TAGS = {"serverless", "otlp"}
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd"})
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd"}).difference({"netcgo"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
 TRACE_AGENT_TAGS = {"docker", "containerd", "datadog.no_waf", "kubeapiserver", "kubelet", "otlp", "netcgo", "podman"}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -139,7 +139,7 @@ SECURITY_AGENT_TAGS = {
 SERVERLESS_TAGS = {"serverless", "otlp"}
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd", "netcgo"})
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
 TRACE_AGENT_TAGS = {"docker", "containerd", "datadog.no_waf", "kubeapiserver", "kubelet", "otlp", "netcgo", "podman"}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -139,7 +139,7 @@ SECURITY_AGENT_TAGS = {
 SERVERLESS_TAGS = {"serverless", "otlp"}
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd"}).difference({"netcgo"})
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "remotewmonly"}).difference({"python", "systemd", "netcgo"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
 TRACE_AGENT_TAGS = {"docker", "containerd", "datadog.no_waf", "kubeapiserver", "kubelet", "otlp", "netcgo", "podman"}

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -328,7 +328,9 @@ def create_dir_if_needed(dir):
 
 
 @task
-def build_embed_syscall_tester(ctx, arch: str | Arch = CURRENT_ARCH, static=True, compiler="clang"):
+def build_embed_syscall_tester(
+    ctx, arch: str | Arch = CURRENT_ARCH, static=True, compiler="clang", ebpf_compiler="clang"
+):
     arch = Arch.from_str(arch)
     check_for_ninja(ctx)
     build_dir = os.path.join("pkg", "security", "tests", "syscall_tester", "bin")
@@ -338,7 +340,7 @@ def build_embed_syscall_tester(ctx, arch: str | Arch = CURRENT_ARCH, static=True
     nf_path = os.path.join(ctx.cwd, 'syscall-tester.ninja')
     with open(nf_path, 'w') as ninja_file:
         nw = NinjaWriter(ninja_file, width=120)
-        ninja_define_ebpf_compiler(nw, arch=arch)
+        ninja_define_ebpf_compiler(nw, arch=arch, compiler=ebpf_compiler)
         ninja_define_exe_compiler(nw, compiler=compiler)
 
         ninja_syscall_tester(nw, build_dir, static=static, compiler=compiler)
@@ -380,7 +382,7 @@ def build_functional_tests(
                 bundle_ebpf=bundle_ebpf,
                 ebpf_compiler=ebpf_compiler,
             )
-        build_embed_syscall_tester(ctx, compiler=syscall_tester_compiler)
+        build_embed_syscall_tester(ctx, compiler=syscall_tester_compiler, ebpf_compiler=ebpf_compiler)
 
     arch = Arch.from_str(arch)
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, static=static, arch=arch)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -621,6 +621,7 @@ def build(
     with_unit_test=False,
     bundle=True,
     ebpf_compiler='clang',
+    static=False,
 ):
     """
     Build the system-probe
@@ -647,6 +648,7 @@ def build(
         strip_binary=strip_binary,
         bundle=bundle,
         arch=arch,
+        static=static,
     )
 
 
@@ -673,6 +675,7 @@ def build_sysprobe_binary(
     bundle_ebpf=False,
     strip_binary=False,
     bundle=True,
+    static=False,
 ) -> None:
     if bundle and not is_windows:
         return agent_build(
@@ -686,13 +689,18 @@ def build_sysprobe_binary(
 
     arch_obj = Arch.from_str(arch)
 
-    ldflags, gcflags, env = get_build_flags(ctx, install_path=install_path, major_version=major_version, arch=arch_obj)
+    ldflags, gcflags, env = get_build_flags(
+        ctx, install_path=install_path, major_version=major_version, python_runtimes=python_runtimes, arch=arch_obj, static=static
+    )
 
     build_tags = get_default_build_tags(build="system-probe")
     if bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
     if strip_binary:
         ldflags += ' -s -w'
+
+    if static:
+        build_tags.extend(["osusergo", "netgo"])
 
     if os.path.exists(binary):
         os.remove(binary)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -701,6 +701,7 @@ def build_sysprobe_binary(
 
     if static:
         build_tags.extend(["osusergo", "netgo"])
+        build_tags = list(set(build_tags).difference({"netcgo"}))
 
     if os.path.exists(binary):
         os.remove(binary)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -690,7 +690,12 @@ def build_sysprobe_binary(
     arch_obj = Arch.from_str(arch)
 
     ldflags, gcflags, env = get_build_flags(
-        ctx, install_path=install_path, major_version=major_version, python_runtimes=python_runtimes, arch=arch_obj, static=static
+        ctx,
+        install_path=install_path,
+        major_version=major_version,
+        python_runtimes=python_runtimes,
+        arch=arch_obj,
+        static=static,
     )
 
     build_tags = get_default_build_tags(build="system-probe")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -693,7 +693,6 @@ def build_sysprobe_binary(
         ctx,
         install_path=install_path,
         major_version=major_version,
-        python_runtimes=python_runtimes,
         arch=arch_obj,
         static=static,
     )
@@ -1509,6 +1508,7 @@ def build_cws_object_files(
         strip_object_files=strip_object_files,
         kernel_release=kernel_release,
         with_unit_test=with_unit_test,
+        ebpf_compiler=ebpf_compiler,
     )
 
     if bundle_ebpf:


### PR DESCRIPTION
### What does this PR do?

It adds the possibility to build system-probe statically with: `inv -e system-probe.build --static --bundle-ebpf --no-bundle`

### Motivation

Been able to ship a static binary for internal POC

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->