### PR TITLE
automate chocolatey build job

### DIFF
--- a/.gitlab/choco_build/choco_build.yml
+++ b/.gitlab/choco_build/choco_build.yml
@@ -29,7 +29,7 @@ windows_choco_online_7_x64:
     !reference [.on_deploy_stable_or_beta_repo_branch]
   stage: choco_and_install_script_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["deploy_staging_windows_tags-7", "deploy_packages_windows-x64-7"]
+  needs: ["deploy_packages_windows-x64-7"]
   variables:
     ARCH: "x64"
   script:
@@ -46,8 +46,9 @@ windows_choco_online_7_x64:
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e BUCKET_BRANCH="$BUCKET_BRANCH" 
       486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
-      c:\mnt\tasks\winbuildscripts\chocopack.bat online
+      c:\mnt\tasks\winbuildscripts\chocopack.bat online c:\mnt\temp
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    - Remove-Item -Path "temp\" -Recurse -Force
     - copy build-out\*.nupkg omnibus\pkg
     - $CopyNupkgToS3 = "$S3_CP_CMD --recursive --exclude '*' --include '*.nupkg' build-out $S3_RELEASE_ARTIFACTS_URI/choco/nupkg"
     - Invoke-Expression $CopyNupkgToS3

--- a/.gitlab/choco_build/choco_build.yml
+++ b/.gitlab/choco_build/choco_build.yml
@@ -23,23 +23,30 @@ windows_choco_offline_7_x64:
     paths:
       - omnibus/pkg
 
-# The online version of the choco job fetches the msi package from S3 so
-# it is run only once the msi package is pushed
+# The online version of the choco job gets the msi package through the gitlab artifacts
 windows_choco_online_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_manual]
+    !reference [.on_deploy_stable_or_beta_repo_branch]
   stage: choco_and_install_script_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["deploy_staging_windows_tags-7"]
+  needs: ["deploy_staging_windows_tags-7", "deploy_packages_windows-x64-7"]
   variables:
     ARCH: "x64"
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
-    - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
+    - mkdir temp\
+    - copy omnibus\pkg\*.msi temp\
+    - if (Test-Path omnibus) { remove-item -recurse -force omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir omnibus\pkg
-    - docker run --rm -v "$(Get-Location):c:\mnt" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\tasks\winbuildscripts\chocopack.bat online
+    - >
+      docker run --rm 
+      -v "$(Get-Location):c:\mnt"
+      -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
+      -e BUCKET_BRANCH="$BUCKET_BRANCH" 
+      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      c:\mnt\tasks\winbuildscripts\chocopack.bat online
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - copy build-out\*.nupkg omnibus\pkg
     - $CopyNupkgToS3 = "$S3_CP_CMD --recursive --exclude '*' --include '*.nupkg' build-out $S3_RELEASE_ARTIFACTS_URI/choco/nupkg"

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -18,6 +18,9 @@ deploy_packages_windows-x64-7:
       --include "datadog-agent-7*.msi"
       --include "datadog-agent-7*.debug.zip"
       $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+  artifacts:
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
 
 deploy_staging_windows_tags-7:
   rules:

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -15,12 +15,12 @@ $env:chocolateyUseWindowsCompression = 'true'; Invoke-Expression ((New-Object Sy
 pip3 install -r requirements.txt
 
 $outputDirectory = "c:\mnt\build-out"
-$rawAgentVersion = (inv agent.version)
+$rawAgentVersion = (inv agent.version --url-safe --major-version 7)
 $copyright = "Datadog {0}" -f (Get-Date).Year
 
 $releasePattern = "(\d+\.\d+\.\d+)"
 $releaseCandidatePattern = "(\d+\.\d+\.\d+)-rc\.(\d+)"
-$develPattern = "(\d+\.\d+\.\d+)-devel\+git\.\d+\.(.+)"
+$develPattern = "(\d+\.\d+\.\d+)-devel\.git\.\d+\.(.+)"
 
 $nuspecFile = "c:\mnt\chocolatey\datadog-agent-online.nuspec"
 $licensePath = "c:\mnt\chocolatey\tools-online\LICENSE.txt"
@@ -61,25 +61,26 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DataDog/datadog-agent/
 
 Write-Host "Generating Chocolatey $installMethod package version $agentVersion in $outputDirectory"
 
-Write-Host ("Downloading {0}" -f $url)
-$statusCode = -1
-try {
-    $tempMsi = "$(Get-Location)\ddagent.msi"
-    Remove-Item $tempMsi -ErrorAction Ignore
-    (New-Object net.webclient).Downloadfile($url, $tempMsi)
-    $checksum = (Get-FileHash $tempMsi -Algorithm SHA256).Hash
-    Remove-Item $tempMsi
-}
-catch {
-    Write-Host "Could not generate checksum for package $($url): $($_)"
-    exit 4
-}
-
 if (!(Test-Path $outputDirectory)) {
     New-Item -ItemType Directory -Path $outputDirectory
 }
 
 if ($installMethod -eq "online") {
+    $statusCode = -1
+    try {
+        $tempMsi = "$(Get-Location)\temp\datadog-agent-$rawAgentVersion-1-x86_64.msi"
+        if (!(Test-Path $tempMsi)) {
+            Write-Host "Error: Could not find MSI file for version $rawAgentVersion-1 in temp directory"
+            Get-ChildItem "$(Get-Location)\temp"
+            exit 1 
+        }
+        $checksum = (Get-FileHash $tempMsi -Algorithm SHA256).Hash
+        Remove-Item -Path "$(Get-Location)\temp" -Recurse -Force
+    } 
+    catch {
+        Write-Host "Error: Could not generate checksum for package $($tempMsi): $($_)"
+        exit 4
+    }
     # Set the $url in the install script
     (Get-Content $installScript).replace('$__url_from_ci__', '"' +  $url  + '"').replace('$__checksum_from_ci__', '"' +  $checksum  + '"') | Set-Content $installScript
 }

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -4,7 +4,7 @@ Param(
     [String]
     $installMethod,
 
-    [Parameter(Mandatory=$true,Position=1)]
+    [Parameter(Mandatory=$false,Position=1)]
     [String] 
     $msiDirectory
 )
@@ -74,7 +74,7 @@ if ($installMethod -eq "online") {
         $tempMsi = Join-Path -Path "$msiDirectory" "datadog-agent-$rawAgentVersion-1-x86_64.msi"
         if (!(Test-Path $tempMsi)) {
             Write-Host "Error: Could not find MSI file in $tempMsi"
-            Get-ChildItem "$(Get-Location)\temp"
+            Get-ChildItem "$msiDirectory"
             exit 1 
         }
         $checksum = (Get-FileHash $tempMsi -Algorithm SHA256).Hash

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -2,7 +2,11 @@ Param(
     [Parameter(Mandatory=$true,Position=0)]
     [ValidateSet("offline", "online")]
     [String]
-    $installMethod
+    $installMethod,
+
+    [Parameter(Mandatory=$true,Position=1)]
+    [String] 
+    $msiDirectory
 )
 
 $ErrorActionPreference = 'Stop';
@@ -66,16 +70,14 @@ if (!(Test-Path $outputDirectory)) {
 }
 
 if ($installMethod -eq "online") {
-    $statusCode = -1
     try {
-        $tempMsi = "$(Get-Location)\temp\datadog-agent-$rawAgentVersion-1-x86_64.msi"
+        $tempMsi = Join-Path -Path "$msiDirectory" "datadog-agent-$rawAgentVersion-1-x86_64.msi"
         if (!(Test-Path $tempMsi)) {
-            Write-Host "Error: Could not find MSI file for version $rawAgentVersion-1 in temp directory"
+            Write-Host "Error: Could not find MSI file in $tempMsi"
             Get-ChildItem "$(Get-Location)\temp"
             exit 1 
         }
         $checksum = (Get-FileHash $tempMsi -Algorithm SHA256).Hash
-        Remove-Item -Path "$(Get-Location)\temp" -Recurse -Force
     } 
     catch {
         Write-Host "Error: Could not generate checksum for package $($tempMsi): $($_)"

--- a/tasks/winbuildscripts/chocopack.bat
+++ b/tasks/winbuildscripts/chocopack.bat
@@ -2,7 +2,7 @@ if not exist c:\mnt\ goto nomntdir
 
 @echo c:\mnt found, continuing
 
-Powershell -C "C:\mnt\tasks\winbuildscripts\Generate-Chocolatey-Package.ps1 %1" || exit /b 1
+Powershell -C "C:\mnt\tasks\winbuildscripts\Generate-Chocolatey-Package.ps1 %1 %2" || exit /b 1
 goto :EOF
 
 :nomntdir


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR removes the dependency on the `agent-release-management` pipeline for the chocolatey build online job. Instead of relying on the MSI promotion job from `agent-release-management`, the MSI package is now retrieved through GitLab artifacts from a previous job (`deploy_packages_windows-x64-7`).

### Motivation
While automating the chocolatey releases, a circular dependency occurred and broke the release pipeline. I moved the `choco_deploy` job to `agent-release-management` to automate the chocolatey release. However, the `choco_build` job depended on the `agent-release-management pipeline` to finish, while the `choco_deploy` job inside `agent-release-management` was waiting for `choco_build` in the `datadog-agent` pipeline to complete.

### Describe how to test/QA your changes
I created a [test branch](https://github.com/DataDog/datadog-agent/compare/sabrina/automate-chocolatey...sabrina/automate-chocolatey-test?) that branches off my changes and modifies the online job to manual. Then I ran a test [deployment pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/677252029) using `inv pipeline.run --deploy` on the test branch. Afterwards, I verified that:

- the chocolatey package contains both the URL and checksum

- the nupkg is successfully uploaded to `dd-release-artifacts` s3 bucket without waiting for the MSI promotion job in `agent-release-management
`
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->