### PR TITLE
fix: remove warning for DD_GIT environment variables (#30123)

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1882,6 +1882,9 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		"DD_POD_NAME": {},
 		// this variable is used by tracers
 		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": {},
+		// these variables are used by source code integration
+		"DD_GIT_COMMIT_SHA":     {},
+		"DD_GIT_REPOSITORY_URL": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds `DD_GIT_COMMIT_SHA` and `DD_GIT_REPOSITORY_URL` to the list of environment variables to ignore in order to eliminate benign warning messages that appear during the startup of the Datadog Agent.


### Motivation

Fix #30123

After upgrading to Datadog Agent 7.57.2 in our EKS cluster, we encountered unnecessary warning messages related to `DD_GIT_COMMIT_SHA` and `DD_GIT_REPOSITORY_URL`. These warnings, originating from variables present in the base image, clutter the logs and make it harder to monitor the agents. Ignoring these variables improves log clarity and reduces noise.


### Describe how to test/QA your changes

1. Deploy an EKS cluster with the updated Datadog Agent that includes this change.
2. Start the agent and observe the logs.
3. Ensure that there are no warning messages related to `DD_GIT_COMMIT_SHA` and `DD_GIT_REPOSITORY_URL`.


### Possible Drawbacks / Trade-offs

No significant drawbacks anticipated from this change.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->