### PR TITLE
remove WriteConfig action

### DIFF
--- a/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/InstallerCustomActions/CustomAction.cs
@@ -49,12 +49,6 @@ namespace Datadog.InstallerCustomActions
         }
 
         [CustomAction]
-        public static ActionResult WriteConfig(Session session)
-        {
-            return Datadog.CustomActions.ConfigCustomActions.WriteConfig(session);
-        }
-
-        [CustomAction]
         public static ActionResult ProcessDdAgentUserCredentials(Session session)
         {
             return Datadog.CustomActions.ProcessUserCustomActions.ProcessDdAgentUserCredentials(session);

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstallerCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstallerCustomActions.cs
@@ -7,7 +7,6 @@ namespace WixSetup.Datadog_Installer
     {
         public ManagedAction RunAsAdmin { get; }
         public ManagedAction ReadConfig { get; }
-        public ManagedAction WriteConfig { get; }
         public ManagedAction ReadInstallState { get; }
         public ManagedAction WriteInstallState { get; }
         public ManagedAction RollbackWriteInstallState { get; }
@@ -71,24 +70,6 @@ namespace WixSetup.Datadog_Installer
                 Execute = Execute.firstSequence
             }
             .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
-
-            WriteConfig = new CustomAction<CustomActions>(
-                new Id(nameof(WriteConfig)),
-                CustomActions.WriteConfig,
-                Return.check,
-                When.Before,
-                Step.InstallServices,
-                Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
-            )
-            {
-                Execute = Execute.deferred,
-                Impersonate = false
-            }
-            .SetProperties(
-                "APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]," +
-                "APIKEY=[APIKEY], " +
-                "SITE=[SITE]")
-            .HideTarget(true);
 
             OpenMsiLog = new CustomAction<CustomActions>(
                 new Id(nameof(OpenMsiLog)),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove `WriteConfig` action from Datadog Installer MSI

### Motivation
https://datadoghq.atlassian.net/browse/WINA-893
Agent MSI is responsible for placing config, and this installer does not have the `*.yaml.example` files, so this action has no intended effects.

It did have an unintended effect, since https://github.com/DataDog/datadog-agent/pull/28164, of deleting the `auth_token` out from under the running Agent, creating errors in the agent log files until the Agent is restarted, which should happen soon anyway as of https://github.com/DataDog/datadog-agent/pull/30107

### Describe how to test/QA your changes
upgrade installer and ensure it doesn't delete the `auth_token` from the Agent

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
no changelog, not yet released