### PR TITLE
[CONTP-425] Pod level GPU tags and tag standardized name

### DIFF
--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -231,8 +231,8 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 	}
 
 	// gpu tags from container resource requests
-	for _, GPUType := range container.Resources.GPUTypeList {
-		tagList.AddLow(tags.KubeGPUType, GPUType)
+	for _, gpuVendor := range container.Resources.GPUVendorList {
+		tagList.AddLow(tags.KubeGPUVendor, gpuVendor)
 	}
 
 	low, orch, high, standard := tagList.Compute()
@@ -362,8 +362,8 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 	}
 
 	// gpu requested vendor as tags
-	for _, GPUVendor := range pod.GPUTypeList {
-		tagList.AddLow(tags.KubeGPUType, GPUVendor)
+	for _, gpuVendor := range pod.GPUVendorList {
+		tagList.AddLow(tags.KubeGPUVendor, gpuVendor)
 	}
 
 	kubeServiceDisabled := false

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_extract.go
@@ -334,6 +334,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 	tagList.AddLow(tags.KubePriorityClass, pod.PriorityClass)
 	tagList.AddLow(tags.KubeQOS, pod.QOSClass)
 	tagList.AddLow(tags.KubeRuntimeClass, pod.RuntimeClass)
+	tagList.AddLow(tags.KubeGPUType, pod.GPUType)
 
 	c.extractTagsFromPodLabels(pod, tagList)
 

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -852,7 +852,7 @@ func TestHandleKubePod(t *testing.T) {
 					Name:      podName,
 					Namespace: podNamespace,
 				},
-				GPUTypeList: []string{"nvidia"},
+				GPUVendorList: []string{"nvidia"},
 				Containers: []workloadmeta.OrchestratorContainer{
 					{
 						ID:    fullyFleshedContainerID,
@@ -871,7 +871,7 @@ func TestHandleKubePod(t *testing.T) {
 					},
 					LowCardTags: []string{
 						fmt.Sprintf("kube_namespace:%s", podNamespace),
-						"kube_gpu_type:nvidia",
+						"gpu_vendor:nvidia",
 					},
 					StandardTags: []string{},
 				},
@@ -892,7 +892,7 @@ func TestHandleKubePod(t *testing.T) {
 						"image_name:datadog/agent",
 						"image_tag:latest",
 						"short_image:agent",
-						"kube_gpu_type:nvidia",
+						"gpu_vendor:nvidia",
 					}, standardTags...),
 					StandardTags: standardTags,
 				},
@@ -2126,7 +2126,7 @@ func TestHandleContainer(t *testing.T) {
 					Name: containerName,
 				},
 				Resources: workloadmeta.ContainerResources{
-					GPUTypeList: []string{"nvidia"},
+					GPUVendorList: []string{"nvidia"},
 				},
 			},
 			expected: []*types.TagInfo{
@@ -2139,7 +2139,7 @@ func TestHandleContainer(t *testing.T) {
 					},
 					OrchestratorCardTags: []string{},
 					LowCardTags: []string{
-						"kube_gpu_type:nvidia",
+						"gpu_vendor:nvidia",
 					},
 					StandardTags: []string{},
 				},

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -844,6 +844,60 @@ func TestHandleKubePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod with containers requesting gpu resources",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+				},
+				GPUType: "nvidia",
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:    fullyFleshedContainerID,
+						Name:  containerName,
+						Image: image,
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:       podSource,
+					EntityID:     podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						"kube_gpu_type:nvidia",
+					},
+					StandardTags: []string{},
+				},
+				{
+					Source:   podSource,
+					EntityID: fullyFleshedContainerTaggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_id:%s", fullyFleshedContainerID),
+						fmt.Sprintf("display_container_name:%s_%s", runtimeContainerName, podName),
+					},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: append([]string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						fmt.Sprintf("kube_container_name:%s", containerName),
+						"image_id:datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
+						"image_name:datadog/agent",
+						"image_tag:latest",
+						"short_image:agent",
+						"kube_gpu_type:nvidia",
+					}, standardTags...),
+					StandardTags: standardTags,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/taggerimpl/collectors/workloadmeta_test.go
@@ -852,7 +852,7 @@ func TestHandleKubePod(t *testing.T) {
 					Name:      podName,
 					Namespace: podNamespace,
 				},
-				GPUType: "nvidia",
+				GPUTypeList: []string{"nvidia"},
 				Containers: []workloadmeta.OrchestratorContainer{
 					{
 						ID:    fullyFleshedContainerID,
@@ -2126,7 +2126,7 @@ func TestHandleContainer(t *testing.T) {
 					Name: containerName,
 				},
 				Resources: workloadmeta.ContainerResources{
-					GPUType: "nvidia",
+					GPUTypeList: []string{"nvidia"},
 				},
 			},
 			expected: []*types.TagInfo{

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -91,7 +91,7 @@ const (
 
 	// GPU related tags
 
-	// KubeGPUVendor the tag for the Kubernetes Resource GPU type
+	// KubeGPUVendor the tag for the Kubernetes Resource GPU vendor
 	KubeGPUVendor = "gpu_vendor"
 
 	// OpenshiftDeploymentConfig is the tag for the OpenShift deployment config name

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -52,8 +52,6 @@ const (
 	KubeContainerName = "kube_container_name"
 	// KubeOwnerRefKind is the tag for the Kubernetes owner reference kind
 	KubeOwnerRefKind = "kube_ownerref_kind"
-	// KubeGPUType is the tag for the Kubernetes Resource GPU type
-	KubeGPUType = "kube_gpu_type"
 
 	// KubePod is the tag for the pod name
 	KubePod = "pod_name"
@@ -90,6 +88,11 @@ const (
 	KubeAppPartOf = "kube_app_part_of"
 	// KubeAppManagedBy is the tag for the "app.kubernetes.io/managed-by" Kubernetes label
 	KubeAppManagedBy = "kube_app_managed_by"
+
+	// GPU related tags
+
+	// KubeGPUVendor the tag for the Kubernetes Resource GPU type
+	KubeGPUVendor = "gpu_vendor"
 
 	// OpenshiftDeploymentConfig is the tag for the OpenShift deployment config name
 	OpenshiftDeploymentConfig = "oshift_deployment_config"

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -422,7 +422,7 @@ func (c ContainerHealthStatus) String(verbose bool) string {
 type ContainerResources struct {
 	GPURequest    *uint64 // Number of GPUs
 	GPULimit      *uint64
-	GPUTypeList   []string // The type of GPU requested (eg. nvidia, amd, intel)
+	GPUVendorList []string // The type of GPU requested (eg. nvidia, amd, intel)
 	CPURequest    *float64 // Percentage 0-100*numCPU (aligned with CPU Limit from metrics provider)
 	CPULimit      *float64
 	MemoryRequest *uint64 // Bytes
@@ -444,8 +444,8 @@ func (cr ContainerResources) String(bool) string {
 	if cr.MemoryLimit != nil {
 		_, _ = fmt.Fprintln(&sb, "TargetMemoryLimit:", *cr.MemoryLimit)
 	}
-	if cr.GPUTypeList != nil {
-		_, _ = fmt.Fprintln(&sb, "GPUType:", cr.GPUTypeList)
+	if cr.GPUVendorList != nil {
+		_, _ = fmt.Fprintln(&sb, "GPUVendor:", cr.GPUVendorList)
 	}
 	return sb.String()
 }
@@ -678,7 +678,7 @@ type KubernetesPod struct {
 	IP                         string
 	PriorityClass              string
 	QOSClass                   string
-	GPUTypeList                []string
+	GPUVendorList              []string
 	RuntimeClass               string
 	KubeServices               []string
 	NamespaceLabels            map[string]string
@@ -746,7 +746,7 @@ func (p KubernetesPod) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
 		_, _ = fmt.Fprintln(&sb, "QOS Class:", p.QOSClass)
-		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUTypeList)
+		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUVendorList)
 		_, _ = fmt.Fprintln(&sb, "Runtime Class:", p.RuntimeClass)
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -678,6 +678,7 @@ type KubernetesPod struct {
 	IP                         string
 	PriorityClass              string
 	QOSClass                   string
+	GPUType                    string
 	RuntimeClass               string
 	KubeServices               []string
 	NamespaceLabels            map[string]string

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -746,6 +746,7 @@ func (p KubernetesPod) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
 		_, _ = fmt.Fprintln(&sb, "QOS Class:", p.QOSClass)
+		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUType)
 		_, _ = fmt.Fprintln(&sb, "Runtime Class:", p.RuntimeClass)
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -746,7 +746,7 @@ func (p KubernetesPod) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
 		_, _ = fmt.Fprintln(&sb, "QOS Class:", p.QOSClass)
-		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUVendorList)
+		_, _ = fmt.Fprintln(&sb, "GPU Vendor:", p.GPUVendorList)
 		_, _ = fmt.Fprintln(&sb, "Runtime Class:", p.RuntimeClass)
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -422,7 +422,7 @@ func (c ContainerHealthStatus) String(verbose bool) string {
 type ContainerResources struct {
 	GPURequest    *uint64 // Number of GPUs
 	GPULimit      *uint64
-	GPUType       string   // The type of GPU requested (eg. nvidia, amd, intel)
+	GPUTypeList   []string // The type of GPU requested (eg. nvidia, amd, intel)
 	CPURequest    *float64 // Percentage 0-100*numCPU (aligned with CPU Limit from metrics provider)
 	CPULimit      *float64
 	MemoryRequest *uint64 // Bytes
@@ -444,8 +444,8 @@ func (cr ContainerResources) String(bool) string {
 	if cr.MemoryLimit != nil {
 		_, _ = fmt.Fprintln(&sb, "TargetMemoryLimit:", *cr.MemoryLimit)
 	}
-	if cr.GPUType != "" {
-		_, _ = fmt.Fprintln(&sb, "GPUType:", cr.GPUType)
+	if cr.GPUTypeList != nil {
+		_, _ = fmt.Fprintln(&sb, "GPUType:", cr.GPUTypeList)
 	}
 	return sb.String()
 }
@@ -678,7 +678,7 @@ type KubernetesPod struct {
 	IP                         string
 	PriorityClass              string
 	QOSClass                   string
-	GPUType                    string
+	GPUTypeList                []string
 	RuntimeClass               string
 	KubeServices               []string
 	NamespaceLabels            map[string]string
@@ -746,7 +746,7 @@ func (p KubernetesPod) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
 		_, _ = fmt.Fprintln(&sb, "QOS Class:", p.QOSClass)
-		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUType)
+		_, _ = fmt.Fprintln(&sb, "GPU Type:", p.GPUTypeList)
 		_, _ = fmt.Fprintln(&sb, "Runtime Class:", p.RuntimeClass)
 		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
 		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -28,7 +28,7 @@ func TestDump(t *testing.T) {
 			Name: "ctr-image",
 		},
 		Resources: wmdef.ContainerResources{
-			GPUTypeList: []string{"nvidia"},
+			GPUVendorList: []string{"nvidia"},
 		},
 		Runtime:       wmdef.ContainerRuntimeDocker,
 		RuntimeFlavor: wmdef.ContainerRuntimeFlavorKata,
@@ -86,7 +86,7 @@ Runtime: docker
 RuntimeFlavor: kata
 Running: false
 ----------- Resources -----------
-GPUType: [nvidia]
+GPUVendor: [nvidia]
 `,
 				},
 			},
@@ -124,7 +124,7 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
-GPUType: [nvidia]
+GPUVendor: [nvidia]
 Hostname: 
 Network IPs: 
 PID: 0
@@ -183,7 +183,7 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
-GPUType: [nvidia]
+GPUVendor: [nvidia]
 Hostname: 
 Network IPs: 
 PID: 1

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -28,7 +28,7 @@ func TestDump(t *testing.T) {
 			Name: "ctr-image",
 		},
 		Resources: wmdef.ContainerResources{
-			GPUType: "nvidia",
+			GPUTypeList: []string{"nvidia"},
 		},
 		Runtime:       wmdef.ContainerRuntimeDocker,
 		RuntimeFlavor: wmdef.ContainerRuntimeFlavorKata,
@@ -53,9 +53,6 @@ func TestDump(t *testing.T) {
 		},
 		PID:        1,
 		CgroupPath: "/default/ctr-id",
-		Resources: wmdef.ContainerResources{
-			GPUType: "nvidia",
-		},
 	}
 
 	s.handleEvents([]wmdef.CollectorEvent{
@@ -89,7 +86,7 @@ Runtime: docker
 RuntimeFlavor: kata
 Running: false
 ----------- Resources -----------
-GPUType: nvidia
+GPUType: [nvidia]
 `,
 				},
 			},
@@ -127,7 +124,7 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
-GPUType: nvidia
+GPUType: [nvidia]
 Hostname: 
 Network IPs: 
 PID: 0
@@ -157,7 +154,6 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
-GPUType: nvidia
 Hostname: 
 Network IPs: 
 PID: 1
@@ -187,7 +183,7 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
-GPUType: nvidia
+GPUType: [nvidia]
 Hostname: 
 Network IPs: 
 PID: 1

--- a/releasenotes/notes/kube-gpu-container-tag-38d7894664964220.yaml
+++ b/releasenotes/notes/kube-gpu-container-tag-38d7894664964220.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Introduce new Kubernetes tag `kube_gpu_type` for the GPU resource requested by a container.
+    Introduce new Kubernetes tag `gpu_vendor` for the GPU resource requested by a container.

--- a/releasenotes/notes/kube-gpu-container-tag-38d7894664964220.yaml
+++ b/releasenotes/notes/kube-gpu-container-tag-38d7894664964220.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Introduce new Kubernetes container tag `kube_gpu_type` for the GPU resource requested by a container.
+    Introduce new Kubernetes tag `kube_gpu_type` for the GPU resource requested by a container.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds Pod level GPU tags and renames the tag to gpu_vendor

### Motivation

Support gpu monitoring in the k8s explorer. Expanding on the container level tags added in this [previous PR](https://github.com/DataDog/datadog-agent/pull/29579).

After discussion with the gpu-monitoring-squad, the best name for the GPU tag was determined to be `gpu_vendor` and this PR also works to replace the name to this tag.

### Describe how to test/QA your changes

Deploying the following dummy-app

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-nginx-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-nginx-app
  template:
    metadata:
      labels:
        app: dummy-nginx-app
    spec:
      containers:
        - name: dummy-nginx-app
          image: nginx
          resources:
            requests:
              nvidia.com/gpu: "0"
            limits:
              nvidia.com/gpu: "0"
```

Deploy the following agent configuration

```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: <insert_name>
agents:
  image:
    repository: <insert_repo>
    tag: <insert_tag>
    pullPolicy: Always
```

The expected results are for the gpu_vendor tag showcasing nvidia for the nginx pod.

```
=== Entity kubernetes_pod_uid://e8ea6f84-c08d-41eb-a5f3-33c3b7c73afb ===
== Source workloadmeta-kubernetes_pod =
=Tags: [kube_deployment:dummy-nginx-app gpu_vendor:nvidia kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-7794f89cf kube_qos:Burstable kube_replica_set:dummy-nginx-app-7794f89cf pod_name:dummy-nginx-app-7794f89cf-9mqss pod_phase:running]
===
```

### Possible Drawbacks / Trade-offs

Adds a low cardinality tag at the pod level. GPU types can only take a handful of values so not a problem.