### PR TITLE
[CWS] Fix a load controller issue where tags were resolved multiple times

### DIFF
--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -615,7 +615,8 @@ func (ad *ActivityDump) ResolveTags() error {
 
 // resolveTags thread unsafe version ot ResolveTags
 func (ad *ActivityDump) resolveTags() error {
-	if len(ad.Tags) >= 10 || len(ad.Metadata.ContainerID) == 0 {
+	selector := ad.GetWorkloadSelector()
+	if selector != nil {
 		return nil
 	}
 

--- a/pkg/security/security_profile/dump/load_controller.go
+++ b/pkg/security/security_profile/dump/load_controller.go
@@ -102,7 +102,7 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 	}
 
 	// compute the duration it took to reach the dump size threshold
-	timeToThreshold := time.Now().Sub(ad.Start)
+	timeToThreshold := time.Since(ad.Start)
 
 	// set new load parameters
 	newDump.SetTimeout(ad.LoadConfig.Timeout - timeToThreshold)

--- a/pkg/security/security_profile/dump/load_controller.go
+++ b/pkg/security/security_profile/dump/load_controller.go
@@ -87,6 +87,7 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 	newDump.Metadata.ContainerID = ad.Metadata.ContainerID
 	newDump.Metadata.DifferentiateArgs = ad.Metadata.DifferentiateArgs
 	newDump.Tags = ad.Tags
+	newDump.selector = ad.selector
 
 	// copy storage requests
 	for _, reqList := range ad.StorageRequests {
@@ -101,7 +102,7 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 	}
 
 	// compute the duration it took to reach the dump size threshold
-	timeToThreshold := ad.End.Sub(ad.Start)
+	timeToThreshold := time.Now().Sub(ad.Start)
 
 	// set new load parameters
 	newDump.SetTimeout(ad.LoadConfig.Timeout - timeToThreshold)

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -852,6 +852,9 @@ func (adm *ActivityDumpManager) triggerLoadController() {
 
 	// handle overweight dumps
 	for _, ad := range dumps {
+		// restart a new dump for the same workload
+		newDump := adm.loadController.NextPartialDump(ad)
+
 		// stop the dump but do not release the cgroup
 		ad.Finalize(false)
 		seclog.Infof("tracing paused for [%s]", ad.GetSelectorStr())
@@ -866,9 +869,6 @@ func (adm *ActivityDumpManager) triggerLoadController() {
 		} else {
 			adm.emptyDropped.Inc()
 		}
-
-		// restart a new dump for the same workload
-		newDump := adm.loadController.NextPartialDump(ad)
 
 		adm.Lock()
 		if err := adm.insertActivityDump(newDump); err != nil {

--- a/pkg/security/tests/fake_tags_resolver.go
+++ b/pkg/security/tests/fake_tags_resolver.go
@@ -40,7 +40,6 @@ func (fr *FakeResolver) Stop() error {
 func (fr *FakeResolver) Resolve(containerID string) []string {
 	fakeTags := []string{
 		"image_tag:latest",
-		"container_id:" + containerID,
 	}
 	fr.Lock()
 	defer fr.Unlock()


### PR DESCRIPTION
### What does this PR do?

Error logs when finalizing dumps were generated on each subsequent dump once the load controller triggers.
The issue was cause by calling the "finalizer" multiple times for the same dump, adding the containerID as tag.
Also, the tags were resolved on each subsequent dump.

Now, we call finalize only on dumps we are about to persist/send (before copying it). And we avoid resolving multiple times the tags for the same workload.

### Motivation

Get rid of some spamy error logs

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->