### PR TITLE
[smp]: move smp junit upload to new job

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -124,12 +124,6 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
-    # invoke task has additional logic that does not seem to apply well to SMP's
-    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
-    # uploading JUnit XML, so the upload command below respects that convention.
-    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
-    - datadog-ci junit upload --service datadog-agent outputs/junit.xml
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result
@@ -156,7 +150,7 @@ single-machine-performance-regression_detector-pr-comment:
   variables:
     # Not using the entrypoint script for the pr-commenter image
     FF_KUBERNETES_HONOR_ENTRYPOINT: false
-  allow_failure: true  # allow_failure here should have same setting as in job above
+  allow_failure: true
   script: # ignore error message about no PR, because it happens for dev branches without PRs
     # We need to transform the Markdown report into a valid JSON string (without
     # quotes) in order to pass a well-formed payload to the PR commenting
@@ -201,3 +195,21 @@ single-machine-performance-regression_detector-pr-comment:
         exit 0
       fi
       exit $exitcode
+
+single-machine-performance-regression_detector-junit-upload:
+  stage: functional_test
+  rules:
+    - !reference [.except_main_or_release_branch]
+    - when: on_success
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:docker"]
+  needs:
+    - job: single-machine-performance-regression_detector
+  allow_failure: true
+  script:
+    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
+    # invoke task has additional logic that does not seem to apply well to SMP's
+    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
+    # uploading JUnit XML, so the upload command below respects that convention.
+    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
+    - datadog-ci junit upload --service datadog-agent outputs/junit.xml


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

While working with a colleague on another task, I noticed that fetching secrets took a surprisingly long time. Moving secrets fetching and our JUnit XML upload operations to a separate step helps clean up the signal we get from Pipeline Visibility regarding Regression Detector job execution times.

### Motivation

More meaningful statistics from SMP's Test Visibility monitoring.

### Describe how to test/QA your changes

SMP tests should continue to be uploaded to Test Visibility.

### Possible Drawbacks / Trade-offs

We use Pipeline Visibility to get a quick aggregate view of SMP's health in Agent CI -- particularly to understand if Agent CI jobs are terminating due to timeouts. If secrets fetching or uploading JUnit XML take nontrivial amounts of time (say, more than a dozen seconds each), then we mistakenly attribute GitLab CI timeouts to under-provisioning of SMP runners in our backend, potentially causing us to overallocate capacity. Moving the JUnit XML upload step to a separate job should fix that attribution problem.

### Additional Notes

n/a

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->