### PR TITLE
[tagger] Delete param in createTaggerClient() that's always nil

### DIFF
--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -114,10 +114,9 @@ type TaggerClient struct {
 	log log.Component
 }
 
-func createTaggerClient(defaultTagger taggerComp.Component, captureTagger taggerComp.Component, l log.Component) *TaggerClient {
+func createTaggerClient(defaultTagger taggerComp.Component, l log.Component) *TaggerClient {
 	return &TaggerClient{
 		defaultTagger: defaultTagger,
-		captureTagger: captureTagger,
 		log:           l,
 	}
 }
@@ -135,24 +134,24 @@ func newTaggerClient(deps dependencies) provides {
 
 		if err != nil {
 			deps.Log.Errorf("unable to deps.Configure the remote tagger: %s", err)
-			taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), nil, deps.Log)
+			taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), deps.Log)
 		} else if options.Disabled {
 			deps.Log.Errorf("remote tagger is disabled in clc runner.")
-			taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), nil, deps.Log)
+			taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), deps.Log)
 		} else {
 			filter := types.NewFilterBuilder().Exclude(types.KubernetesPodUID).Build(types.HighCardinality)
-			taggerClient = createTaggerClient(remote.NewTagger(options, deps.Config, telemetryStore, filter), nil, deps.Log)
+			taggerClient = createTaggerClient(remote.NewTagger(options, deps.Config, telemetryStore, filter), deps.Log)
 		}
 	case taggerComp.NodeRemoteTaggerAgent:
 		options, _ := remote.NodeAgentOptions(deps.Config)
-		taggerClient = createTaggerClient(remote.NewTagger(options, deps.Config, telemetryStore, types.NewMatchAllFilter()), nil, deps.Log)
+		taggerClient = createTaggerClient(remote.NewTagger(options, deps.Config, telemetryStore, types.NewMatchAllFilter()), deps.Log)
 	case taggerComp.LocalTaggerAgent:
-		taggerClient = createTaggerClient(local.NewTagger(deps.Config, deps.Wmeta, telemetryStore), nil, deps.Log)
+		taggerClient = createTaggerClient(local.NewTagger(deps.Config, deps.Wmeta, telemetryStore), deps.Log)
 	case taggerComp.FakeTagger:
 		// all binaries are expected to provide their own tagger at startup. we
 		// provide a fake tagger for testing purposes, as calling the global
 		// tagger without proper initialization is very common there.
-		taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), nil, deps.Log)
+		taggerClient = createTaggerClient(local.NewFakeTagger(deps.Config, telemetryStore), deps.Log)
 	}
 
 	if taggerClient != nil {


### PR DESCRIPTION
### What does this PR do?

Small cleanup in the tagger. Deletes a function param in `createTaggerClient` that's always sent as nil.

### Describe how to test/QA your changes

Unit and e2e tests cover this.