### PR TITLE
[EVPProxy] Do not manually cancel the request context

### DIFF
--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -181,6 +181,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	timeout := getConfiguredEVPRequestTimeoutDuration(t.conf)
 	req.Header.Set("X-Datadog-Timeout", strconv.Itoa((int(timeout.Seconds()))))
 	deadline := time.Now().Add(timeout)
+	//nolint:govet,lostcancel we don't need to manually cancel this context, we can rely on the parent context being cancelled
 	ctx, _ := context.WithDeadline(req.Context(), deadline)
 	req = req.WithContext(ctx)
 

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -181,9 +181,8 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	timeout := getConfiguredEVPRequestTimeoutDuration(t.conf)
 	req.Header.Set("X-Datadog-Timeout", strconv.Itoa((int(timeout.Seconds()))))
 	deadline := time.Now().Add(timeout)
-	ctx, ctxCancel := context.WithDeadline(req.Context(), deadline)
+	ctx, _ := context.WithDeadline(req.Context(), deadline)
 	req = req.WithContext(ctx)
-	defer ctxCancel()
 
 	// Set target URL and API key header (per domain)
 	req.URL.Scheme = "https"


### PR DESCRIPTION
### Context
In https://github.com/DataDog/datadog-agent/pull/26336 I added a timeout to the request context so that requests don't wait forever.

However, I also added a `defer ctxCancel()` call that manually cancelled the context at the end of the `RoundTrip`. This is not necessary because the parent context will already be cancelled when done, and furthermore it was causing problems with chunked  (`Transfer-Encoding: chunked`) responses.

### What does this PR do?
Do not cancel the context manually.

### Describe how to test/QA your changes
There's a reproducer in this ticket: https://datadoghq.atlassian.net/browse/SDTEST-1010?focusedCommentId=1947043
