### PR TITLE
Auto multiline V2 fix truncated log tag when log is single line

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -75,7 +75,7 @@ func (b *bucket) flush() *message.Message {
 		msg.ParsingExtra.IsTruncated = true
 		tlmTags[0] = "true"
 		if b.tagTruncatedLogs {
-			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("auto_multiline"))
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the tag on single line logs captured by the multi line aggregator. 
The telemetry metrics disagreed with the tagged logs causing the collected data to be inaccurate. 

Also adjusted the truncation threshold to be `>=` instead of `>` to align with the `single_line_handler` behavior. 
This change should have no visible behavior change - just more correct tagging (when enabled). 

### Motivation

Fix incorrect behavior. 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[](https://datadoghq.atlassian.net/browse/AMLII-2117)