### PR TITLE
usm: file registry: Propagate activation error

### DIFF
--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -171,7 +171,7 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 		}
 
 		// we are calling `deactivationCB` here as some uprobes could be already attached
-		err = deactivationCB(FilePath{ID: pathID})
+		_ = deactivationCB(FilePath{ID: pathID})
 		if r.blocklistByID != nil {
 			// add `pathID` to blocklist so we don't attempt to re-register files
 			// that are problematic for some reason

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -218,7 +218,8 @@ func TestFailedRegistration(t *testing.T) {
 	require.NoError(t, err)
 	pid := uint32(cmd.Process.Pid)
 
-	require.NoError(t, r.Register(path, pid, registerCallback, IgnoreCB, IgnoreCB))
+	err = r.Register(path, pid, registerCallback, IgnoreCB, IgnoreCB)
+	require.ErrorIs(t, err, registerRecorder.ReturnError)
 
 	// First let's assert that the callback was executed once, but there are no
 	// registered processes because the registration should have failed


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When the activation fails and we add something to the blocked list, actually report the error from the activation.  Currently it gets overwritten from the error from the deactivation which is usually nil.

This is only useful when debugging using the debug endpoint or during testing, since the error value is not used in other cases.

### Motivation

Found when adding debug prints to print the errors from `AttachPid`.

### Describe how to test/QA your changes

Test cases modified to match.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->