### PR TITLE
[CWS] sbom: speedup code path when the package is not there

### DIFF
--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -100,6 +100,9 @@ func (fq *fileQuerier) queryHashWithNegativeCache(hash uint64) *Package {
 
 	pkg := fq.queryHash(hash)
 	if pkg == nil {
+		if fq.lastNegativeCache == nil {
+			fq.lastNegativeCache = newFixedSizeQueue[uint64](2)
+		}
 		fq.lastNegativeCache.push(hash)
 	}
 
@@ -140,6 +143,10 @@ func (q *fixedSizeQueue[T]) push(value T) {
 }
 
 func (q *fixedSizeQueue[T]) contains(value T) bool {
+	if q == nil {
+		return false
+	}
+
 	for _, v := range q.queue {
 		if v == value {
 			return true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR speeds up the file querier for SBOMs by adding two fast paths:
- first it adds a layer of `slices.Contains` that will be optimized to first check if we even need to start the double for loop
- second it adds a negative lookup cache, i.e. hashes that don't match any package, with 2 values in it (because of the `/usr/` edge case in our query code) 

The main goal of this is to speed up the case where we query a package and return nil, which is quite frequent.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->