### PR TITLE
[CWS/CSPM] set cardinality of `.containers_running` to `orch`

### DIFF
--- a/pkg/security/telemetry/telemetry.go
+++ b/pkg/security/telemetry/telemetry.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -47,7 +48,7 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 			continue
 		}
 
-		c.TelemetrySender.Gauge(metricName, 1.0, []string{"container_id:" + container.ID})
+		c.TelemetrySender.Gauge(metricName, 1.0, []string{"container_id:" + container.ID, constants.CardinalityTagPrefix + "orch"})
 	}
 	c.TelemetrySender.Commit()
 }


### PR DESCRIPTION
### What does this PR do?

With the default cardinality, the `.containers_running` metrics are tagged with `container_id` twice:
- once manually in the telemetry code
- once by the agent statsd code with `container_id:<container id of the security-agent>`

The goal of this PR is to disable this second point, by setting the cardinality manually to orch, which will remove the `container_id` and `display_container_name` tags ([doc](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#out-of-the-box-tags)).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->