### PR TITLE
[System-Probe] Exposed NSKey as public method to config

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -148,7 +148,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(diNS("enabled")) {
 		c.EnabledModules[DynamicInstrumentationModule] = struct{}{}
 	}
-	if cfg.GetBool(nskey("ebpf_check", "enabled")) {
+	if cfg.GetBool(NSkey("ebpf_check", "enabled")) {
 		c.EnabledModules[EBPFModule] = struct{}{}
 	}
 	if cfg.GetBool("system_probe_config.language_detection.enabled") {

--- a/cmd/system-probe/config/ns.go
+++ b/cmd/system-probe/config/ns.go
@@ -42,9 +42,14 @@ func evNS(k ...string) string {
 	return NSkey("event_monitoring_config", k...)
 }
 
-// NSkey returns a full key path in the config file by joining multiple path fragments
+// NSkey returns a full key path in the config file by joining the given namespace and the rest of the path fragments
 func NSkey(ns string, pieces ...string) string {
 	return strings.Join(append([]string{ns}, pieces...), ".")
+}
+
+// FullKeyPath returns a full key path in the config file by joining multiple path fragments
+func FullKeyPath(pieces ...string) string {
+	return strings.Join(pieces, ".")
 }
 
 // wcdNS addes 'windows_crash_detection' namespace to config key

--- a/cmd/system-probe/config/ns.go
+++ b/cmd/system-probe/config/ns.go
@@ -9,64 +9,65 @@ import "strings"
 
 // spNS adds `system_probe_config` namespace to configuration key
 func spNS(k ...string) string {
-	return nskey("system_probe_config", k...)
+	return NSkey("system_probe_config", k...)
 }
 
 // netNS adds `network_config` namespace to configuration key
 func netNS(k ...string) string {
-	return nskey("network_config", k...)
+	return NSkey("network_config", k...)
 }
 
 // smNS adds `service_monitoring_config` namespace to configuration key
 func smNS(k ...string) string {
-	return nskey("service_monitoring_config", k...)
+	return NSkey("service_monitoring_config", k...)
 }
 
 // ccmNS adds `ccm_network_config` namespace to a configuration key
 func ccmNS(k ...string) string {
-	return nskey("ccm_network_config", k...)
+	return NSkey("ccm_network_config", k...)
 }
 
 // diNS adds `dynamic_instrumentation` namespace to configuration key
 func diNS(k ...string) string {
-	return nskey("dynamic_instrumentation", k...)
+	return NSkey("dynamic_instrumentation", k...)
 }
 
 // secNS adds `runtime_security_config` namespace to configuration key
 func secNS(k ...string) string {
-	return nskey("runtime_security_config", k...)
+	return NSkey("runtime_security_config", k...)
 }
 
 // evNS adds `event_monitoring_config` namespace to configuration key
 func evNS(k ...string) string {
-	return nskey("event_monitoring_config", k...)
+	return NSkey("event_monitoring_config", k...)
 }
 
-func nskey(ns string, pieces ...string) string {
+// NSkey returns a full key path in the config file by joining multiple path fragments
+func NSkey(ns string, pieces ...string) string {
 	return strings.Join(append([]string{ns}, pieces...), ".")
 }
 
 // wcdNS addes 'windows_crash_detection' namespace to config key
 func wcdNS(k ...string) string {
-	return nskey("windows_crash_detection", k...)
+	return NSkey("windows_crash_detection", k...)
 }
 
 // pngNS adds `ping` namespace to config key
 func pngNS(k ...string) string {
-	return nskey("ping", k...)
+	return NSkey("ping", k...)
 }
 
 // tracerouteNS adds `traceroute` namespace to config key
 func tracerouteNS(k ...string) string {
-	return nskey("traceroute", k...)
+	return NSkey("traceroute", k...)
 }
 
 // discoveryNS adds `discovery` namespace to config key
 func discoveryNS(k ...string) string {
-	return nskey("discovery", k...)
+	return NSkey("discovery", k...)
 }
 
 // gpuNS adds `gpu_monitoring` namespace to config key
 func gpuNS(k ...string) string {
-	return nskey("gpu_monitoring", k...)
+	return NSkey("gpu_monitoring", k...)
 }


### PR DESCRIPTION
### What does this PR do?

Exposed existing method to get a full key path to be public

### Motivation

avoid code duplication, currently many SP modules implement this method internally in their respective config packages.

Examples:
ebpf-check module [key](https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/config.go#L84) func
network-tracer [join](https://github.com/DataDog/datadog-agent/blob/main/pkg/network/config/config.go#L295) func

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

I will migrate the modules to use the method in a separate PR