### PR TITLE
[corechecks/kubernetesapiserver] Stop depending on global tagger instance

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -478,7 +478,7 @@ func startAgent(
 	_ sysprobeconfig.Component,
 	server dogstatsdServer.Component,
 	wmeta workloadmeta.Component,
-	_ tagger.Component,
+	tagger tagger.Component,
 	ac autodiscovery.Component,
 	rcclient rcclient.Component,
 	_ optional.Option[logsAgent.Component],
@@ -579,7 +579,7 @@ func startAgent(
 	jmxfetch.RegisterWith(ac)
 
 	// Set up check collector
-	commonchecks.RegisterChecks(wmeta, cfg, telemetry)
+	commonchecks.RegisterChecks(wmeta, tagger, cfg, telemetry)
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(optional.NewOption(collector), demultiplexer, logReceiver), true)
 
 	demultiplexer.AddAgentStartupTelemetry(version.AgentVersion)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -372,7 +372,7 @@ func start(log log.Component,
 	common.LoadComponents(secretResolver, wmeta, ac, config.GetString("confd_path"))
 
 	// Set up check collector
-	registerChecks(wmeta, config)
+	registerChecks(wmeta, taggerComp, config)
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(optional.NewOption(collector), demultiplexer, logReceiver), true)
 
 	// start the autoconfig, this will immediately run any configured check
@@ -577,7 +577,7 @@ func initializeRemoteConfigClient(rcService rccomp.Component, config config.Comp
 	return rcClient, nil
 }
 
-func registerChecks(wlm workloadmeta.Component, cfg config.Component) {
+func registerChecks(wlm workloadmeta.Component, tagger tagger.Component, cfg config.Component) {
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
@@ -586,7 +586,7 @@ func registerChecks(wlm workloadmeta.Component, cfg config.Component) {
 	corecheckLoader.RegisterCheck(filehandles.CheckName, filehandles.Factory())
 
 	// Flavor specific checks
-	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory())
+	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory(tagger))
 	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory())
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(disk.CheckName, disk.Factory())

--- a/comp/core/tagger/global.go
+++ b/comp/core/tagger/global.go
@@ -92,11 +92,6 @@ func List() types.TaggerListResponse {
 	return types.TaggerListResponse{}
 }
 
-// GetTaggerInstance returns the global Tagger instance
-func GetTaggerInstance() Component {
-	return globalTagger
-}
-
 // SetNewCaptureTagger will set capture tagger in global tagger instance by using provided capture tagger
 func SetNewCaptureTagger(newCaptureTagger Component) {
 	if globalTagger != nil {

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -254,7 +254,7 @@ func run(
 	cliParams *cliParams,
 	demultiplexer demultiplexer.Component,
 	wmeta workloadmeta.Component,
-	_ tagger.Component,
+	tagger tagger.Component,
 	ac autodiscovery.Component,
 	secretResolver secrets.Component,
 	agentAPI internalAPI.Component,
@@ -289,7 +289,7 @@ func run(
 	// TODO: (components) - Until the checks are components we set there context so they can depends on components.
 	check.InitializeInventoryChecksContext(invChecks)
 	pkgcollector.InitPython(common.GetPythonPaths()...)
-	commonchecks.RegisterChecks(wmeta, config, telemetry)
+	commonchecks.RegisterChecks(wmeta, tagger, config, telemetry)
 
 	common.LoadComponents(secretResolver, wmeta, ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 	ac.LoadAndRun(context.Background())

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
@@ -14,6 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	obj "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -82,8 +83,10 @@ func TestParseComponentStatus(t *testing.T) {
 		Items: nil,
 	}
 
+	tagger := taggerimpl.SetupFakeTagger(t)
+
 	// FIXME: use the factory instead
-	kubeASCheck := NewKubeASCheck(core.NewCheckBase(CheckName), &KubeASConfig{})
+	kubeASCheck := NewKubeASCheck(core.NewCheckBase(CheckName), &KubeASConfig{}, tagger)
 
 	mocked := mocksender.NewMockSender(kubeASCheck.ID())
 	mocked.On("ServiceCheck", "kube_apiserver_controlplane.up", servicecheck.ServiceCheckOK, "", []string{"component:Zookeeper"}, "imok")

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -33,9 +34,11 @@ func TestReportClusterQuotas(t *testing.T) {
 	pkgconfigsetup.Datadog().SetWithoutSource("cluster_name", "test-cluster-name")
 	defer pkgconfigsetup.Datadog().SetWithoutSource("cluster_name", prevClusterName)
 
+	tagger := taggerimpl.SetupFakeTagger(t)
+
 	instanceCfg := []byte("")
 	initCfg := []byte("")
-	kubeASCheck := newCheck().(*KubeASCheck)
+	kubeASCheck := newCheck(tagger).(*KubeASCheck)
 	err = kubeASCheck.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, instanceCfg, initCfg, "test")
 	require.NoError(t, err)
 

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/stub.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/stub.go
@@ -9,6 +9,7 @@
 package kubernetesapiserver
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
@@ -19,6 +20,6 @@ const (
 )
 
 // Factory creates a new check factory
-func Factory() optional.Option[func() check.Check] {
+func Factory(_ tagger.Component) optional.Option[func() check.Check] {
 	return optional.NewNoneOption[func() check.Check]()
 }

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -8,6 +8,7 @@ package commonchecks
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -53,7 +54,7 @@ import (
 )
 
 // RegisterChecks registers all core checks
-func RegisterChecks(store workloadmeta.Component, cfg config.Component, telemetry telemetry.Component) {
+func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg config.Component, telemetry telemetry.Component) {
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
@@ -70,7 +71,7 @@ func RegisterChecks(store workloadmeta.Component, cfg config.Component, telemetr
 
 	// Flavor specific checks
 	corecheckLoader.RegisterCheck(load.CheckName, load.Factory())
-	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory())
+	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory(tagger))
 	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory())
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(pod.CheckName, pod.Factory(store, cfg))


### PR DESCRIPTION
### What does this PR do?

This PR is a step towards removing the global tagger instance defined in `comp/core/tagger/global.go`.

This PR modifies the `kubernetesapiserver` check so that it depends on the tagger component passed by parameter instead of calling `GetTaggerInstance()` to rely on the global tagger instance.

The `kubernetesapiserver` check was the only caller of `GetTaggerInstance()`, so this PR also deletes it.


### Describe how to test/QA your changes

It's a refactor that shouldn't change behavior. As a quick check, go to the events page and check that kubernetes events are still tagged as expected.