### PR TITLE
(fleet) remove existing package entry in the DB on re-install

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -186,6 +186,10 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 		return fmt.Errorf("could not create temporary directory: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	err = i.db.DeletePackage(pkg.Name)
+	if err != nil {
+		return fmt.Errorf("could not remove package installation in db: %w", err)
+	}
 	configDir := filepath.Join(i.userConfigsDir, pkg.Name)
 	err = pkg.ExtractLayers(oci.DatadogPackageLayerMediaType, tmpDir)
 	if err != nil {

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -177,7 +177,7 @@ func TestReinstallAfterErrror(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Make the v2 package directory read-only, so the installation will fail
-	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0555)
+	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0000)
 	assert.NoError(t, err)
 	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV2), nil)
 	assert.Error(t, err)

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -121,4 +123,111 @@ func TestUninstallExperiment(t *testing.T) {
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), r.StableFS())
 	// we do not rollback configuration examples to their previous versions currently
 	fixtures.AssertEqualFS(t, s.ConfigFS(fixtures.FixtureSimpleV2), installer.ConfigFS(fixtures.FixtureSimpleV2))
+}
+
+func TestInstallSkippedWhenAlreadyInstalled(t *testing.T) {
+	s := fixtures.NewServer(t)
+	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
+
+	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	lastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+
+	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r = installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	newLastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+	assert.Equal(t, lastModTime, newLastModTime)
+}
+
+func TestReinstallAfterDBClean(t *testing.T) {
+	s := fixtures.NewServer(t)
+	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
+
+	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	lastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+
+	installer.db.DeletePackage(fixtures.FixtureSimpleV1.Package)
+
+	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r = installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	newLastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+	assert.NotEqual(t, lastModTime, newLastModTime)
+}
+
+func TestReinstallAfterErrror(t *testing.T) {
+	s := fixtures.NewServer(t)
+	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
+	defer installer.db.Close()
+
+	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	lastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+
+	// Make the v2 package directory read-only, so the installation will fail
+	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0555)
+	assert.NoError(t, err)
+	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV2), nil)
+	assert.Error(t, err)
+	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0755)
+	assert.NoError(t, err)
+
+	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r = installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+	newLastModTime, err := latestModTimeFS(r.StableFS(), ".")
+	assert.NoError(t, err)
+	assert.NotEqual(t, lastModTime, newLastModTime)
+}
+
+func latestModTimeFS(fsys fs.FS, dirPath string) (time.Time, error) {
+	var latestTime time.Time
+
+	// Read the directory entries
+	entries, err := fs.ReadDir(fsys, dirPath)
+	if err != nil {
+		return latestTime, err
+	}
+
+	for _, entry := range entries {
+		// Get full path of the entry
+		entryPath := path.Join(dirPath, entry.Name())
+
+		// Get file info to access modification time
+		info, err := fs.Stat(fsys, entryPath)
+		if err != nil {
+			return latestTime, err
+		}
+
+		// Update the latest modification time
+		if info.ModTime().After(latestTime) {
+			latestTime = info.ModTime()
+		}
+
+		// If the entry is a directory, recurse into it
+		if entry.IsDir() {
+			subLatestTime, err := latestModTimeFS(fsys, entryPath) // Recurse into subdirectory
+			if err != nil {
+				return latestTime, err
+			}
+			// Compare times
+			if subLatestTime.After(latestTime) {
+				latestTime = subLatestTime
+			}
+		}
+	}
+
+	return latestTime, nil
 }

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -165,33 +165,6 @@ func TestReinstallAfterDBClean(t *testing.T) {
 	assert.NotEqual(t, lastModTime, newLastModTime)
 }
 
-func TestReinstallAfterErrror(t *testing.T) {
-	s := fixtures.NewServer(t)
-	installer := newTestPackageManager(t, s, t.TempDir(), t.TempDir())
-	defer installer.db.Close()
-
-	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
-	assert.NoError(t, err)
-	r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
-	lastModTime, err := latestModTimeFS(r.StableFS(), ".")
-	assert.NoError(t, err)
-
-	// Make the v2 package directory read-only, so the installation will fail
-	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0000)
-	assert.NoError(t, err)
-	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV2), nil)
-	assert.Error(t, err)
-	err = os.Chmod(filepath.Join(installer.packages.RootPath(), fixtures.FixtureSimpleV2.Package), 0755)
-	assert.NoError(t, err)
-
-	err = installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
-	assert.NoError(t, err)
-	r = installer.packages.Get(fixtures.FixtureSimpleV1.Package)
-	newLastModTime, err := latestModTimeFS(r.StableFS(), ".")
-	assert.NoError(t, err)
-	assert.NotEqual(t, lastModTime, newLastModTime)
-}
-
 func latestModTimeFS(fsys fs.FS, dirPath string) (time.Time, error) {
 	var latestTime time.Time
 


### PR DESCRIPTION
When `installer install <pkg>` is called multiple times we can have the following sequence:
- Install pkg v1 :ok:
- Install pkg v2 :fail:

Before this would lead to v1 still being marked as installed while the failed install of v2 might have broke v1. As such this PR removes the mark that v1 was installed before starting to install v2.
