### PR TITLE
Delete old binary size comment before creating new one.

### DIFF
--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -159,6 +159,5 @@ jobs:
         if: steps.should.outputs.should_run == 'true'
         with:
           header: serverless-binary-size
-          hide_and_recreate: true
-          hide_classify: "RESOLVED"
+          recreate: true
           path: ${{ steps.write.outputs.filename }}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Deletes old binary size comments on PR's before creating a new one.

### Motivation

The binary size action is run on every push. When the old comments are not cleaned up, they can really stack up.

<img width="965" alt="Screenshot 2024-10-15 at 8 29 15 AM" src="https://github.com/user-attachments/assets/704d4a4e-a16a-4065-8413-8aed70327a51">

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->