### PR TITLE
network-path: memory and CPU optimization to `parseTCP`

### DIFF
--- a/pkg/networkpath/traceroute/tcp/utils.go
+++ b/pkg/networkpath/traceroute/tcp/utils.go
@@ -231,7 +231,7 @@ func handlePackets(ctx context.Context, conn rawConnWrapper, listener string, lo
 		if listener == "icmp" {
 			icmpResponse, err := parseICMP(header, packet)
 			if err != nil {
-				log.Tracef("failed to parse ICMP packet: %s", err.Error())
+				log.Tracef("failed to parse ICMP packet: %s", err)
 				continue
 			}
 			if icmpMatch(localIP, localPort, remoteIP, remotePort, seqNum, icmpResponse) {
@@ -240,7 +240,7 @@ func handlePackets(ctx context.Context, conn rawConnWrapper, listener string, lo
 		} else if listener == "tcp" {
 			tcpResp, err := tp.parseTCP(header, packet)
 			if err != nil {
-				log.Tracef("failed to parse TCP packet: %s", err.Error())
+				log.Tracef("failed to parse TCP packet: %s", err)
 				continue
 			}
 			if tcpMatch(localIP, localPort, remoteIP, remotePort, seqNum, tcpResp) {

--- a/pkg/networkpath/traceroute/tcp/utils.go
+++ b/pkg/networkpath/traceroute/tcp/utils.go
@@ -201,6 +201,7 @@ func listenPackets(icmpConn rawConnWrapper, tcpConn rawConnWrapper, timeout time
 // timeout or if the listener is canceled, it should return a canceledError
 func handlePackets(ctx context.Context, conn rawConnWrapper, listener string, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32) (net.IP, uint16, layers.ICMPv4TypeCode, time.Time, error) {
 	buf := make([]byte, 1024)
+	tp := newTCPParser()
 	for {
 		select {
 		case <-ctx.Done():
@@ -237,7 +238,7 @@ func handlePackets(ctx context.Context, conn rawConnWrapper, listener string, lo
 				return icmpResponse.SrcIP, 0, icmpResponse.TypeCode, received, nil
 			}
 		} else if listener == "tcp" {
-			tcpResp, err := parseTCP(header, packet)
+			tcpResp, err := tp.parseTCP(header, packet)
 			if err != nil {
 				log.Tracef("failed to parse TCP packet: %s", err.Error())
 				continue
@@ -309,7 +310,18 @@ func parseICMP(header *ipv4.Header, payload []byte) (*icmpResponse, error) {
 	return &icmpResponse, nil
 }
 
-func parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse, error) {
+type tcpParser struct {
+	layer               layers.TCP
+	decodingLayerParser *gopacket.DecodingLayerParser
+}
+
+func newTCPParser() *tcpParser {
+	tcpParser := &tcpParser{}
+	tcpParser.decodingLayerParser = gopacket.NewDecodingLayerParser(layers.LayerTypeTCP, &tcpParser.layer)
+	return tcpParser
+}
+
+func (tp *tcpParser) parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse, error) {
 	tcpResponse := tcpResponse{}
 
 	if header.Protocol != IPProtoTCP || header.Version != 4 ||
@@ -319,13 +331,14 @@ func parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse, error) {
 	tcpResponse.SrcIP = header.Src
 	tcpResponse.DstIP = header.Dst
 
-	var tcpLayer layers.TCP
 	decoded := []gopacket.LayerType{}
-	tcpParser := gopacket.NewDecodingLayerParser(layers.LayerTypeTCP, &tcpLayer)
-	if err := tcpParser.DecodeLayers(payload, &decoded); err != nil {
+
+	if err := tp.decodingLayerParser.DecodeLayers(payload, &decoded); err != nil {
 		return nil, fmt.Errorf("failed to decode TCP packet: %w", err)
 	}
-	tcpResponse.TCPResponse = &tcpLayer
+	copiedLayer := tp.layer
+	tcpResponse.TCPResponse = &copiedLayer
+	tp.layer = layers.TCP{}
 
 	return &tcpResponse, nil
 }

--- a/pkg/networkpath/traceroute/tcp/utils.go
+++ b/pkg/networkpath/traceroute/tcp/utils.go
@@ -331,8 +331,7 @@ func (tp *tcpParser) parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse
 	tcpResponse.SrcIP = header.Src
 	tcpResponse.DstIP = header.Dst
 
-	decoded := []gopacket.LayerType{}
-
+	var decoded []gopacket.LayerType
 	if err := tp.decodingLayerParser.DecodeLayers(payload, &decoded); err != nil {
 		return nil, fmt.Errorf("failed to decode TCP packet: %w", err)
 	}

--- a/pkg/networkpath/traceroute/tcp/utils.go
+++ b/pkg/networkpath/traceroute/tcp/utils.go
@@ -312,6 +312,7 @@ func parseICMP(header *ipv4.Header, payload []byte) (*icmpResponse, error) {
 
 type tcpParser struct {
 	layer               layers.TCP
+	decoded             []gopacket.LayerType
 	decodingLayerParser *gopacket.DecodingLayerParser
 }
 
@@ -327,8 +328,7 @@ func (tp *tcpParser) parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse
 		return nil, fmt.Errorf("invalid IP header for TCP packet: %+v", header)
 	}
 
-	var decoded []gopacket.LayerType
-	if err := tp.decodingLayerParser.DecodeLayers(payload, &decoded); err != nil {
+	if err := tp.decodingLayerParser.DecodeLayers(payload, &tp.decoded); err != nil {
 		return nil, fmt.Errorf("failed to decode TCP packet: %w", err)
 	}
 

--- a/pkg/networkpath/traceroute/tcp/utils_test.go
+++ b/pkg/networkpath/traceroute/tcp/utils_test.go
@@ -331,6 +331,22 @@ func Test_parseTCP(t *testing.T) {
 	}
 }
 
+func BenchmarkParseTCP(b *testing.B) {
+	ipv4Header := createMockIPv4Header(srcIP, dstIP, 6) // 6 is TCP
+	tcpLayer := createMockTCPLayer(12345, 443, 28394, 12737, true, true, true)
+
+	// full packet
+	_, fullTCPPacket := createMockTCPPacket(ipv4Header, tcpLayer)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := parseTCP(ipv4Header, fullTCPPacket)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func (m *mockRawConn) SetReadDeadline(t time.Time) error {
 	if m.setReadDeadlineErr != nil {
 		return m.setReadDeadlineErr

--- a/pkg/networkpath/traceroute/tcp/utils_test.go
+++ b/pkg/networkpath/traceroute/tcp/utils_test.go
@@ -305,7 +305,7 @@ func Test_parseTCP(t *testing.T) {
 			expected: &tcpResponse{
 				SrcIP:       srcIP,
 				DstIP:       dstIP,
-				TCPResponse: encodedTCPLayer,
+				TCPResponse: *encodedTCPLayer,
 			},
 			errMsg: "",
 		},

--- a/pkg/networkpath/traceroute/tcp/utils_test.go
+++ b/pkg/networkpath/traceroute/tcp/utils_test.go
@@ -311,9 +311,10 @@ func Test_parseTCP(t *testing.T) {
 		},
 	}
 
+	tp := newTCPParser()
 	for _, test := range tt {
 		t.Run(test.description, func(t *testing.T) {
-			actual, err := parseTCP(test.inHeader, test.inPayload)
+			actual, err := tp.parseTCP(test.inHeader, test.inPayload)
 			if test.errMsg != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.errMsg)
@@ -338,9 +339,11 @@ func BenchmarkParseTCP(b *testing.B) {
 	// full packet
 	_, fullTCPPacket := createMockTCPPacket(ipv4Header, tcpLayer)
 
+	tp := newTCPParser()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := parseTCP(ipv4Header, fullTCPPacket)
+		_, err := tp.parseTCP(ipv4Header, fullTCPPacket)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In some profiles we can see that the network path traceroute feature is, in some cases, allocating a lot of memory: [example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astingchameleon%20&agg_m=count&agg_m_source=base&agg_t=count&color_by=package&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AgAAAZKWXUtjprEfJQAAAAAAAAAYAAAAAEFaS1dYVXV4QUFCdmtHZWY0Q2Q3REFBQQAAACQAAAAAMDE5Mjk2NWUtYzk0NC00OTk3LWEwYWMtYjE1YWRhYTI5MGRl&fromUser=true&group_by=line&limit=100&my_code=disabled&profile_type=alloc-size&profileId=AZKWXUuxAABvkGef4Cd7DAAA&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&start=1729097200736&end=1729100800736&paused=true).

The goal of this PR is to improve the performance of the `parseTCP` function from an allocation standpoint but also from a CPU usage point of view.

Benchmarks:
```
$ go test -benchmem -run=^$ -tags test -bench ^BenchmarkParseTCP$ github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/tcp
# before
BenchmarkParseTCP-10    	 3401749	       338.8 ns/op	     816 B/op	      13 allocs/op
# after
BenchmarkParseTCP-10    	10998318	       103.4 ns/op	     384 B/op	       1 allocs/op

# benchstat
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/tcp
cpu: Apple M1 Max
            │   old.txt    │               new.txt               │
            │    sec/op    │   sec/op     vs base                │
ParseTCP-10   334.90n ± 1%   95.70n ± 2%  -71.43% (p=0.000 n=10)

            │  old.txt   │              new.txt               │
            │    B/op    │    B/op     vs base                │
ParseTCP-10   816.0 ± 0%   384.0 ± 0%  -52.94% (p=0.000 n=10)

            │   old.txt   │              new.txt               │
            │  allocs/op  │ allocs/op   vs base                │
ParseTCP-10   13.000 ± 0%   1.000 ± 0%  -92.31% (p=0.000 n=10)
```

The main things this PR does, is move the things that are not moving, that are re-usable from one call to `parseTCP` to the next to a structure, owned by `handlePackets`. This allows `parseTCP` to reduce drastically the amount of allocation required.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->