### PR TITLE
Reduce uploads to dd-ci-artefacts-build-stable

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -2,7 +2,6 @@
 .docker_build_job_definition:
   stage: container_build
   script:
-    - aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
     - |
@@ -24,6 +23,18 @@
   retry: 2
   timeout: 30m
 
+# Base template for jobs that don't rely on the packaging job artifacts but
+# rather from binaries stored in the 'dd-ci-artefacts-build-stable' bucket
+.docker_build_s3:
+  before_script:
+    - aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
+
+# Base template to move the packaged artifact from gitlab into the build
+# context
+.docker_build_artifact:
+  before_script:
+    - mv $OMNIBUS_PACKAGE_DIR/*.deb $BUILD_CONTEXT
+
 .docker_build_job_definition_amd64:
   extends: .docker_build_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -40,13 +51,12 @@
 
 # build agent7 image
 docker_build_agent7:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: agent_deb-x64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -67,13 +77,12 @@ single_machine_performance-amd64-a7:
     IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-amd64
 
 docker_build_agent7_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: agent_deb-arm64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -82,13 +91,12 @@ docker_build_agent7_arm64:
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: agent_deb-x64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -96,13 +104,12 @@ docker_build_agent7_jmx:
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
 docker_build_agent7_jmx_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: agent_deb-arm64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -111,13 +118,12 @@ docker_build_agent7_jmx_arm64:
 
 # build agent7 UA image
 docker_build_ot_agent7:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: ot_agent_deb-x64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -125,13 +131,12 @@ docker_build_ot_agent7:
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_amd64.deb
 
 docker_build_ot_agent7_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: ot_agent_deb-arm64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -140,13 +145,12 @@ docker_build_ot_agent7_arm64:
 
 # build agent7 jmx image
 docker_build_ot_agent7_jmx:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: ot_agent_deb-x64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -154,13 +158,12 @@ docker_build_ot_agent7_jmx:
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_amd64.deb
 
 docker_build_ot_agent7_jmx_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - job: ot_agent_deb-arm64-a7
-      artifacts: false
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -169,7 +172,7 @@ docker_build_ot_agent7_jmx_arm64:
 
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_s3]
   rules: !reference [.on_tag_or_a7]
   needs:
     - job: cluster_agent-build_amd64
@@ -182,10 +185,11 @@ docker_build_cluster_agent_amd64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
   before_script:
+    - !reference [.docker_build_s3, before_script]
     - cp -Rvf Dockerfiles/agent/nosys-seccomp Dockerfiles/cluster-agent/
 
 docker_build_cluster_agent_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_s3]
   rules: !reference [.on_tag_or_a7]
   needs:
     - job: cluster_agent-build_arm64
@@ -198,11 +202,12 @@ docker_build_cluster_agent_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
   before_script:
+    - !reference [.docker_build_s3, before_script]
     - cp -Rvf Dockerfiles/agent/nosys-seccomp Dockerfiles/cluster-agent/
 
 # build the cws-instrumentation image
 docker_build_cws_instrumentation_amd64:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_s3]
   rules: !reference [.on_tag_or_a7]
   needs:
     - job: cws_instrumentation-build_amd64
@@ -212,7 +217,7 @@ docker_build_cws_instrumentation_amd64:
     BUILD_CONTEXT: Dockerfiles/cws-instrumentation
 
 docker_build_cws_instrumentation_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_s3]
   rules: !reference [.on_tag_or_a7]
   needs:
     - job: cws_instrumentation-build_arm64
@@ -223,7 +228,7 @@ docker_build_cws_instrumentation_arm64:
 
 # build the dogstatsd image
 docker_build_dogstatsd_amd64:
-  extends: .docker_build_job_definition_amd64
+  extends: [.docker_build_job_definition_amd64, .docker_build_s3]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -237,7 +242,7 @@ docker_build_dogstatsd_amd64:
 
 # build the dogstatsd image
 docker_build_dogstatsd_arm64:
-  extends: .docker_build_job_definition_arm64
+  extends: [.docker_build_job_definition_arm64, .docker_build_s3]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/package_build/heroku.yml
+++ b/.gitlab/package_build/heroku.yml
@@ -31,8 +31,6 @@
     - inv -e omnibus.build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --flavor heroku
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.lint_linux_packages]
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent-dbg_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DBG_DEB
     - !reference [.upload_sbom_artifacts]
   variables:
     KUBERNETES_MEMORY_REQUEST: "32Gi"

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -7,7 +7,6 @@
     - !reference [.setup_deb_signing_key]
     - inv -e omnibus.build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps --target-project ${DD_PROJECT} ${OMNIBUS_EXTRA_ARGS}
     - !reference [.lint_linux_packages]
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-${DD_PROJECT}_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -68,7 +67,6 @@ agent_deb-arm64-a7:
     - !reference [.setup_deb_signing_key]
     - inv -e omnibus.build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps --target-project ${DD_PROJECT} --flavor ot ${OMNIBUS_EXTRA_ARGS}
     - !reference [.lint_linux_packages]
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-ot-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
 
 ot_agent_deb-x64-a7:
   extends: [.package_ot_deb_common, .package_deb_x86, .package_deb_agent_7]
@@ -126,7 +124,6 @@ installer_deb-arm64:
     - !reference [.setup_deb_signing_key]
     - inv -e omnibus.build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps --flavor iot
     - !reference [.lint_linux_packages]
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -59,9 +59,7 @@
     - ls -l ${OUTPUT_DIR}/
     - datadog-package merge ${OUTPUT_DIR}/*.tar
     # We need to propagate the exact version in the pipeline artifact
-    - cp merged.tar ${OMNIBUS_PACKAGE_DIR}/${MERGED_FILE}
-    # Only the major version is needed in the S3 bucket
-    - $S3_CP_CMD merged.tar $S3_ARTIFACTS_URI/${OCI_PRODUCT}_7_oci.tar
+    - mv merged.tar ${OMNIBUS_PACKAGE_DIR}/${MERGED_FILE}
   artifacts:
     paths:
       - ${OMNIBUS_PACKAGE_DIR}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Stop uploading deb & OCI packages to `dd-ci-artefacts-build-stable`

### Motivation

The OCI artifacts are never read from, which means we were uploading ≃800MB for no purpose in each pipeline.
The DEB packages are used when building containers, but always in the same pipeline, so we can simplify things by relying on gitlab artifacts, and reduce a bit the amount of S3 buckets we rely on.

BARX-612

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

:warning: This means that we won't be able to rebuild an image for a given pipeline by simply restarting the job.
For pipeline containers, that seems OK.
For RCs/releases, this might be problematic. We would need to introduce a fallback to download from `dd-release-artifacts` for such pipelines.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->