### PR TITLE
[CWS] Fix event trace cgroup for systemd cgroups

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -100,10 +100,11 @@ __attribute__((always_inline)) u64 trace_new_cgroup(void *ctx, u64 now, containe
         return 0;
     }
 
-    if (cgroup->cgroup_flags != 0 && ((cgroup->cgroup_flags & 0b111) != CGROUP_MANAGER_SYSTEMD)) {
-        copy_container_id(container_id, evt->container.container_id);
+    if ((cgroup->cgroup_flags & 0b111) == CGROUP_MANAGER_SYSTEMD) {
+        return 0;
     }
 
+    copy_container_id(container_id, evt->container.container_id);
     evt->container.cgroup_context = *cgroup;
     evt->cookie = cookie;
     evt->config = config;


### PR DESCRIPTION
### What does this PR do?

We discovered that we have a lot of warning logs of HandleCGroupTracingEvent with trace cgroup events coming with an empty containerID. This PR should fix the issue by avoiding to send kernel events for systemd cgroups.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->