### PR TITLE
Remove agent7 occurrences

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -467,22 +467,11 @@ workflow:
     when: never
   - <<: *if_main_branch
 
-.on_main_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_main_branch
-
-.on_tag_or_a7:
+.on_tag_or_a6:
   - <<: *if_mergequeue
     when: never
   - <<: *if_tagged_commit
-  - <<: *if_version_7
-
-.on_tag_or_a7_all_builds:
-  - <<: *if_not_run_all_builds
-    when: never
-  - <<: *if_tagged_commit
-  - <<: *if_version_7
+  - <<: *if_version_6
 
 .on_deploy:
   - <<: *if_deploy
@@ -530,6 +519,19 @@ workflow:
     variables:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
+
+# rule to trigger job for internal image deployment if deploy is set or
+# manually if not
+.on_deploy_a6_internal_or_manual:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_deploy
+    variables:
+      RELEASE_PROD: "true"
+  - when: manual
+    allow_failure: true
+    variables:
+      RELEASE_PROD: "false"
 
 # Same as on_deploy_a6_manual, except the job would not run on pipelines
 # using beta branch, it would only run for the final release.
@@ -580,123 +582,13 @@ workflow:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-.on_deploy_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_deploy
-
-.on_deploy_a7_failure:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_deploy
-    when: on_failure
-
-.on_deploy_a7_rc:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-.on_deploy_a7_manual:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      DSD_REPOSITORY: dogstatsd-dev
-      IMG_REGISTRIES: dev
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-# rule to trigger job for internal image deployment if deploy is set or
-# manually if not
-.on_deploy_a7_internal_or_manual:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_deploy
-    variables:
-      RELEASE_PROD: "true"
-  - when: manual
-    allow_failure: true
-    variables:
-      RELEASE_PROD: "false"
-
-# Same as on_deploy_a7_manual, except the job would not run on pipelines
-# using beta branch, it would only run for the final release.
-.on_deploy_a7_manual_final:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_deploy_on_beta_repo_branch
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      DSD_REPOSITORY: dogstatsd-dev
-      IMG_REGISTRIES: dev
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-# This rule is a variation of on_deploy_a7_manual where
-# the job is usually run manually, except when the pipeline
-# builds an RC: in this case, the job is run automatically.
-# This is done to reduce the number of manual steps that have
-# to be done when creating RCs.
-.on_deploy_a7_manual_auto_on_rc:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      DSD_REPOSITORY: dogstatsd-dev
-      IMG_REGISTRIES: dev
-  - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
 # This is used for image vulnerability scanning. Because agent 6
 # uses python 2, which has many vulnerabilities that will not get
 # patched, we do not wish to scan this image. For this reason, only
 # agent 7 versions should be published internally using these
-# configurations.
-.on_deploy_a7_internal_rc:
-  - <<: *if_not_version_7
+# configurations. -> then we should remove this
+.on_deploy_a6_internal_rc:
+  - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
     when: never
@@ -708,10 +600,10 @@ workflow:
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
-# Same as on_deploy_a7_manual_final, except the job is used to publish images
+# Same as on_deploy_a6_manual_final, except the job is used to publish images
 # to our internal registries.
-.on_deploy_a7_internal_manual_final:
-  - <<: *if_not_version_7
+.on_deploy_a6_internal_manual_final:
+  - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
     when: never
@@ -955,20 +847,20 @@ workflow:
 # Default kitchen tests are also run on dev branches
 # In that case, the target OS versions is a subset of the
 # available versions, stored in DEFAULT_KITCHEN_OSVERS
-.on_default_kitchen_tests_a7:
+.on_default_kitchen_tests_a6:
   - <<: *if_mergequeue
     when: never
-  - <<: *if_not_version_7
+  - <<: *if_not_version_6
     when: never
   - <<: *if_installer_tests
   - <<: *if_auto_e2e_tests
     variables:
       KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
 
-.on_default_new-e2e_tests_a7:
+.on_default_new-e2e_tests_a6:
   - <<: *if_mergequeue
     when: never
-  - <<: *if_not_version_7
+  - <<: *if_not_version_6
     when: never
   - <<: *if_disable_e2e_tests
     when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,6 @@ variables:
   DEB_TESTING_S3_BUCKET: apttesting.datad0g.com
   RPM_TESTING_S3_BUCKET: yumtesting.datad0g.com
   WINDOWS_TESTING_S3_BUCKET_A6: pipelines/A6/$CI_PIPELINE_ID
-  WINDOWS_TESTING_S3_BUCKET_A7: pipelines/A7/$CI_PIPELINE_ID
   WINDOWS_BUILDS_S3_BUCKET: $WIN_S3_BUCKET/builds
   DEB_RPM_TESTING_BUCKET_BRANCH: testing # branch of the DEB_TESTING_S3_BUCKET and RPM_TESTING_S3_BUCKET repos to release to, 'testing'
   S3_CP_OPTIONS: --only-show-errors --region us-east-1 --sse AES256
@@ -153,7 +152,6 @@ variables:
   GENERAL_ARTIFACTS_CACHE_BUCKET_URL: https://dd-agent-omnibus.s3.amazonaws.com
   S3_DSD6_URI: s3://dsd6-staging
   RELEASE_VERSION_6: nightly
-  RELEASE_VERSION_7: nightly-a7
 
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
@@ -252,10 +250,10 @@ variables:
 # Condition mixins for simplification of rules
 #
 .if_main_branch: &if_main_branch
-  if: $CI_COMMIT_BRANCH == "main"
+  if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "6.53.x"
 
 .if_not_main_branch: &if_not_main_branch
-  if: $CI_COMMIT_BRANCH != "main"
+  if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "6.53.x"
 
 .if_release_branch: &if_release_branch
   if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
@@ -265,9 +263,6 @@ variables:
 
 .if_not_version_6: &if_not_version_6
   if: $RELEASE_VERSION_6 == ""
-
-.if_version_7: &if_version_7
-  if: $RELEASE_VERSION_7 != ""
 
 .if_not_version_7: &if_not_version_7
   if: $RELEASE_VERSION_7 == ""
@@ -412,38 +407,6 @@ workflow:
   - when: manual
     allow_failure: true
 
-.on_a6:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_version_6
-
-.on_a6_manual:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_version_6
-    when: manual
-    allow_failure: true
-
-.on_a7:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_version_7
-
-.on_a7_manual:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_version_7
-    when: manual
-    allow_failure: true
-
-.except_no_a6_or_no_a7:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_not_version_7
-    when: never
-
 .on_dev_branch_manual:
   - <<: *if_mergequeue
     when: never
@@ -462,17 +425,6 @@ workflow:
     when: manual
     allow_failure: true
 
-.on_main_a6:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_main_branch
-
-.on_tag_or_a6:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_tagged_commit
-  - <<: *if_version_6
-
 .on_deploy:
   - <<: *if_deploy
 
@@ -480,20 +432,7 @@ workflow:
   - <<: *if_deploy
     when: on_failure
 
-.on_deploy_a6:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_deploy
-
-.on_deploy_a6_failure:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_deploy
-    when: on_failure
-
-.on_deploy_a6_rc:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_rc:
   - <<: *if_not_deploy
     when: never
   - <<: *if_rc_tag_on_beta_repo_branch
@@ -503,9 +442,7 @@ workflow:
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-.on_deploy_a6_manual:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_manual:
   - <<: *if_not_deploy
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
@@ -522,9 +459,8 @@ workflow:
 
 # rule to trigger job for internal image deployment if deploy is set or
 # manually if not
-.on_deploy_a6_internal_or_manual:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_internal_or_manual:
+  - !reference [.except_mergequeue]
   - <<: *if_deploy
     variables:
       RELEASE_PROD: "true"
@@ -533,11 +469,9 @@ workflow:
     variables:
       RELEASE_PROD: "false"
 
-# Same as on_deploy_a6_manual, except the job would not run on pipelines
+# Same as on_deploy_manual, except the job would not run on pipelines
 # using beta branch, it would only run for the final release.
-.on_deploy_a6_manual_final:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_manual_final:
   - <<: *if_not_deploy
     when: never
   - <<: *if_deploy_on_beta_repo_branch
@@ -554,14 +488,12 @@ workflow:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-# This rule is a variation of on_deploy_a6_manual where
+# This rule is a variation of on_deploy_manual where
 # the job is usually run manually, except when the pipeline
 # builds an RC: in this case, the job is run automatically.
 # This is done to reduce the number of manual steps that have
 # to be done when creating RCs.
-.on_deploy_a6_manual_auto_on_rc:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_manual_auto_on_rc:
   - <<: *if_not_deploy
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
@@ -587,9 +519,7 @@ workflow:
 # patched, we do not wish to scan this image. For this reason, only
 # agent 7 versions should be published internally using these
 # configurations. -> then we should remove this
-.on_deploy_a6_internal_rc:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_internal_rc:
   - <<: *if_not_deploy
     when: never
   - <<: *if_rc_tag_on_beta_repo_branch
@@ -600,11 +530,9 @@ workflow:
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
-# Same as on_deploy_a6_manual_final, except the job is used to publish images
+# Same as on_deploy_manual_final, except the job is used to publish images
 # to our internal registries.
-.on_deploy_a6_internal_manual_final:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_internal_manual_final:
   - <<: *if_not_deploy
     when: never
   - <<: *if_deploy_on_beta_repo_branch
@@ -619,16 +547,7 @@ workflow:
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
-.on_deploy_nightly_repo_branch_a6:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_not_nightly_or_dev_repo_branch
-    when: never
-  - <<: *if_deploy
-
-.on_deploy_nightly_repo_branch_a7:
-  - <<: *if_not_version_7
-    when: never
+.on_deploy_nightly_repo_branch:
   - <<: *if_not_nightly_or_dev_repo_branch
     when: never
   - <<: *if_deploy
@@ -638,73 +557,9 @@ workflow:
     when: never
   - <<: *if_deploy
 
-.on_deploy_stable_or_beta_repo_branch_a6:
-  - <<: *if_not_version_6
-    when: never
+.on_deploy_stable_or_beta_repo_branch_manual:
   - <<: *if_not_stable_or_beta_repo_branch
     when: never
-  - <<: *if_deploy
-
-.on_deploy_stable_or_beta_repo_branch_a6_manual:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_deploy
-    when: manual
-    allow_failure: true
-
-.on_deploy_stable_or_beta_repo_branch_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_deploy
-
-.on_deploy_stable_or_beta_repo_branch_a7_manual:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_deploy
-    when: manual
-    allow_failure: true
-
-.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
-  - <<: *if_deploy_on_stable_repo_branch
-    when: on_success
-  - when: never
-
-.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual_on_stable:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
-  - <<: *if_deploy_on_stable_repo_branch
-    when: manual
-    allow_failure: true
-  - when: never
-
-# This rule is a variation of on_deploy_stable_or_beta_repo_branch_a7_manual where
-# the job is usually run manually, except when the pipeline
-# builds an RC: in this case, the job is run automatically.
-# This is done to reduce the number of manual steps that have
-# to be done when creating RCs.
-.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
   - <<: *if_deploy
     when: manual
     allow_failure: true
@@ -722,15 +577,6 @@ workflow:
     allow_failure: true
   - when: on_success
 
-.on_deploy_stable_repo_branch_a7_manual:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_repo_branch
-    when: never
-  - <<: *if_deploy
-    when: manual
-    allow_failure: true
-
 .except_deploy:
   - <<: *if_deploy
     when: never
@@ -739,20 +585,6 @@ workflow:
 .except_no_tests_no_deploy:
   - if: $DEPLOY_AGENT == "false" && $RUN_E2E_TESTS == "off"
     when: never
-
-.on_a6_except_deploy:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_deploy
-    when: never
-  - when: on_success
-
-.on_a7_except_deploy:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_deploy
-    when: never
-  - when: on_success
 
 .on_main_or_release_branch:
   - <<: *if_main_branch
@@ -783,84 +615,39 @@ workflow:
 .on_all_builds:
   - <<: *if_run_all_builds
 
-.on_all_builds_a6:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_run_all_builds
-
-.on_all_builds_a6_manual:
-  - <<: *if_not_version_6
-    when: never
+.on_all_builds_manual:
   - <<: *if_run_all_builds
     when: manual
     allow_failure: true
 
-.on_all_builds_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_run_all_builds
-
-.on_all_builds_a7_manual:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_run_all_builds
-    when: manual
-    allow_failure: true
-
-.on_kitchen_tests_a6:
-  - <<: *if_not_version_6
-    when: never
+.on_kitchen_tests:
   - <<: *if_installer_tests
 
-.on_kitchen_tests_a6_always:
-  - <<: *if_not_version_6
-    when: never
+.on_kitchen_tests_always:
   - <<: *if_installer_tests
     when: always
 
-.on_all_kitchen_builds_a6:
-  - <<: *if_not_version_6
-    when: never
+.on_all_kitchen_builds:
   - <<: *if_not_run_all_builds
     when: never
   - <<: *if_installer_tests
 
-.on_kitchen_tests_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_installer_tests
-
-.on_all_kitchen_builds_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_run_all_builds
-    when: never
-  - <<: *if_installer_tests
-
-.on_all_new-e2e_tests_a7:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_run_all_builds
-    when: never
+.on_all_install_script_tests:
   - <<: *if_installer_tests
 
 # Default kitchen tests are also run on dev branches
 # In that case, the target OS versions is a subset of the
 # available versions, stored in DEFAULT_KITCHEN_OSVERS
-.on_default_kitchen_tests_a6:
+.on_default_kitchen_tests:
   - <<: *if_mergequeue
-    when: never
-  - <<: *if_not_version_6
     when: never
   - <<: *if_installer_tests
   - <<: *if_auto_e2e_tests
     variables:
       KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
 
-.on_default_new-e2e_tests_a6:
+.on_default_new-e2e_tests:
   - <<: *if_mergequeue
-    when: never
-  - <<: *if_not_version_6
     when: never
   - <<: *if_disable_e2e_tests
     when: never
@@ -868,18 +655,6 @@ workflow:
   - <<: *if_auto_e2e_tests
     variables:
       E2E_OSVERS: $E2E_BRANCH_OSVERS
-
-.on_default_kitchen_tests_a7_always:
-  - <<: *if_mergequeue
-    when: never
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_installer_tests
-    when: always
-  - <<: *if_auto_e2e_tests
-    when: always
-    variables:
-      KITCHEN_OSVERS: $DEFAULT_KITCHEN_OSVERS
 
 .on_main_or_testing_cleanup:
   - <<: *if_main_branch
@@ -915,7 +690,7 @@ workflow:
   - <<: *if_run_all_kmt_tests
   - changes:
       paths: *security_agent_change_paths
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -928,7 +703,7 @@ workflow:
         - test/new-e2e/tests/windows/install-test/**/*
         - test/new-e2e/tests/windows/domain-test/**/*
         - tasks/msi.py
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .on_windows_installer_changes_or_manual:
   - <<: *if_disable_e2e_tests
@@ -974,7 +749,7 @@ workflow:
   - <<: *if_run_all_kmt_tests
   - changes:
       paths: *system_probe_change_paths
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -988,7 +763,7 @@ workflow:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/test-infra-definition/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -1013,7 +788,7 @@ workflow:
       paths:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .always_on_container_or_e2e_changes_or_manual:
   - <<: *if_disable_e2e_tests
@@ -1032,7 +807,7 @@ workflow:
       paths:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - changes:
       paths:
         - comp/core/tagger/**/*
@@ -1054,7 +829,7 @@ workflow:
         - pkg/util/cgroups/**/*
         - test/new-e2e/tests/containers/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: always
   - when: manual
     allow_failure: true
@@ -1082,7 +857,7 @@ workflow:
         - pkg/util/cgroups/**/*
         - test/new-e2e/tests/containers/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -1094,7 +869,7 @@ workflow:
         - pkg/config/remote/**/*
         - comp/remote-config/**/*
         - test/new-e2e/tests/remote-config/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1105,11 +880,11 @@ workflow:
     when: never
   - changes:
       paths: *system_probe_change_paths
-      compare_to: 7.53.x
+      compare_to: 6.53.x
     when: on_success
   - changes:
       paths: *security_agent_change_paths
-      compare_to: 7.53.x
+      compare_to: 6.53.x
     when: on_success
   - when: manual
     allow_failure: true
@@ -1120,7 +895,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for ASC
         - test/new-e2e/tests/agent-shared-components/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
 
 .on_subcommands_or_e2e_changes_or_manual:
@@ -1131,7 +906,7 @@ workflow:
         - pkg/**/*
         - comp/**/*
         - test/new-e2e/tests/agent-subcommands/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
 
 .on_language-detection_or_e2e_changes_or_manual:
@@ -1140,7 +915,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for language detection
         - test/new-e2e/tests/language-detection/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1150,7 +925,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for npm
         - test/new-e2e/tests/npm/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1160,7 +935,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for AML
         - test/new-e2e/tests/agent-metrics-logs/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1170,7 +945,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for CWS
         - test/new-e2e/tests/cws/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1180,7 +955,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for process
         - test/new-e2e/tests/process/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1190,7 +965,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for orchestrator
         - test/new-e2e/tests/orchestrator/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   - when: manual
     allow_failure: true
 
@@ -1205,6 +980,19 @@ workflow:
     when: manual
     allow_failure: true
 
+.on_installer_or_e2e_changes:
+  - !reference [.on_e2e_main_release_or_rc]
+  - changes:
+      paths:
+        - .gitlab/**/*
+        - omnibus/config/**/*
+        - pkg/fleet/**/*
+        - cmd/installer/**/*
+        - test/new-e2e/tests/installer/**/*
+        - tasks/installer.py
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    when: on_success
+
 .on_apm_or_e2e_changes_or_manual:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
@@ -1214,7 +1002,7 @@ workflow:
         - comp/trace/**/*
         - test/new-e2e/tests/apm/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -1236,7 +1024,7 @@ workflow:
         - cmd/updater/**/*
         - test/new-e2e/tests/updater/**/*
         - test/new-e2e/go.mod
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true
@@ -1285,14 +1073,14 @@ workflow:
         - .gitlab/package_build.yml
         - release.json
         - .gitlab/package_build/**/*
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .on_go-version_change:
   - !reference [.except_mergequeue] # The prerequisites are not run in the mergequeue pipeline so we need to skip this rule
   - changes:
       paths:
         - .go-version
-      compare_to: 7.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: 6.53.x # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .on_fakeintake_changes: &on_fakeintake_changes
   changes:

--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -15,7 +15,7 @@
 cluster_agent-build_amd64:
   extends: .cluster_agent-build_common
   rules:
-    !reference [.on_tag_or_a7]
+    !reference [.on_tag_or_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -28,7 +28,7 @@ cluster_agent-build_amd64:
 cluster_agent-build_arm64:
   extends: .cluster_agent-build_common
   rules:
-    !reference [.on_tag_or_a7]
+    !reference [.on_tag_or_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -4,7 +4,7 @@
   needs: ["go_mod_tidy_check"]
   script:
     - inv check-go-version
-    - inv -e cluster-agent.build --release-version "$RELEASE_VERSION_7"
+    - inv -e cluster-agent.build --release-version "$RELEASE_VERSION_6"
     - $S3_CP_CMD $CI_PROJECT_DIR/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTIFACTS_URI/datadog-cluster-agent.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/Dockerfiles/cluster-agent/datadog-cluster.yaml $S3_ARTIFACTS_URI/datadog-cluster.yaml
     - $S3_CP_CMD $CI_PROJECT_DIR/Dockerfiles/cluster-agent/security-agent-policies $S3_ARTIFACTS_URI/security-agent-policies --recursive
@@ -15,7 +15,8 @@
 cluster_agent-build_amd64:
   extends: .cluster_agent-build_common
   rules:
-    !reference [.on_tag_or_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -28,7 +29,8 @@ cluster_agent-build_amd64:
 cluster_agent-build_arm64:
   extends: .cluster_agent-build_common
   rules:
-    !reference [.on_tag_or_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -1,7 +1,8 @@
 ---
 cluster_agent_cloudfoundry-build_amd64:
   rules:
-    !reference [.on_a7]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -20,5 +21,5 @@ cluster_agent_cloudfoundry-build_amd64:
     - inv -e cluster-agent-cloudfoundry.build
     - cd $CI_PROJECT_DIR/$CLUSTER_AGENT_CLOUDFOUNDRY_BINARIES_DIR
     - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 6)
     - tar cf $OMNIBUS_PACKAGE_DIR/datadog-cluster-agent-cloudfoundry-$PACKAGE_VERSION-$ARCH.tar.xz datadog-cluster-agent-cloudfoundry

--- a/.gitlab/binary_build/cws_instrumentation.yml
+++ b/.gitlab/binary_build/cws_instrumentation.yml
@@ -10,7 +10,7 @@
 cws_instrumentation-build_amd64:
   extends: .cws_instrumentation-build_common
   rules:
-    !reference [.on_tag_or_a7]
+    !reference [.on_tag_or_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -23,7 +23,7 @@ cws_instrumentation-build_amd64:
 cws_instrumentation-build_arm64:
   extends: .cws_instrumentation-build_common
   rules:
-    !reference [.on_tag_or_a7]
+    !reference [.on_tag_or_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/binary_build/cws_instrumentation.yml
+++ b/.gitlab/binary_build/cws_instrumentation.yml
@@ -10,7 +10,8 @@
 cws_instrumentation-build_amd64:
   extends: .cws_instrumentation-build_common
   rules:
-    !reference [.on_tag_or_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -23,7 +24,8 @@ cws_instrumentation-build_amd64:
 cws_instrumentation-build_arm64:
   extends: .cws_instrumentation-build_common
   rules:
-    !reference [.on_tag_or_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/check_deploy/check_deploy.yml
+++ b/.gitlab/check_deploy/check_deploy.yml
@@ -8,7 +8,7 @@
 # overwrite a public package). To update an erroneous package, first remove it
 # from our S3 bucket.
 check_already_deployed_version_6:
-  rules: !reference [.on_deploy_a6]
+  rules: !reference [.on_deploy]
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
@@ -18,15 +18,3 @@ check_already_deployed_version_6:
   script:
     - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_6*_amd64.deb
     - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_6*_arm64.deb
-
-check_already_deployed_version_7:
-  rules: !reference [.on_deploy_a7]
-  stage: check_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  dependencies: ["agent_deb-x64-a7", "agent_deb-arm64-a7"]
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_7*_amd64.deb
-    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_7*_arm64.deb

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -41,7 +41,9 @@
 # build agent6 py2 image
 docker_build_agent6:
   extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -53,7 +55,9 @@ docker_build_agent6:
 
 docker_build_agent6_arm64:
   extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_all_builds_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: agent_deb-arm64-a6
       artifacts: false
@@ -66,7 +70,9 @@ docker_build_agent6_arm64:
 # build agent6 py2 jmx image
 docker_build_agent6_jmx:
   extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -80,7 +86,9 @@ docker_build_agent6_jmx:
 # build agent6 py2 jmx image
 docker_build_agent6_jmx_arm64:
   extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_all_builds_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: agent_deb-arm64-a6
       artifacts: false
@@ -95,7 +103,9 @@ docker_build_agent6_jmx_arm64:
 # build agent6 jmx unified image (including python3)
 docker_build_agent6_py2py3_jmx:
   extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: agent_deb-x64-a6
       artifacts: false
@@ -105,71 +115,25 @@ docker_build_agent6_py2py3_jmx:
     TAG_SUFFIX: -6-py2py3-jmx
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
 
-# build agent7 image
-docker_build_agent7:
-  extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_a7]
-  needs:
-    - job: agent_deb-x64-a7
-      artifacts: false
-  variables:
-    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    BUILD_CONTEXT: Dockerfiles/agent
-    TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
-
-single_machine_performance-amd64-a7:
+single_machine_performance-amd64-a6:
   extends: .docker_publish_job_definition
   stage: container_build
-  rules: !reference [.on_a7]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
-    - docker_build_agent7
+    - docker_build_agent6
   variables:
     IMG_REGISTRIES: internal-aws-smp
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-    IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-amd64
-
-docker_build_agent7_arm64:
-  extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_a7]
-  needs:
-    - job: agent_deb-arm64-a7
-      artifacts: false
-  variables:
-    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    BUILD_CONTEXT: Dockerfiles/agent
-    TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
-
-# build agent7 jmx image
-docker_build_agent7_jmx:
-  extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_a7]
-  needs:
-    - job: agent_deb-x64-a7
-      artifacts: false
-  variables:
-    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    BUILD_CONTEXT: Dockerfiles/agent
-    TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
-
-docker_build_agent7_jmx_arm64:
-  extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_a7]
-  needs:
-    - job: agent_deb-arm64-a7
-      artifacts: false
-  variables:
-    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    BUILD_CONTEXT: Dockerfiles/agent
-    TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64
+    IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-6-amd64
 
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:
   extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_tag_or_a7]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: cluster_agent-build_amd64
       artifacts: false
@@ -181,7 +145,9 @@ docker_build_cluster_agent_amd64:
 
 docker_build_cluster_agent_arm64:
   extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_tag_or_a7]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: cluster_agent-build_arm64
       artifacts: false
@@ -194,7 +160,9 @@ docker_build_cluster_agent_arm64:
 # build the cws-instrumentation image
 docker_build_cws_instrumentation_amd64:
   extends: .docker_build_job_definition_amd64
-  rules: !reference [.on_tag_or_a7]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: cws_instrumentation-build_amd64
       artifacts: false
@@ -204,7 +172,9 @@ docker_build_cws_instrumentation_amd64:
 
 docker_build_cws_instrumentation_arm64:
   extends: .docker_build_job_definition_arm64
-  rules: !reference [.on_tag_or_a7]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - job: cws_instrumentation-build_arm64
       artifacts: false

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -100,4 +100,3 @@
 
 include:
   - .gitlab/container_build/docker_windows_agent6.yml
-  - .gitlab/container_build/docker_windows_agent7.yml

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -65,20 +65,12 @@
     - docker rmi ${TARGET_TAG}
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 
-.docker_build_agent7_windows_common:
-  extends:
-    - .docker_build_agent_windows_common
-  rules: !reference [.on_a7]
-  needs:
-    ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
-
 .docker_build_agent6_windows_common:
   extends:
     - .docker_build_agent_windows_common
-  rules: !reference [.on_a6]
+  rules: 
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"
@@ -87,13 +79,6 @@
 .docker_build_agent6_windows_servercore_common:
   extends:
     - .docker_build_agent6_windows_common
-  variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
-    SERVERCORE: "-servercore"
-
-.docker_build_agent7_windows_servercore_common:
-  extends:
-    - .docker_build_agent7_windows_common
   variables:
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
     SERVERCORE: "-servercore"

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -1,74 +1,74 @@
 ---
-docker_build_agent7_windows1809:
+docker_build_agent6_windows1809:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent6_windows_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7
+    TAG_SUFFIX: -6
     WITH_JMX: "false"
 
-docker_build_agent7_windows1809_jmx:
+docker_build_agent6_windows1809_jmx:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent6_windows_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7-jmx
+    TAG_SUFFIX: -6-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows2022_jmx:
+docker_build_agent6_windows2022_jmx:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent6_windows_common
   tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  needs: ["windows_msi_and_bosh_zip_x64-a6", "build_windows_container_entrypoint"]
   variables:
     VARIANT: ltsc2022
-    TAG_SUFFIX: -7-jmx
+    TAG_SUFFIX: -6-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows2022:
+docker_build_agent6_windows2022:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent6_windows_common
   tags: ["runner:windows-docker", "windowsversion:2022"]
   variables:
     VARIANT: ltsc2022
-    TAG_SUFFIX: "-7"
+    TAG_SUFFIX: "-6"
     WITH_JMX: "false"
 
-docker_build_agent7_windows1809_core:
+docker_build_agent6_windows1809_core:
   extends:
-    - .docker_build_agent7_windows_servercore_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7
+    TAG_SUFFIX: -6
     WITH_JMX: "false"
 
-docker_build_agent7_windows1809_core_jmx:
+docker_build_agent6_windows1809_core_jmx:
   extends:
-    - .docker_build_agent7_windows_servercore_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
-    TAG_SUFFIX: -7-jmx
+    TAG_SUFFIX: -6-jmx
     WITH_JMX: "true"
 
-docker_build_agent7_windows2022_core:
+docker_build_agent6_windows2022_core:
   extends:
-    - .docker_build_agent7_windows_servercore_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:2022"]
   variables:
     VARIANT: ltsc2022
-    TAG_SUFFIX: "-7"
+    TAG_SUFFIX: "-6"
     WITH_JMX: "false"
 
-docker_build_agent7_windows2022_core_jmx:
+docker_build_agent6_windows2022_core_jmx:
   extends:
-    - .docker_build_agent7_windows_servercore_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  needs: ["windows_msi_and_bosh_zip_x64-a6", "build_windows_container_entrypoint"]
   variables:
     VARIANT: ltsc2022
-    TAG_SUFFIX: -7-jmx
+    TAG_SUFFIX: -6-jmx
     WITH_JMX: "true"

--- a/.gitlab/container_scan/container_scan.yml
+++ b/.gitlab/container_scan/container_scan.yml
@@ -42,7 +42,7 @@ dca_scan_nightly:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
+    !reference [.on_deploy_nightly_repo_branch_a6]
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev
@@ -87,7 +87,7 @@ dca_scan_master:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_main_a7]
+    !reference [.on_main_a6]
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev

--- a/.gitlab/container_scan/container_scan.yml
+++ b/.gitlab/container_scan/container_scan.yml
@@ -8,7 +8,7 @@ scan_nightly-a6:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_deploy_nightly_repo_branch_a6]
+    !reference [.on_deploy_nightly_repo_branch]
   needs:
     - docker_build_agent6
     - docker_build_agent6_jmx
@@ -21,28 +21,11 @@ scan_nightly-a6:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64
         IMG_DESTINATIONS: agent-scan:${BUCKET_BRANCH}-py2-jmx
 
-scan_nightly-a7:
-  extends: .docker_publish_job_definition
-  stage: container_scan
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-        IMG_DESTINATIONS: agent-scan:${BUCKET_BRANCH}-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64
-        IMG_DESTINATIONS: agent-scan:${BUCKET_BRANCH}-py3-jmx
-
 dca_scan_nightly:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_deploy_nightly_repo_branch_a6]
+    !reference [.on_deploy_nightly_repo_branch]
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev
@@ -53,7 +36,7 @@ scan_master-a6:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_main_a6]
+    !reference [.on_main]
   needs:
     - docker_build_agent6
     - docker_build_agent6_jmx
@@ -66,28 +49,11 @@ scan_master-a6:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64
         IMG_DESTINATIONS: agent-scan:master-py2-jmx
 
-scan_master-a7:
-  extends: .docker_publish_job_definition
-  stage: container_scan
-  rules:
-    !reference [.on_main_a7]
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-        IMG_DESTINATIONS: agent-scan:master-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64
-        IMG_DESTINATIONS: agent-scan:master-py3-jmx
-
 dca_scan_master:
   extends: .docker_publish_job_definition
   stage: container_scan
   rules:
-    !reference [.on_main_a6]
+    !reference [.on_main]
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev

--- a/.gitlab/deploy_containers/deploy_containers.yml
+++ b/.gitlab/deploy_containers/deploy_containers.yml
@@ -1,6 +1,6 @@
 ---
 # deploy containers stage
-# Contains jobs which create child pipelines to deploy Agent 6 & 7 to staging repositories and to Dockerhub / GCR.
+# Contains jobs which create child pipelines to deploy Agent 6 to staging repositories and to Dockerhub / GCR.
 
 #
 # Agent v6
@@ -9,7 +9,7 @@
 deploy_containers-a6:
   stage: deploy_containers
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     BUCKET_BRANCH: $BUCKET_BRANCH
@@ -19,33 +19,10 @@ deploy_containers-a6:
 deploy_containers-a6-on-failure:
   stage: deploy_containers
   rules:
-    !reference [.on_deploy_a6_failure]
+    !reference [.on_deploy_failure]
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     BUCKET_BRANCH: $BUCKET_BRANCH
     FORCE_MANUAL: "true"
   trigger:
     include: .gitlab/deploy_containers/deploy_containers_a6.yml
-
-
-deploy_containers-a7:
-  stage: deploy_containers
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-    BUCKET_BRANCH: $BUCKET_BRANCH
-  trigger:
-    include: .gitlab/deploy_containers/deploy_containers_a7.yml
-
-
-deploy_containers-a7-on-failure:
-  stage: deploy_containers
-  rules:
-    !reference [.on_deploy_a7_failure]
-  variables:
-    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-    BUCKET_BRANCH: $BUCKET_BRANCH
-    FORCE_MANUAL: "true"
-  trigger:
-    include: .gitlab/deploy_containers/deploy_containers_a7.yml

--- a/.gitlab/deploy_containers/deploy_containers_a6.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a6.yml
@@ -1,6 +1,6 @@
 ---
 # deploy containers stage
-# Contains jobs which deploy Agent 6 & 7 to staging repositories and to Dockerhub / GCR.
+# Contains jobs which deploy Agent 6 to staging repositories and to Dockerhub / GCR.
 
 stages:
   - deploy_containers

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -1,6 +1,6 @@
 ---
 # deploy containers stage
-# Contains jobs which deploy Agent 6 & 7 to staging repositories and to Dockerhub / GCR.
+# Contains jobs which deploy Agent 6 to staging repositories and to Dockerhub / GCR.
 
 stages:
   - deploy_containers
@@ -13,24 +13,24 @@ include:
 # Image tagging & manifest publication
 #
 #
-# Agent v7
+# Agent v6
 #
-.deploy_containers-a7-base:
+.deploy_containers-a6-base:
   extends: .docker_publish_job_definition
   stage: deploy_containers
   dependencies: []
   before_script:
     - source /root/.bashrc
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 6 --url-safe --pipeline-id $PARENT_PIPELINE_ID)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${FLAVOR}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${FLAVOR}-amd64"
+    - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-6${JMX}-amd64,${IMG_BASE_SRC}-6${JMX}-arm64"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-6${JMX}-win1809${FLAVOR}-amd64,${IMG_BASE_SRC}-6${JMX}-winltsc2022${FLAVOR}-amd64"
     - if [[ "$FLAVOR" == "-linux" ]]; then export IMG_SOURCES="${IMG_LINUX_SOURCES}"; elif [[ "$FLAVOR" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${FLAVOR}${JMX}"
 
 
-.deploy_containers-a7_external:
-  extends: .deploy_containers-a7-base
+.deploy_containers-a6_external:
+  extends: .deploy_containers-a6-base
   parallel:
     matrix:
       - JMX:
@@ -42,17 +42,17 @@ include:
           - "-linux"
 
 
-deploy_containers-a7:
-  extends: .deploy_containers-a7_external
+deploy_containers-a6:
+  extends: .deploy_containers-a6_external
   rules:
     !reference [.manual_on_deploy_auto_on_rc]
 
-deploy_containers-a7-rc:
-  extends: .deploy_containers-a7_external
+deploy_containers-a6-rc:
+  extends: .deploy_containers-a6_external
   rules:
     !reference [.on_rc]
   variables:
-    VERSION: 7-rc
+    VERSION: 6-rc
 
 deploy_containers-a7_internal:
   extends: .deploy_containers-a7-base
@@ -62,19 +62,19 @@ deploy_containers-a7_internal:
     JMX: "-jmx"
 
 
-deploy_containers-a7_internal-rc:
-  extends: .deploy_containers-a7-base
+deploy_containers-a6_internal-rc:
+  extends: .deploy_containers-a6-base
   rules:
     !reference [.on_internal_rc]
   variables:
-    VERSION: 7-rc
+    VERSION: 6-rc
 
 
 #
 # Latest publication
 #
 
-deploy_containers_latest-a7:
+deploy_containers_latest-a6:
   extends: .docker_publish_job_definition
   stage: deploy_containers
   rules:
@@ -82,21 +82,21 @@ deploy_containers_latest-a7:
   dependencies: []
   parallel:
     matrix:
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
         IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7,${AGENT_REPOSITORY}:latest
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:6,${AGENT_REPOSITORY}:latest
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx"
         IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx,${AGENT_REPOSITORY}:latest-jmx
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:6-jmx,${AGENT_REPOSITORY}:latest-jmx
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
         IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore,${AGENT_REPOSITORY}:latest-servercore
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:6-servercore,${AGENT_REPOSITORY}:latest-servercore
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx"
         IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:6-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
 
-deploy_containers_latest-a7_internal:
+deploy_containers_latest-a6_internal:
   extends: .docker_publish_job_definition
   stage: deploy_containers
   rules:
@@ -104,6 +104,6 @@ deploy_containers_latest-a7_internal:
   dependencies: []
   parallel:
     matrix:
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx"
         IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:6-jmx

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -18,26 +18,26 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
-# will push the `7.xx.y-rc.z` tags
+# will push the `6.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a6_rc]
+  rules: !reference [.on_deploy_rc]
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a6_rc]
+  rules: !reference [.on_deploy_rc]
   variables:
     VERSION: rc
 
-# will push the `7.xx.y` tags
+# will push the `6.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a6_manual_final]
+  rules: !reference [.on_deploy_manual_final]
 
 # will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a6_manual_final]
+  rules: !reference [.on_deploy_manual_final]
   variables:
     VERSION: latest

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -12,7 +12,7 @@ include:
   dependencies: []
   before_script:
     - source /root/.bashrc
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 6 --url-safe)"; fi
     - if [[ "$CWS_INSTRUMENTATION_REPOSITORY" == "" ]]; then export CWS_INSTRUMENTATION_REPOSITORY="cws-instrumentation"; fi
     - export IMG_BASE_SRC="${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
@@ -21,23 +21,23 @@ include:
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a7_rc]
+  rules: !reference [.on_deploy_a6_rc]
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a7_rc]
+  rules: !reference [.on_deploy_a6_rc]
   variables:
     VERSION: rc
 
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a7_manual_final]
+  rules: !reference [.on_deploy_a6_manual_final]
 
 # will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_a7_manual_final]
+  rules: !reference [.on_deploy_a6_manual_final]
   variables:
     VERSION: latest

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -16,7 +16,7 @@ include:
       artifacts: false
   before_script:
     - source /root/.bashrc
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 6 --url-safe)"; fi
     - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
     - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
@@ -24,32 +24,32 @@ include:
 
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_manual_auto_on_rc]
+  rules: !reference [.on_deploy_a6_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_rc]
+  rules: !reference [.on_deploy_a6_rc]
   variables:
     VERSION: rc
 
 deploy_containers-dca-latest:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_manual_final]
+  rules: !reference [.on_deploy_a6_manual_final]
   variables:
     VERSION: latest
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_internal_manual_final]
+  rules: !reference [.on_deploy_a6_internal_manual_final]
 
 deploy_containers-dca_internal-rc:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_internal_rc]
+  rules: !reference [.on_deploy_a6_internal_rc]
   variables:
     VERSION: rc
 
 deploy_containers-dca_internal-latest:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a7_internal_manual_final]
+  rules: !reference [.on_deploy_a6_internal_manual_final]
   variables:
     VERSION: latest

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -24,32 +24,32 @@ include:
 
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_manual_auto_on_rc]
+  rules: !reference [.on_deploy_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_rc]
+  rules: !reference [.on_deploy_rc]
   variables:
     VERSION: rc
 
 deploy_containers-dca-latest:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_manual_final]
+  rules: !reference [.on_deploy_manual_final]
   variables:
     VERSION: latest
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_internal_manual_final]
+  rules: !reference [.on_deploy_internal_manual_final]
 
 deploy_containers-dca_internal-rc:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_internal_rc]
+  rules: !reference [.on_deploy_internal_rc]
   variables:
     VERSION: rc
 
 deploy_containers-dca_internal-latest:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_a6_internal_manual_final]
+  rules: !reference [.on_deploy_internal_manual_final]
   variables:
     VERSION: latest

--- a/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
@@ -1,7 +1,7 @@
 ---
 deploy_cluster_agent_cloudfoundry:
   rules:
-    !reference [.on_deploy_a7]
+    !reference [.on_deploy_a6]
   stage: deploy_packages
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]

--- a/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
@@ -1,7 +1,7 @@
 ---
 deploy_cluster_agent_cloudfoundry:
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   stage: deploy_packages
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -12,7 +12,7 @@
   extends: .deploy_packages_deb
   stage: deploy_packages
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     MAJOR_VERSION: 6
 
@@ -31,7 +31,7 @@
   extends: .deploy_packages_rpm
   stage: deploy_packages
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     MAJOR_VERSION: 6
 
@@ -45,6 +45,6 @@
   extends: .deploy_packages_suse_rpm
   stage: deploy_packages
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     MAJOR_VERSION: 6

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -16,14 +16,6 @@
   variables:
     MAJOR_VERSION: 6
 
-.deploy_packages_deb-7:
-  extends: .deploy_packages_deb
-  stage: deploy_packages
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    MAJOR_VERSION: 7
-
 .deploy_packages_rpm:
   resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
@@ -43,14 +35,6 @@
   variables:
     MAJOR_VERSION: 6
 
-.deploy_packages_rpm-7:
-  extends: .deploy_packages_rpm
-  stage: deploy_packages
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    MAJOR_VERSION: 7
-
 .deploy_packages_suse_rpm:
   extends: .deploy_packages_rpm
   variables:
@@ -64,11 +48,3 @@
     !reference [.on_deploy_a6]
   variables:
     MAJOR_VERSION: 6
-
-.deploy_packages_suse_rpm-7:
-  extends: .deploy_packages_suse_rpm
-  stage: deploy_packages
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    MAJOR_VERSION: 7

--- a/.gitlab/deploy_packages/include.yml
+++ b/.gitlab/deploy_packages/include.yml
@@ -1,6 +1,6 @@
 ---
 # deploy_packages stage
-# Contains jobs which deploy Agent 6 & 7 to staging repositories.
+# Contains jobs which deploy Agent 6 to staging repositories.
 # Jobs are expected to depend on the underlying build job and
 # start as soon as possible.
 

--- a/.gitlab/deploy_packages/nix.yml
+++ b/.gitlab/deploy_packages/nix.yml
@@ -39,47 +39,8 @@ deploy_packages_suse_rpm-x64-6:
   variables:
     PACKAGE_ARCH: x86_64
 
-#
-# Agent v7
-#
-deploy_packages_deb-x64-7:
-  extends: .deploy_packages_deb-7
-  needs: [ agent_deb-x64-a7 ]
-  variables:
-    PACKAGE_ARCH: amd64
-
-deploy_packages_deb-arm64-7:
-  extends: .deploy_packages_deb-7
-  needs: [ agent_deb-arm64-a7 ]
-  variables:
-    PACKAGE_ARCH: arm64
-
-deploy_packages_heroku_deb-x64-7:
-  extends: .deploy_packages_deb-7
-  needs: [ agent_heroku_deb-x64-a7 ]
-  variables:
-    PACKAGE_ARCH: amd64
-
-deploy_packages_rpm-x64-7:
-  extends: .deploy_packages_rpm-7
-  needs: [ agent_rpm-x64-a7 ]
-  variables:
-    PACKAGE_ARCH: x86_64
-
-deploy_packages_rpm-arm64-7:
-  extends: .deploy_packages_rpm-7
-  needs: [ agent_rpm-arm64-a7 ]
-  variables:
-    PACKAGE_ARCH: aarch64
-
-deploy_packages_suse_rpm-x64-7:
-  extends: .deploy_packages_suse_rpm-7
-  needs: [ agent_suse-x64-a7 ]
-  variables:
-    PACKAGE_ARCH: x86_64
-
-deploy_packages_suse_rpm-arm64-7:
-  extends: .deploy_packages_suse_rpm-7
-  needs: [ agent_suse-arm64-a7 ]
+deploy_packages_suse_rpm-arm64-6:
+  extends: .deploy_packages_suse_rpm-6
+  needs: [ agent_suse-arm64-a6 ]
   variables:
     PACKAGE_ARCH: aarch64

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -4,7 +4,7 @@
 #
 deploy_packages_windows-x64-6:
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   stage: deploy_packages
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
@@ -19,33 +19,13 @@ deploy_packages_windows-x64-6:
       --include "datadog-agent-6*.debug.zip"
       $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
 
-#
-# Agent v7
-#
-deploy_packages_windows-x64-7:
+deploy_staging_windows_tags-6:
   rules:
-    !reference [.on_deploy_a7]
+    !reference [.on_deploy_stable_or_beta_repo_branch]
   stage: deploy_packages
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7"]
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD
-      --recursive
-      --exclude "*"
-      --include "datadog-agent-7*.msi"
-      --include "datadog-agent-7*.debug.zip"
-      $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/ || true
-
-deploy_staging_windows_tags-7:
-  rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7]
-  stage: deploy_packages
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
+  needs: ["windows_msi_and_bosh_zip_x64-a6", "windows_zip_agent_binaries_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
@@ -53,17 +33,17 @@ deploy_staging_windows_tags-7:
     - $S3_CP_CMD
       --recursive
       --exclude "*"
-      --include "datadog-agent-7.*.zip"
+      --include "datadog-agent-6.*.zip"
       $OMNIBUS_PACKAGE_DIR
-      $S3_DSD6_URI/windows/agent7/bosh/
+      $S3_DSD6_URI/windows/agent6/bosh/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     # used for cloudfoundry buildpack and azure-app-services
     - $S3_CP_CMD
       --recursive
       --exclude "*"
-      --include "agent-binaries-7.*.zip"
-      $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/buildpack/
+      --include "agent-binaries-6.*.zip"
+      $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent6/buildpack/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -5,7 +5,7 @@ include:
 dev_branch-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_a6_manual]
+  rules: !reference [.manual]
   needs:
     - docker_build_agent6
     - docker_build_agent6_jmx
@@ -24,7 +24,7 @@ dev_branch-a6:
 dev_branch_multiarch-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_all_builds_a6_manual]
+  rules: !reference [.manual]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -42,28 +42,10 @@ dev_branch_multiarch-a6:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-py2py3-jmx-amd64
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2py3-jmx
 
-dev_branch_multiarch-a7:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules: !reference [.on_a7_manual]
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_arm64
-    - docker_build_agent7_jmx
-    - docker_build_agent7_jmx_arm64
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
-
 dev_master-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_main_a6]
+  rules: !reference [.on_main]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -79,28 +61,10 @@ dev_master-a6:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-arm64
         IMG_DESTINATIONS: agent-dev:master-jmx,agent-dev:master-py2-jmx
 
-dev_master-a7:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules: !reference [.on_main_a7]
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_arm64
-    - docker_build_agent7_jmx
-    - docker_build_agent7_jmx_arm64
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-        IMG_DESTINATIONS: agent-dev:master-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
-        IMG_DESTINATIONS: agent-dev:master-py3-jmx
-
 dca_dev_branch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_a7_manual]
+  rules: !reference [.manual]
   needs:
     - docker_build_cluster_agent_amd64
   variables:
@@ -111,7 +75,7 @@ dca_dev_branch:
 dca_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_all_builds_a7_manual]
+  rules: !reference [.on_all_builds_manual]
   needs:
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
@@ -123,7 +87,7 @@ dca_dev_branch_multiarch:
 dca_dev_master:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_main_a7]
+  rules: !reference [.on_main]
   needs:
     - docker_build_cluster_agent_amd64
   variables:
@@ -134,7 +98,7 @@ dca_dev_master:
 cws_instrumentation_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_all_builds_a7_manual]
+  rules: !reference [.on_all_builds_manual]
   needs:
     - docker_build_cws_instrumentation_amd64
     - docker_build_cws_instrumentation_arm64
@@ -147,7 +111,7 @@ cws_instrumentation_dev_branch_multiarch:
 dev_nightly_docker_hub-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_deploy_nightly_repo_branch_a6]
+  rules: !reference [.on_deploy_nightly_repo_branch]
   needs:
     - docker_build_agent6
     - docker_build_agent6_arm64
@@ -164,35 +128,35 @@ dev_nightly_docker_hub-a6:
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-jmx,agent-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py2-jmx,agent-dev:nightly-${CI_COMMIT_REF_SLUG}-py2-jmx
 
 # deploys nightlies to agent-dev
-dev_nightly-a7:
+dev_nightly-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_deploy_nightly_repo_branch_a7]
+  rules: !reference [.on_deploy_nightly_repo_branch]
   needs:
-    - docker_build_agent7
-    - docker_build_agent7_arm64
-    - docker_build_agent7_jmx
-    - docker_build_agent7_jmx_arm64
+    - docker_build_agent6
+    - docker_build_agent6_arm64
+    - docker_build_agent6_jmx
+    - docker_build_agent6_jmx_arm64
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-arm64
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py3,agent-dev:nightly-${CI_COMMIT_REF_SLUG}-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
+      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-arm64
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py3-jmx,agent-dev:nightly-${CI_COMMIT_REF_SLUG}-py3-jmx
 
 # deploy nightly build to single-machine-performance
-single_machine_performance-nightly-amd64-a7:
+single_machine_performance-nightly-amd64-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules: !reference [.on_scheduled_main]
   needs:
-    - docker_build_agent7
+    - docker_build_agent6
   variables:
     IMG_REGISTRIES: internal-aws-smp
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64
+    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-6-amd64
 
 # push images to `datadog-agent-qa` ECR for the end-to-end tests defined in `e2e.yml`
 qa_agent:
@@ -208,7 +172,7 @@ qa_agent:
     - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-winltsc2022-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 qa_dca:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -202,10 +202,10 @@ qa_agent:
     - !reference [.on_container_or_e2e_changes_or_manual]
     - !reference [.on_apm_or_e2e_changes_or_manual]
   needs:
-    - docker_build_agent7
-    - docker_build_agent7_arm64
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows2022
+    - docker_build_agent6
+    - docker_build_agent6_arm64
+    - docker_build_agent6_windows1809_core
+    - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64

--- a/.gitlab/dev_container_deploy/docker_windows.yml
+++ b/.gitlab/dev_container_deploy/docker_windows.yml
@@ -2,42 +2,11 @@
 include:
   - .gitlab/common/container_publish_job_templates.yml
 
-dev_branch-a7-windows:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
-  needs:
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows1809_core
-    - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
-
 dev_branch-a6-windows:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    !reference [.on_a6_manual]
+    !reference [.manual]
   needs:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows2022_core
@@ -49,42 +18,11 @@ dev_branch-a6-windows:
         IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
-dev_master-a7-windows:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    !reference [.on_main_a7]
-  needs:
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows1809_core
-    - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:master-py3-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
-
 dev_master-a6-windows:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    !reference [.on_main_a6]
+    !reference [.on_main]
   needs:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows2022_core
@@ -96,42 +34,11 @@ dev_master-a6-windows:
         IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
-dev_nightly-a7-windows:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
-  needs:
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows1809_core
-    - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-winltsc2022-amd64"
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
-      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-winltsc2022-servercore-amd64"
-        IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
-
 dev_nightly-a6-windows:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    !reference [.on_deploy_nightly_repo_branch_a6]
+    !reference [.on_deploy_nightly_repo_branch]
   needs:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows2022_core

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -117,6 +117,7 @@ k8s-e2e-otlp-main:
     E2E_PIPELINE_ID: $CI_PIPELINE_ID
     E2E_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
     E2E_OUTPUT_DIR: $CI_PROJECT_DIR/e2e-output
+    E2E_MAJOR_VERSION: 6
   script:
     - inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS}
   after_script:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -24,7 +24,7 @@
 .k8s_e2e_template_needs_dev:
   extends: .k8s_e2e_template
   needs:
-    - dev_branch_multiarch-a7
+    - dev_branch_multiarch-a6
     - dca_dev_branch
 
 .k8s_e2e_template_dev:
@@ -41,7 +41,7 @@
 .k8s_e2e_template_needs_main:
   extends: .k8s_e2e_template
   needs:
-    - dev_master-a7
+    - dev_master-a6
     - dca_dev_master
 
 .k8s_e2e_template_main_with_cws_cspm_init:
@@ -139,13 +139,13 @@ k8s-e2e-otlp-main:
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
-    - deploy_deb_testing-a7_x64
+    - deploy_deb_testing-a6_x64
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - deploy_deb_testing-a6_x64
+    - deploy_windows_testing-a6
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
@@ -223,9 +223,9 @@ new-e2e-npm:
   rules: !reference [.on_npm_or_e2e_changes_or_manual]
   needs:
     - qa_agent
-    - deploy_deb_testing-a7_x64
-    - deploy_rpm_testing-a7_x64
-    - deploy_windows_testing-a7
+    - deploy_deb_testing-a6_x64
+    - deploy_rpm_testing-a6_x64
+    - deploy_windows_testing-a6
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
@@ -241,7 +241,7 @@ new-e2e-cws:
   extends: .new_e2e_template
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
   needs:
-    - deploy_deb_testing-a7_x64
+    - deploy_deb_testing-a6_x64
     - qa_cws_instrumentation
     - qa_agent
   variables:
@@ -273,7 +273,7 @@ new-e2e-apm:
   rules: !reference [.on_apm_or_e2e_changes_or_manual]
   needs:
     - qa_agent
-    - deploy_deb_testing-a7_x64
+    - deploy_deb_testing-a6_x64
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent

--- a/.gitlab/functional_test/common.yml
+++ b/.gitlab/functional_test/common.yml
@@ -13,7 +13,7 @@
     !reference [.on_system_probe_or_e2e_changes_or_manual]
   timeout: 3h
   variables:
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
     CHEF_VERSION: 14.15.6
 
@@ -25,6 +25,6 @@
     !reference [.manual]
   stage: functional_test
   variables:
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
     CHEF_VERSION: 14.15.6

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -6,7 +6,7 @@ single-machine-performance-regression_detector:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
   needs:
-    - job: single_machine_performance-amd64-a7
+    - job: single_machine_performance-amd64-a6
       artifacts: false
   artifacts:
     expire_in: 1 weeks
@@ -58,15 +58,15 @@ single-machine-performance-regression_detector:
     - BASELINE_SHA="${SMP_MERGE_BASE}"
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
-    - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
+    - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-6-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"
     - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"
     # Copy the baseline SHA to SMP for debugging purposes later
     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
-    - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
+    - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-6-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
-    - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
+    - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-6-amd64
     - echo "${CI_COMMIT_SHA} | ${COMPARISON_IMAGE}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -162,7 +162,7 @@ kitchen_stress_security_agent:
   stage: functional_test
   needs: ["tests_ebpf_x64", "prepare_ebpf_functional_tests_x64"]
   variables:
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
   before_script:
     - pushd $DD_AGENT_TESTING_DIR
@@ -189,9 +189,9 @@ kitchen_test_security_agent_windows_x64:
     KITCHEN_OSVERS: "win2016"
     CHEF_VERSION: 14.12.9 # newer versions error out during kitchen setup of azure VM
   before_script:
-    - export WINDOWS_DDPROCMON_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_DRIVER")
-    - export WINDOWS_DDPROCMON_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_VERSION")
-    - export WINDOWS_DDPROCMON_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_SHASUM")
+    - export WINDOWS_DDPROCMON_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_DRIVER")
+    - export WINDOWS_DDPROCMON_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_VERSION")
+    - export WINDOWS_DDPROCMON_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_SHASUM")
     - pushd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   script:

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -8,7 +8,7 @@
 
 kitchen_test_system_probe_windows_x64:
   extends:
-    - .kitchen_agent_a7
+    - .kitchen_agent_a6
     - .kitchen_os_windows
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
@@ -20,9 +20,9 @@ kitchen_test_system_probe_windows_x64:
     KITCHEN_OSVERS: "win2016"
     CHEF_VERSION: 14.12.9 # newer versions error out during kitchen setup of azure VM
   before_script:
-    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_DRIVER")
-    - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_VERSION")
-    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_SHASUM")
+    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDNPM_DRIVER")
+    - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDNPM_VERSION")
+    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDNPM_SHASUM")
     - pushd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   script:

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -4,7 +4,7 @@ single-machine-performance-workload-checks:
   tags: ["runner:docker"]
   rules: !reference [.on_scheduled_main]
   needs:
-    - job: single_machine_performance-nightly-amd64-a7
+    - job: single_machine_performance-nightly-amd64-a6
       artifacts: false
   artifacts:
     expire_in: 1 weeks
@@ -33,7 +33,7 @@ single-machine-performance-workload-checks:
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
     - CURRENT_DATE=$(date --utc '+%Y_%m_%d')
-    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-6-amd64
     # Copy the TARGET_IMAGE to SMP for debugging purposes later
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -14,8 +14,8 @@ test_install_script:
       --variable TESTING_APT_URL
       --variable TESTING_YUM_URL
       --variable TEST_PIPELINE_ID"
-  needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_suse_rpm_testing_x64-a6", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64", "deploy_suse_rpm_testing_x64-a7"]
+  needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_suse_rpm_testing_x64-a6"]
   rules:
-    - !reference [.except_no_a6_or_no_a7]
+    - !reference [.except_mergequeue]
     - !reference [.on_deploy]
 

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -4,11 +4,11 @@
 
 docker_trigger_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a7_internal_or_manual]
+  rules: !reference [.on_deploy_a6_internal_or_manual]
   needs:
-    - job: docker_build_agent7_jmx
+    - job: docker_build_agent6_jmx
       artifacts: false
-    - job: docker_build_agent7_jmx_arm64
+    - job: docker_build_agent6_jmx_arm64
       artifacts: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -50,7 +50,7 @@ docker_trigger_internal:
 
 docker_trigger_cluster_agent_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy_a6]
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false
@@ -97,7 +97,7 @@ docker_trigger_cluster_agent_internal:
 
 docker_trigger_cws_instrumentation_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy_a6]
   needs:
     - job: docker_build_cws_instrumentation_amd64
       artifacts: false

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -4,7 +4,7 @@
 
 docker_trigger_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a6_internal_or_manual]
+  rules: !reference [.on_deploy_internal_or_manual]
   needs:
     - job: docker_build_agent6_jmx
       artifacts: false
@@ -50,7 +50,7 @@ docker_trigger_internal:
 
 docker_trigger_cluster_agent_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a6]
+  rules: !reference [.on_deploy]
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false
@@ -97,7 +97,7 @@ docker_trigger_cluster_agent_internal:
 
 docker_trigger_cws_instrumentation_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy_a6]
+  rules: !reference [.on_deploy]
   needs:
     - job: docker_build_cws_instrumentation_amd64
       artifacts: false

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -14,7 +14,7 @@ internal_kubernetes_deploy_experimental:
       when: never
     - if: $DDR != "true"
       when: never
-    - !reference [.on_deploy_a7]
+    - !reference [.on_deploy_a6]
   needs:
     - job: docker_trigger_internal
       artifacts: false
@@ -56,7 +56,7 @@ notify-slack:
       when: never
     - if: $DDR != "true"
       when: never
-    - !reference [.on_deploy_a7]
+    - !reference [.on_deploy_a6]
   tags: ["arch:amd64"]
   needs: ["internal_kubernetes_deploy_experimental"]
   script:

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -14,7 +14,7 @@ internal_kubernetes_deploy_experimental:
       when: never
     - if: $DDR != "true"
       when: never
-    - !reference [.on_deploy_a6]
+    - !reference [.on_deploy]
   needs:
     - job: docker_trigger_internal
       artifacts: false
@@ -56,7 +56,7 @@ notify-slack:
       when: never
     - if: $DDR != "true"
       when: never
-    - !reference [.on_deploy_a6]
+    - !reference [.on_deploy]
   tags: ["arch:amd64"]
   needs: ["internal_kubernetes_deploy_experimental"]
   script:

--- a/.gitlab/kitchen_cleanup/cleanup.yml
+++ b/.gitlab/kitchen_cleanup/cleanup.yml
@@ -8,7 +8,7 @@
     - aws s3 rm s3://$DEB_TESTING_S3_BUCKET/dists/pipeline-$DD_PIPELINE_ID --recursive
     - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/testing/pipeline-$DD_PIPELINE_ID --recursive
     - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/testing/suse/pipeline-$DD_PIPELINE_ID --recursive
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
     - aws s3 rm s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET --recursive
     - cd $OMNIBUS_PACKAGE_DIR
     # Remove all deb packages for the pipeline in the pool

--- a/.gitlab/kitchen_cleanup/kitchen_cleanup.yml
+++ b/.gitlab/kitchen_cleanup/kitchen_cleanup.yml
@@ -11,13 +11,6 @@
 kitchen_cleanup_azure-a6:
   extends: .kitchen_cleanup_azure_common
   rules:
-    !reference [.on_kitchen_tests_a6_always]
+    !reference [.on_kitchen_tests_always]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
-
-kitchen_cleanup_azure-a7:
-  extends: .kitchen_cleanup_azure_common
-  rules:
-    !reference [.on_default_kitchen_tests_a7_always]
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -15,7 +15,7 @@
 
 .setup_signing_keys_package:
   &setup_signing_keys_package # Set up prod apt repo to get the datadog-signing-keys package
-  - echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list
+  - echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list
   - touch /usr/share/keyrings/datadog-archive-keyring.gpg
   - chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
   - curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
@@ -49,7 +49,10 @@
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_deb_testing-a6_x64:
-  rules: !reference [.on_kitchen_tests_a6]
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   extends:
     - .deploy_deb_testing-a6
   needs:
@@ -70,7 +73,10 @@ deploy_deb_testing-a6_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a6_arm64:
-  rules: !reference [.on_all_kitchen_builds_a6]
+  rules:
+    - !reference [.on_all_install_script_tests]
+    - !reference [.on_installer_or_e2e_changes]
+    - !reference [.manual]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6"]
@@ -82,54 +88,6 @@ deploy_deb_testing-a6_arm64:
 
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 6 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_6*arm64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 6 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
-
-.deploy_deb_testing-a7:
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  <<: *deploy_deb_resource_group-a7
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR
-
-deploy_deb_testing-a7_x64:
-  rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.on_a7]
-  extends:
-    - .deploy_deb_testing-a7
-  needs:
-    [
-      "agent_deb-x64-a7",
-      "agent_heroku_deb-x64-a7",
-      "lint_linux-x64",
-    ]
-  script:
-    - *setup_apt_signing_key
-    - set +x # make sure we don't output the creds to the build log
-
-    - *setup_signing_keys_package
-
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
-
-deploy_deb_testing-a7_arm64:
-  rules: !reference [.on_all_kitchen_builds_a7]
-  extends:
-    - .deploy_deb_testing-a7
-  needs: ["agent_deb-arm64-a7", "lint_linux-arm64"]
-  script:
-    - *setup_apt_signing_key
-    - set +x # make sure we don't output the creds to the build log
-
-    - *setup_signing_keys_package
-
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*arm64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID-arm64" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 .deploy_rpm_testing-a6:
   stage: kitchen_deploy
@@ -159,7 +117,10 @@ deploy_rpm_testing-a6_x64:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
 
 deploy_rpm_testing-a6_arm64:
-  rules: !reference [.on_all_kitchen_builds_a6]
+  rules:
+    - !reference [.on_all_install_script_tests]
+    - !reference [.on_installer_or_e2e_changes]
+    - !reference [.manual]
   extends:
     - .deploy_rpm_testing-a6
   needs:
@@ -173,7 +134,10 @@ deploy_rpm_testing-a6_arm64:
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*aarch64.rpm
 
 deploy_suse_rpm_testing_x64-a6:
-  rules: !reference [.on_kitchen_tests_a6]
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
@@ -192,48 +156,30 @@ deploy_suse_rpm_testing_x64-a6:
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-6.*x86_64.rpm
 
-deploy_suse_rpm_testing_x64-a7:
+deploy_suse_rpm_testing_arm64-a6:
   rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.on_a7]
+    - !reference [.on_kitchen_tests]
+    - !reference [.on_installer_or_e2e_changes]
+    - !reference [.manual]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs:
-    [
-      "agent_suse-x64-a7",
-      "lint_linux-x64",
-    ]
+  needs: ["agent_suse-arm64-a6", "lint_linux-arm64"]
   variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
+    DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
     - source /root/.bashrc
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
   script:
     - *setup_rpm_signing_key
     - set +x
-    - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*x86_64.rpm
-
-deploy_suse_rpm_testing_arm64-a7:
-  rules: !reference [.on_kitchen_tests_a7]
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  needs: ["agent_suse-arm64-a7", "lint_linux-arm64"]
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  script:
-    - *setup_rpm_signing_key
-    - set +x
-    - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*aarch64.rpm
+    - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/6/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID --repodata-store-public-key $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-6.*aarch64.rpm
 
 deploy_windows_testing-a6:
   rules:
-    - !reference [.on_kitchen_tests_a6]
-    - !reference [.on_windows_installer_changes_or_manual]
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
@@ -243,19 +189,3 @@ deploy_windows_testing-a6:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6.*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-
-deploy_windows_testing-a7:
-  rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.on_a7]
-    - !reference [.on_windows_installer_changes_or_manual]
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  needs:
-    ["lint_windows-x64", "windows_msi_and_bosh_zip_x64-a7"]
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A7 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/.gitlab/kitchen_deploy/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy/kitchen_deploy.yml
@@ -37,9 +37,6 @@
 .deploy_deb_resource_group-a6: &deploy_deb_resource_group-a6
   resource_group: deploy_deb_a6
 
-.deploy_deb_resource_group-a7: &deploy_deb_resource_group-a7
-  resource_group: deploy_deb_a7
-
 .deploy_deb_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
@@ -145,7 +142,10 @@ deploy_deb_testing-a7_arm64:
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_rpm_testing-a6_x64:
-  rules: !reference [.on_kitchen_tests_a6]
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
   extends:
     - .deploy_rpm_testing-a6
   needs:
@@ -171,42 +171,6 @@ deploy_rpm_testing-a6_arm64:
     - *setup_rpm_signing_key
     - set +x
     - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-6.*aarch64.rpm
-
-.deploy_rpm_testing-a7:
-  stage: kitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["arch:amd64"]
-  variables:
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
-  before_script:
-    - source /root/.bashrc
-    - ls $OMNIBUS_PACKAGE_DIR
-
-deploy_rpm_testing-a7_x64:
-  rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.on_a7]
-  extends:
-    - .deploy_rpm_testing-a7
-  needs:
-    [
-      "agent_rpm-x64-a7",
-      "lint_linux-x64",
-    ]
-  script:
-    - *setup_rpm_signing_key
-    - set +x
-    - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
-
-deploy_rpm_testing-a7_arm64:
-  rules: !reference [.on_all_kitchen_builds_a7]
-  extends:
-    - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-arm64-a7", "lint_linux-arm64"]
-  script:
-    - *setup_rpm_signing_key
-    - set +x
-    - echo "$RPM_SIGNING_PASSPHRASE" | rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $RPM_GPG_KEY_ID $OMNIBUS_PACKAGE_DIR/datadog-*-7.*aarch64.rpm
 
 deploy_suse_rpm_testing_x64-a6:
   rules: !reference [.on_kitchen_tests_a6]

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -22,20 +22,20 @@
 # Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
-.kitchen_scenario_centos_no_support_for_fips_a7:
+.kitchen_scenario_centos_no_support_for_fips_a6:
   extends:
-    - .kitchen_agent_a7
+    - .kitchen_agent_a6
     - .kitchen_os_centos_no_support_for_fips
     - .kitchen_azure_x64
-  needs: ["deploy_rpm_testing-a7_x64"]
+  needs: ["deploy_rpm_testing-a6_x64"]
 
 # Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------
 
-kitchen_centos_process_agent-a7:
+kitchen_centos_process_agent-a6:
   variables:
     KITCHEN_OSVERS: "rhel-81"
     DEFAULT_KITCHEN_OSVERS: "rhel-81"
   extends:
-    - .kitchen_scenario_centos_no_support_for_fips_a7
+    - .kitchen_scenario_centos_no_support_for_fips_a6
     - .kitchen_test_process_agent

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -18,26 +18,26 @@
 # Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
-.kitchen_scenario_debian_a7_x64:
+.kitchen_scenario_debian_a6_x64:
   variables:
     KITCHEN_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
-    - .kitchen_agent_a7
+    - .kitchen_agent_a6
     - .kitchen_os_debian
     - .kitchen_azure_x64
-  needs: ["deploy_deb_testing-a7_x64"]
+  needs: ["deploy_deb_testing-a6_x64"]
 
 # We only want to run step-by-step tests on deploy pipelines,
 # which is why they have a different rule (if_deploy_6/7)
 
-kitchen_debian_process_agent-a7:
+kitchen_debian_process_agent-a6:
   rules:
-    - !reference [.on_default_kitchen_tests_a7]
+    - !reference [.on_default_kitchen_tests]
   variables:
     KITCHEN_OSVERS: "debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
-    - .kitchen_scenario_debian_a7_x64
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_process_agent

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -48,7 +48,7 @@
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
   parallel:
     matrix:
-      - START_MAJOR_VERSION: [5, 6, 7]
+      - START_MAJOR_VERSION: [6]
         END_MAJOR_VERSION: [7]
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME )

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -1,13 +1,7 @@
 .new-e2e_agent_a6:
-  rules: !reference [.on_kitchen_tests_a6] #TODO: Change when migration is complete to another name without 'kitchen'
+  rules: !reference [.on_kitchen_tests] #TODO: Change when migration is complete to another name without 'kitchen'
   variables:
     AGENT_MAJOR_VERSION: 6
-  retry: 1
-
-.new-e2e_agent_a7:
-  rules: !reference [.on_kitchen_tests_a7] #TODO: Change when migration is complete to another name without 'kitchen'
-  variables:
-    AGENT_MAJOR_VERSION: 7
   retry: 1
 
 .new-e2e_install_script:

--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -42,7 +42,7 @@
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
   parallel:
     matrix:
-      - START_MAJOR_VERSION: [6]
+      - START_MAJOR_VERSION: [5, 6, 7]
         END_MAJOR_VERSION: [7]
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME )

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -84,9 +84,9 @@ new-e2e-agent-platform-package-signing-amazonlinux-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
-    - .new-e2e_amazonlinux_a7_x86_64
+    - .new-e2e_amazonlinux_a6_x86_64
     - .new-e2e_package_signing
-  rules: !reference [.on_default_new-e2e_tests_a7]
+  rules: !reference [.on_default_new-e2e_tests_a6]
 
 new-e2e-agent-platform-step-by-step-amazonlinux-a6-x86_64:
   stage: kitchen_testing
@@ -146,8 +146,8 @@ new-e2e-agent-platform-install-script-upgrade7-amazonlinux-x64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_amazonlinux_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -18,22 +18,6 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs: ["deploy_rpm_testing-a6_arm64"]
 
-.new-e2e_amazonlinux_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_x64"]
-
-.new-e2e_amazonlinux_a7_arm64:
-  variables:
-    E2E_ARCH: arm64
-    E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    E2E_BRANCH_OSVERS: "amazonlinux2023"
-  needs: ["deploy_rpm_testing-a7_arm64"]
-
 new-e2e-agent-platform-install-script-amazonlinux-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -56,37 +40,13 @@ new-e2e-agent-platform-install-script-amazonlinux-a6-arm64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-amazonlinux-a7-x64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-amazonlinux-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_arm64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_all_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
 new-e2e-agent-platform-package-signing-amazonlinux-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_amazonlinux_a6_x86_64
     - .new-e2e_package_signing
-  rules: !reference [.on_default_new-e2e_tests_a6]
+  rules: !reference [.on_default_new-e2e_tests]
 
 new-e2e-agent-platform-step-by-step-amazonlinux-a6-x86_64:
   stage: kitchen_testing
@@ -97,7 +57,7 @@ new-e2e-agent-platform-step-by-step-amazonlinux-a6-x86_64:
     - .new-e2e_amazonlinux_a6_x86_64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -110,44 +70,7 @@ new-e2e-agent-platform-step-by-step-amazonlinux-a6-arm64:
     - .new-e2e_amazonlinux_a6_arm64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-amazonlinux-a7-x64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_x86_64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-amazonlinux-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_arm64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-amazonlinux-x64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a6_x86_64
-    - .new-e2e_agent_a6
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -161,18 +84,3 @@ new-e2e-agent-platform-install-script-upgrade6-amazonlinux-x64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-amazonlinux-iot-agent-x64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
-        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -10,22 +10,6 @@
     E2E_BRANCH_OSVERS: "centos-79"
   needs: ["deploy_rpm_testing-a6_x64"]
 
-.new-e2e_centos_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "centos-79,rhel-86"
-    E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
-    E2E_BRANCH_OSVERS: "centos-79"
-  needs: ["deploy_rpm_testing-a7_x64"]
-
-.new-e2e_centos-fips_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "rhel-86-fips"
-    E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
-    E2E_BRANCH_OSVERS: "rhel-86-fips"
-  needs: ["deploy_rpm_testing-a7_x64"]
-
 .new-e2e_centos-fips_a6_x86_64:
   variables:
     E2E_ARCH: x86_64
@@ -33,14 +17,6 @@
     E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs: ["deploy_rpm_testing-a6_x64"]
-
-.new-e2e_centos6_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "centos-610"
-    E2E_BRANCH_OSVERS: "centos-610"
-    E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
-  needs: ["deploy_rpm_testing-a7_x64"]
 
 new-e2e-agent-platform-install-script-centos-a6-x86_64:
   stage: kitchen_testing
@@ -175,8 +151,8 @@ new-e2e-agent-platform-install-script-upgrade7-centos-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_centos_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
 
@@ -231,8 +207,8 @@ new-e2e-agent-platform-install-script-upgrade7-centos-fips-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_centos-fips_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
   parallel:

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -29,38 +29,26 @@ new-e2e-agent-platform-install-script-centos-a6-x86_64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-centos-a7-x86_64:
+new-e2e-agent-platform-install-script-centos-iot-agent-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-centos-iot-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
+    - .new-e2e_centos_a6_x86_64
+    - .new-e2e_agent_a6
+  rules: !reference [.on_default_new-e2e_tests]
   variables:
     FLAVOR: datadog-iot-agent
 
-new-e2e-agent-platform-install-script-centos-dogstatsd-a7-x86_64:
+new-e2e-agent-platform-install-script-centos-dogstatsd-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_centos_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-dogstatsd
 
@@ -75,41 +63,6 @@ new-e2e-agent-platform-install-script-centos-fips-a6-x86_64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-centos-fips-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-centos-fips-iot-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-iot-agent
-
-new-e2e-agent-platform-install-script-centos-fips-dogstatsd-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-dogstatsd
-
 new-e2e-agent-platform-step-by-step-centos-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -118,19 +71,7 @@ new-e2e-agent-platform-step-by-step-centos-a6-x86_64:
     - .new-e2e_os_centos
     - .new-e2e_centos_a6_x86_64
     - .new-e2e_agent_a6
-  rules: !reference [.on_deploy_a6]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-centos-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_deploy_a7]
+  rules: !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -145,83 +86,22 @@ new-e2e-agent-platform-install-script-upgrade6-centos-x86_64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-upgrade7-centos-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_centos
-    - .new-e2e_centos_a6_x86_64
-    - .new-e2e_agent_a6
+.new-e2e_centos6_a6_x86_64:
   variables:
-    FLAVOR: datadog-agent
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "centos-610"
+    E2E_BRANCH_OSVERS: "centos-610"
+    E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
+  needs:
+    - go_tools_deps
+    - deploy_rpm_testing-a6_x64
 
-new-e2e-agent-platform-install-script-upgrade7-centos-iot-agent-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
-        END_MAJOR_VERSION: [7]
-
-new-e2e-agent-platform-install-script-upgrade7-centos-fips-iot-agent-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
-        END_MAJOR_VERSION: [7]
-
-new-e2e-agent-platform-install-script-upgrade6-centos-fips-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade6
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [6]
-
-new-e2e-agent-platform-install-script-upgrade7-centos-fips-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6, 7]
-        END_MAJOR_VERSION: [7]
-
-new-e2e-agent-platform-rpm-centos6-a7-x86_64:
+new-e2e-agent-platform-rpm-centos6-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_rpm
     - .new-e2e_os_centos
-    - .new-e2e_centos6_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
+    - .new-e2e_centos6_a6_x86_64
+    - .new-e2e_agent_a6
+  rules: !reference [.on_default_new-e2e_tests]

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -202,8 +202,8 @@ new-e2e-agent-platform-install-script-upgrade7-debian-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_debian_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -18,22 +18,6 @@
     E2E_BRANCH_OSVERS: "debian-10"
   needs: ["deploy_deb_testing-a6_arm64"]
 
-.new-e2e_debian_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
-    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
-    E2E_BRANCH_OSVERS: "debian-11"
-  needs: ["deploy_deb_testing-a7_x64"]
-
-.new-e2e_debian_a7_arm64:
-  variables:
-    E2E_ARCH: arm64
-    E2E_OSVERS: "debian-10"
-    E2E_CWS_SUPPORTED_OSVERS: "debian-10"
-    E2E_BRANCH_OSVERS: "debian-10"
-  needs: ["deploy_deb_testing-a7_arm64"]
-
 new-e2e-agent-platform-install-script-debian-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -56,50 +40,26 @@ new-e2e-agent-platform-install-script-debian-a6-arm64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-debian-a7-x86_64:
+new-e2e-agent-platform-install-script-debian-iot-agent-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-debian-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_arm64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_all_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-debian-iot-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
+    - .new-e2e_debian_a6_x86_64
+    - .new-e2e_agent_a6
+  rules: !reference [.on_default_new-e2e_tests]
   variables:
     FLAVOR: datadog-iot-agent
 
-new-e2e-agent-platform-install-script-debian-dogstatsd-a7-x86_64:
+new-e2e-agent-platform-install-script-debian-dogstatsd-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_debian_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-dogstatsd
 
@@ -114,52 +74,15 @@ new-e2e-agent-platform-install-script-debian-heroku-agent-a6-x86_64:
   variables:
     FLAVOR: datadog-heroku-agent
 
-new-e2e-agent-platform-install-script-debian-heroku-agent-a7-x86_64:
+new-e2e-agent-platform-package-signing-debian-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-heroku-agent
-
-new-e2e-agent-platform-package-signing-debian-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a6_x86_64
     - .new-e2e_package_signing
-  rules: !reference [.on_default_new-e2e_tests_a7]
+  rules: !reference [.on_default_new-e2e_tests]
 
-new-e2e-agent-platform-step-by-step-debian-a7-x64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-debian-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_arm64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-debian-a6-x86_64:
+new-e2e-agent-platform-step-by-step-debian-a6-x64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
@@ -168,7 +91,7 @@ new-e2e-agent-platform-step-by-step-debian-a6-x86_64:
     - .new-e2e_debian_a6_x86_64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -181,7 +104,20 @@ new-e2e-agent-platform-step-by-step-debian-a6-arm64:
     - .new-e2e_debian_a6_arm64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
+  variables:
+    FLAVOR: datadog-agent
+
+new-e2e-agent-platform-step-by-step-debian-a6-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_step_by_step
+    - .new-e2e_os_debian
+    - .new-e2e_debian_a6_x86_64
+    - .new-e2e_agent_a6
+  rules:
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -195,29 +131,3 @@ new-e2e-agent-platform-install-script-upgrade6-debian-x86_64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-debian-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-debian-iot-agent-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
-        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -143,13 +143,13 @@ new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
   parallel:
     matrix:
-      - START_MAJOR_VERSION: [6,7]
+      - START_MAJOR_VERSION: [6]
         END_MAJOR_VERSION: [7]
 
 new-e2e-agent-platform-install-script-upgrade6-suse-x86_64:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -16,21 +16,13 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_suse_rpm_testing_x64-a6"]
 
-.new-e2e_suse_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "sles-12,sles-15"
-    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
-    E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_x64-a7"]
-
-.new-e2e_suse_a7_arm64:
+.new-e2e_suse_a6_arm64:
   variables:
     E2E_ARCH: arm64
     E2E_OSVERS: "sles-15"
     E2E_CWS_SUPPORTED_OSVERS: "sles-15"
     E2E_BRANCH_OSVERS: "sles-15"
-  needs: ["deploy_suse_rpm_testing_arm64-a7"]
+  needs: ["deploy_suse_rpm_testing_arm64-a6"]
 
 new-e2e-agent-platform-install-script-suse-a6-x86_64:
   stage: kitchen_testing
@@ -43,60 +35,47 @@ new-e2e-agent-platform-install-script-suse-a6-x86_64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-suse-a7-x86_64:
+new-e2e-agent-platform-install-script-suse-a6-arm64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
+    - .new-e2e_suse_a6_arm64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-suse-a7-arm64:
+new-e2e-agent-platform-install-script-suse-iot-agent-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_arm64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_all_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-suse-iot-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
-  rules: !reference [.on_default_new-e2e_tests_a7]
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
+  rules: !reference [.on_default_new-e2e_tests]
   variables:
     FLAVOR: datadog-iot-agent
 
-new-e2e-agent-platform-install-script-suse-dogstatsd-a7-x86_64:
+new-e2e-agent-platform-install-script-suse-dogstatsd-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-dogstatsd
 
-new-e2e-agent-platform-package-signing-suse-a7-x86_64:
+new-e2e-agent-platform-package-signing-suse-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
-    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_suse_a6_x86_64
     - .new-e2e_package_signing
-  rules: !reference [.on_default_new-e2e_tests_a7]
+  rules: !reference [.on_default_new-e2e_tests]
 
 new-e2e-agent-platform-step-by-step-suse-a6-x86_64:
   stage: kitchen_testing
@@ -107,56 +86,28 @@ new-e2e-agent-platform-step-by-step-suse-a6-x86_64:
     - .new-e2e_suse_a6_x86_64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-step-by-step-suse-a7-x86_64:
+new-e2e-agent-platform-step-by-step-suse-a6-arm64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_step_by_step
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-suse-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a7_arm64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_suse_a6_arm64
     - .new-e2e_agent_a6
+  rules:
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
 
 new-e2e-agent-platform-install-script-upgrade6-suse-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
-    - .new-e2e_script_upgrade7
+    - .new-e2e_script_upgrade6
     - .new-e2e_os_suse
     - .new-e2e_suse_a6_x86_64
     - .new-e2e_agent_a6
@@ -165,19 +116,4 @@ new-e2e-agent-platform-install-script-upgrade6-suse-x86_64:
   parallel:
     matrix:
       - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [6]
-
-new-e2e-agent-platform-install-script-upgrade7-suse-iot-agent-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
         END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -197,8 +197,8 @@ new-e2e-agent-platform-install-script-upgrade7-ubuntu-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_ubuntu_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -31,22 +31,6 @@
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs: ["deploy_deb_testing-a6_arm64"]
 
-.new-e2e_ubuntu_a7_x86_64:
-  variables:
-    E2E_ARCH: x86_64
-    E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
-    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
-    E2E_BRANCH_OSVERS: "ubuntu-22-04"
-  needs: ["deploy_deb_testing-a7_x64"]
-
-.new-e2e_ubuntu_a7_arm64:
-  variables:
-    E2E_ARCH: arm64
-    E2E_OSVERS: "ubuntu-18-04,ubuntu-20-04"
-    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04"
-    E2E_BRANCH_OSVERS: "ubuntu-20-04"
-  needs: ["deploy_deb_testing-a7_arm64"]
-
 new-e2e-agent-platform-install-script-ubuntu-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -69,51 +53,25 @@ new-e2e-agent-platform-install-script-ubuntu-a6-arm64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-ubuntu-a7-x86_64:
+new-e2e-agent-platform-install-script-ubuntu-iot-agent-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_default_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-ubuntu-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_arm64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_all_new-e2e_tests_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-ubuntu-iot-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_ubuntu_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-iot-agent
 
-new-e2e-agent-platform-install-script-ubuntu-dogstatsd-a7-x86_64:
+new-e2e-agent-platform-install-script-ubuntu-dogstatsd-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
+    - .new-e2e_ubuntu_a6_x86_64
+    - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-dogstatsd
 
@@ -128,17 +86,6 @@ new-e2e-agent-platform-install-script-ubuntu-heroku-agent-a6-x86_64:
   variables:
     FLAVOR: datadog-heroku-agent
 
-new-e2e-agent-platform-install-script-ubuntu-heroku-agent-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-heroku-agent
-
 new-e2e-agent-platform-step-by-step-ubuntu-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -148,7 +95,7 @@ new-e2e-agent-platform-step-by-step-ubuntu-a6-x86_64:
     - .new-e2e_ubuntu_a6_x86_64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -161,44 +108,7 @@ new-e2e-agent-platform-step-by-step-ubuntu-a6-arm64:
     - .new-e2e_ubuntu_a6_arm64
     - .new-e2e_agent_a6
   rules:
-    !reference [.on_deploy_a6]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-ubuntu-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-step-by-step-ubuntu-a7-arm64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_step_by_step
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_arm64
-    - .new-e2e_agent_a7
-  rules:
-    !reference [.on_deploy_a7]
-  variables:
-    FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-ubuntu-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a6_x86_64
-    - .new-e2e_agent_a6
+    !reference [.on_deploy]
   variables:
     FLAVOR: datadog-agent
 
@@ -212,18 +122,3 @@ new-e2e-agent-platform-install-script-upgrade6-ubuntu-x86_64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
-
-new-e2e-agent-platform-install-script-upgrade7-ubuntu-iot-agent-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade7
-    - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
-    - .new-e2e_agent_a7
-  variables:
-    FLAVOR: datadog-iot-agent
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [7]
-        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -93,15 +93,15 @@ new-e2e-windows-agent-domain-tests-a7-x86_64:
 
 ## single test for PRs
 ## skipped if the full tests are running
-new-e2e-windows-agent-msi-upgrade-windows-server-a7-x86_64:
+new-e2e-windows-agent-msi-upgrade-windows-server-a6-x86_64:
   stage: kitchen_testing
   extends:
     - .new-e2e_windows_msi
-    - .new-e2e_windows_a7_x86_64
+    - .new-e2e_windows_a6_x86_64
   rules:
     - !reference [.except_main_or_release_branch]
     - !reference [.except_windows_installer_changes]
-    - !reference [.on_default_new-e2e_tests_a7]
+    - !reference [.on_default_new-e2e_tests_a6]
     # must be last since it ends with when: on_success
     - !reference [.except_deploy]
   variables:

--- a/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/windows.yml
@@ -56,39 +56,20 @@ new-e2e-windows-agent-msi-windows-server-a6-x86_64:
     - .new-e2e_windows_a6_x86_64
     - .new-e2e_windows_installer_tests
   rules:
-    - !reference [.on_deploy_a6]
+    - !reference [.on_deploy]
     - !reference [.on_windows_installer_changes_or_manual]
 
-# Agent 7
-.new-e2e_windows_a7_x86_64:
-  variables:
-    WINDOWS_AGENT_ARCH: "x86_64"
-  extends:
-    - .new-e2e_windows_msi
-    - .new-e2e_agent_a7
-  needs: ["deploy_windows_testing-a7"]
-
-## full tests
-new-e2e-windows-agent-msi-windows-server-a7-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new-e2e_windows_a7_x86_64
-    - .new-e2e_windows_installer_tests
-  rules:
-    - !reference [.on_deploy_a7]
-    - !reference [.on_windows_installer_changes_or_manual]
-
-new-e2e-windows-agent-domain-tests-a7-x86_64:
+new-e2e-windows-agent-domain-tests-a6-x86_64:
   stage: kitchen_testing
   variables:
     WINDOWS_AGENT_ARCH: "x86_64"
   extends:
     - .new_e2e_template
     - .new-e2e_windows_domain_test
-    - .new-e2e_agent_a7
-  needs: ["deploy_windows_testing-a7"]
+    - .new-e2e_agent_a6
+  needs: ["deploy_windows_testing-a6"]
   rules:
-    - !reference [.on_deploy_a7]
+    - !reference [.on_deploy]
     - !reference [.on_windows_installer_changes_or_manual]
 
 ## single test for PRs
@@ -101,7 +82,7 @@ new-e2e-windows-agent-msi-upgrade-windows-server-a6-x86_64:
   rules:
     - !reference [.except_main_or_release_branch]
     - !reference [.except_windows_installer_changes]
-    - !reference [.on_default_new-e2e_tests_a6]
+    - !reference [.on_default_new-e2e_tests]
     # must be last since it ends with when: on_success
     - !reference [.except_deploy]
   variables:

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -22,18 +22,18 @@
 # Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
-.kitchen_scenario_suse_x64_a7:
+.kitchen_scenario_suse_x64_a6:
   extends:
-    - .kitchen_agent_a7
+    - .kitchen_agent_a6
     - .kitchen_os_suse
     - .kitchen_azure_x64
-  needs: ["deploy_suse_rpm_testing_x64-a7"]
+  needs: ["deploy_suse_rpm_testing_x64-a6"]
 
 # Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------
 
-kitchen_suse_process_agent_x64-a7:
+kitchen_suse_process_agent_x64-a6:
   extends:
-    - .kitchen_scenario_suse_x64_a7
+    - .kitchen_scenario_suse_x64_a6
     - .kitchen_test_process_agent
 

--- a/.gitlab/kitchen_testing/testing.yml
+++ b/.gitlab/kitchen_testing/testing.yml
@@ -80,7 +80,7 @@
 .kitchen_agent_a6:
   extends: .kitchen_common_with_junit
   rules:
-    !reference [.on_kitchen_tests_a6]
+    !reference [.on_kitchen_tests]
   variables:
     AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -88,7 +88,7 @@
 .kitchen_agent_a7:
   extends: .kitchen_common_with_junit
   rules:
-    !reference [.on_kitchen_tests_a7]
+    !reference [.on_kitchen_tests]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -18,25 +18,25 @@
 # Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
-.kitchen_scenario_ubuntu_a7_x64:
+.kitchen_scenario_ubuntu_a6_x64:
   variables:
     KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     KITCHEN_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
     DEFAULT_KITCHEN_OSVERS: "ubuntu-22-04"
   extends:
-    - .kitchen_agent_a7
+    - .kitchen_agent_a6
     - .kitchen_os_ubuntu
     - .kitchen_azure_x64
-  needs: ["deploy_deb_testing-a7_x64"]
+  needs: ["deploy_deb_testing-a6_x64"]
 
 # Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------
 
-kitchen_ubuntu_process_agent-a7:
+kitchen_ubuntu_process_agent-a6:
   variables:
     KITCHEN_OSVERS: "ubuntu-20-04"
     DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   extends:
-    - .kitchen_scenario_ubuntu_a7_x64
+    - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_process_agent
   allow_failure: true

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -138,7 +138,7 @@
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_windows
-  needs: ["deploy_windows_testing-a7"]
+  needs: ["deploy_windows_testing-a6"]
 
 # Kitchen: final test matrix (test types * scenarios)
 # ----------------------------------------------
@@ -159,11 +159,6 @@ kitchen_windows_installer_npm_driver-a7:
 kitchen_windows_installer_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
-    - .kitchen_test_windows_installer_agent
-
-kitchen_windows_installer_agent-a7:
-  extends:
-    - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_agent
 
 kitchen_windows_upgrade5_agent-a6:

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -16,7 +16,7 @@
     KITCHEN_OSVERS: "win2016,win2019,win2019cn,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
     - cd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   # Windows kitchen tests are slower and more fragile (lots of WinRM::WinRMAuthorizationError and/or execution expired errors)
@@ -34,7 +34,7 @@
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2016"
   before_script:  # Use a smaller set of TEST_PLATFORMS than .kitchen_os_windows
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
     - cd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
   script:
@@ -46,11 +46,11 @@
   extends:
     - .kitchen_azure_x64
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
-    - export WINDOWS_DDPROCMON_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_DRIVER")
-    - export WINDOWS_DDPROCMON_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_VERSION")
-    - export WINDOWS_DDPROCMON_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDPROCMON_SHASUM")
+    - WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
+    - RELEASE_VERSION=$RELEASE_VERSION_6
+    - export WINDOWS_DDPROCMON_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_DRIVER")
+    - export WINDOWS_DDPROCMON_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_VERSION")
+    - export WINDOWS_DDPROCMON_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_6::WINDOWS_DDPROCMON_SHASUM")
 
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
     - cd $DD_AGENT_TESTING_DIR
@@ -72,8 +72,8 @@
   extends:
     - .kitchen_azure_x64
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
+    - export RELEASE_VERSION=$RELEASE_VERSION_6
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
     - cd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
@@ -95,8 +95,8 @@
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2016"
   before_script:  # Use only 2016 and 2019 for testing that we upgrade properly and don't install the driver when not specified
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
-    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
+    - export RELEASE_VERSION=$RELEASE_VERSION_6
     - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
     - cd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
@@ -134,26 +134,20 @@
     - .kitchen_os_windows
   needs: ["deploy_windows_testing-a6"]
 
-.kitchen_scenario_windows_a7:
-  extends:
-    - .kitchen_agent_a7
-    - .kitchen_os_windows
-  needs: ["deploy_windows_testing-a6"]
-
 # Kitchen: final test matrix (test types * scenarios)
 # ----------------------------------------------
 
-kitchen_windows_installer_npm_install_scenarios-a7:
+kitchen_windows_installer_npm_install_scenarios-a6:
   extends:
-    - .kitchen_scenario_windows_a7
+    - .kitchen_scenario_windows_a6
     - .kitchen_test_windows_installer_npm
 
-kitchen_windows_installer_npm_driver-a7:
+kitchen_windows_installer_npm_driver-a6:
   # Run NPM driver installer test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_default_kitchen_tests_a7]
+    !reference [.on_default_kitchen_tests]
   extends:
-    - .kitchen_scenario_windows_a7
+    - .kitchen_scenario_windows_a6
     - .kitchen_test_windows_installer_driver
 
 kitchen_windows_installer_agent-a6:
@@ -161,33 +155,23 @@ kitchen_windows_installer_agent-a6:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_windows_installer_agent
 
-kitchen_windows_upgrade5_agent-a6:
-  extends:
-    - .kitchen_scenario_windows_a6
-    - .kitchen_test_upgrade5_agent
-
-kitchen_windows_upgrade5_agent-a7:
-  extends:
-    - .kitchen_scenario_windows_a7
-    - .kitchen_test_upgrade5_agent
-
 kitchen_windows_upgrade6_agent-a7:
   extends:
-    - .kitchen_scenario_windows_a7
+    - .kitchen_scenario_windows_a6
     - .kitchen_test_upgrade6_agent
 
-kitchen_windows_process_agent-a7:
+kitchen_windows_process_agent-a6:
   variables:
     KITCHEN_OSVERS: "win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   extends:
-    - .kitchen_scenario_windows_a7
+    - .kitchen_scenario_windows_a6
     - .kitchen_test_process_agent
 
-kitchen_windows_installer_cws-a7:
+kitchen_windows_installer_cws-a6:
   # Run NPM driver installer test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_default_kitchen_tests_a7]
+    !reference [.on_default_kitchen_tests]
   extends:
-    - .kitchen_scenario_windows_a7
+    - .kitchen_scenario_windows_a6
     - .kitchen_test_windows_cws

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -5,7 +5,7 @@ include:
 #
 # Use these steps to revert the latest tags to a previous release
 # while maintaining content trust signatures
-# - Create a pipeline on main with the RELEASE_6 and/or RELEASE_7 env vars
+# - Create a pipeline on main with the RELEASE_6  env vars
 # - in the gitlab pipeline view, trigger the step (in the first column)
 #
 revert_latest_6:
@@ -21,28 +21,6 @@ revert_latest_6:
         IMG_DESTINATIONS: agent:6,agent:latest-py2
       - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_6}-jmx
         IMG_DESTINATIONS: agent:6-jmx,agent:latest-py2-jmx
-
-revert_latest_7:
-  extends: .docker_publish_job_definition
-  rules: !reference [.on_main_manual]
-  stage: maintenance_jobs
-  variables:
-    NEW_LATEST_RELEASE_7: "" # tag name of the non-jmx version, for example "7.21.0"
-    IMG_REGISTRIES: public
-  parallel:
-    matrix:
-      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: agent:7,agent:latest
-      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-jmx
-        IMG_DESTINATIONS: agent:7-jmx,agent:latest-jmx
-      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore
-        IMG_DESTINATIONS: agent:7-servercore,agent:latest-servercore
-      - IMG_SOURCES: datadog/agent:${NEW_LATEST_RELEASE_7}-servercore-jmx
-        IMG_DESTINATIONS: agent:7-servercore-jmx,agent:latest-servercore-jmx
-      - IMG_SOURCES: datadog/dogstatsd:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: dogstatsd:7,dogstatsd:latest
-      - IMG_SOURCES: datadog/cluster-agent:${NEW_LATEST_RELEASE_7}
-        IMG_DESTINATIONS: cluster-agent:latest
 
 #
 # Use this step to delete a tag of a given image

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -5,7 +5,7 @@ include:
 #
 # Use these steps to revert the latest tags to a previous release
 # while maintaining content trust signatures
-# - Create a pipeline on main with the RELEASE_6  env vars
+# - Create a pipeline on main with the RELEASE_6 env vars
 # - in the gitlab pipeline view, trigger the step (in the first column)
 #
 revert_latest_6:

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -63,7 +63,7 @@ notify_github:
     - !reference [.except_mergequeue]
     - !reference [.except_main_or_release_branch]
     - !reference [.except_no_tests_no_deploy]
-    - if: $RELEASE_VERSION_7 != ""
+    - if: $RELEASE_VERSION_6 != ""
       changes:
         paths:
           - '**/*.go'
@@ -71,7 +71,7 @@ notify_github:
       when: on_success
     - when: never
   needs:
-    - job: "deploy_deb_testing-a7_x64"
+    - job: "deploy_deb_testing-a6_x64"
       optional: true
   dependencies: []
   allow_failure: true

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -39,7 +39,8 @@
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -59,33 +60,10 @@ agent_deb-x64-a6:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
-agent_deb-x64-a7:
-  extends: .agent_build_common_deb
-  rules:
-    - !reference [.on_a7]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: amd64
-    DESTINATION_DEB: "datadog-agent_7_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_amd64.deb"
-  before_script:
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
-
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
-    - !reference [.on_all_builds_a6]
+    - !reference [.on_all_builds]
     - !reference [.on_packaging_change]
     - !reference [.on_go-version_change]
   stage: package_build
@@ -107,39 +85,9 @@ agent_deb-arm64-a6:
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
-agent_deb-arm64-a7:
-  extends: .agent_build_common_deb
-  rules:
-    - !reference [.on_a7]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
-  tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: arm64
-    DESTINATION_DEB: "datadog-agent_7_arm64.deb"
-    DESTINATION_DBG_DEB: "datadog-agent-dbg_7_arm64.deb"
-  before_script:
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
-
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6
   variables:
     DESTINATION_DEB: "datadog-heroku-agent_6_amd64.deb"
     DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_6_amd64.deb"
-    FLAVOR: heroku
-
-agent_heroku_deb-x64-a7:
-  extends: agent_deb-x64-a7
-  variables:
-    DESTINATION_DEB: "datadog-heroku-agent_7_amd64.deb"
-    DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_7_amd64.deb"
     FLAVOR: heroku

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -34,7 +34,8 @@
 agent_rpm-x64-a6:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -52,35 +53,12 @@ agent_rpm-x64-a6:
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_6
-
-# build Agent package for rpm-x64
-agent_rpm-x64-a7:
-  extends: .agent_build_common_rpm
-  rules:
-    - !reference [.on_a7]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: amd64
-  before_script:
-    - source /root/.bashrc
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 # build Agent package for rpm-arm64
 agent_rpm-arm64-a6:
   extends: .agent_build_common_rpm
   rules:
-    - !reference [.on_all_builds_a6]
+    - !reference [.on_all_builds]
     - !reference [.on_packaging_change]
     - !reference [.on_go-version_change]
   stage: package_build
@@ -100,28 +78,3 @@ agent_rpm-arm64-a6:
   before_script:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_6
-
-# build Agent package for rpm-arm64
-agent_rpm-arm64-a7:
-  extends: .agent_build_common_rpm
-  rules:
-    - !reference [.on_all_builds_a7]
-    - !reference [.on_packaging_change]
-    - !reference [.on_go-version_change]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
-  tags: ["arch:arm64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: arm64
-  before_script:
-    - source /root/.bashrc
-    - export RELEASE_VERSION=$RELEASE_VERSION_7

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -37,7 +37,8 @@
 agent_suse-x64-a6:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -56,35 +57,12 @@ agent_suse-x64-a6:
     - source /root/.bashrc
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
-# build Agent package for suse-x64
-agent_suse-x64-a7:
-  extends: .agent_build_common_suse_rpm
-  rules:
-    - !reference [.on_a7]
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: "3"
-    PACKAGE_ARCH: amd64
-  before_script:
-    - source /root/.bashrc
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
-
 # build Agent package for suse-arm64
 # This is a bit hackish and mostly mimics the CentOS7/arm64 build
-agent_suse-arm64-a7:
+agent_suse-arm64-a6:
   extends: .agent_build_common_suse_rpm
   rules:
-    - !reference [.on_all_builds_a7]
+    - !reference [.on_all_builds]
     - !reference [.on_packaging_change]
     - !reference [.on_go-version_change]
   stage: package_build
@@ -98,10 +76,10 @@ agent_suse-arm64-a7:
       "generate_minimized_btfs_arm64",
     ]
   variables:
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: "3"
     PACKAGE_ARCH: arm64
     OMNIBUS_TASK_EXTRA_PARAMS: "--host-distribution=suse"
   before_script:
     - source /root/.bashrc
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
+    - export RELEASE_VERSION=$RELEASE_VERSION_6

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -56,21 +56,23 @@
   variables:
     OMNIBUS_TARGET: main
 
-windows_msi_and_bosh_zip_x64-a7:
+windows_msi_and_bosh_zip_x64-a6:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_a7]
+    - !reference [.except_mergequeue]
+    - when: on_success
   variables:
     ARCH: "x64"
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: "3"
   before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_7
+    - set RELEASE_VERSION $RELEASE_VERSION_6
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 6
@@ -80,18 +82,19 @@ windows_msi_x64-a6:
   timeout: 3h
 
 # cloudfoundry IoT build for Windows
-windows_zip_agent_binaries_x64-a7:
+windows_zip_agent_binaries_x64-a6:
   rules:
-    - !reference [.on_a7]
+    - !reference [.except_mergequeue]
+    - when: on_success
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     ARCH: "x64"
-    AGENT_MAJOR_VERSION: 7
+    AGENT_MAJOR_VERSION: 6
     OMNIBUS_TARGET: agent_binaries
   before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_7
+    - set RELEASE_VERSION $RELEASE_VERSION_6
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -33,7 +33,7 @@
 
 send_pkg_size-a6:
   allow_failure: true
-  rules: !reference [.on_deploy_a6]
+  rules: !reference [.on_deploy]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -87,95 +87,6 @@ send_pkg_size-a6:
             {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM64_RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]}
           ]}" \
       "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"
-
-send_pkg_size-a7:
-  allow_failure: true
-  rules: !reference [.on_deploy_a7]
-  stage: pkg_metrics
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs:
-    - agent_deb-x64-a7
-    - agent_deb-arm64-a7
-    - agent_heroku_deb-x64-a7
-    - agent_rpm-arm64-a7
-    - agent_rpm-x64-a7
-    - agent_suse-x64-a7
-  before_script:
-    # FIXME: tmp while we uppdate the base image
-    - apt-get install -y wget rpm2cpio cpio
-    - ls -l $OMNIBUS_PACKAGE_DIR
-    - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
-  script:
-    - source /root/.bashrc
-    - !reference [.add_metric_func, script]
-
-    - source /root/.bashrc
-    - mkdir -p /tmp/amd64-deb/agent /tmp/amd64-deb/dogstatsd /tmp/amd64-deb/iot-agent /tmp/amd64-deb/heroku-agent
-    - mkdir -p /tmp/arm64-deb/agent /tmp/arm64-deb/dogstatsd /tmp/arm64-deb/iot-agent
-    - mkdir -p /tmp/amd64-rpm/agent /tmp/amd64-rpm/dogstatsd /tmp/amd64-rpm/iot-agent
-    - mkdir -p /tmp/arm64-rpm/agent /tmp/arm64-rpm/iot-agent
-    - mkdir -p /tmp/amd64-suse/agent /tmp/amd64-suse/dogstatsd /tmp/amd64-suse/iot-agent
-
-    - |
-      add_metrics() {
-          local base="${1}"
-          local os="${2}"
-          local arch="${3}"
-
-          # record the total uncompressed size of each package
-          for package in agent dogstatsd iot-agent heroku-agent; do
-              if [ ! -d "${base}/${package}" ]; then continue; fi
-              add_metric datadog.agent.package.size $(du -sB1 "${base}/${package}" | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:${package} agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          done
-
-          # record the size of each of the important binaries in each package
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          if [[ "$arch" == "amd64" || "$os" == "debian" ]]; then add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}; fi
-          add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
-          if [ -f "${base}/heroku-agent/opt/datadog-agent/bin/agent/agent" ]; then
-              add_metric datadog.agent.binary.size $(du -sB1 ${base}/heroku-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:heroku-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch};
-          fi
-      }
-
-    # We silence dpkg and cpio output so we don't exceed gitlab log limit
-
-    # debian
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_amd64.deb /tmp/amd64-deb/agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/amd64-deb/iot-agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/amd64-deb/dogstatsd > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent_7*_amd64.deb /tmp/amd64-deb/heroku-agent > /dev/null
-    - add_metrics /tmp/amd64-deb debian amd64
-
-    # debian arm64
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_arm64.deb /tmp/arm64-deb/agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_arm64.deb /tmp/arm64-deb/iot-agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_arm64.deb /tmp/arm64-deb/dogstatsd > /dev/null
-    - add_metrics /tmp/arm64-deb debian arm64
-
-    # centos
-    - cd /tmp/amd64-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/amd64-rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/amd64-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/amd64-rpm centos amd64
-
-    # centos arm64
-    - cd /tmp/arm64-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
-    - cd /tmp/arm64-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/arm64-rpm centos arm64
-
-    # suse
-    - cd /tmp/amd64-suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/amd64-suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/amd64-suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/amd64-suse suse amd64
-
-    # Send package and binary size metrics
-    - !reference [.send_metrics, script]
 
 .check_pkg_size:
   stage: pkg_metrics
@@ -239,7 +150,9 @@ send_pkg_size-a7:
 
 check_pkg_size-amd64-a6:
   extends: .check_pkg_size
-  rules: !reference [.on_a6]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
@@ -258,7 +171,7 @@ check_pkg_size-amd64-a6:
 
 check_pkg_size-arm64-a6:
   extends: .check_pkg_size
-  rules: !reference [.on_all_builds_a6]
+  rules: !reference [.on_all_builds]
   needs:
     - agent_deb-arm64-a6
     - agent_rpm-arm64-a6
@@ -272,50 +185,4 @@ check_pkg_size-arm64-a6:
     - |
       declare -Ar max_sizes=(
           ["datadog-agent"]="140000000"
-      )
-
-check_pkg_size-amd64-a7:
-  extends: .check_pkg_size
-  rules: !reference [.on_a7]
-  needs:
-    - agent_deb-x64-a7
-    - agent_heroku_deb-x64-a7
-    - agent_rpm-x64-a7
-    - agent_suse-x64-a7
-  variables:
-    MAJOR_VERSION: 7
-    FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd datadog-heroku-agent"
-    ARCH: "amd64"
-  before_script:
-    # FIXME: ["datadog-agent"]="140000000" and ["datadog-heroku-agent"]="140000000" should
-    # be replaced by "50000000"
-    # "70000000" is needed as of now because of multiple large additions in 7.45
-    - |
-      declare -Ar max_sizes=(
-          ["datadog-agent"]="140000000"
-          ["datadog-iot-agent"]="10000000"
-          ["datadog-dogstatsd"]="10000000"
-          ["datadog-heroku-agent"]="70000000"
-          ["datadog-agentless-scanner"]="10000000"
-      )
-
-check_pkg_size-arm64-a7:
-  extends: .check_pkg_size
-  rules: !reference [.on_all_builds_a7]
-  needs:
-    - agent_deb-arm64-a7
-    - agent_rpm-arm64-a7
-  variables:
-    MAJOR_VERSION: 7
-    FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
-    ARCH: "arm64"
-  before_script:
-    # FIXME: ["datadog-agent"]="140000000" should be replaced by "70000000"
-    # "140000000" is needed as of now because of multiple large additions in 7.45
-    - |
-      declare -Ar max_sizes=(
-          ["datadog-agent"]="140000000"
-          ["datadog-iot-agent"]="10000000"
-          ["datadog-dogstatsd"]="10000000"
-          ["datadog-agentless-scanner"]="10000000"
       )

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -83,7 +83,8 @@ tests_deb-x64-py2:
     - .linux_x64
   rules:
     - !reference [.except_disable_unit_tests]
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   variables:
     PYTHON_RUNTIMES: '2'
     CONDA_ENV: ddpy2
@@ -135,7 +136,8 @@ tests_rpm-x64-py2:
   extends: .rtloader_tests
   rules:
     - !reference [.except_disable_unit_tests]
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
@@ -158,7 +160,8 @@ tests_deb-arm64-py2:
   extends: .rtloader_tests
   rules:
     - !reference [.except_disable_unit_tests]
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:
@@ -185,7 +188,8 @@ tests_rpm-arm64-py2:
   extends: .rtloader_tests
   rules:
     - !reference [.except_disable_unit_tests]
-    - !reference [.on_a6]
+    - !reference [.except_mergequeue]
+    - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -102,15 +102,6 @@ lint_linux-x64:
   extends:
     - .linux_lint
     - .linux_x64
-tests_flavor_iot_deb-x64:
-  extends:
-    - .rtloader_tests
-    - .linux_tests_with_upload
-    - .linux_x64
-  variables:
-    PYTHON_RUNTIMES: '3'
-    CONDA_ENV: ddpy3
-    FLAVORS: '--flavors iot'
 
 tests_flavor_heroku_deb-x64:
   extends:

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -16,10 +16,9 @@
     RELEASE_PRODUCT: datadog-agent
     TARGET_REPO_BRANCH: $BUCKET_BRANCH
   script:
-    # agent-release-management creates pipeline for both Agent 6 and Agent 7
-    # when triggered with major version 7
+    # agent-release-management creates pipeline for Agent 6 
     - source /root/.bashrc
-    - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
+    - export RELEASE_VERSION=$(inv agent.version --major-version 6 --url-safe --omnibus-format)-1
     - export GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $GITLAB_SCHEDULER_TOKEN_SSM_NAME)
     - 'inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "main"
       --variable ACTION

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -404,8 +404,7 @@ def query_version(ctx, git_sha_length=7, prefix=None, major_version_hint=None):
             cmd += " --match \"[0-9]*\""
     if git_sha_length and type(git_sha_length) == int:
         cmd += f" --abbrev={git_sha_length}"
-    print(f"command is {cmd}")
-    described_version = ctx.run(cmd).stdout.strip()
+    described_version = ctx.run(cmd, hide=True).stdout.strip()
 
     # for the example above, 6.0.0-beta.0-1-g4f19118, this will be 1
     commit_number_match = re.match(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$", described_version)

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -404,7 +404,8 @@ def query_version(ctx, git_sha_length=7, prefix=None, major_version_hint=None):
             cmd += " --match \"[0-9]*\""
     if git_sha_length and type(git_sha_length) == int:
         cmd += f" --abbrev={git_sha_length}"
-    described_version = ctx.run(cmd, hide=True).stdout.strip()
+    print(f"command is {cmd}")
+    described_version = ctx.run(cmd).stdout.strip()
 
     # for the example above, 6.0.0-beta.0-1-g4f19118, this will be 1
     commit_number_match = re.match(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$", described_version)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1576,8 +1576,8 @@ def cleanup(ctx):
 def check_omnibus_branches(ctx):
     base_branch = _get_release_json_value('base_branch')
     if base_branch == '6.53.x':
-        omnibus_ruby_branch = 'datadog-5.5.0'
-        omnibus_software_branch = 'master'
+        omnibus_ruby_branch = '6.53.x'
+        omnibus_software_branch = '6.53.x'
     else:
         omnibus_ruby_branch = base_branch
         omnibus_software_branch = base_branch

--- a/tasks/unit-tests/testdata/fake_gitlab-ci.yml
+++ b/tasks/unit-tests/testdata/fake_gitlab-ci.yml
@@ -396,18 +396,18 @@ workflow:
   - <<: *if_deploy
     when: on_failure
 
-.on_deploy_a6:
+.on_deploy:
   - <<: *if_not_version_6
     when: never
   - <<: *if_deploy
 
-.on_deploy_a6_failure:
+.on_deploy_failure:
   - <<: *if_not_version_6
     when: never
   - <<: *if_deploy
     when: on_failure
 
-.on_deploy_a6_rc:
+.on_deploy_rc:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
@@ -419,7 +419,7 @@ workflow:
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-.on_deploy_a6_manual:
+.on_deploy_manual:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
@@ -436,9 +436,9 @@ workflow:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-# Same as on_deploy_a6_manual, except the job would not run on pipelines
+# Same as on_deploy_manual, except the job would not run on pipelines
 # using beta branch, it would only run for the final release.
-.on_deploy_a6_manual_final:
+.on_deploy_manual_final:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
@@ -457,12 +457,12 @@ workflow:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-# This rule is a variation of on_deploy_a6_manual where
+# This rule is a variation of on_deploy_manual where
 # the job is usually run manually, except when the pipeline
 # builds an RC: in this case, the job is run automatically.
 # This is done to reduce the number of manual steps that have
 # to be done when creating RCs.
-.on_deploy_a6_manual_auto_on_rc:
+.on_deploy_manual_auto_on_rc:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
@@ -630,7 +630,7 @@ workflow:
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
-.on_deploy_nightly_repo_branch_a6:
+.on_deploy_nightly_repo_branch:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_nightly_repo_branch


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove all reference of `agent7` for the `agent6` branch

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-375

### Describe how to test/QA your changes
No more agent7 jobs triggered and the configuration can generate the pipeline.

### Possible Drawbacks / Trade-offs
All `kmt`/`new-e2e` tests are failing, because we still need to have a valid version of test-infra definition image (will come in a next PR)
Security and system probe kitchen tests are partially failing. TBC with these teams if these tests can be fixed or marked as flaky

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->