### PR TITLE
[NPM-3357] Handle netlink not permitted when checking connection existence

### DIFF
--- a/pkg/network/netlink/conntrack.go
+++ b/pkg/network/netlink/conntrack.go
@@ -36,6 +36,10 @@ type Conntrack interface {
 // `netNS` is the network namespace for the conntrack operations.
 // A value of `0` will use the current thread's network namespace
 func NewConntrack(netNS netns.NsHandle) (Conntrack, error) {
+	if !isNetlinkConntrackSupported() {
+		return nil, ErrNotPermitted
+	}
+
 	conn, err := NewSocket(netNS)
 	if err != nil {
 		return nil, err

--- a/pkg/network/tracer/cached_conntrack_test.go
+++ b/pkg/network/tracer/cached_conntrack_test.go
@@ -78,6 +78,52 @@ func TestCachedConntrackIgnoreErrExists(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCachedConntrackIgnoreErrNotPermitted(t *testing.T) {
+	createCalled := false
+	cache := newCachedConntrack("/proc", func(_ netns.NsHandle) (netlink.Conntrack, error) {
+		createCalled = true
+		return nil, netlink.ErrNotPermitted
+	}, 1)
+
+	t.Cleanup(func() { cache.Close() })
+
+	c := &network.ConnectionStats{
+		NetNS: 123455,
+		Pid:   1,
+	}
+
+	exists, err := cache.Exists(c)
+	require.True(t, createCalled, "conntrack creator not called")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestCachedConntrackCacheCreatorError(t *testing.T) {
+	createCalled := false
+	cache := newCachedConntrack("/proc", func(_ netns.NsHandle) (netlink.Conntrack, error) {
+		createCalled = true
+		return nil, assert.AnError
+	}, 1)
+
+	t.Cleanup(func() { cache.Close() })
+
+	c := &network.ConnectionStats{
+		NetNS: 123455,
+		Pid:   1,
+	}
+
+	exists, err := cache.Exists(c)
+	require.True(t, createCalled, "conntrack creator not called")
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.False(t, exists)
+
+	createCalled = false
+	exists, err = cache.Exists(c)
+	require.False(t, createCalled, "conntrack creator called")
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.False(t, exists)
+}
+
 func TestCachedConntrackExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -740,7 +740,8 @@ func (t *Tracer) connectionExpired(conn *network.ConnectionStats, latestTime uin
 
 	// skip connection check for udp connections or if
 	// the pid for the connection is dead
-	if conn.Type == network.UDP || !procutil.PidExists(int(conn.Pid)) {
+	// conn.Pid can be 0 when ebpf-less tracer is running
+	if conn.Type == network.UDP || (conn.Pid > 0 && !procutil.PidExists(int(conn.Pid))) {
 		return true
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a persistent warning log on platforms that don't support netlink conntracker, when querying for a connection (to check if it still exists). We now check if conntrack is supported (i.e. has permissions) in this code, and skip the existence check for the connection if it is not.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->