### PR TITLE
[CWS] add more docker test jobs to KMT

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -167,7 +167,25 @@ kmt_run_secagent_tests_x64_docker:
   parallel:
     matrix:
       - TAG:
+          - "ubuntu_18.04"
+          - "ubuntu_20.04"
+          - "ubuntu_22.04"
+          - "ubuntu_23.10"
           - "ubuntu_24.04"
+          - "amazon_4.14"
+          - "amazon_5.4"
+          - "amazon_5.10"
+          - "amazon_2023"
+          - "fedora_37"
+          - "fedora_38"
+          - "debian_10"
+          - "debian_11"
+          - "debian_12"
+          - "centos_7.9"
+          - "oracle_8.9"
+          - "oracle_9.3"
+          - "rocky_8.5"
+          - "rocky_9.3"
         TEST_SET: [cws_docker]
   after_script:
     - !reference [.collect_outcomes_kmt]

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -32,7 +32,7 @@ kmt_setup_env_secagent_arm64:
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
     TEST_COMPONENT: security-agent
-    TEST_SETS: cws_host
+    TEST_SETS: cws_host,cws_docker
 
 kmt_setup_env_secagent_x64:
   extends:
@@ -221,6 +221,39 @@ kmt_run_secagent_tests_arm64:
           - "rocky_9.3"
           - "opensuse_15.5"
         TEST_SET: ["cws_host"]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_arm64_docker:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs:
+    - kmt_setup_env_secagent_arm64
+    - upload_dependencies_secagent_arm64
+    - upload_secagent_tests_arm64
+  variables:
+    ARCH: "arm64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+          - "ubuntu_23.10"
+          - "ubuntu_24.04"
+          - "amazon_5.4"
+          - "amazon_5.10"
+          - "amazon_2023"
+          - "fedora_37"
+          - "fedora_38"
+          - "debian_11"
+          - "debian_12"
+          - "oracle_8.9"
+          - "oracle_9.3"
+          - "rocky_8.5"
+          - "rocky_9.3"
+        TEST_SET: ["cws_docker"]
   after_script:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]


### PR DESCRIPTION
### What does this PR do?

This PR adds more docker CWS KMT functional tests. Based on https://github.com/DataDog/datadog-agent/pull/30098 adding the support for this.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->