### PR TITLE
fix(fleet): Fix flaky test

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,6 +11,3 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-
-test/new-e2e/tests/installer:
-  - TestPackages/upgrade_scenario_ubuntu_22_04_x86_64/TestUpgradeSuccessful

--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -106,7 +106,7 @@ func (h *Host) AssertSystemdEvents(since JournaldTimestamp, events SystemdEventS
 		}
 		lastSearchedEvents = searchedEvents
 		return j == len(events.Events)
-	}, 30*time.Second, 1*time.Second)
+	}, 60*time.Second, 1*time.Second)
 
 	if !success {
 		logs := h.journaldLogsSince(since)

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -229,6 +229,11 @@ func envForceVersion(pkg, version string) string {
 }
 
 func (s *packageBaseSuite) Purge() {
+	// Reset the systemctl failed counter, best effort as they may not be loaded
+	for _, service := range []string{agentUnit, agentUnitXP, traceUnit, traceUnitXP, processUnit, processUnitXP, probeUnit, probeUnitXP, securityUnit, securityUnitXP} {
+		s.Env().RemoteHost.Execute(fmt.Sprintf("sudo systemctl reset-failed %s", service))
+	}
+
 	s.Env().RemoteHost.MustExecute("sudo apt-get remove -y --purge datadog-installer || sudo yum remove -y datadog-installer || sudo zypper remove -y datadog-installer")
 }
 

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -348,6 +348,10 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 		s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)
 
 		// ensure experiment is running
+		s.host.WaitForUnitActive(
+			"datadog-agent-trace-exp.service",
+			"datadog-agent-process-exp.service",
+		)
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(traceUnitXP))
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(processUnitXP))
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Skipped(securityUnitXP))
@@ -370,7 +374,7 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 			Unordered(host.SystemdEvents().
 				Started(traceUnit).
 				Started(processUnit).
-				SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
+				SkippedIf(probeUnit, s.installMethod != InstallMethodAnsible).
 				Skipped(securityUnit),
 			),
 		)


### PR DESCRIPTION
### What does this PR do?
- Removes a test marked as flaky that isn't
- Try to fix another flaky test by
  - Making sure to grab all systemd events
  - Resetting the failed systemd counter after each job -- that may make the experiment fail right at start
  - Waiting for the exp units to actually be started -- this should change anything but if the experiment failing right up is the right thing we'll know

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->