### PR TITLE
Drop the unattended-upgrades from the debian AMIs

### DIFF
--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -3,12 +3,12 @@
         "x86_64": {
             "debian-9": "ami-0182559468c1975fe",
             "debian-10": "ami-067a196d70cb53732",
-            "debian-11": "ami-0607e701db389efe7",
-            "debian-12": "ami-07edaec601cf2b6d3"
+            "debian-11": "ami-0698acab5370075a9",
+            "debian-12": "ami-0eef9d92ec044bc94"
         },
         "arm64": {
             "debian-10": "ami-0b6ee4b8f4aa91fb4",
-            "debian-11": "ami-00988b9ead6afb0b1",
+            "debian-11": "ami-0eec63b0513577808",
             "debian-12": "ami-02aab8d5301cb8d68"
         }
     },


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Drop the unattended-upgrades from the debian AMIs.

### Motivation

We are facing issues because of the `unattended-upgrades` because of the apt lock. [We disabled it during the tests](https://github.com/DataDog/datadog-agent/pull/27613) but that's not enough because sometimes it's already running at that time. Disabling it in the AMI will fix the issue.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The AMIs that I did not update already had the unattended-upgrades disabled.

https://datadoghq.atlassian.net/browse/ADXT-500