### PR TITLE
(fleet) switch from docker.io to install.datad0g.com for staging packages

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -295,7 +295,7 @@ func (d *DownloadedPackage) WriteOCILayout(dir string) error {
 func PackageURL(env *env.Env, pkg string, version string) string {
 	switch env.Site {
 	case "datad0g.com":
-		return fmt.Sprintf("oci://docker.io/datadog/%s-package-dev:%s", strings.TrimPrefix(pkg, "datadog-"), version)
+		return fmt.Sprintf("oci://install.datad0g.com/%s-package-dev:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	default:
 		return fmt.Sprintf("oci://gcr.io/datadoghq/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	}

--- a/pkg/fleet/internal/oci/download_test.go
+++ b/pkg/fleet/internal/oci/download_test.go
@@ -122,12 +122,12 @@ func TestGetRefAndKeychain(t *testing.T) {
 	}
 
 	tests := []test{
-		{url: "docker.io/datadog/agent-package-dev:latest", expectedRef: "docker.io/datadog/agent-package-dev:latest", expectedKeychain: authn.DefaultKeychain},
+		{url: "install.datad0g.com/agent-package-dev:latest", expectedRef: "install.datad0g.com/agent-package-dev:latest", expectedKeychain: authn.DefaultKeychain},
 		{url: "gcr.io/datadoghq/agent-package@sha256:1234", expectedRef: "gcr.io/datadoghq/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
-		{url: "docker.io/datadog/agent-package-dev:latest", registryOverride: "fake.io", expectedRef: "fake.io/agent-package-dev:latest", expectedKeychain: authn.DefaultKeychain},
+		{url: "install.datad0g.com/agent-package-dev:latest", registryOverride: "fake.io", expectedRef: "fake.io/agent-package-dev:latest", expectedKeychain: authn.DefaultKeychain},
 		{url: "gcr.io/datadoghq/agent-package@sha256:1234", registryOverride: "fake.io", expectedRef: "fake.io/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
 		{
-			url:                "docker.io/datadog/agent-package-dev:latest",
+			url:                "install.datad0g.com/agent-package-dev:latest",
 			regOverrideByImage: map[string]string{"agent-package-dev": "fake.io"},
 			expectedRef:        "fake.io/agent-package-dev:latest",
 			expectedKeychain:   authn.DefaultKeychain,
@@ -200,7 +200,7 @@ func TestPackageURL(t *testing.T) {
 	}
 
 	tests := []test{
-		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://docker.io/datadog/agent-package-dev:latest"},
+		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://install.datad0g.com/agent-package-dev:latest"},
 		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://gcr.io/datadoghq/agent-package:1.2.3"},
 	}
 


### PR DESCRIPTION


This PR siwtches the default source of staging packages from docker.io to install.datad0g.com.

