### PR TITLE
[NDM Autodiscovery] Add unit test to verify Unmarshal of YAML

### DIFF
--- a/pkg/config/autodiscovery/autodiscovery_test.go
+++ b/pkg/config/autodiscovery/autodiscovery_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	snmplistener "github.com/DataDog/datadog-agent/pkg/snmp"
 )
 
 func TestDiscoverComponentsFromConfigForSnmp(t *testing.T) {
@@ -45,4 +46,27 @@ snmp_listener:
 	assert.NoError(t, err)
 	_, configListeners = DiscoverComponentsFromConfig()
 	assert.Empty(t, len(configListeners))
+}
+
+func TestUnmarshalFromConfigForSnmp(t *testing.T) {
+	pkgconfigsetup.Datadog().SetConfigType("yaml")
+
+	err := pkgconfigsetup.Datadog().ReadConfig(strings.NewReader(`
+network_devices:
+  autodiscovery:
+    configs:
+      - network_address: 127.0.0.1/30
+        ignored_ip_addresses:
+          - 127.0.0.2
+`))
+	assert.NoError(t, err)
+
+	configs := []snmplistener.Config{}
+	err = pkgconfigsetup.Datadog().UnmarshalKey("network_devices.autodiscovery.configs", &configs)
+	assert.NoError(t, err)
+
+	assert.Len(t, configs, 1)
+	assert.Equal(t, "127.0.0.1/30", configs[0].Network)
+	assert.Equal(t, 1, len(configs[0].IgnoredIPAddresses))
+	assert.Contains(t, configs[0].IgnoredIPAddresses, "127.0.0.2")
 }


### PR DESCRIPTION
### What does this PR do?
Adds unit test for a bug that currently exists in the NDM Autodiscovery Listener. This PR does NOT fix the problem.

### Motivation
When adding `ignored_ip_addresses` to the NDM Autodiscovery config in `datadog.yaml`, the SNMP Listener fails to start and no error is logged.

### Describe how to test/QA your changes
Unit test included in PR

### Possible Drawbacks / Trade-offs

### Additional Notes
TODO: Add link to Issue