### PR TITLE
[NPM] Always enable connection protocol map cleaner

### DIFF
--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -363,12 +363,11 @@ func (t *ebpfTracer) Stop() {
 }
 
 func (t *ebpfTracer) GetMap(name string) *ebpf.Map {
-	switch name {
-	case probes.ConnectionProtocolMap:
-	default:
+	m, _, err := t.m.GetMap(name)
+	if err != nil {
+		log.Warnf("error retrieving map %s: %s", name, err)
 		return nil
 	}
-	m, _, _ := t.m.GetMap(name)
 	return m
 }
 

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -363,11 +363,7 @@ func (t *ebpfTracer) Stop() {
 }
 
 func (t *ebpfTracer) GetMap(name string) *ebpf.Map {
-	m, _, err := t.m.GetMap(name)
-	if err != nil {
-		log.Warnf("error retrieving map %s: %s", name, err)
-		return nil
-	}
+	m, _, _ := t.m.GetMap(name)
 	return m
 }
 

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -362,13 +362,12 @@ func (t *ebpfTracer) Stop() {
 	})
 }
 
-func (t *ebpfTracer) GetMap(name string) *ebpf.Map {
+func (t *ebpfTracer) GetMap(name string) (*ebpf.Map, error) {
 	m, _, err := t.m.GetMap(name)
 	if err != nil {
-		log.Warnf("error retrieving map %s: %s", name, err)
-		return nil
+		return nil, fmt.Errorf("error getting map %s: %w", name, err)
 	}
-	return m
+	return m, nil
 }
 
 func (t *ebpfTracer) GetConnections(buffer *network.ConnectionBuffer, filter func(*network.ConnectionStats) bool) error {

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -363,7 +363,11 @@ func (t *ebpfTracer) Stop() {
 }
 
 func (t *ebpfTracer) GetMap(name string) *ebpf.Map {
-	m, _, _ := t.m.GetMap(name)
+	m, _, err := t.m.GetMap(name)
+	if err != nil {
+		log.Warnf("error retrieving map %s: %s", name, err)
+		return nil
+	}
 	return m
 }
 

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -306,7 +306,7 @@ func (t *ebpfLessTracer) Remove(conn *network.ConnectionStats) error {
 
 // GetMap returns the underlying named map. This is useful if any maps are shared with other eBPF components.
 // An individual ebpfLessTracer implementation may choose which maps to expose via this function.
-func (t *ebpfLessTracer) GetMap(string) *ebpf.Map { return nil }
+func (t *ebpfLessTracer) GetMap(string) (*ebpf.Map, error) { return nil, nil }
 
 // DumpMaps (for debugging purpose) returns all maps content by default or selected maps from maps parameter.
 func (t *ebpfLessTracer) DumpMaps(_ io.Writer, _ ...string) error {

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -54,7 +54,7 @@ type Tracer interface {
 	Remove(conn *network.ConnectionStats) error
 	// GetMap returns the underlying named map. This is useful if any maps are shared with other eBPF components.
 	// An individual tracer implementation may choose which maps to expose via this function.
-	GetMap(string) *ebpf.Map
+	GetMap(string) (*ebpf.Map, error)
 	// DumpMaps (for debugging purpose) returns all maps content by default or selected maps from maps parameter.
 	DumpMaps(w io.Writer, maps ...string) error
 	// Type returns the type of the underlying ebpf tracer that is currently loaded

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -183,18 +183,13 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 	}
 
 	tr.reverseDNS = newReverseDNS(cfg, telemetryComponent)
-	tr.usmMonitor = newUSMMonitor(cfg)
+	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer)
 
-	if cfg.ProtocolClassificationEnabled {
-		connectionProtocolMap := tr.ebpfTracer.GetMap(probes.ConnectionProtocolMap)
-		if connectionProtocolMap == nil {
-			log.Warn("could not get connection_protocol map, will not be able to expire connection_protocol data")
-		} else {
-			tr.connectionProtocolMapCleaner, err = usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
-			if err != nil {
-				log.Warnf("could not setup connection protocol map cleaner: %s", err)
-			}
-		}
+	connectionProtocolMap := tr.ebpfTracer.GetMap(probes.ConnectionProtocolMap)
+
+	tr.connectionProtocolMapCleaner, err = usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
+	if err != nil {
+		log.Warnf("could not setup connection protocol map cleaner: %s", err)
 	}
 
 	if cfg.EnableProcessEventMonitoring {
@@ -843,14 +838,18 @@ func (t *Tracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
 	return nil, nil
 }
 
-func newUSMMonitor(c *config.Config) *usm.Monitor {
+func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
+	// Shared map between NPM and USM
+	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
+
 	if !usmconfig.IsUSMSupportedAndEnabled(c) {
 		// If USM is not supported, or if USM is not enabled, we should not start the USM monitor.
 		// We should still clean the connection protocol map as it is used by NPM.
+		usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
 		return nil
 	}
 
-	monitor, err := usm.NewMonitor(c)
+	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
 	if err != nil {
 		log.Errorf("usm initialization failed: %s", err)
 		return nil

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -185,11 +185,17 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 	tr.reverseDNS = newReverseDNS(cfg, telemetryComponent)
 	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer)
 
-	connectionProtocolMap := tr.ebpfTracer.GetMap(probes.ConnectionProtocolMap)
-
-	tr.connectionProtocolMapCleaner, err = usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
-	if err != nil {
-		log.Warnf("could not setup connection protocol map cleaner: %s", err)
+	// Setup the connection_protocol map cleaner if protocol classification is enabled and USM is disabled
+	if cfg.ProtocolClassificationEnabled && !usmconfig.IsUSMSupportedAndEnabled(cfg) {
+		connectionProtocolMap := tr.ebpfTracer.GetMap(probes.ConnectionProtocolMap)
+		if connectionProtocolMap == nil {
+			log.Warn("could not get connection_protocol map, will not be able to expire connection_protocol data")
+		} else {
+			tr.connectionProtocolMapCleaner, err = usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
+			if err != nil {
+				log.Warnf("could not setup connection protocol map cleaner: %s", err)
+			}
+		}
 	}
 
 	if cfg.EnableProcessEventMonitoring {
@@ -839,15 +845,13 @@ func (t *Tracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
 }
 
 func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
-	// Shared map between NPM and USM
-	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
-
 	if !usmconfig.IsUSMSupportedAndEnabled(c) {
 		// If USM is not supported, or if USM is not enabled, we should not start the USM monitor.
-		// We should still clean the connection protocol map as it is used by NPM.
-		usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
 		return nil
 	}
+
+	// Shared map between NPM and USM
+	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
 
 	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
 	if err != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -888,7 +888,7 @@ const connProtoTTL = 3 * time.Minute
 const connProtoCleaningInterval = 5 * time.Minute
 
 // setupConnectionProtocolMapCleaner sets up a map cleaner for the connectionProtocolMap.
-// It will clean the map every connProtoCleaningInterval if entries are older than connProtoTTL.
+// It will run every connProtoCleaningInterval and delete entries older than connProtoTTL.
 func setupConnectionProtocolMapCleaner(connectionProtocolMap *ebpf.Map) (*ddebpf.MapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper], error) {
 	mapCleaner, err := ddebpf.NewMapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper](connectionProtocolMap, 1024)
 	if err != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -828,13 +828,15 @@ func (t *Tracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
 }
 
 func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
+	// Shared map between NPM and USM
+	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
+
 	if !usmconfig.IsUSMSupportedAndEnabled(c) {
 		// If USM is not supported, or if USM is not enabled, we should not start the USM monitor.
+		// We should still clean the connection protocol map as it is used by NPM.
+		usm.SetupConnectionProtocolMapCleaner(connectionProtocolMap)
 		return nil
 	}
-
-	// Shared with the USM program
-	connectionProtocolMap := tracer.GetMap(probes.ConnectionProtocolMap)
 
 	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
 	if err != nil {

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -226,7 +226,7 @@ func (e *ebpfProgram) Start() error {
 		}
 		e.connectionProtocolMap = m
 	}
-	mapCleaner, err := e.setupMapCleaner()
+	mapCleaner, err := SetupConnectionProtocolMapCleaner(e.connectionProtocolMap)
 	if err != nil {
 		log.Errorf("error creating map cleaner: %s", err)
 	} else {
@@ -488,8 +488,8 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 const connProtoTTL = 3 * time.Minute
 const connProtoCleaningInterval = 5 * time.Minute
 
-func (e *ebpfProgram) setupMapCleaner() (*ddebpf.MapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper], error) {
-	mapCleaner, err := ddebpf.NewMapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper](e.connectionProtocolMap, 1024)
+func SetupConnectionProtocolMapCleaner(connectionProtocolMap *ebpf.Map) (*ddebpf.MapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper], error) {
+	mapCleaner, err := ddebpf.NewMapCleaner[netebpf.ConnTuple, netebpf.ProtocolStackWrapper](connectionProtocolMap, 1024)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -52,7 +53,7 @@ type Monitor struct {
 }
 
 // NewMonitor returns a new Monitor instance
-func NewMonitor(c *config.Config) (m *Monitor, err error) {
+func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, err error) {
 	defer func() {
 		// capture error and wrap it
 		if err != nil {
@@ -62,7 +63,7 @@ func NewMonitor(c *config.Config) (m *Monitor, err error) {
 		}
 	}()
 
-	mgr, err := newEBPFProgram(c)
+	mgr, err := newEBPFProgram(c, connectionProtocolMap)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ebpf program: %w", err)
 	}

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -53,7 +52,7 @@ type Monitor struct {
 }
 
 // NewMonitor returns a new Monitor instance
-func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, err error) {
+func NewMonitor(c *config.Config) (m *Monitor, err error) {
 	defer func() {
 		// capture error and wrap it
 		if err != nil {
@@ -63,7 +62,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, 
 		}
 	}()
 
-	mgr, err := newEBPFProgram(c, connectionProtocolMap)
+	mgr, err := newEBPFProgram(c)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ebpf program: %w", err)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Always runs the map cleaner for the `connection_protocol` map even when USM is disabled, as it is used by NPM and can be leaky. Also supports USM enabled and NPM disabled.

### Motivation

https://datadoghq.atlassian.net/browse/NPM-3695

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->