### PR TITLE
usm: kafka: Reorder operations to reduce mutex lock time

### DIFF
--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -46,7 +46,7 @@ func (statKeeper *StatKeeper) Process(tx *EbpfTx) {
 		return
 	}
 
-	// Extract operation is an expensive operation but, it is also concurrent safe, so we can do it here
+	// extractTopicName is an expensive operation but, it is also concurrent safe, so we can do it here
 	// without holding the lock.
 	key := Key{
 		RequestAPIKey:  tx.APIKey(),

--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -39,6 +39,13 @@ func NewStatkeeper(c *config.Config, telemetry *Telemetry) *StatKeeper {
 
 // Process processes the kafka transaction
 func (statKeeper *StatKeeper) Process(tx *EbpfTx) {
+	latency := tx.RequestLatency()
+	// Produce requests with acks = 0 do not receive a response, and as a result, have no latency
+	if tx.APIKey() == FetchAPIKey && latency <= 0 {
+		statKeeper.telemetry.invalidLatency.Add(1)
+		return
+	}
+
 	statKeeper.statsMutex.Lock()
 	defer statKeeper.statsMutex.Unlock()
 
@@ -56,13 +63,6 @@ func (statKeeper *StatKeeper) Process(tx *EbpfTx) {
 		}
 		requestStats = NewRequestStats()
 		statKeeper.stats[key] = requestStats
-	}
-
-	latency := tx.RequestLatency()
-	// Produce requests with acks = 0 do not receive a response, and as a result, have no latency
-	if key.RequestAPIKey == FetchAPIKey && latency <= 0 {
-		statKeeper.telemetry.invalidLatency.Add(1)
-		return
 	}
 
 	requestStats.AddRequest(int32(tx.ErrorCode()), int(tx.RecordsCount()), uint64(tx.Transaction.Tags), latency)

--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -46,15 +46,17 @@ func (statKeeper *StatKeeper) Process(tx *EbpfTx) {
 		return
 	}
 
-	statKeeper.statsMutex.Lock()
-	defer statKeeper.statsMutex.Unlock()
-
+	// Extract operation is an expensive operation but, it is also concurrent safe, so we can do it here
+	// without holding the lock.
 	key := Key{
 		RequestAPIKey:  tx.APIKey(),
 		RequestVersion: tx.APIVersion(),
 		TopicName:      statKeeper.extractTopicName(&tx.Transaction),
 		ConnectionKey:  tx.ConnTuple(),
 	}
+
+	statKeeper.statsMutex.Lock()
+	defer statKeeper.statsMutex.Unlock()
 	requestStats, ok := statKeeper.stats[key]
 	if !ok {
 		if len(statKeeper.stats) >= statKeeper.maxEntries {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reorder operations kafka process method to reduce mutex lock time

### Motivation

Can help processing more events on high-loaded environments

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The change also removes empty fetch requests without a valid latencies.
Such requests in the past would have create an entry in the `stats` map, but without any valid request being added to it.
