### PR TITLE
[EBPF-589] Initialize process monitor as a module

### DIFF
--- a/cmd/system-probe/api/module/factory_linux.go
+++ b/cmd/system-probe/api/module/factory_linux.go
@@ -17,4 +17,8 @@ type Factory struct {
 	ConfigNamespaces []string
 	Fn               func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
 	NeedsEBPF        func() bool
+
+	// IgnoreForSuccessCheck can be set to true if system-probe should not consider this module when checking
+	// if at least one module was successfully loaded.
+	IgnoreForSuccessCheck bool
 }

--- a/cmd/system-probe/api/module/factory_others.go
+++ b/cmd/system-probe/api/module/factory_others.go
@@ -16,4 +16,8 @@ type Factory struct {
 	Name             sysconfigtypes.ModuleName
 	ConfigNamespaces []string
 	Fn               func(cfg *sysconfigtypes.Config, deps FactoryDependencies) (Module, error)
+
+	// IgnoreForSuccessCheck can be set to true if system-probe should not consider this module when checking
+	// if at least one module was successfully loaded.
+	IgnoreForSuccessCheck bool
 }

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -146,7 +146,8 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(spNS("process_config.enabled")) {
 		c.EnabledModules[ProcessModule] = struct{}{}
 	}
-	if cfg.GetBool(diNS("enabled")) {
+	dynInstEnabled := cfg.GetBool(diNS("enabled"))
+	if dynInstEnabled {
 		c.EnabledModules[DynamicInstrumentationModule] = struct{}{}
 	}
 	if cfg.GetBool(nskey("ebpf_check", "enabled")) {
@@ -190,7 +191,7 @@ func load() (*types.Config, error) {
 		cfg.GetBool(smNS("tls", "istio", "enabled")) ||
 		cfg.GetBool(smNS("tls", "nodejs", "enabled")))
 
-	if gpuEnabled || (usmEnabled && usmNeedsProcessMonitor) {
+	if gpuEnabled || (usmEnabled && usmNeedsProcessMonitor) || dynInstEnabled {
 		c.EnabledModules[ProcessMonitorModule] = struct{}{}
 	}
 

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -182,7 +182,15 @@ func load() (*types.Config, error) {
 	}
 
 	// Enable process monitor if there are modules that require it (USM, GPU monitoring)
-	if gpuEnabled || usmEnabled {
+	// Options taken from pkg/network/usm/config.NeedProcessMonitor, which we cannot import here
+	// due to a import cycle.
+	// This is a temporary fix until we introduce proper dependency management, see EBPF-589
+	usmNeedsProcessMonitor := (cfg.GetBool(smNS("tls", "native", "enabled")) ||
+		cfg.GetBool(smNS("tls", "go", "enabled")) ||
+		cfg.GetBool(smNS("tls", "istio", "enabled")) ||
+		cfg.GetBool(smNS("tls", "nodejs", "enabled")))
+
+	if gpuEnabled || (usmEnabled && usmNeedsProcessMonitor) {
 		c.EnabledModules[ProcessMonitorModule] = struct{}{}
 	}
 

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -35,6 +35,7 @@ const (
 	TCPQueueLengthTracerModule   types.ModuleName = "tcp_queue_length_tracer"
 	ProcessModule                types.ModuleName = "process"
 	EventMonitorModule           types.ModuleName = "event_monitor"
+	ProcessMonitorModule         types.ModuleName = "process_monitor"
 	DynamicInstrumentationModule types.ModuleName = "dynamic_instrumentation"
 	EBPFModule                   types.ModuleName = "ebpf"
 	LanguageDetectionModule      types.ModuleName = "language_detection"
@@ -163,7 +164,9 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(discoveryNS("enabled")) {
 		c.EnabledModules[DiscoveryModule] = struct{}{}
 	}
-	if cfg.GetBool(gpuNS("enabled")) {
+
+	gpuEnabled := cfg.GetBool(gpuNS("enabled"))
+	if gpuEnabled {
 		c.EnabledModules[GPUMonitoringModule] = struct{}{}
 	}
 
@@ -176,6 +179,11 @@ func load() (*types.Config, error) {
 			// module is enabled, to allow the core agent to detect our own crash
 			c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
 		}
+	}
+
+	// Enable process monitor if there are modules that require it (USM, GPU monitoring)
+	if gpuEnabled || usmEnabled {
+		c.EnabledModules[ProcessMonitorModule] = struct{}{}
 	}
 
 	c.Enabled = len(c.EnabledModules) > 0

--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -20,10 +20,6 @@ var All = []module.Factory{
 	NetworkTracer,
 	TCPQueueLength,
 	OOMKillProbe,
-	ProcessMonitor,
-	// there is a dependency from EventMonitor -> NetworkTracer,ProcessMonitor
-	// so EventMonitor has to follow NetworkTracer and ProcessMonitor
-	EventMonitor,
 	Process,
 	DynamicInstrumentation,
 	LanguageDetectionModule,
@@ -32,6 +28,12 @@ var All = []module.Factory{
 	Traceroute,
 	DiscoveryModule,
 	GPUMonitoring,
+	// Other modules (NetworkTracer,GpuMonitoring,DynamicInstrumentation) use the process
+	// monitor so they must set up their callbacks before we call initializes
+	ProcessMonitor,
+	// EventMonitor must be initialized after ProcessMonitor, if we are using EventStream
+	// for process monitoring, starting the event monitor will scan existing processes
+	EventMonitor,
 }
 
 func inactivityEventLog(_ time.Duration) {

--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -20,8 +20,9 @@ var All = []module.Factory{
 	NetworkTracer,
 	TCPQueueLength,
 	OOMKillProbe,
-	// there is a dependency from EventMonitor -> NetworkTracer
-	// so EventMonitor has to follow NetworkTracer
+	ProcessMonitor,
+	// there is a dependency from EventMonitor -> NetworkTracer,ProcessMonitor
+	// so EventMonitor has to follow NetworkTracer and ProcessMonitor
 	EventMonitor,
 	Process,
 	DynamicInstrumentation,

--- a/cmd/system-probe/modules/all_linux_arm64.go
+++ b/cmd/system-probe/modules/all_linux_arm64.go
@@ -20,10 +20,6 @@ var All = []module.Factory{
 	NetworkTracer,
 	TCPQueueLength,
 	OOMKillProbe,
-	ProcessMonitor,
-	// there is a dependency from EventMonitor -> NetworkTracer,ProcessMonitor
-	// so EventMonitor has to follow NetworkTracer and ProcessMonitor
-	EventMonitor,
 	Process,
 	DynamicInstrumentation,
 	LanguageDetectionModule,
@@ -32,6 +28,12 @@ var All = []module.Factory{
 	Traceroute,
 	DiscoveryModule,
 	GPUMonitoring,
+	// Other modules (NetworkTracer,GpuMonitoring,DynamicInstrumentation) use the process
+	// monitor so they must set up their callbacks before we call initializes
+	ProcessMonitor,
+	// EventMonitor must be initialized after ProcessMonitor, if we are using EventStream
+	// for process monitoring, starting the event monitor will scan existing processes
+	EventMonitor,
 }
 
 func inactivityEventLog(_ time.Duration) {

--- a/cmd/system-probe/modules/all_linux_arm64.go
+++ b/cmd/system-probe/modules/all_linux_arm64.go
@@ -20,8 +20,9 @@ var All = []module.Factory{
 	NetworkTracer,
 	TCPQueueLength,
 	OOMKillProbe,
-	// there is a dependency from EventMonitor -> NetworkTracer
-	// so EventMonitor has to follow NetworkTracer
+	ProcessMonitor,
+	// there is a dependency from EventMonitor -> NetworkTracer,ProcessMonitor
+	// so EventMonitor has to follow NetworkTracer and ProcessMonitor
 	EventMonitor,
 	Process,
 	DynamicInstrumentation,

--- a/cmd/system-probe/modules/processmonitor.go
+++ b/cmd/system-probe/modules/processmonitor.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/process/monitor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+)
+
+func isEventStreamEnabled() bool {
+	eventStreamUSM := pkgconfigsetup.SystemProbe().GetBool("service_monitoring_config.enable_event_stream")
+	eventStreamProcMon := pkgconfigsetup.SystemProbe().GetBool("process_monitoring_config.enable_event_stream")
+
+	return eventStreamUSM || eventStreamProcMon
+}
+
+// ProcessMonitor - Event monitor Factory
+var ProcessMonitor = module.Factory{
+	Name:             config.ProcessMonitorModule,
+	ConfigNamespaces: processMonitorModuleConfigNamespaces,
+	Fn:               createProcessMonitorModule,
+	NeedsEBPF: func() bool {
+		return isEventStreamEnabled()
+	},
+}
+
+var processMonitorModuleConfigNamespaces = []string{"process_monitoring_config", "service_monitoring_config"}
+
+func createProcessMonitorModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
+	log.Infof("Initializing process monitor...")
+	processMonitor := monitor.GetProcessMonitor()
+	if processMonitor == nil {
+		return nil, errors.New("could not get process monitor")
+	}
+
+	err := processMonitor.Initialize(isEventStreamEnabled())
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize process monitor: %w", err)
+	}
+
+	return &processMonitorModule{}, nil
+}
+
+type processMonitorModule struct {
+}
+
+func (m *processMonitorModule) GetStats() map[string]interface{} {
+	return nil
+}
+
+func (m *processMonitorModule) Register(_ *module.Router) error {
+	return nil
+}
+
+func (m *processMonitorModule) Close() {
+}

--- a/cmd/system-probe/modules/processmonitor.go
+++ b/cmd/system-probe/modules/processmonitor.go
@@ -39,20 +39,23 @@ var processMonitorModuleConfigNamespaces = []string{"service_monitoring_config"}
 
 func createProcessMonitorModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 	log.Infof("Initializing process monitor...")
-	processMonitor := monitor.GetProcessMonitor()
-	if processMonitor == nil {
+	module := &processMonitorModule{
+		procMon: monitor.GetProcessMonitor(),
+	}
+	if module.procMon == nil {
 		return nil, errors.New("could not get process monitor")
 	}
 
-	err := processMonitor.Initialize(isEventStreamEnabled())
+	err := module.procMon.Initialize(isEventStreamEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize process monitor: %w", err)
 	}
 
-	return &processMonitorModule{}, nil
+	return module, nil
 }
 
 type processMonitorModule struct {
+	procMon *monitor.ProcessMonitor
 }
 
 func (m *processMonitorModule) GetStats() map[string]interface{} {
@@ -64,4 +67,5 @@ func (m *processMonitorModule) Register(_ *module.Router) error {
 }
 
 func (m *processMonitorModule) Close() {
+	m.procMon.Stop()
 }

--- a/cmd/system-probe/modules/processmonitor.go
+++ b/cmd/system-probe/modules/processmonitor.go
@@ -21,10 +21,7 @@ import (
 )
 
 func isEventStreamEnabled() bool {
-	eventStreamUSM := pkgconfigsetup.SystemProbe().GetBool("service_monitoring_config.enable_event_stream")
-	eventStreamProcMon := pkgconfigsetup.SystemProbe().GetBool("process_monitoring_config.enable_event_stream")
-
-	return eventStreamUSM || eventStreamProcMon
+	return pkgconfigsetup.SystemProbe().GetBool("service_monitoring_config.enable_event_stream")
 }
 
 // ProcessMonitor - Event monitor Factory
@@ -37,7 +34,7 @@ var ProcessMonitor = module.Factory{
 	},
 }
 
-var processMonitorModuleConfigNamespaces = []string{"process_monitoring_config", "service_monitoring_config"}
+var processMonitorModuleConfigNamespaces = []string{"service_monitoring_config"}
 
 func createProcessMonitorModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 	log.Infof("Initializing process monitor...")

--- a/cmd/system-probe/modules/processmonitor.go
+++ b/cmd/system-probe/modules/processmonitor.go
@@ -32,6 +32,7 @@ var ProcessMonitor = module.Factory{
 	NeedsEBPF: func() bool {
 		return isEventStreamEnabled()
 	},
+	IgnoreForSuccessCheck: true,
 }
 
 var processMonitorModuleConfigNamespaces = []string{"service_monitoring_config"}

--- a/pkg/dynamicinstrumentation/di.go
+++ b/pkg/dynamicinstrumentation/di.go
@@ -123,10 +123,7 @@ func RunDynamicInstrumentation(opts *DIOptions) (*GoDI, error) {
 		}
 		stopFunctions = append(stopFunctions, stopFileConfigManager)
 	} else {
-		cm, err := diconfig.NewRCConfigManager()
-		if err != nil {
-			return nil, fmt.Errorf("could not create new RC config manager: %w", err)
-		}
+		cm := diconfig.NewRCConfigManager()
 		goDI = &GoDI{
 			ConfigManager: cm,
 			lu:            uploader.NewLogUploader(),

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -15,6 +15,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/google/uuid"
+
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/codegen"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diagnostics"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -22,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/eventparser"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/proctracker"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ratelimiter"
-	"github.com/cilium/ebpf/ringbuf"
-	"github.com/google/uuid"
 )
 
 type rcConfig struct {
@@ -65,19 +66,16 @@ type RCConfigManager struct {
 }
 
 // NewRCConfigManager creates a new configuration manager which utilizes remote-config
-func NewRCConfigManager() (*RCConfigManager, error) {
+func NewRCConfigManager() *RCConfigManager {
 	log.Info("Creating new RC config manager")
 	cm := &RCConfigManager{
 		callback: applyConfigUpdate,
 	}
 
 	cm.procTracker = proctracker.NewProcessTracker(cm.updateProcesses)
-	err := cm.procTracker.Start()
-	if err != nil {
-		return nil, fmt.Errorf("could not start process tracker: %w", err)
-	}
+	cm.procTracker.Start()
 	cm.diProcs = ditypes.NewDIProcs()
-	return cm, nil
+	return cm
 }
 
 // GetProcInfos returns the state of the RCConfigManager

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -41,13 +41,10 @@ func NewReaderConfigManager() (*ReaderConfigManager, error) {
 	}
 
 	cm.procTracker = proctracker.NewProcessTracker(cm.updateProcessInfo)
-	err := cm.procTracker.Start()
-	if err != nil {
-		return nil, err
-	}
+	cm.procTracker.Start()
 
 	reader := NewConfigWriter(cm.updateServiceConfigs)
-	err = reader.Start()
+	err := reader.Start()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -21,9 +21,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
@@ -31,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"golang.org/x/sys/unix"
 )
 
 type processTrackerCallback func(ditypes.DIProcs)
@@ -62,20 +64,13 @@ func NewProcessTracker(callback processTrackerCallback) *ProcessTracker {
 // Start subscribes to exec and exit events so dynamic instrumentation can be made
 // aware of new processes that may need to be instrumented or instrumented processes
 // that should no longer be instrumented
-func (pt *ProcessTracker) Start() error {
+func (pt *ProcessTracker) Start() {
 
 	unsubscribeExec := pt.pm.SubscribeExec(pt.handleProcessStart)
 	unsubscribeExit := pt.pm.SubscribeExit(pt.handleProcessStop)
 
 	pt.unsubscribe = append(pt.unsubscribe, unsubscribeExec)
 	pt.unsubscribe = append(pt.unsubscribe, unsubscribeExit)
-
-	err := pt.pm.Initialize(false)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Stop unsubscribes from exec and exit events

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -24,7 +24,6 @@ const (
 	netNS = "network_config"
 	smNS  = "service_monitoring_config"
 	evNS  = "event_monitoring_config"
-	pmNs  = "process_monitoring_config"
 
 	defaultUDPTimeoutSeconds       = 30
 	defaultUDPStreamTimeoutSeconds = 120

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -24,6 +24,7 @@ const (
 	netNS = "network_config"
 	smNS  = "service_monitoring_config"
 	evNS  = "event_monitoring_config"
+	pmNs  = "process_monitoring_config"
 
 	defaultUDPTimeoutSeconds       = 30
 	defaultUDPStreamTimeoutSeconds = 120

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -24,7 +24,6 @@ import (
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
-	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	usmstate "github.com/DataDog/datadog-agent/pkg/network/usm/state"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
@@ -130,11 +129,6 @@ func (m *Monitor) Start() error {
 	err = m.ebpfProgram.Start()
 	if err != nil {
 		return err
-	}
-
-	// Need to explicitly save the error in `err` so the defer function could save the startup error.
-	if usmconfig.NeedProcessMonitor(m.cfg) {
-		err = m.processMonitor.Initialize(m.cfg.EnableUSMEventStream)
 	}
 
 	return err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves the initialization of `ProcessMonitor` to a single module, instead of each module initializing it by itself. It also introduces a new variable for the `module.Factory` called `IgnoreForSuccessCheck`, which ensures that system-probe will still fail initialization if other modules fail but the new process-monitor module is succesful.

### Motivation

The `ProcessMonitor` object is a singleton, but needs to be initialized after all callbacks have been registered so that they receive events for existing processes. Since we have added the GPU monitoring and Dynamic Instrumentation modules which use the process monitor, it can no longer be initialized in the network tracer module. Another problem was that each module would try to initialize the process monitor with different options, causing inconsistencies there.

This is a temporary solution while we plan and develop a better way for system-probe to deal with these dependencies in a generic manner that guarantees proper ordering and initialization only when needed.

https://datadoghq.atlassian.net/browse/EBPF-589

### Describe how to test/QA your changes

Tested locally by:

* starting system probe with USM, GPU, DI enabled and checking that the process monitor is initialized after their callbacks are registered (checking logs)
* Forcing a failure in all modules except the process monitor and checking that system-probe stops.

### Possible Drawbacks / Trade-offs

### Additional Notes

We have not introduced a new config to control the event stream, instead using the existing USM config (`service_monitoring_config.enable_event_stream`) despite that not being used only in USM anymore. A proper configuration option should be defined once we get a better system for managing these dependencies.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->