### PR TITLE
Fix suse step-by-step install e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -63,8 +63,8 @@
     },
     "suse": {
         "x86_64": {
-            "sles-12": "ami-08d21b039336d9351",
-            "sles-15": "ami-08f3662e2d5b3989a"
+            "sles-12": "ami-058c3f61e5f37c43f",
+            "sles-15": "ami-067dfda331f8296b0"
         },
         "arm64": {
             "sles-15": "ami-0d446ba26bbe19573"

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -262,8 +262,8 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 	var err error
 
 	// Disable all existing non-datadog repos to avoid issues during refresh (which is hard to prevent zypper from doing spontaneously);
-	// we don't need them to install the Agent anyway
-	ExecuteWithoutError(nil, VMclient, "sudo rm /etc/zypp/repos.d/*.repo")
+	// we don't need them to install the Agent anyway.
+	ExecuteWithoutError(nil, VMclient, "sudo rm -f /etc/zypp/repos.d/*.repo")
 
 	fileContent := fmt.Sprintf("[datadog]\n"+
 		"name = Datadog, Inc.\n"+


### PR DESCRIPTION
### What does this PR do?

- It adds the `-f` flag when removing the repo files for zypper so that the command doesn't fail if there aren't any files to begin with.
- It pins the suse images to the right AMI's (by incorporating https://github.com/DataDog/datadog-agent/pull/30211)

### Motivation

This command started to fail this morning (#incident-31580).

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->