### PR TITLE
[EBPF-578] gpu: move types from common model back into sysprobe module

### DIFF
--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -7,50 +7,6 @@
 // the gpu core agent check
 package model
 
-// MemoryAllocation represents a memory allocation event
-type MemoryAllocation struct {
-	// Start is the kernel-time timestamp of the allocation event
-	StartKtime uint64 `json:"start"`
-
-	// End is the kernel-time timestamp of the deallocation event. If 0, this means the allocation was not deallocated yet
-	EndKtime uint64 `json:"end"`
-
-	// Size is the size of the allocation in bytes
-	Size uint64 `json:"size"`
-
-	// IsLeaked is true if the allocation was not deallocated
-	IsLeaked bool `json:"is_leaked"`
-}
-
-// KernelSpan represents a span of time during which one or more kernels were running on a GPU until
-// a synchronization event happened
-type KernelSpan struct {
-	// StartKtime is the kernel-time timestamp of the start of the span, the moment the first kernel was launched
-	StartKtime uint64 `json:"start"`
-
-	// EndKtime is the kernel-time timestamp of the end of the span, the moment the synchronization event happened
-	EndKtime uint64 `json:"end"`
-
-	// AvgThreadCount is the average number of threads running on the GPU during the span
-	AvgThreadCount uint64 `json:"avg_thread_count"`
-
-	// NumKernels is the number of kernels that were launched during the span
-	NumKernels uint64 `json:"num_kernels"`
-}
-
-// StreamKey is a unique identifier for a CUDA stream
-type StreamKey struct {
-	Pid    uint32 `json:"pid"`
-	Stream uint64 `json:"stream"`
-}
-
-// StreamData contains kernel spans and allocations for a stream
-type StreamData struct {
-	Key         StreamKey           `json:"key"`
-	Spans       []*KernelSpan       `json:"spans"`
-	Allocations []*MemoryAllocation `json:"allocations"`
-}
-
 // ProcessStats contains the GPU stats for a given PID
 type ProcessStats struct {
 	UtilizationPercentage float64 `json:"utilization_percentage"`

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -13,7 +13,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
@@ -28,7 +27,7 @@ type cudaEventConsumer struct {
 	eventHandler   ddebpf.EventHandler
 	once           sync.Once
 	closed         chan struct{}
-	streamHandlers map[model.StreamKey]*StreamHandler
+	streamHandlers map[streamKey]*StreamHandler
 	wg             sync.WaitGroup
 	running        atomic.Bool
 	cfg            *Config
@@ -39,7 +38,7 @@ func newCudaEventConsumer(eventHandler ddebpf.EventHandler, cfg *Config) *cudaEv
 	return &cudaEventConsumer{
 		eventHandler:   eventHandler,
 		closed:         make(chan struct{}),
-		streamHandlers: make(map[model.StreamKey]*StreamHandler),
+		streamHandlers: make(map[streamKey]*StreamHandler),
 		cfg:            cfg,
 	}
 }
@@ -104,7 +103,7 @@ func (c *cudaEventConsumer) Start() {
 				header := (*gpuebpf.CudaEventHeader)(unsafe.Pointer(&batchData.Data[0]))
 
 				pid := uint32(header.Pid_tgid >> 32)
-				streamKey := model.StreamKey{Pid: pid, Stream: header.Stream_id}
+				streamKey := streamKey{pid: pid, stream: header.Stream_id}
 
 				if _, ok := c.streamHandlers[streamKey]; !ok {
 					c.streamHandlers[streamKey] = newStreamHandler()
@@ -148,8 +147,8 @@ func (c *cudaEventConsumer) Start() {
 
 func (c *cudaEventConsumer) handleProcessExit(pid uint32) {
 	for key, handler := range c.streamHandlers {
-		if key.Pid == pid {
-			log.Debugf("Process %d ended, marking stream %d as ended", pid, key.Stream)
+		if key.pid == pid {
+			log.Debugf("Process %d ended, marking stream %d as ended", pid, key.stream)
 			// the probe is responsible for deleting the stream handler
 			_ = handler.markEnd()
 		}
@@ -164,8 +163,8 @@ func (c *cudaEventConsumer) checkClosedProcesses() {
 	})
 
 	for key, handler := range c.streamHandlers {
-		if _, ok := seenPIDs[key.Pid]; !ok {
-			log.Debugf("Process %d ended, marking stream %d as ended", key.Pid, key.Stream)
+		if _, ok := seenPIDs[key.pid]; !ok {
+			log.Debugf("Process %d ended, marking stream %d as ended", key.pid, key.stream)
 			_ = handler.markEnd()
 		}
 	}

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -68,8 +68,8 @@ func TestProbeCanReceiveEvents(t *testing.T) {
 	var handlerStream, handlerGlobal *StreamHandler
 	require.Eventually(t, func() bool {
 		for key, h := range probe.consumer.streamHandlers {
-			if key.Pid == uint32(cmd.Process.Pid) {
-				if key.Stream == 0 {
+			if key.pid == uint32(cmd.Process.Pid) {
+				if key.stream == 0 {
 					handlerGlobal = h
 				} else {
 					handlerStream = h
@@ -82,15 +82,15 @@ func TestProbeCanReceiveEvents(t *testing.T) {
 
 	require.Equal(t, 1, len(handlerStream.kernelSpans))
 	span := handlerStream.kernelSpans[0]
-	require.Equal(t, uint64(1), span.NumKernels)
-	require.Equal(t, uint64(1*2*3*4*5*6), span.AvgThreadCount)
-	require.Greater(t, span.EndKtime, span.StartKtime)
+	require.Equal(t, uint64(1), span.numKernels)
+	require.Equal(t, uint64(1*2*3*4*5*6), span.avgThreadCount)
+	require.Greater(t, span.endKtime, span.startKtime)
 
 	require.Equal(t, 1, len(handlerGlobal.allocations))
 	alloc := handlerGlobal.allocations[0]
-	require.Equal(t, uint64(100), alloc.Size)
-	require.False(t, alloc.IsLeaked)
-	require.Greater(t, alloc.EndKtime, alloc.StartKtime)
+	require.Equal(t, uint64(100), alloc.size)
+	require.False(t, alloc.isLeaked)
+	require.Greater(t, alloc.endKtime, alloc.startKtime)
 }
 
 func TestProbeCanGenerateStats(t *testing.T) {

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -14,14 +14,14 @@ import (
 // statsGenerator connects to the active stream handlers and generates stats for the GPU monitoring, by distributing
 // the data to the aggregators which are responsible for computing the metrics.
 type statsGenerator struct {
-	streamHandlers      map[model.StreamKey]*StreamHandler // streamHandlers contains the map of active stream handlers.
-	lastGenerationKTime int64                              // lastGenerationTime is the kernel time of the last stats generation.
-	currGenerationKTime int64                              // currGenerationTime is the kernel time of the current stats generation.
-	aggregators         map[uint32]*aggregator             // aggregators contains the map of aggregators
-	sysCtx              *systemContext                     // sysCtx is the system context with global GPU-system data
+	streamHandlers      map[streamKey]*StreamHandler // streamHandlers contains the map of active stream handlers.
+	lastGenerationKTime int64                        // lastGenerationTime is the kernel time of the last stats generation.
+	currGenerationKTime int64                        // currGenerationTime is the kernel time of the current stats generation.
+	aggregators         map[uint32]*aggregator       // aggregators contains the map of aggregators
+	sysCtx              *systemContext               // sysCtx is the system context with global GPU-system data
 }
 
-func newStatsGenerator(sysCtx *systemContext, currKTime int64, streamHandlers map[model.StreamKey]*StreamHandler) *statsGenerator {
+func newStatsGenerator(sysCtx *systemContext, currKTime int64, streamHandlers map[streamKey]*StreamHandler) *statsGenerator {
 	return &statsGenerator{
 		streamHandlers:      streamHandlers,
 		aggregators:         make(map[uint32]*aggregator),
@@ -37,7 +37,7 @@ func (g *statsGenerator) getStats(nowKtime int64) *model.GPUStats {
 	g.currGenerationKTime = nowKtime
 
 	for key, handler := range g.streamHandlers {
-		aggr := g.getOrCreateAggregator(key.Pid)
+		aggr := g.getOrCreateAggregator(key.pid)
 		currData := handler.getCurrentData(uint64(nowKtime))
 		pastData := handler.getPastData(true)
 

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -13,13 +13,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
-func getStatsGeneratorForTest(t *testing.T) (*statsGenerator, map[model.StreamKey]*StreamHandler, int64) {
+func getStatsGeneratorForTest(t *testing.T) (*statsGenerator, map[streamKey]*StreamHandler, int64) {
 	sysCtx, err := getSystemContext(testutil.GetBasicNvmlMock())
 	require.NoError(t, err)
 	require.NotNil(t, sysCtx)
@@ -28,7 +27,7 @@ func getStatsGeneratorForTest(t *testing.T) (*statsGenerator, map[model.StreamKe
 	require.NoError(t, err)
 
 	// Align mock time with boot time for consistent time resolution
-	streamHandlers := make(map[model.StreamKey]*StreamHandler)
+	streamHandlers := make(map[streamKey]*StreamHandler)
 	statsGen := newStatsGenerator(sysCtx, ktime, streamHandlers)
 	require.NotNil(t, statsGen)
 
@@ -42,7 +41,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 	pid := uint32(1)
 	streamID := uint64(120)
 	pidTgid := uint64(pid)<<32 + uint64(pid)
-	skeyKern := model.StreamKey{Pid: pid, Stream: streamID}
+	skeyKern := streamKey{pid: pid, stream: streamID}
 	streamHandlers[skeyKern] = &StreamHandler{
 		processEnded: false,
 		kernelLaunches: []gpuebpf.CudaKernelLaunch{
@@ -57,7 +56,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 	}
 
 	allocSize := uint64(10)
-	skeyAlloc := model.StreamKey{Pid: pid, Stream: 0}
+	skeyAlloc := streamKey{pid: pid, stream: 0}
 	streamHandlers[skeyAlloc] = &StreamHandler{
 		processEnded: false,
 		memAllocEvents: map[uint64]gpuebpf.CudaMemEvent{
@@ -93,30 +92,30 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 
 	pid := uint32(1)
 	streamID := uint64(120)
-	skeyKern := model.StreamKey{Pid: pid, Stream: streamID}
+	skeyKern := streamKey{pid: pid, stream: streamID}
 	numThreads := uint64(5)
 	streamHandlers[skeyKern] = &StreamHandler{
 		processEnded: false,
-		kernelSpans: []*model.KernelSpan{
+		kernelSpans: []*kernelSpan{
 			{
-				StartKtime:     uint64(startKtime),
-				EndKtime:       uint64(endKtime),
-				AvgThreadCount: numThreads,
-				NumKernels:     10,
+				startKtime:     uint64(startKtime),
+				endKtime:       uint64(endKtime),
+				avgThreadCount: numThreads,
+				numKernels:     10,
 			},
 		},
 	}
 
 	allocSize := uint64(10)
-	skeyAlloc := model.StreamKey{Pid: pid, Stream: 0}
+	skeyAlloc := streamKey{pid: pid, stream: 0}
 	streamHandlers[skeyAlloc] = &StreamHandler{
 		processEnded: false,
-		allocations: []*model.MemoryAllocation{
+		allocations: []*memoryAllocation{
 			{
-				StartKtime: uint64(startKtime),
-				EndKtime:   uint64(endKtime),
-				Size:       allocSize,
-				IsLeaked:   false,
+				startKtime: uint64(startKtime),
+				endKtime:   uint64(endKtime),
+				size:       allocSize,
+				isLeaked:   false,
 			},
 		},
 	}
@@ -146,7 +145,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 
 	pid := uint32(1)
 	streamID := uint64(120)
-	skeyKern := model.StreamKey{Pid: pid, Stream: streamID}
+	skeyKern := streamKey{pid: pid, stream: streamID}
 	pidTgid := uint64(pid)<<32 + uint64(pid)
 	numThreads := uint64(5)
 	streamHandlers[skeyKern] = &StreamHandler{
@@ -160,26 +159,26 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 				Block_size:      gpuebpf.Dim3{X: 1, Y: 1, Z: 1},
 			},
 		},
-		kernelSpans: []*model.KernelSpan{
+		kernelSpans: []*kernelSpan{
 			{
-				StartKtime:     uint64(startKtime),
-				EndKtime:       uint64(endKtime),
-				AvgThreadCount: numThreads,
-				NumKernels:     10,
+				startKtime:     uint64(startKtime),
+				endKtime:       uint64(endKtime),
+				avgThreadCount: numThreads,
+				numKernels:     10,
 			},
 		},
 	}
 
 	allocSize := uint64(10)
-	skeyAlloc := model.StreamKey{Pid: pid, Stream: 0}
+	skeyAlloc := streamKey{pid: pid, stream: 0}
 	streamHandlers[skeyAlloc] = &StreamHandler{
 		processEnded: false,
-		allocations: []*model.MemoryAllocation{
+		allocations: []*memoryAllocation{
 			{
-				StartKtime: uint64(startKtime),
-				EndKtime:   uint64(endKtime),
-				Size:       allocSize,
-				IsLeaked:   false,
+				startKtime: uint64(startKtime),
+				endKtime:   uint64(endKtime),
+				size:       allocSize,
+				isLeaked:   false,
 			},
 		},
 		memAllocEvents: map[uint64]gpuebpf.CudaMemEvent{

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -10,7 +10,6 @@ package gpu
 import (
 	"math"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -21,9 +20,53 @@ import (
 type StreamHandler struct {
 	kernelLaunches []gpuebpf.CudaKernelLaunch
 	memAllocEvents map[uint64]gpuebpf.CudaMemEvent
-	kernelSpans    []*model.KernelSpan
-	allocations    []*model.MemoryAllocation
+	kernelSpans    []*kernelSpan
+	allocations    []*memoryAllocation
 	processEnded   bool // A marker to indicate that the process has ended, and this handler should be flushed
+}
+
+// streamKey is a unique identifier for a CUDA stream
+type streamKey struct {
+	pid    uint32
+	stream uint64
+}
+
+// streamData contains kernel spans and allocations for a stream
+type streamData struct {
+	key         streamKey
+	spans       []*kernelSpan
+	allocations []*memoryAllocation
+}
+
+// memoryAllocation represents a memory allocation event
+type memoryAllocation struct {
+	// Start is the kernel-time timestamp of the allocation event
+	startKtime uint64
+
+	// End is the kernel-time timestamp of the deallocation event. If 0, this means the memory was not deallocated yet
+	endKtime uint64
+
+	// size is the size of the allocation in bytes
+	size uint64
+
+	// isLeaked is true if the allocation was not deallocated
+	isLeaked bool
+}
+
+// kernelSpan represents a span of time during which one or more kernels were
+// running on a GPU until a synchronization event happened
+type kernelSpan struct {
+	// startKtime is the kernel-time timestamp of the start of the span, the moment the first kernel was launched
+	startKtime uint64
+
+	// endKtime is the kernel-time timestamp of the end of the span, the moment the synchronization event happened
+	endKtime uint64
+
+	// avgThreadCount is the average number of threads running on the GPU during the span
+	avgThreadCount uint64
+
+	// numKernels is the number of kernels that were launched during the span
+	numKernels uint64
 }
 
 func newStreamHandler() *StreamHandler {
@@ -50,11 +93,11 @@ func (sh *StreamHandler) handleMemEvent(event *gpuebpf.CudaMemEvent) {
 		return
 	}
 
-	data := model.MemoryAllocation{
-		StartKtime: alloc.Header.Ktime_ns,
-		EndKtime:   event.Header.Ktime_ns,
-		Size:       alloc.Size,
-		IsLeaked:   false, // Came from a free event, so it's not a leak
+	data := memoryAllocation{
+		startKtime: alloc.Header.Ktime_ns,
+		endKtime:   event.Header.Ktime_ns,
+		size:       alloc.Size,
+		isLeaked:   false, // Came from a free event, so it's not a leak
 	}
 
 	sh.allocations = append(sh.allocations, &data)
@@ -83,11 +126,11 @@ func (sh *StreamHandler) handleSync(event *gpuebpf.CudaSync) {
 	sh.markSynchronization(event.Header.Ktime_ns)
 }
 
-func (sh *StreamHandler) getCurrentKernelSpan(maxTime uint64) *model.KernelSpan {
-	span := model.KernelSpan{
-		StartKtime: math.MaxUint64,
-		EndKtime:   maxTime,
-		NumKernels: 0,
+func (sh *StreamHandler) getCurrentKernelSpan(maxTime uint64) *kernelSpan {
+	span := kernelSpan{
+		startKtime: math.MaxUint64,
+		endKtime:   maxTime,
+		numKernels: 0,
 	}
 
 	for _, launch := range sh.kernelLaunches {
@@ -97,33 +140,33 @@ func (sh *StreamHandler) getCurrentKernelSpan(maxTime uint64) *model.KernelSpan 
 			continue
 		}
 
-		span.StartKtime = min(launch.Header.Ktime_ns, span.StartKtime)
-		span.EndKtime = max(launch.Header.Ktime_ns, span.EndKtime)
+		span.startKtime = min(launch.Header.Ktime_ns, span.startKtime)
+		span.endKtime = max(launch.Header.Ktime_ns, span.endKtime)
 		blockSize := launch.Block_size.X * launch.Block_size.Y * launch.Block_size.Z
 		blockCount := launch.Grid_size.X * launch.Grid_size.Y * launch.Grid_size.Z
-		span.AvgThreadCount += uint64(blockSize) * uint64(blockCount)
-		span.NumKernels++
+		span.avgThreadCount += uint64(blockSize) * uint64(blockCount)
+		span.numKernels++
 	}
 
-	if span.NumKernels == 0 {
+	if span.numKernels == 0 {
 		return nil
 	}
 
-	span.AvgThreadCount /= uint64(span.NumKernels)
+	span.avgThreadCount /= uint64(span.numKernels)
 
 	return &span
 }
 
 // getPastData returns all the events that have finished (kernel spans with synchronizations/allocations that have been freed)
 // If flush is true, the data will be cleared from the handler
-func (sh *StreamHandler) getPastData(flush bool) *model.StreamData {
+func (sh *StreamHandler) getPastData(flush bool) *streamData {
 	if len(sh.kernelSpans) == 0 && len(sh.allocations) == 0 {
 		return nil
 	}
 
-	data := &model.StreamData{
-		Spans:       sh.kernelSpans,
-		Allocations: sh.allocations,
+	data := &streamData{
+		spans:       sh.kernelSpans,
+		allocations: sh.allocations,
 	}
 
 	if flush {
@@ -136,23 +179,23 @@ func (sh *StreamHandler) getPastData(flush bool) *model.StreamData {
 
 // getCurrentData returns the current state of the stream (kernels that are still running, and allocations that haven't been freed)
 // as this data needs to be treated differently from past/finished data.
-func (sh *StreamHandler) getCurrentData(now uint64) *model.StreamData {
+func (sh *StreamHandler) getCurrentData(now uint64) *streamData {
 	if len(sh.kernelLaunches) == 0 && len(sh.memAllocEvents) == 0 {
 		return nil
 	}
 
-	data := &model.StreamData{}
+	data := &streamData{}
 	span := sh.getCurrentKernelSpan(now)
 	if span != nil {
-		data.Spans = append(data.Spans, span)
+		data.spans = append(data.spans, span)
 	}
 
 	for _, alloc := range sh.memAllocEvents {
-		data.Allocations = append(data.Allocations, &model.MemoryAllocation{
-			StartKtime: alloc.Header.Ktime_ns,
-			EndKtime:   0,
-			Size:       alloc.Size,
-			IsLeaked:   false,
+		data.allocations = append(data.allocations, &memoryAllocation{
+			startKtime: alloc.Header.Ktime_ns,
+			endKtime:   0,
+			size:       alloc.Size,
+			isLeaked:   false,
 		})
 	}
 
@@ -172,11 +215,11 @@ func (sh *StreamHandler) markEnd() error {
 
 	// Close all allocations. Treat them as leaks, as they weren't freed properly
 	for _, alloc := range sh.memAllocEvents {
-		data := model.MemoryAllocation{
-			StartKtime: alloc.Header.Ktime_ns,
-			EndKtime:   uint64(nowTs),
-			Size:       alloc.Size,
-			IsLeaked:   true,
+		data := memoryAllocation{
+			startKtime: alloc.Header.Ktime_ns,
+			endKtime:   uint64(nowTs),
+			size:       alloc.Size,
+			isLeaked:   true,
 		}
 		sh.allocations = append(sh.allocations, &data)
 	}

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -45,13 +45,13 @@ func TestKernelLaunchesHandled(t *testing.T) {
 	currTime := uint64(100)
 	currData := stream.getCurrentData(currTime)
 	require.NotNil(t, currData)
-	require.Len(t, currData.Spans, 1)
+	require.Len(t, currData.spans, 1)
 
-	span := currData.Spans[0]
-	require.Equal(t, kernStartTime, span.StartKtime)
-	require.Equal(t, currTime, span.EndKtime)
-	require.Equal(t, uint64(numLaunches), span.NumKernels)
-	require.Equal(t, uint64(threadCount), span.AvgThreadCount)
+	span := currData.spans[0]
+	require.Equal(t, kernStartTime, span.startKtime)
+	require.Equal(t, currTime, span.endKtime)
+	require.Equal(t, uint64(numLaunches), span.numKernels)
+	require.Equal(t, uint64(threadCount), span.avgThreadCount)
 
 	// Now we mark a sync event
 	syncTime := uint64(200)
@@ -61,12 +61,12 @@ func TestKernelLaunchesHandled(t *testing.T) {
 	pastData := stream.getPastData(true)
 	require.NotNil(t, pastData)
 
-	require.Len(t, pastData.Spans, 1)
-	span = pastData.Spans[0]
-	require.Equal(t, kernStartTime, span.StartKtime)
-	require.Equal(t, syncTime, span.EndKtime)
-	require.Equal(t, uint64(numLaunches), span.NumKernels)
-	require.Equal(t, uint64(threadCount), span.AvgThreadCount)
+	require.Len(t, pastData.spans, 1)
+	span = pastData.spans[0]
+	require.Equal(t, kernStartTime, span.startKtime)
+	require.Equal(t, syncTime, span.endKtime)
+	require.Equal(t, uint64(numLaunches), span.numKernels)
+	require.Equal(t, uint64(threadCount), span.avgThreadCount)
 
 	// We should have no current data
 	require.Nil(t, stream.getCurrentData(currTime))
@@ -112,13 +112,13 @@ func TestMemoryAllocationsHandled(t *testing.T) {
 	currTime := uint64(100)
 	currData := stream.getCurrentData(currTime)
 	require.NotNil(t, currData)
-	require.Len(t, currData.Allocations, 1)
+	require.Len(t, currData.allocations, 1)
 
-	memAlloc := currData.Allocations[0]
-	require.Equal(t, memAllocTime, memAlloc.StartKtime)
-	require.Equal(t, uint64(0), memAlloc.EndKtime) // Not deallocated yet
-	require.Equal(t, false, memAlloc.IsLeaked)     // Cannot say this is a leak yet
-	require.Equal(t, allocSize, memAlloc.Size)
+	memAlloc := currData.allocations[0]
+	require.Equal(t, memAllocTime, memAlloc.startKtime)
+	require.Equal(t, uint64(0), memAlloc.endKtime) // Not deallocated yet
+	require.Equal(t, false, memAlloc.isLeaked)     // Cannot say this is a leak yet
+	require.Equal(t, allocSize, memAlloc.size)
 
 	// Now we free the memory
 	stream.handleMemEvent(free)
@@ -127,12 +127,12 @@ func TestMemoryAllocationsHandled(t *testing.T) {
 	pastData := stream.getPastData(true)
 	require.NotNil(t, pastData)
 
-	require.Len(t, pastData.Allocations, 1)
-	memAlloc = pastData.Allocations[0]
-	require.Equal(t, memAllocTime, memAlloc.StartKtime)
-	require.Equal(t, memFreeTime, memAlloc.EndKtime) // Not deallocated yet
-	require.Equal(t, false, memAlloc.IsLeaked)       // Cannot say this is a leak yet
-	require.Equal(t, allocSize, memAlloc.Size)
+	require.Len(t, pastData.allocations, 1)
+	memAlloc = pastData.allocations[0]
+	require.Equal(t, memAllocTime, memAlloc.startKtime)
+	require.Equal(t, memFreeTime, memAlloc.endKtime) // Not deallocated yet
+	require.Equal(t, false, memAlloc.isLeaked)       // Cannot say this is a leak yet
+	require.Equal(t, allocSize, memAlloc.size)
 
 	// We should have no current data
 	require.Nil(t, stream.getCurrentData(currTime))
@@ -167,11 +167,11 @@ func TestMemoryAllocationsDetectLeaks(t *testing.T) {
 	pastData := stream.getPastData(true)
 	require.NotNil(t, pastData)
 
-	require.Len(t, pastData.Allocations, 1)
-	memAlloc := pastData.Allocations[0]
-	require.Equal(t, memAllocTime, memAlloc.StartKtime)
-	require.Equal(t, true, memAlloc.IsLeaked)
-	require.Equal(t, allocSize, memAlloc.Size)
+	require.Len(t, pastData.allocations, 1)
+	memAlloc := pastData.allocations[0]
+	require.Equal(t, memAllocTime, memAlloc.startKtime)
+	require.Equal(t, true, memAlloc.isLeaked)
+	require.Equal(t, allocSize, memAlloc.size)
 }
 
 func TestMemoryAllocationsNoCrashOnInvalidFree(t *testing.T) {
@@ -279,20 +279,20 @@ func TestMemoryAllocationsMultipleAllocsHandled(t *testing.T) {
 	pastData := stream.getPastData(true)
 	require.NotNil(t, pastData)
 
-	require.Len(t, pastData.Allocations, 2)
+	require.Len(t, pastData.allocations, 2)
 	foundAlloc1, foundAlloc2 := false, false
 
-	for _, alloc := range pastData.Allocations {
-		if alloc.StartKtime == memAllocTime1 {
+	for _, alloc := range pastData.allocations {
+		if alloc.startKtime == memAllocTime1 {
 			foundAlloc1 = true
-			require.Equal(t, memFreeTime1, alloc.EndKtime)
-			require.Equal(t, false, alloc.IsLeaked)
-			require.Equal(t, allocSize1, alloc.Size)
-		} else if alloc.StartKtime == memAllocTime2 {
+			require.Equal(t, memFreeTime1, alloc.endKtime)
+			require.Equal(t, false, alloc.isLeaked)
+			require.Equal(t, allocSize1, alloc.size)
+		} else if alloc.startKtime == memAllocTime2 {
 			foundAlloc2 = true
-			require.Equal(t, memFreeTime2, alloc.EndKtime)
-			require.Equal(t, false, alloc.IsLeaked)
-			require.Equal(t, allocSize2, alloc.Size)
+			require.Equal(t, memFreeTime2, alloc.endKtime)
+			require.Equal(t, false, alloc.isLeaked)
+			require.Equal(t, allocSize2, alloc.size)
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Following the refactor in https://github.com/DataDog/datadog-agent/pull/30210, some types do not need to be exported anymore, so they are moved back to the `pkg/gpu` package.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->