### PR TITLE
[CWS] make use of `os.ReadFile` in `LoadProtoFromFile`

### DIFF
--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -11,7 +11,6 @@ package profile
 import (
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"slices"
@@ -188,13 +187,7 @@ func (p *SecurityProfile) NewProcessNodeCallback(_ *activity_tree.ProcessNode) {
 
 // LoadProtoFromFile loads proto profile from file
 func LoadProtoFromFile(filepath string) (*proto.SecurityProfile, error) {
-	f, err := os.Open(filepath)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't open profile: %w", err)
-	}
-	defer f.Close()
-
-	raw, err := io.ReadAll(f)
+	raw, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read profile: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Directly use `os.ReadFile` instead of `os.Open + io.ReadAll` when reading security profiles from files. The main goal of this is that `ReadFile` actually stats the file and use the file size to pre-allocate the buffer size. This gives multiple benefits: less read syscalls (one big read instead of multiple chunk reads), and less buffer re-allocation (we can expect to directly allocate the correct buffer size instead of needed to re-allocate + copy if the buffer is full).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->