### PR TITLE
Revert "[e2e] Mark TestEKSSuite as flaky (#30116)"

### DIFF
--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
@@ -34,7 +33,6 @@ func TestEKSSuite(t *testing.T) {
 	if err == nil {
 		initOnly = initOnlyParam
 	}
-	flake.Mark(t)
 	suite.Run(t, &eksSuite{initOnly: initOnly})
 }
 

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -75,7 +75,7 @@ func (suite *eksSuite) SetupSuite() {
 	suite.Fakeintake = fakeintake.Client()
 
 	kubeCluster := &components.KubernetesCluster{}
-	kubeSerialized, err := json.Marshal(stackOutput.Outputs["dd-Cluster-aws-eks"].Value)
+	kubeSerialized, err := json.Marshal(stackOutput.Outputs["dd-Cluster-eks"].Value)
 	suite.Require().NoError(err)
 	suite.Require().NoError(kubeCluster.Import(kubeSerialized, &kubeCluster))
 	suite.Require().NoError(kubeCluster.Init(suite))


### PR DESCRIPTION
This reverts commit 3affe43dbdc1a8d2b0fbdeec5b6a11050f73d4f5.

### What does this PR do?

Re-enable `TestEKSSuite` e2e tests.

### Motivation

#incident-31505 has been fixed by DataDog/helm-charts#1559.

### Describe how to test/QA your changes

Check that `TestEKSSuite` is now passing.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes

n/a