### PR TITLE
Fix OTel Agent EKS test

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/kubernetes"
@@ -26,7 +25,6 @@ type iaEKSTestSuite struct {
 }
 
 func TestOTelAgentIAEKS(t *testing.T) {
-	flake.Mark(t)
 	values := `
 datadog:
   logs:

--- a/test/new-e2e/tests/otel/utils/pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/pipelines_utils.go
@@ -465,7 +465,7 @@ func createCalendarApp(ctx context.Context, s OTelTestSuite) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:            name,
-						Image:           "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog/opentelemetry-examples:calendar-go-rest-0.15",
+						Image:           "ghcr.io/datadog/apps-calendar-go:main",
 						ImagePullPolicy: "IfNotPresent",
 						Ports: []corev1.ContainerPort{{
 							Name:          "http",

--- a/test/new-e2e/tests/otel/utils/pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/pipelines_utils.go
@@ -465,7 +465,7 @@ func createCalendarApp(ctx context.Context, s OTelTestSuite) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:            name,
-						Image:           "datadog/opentelemetry-examples:calendar-go-rest-0.15",
+						Image:           "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog/opentelemetry-examples:calendar-go-rest-0.15",
 						ImagePullPolicy: "IfNotPresent",
 						Ports: []corev1.ContainerPort{{
 							Name:          "http",

--- a/test/new-e2e/tests/otel/utils/pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/pipelines_utils.go
@@ -390,7 +390,7 @@ func TestCalendarApp(s OTelTestSuite) {
 		logs, err := s.Env().FakeIntake.Client().FilterLogs(calendarService, fakeintake.WithMessageContaining(logBody))
 		assert.NoError(c, err)
 		assert.NotEmpty(c, logs)
-	}, 60*time.Minute, 10*time.Second)
+	}, 30*time.Minute, 10*time.Second)
 }
 
 func createCalendarApp(ctx context.Context, s OTelTestSuite) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes OTel Agent EKS test which was flaky due to dockerhub pull rate limits. This PR updates the image URL, removes the flake marker, and shortens the calendar start timeout to 30 minutes.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
OTEL-2141