### PR TITLE
[DBM] Fix nil pointer error on Oracle DBM query when check connection is lost before SELECT

### DIFF
--- a/releasenotes/notes/oracle-reconnect-on-connection-lose-before-select-54d2b6ad6811d1ea.yaml
+++ b/releasenotes/notes/oracle-reconnect-on-connection-lose-before-select-54d2b6ad6811d1ea.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix nil pointer error on Oracle DBM query when check connection is lost before SELECT.

--- a/releasenotes/notes/oracle-reconnect-on-connection-lose-before-select-54d2b6ad6811d1ea.yaml
+++ b/releasenotes/notes/oracle-reconnect-on-connection-lose-before-select-54d2b6ad6811d1ea.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix nil pointer error on Oracle DBM query when check connection is lost before SELECT.
+    Fix nil pointer error on Oracle DBM query when the check's connection is lost before SELECT statement executes.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes nil pointer error on Oracle DBM query when check connection is lost before SELECT

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-1185

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->