### PR TITLE
[e2e] Mark TestEKSSuite as flaky

### DIFF
--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
@@ -33,6 +34,7 @@ func TestEKSSuite(t *testing.T) {
 	if err == nil {
 		initOnly = initOnlyParam
 	}
+	flake.Mark(t)
 	suite.Run(t, &eksSuite{initOnly: initOnly})
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `TestEKSSuite` is failing consistently since October 14, 6pm CET. Marking as flake until we investigate why.

### Motivation

#incident-31505

### Describe how to test/QA your changes

Verify that the test was skipped: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/671853306.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a