### PR TITLE
[Fleet Automation] Restart the Datadog Installer & Agent services at the end of the script

### DIFF
--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -288,6 +288,8 @@ catch {
 }
 finally {
    Write-Host "Cleaning up..."
-   Remove-Item -Force -EA SilentlyContinue $installer
+   if ($installer -and (Test-Path $installer)) {
+      Remove-Item -Force -EA SilentlyContinue $installer
+   }
 }
 Write-Host "Datadog Install Script finished!"

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -151,10 +151,11 @@ function Start-ProcessWithOutput {
 function Test-DatadogAgentPresence() {
    # Rudimentary check for the Agent presence, the `datadogagent` service should exist, and so should the `InstallPath` key in the registry.
    # We check that particular key since we use it later in the script to restart the service.
-   return 
+   return ( 
       ((Get-Service "datadogagent" -ea silent | Measure-Object).Count -eq 1) -and
       (Test-Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent") -and
       ($null -ne (Get-Item -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent").GetValue("InstallPath"))
+   )
 }
 
 function Update-DatadogAgentConfig() {

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -27,11 +27,13 @@ class ExitCodeException : Exception {
 }
 
 function Get-DatadogConfigPath() {
-   $configFile = Join-Path (Get-ItemPropertyValue -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent" -Name "ConfigRoot") "datadog.yaml"
-   if (-Not $configFile) {
-      $configFile = "C:\\ProgramData\\Datadog\\datadog.yaml"
+   if (
+      (Test-Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent") -and
+      ($null -ne (Get-Item -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent").GetValue("ConfigRoot"))
+   ) {
+      return (Join-Path (Get-ItemPropertyValue -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent" -Name "ConfigRoot") "datadog.yaml")
    }
-   return $configFile
+   return "C:\\ProgramData\\Datadog\\datadog.yaml"
 }
 
 function Update-DatadogConfigFile($regex, $replacement) {

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -44,8 +44,15 @@ function Send-Telemetry($payload) {
       "DD-Api-Key"   = $env:DD_API_KEY
       "Content-Type" = "application/json"
    }
-   $result = Invoke-WebRequest -Uri $telemetryUrl -Method POST -Body $payload -Headers $requestHeaders
-   Write-Host "Sending telemetry: $($result.StatusCode)"
+   try {
+      $result = Invoke-WebRequest -Uri $telemetryUrl -Method POST -Body $payload -Headers $requestHeaders
+      Write-Host "Sending telemetry: $($result.StatusCode)"
+   } catch {
+      # Don't propagate errors when sending telemetry, because our error handling code will also
+      # try to send telemetry.
+      # It's enough to just print a message since there's no further error handling to be done.
+      Write-Host "Error sending telemetry"
+   }
 }
 
 function Show-Error($errorMessage, $errorCode) {

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -184,7 +184,11 @@ try {
 
    # Rudimentary check for the Agent presence, the `datadogagent` service should exist, and so should the `InstallPath` key in the registry.
    # We check that particular key since we use it later in the script to restart the service.
-   if (((Get-Service "datadogagent" -ea silent | Measure-Object).Count -eq 0) -or ($null -eq (Get-Item -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent").GetValue("InstallPath"))) {
+   if (
+       ((Get-Service "datadogagent" -ea silent | Measure-Object).Count -eq 0) -or
+       (-Not (Test-Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent")) -or
+       ($null -eq (Get-Item -Path "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent").GetValue("InstallPath"))
+      ) {
       throw "Agent is not installed"
    }
 

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -275,7 +275,7 @@ try {
    Write-Host "Starting Datadog Installer service"
    Restart-Service "Datadog Installer"
    # This command handles restarting the dependent services as well
-   Write-Host "Stopping Datadog Agent services"
+   Write-Host "Starting Datadog Agent services"
    & ((Get-ItemProperty "HKLM:\\SOFTWARE\\Datadog\\Datadog Agent").InstallPath + "bin\\agent.exe") restart-service
 }
 catch [ExitCodeException] {

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -191,11 +191,7 @@ try {
    $myWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
    $myWindowsPrincipal = new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
    $adminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
-   if ($myWindowsPrincipal.IsInRole($adminRole)) {
-      # We are running "as Administrator"
-      $Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
-   }
-   else {
+   if (-not $myWindowsPrincipal.IsInRole($adminRole)) {
       # We are not running "as Administrator"
       $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
       $newProcess.Arguments = $myInvocation.MyCommand.Definition;


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR changes the PowerShell install script to restart the Datadog Agent and Installer services at the end of the script. This ensures that the changes to the configuration are taken into account.
It also changes the Agent detection slightly.

### Motivation
The configuration changes should be taken into account after the script has run.

https://datadoghq.atlassian.net/browse/WINA-1089
https://datadoghq.atlassian.net/browse/WINA-1087
https://datadoghq.atlassian.net/browse/WINA-1115
https://datadoghq.atlassian.net/browse/WINA-1116

### Describe how to test/QA your changes
Run the PowerShell script over an existing installation. The resulting installation state should reflect the changes made into the configuration.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->