### PR TITLE
Enable peer tags aggregation by default

### DIFF
--- a/cmd/trace-agent/test/testsuite/otlp_test.go
+++ b/cmd/trace-agent/test/testsuite/otlp_test.go
@@ -313,6 +313,7 @@ otlp_config:
       endpoint: 0.0.0.0:5111
 apm_config:
   env: my-env
+  compute_stats_by_span_kind: false
 `, port)
 		if err := r.RunAgent([]byte(c)); err != nil {
 			t.Fatal(err)

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -2308,15 +2308,37 @@ func TestSetMaxMemCPU(t *testing.T) {
 }
 
 func TestPeerTagsAggregation(t *testing.T) {
-	t.Run("disabled", func(t *testing.T) {
+	t.Run("default-enabled", func(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
+			MockModule(),
+		))
+		cfg := config.Object()
+		assert.True(t, cfg.PeerTagsAggregation)
+		assert.Nil(t, cfg.PeerTags)
+
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "_dd.base_service") // global base peer tag precursor
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")      // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")        // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname")    // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")     // known peer tag precursors that should be loaded from peer_tags.ini
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		overrides := map[string]interface{}{
+			"apm_config.peer_service_aggregation": true,
+			"apm_config.peer_tags_aggregation":    false,
+		}
+		config := fxutil.Test[Component](t, fx.Options(
+			corecomp.MockModule(),
+			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
 		cfg := config.Object()
 		require.NotNil(t, cfg)
 		assert.False(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
+		assert.Nil(t, cfg.ConfiguredPeerTags())
 	})
 
 	t.Run("deprecated-enabled", func(t *testing.T) {
@@ -2333,10 +2355,15 @@ func TestPeerTagsAggregation(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")   // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")     // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname") // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")  // known peer tag precursors that should be loaded from peer_tags.ini
 	})
-	t.Run("enabled", func(t *testing.T) {
+
+	t.Run("deprecated-disabled", func(t *testing.T) {
 		overrides := map[string]interface{}{
-			"apm_config.peer_tags_aggregation": true,
+			"apm_config.peer_service_aggregation": false,
 		}
 
 		config := fxutil.Test[Component](t, fx.Options(
@@ -2345,9 +2372,12 @@ func TestPeerTagsAggregation(t *testing.T) {
 			MockModule(),
 		))
 		cfg := config.Object()
+		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
+		assert.NotNil(t, cfg.ConfiguredPeerTags())
 	})
+
 	t.Run("both-enabled", func(t *testing.T) {
 		overrides := map[string]interface{}{
 			"apm_config.peer_service_aggregation": true,
@@ -2363,10 +2393,34 @@ func TestPeerTagsAggregation(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
+		assert.NotNil(t, cfg.ConfiguredPeerTags())
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")   // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")     // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname") // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")  // known peer tag precursors that should be loaded from peer_tags.ini
+	})
+
+	t.Run("both-disabled", func(t *testing.T) {
+		overrides := map[string]interface{}{
+			"apm_config.peer_service_aggregation": false,
+			"apm_config.peer_tags_aggregation":    false,
+		}
+
+		config := fxutil.Test[Component](t, fx.Options(
+			corecomp.MockModule(),
+			fx.Replace(corecomp.MockParams{Overrides: overrides}),
+			MockModule(),
+		))
+		cfg := config.Object()
+		require.NotNil(t, cfg)
+		assert.False(t, cfg.PeerTagsAggregation)
+		assert.Nil(t, cfg.PeerTags)
+		assert.Nil(t, cfg.ConfiguredPeerTags())
 	})
 	t.Run("disabled-user-tags", func(t *testing.T) {
 		overrides := map[string]interface{}{
-			"apm_config.peer_tags": []string{"user_peer_tag"},
+			"apm_config.peer_tags_aggregation": false,
+			"apm_config.peer_tags":             []string{"user_peer_tag"},
 		}
 
 		config := fxutil.Test[Component](t, fx.Options(
@@ -2378,11 +2432,11 @@ func TestPeerTagsAggregation(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.False(t, cfg.PeerTagsAggregation)
 		assert.Equal(t, []string{"user_peer_tag"}, cfg.PeerTags)
+		assert.Nil(t, cfg.ConfiguredPeerTags())
 	})
-	t.Run("deprecated-enabled-user-tags", func(t *testing.T) {
+	t.Run("default-enabled-user-tags", func(t *testing.T) {
 		overrides := map[string]interface{}{
-			"apm_config.peer_tags":                []string{"user_peer_tag"},
-			"apm_config.peer_service_aggregation": true,
+			"apm_config.peer_tags": []string{"user_peer_tag"},
 		}
 
 		config := fxutil.Test[Component](t, fx.Options(
@@ -2393,6 +2447,11 @@ func TestPeerTagsAggregation(t *testing.T) {
 		cfg := config.Object()
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Equal(t, []string{"user_peer_tag"}, cfg.PeerTags)
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "user_peer_tag")
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")   // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")     // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname") // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")  // known peer tag precursors that should be loaded from peer_tags.ini
 	})
 	t.Run("enabled-user-tags", func(t *testing.T) {
 		overrides := map[string]interface{}{
@@ -2409,30 +2468,35 @@ func TestPeerTagsAggregation(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Equal(t, []string{"user_peer_tag"}, cfg.PeerTags)
-	})
-	t.Run("both-enabled-user-tags", func(t *testing.T) {
-		overrides := map[string]interface{}{
-			"apm_config.peer_tags":                []string{"user_peer_tag"},
-			"apm_config.peer_tags_aggregation":    true,
-			"apm_config.peer_service_aggregation": true,
-		}
-
-		config := fxutil.Test[Component](t, fx.Options(
-			corecomp.MockModule(),
-			fx.Replace(corecomp.MockParams{Overrides: overrides}),
-			MockModule(),
-		))
-		cfg := config.Object()
-		require.NotNil(t, cfg)
-		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Equal(t, []string{"user_peer_tag"}, cfg.PeerTags)
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "user_peer_tag")
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")   // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")     // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname") // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")  // known peer tag precursors that should be loaded from peer_tags.ini
 	})
 }
 
 func TestComputeStatsBySpanKind(t *testing.T) {
-	t.Run("disabled", func(t *testing.T) {
+
+	t.Run("default-enabled", func(t *testing.T) {
 		config := fxutil.Test[Component](t, fx.Options(
 			corecomp.MockModule(),
+			MockModule(),
+		))
+		cfg := config.Object()
+
+		require.NotNil(t, cfg)
+		assert.True(t, cfg.ComputeStatsBySpanKind)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		overrides := map[string]interface{}{
+			"apm_config.compute_stats_by_span_kind": false,
+		}
+		config := fxutil.Test[Component](t, fx.Options(
+			corecomp.MockModule(),
+			fx.Replace(corecomp.MockParams{Overrides: overrides}),
 			MockModule(),
 		))
 		cfg := config.Object()

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -2363,6 +2363,7 @@ func TestPeerTagsAggregation(t *testing.T) {
 
 	t.Run("deprecated-disabled", func(t *testing.T) {
 		overrides := map[string]interface{}{
+			// Setting peer_service_aggregation to false has no effect. Nobody should be using this flag, though some previous beta customers might still need to migrate to peer_tags_aggregation.
 			"apm_config.peer_service_aggregation": false,
 		}
 
@@ -2376,6 +2377,10 @@ func TestPeerTagsAggregation(t *testing.T) {
 		assert.True(t, cfg.PeerTagsAggregation)
 		assert.Nil(t, cfg.PeerTags)
 		assert.NotNil(t, cfg.ConfiguredPeerTags())
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.hostname")   // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "db.system")     // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.hostname") // known peer tag precursors that should be loaded from peer_tags.ini
+		assert.Contains(t, cfg.ConfiguredPeerTags(), "peer.service")  // known peer tag precursors that should be loaded from peer_tags.ini
 	})
 
 	t.Run("both-enabled", func(t *testing.T) {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -224,13 +224,31 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.ConnectionLimit = core.GetInt("apm_config.connection_limit")
 	}
 
-	// NOTE: maintain backwards-compatibility with old peer service flag that will eventually be deprecated.
-	c.PeerTagsAggregation = core.GetBool("apm_config.peer_service_aggregation")
-	if c.PeerTagsAggregation {
+	/**
+	 * NOTE: PeerTagsAggregation is on by default as of Oct 2024. To get the default experience,
+	 * customers DO NOT NEED to set "apm_config.peer_service_aggregation" (deprecated) or "apm_config.peer_tags_aggregation" (previously defaulted to false, now true).
+	 * However, to prevent breaking changes, we still respect the old flags if EITHER of them are explicitly set to "false".
+	 */
+	shouldDisablePeerTagAggregation := false
+	if core.IsSet("apm_config.peer_service_aggregation") {
+		shouldDisablePeerTagAggregation = !core.GetBool("apm_config.peer_service_aggregation")
 		log.Warn("`apm_config.peer_service_aggregation` is deprecated, please use `apm_config.peer_tags_aggregation` instead")
 	}
-	c.PeerTagsAggregation = c.PeerTagsAggregation || core.GetBool("apm_config.peer_tags_aggregation")
-	c.ComputeStatsBySpanKind = core.GetBool("apm_config.compute_stats_by_span_kind")
+
+	if core.IsSet("apm_config.peer_tags_aggregation") {
+		// If peer_tags_aggregation is explicitly set, it takes precedence over peer_service_aggregation.
+		shouldDisablePeerTagAggregation = !core.GetBool("apm_config.peer_tags_aggregation")
+	}
+
+	if shouldDisablePeerTagAggregation {
+		c.PeerTagsAggregation = false
+		log.Info("peer tags aggregation is explicitly disabled. To enable it, remove `apm_config.peer_tags_aggregation: false` and `apm_config.peer_service_aggregation: false` from your configuration")
+	}
+
+	if core.IsSet("apm_config.compute_stats_by_span_kind") {
+		c.ComputeStatsBySpanKind = core.GetBool("apm_config.compute_stats_by_span_kind")
+	}
+
 	if core.IsSet("apm_config.peer_tags") {
 		c.PeerTags = core.GetStringSlice("apm_config.peer_tags")
 	}

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -227,22 +227,14 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	/**
 	 * NOTE: PeerTagsAggregation is on by default as of Oct 2024. To get the default experience,
 	 * customers DO NOT NEED to set "apm_config.peer_service_aggregation" (deprecated) or "apm_config.peer_tags_aggregation" (previously defaulted to false, now true).
-	 * However, to prevent breaking changes, we still respect the old flags if EITHER of them are explicitly set to "false".
+	 * However, customers may opt out by explicitly setting "apm_config.peer_tags_aggregation" to "false".
 	 */
-	shouldDisablePeerTagAggregation := false
-	if core.IsSet("apm_config.peer_service_aggregation") {
-		shouldDisablePeerTagAggregation = !core.GetBool("apm_config.peer_service_aggregation")
-		log.Warn("`apm_config.peer_service_aggregation` is deprecated, please use `apm_config.peer_tags_aggregation` instead")
-	}
-
 	if core.IsSet("apm_config.peer_tags_aggregation") {
-		// If peer_tags_aggregation is explicitly set, it takes precedence over peer_service_aggregation.
-		shouldDisablePeerTagAggregation = !core.GetBool("apm_config.peer_tags_aggregation")
+		c.PeerTagsAggregation = core.GetBool("apm_config.peer_tags_aggregation")
 	}
 
-	if shouldDisablePeerTagAggregation {
-		c.PeerTagsAggregation = false
-		log.Info("peer tags aggregation is explicitly disabled. To enable it, remove `apm_config.peer_tags_aggregation: false` and `apm_config.peer_service_aggregation: false` from your configuration")
+	if !c.PeerTagsAggregation {
+		log.Info("peer tags aggregation is explicitly disabled. To enable it, remove `apm_config.peer_tags_aggregation: false` from your configuration")
 	}
 
 	if core.IsSet("apm_config.compute_stats_by_span_kind") {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -225,21 +225,17 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	}
 
 	/**
-	 * NOTE: PeerTagsAggregation is on by default as of Oct 2024. To get the default experience,
+	 * NOTE: PeerTagsAggregation is on by default as of Q4 2024. To get the default experience,
 	 * customers DO NOT NEED to set "apm_config.peer_service_aggregation" (deprecated) or "apm_config.peer_tags_aggregation" (previously defaulted to false, now true).
 	 * However, customers may opt out by explicitly setting "apm_config.peer_tags_aggregation" to "false".
 	 */
-	if core.IsSet("apm_config.peer_tags_aggregation") {
-		c.PeerTagsAggregation = core.GetBool("apm_config.peer_tags_aggregation")
-	}
+	c.PeerTagsAggregation = core.GetBool("apm_config.peer_tags_aggregation")
 
 	if !c.PeerTagsAggregation {
 		log.Info("peer tags aggregation is explicitly disabled. To enable it, remove `apm_config.peer_tags_aggregation: false` from your configuration")
 	}
 
-	if core.IsSet("apm_config.compute_stats_by_span_kind") {
-		c.ComputeStatsBySpanKind = core.GetBool("apm_config.compute_stats_by_span_kind")
-	}
+	c.ComputeStatsBySpanKind = core.GetBool("apm_config.compute_stats_by_span_kind")
 
 	if core.IsSet("apm_config.peer_tags") {
 		c.PeerTags = core.GetStringSlice("apm_config.peer_tags")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1330,23 +1330,23 @@ api_key:
   #
   # connection_limit: 2000
 
-  ## @param compute_stats_by_span_kind - bool - default: false
-  ## @env DD_APM_COMPUTE_STATS_BY_SPAN_KIND - bool - default: false
-  ## [BETA] Enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer).
+  ## @param compute_stats_by_span_kind - bool - default: true
+  ## @env DD_APM_COMPUTE_STATS_BY_SPAN_KIND - bool - default: true
+  ## Enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer).
   ## If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
   ## NOTE: For stats computed from OTel traces, only top-level spans are considered when this option is off.
   ## If you are sending OTel traces and want stats on non-top-level spans, this flag will need to be enabled.
   ## If you are sending OTel traces and do not want stats computed by span kind, you need to disable this flag and remove the "enable_otlp_compute_top_level_by_span_kind" APM feature if present.
-  # compute_stats_by_span_kind: false
+  # compute_stats_by_span_kind: true
 
-  ## @param peer_service_aggregation - bool - default: false
-  ## @env DD_APM_PEER_SERVICE_AGGREGATION - bool - default: false
+  ## @param peer_service_aggregation - bool - default: true
+  ## @env DD_APM_PEER_SERVICE_AGGREGATION - bool - default: true
   ## DEPRECATED - please use `peer_tags_aggregation` instead.
-  # peer_service_aggregation: false
+  # peer_service_aggregation: true
 
-  ## @param peer_tags_aggregation - bool - default: false
-  ## @env DD_APM_PEER_TAGS_AGGREGATION - bool - default: false
-  ## [BETA] Enables aggregation of peer related tags (e.g., `peer.service`, `db.instance`, etc.) in the Agent.
+  ## @param peer_tags_aggregation - bool - default: true
+  ## @env DD_APM_PEER_TAGS_AGGREGATION - bool - default: true
+  ## Enables aggregation of peer related tags (e.g., `peer.service`, `db.instance`, etc.) in the Agent.
   ## If disabled, aggregated trace stats will not include these tags as dimensions on trace metrics.
   ## For the best experience with peer tags, Datadog also recommends enabling `compute_stats_by_span_kind`.
   ## If you are using an OTel tracer, it's best to have both enabled because client/producer spans with relevant peer tags
@@ -1355,11 +1355,11 @@ api_key:
   ## A high cardinality of peer tags or APM resources can also contribute to higher CPU and memory consumption.
   ## You can check for the cardinality of these fields by making trace search queries in the Datadog UI.
   ## The default list of peer tags can be found in pkg/trace/stats/concentrator.go.
-  # peer_tags_aggregation: false
+  # peer_tags_aggregation: true
 
   ## @param peer_tags - list of strings - optional
   ## @env DD_APM_PEER_TAGS - list of strings - optional
-  ## [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+  ## Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
   ## and will drop ones that are unapproved.
   # peer_tags: []
 

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -77,9 +77,9 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", true, "DD_APM_REMOTE_TAGGER")                                                     //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", false, "DD_APM_PEER_SERVICE_AGGREGATION")                              //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_tags_aggregation", false, "DD_APM_PEER_TAGS_AGGREGATION")                                    //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", false, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                          //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", true, "DD_APM_PEER_SERVICE_AGGREGATION")                               //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.peer_tags_aggregation", true, "DD_APM_PEER_TAGS_AGGREGATION")                                     //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", true, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                           //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled", false, "DD_APM_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.disabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES")

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -929,21 +929,31 @@ func TestEnablePeerServiceStatsAggregationEnv(t *testing.T) {
 }
 
 func TestEnablePeerTagsAggregationEnv(t *testing.T) {
-	t.Setenv("DD_APM_PEER_TAGS_AGGREGATION", "true")
 	testConfig := newTestConf()
 	require.True(t, testConfig.GetBool("apm_config.peer_tags_aggregation"))
+
+	t.Setenv("DD_APM_PEER_TAGS_AGGREGATION", "true")
+	testConfig = newTestConf()
+	require.True(t, testConfig.GetBool("apm_config.peer_tags_aggregation"))
+
 	t.Setenv("DD_APM_PEER_TAGS_AGGREGATION", "false")
 	testConfig = newTestConf()
 	require.False(t, testConfig.GetBool("apm_config.peer_tags_aggregation"))
 }
 
 func TestEnableStatsComputationBySpanKindYAML(t *testing.T) {
-	datadogYaml := `
+	datadogYaml := ""
+	testConfig := confFromYAML(t, datadogYaml)
+	err := setupFipsEndpoints(testConfig)
+	require.NoError(t, err)
+	require.True(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))
+
+	datadogYaml = `
 apm_config:
   compute_stats_by_span_kind: false
 `
-	testConfig := confFromYAML(t, datadogYaml)
-	err := setupFipsEndpoints(testConfig)
+	testConfig = confFromYAML(t, datadogYaml)
+	err = setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
 	require.False(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))
 
@@ -958,9 +968,13 @@ apm_config:
 }
 
 func TestComputeStatsBySpanKindEnv(t *testing.T) {
-	t.Setenv("DD_APM_COMPUTE_STATS_BY_SPAN_KIND", "false")
 	testConfig := newTestConf()
+	require.True(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))
+
+	t.Setenv("DD_APM_COMPUTE_STATS_BY_SPAN_KIND", "false")
+	testConfig = newTestConf()
 	require.False(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))
+
 	t.Setenv("DD_APM_COMPUTE_STATS_BY_SPAN_KIND", "true")
 	testConfig = newTestConf()
 	require.True(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -537,7 +537,9 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 
-		Features: make(map[string]struct{}),
+		Features:               make(map[string]struct{}),
+		PeerTagsAggregation:    true,
+		ComputeStatsBySpanKind: true,
 	}
 }
 

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -36,32 +36,31 @@ func TestInAzureAppServices(t *testing.T) {
 func TestPeerTagsAggregation(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		cfg := New()
+		cfg.PeerTagsAggregation = false
 		assert.False(t, cfg.PeerTagsAggregation)
 		assert.Empty(t, cfg.PeerTags)
 		assert.Empty(t, cfg.ConfiguredPeerTags())
 	})
 
-	t.Run("enabled", func(t *testing.T) {
+	t.Run("default-enabled", func(t *testing.T) {
 		cfg := New()
-		cfg.PeerTagsAggregation = true
 		assert.Empty(t, cfg.PeerTags)
 		assert.Equal(t, basePeerTags, cfg.ConfiguredPeerTags())
 	})
 	t.Run("disabled-user-tags", func(t *testing.T) {
 		cfg := New()
+		cfg.PeerTagsAggregation = false
 		cfg.PeerTags = []string{"user_peer_tag"}
 		assert.False(t, cfg.PeerTagsAggregation)
 		assert.Empty(t, cfg.ConfiguredPeerTags())
 	})
 	t.Run("enabled-user-tags", func(t *testing.T) {
 		cfg := New()
-		cfg.PeerTagsAggregation = true
 		cfg.PeerTags = []string{"user_peer_tag"}
 		assert.Equal(t, append(basePeerTags, "user_peer_tag"), cfg.ConfiguredPeerTags())
 	})
 	t.Run("dedup", func(t *testing.T) {
 		cfg := New()
-		cfg.PeerTagsAggregation = true
 		cfg.PeerTags = basePeerTags[:2]
 		assert.Equal(t, basePeerTags, cfg.ConfiguredPeerTags())
 	})

--- a/releasenotes/notes/apm-peer-tag-aggr-defaults-bd89eb1e93393219.yaml
+++ b/releasenotes/notes/apm-peer-tag-aggr-defaults-bd89eb1e93393219.yaml
@@ -1,0 +1,20 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    * Parameter ``peer_tags_aggregation`` (a.k.a. environment variable ``DD_APM_PEER_TAGS_AGGREGATION``) is now enabled by default. This means that aggregation of peer related tags (e.g., `peer.service`, `db.instance`, etc.) now happens in the Agent, which enables statistics for Inferred Entities. If you want to disable this feature, set `peer_tags_aggregation` to `false` in your Agent configuration.
+
+    * Parameter ``compute_stats_by_span_kind`` (a.k.a. environment variable ``DD_APM_COMPUTE_STATS_BY_SPAN_KIND``) is now enabled by default. This means spans with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed. If you want to disable this feature, set `compute_stats_by_span_kind` to `false` in your Agent configuration.
+
+      Note: When using ``peer_tags_aggregation`` and ``compute_stats_by_span_kind``, a high cardinality of peer tags or APM resources can contribute to higher CPU and memory consumption. If enabling both causes the Agent to consume too many resources, try disabling `compute_stats_by_span_kind` first.
+
+    It is recommended that you update your tracing libraries according to the instructions `here <https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=java#apm-tracing-library-configuration>`_ and set ``DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED`` (or ``dd.trace.remove.integration-service-names.enabled``) to ``true``.
+features:
+  - |
+    `Inferred Service dependencies <https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/>`_ are now Generally Available and enabled by default. Inferred Services of all kinds now have trace metrics and are available in dependency maps.

--- a/releasenotes/notes/apm-peer-tag-aggr-defaults-bd89eb1e93393219.yaml
+++ b/releasenotes/notes/apm-peer-tag-aggr-defaults-bd89eb1e93393219.yaml
@@ -17,4 +17,4 @@ upgrade:
     It is recommended that you update your tracing libraries according to the instructions `here <https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=java#apm-tracing-library-configuration>`_ and set ``DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED`` (or ``dd.trace.remove.integration-service-names.enabled``) to ``true``.
 features:
   - |
-    `Inferred Service dependencies <https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/>`_ are now Generally Available and enabled by default. Inferred Services of all kinds now have trace metrics and are available in dependency maps.
+    `Inferred Service dependencies <https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/>`_ are now Generally Available (exiting Beta) and enabled by default. Inferred Services of all kinds now have trace metrics and are available in dependency maps. `apm_config.peer_tags_aggregation` and `apm_config.compute_stats_by_span_kind` both now default to `true` unless explicitly set to `false`.

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -146,10 +146,12 @@ func (s *DockerFakeintakeSuite) TestStatsForService() {
 	s.Require().NoError(err)
 
 	service := fmt.Sprintf("tracegen-stats-%s", s.transport)
+	addSpanTags := "peer.hostname:foo,span.kind:client"
+	expectPeerTag := "peer.hostname:foo"
 	defer waitTracegenShutdown(&s.Suite, s.Env().FakeIntake)
-	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport})()
+	defer runTracegenDocker(s.Env().RemoteHost, service, tracegenCfg{transport: s.transport, addSpanTags: addSpanTags})()
 	s.EventuallyWithTf(func(c *assert.CollectT) {
-		testStatsForService(s.T(), c, service, s.Env().FakeIntake)
+		testStatsForService(s.T(), c, service, expectPeerTag, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding stats")
 }
 

--- a/test/new-e2e/tests/apm/tracegen.go
+++ b/test/new-e2e/tests/apm/tracegen.go
@@ -31,38 +31,41 @@ func (t transport) String() string {
 }
 
 type tracegenCfg struct {
-	transport transport
+	transport   transport
+	addSpanTags string
 }
 
 func runTracegenDocker(h *components.RemoteHost, service string, cfg tracegenCfg) (shutdown func()) {
 	var run, rm string
 	if cfg.transport == uds {
-		run, rm = tracegenUDSCommands(service)
+		run, rm = tracegenUDSCommands(service, cfg.addSpanTags)
 	} else if cfg.transport == tcp {
-		run, rm = tracegenTCPCommands(service)
+		run, rm = tracegenTCPCommands(service, cfg.addSpanTags)
 	}
 	h.MustExecute(rm) // kill any existing leftover container
 	h.MustExecute(run)
 	return func() { h.MustExecute(rm) }
 }
 
-func tracegenUDSCommands(service string) (string, string) {
+func tracegenUDSCommands(service string, peerTags string) (string, string) {
 	// TODO: use a proper docker-compose definition for tracegen
 	run := "docker run -d --rm --name " + service +
 		" -v /var/run/datadog/:/var/run/datadog/ " +
 		" -e DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket " +
 		" -e DD_SERVICE=" + service +
 		" -e DD_GIT_COMMIT_SHA=abcd1234 " +
+		" -e TRACEGEN_ADDSPANTAGS=" + peerTags +
 		" ghcr.io/datadog/apps-tracegen:main"
 	rm := "docker rm -f " + service
 	return run, rm
 }
 
-func tracegenTCPCommands(service string) (string, string) {
+func tracegenTCPCommands(service string, peerTags string) (string, string) {
 	// TODO: use a proper docker-compose definition for tracegen
 	run := "docker run -d --network host --rm --name " + service +
 		" -e DD_SERVICE=" + service +
 		" -e DD_GIT_COMMIT_SHA=abcd1234 " +
+		" -e TRACEGEN_ADDSPANTAGS=" + peerTags +
 		" ghcr.io/datadog/apps-tracegen:main"
 	rm := "docker rm -f " + service
 	return run, rm


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/APMST-1371

### What does this PR do?
Flips default setting to "true" for three flags:
- apm_config.peer_service_aggregation
- apm_config.peer_tags_aggregation
- apm_config.compute_stats_by_span_kind

### Motivation
The intent is to enable peer tags aggregation (and the related "stats by span kind" aggregation) as the default option, effectively moving from "Opt-In" to "Opt-Out" for the Service Representation project (docs [here](https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=java)). This project is moving toward General Availability and we would like to land this before the Nov 1 code freeze.

This is a non-breaking change: all back-end data and pipelines are already updated, and inferred entities are appearing throughout APM. This setting ensures that those inferred entities will have stats properly aggregated and attributed to them.

### Describe how to test/QA your changes
I am unsure how to thoroughly test the trace agent. I have updated and added unit tests, but I would greatly appreciate some help confirming the changes or devising a test plan to help confirm the changes!

### Possible Drawbacks / Trade-offs
This shouldn't have any breaking implications for our customers.

However, as the comments in the template config suggest, the additional aggregation could cause resource usage to increase. We have a few hundred customers using the feature today, but it is possible a wide rollout could expose more performance issues. I'm also looking for guidance from the team on if / how we need to address any such performance regression testing.

