### PR TITLE
Cut tagger stream event responses into chunks of 4MB max size each

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -53,6 +53,8 @@ var (
 	apiRouter *mux.Router
 )
 
+const maxMessageSize = 4 * 1024 * 1024 // 4 MB
+
 // StartServer creates the router and starts the HTTP server
 func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component) error {
 	// create the root HTTP router
@@ -122,8 +124,6 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 
 		return struct{}{}, nil
 	})
-
-	const maxMessageSize = 4 * 1024 * 1024 // 4 MB
 
 	opts := []grpc.ServerOption{
 		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -31,6 +31,7 @@ import (
 
 const cmdServerName string = "CMD API Server"
 const cmdServerShortName string = "CMD"
+const maxMessageSize = 4 * 1024 * 1024 // 4 MB
 
 func (server *apiServer) startCMDServer(
 	cmdAddr string,
@@ -48,7 +49,7 @@ func (server *apiServer) startCMDServer(
 
 	// gRPC server
 	authInterceptor := grpcutil.AuthInterceptor(parseToken)
-	const maxMessageSize = 4 * 1024 * 1024 // 4 MB
+
 	opts := []grpc.ServerOption{
 		grpc.Creds(credentials.NewClientTLSFromCert(tlsCertPool, cmdAddr)),
 		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),

--- a/comp/core/tagger/taggerimpl/server/server.go
+++ b/comp/core/tagger/taggerimpl/server/server.go
@@ -30,12 +30,14 @@ const (
 // Server is a grpc server that streams tagger entities
 type Server struct {
 	taggerComponent tagger.Component
+	maxMessageSize  int
 }
 
 // NewServer returns a new Server
-func NewServer(t tagger.Component) *Server {
+func NewServer(t tagger.Component, maxMessageSize int) *Server {
 	return &Server{
 		taggerComponent: t,
+		maxMessageSize:  maxMessageSize,
 	}
 }
 
@@ -86,16 +88,20 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 				responseEvents = append(responseEvents, e)
 			}
 
-			err = grpc.DoWithTimeout(func() error {
-				return out.Send(&pb.StreamTagsResponse{
-					Events: responseEvents,
-				})
-			}, taggerStreamSendTimeout)
+			// Split events into chunks and send each one
+			chunks := splitEvents(responseEvents, s.maxMessageSize)
+			for _, chunk := range chunks {
+				err = grpc.DoWithTimeout(func() error {
+					return out.Send(&pb.StreamTagsResponse{
+						Events: chunk,
+					})
+				}, taggerStreamSendTimeout)
 
-			if err != nil {
-				log.Warnf("error sending tagger event: %s", err)
-				s.taggerComponent.GetTaggerTelemetryStore().ServerStreamErrors.Inc()
-				return err
+				if err != nil {
+					log.Warnf("error sending tagger event: %s", err)
+					s.taggerComponent.GetTaggerTelemetryStore().ServerStreamErrors.Inc()
+					return err
+				}
 			}
 
 		case <-out.Context().Done():

--- a/comp/core/tagger/taggerimpl/server/util.go
+++ b/comp/core/tagger/taggerimpl/server/util.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+// splitBySize splits the given slice into contiguous non-overlapping subslices such that
+// the size of each sub-slice is at most maxChunkSize.
+// The size of each item is calculated using computeSize
+//
+// This function assumes that the size of each single item of the initial slice is not larger than maxChunkSize
+func splitBySize[T any](slice []T, maxChunkSize int, computeSize func(T) int) [][]T {
+	var chunks [][]T
+	currentChunk := []T{}
+	currentSize := 0
+
+	for _, item := range slice {
+		eventSize := computeSize(item)
+		if currentSize+eventSize > maxChunkSize {
+			chunks = append(chunks, currentChunk)
+			currentChunk = []T{}
+			currentSize = 0
+		}
+		currentChunk = append(currentChunk, item)
+		currentSize += eventSize
+	}
+	if len(currentChunk) > 0 {
+		chunks = append(chunks, currentChunk)
+	}
+	return chunks
+}
+
+// splitEvents splits the array of events to chunks with at most maxChunkSize each
+func splitEvents(events []*pb.StreamTagsEvent, maxChunkSize int) [][]*pb.StreamTagsEvent {
+	return splitBySize(
+		events,
+		maxChunkSize,
+		func(event *pb.StreamTagsEvent) int { return proto.Size(event) },
+	)
+}

--- a/comp/core/tagger/taggerimpl/server/util.go
+++ b/comp/core/tagger/taggerimpl/server/util.go
@@ -17,6 +17,9 @@ import (
 //
 // This function assumes that the size of each single item of the initial slice is not larger than maxChunkSize
 func splitBySize[T any](slice []T, maxChunkSize int, computeSize func(T) int) [][]T {
+
+	// TODO: return an iter.Seq[[]T] instead of [][]T once we upgrade to golang v1.23
+	// returning iter.Seq[[]T] has better performance in terms of memory consumption
 	var chunks [][]T
 	currentChunk := []T{}
 	currentSize := 0

--- a/comp/core/tagger/taggerimpl/server/util_test.go
+++ b/comp/core/tagger/taggerimpl/server/util_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStreamTagsEvent struct {
+	id   int
+	size int
+}
+
+func TestSplitEvents(t *testing.T) {
+	testCases := []struct {
+		name         string
+		events       []mockStreamTagsEvent
+		maxChunkSize int
+		expected     [][]mockStreamTagsEvent // Expecting indices of events in chunks for easier comparison
+	}{
+		{
+			name:         "Empty input",
+			events:       []mockStreamTagsEvent{},
+			maxChunkSize: 100,
+			expected:     nil, // No chunks expected
+		},
+		{
+			name: "Single event within chunk size",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 50}, // Mock event with size 50
+			},
+			maxChunkSize: 100,
+			expected: [][]mockStreamTagsEvent{
+				{
+					{id: 1, size: 50}, // One chunk with one event
+				},
+			},
+		},
+		{
+			name: "Multiple events all fit in one chunk",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 20}, {id: 2, size: 30}, {id: 3, size: 40}, // Total size = 90
+			},
+			maxChunkSize: 100,
+			expected: [][]mockStreamTagsEvent{
+				{
+					{id: 1, size: 20}, {id: 2, size: 30}, {id: 3, size: 40}, // All events fit in one chunk
+				},
+			},
+		},
+		{
+			name: "Multiple events require splitting",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 40}, {id: 2, size: 50}, {id: 3, size: 60}, // Total size = 150
+			},
+			maxChunkSize: 100,
+			expected: [][]mockStreamTagsEvent{
+				{
+					{id: 1, size: 40},
+					{id: 2, size: 50},
+				},
+				{
+					{id: 3, size: 60},
+				}, // Last event in second chunk
+			},
+		},
+		{
+			name: "Events fit exactly in chunks",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 50}, {id: 2, size: 50}, // Total size = 100
+			},
+			maxChunkSize: 100,
+			expected: [][]mockStreamTagsEvent{
+				{{id: 1, size: 50}, {id: 2, size: 50}}, // Both events fit exactly in one chunk
+			},
+		},
+		{
+			name: "Event size exactly matches or exceeds chunk size",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 100}, {id: 2, size: 101}, // One exactly fits, one exceeds
+			},
+			maxChunkSize: 100,
+			expected: [][]mockStreamTagsEvent{
+				{
+					{id: 1, size: 100},
+				},
+				{
+					{id: 2, size: 101},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			chunks := splitBySize(testCase.events, testCase.maxChunkSize, func(e mockStreamTagsEvent) int { return e.size })
+			assert.Equal(t, testCase.expected, chunks)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR modifies the remote tagger server so that it streams the tagger events in chunks with each chunk having a size of 4 MB at most.

### Motivation

Avoid failure of communication between client and server on large clusters on which the size of the message might exceed 4MB.

### Describe how to test/QA your changes

Ensure that the remote tagger still works as expected.

1. Deploy the agent and cluster agent with the orchestrator cluster check running in a CLC runner and using the cluster tagger. Also configure namespace labels as tags and enable kubernetes tags collection so that the cluster tagger has some tags for pods and namespaces:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  clusterChecks:
    enabled: true
  kubelet:
    tlsVerify: false

  clusterTagger:
    collectKubernetesTags: true

  namespaceLabelsAsTags:
    kubernetes.io/metadata.name: name

clusterChecksRunner:
  enabled: true
  replicas: 1
  env:
    - name: DD_CLC_RUNNER_REMOTE_TAGGER_ENABLED
      value: true

clusterAgent:
  enabled: true
  replicas: 1

  advancedConfd:
    orchestrator.d:
      1.yaml: |-
        cluster_check: true
        init_config:
        instances:
          - collectors:
            - pods
            skip_leader_election: true

```


2. Check that the cluster tagger contains tags for pods and namespaces:

```
kubectl exec <cluster-agent-pod-name> -- agent tagger-list

=== Entity kubernetes_metadata:///namespaces//default ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [name:default]
===

=== Entity kubernetes_metadata:///namespaces//kube-public ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [name:kube-public]
===

=== Entity kubernetes_pod_uid://481c1f63-89ef-4f7e-8b92-25b9e4df2add ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_app_component:clusterchecks-agent kube_app_instance:datadog-agent kube_app_managed_by:Helm kube_app_name:datadog-agent kube_cluster_name:adel-orchestrator-clc kube_deployment:datadog-agent-clusterchecks kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:datadog-agent-clusterchecks-574dfbd86f kube_qos:BestEffort kube_replica_set:datadog-agent-clusterchecks-574dfbd86f pod_name:datadog-agent-clusterchecks-574dfbd86f-ptp8t pod_phase:running]
===

=== Entity kubernetes_metadata:///namespaces//kube-system ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [name:kube-system]
===

=== Entity kubernetes_metadata:///namespaces//local-path-storage ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [name:local-path-storage]
===

=== Entity kubernetes_pod_uid://73d766d6-869e-4e89-8a15-63c11eb6ffb3 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_namespace:kube-system kube_ownerref_kind:node kube_ownerref_name:kind-control-plane kube_priority_class:system-node-critical kube_qos:Burstable pod_name:kube-apiserver-kind-control-plane pod_phase:running]
===

=== Entity kubernetes_pod_uid://75491183-12b9-483f-a8bd-d573f983a53b ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_namespace:default kube_qos:BestEffort pod_name:unschedulable-pod pod_phase:pending]
===

=== Entity kubernetes_pod_uid://ebb6d4f5-9850-4b4a-9a4c-5c7418b2f912 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_namespace:kube-system kube_ownerref_kind:node kube_ownerref_name:kind-control-plane kube_priority_class:system-node-critical kube_qos:Burstable pod_name:kube-scheduler-kind-control-plane pod_phase:running]
===

=== Entity kubernetes_metadata:///namespaces//kube-node-lease ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [name:kube-node-lease]
===

=== Entity kubernetes_pod_uid://3956c4f6-32df-4f6a-b5be-72149745bb00 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_namespace:kube-system kube_ownerref_kind:node kube_ownerref_name:kind-control-plane kube_priority_class:system-node-critical kube_qos:Burstable pod_name:kube-controller-manager-kind-control-plane pod_phase:running]
===

=== Entity kubernetes_pod_uid://541a6a3e-f829-434c-9bb7-dcf3b8840bb2 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_daemon_set:kube-proxy kube_namespace:kube-system kube_ownerref_kind:daemonset kube_ownerref_name:kube-proxy kube_priority_class:system-node-critical kube_qos:BestEffort pod_name:kube-proxy-d2bj9 pod_phase:running]
===

=== Entity kubernetes_pod_uid://620e8961-83ea-4f3d-9256-0bb67b2b959d ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_deployment:local-path-provisioner kube_namespace:local-path-storage kube_ownerref_kind:replicaset kube_ownerref_name:local-path-provisioner-6bc4bddd6b kube_qos:BestEffort kube_replica_set:local-path-provisioner-6bc4bddd6b pod_name:local-path-provisioner-6bc4bddd6b-qjrtf pod_phase:running]
===

=== Entity kubernetes_pod_uid://8ef52246-fd65-48ec-b04d-afc5ab949c25 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_daemon_set:kindnet kube_namespace:kube-system kube_ownerref_kind:daemonset kube_ownerref_name:kindnet kube_qos:Guaranteed pod_name:kindnet-4lzgr pod_phase:running]
===

=== Entity kubernetes_pod_uid://fce5e4a8-db5e-4b4b-8cab-be6029e1b762 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_namespace:kube-system kube_ownerref_kind:node kube_ownerref_name:kind-control-plane kube_priority_class:system-node-critical kube_qos:Burstable pod_name:etcd-kind-control-plane pod_phase:running]
===

=== Entity internal://global-entity-id ===
== Source workloadmeta-static =
=Tags: [kube_cluster_name:adel-orchestrator-clc]
===

=== Entity kubernetes_pod_uid://184c26b0-f03b-4887-896c-092250f61138 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_app_component:cluster-agent kube_app_instance:datadog-agent kube_app_managed_by:Helm kube_app_name:datadog-agent kube_cluster_name:adel-orchestrator-clc kube_deployment:datadog-agent-cluster-agent kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:datadog-agent-cluster-agent-78cdcb7c8 kube_qos:BestEffort kube_replica_set:datadog-agent-cluster-agent-78cdcb7c8 pod_name:datadog-agent-cluster-agent-78cdcb7c8-sf9l4 pod_phase:running]
===

=== Entity kubernetes_pod_uid://23b009dc-8790-41df-a6ad-d315ec695b7b ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_deployment:coredns kube_namespace:kube-system kube_ownerref_kind:replicaset kube_ownerref_name:coredns-5d78c9869d kube_priority_class:system-cluster-critical kube_qos:Burstable kube_replica_set:coredns-5d78c9869d pod_name:coredns-5d78c9869d-7tsr5 pod_phase:running]
===

=== Entity kubernetes_pod_uid://b77e5126-07bd-4c37-b613-616fb8ba38c1 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_app_component:clusterchecks-agent kube_app_instance:datadog-agent kube_app_managed_by:Helm kube_app_name:datadog-agent kube_cluster_name:adel-orchestrator-clc kube_deployment:datadog-agent-clusterchecks kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:datadog-agent-clusterchecks-574dfbd86f kube_qos:BestEffort kube_replica_set:datadog-agent-clusterchecks-574dfbd86f pod_name:datadog-agent-clusterchecks-574dfbd86f-fwkw5 pod_phase:running]
===

=== Entity kubernetes_pod_uid://c4c80235-9a96-4427-9b60-e146a9477eda ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_cluster_name:adel-orchestrator-clc kube_deployment:coredns kube_namespace:kube-system kube_ownerref_kind:replicaset kube_ownerref_name:coredns-5d78c9869d kube_priority_class:system-cluster-critical kube_qos:Burstable kube_replica_set:coredns-5d78c9869d pod_name:coredns-5d78c9869d-frvkc pod_phase:running]
===

=== Entity kubernetes_pod_uid://c4ec4af1-9b22-4273-98dd-6780ceb42563 ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_app_component:agent kube_app_instance:datadog-agent kube_app_managed_by:Helm kube_app_name:datadog-agent kube_cluster_name:adel-orchestrator-clc kube_daemon_set:datadog-agent kube_namespace:default kube_ownerref_kind:daemonset kube_ownerref_name:datadog-agent kube_qos:BestEffort pod_name:datadog-agent-d5j2t pod_phase:running]
===

```

3. Verify that only namespace tags are synced into the CLC runner remote tagger:

```
kubectl <clc_runner_pod_name> -- agent tagger-list


=== Entity kubernetes_metadata:///namespaces//default ===
== Source remote =
=Tags: [name:default]
===

=== Entity kubernetes_metadata:///namespaces//kube-node-lease ===
== Source remote =
=Tags: [name:kube-node-lease]
===

=== Entity kubernetes_metadata:///namespaces//kube-public ===
== Source remote =
=Tags: [name:kube-public]
===

=== Entity kubernetes_metadata:///namespaces//kube-system ===
== Source remote =
=Tags: [name:kube-system]
===

=== Entity kubernetes_metadata:///namespaces//local-path-storage ===
== Source remote =
=Tags: [name:local-path-storage]
===

```


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->