### PR TITLE
[EBPF-577] gpu: add e2e test to check presence of metrics

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -117,7 +117,7 @@ func (v *gpuSuite) TestVectorAddProgramDetected() {
 	v.Require().NotEmpty(out)
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		metricNames := []string{"gpu.memory", "gpu.utilization", "gpu.max_memory"}
+		metricNames := []string{"gpu.memory", "gpu.utilization", "gpu.memory.max"}
 		for _, metricName := range metricNames {
 			metrics, err := v.Env().FakeIntake.Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
 			assert.NoError(c, err)

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -10,8 +10,12 @@ import (
 	"flag"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
@@ -103,4 +107,21 @@ func (v *gpuSuite) TestGPUCheckIsEnabled() {
 
 	gpuCheckStatus := status.RunnerStats.Checks["gpu"]
 	v.Require().Equal(gpuCheckStatus.LastError, "")
+}
+
+func (v *gpuSuite) TestVectorAddProgramDetected() {
+	vm := v.Env().RemoteHost
+
+	out, err := vm.Execute(fmt.Sprintf("docker run --rm --gpus all %s", vectorAddDockerImg))
+	v.Require().NoError(err)
+	v.Require().NotEmpty(out)
+
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		metricNames := []string{"gpu.memory", "gpu.utilization", "gpu.max_memory"}
+		for _, metricName := range metricNames {
+			metrics, err := v.Env().FakeIntake.Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
+			assert.NoError(c, err)
+			assert.Greater(c, len(metrics), 0, "no '%s' with value higher than 0 yet", metricName)
+		}
+	}, 5*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a e2e test that ensures we have metrics received in the fakeintake

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->