### PR TITLE
Make Windows crash dump checks asynchronous.

### DIFF
--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -23,6 +23,7 @@ import (
 
 // allow us to change for testing
 var readfn = doReadCrashDump
+var parseCrashDump = parseWinCrashDump
 
 type logCallbackContext struct {
 	loglines       []string
@@ -107,14 +108,14 @@ func doReadCrashDump(filename string, ctx *logCallbackContext, exterr *uint32) e
 	return nil
 }
 
-func parseCrashDump(wcs *WinCrashStatus) {
+func parseWinCrashDump(wcs *WinCrashStatus) {
 	var ctx logCallbackContext
 	var extendedError uint32
 
 	err := readfn(wcs.FileName, &ctx, &extendedError)
 
 	if err != nil {
-		wcs.Success = false
+		wcs.StatusCode = WinCrashStatusCodeFailed
 		wcs.ErrString = fmt.Sprintf("Failed to load crash dump file %v %x", err, extendedError)
 		log.Errorf("Failed to open crash dump %s: %v %x", wcs.FileName, err, extendedError)
 		return
@@ -122,7 +123,7 @@ func parseCrashDump(wcs *WinCrashStatus) {
 
 	if len(ctx.loglines) < 2 {
 		wcs.ErrString = fmt.Sprintf("Invalid crash dump file %s", wcs.FileName)
-		wcs.Success = false
+		wcs.StatusCode = WinCrashStatusCodeFailed
 		return
 	}
 
@@ -190,5 +191,5 @@ func parseCrashDump(wcs *WinCrashStatus) {
 		wcs.Offender = callsite
 		break
 	}
-	wcs.Success = true
+	wcs.StatusCode = WinCrashStatusCodeSuccess
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -51,12 +51,11 @@ func TestCrashParser(t *testing.T) {
 		FileName: "testdata/crashsample1.txt",
 	}
 	// first read in the sample data
-
-	readfn = testCrashReader
+	OverrideCrashDumpReader(testCrashReader)
 
 	parseCrashDump(wcs)
 
-	assert.True(t, wcs.Success)
+	assert.Equal(t, WinCrashStatusCodeSuccess, wcs.StatusCode)
 	assert.Empty(t, wcs.ErrString)
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")
@@ -72,11 +71,11 @@ func TestCrashParserWithLineSplits(t *testing.T) {
 	}
 	// first read in the sample data
 
-	readfn = testCrashReaderWithLineSplits
+	OverrideCrashDumpReader(testCrashReaderWithLineSplits)
 
 	parseCrashDump(wcs)
 
-	assert.True(t, wcs.Success)
+	assert.Equal(t, WinCrashStatusCodeSuccess, wcs.StatusCode)
 	assert.Empty(t, wcs.ErrString)
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -29,10 +29,26 @@ const (
 	DumpTypeAutomatic    = int(7) // automatic
 )
 
+const (
+	// WinCrashStatusCodeUnknown indicates an invalid or corrupted code.
+	WinCrashStatusCodeUnknown = int(-1)
+
+	// WinCrashStatusCodeSuccess indicates that crash dump processing succeeded
+	// or no crash dump was found.
+	WinCrashStatusCodeSuccess = int(0)
+
+	// WinCrashStatusCodeBusy indicates that crash dump processing is still busy
+	// and no result is yet available.
+	WinCrashStatusCodeBusy = int(1)
+
+	// WinCrashStatusCodeFailed indicates that crash dump processing failed or had an error.
+	WinCrashStatusCodeFailed = int(2)
+)
+
 // WinCrashStatus defines all of the information returned from the system
 // probe to the caller
 type WinCrashStatus struct {
-	Success    bool   `json:"success"`
+	StatusCode int    `json:"statuscode"`
 	ErrString  string `json:"errstring"`
 	FileName   string `json:"filename"`
 	Type       int    `json:"dumptype"`

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && windows
+
+package probe
+
+type readCrashDumpType func(filename string, ctx *logCallbackContext, _ *uint32) error
+type parseCrashDumpType func(wcs *WinCrashStatus)
+
+// SetCachedSettings sets the settings used for tests without reading the Registry.
+func (p *WinCrashProbe) SetCachedSettings(wcs *WinCrashStatus) {
+	p.status = wcs
+}
+
+// OverrideCrashDumpReader relpaces the crash dump reading function for tests.
+func OverrideCrashDumpReader(customCrashReader readCrashDumpType) {
+	readfn = customCrashReader
+}
+
+// OverrideCrashDumpParser relpaces the crash dump parsing function for tests.
+func OverrideCrashDumpParser(customParseCrashDump parseCrashDumpType) {
+	parseCrashDump = customParseCrashDump
+}

--- a/pkg/util/crashreport/crashreport.go
+++ b/pkg/util/crashreport/crashreport.go
@@ -115,6 +115,13 @@ func (wcr *WinCrashReporter) CheckForCrash() (*probe.WinCrashStatus, error) {
 	if !ok {
 		return nil, fmt.Errorf("Raw data has incorrect type")
 	}
+
+	// Crash dump processing is not done yet, nothing to send at the moment. Try later.
+	if crash.StatusCode == probe.WinCrashStatusCodeBusy {
+		log.Infof("Crash dump processing is busy")
+		return nil, nil
+	}
+
 	/*
 	 * originally did this with a sync.once.  The problem is the check is run prior to the
 	 * system probe being successfully started.  This is OK; we just need to detect the BSOD
@@ -124,7 +131,7 @@ func (wcr *WinCrashReporter) CheckForCrash() (*probe.WinCrashStatus, error) {
 	 * we don't need to run any more
 	 */
 	wcr.hasRunOnce = true
-	if !crash.Success {
+	if crash.StatusCode == probe.WinCrashStatusCodeFailed {
 		return nil, fmt.Errorf("Error getting crash data %s", crash.ErrString)
 	}
 

--- a/releasenotes/notes/windowscrashreportasync-1b2c77f9ebeafdd5.yaml
+++ b/releasenotes/notes/windowscrashreportasync-1b2c77f9ebeafdd5.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, the endpoint /windows_crash_detection/check has been modified to report crashes in
+    an asynchronous manner, to allow processing of large crash dumps without blocking or timing out.
+    The first check will return a busy status and continue to do so until the processing is completed.
+


### PR DESCRIPTION
### What does this PR do?
This PR modifies the Windows crash dump checks to be asynchronous.

### Motivation
WIndows crash dumps may be very large (example: 128 GB) and it may take a significant while (e.g. minutes) for the Windbg subsystem to process a dump. The checks for crashes (from agent to system probe) will often timeout before the processing completes. This PR modifies system probe's crash reporting endpoint to return a "busy" status while the crash dump is still being process. Once the processing and report is ready, the endpoint returns a "success" status with the original crash information.

### Describe how to test/QA your changes
A. Manual
1. In a Windows VM, make sure there are no existing crash dumps (e.g. C:\Windows\MEMORY.DMP)
2. Start system probe.
3. Query the endpoint with:  `NamedPipeCmd.exe -method GET -path /windows_crash_detection/check -quiet`.  It should return something like: `{"statuscode":0,"errstring":"","filename":"","dumptype":1,"datestring":"","offender":"","buckcheckcode":""}`
4. Configure Windows to generate full crash dumps.
5. Use a tool (e.g. NotMyFault.exe) to cause a bugcheck, which should generate a crash dump (e.g. C:\Windows\MEMORY.DMP)
6. Wait for the VM to restart.
7. Start system probe.
8. Query the endpoint with:  `NamedPipeCmd.exe -method GET -path /windows_crash_detection/check -quiet`.  It should respond with status 1, like the following: `{"statuscode":1,"errstring":"","filename":"C:\\Windows\\MEMORY.DMP","dumptype":1,"datestring":"","offender":"","buckcheckcode":""}`
9. Wait for a minute or so and query the endpoint again.  It should respond with status 0, like the following: `{"statuscode":0,"errstring":"","filename":"C:\\Windows\\MEMORY.DMP","dumptype":1,"datestring":"Tue Oct  8 11:53:30.883 2024 (UTC - 7:00)","offender":"myfault+0x163e","buckcheckcode":"000000C2"}`

B. Run the following unit tests: wincrash_detect_windows_test.go, crashparse_test.go.

### Possible Drawbacks / Trade-offs
The caller on the crash reporting endpoint previously received a full response with single query. as long the crash dump was not too large.  Now the caller must make at least 2 queries because the first one always returns "busy" status.
