### PR TITLE
[cloudproviders/azure] Include cluster name in hostname by default

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -89,21 +89,7 @@ var vmIDFetcher = cachedfetch.Fetcher{
 
 // GetHostAliases returns the VM ID from the Azure Metadata api
 func GetHostAliases(ctx context.Context) ([]string, error) {
-	aliases := []string{}
-	vm, err := vmIDFetcher.FetchStringSlice(ctx)
-	if err == nil {
-		aliases = append(aliases, vm...)
-	}
-
-	metadata, err := getMetadata(ctx)
-	if err != nil {
-		return aliases, fmt.Errorf("Azure GetHostAliases: unable to query metadata endpoint: %s", err)
-	}
-
-	if isKubernetesTag(metadata.TagsList) {
-		aliases = append(aliases, metadata.OsProfile.ComputerName)
-	}
-	return aliases, err
+	return vmIDFetcher.FetchStringSlice(ctx)
 }
 
 var resourceGroupNameFetcher = cachedfetch.Fetcher{

--- a/releasenotes/notes/azure-aks-hostname-with-cluster-name-15eb1c0339ad1526.yaml
+++ b/releasenotes/notes/azure-aks-hostname-with-cluster-name-15eb1c0339ad1526.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The cluster name is now included by default as part of the hostname in AKS
+    clusters. This is done to avoid conflicts when there are multiple hosts with
+    the same name in different clusters.


### PR DESCRIPTION
### What does this PR do?

Changes the azure hostname provider to include the cluster name by default when running on AKS.
This was the behavior before merging https://github.com/DataDog/datadog-agent/pull/26860

### Describe how to test/QA your changes

Deploy on AKS. `agent hostname` should include the cluster name.