### PR TITLE
[e2e] pin sles-12 and sles-15 AMIs

### DIFF
--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -63,8 +63,8 @@
     },
     "suse": {
         "x86_64": {
-            "sles-12": "ami-08d21b039336d9351",
-            "sles-15": "ami-08f3662e2d5b3989a"
+            "sles-12": "ami-058c3f61e5f37c43f",
+            "sles-15": "ami-067dfda331f8296b0"
         },
         "arm64": {
             "sles-15": "ami-0d446ba26bbe19573"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* pin x86_64 Suse AMIs to our custom AMIs

### Motivation

#incident-31580

Found out we were still using the marketplace AMI, new ones are

`dd-agent-sles-12-x86_64`
![image](https://github.com/user-attachments/assets/b7a0a8d0-ed1e-4b26-a01a-d3bb66b06f3c)

and `dd-agent-sles-15-x86_64`

![image](https://github.com/user-attachments/assets/d962e69e-0a13-4c0f-b740-b8ef7501e21a)


### Describe how to test/QA your changes

Will trigger a deploy pipeline to force execute the step by step test. As a follow up, agent-delivery will change the step by step rule, to run on step by step test changes and on `platforms.json` file changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->