### PR TITLE
[APM] Fix race condition on TestResetBuffer test

### DIFF
--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -257,7 +257,10 @@ func TestResetBuffer(t *testing.T) {
 	runtime.ReadMemStats(&m)
 	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
 
+	w.mu.Lock()
 	w.resetBuffer()
+	w.mu.Unlock()
+
 	runtime.GC()
 	runtime.ReadMemStats(&m)
 	assert.Less(t, m.HeapInuse, uint64(50*1e6))


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This is a fix for https://datadoghq.atlassian.net/browse/APMSP-1325

From the job output:

```
WARNING: DATA RACE
Write at 0x00c0001f45c0 by goroutine 2812:
 github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).resetBuffer()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:233 +0x7c6
  github.com/DataDog/datadog-agent/pkg/trace/writer.TestResetBuffer()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace_test.go:260 +0x7be
  testing.tRunner()
     /Users/runner/.gimme/versions/go1.22.8.darwin.amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /Users/runner/.gimme/versions/go1.22.8.darwin.amd64/src/testing/testing.go:1742 +0x44

Previous write at 0x00c0001f45c0 by goroutine 3014:
  github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).resetBuffer()
    /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:233 +0x53
  github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).flush.deferwrap2()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:243 +0x1f
  runtime.deferreturn()
      /Users/runner/.gimme/versions/go1.22.8.darwin.amd64/src/runtime/panic.go:602 +0x5d
  github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).timeFlush.func1()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:169 +0xc4
 github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).timeFlush()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:170 +0xb3
  github.com/DataDog/datadog-agent/pkg/trace/writer.NewTraceWriter.gowrap1()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:133 +0x33
```

The test was calling directly the TraceWriter.resetBuffer(), which must be lock protected before accessing it.

### Motivation

https://datadoghq.atlassian.net/browse/APMSP-1325

### Describe how to test/QA your changes
N/A
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->