### PR TITLE
[CWS] make sure rate limiters are reset on ruleset changes

### DIFF
--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -35,14 +35,14 @@ const (
 )
 
 var (
-	defaultPerRuleLimiters = map[eval.RuleID]Limiter{
-		RulesetLoadedRuleID:             NewStdLimiter(rate.Inf, 1), // No limit on ruleset loaded
-		HeartbeatRuleID:                 NewStdLimiter(rate.Inf, 1), // No limit on heartbeat
-		AbnormalPathRuleID:              NewStdLimiter(rate.Every(30*time.Second), 1),
-		NoProcessContextErrorRuleID:     NewStdLimiter(rate.Every(30*time.Second), 1),
-		BrokenProcessLineageErrorRuleID: NewStdLimiter(rate.Every(30*time.Second), 1),
-		EBPFLessHelloMessageRuleID:      NewStdLimiter(rate.Inf, 1), // No limit on hello message
-		InternalCoreDumpRuleID:          NewStdLimiter(rate.Every(30*time.Second), 1),
+	defaultPerRuleLimiters = map[eval.RuleID]rate.Limit{
+		RulesetLoadedRuleID:             rate.Inf, // No limit on ruleset loaded
+		HeartbeatRuleID:                 rate.Inf, // No limit on heartbeat
+		AbnormalPathRuleID:              rate.Every(30 * time.Second),
+		NoProcessContextErrorRuleID:     rate.Every(30 * time.Second),
+		BrokenProcessLineageErrorRuleID: rate.Every(30 * time.Second),
+		EBPFLessHelloMessageRuleID:      rate.Inf, // No limit on hello message
+		InternalCoreDumpRuleID:          rate.Every(30 * time.Second),
 	}
 )
 
@@ -72,8 +72,8 @@ func NewRateLimiter(config *config.RuntimeSecurityConfig, client statsd.ClientIn
 }
 
 func (rl *RateLimiter) applyBaseLimitersFromDefault(limiters map[string]Limiter) {
-	for id, limiter := range defaultPerRuleLimiters {
-		limiters[id] = limiter
+	for id, rate := range defaultPerRuleLimiters {
+		limiters[id] = NewStdLimiter(rate, 1)
 	}
 
 	limiter, err := NewAnomalyDetectionLimiter(rl.config.AnomalyDetectionRateLimiterNumKeys, rl.config.AnomalyDetectionRateLimiterNumEventsAllowed, rl.config.AnomalyDetectionRateLimiterPeriod)


### PR DESCRIPTION
### What does this PR do?

This PR makes sure new limiter are created on ruleset changes, so that old limiter trigger do not propagate on new rulesets. The main goal of this PR is to fix the `TestEventTruncatedParents` where the `map` case was triggering the abnormal path limiter preventing the `erpc` test to trigger its one.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->