### PR TITLE
fix(windows): Collapse junit section and prevent error

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -532,7 +532,8 @@ def gitlab_section(section_name, collapsed=False, echo=False):
     """
     - echo: If True, will echo the gitlab section in bold in CLI mode instead of not showing anything
     """
-    section_id = section_name.replace(" ", "_").replace("/", "_")
+    # Specific characters can prevent the generation of the section
+    section_id = re.sub(r"[ :/\\]", "_", section_name)
     in_ci = running_in_gitlab_ci()
     try:
         if in_ci:

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -532,7 +532,7 @@ def gitlab_section(section_name, collapsed=False, echo=False):
     """
     - echo: If True, will echo the gitlab section in bold in CLI mode instead of not showing anything
     """
-    # Specific characters can prevent the generation of the section
+    # Replace with "_" every special character (" ", ":", "/", "\") which prevent the section generation
     section_id = re.sub(r"[ :/\\]", "_", section_name)
     in_ci = running_in_gitlab_ci()
     try:

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -55,8 +55,9 @@ if($err -ne 0){
     [Environment]::Exit($err)
 }
 & inv -e test --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --coverage --cpus 8 --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\$test_output_file $Env:EXTRA_OPTS --build-stdlib $TEST_WASHER_FLAG
-
-$err = $LASTEXITCODE
+If ($LASTEXITCODE -ne "0") {
+    exit $LASTEXITCODE
+}
 
 # Ignore upload failures
 $ErrorActionPreference = "Continue"
@@ -65,11 +66,12 @@ $tmpfile = [System.IO.Path]::GetTempFileName()
 # 1. Upload coverage reports to Codecov
 & "$UT_BUILD_ROOT\tools\ci\fetch_secret.ps1" -parameterName "$Env:CODECOV_TOKEN" -tempFile "$tmpfile"
 If ($LASTEXITCODE -ne "0") {
-    exit $LASTEXITCODE
+    Write-Host "Failed to fetch CODECOV_TOKEN - ignoring"
+    exit "0"
 }
 $Env:CODECOV_TOKEN=$(cat "$tmpfile")
 & inv -e coverage.upload-to-codecov $Env:COVERAGE_CACHE_FLAG
-if($err -ne 0){
+if($LASTEXITCODE -ne "0"){
     Write-Host -ForegroundColor Red "coverage upload failed $err"
 }
 
@@ -80,13 +82,14 @@ Get-ChildItem -Path "$UT_BUILD_ROOT" -Filter "junit-out-*.xml" -Recurse | ForEac
 }
 & "$UT_BUILD_ROOT\tools\ci\fetch_secret.ps1" -parameterName "$Env:API_KEY_ORG2" -tempFile "$tmpfile"
 If ($LASTEXITCODE -ne "0") {
-    exit $LASTEXITCODE
+    Write-Host "Failed to fetch API_KEY - ignoring"
+    exit "0"
 }
 $Env:DATADOG_API_KEY=$(cat "$tmpfile")
 Remove-Item "$tmpfile"
 
 & inv -e junit-upload --tgz-path $Env:JUNIT_TAR
-if($err -ne 0){
+if($LASTEXITCODE -ne "0"){
     Write-Host -ForegroundColor Red "junit upload failed $err"
 }
 

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -69,6 +69,9 @@ If ($LASTEXITCODE -ne "0") {
 }
 $Env:CODECOV_TOKEN=$(cat "$tmpfile")
 & inv -e coverage.upload-to-codecov $Env:COVERAGE_CACHE_FLAG
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "coverage upload failed $err"
+}
 
 # 2. Upload junit files
 # Copy test files to c:\mnt for further gitlab upload
@@ -84,8 +87,7 @@ Remove-Item "$tmpfile"
 
 & inv -e junit-upload --tgz-path $Env:JUNIT_TAR
 if($err -ne 0){
-    Write-Host -ForegroundColor Red "test failed $err"
-    [Environment]::Exit($err)
+    Write-Host -ForegroundColor Red "junit upload failed $err"
 }
 
 Write-Host Test passed


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Collapse the junit upload section on windows context.
- Prevent error raising during junit upload on windows tests.

### Motivation
Have a uniform behaviour on windows and linux. On [windows tests](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/672698516#L1765) the junit logs are still verbose and cumbersome. And as codecov & junit are not run during `after_script` it can cause the script to fail.
[jira](https://datadoghq.atlassian.net/browse/ACIX-485?atlOrigin=eyJpIjoiNDgxZjI0ZTE0M2QwNDkxZmJjNTYzYTUxNTgzZGI0NWMiLCJwIjoiaiJ9)

### Describe how to test/QA your changes
Junit upload well collapsed [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/675311594)

### Possible Drawbacks / Trade-offs

### Additional Notes
Relates with #30031 (failures are retried in case of aws issues)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->