### PR TITLE
[clusteragent] Remove the CPU/memory limits by default for the init container

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -40,7 +40,7 @@ const (
 	mountPath  = "/datadog-lib"
 
 	// defaultMilliCPURequest defines default milli cpu request number.
-	defaultMilliCPURequest int64 = 300 // 0.3 core
+	defaultMilliCPURequest int64 = 50 // 0.05 core
 	// defaultMemoryRequest defines default memory request size.
 	defaultMemoryRequest int64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -39,10 +39,7 @@ const (
 	volumeName = "datadog-auto-instrumentation"
 	mountPath  = "/datadog-lib"
 
-	// defaultMilliCPURequest defines default milli cpu request number.
-	defaultMilliCPURequest int64 = 50 // 0.05 core
-	// defaultMemoryRequest defines default memory request size.
-	defaultMemoryRequest int64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
+	minimumMemoryRequest float64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
 
 	webhookName = "lib_injection"
 )
@@ -55,7 +52,7 @@ type Webhook struct {
 	resources                []string
 	operations               []admissionregistrationv1.OperationType
 	initSecurityContext      *corev1.SecurityContext
-	initResourceRequirements corev1.ResourceRequirements
+	initResourceRequirements initResourceRequirementConfiguration
 	containerRegistry        string
 	injectorImageTag         string
 	injectionFilter          mutatecommon.InjectionFilter
@@ -80,7 +77,7 @@ func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilte
 		return nil, err
 	}
 
-	initResourceRequirements, err := initResources()
+	initResource, err := getInitResourceConfiguration()
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +104,7 @@ func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilte
 		resources:                []string{"pods"},
 		operations:               []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		initSecurityContext:      initSecurityContext,
-		initResourceRequirements: initResourceRequirements,
+		initResourceRequirements: initResource,
 		injectionFilter:          filter,
 		containerRegistry:        containerRegistry,
 		injectorImageTag:         pkgconfigsetup.Datadog().GetString("apm_config.instrumentation.injector_image_tag"),
@@ -564,9 +561,9 @@ func (w *Webhook) extractLibrariesFromAnnotations(pod *corev1.Pod) []libInfo {
 	return libList
 }
 
-func (w *Webhook) initContainerMutators() containerMutators {
+func (w *Webhook) initContainerMutators(requirements corev1.ResourceRequirements) containerMutators {
 	return containerMutators{
-		containerResourceRequirements{w.initResourceRequirements},
+		containerResourceRequirements{requirements},
 		containerSecurityContext{w.initSecurityContext},
 	}
 }
@@ -590,8 +587,113 @@ func (w *Webhook) newInjector(startTime time.Time, pod *corev1.Pod, opts ...inje
 		podMutator(w.version)
 }
 
+// podSumRessourceRequirements computes the sum of cpu/memory necessary for the whole pod.
+// This is computed as max(max(initContainer resources), sum(container resources)) for both limit and request
+func podSumRessourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
+	ressourceRequirement := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+
+	keys := []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU}
+	for _, k := range keys {
+		// Take max(initContainer ressource)
+		for i := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[i]
+			if limit, ok := c.Resources.Limits[k]; ok {
+				existing := ressourceRequirement.Limits[k]
+				if limit.Cmp(existing) == 1 {
+					ressourceRequirement.Limits[k] = limit
+				}
+			}
+			if request, ok := c.Resources.Requests[k]; ok {
+				existing := ressourceRequirement.Requests[k]
+				if request.Cmp(existing) == 1 {
+					ressourceRequirement.Requests[k] = request
+				}
+			}
+		}
+
+		limitSum := resource.Quantity{}
+		reqSum := resource.Quantity{}
+		for i := range pod.Spec.Containers {
+			c := &pod.Spec.Containers[i]
+			if l, ok := c.Resources.Limits[k]; ok {
+				limitSum.Add(l)
+			}
+			if l, ok := c.Resources.Requests[k]; ok {
+				reqSum.Add(l)
+			}
+		}
+		// Take max(sum of container resources)
+		existingLimit := ressourceRequirement.Limits[k]
+		if limitSum.Cmp(existingLimit) == 1 {
+			ressourceRequirement.Limits[k] = limitSum
+		}
+
+		existingReq := ressourceRequirement.Requests[k]
+		if reqSum.Cmp(existingReq) == 1 {
+			ressourceRequirement.Requests[k] = reqSum
+		}
+	}
+
+	return ressourceRequirement
+}
+
+// initContainerResourceRequirements computes init container cpu/memory requests and limits.
+// There are two cases:
+//
+//  1. If a resource quantity was set in config, we use it
+//
+//  2. If no quantity was set, we try to use as much of the resource as we can without impacting
+//     pod scheduling.
+//     Init containers are run one after another. This means that any single init container can use
+//     the maximum amount of the resource requested by the original pod wihtout changing how much of
+//     this resource is necessary.
+//     In particular, for the QoS Guaranteed Limits and Requests have to be equal for every container.
+//     wich means that the max amount of request/limits that we compute is going to be equal to each other
+//     so our init container will also have request == limit.
+//
+//     In the 2nd case, of we wouldn't have enough memory, we bail on injection
+func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequirementConfiguration) (requirements corev1.ResourceRequirements, skipInjection bool) {
+	requirements = corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+	podRequirements := podSumRessourceRequirements(pod)
+
+	for _, k := range [2]corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if q, ok := conf[k]; ok {
+			requirements.Limits[k] = q
+			requirements.Requests[k] = q
+		} else {
+			if maxPodLim, ok := podRequirements.Limits[k]; ok {
+				if k == corev1.ResourceMemory {
+					// If the pod before adding instrumentation init containers would have had a memory limit smaller than
+					// a certain amount, we just don't do anything, for two reasons:
+					// 1. The init containers need quite a lot of memory in order to not OOM
+					// 2. The APM libraries themselves will increase memory footprint of the container by a
+					//   non trivial amount, and we don't want to crash memory constrained apps
+					if maxPodLim.AsApproximateFloat64() <= minimumMemoryRequest {
+						return corev1.ResourceRequirements{}, true
+					}
+				}
+				requirements.Limits[k] = maxPodLim
+			}
+			if maxPodReq, ok := podRequirements.Requests[k]; ok {
+				requirements.Requests[k] = maxPodReq
+			}
+		}
+	}
+	return requirements, false
+}
+
 func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLibInfo) error {
 	if len(config.libs) == 0 {
+		return nil
+	}
+	requirements, skipInjection := initContainerResourceRequirements(pod, w.initResourceRequirements)
+	if skipInjection {
 		return nil
 	}
 
@@ -601,7 +703,7 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
-		initContainerMutators = w.initContainerMutators()
+		initContainerMutators = w.initContainerMutators(requirements)
 		injector              = w.newInjector(time.Now(), pod, injectorWithLibRequirementOptions(libRequirementOptions{
 			initContainerMutators: initContainerMutators,
 		}))
@@ -650,46 +752,28 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 	return lastError
 }
 
-func initResources() (corev1.ResourceRequirements, error) {
-	var resources = corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}}
+type initResourceRequirementConfiguration map[corev1.ResourceName]resource.Quantity
+
+func getInitResourceConfiguration() (initResourceRequirementConfiguration, error) {
+	conf := initResourceRequirementConfiguration{}
 
 	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.cpu") {
 		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.cpu"))
 		if err != nil {
-			return resources, err
+			return conf, err
 		}
-		resources.Requests[corev1.ResourceCPU] = quantity
-	} else {
-		resources.Requests[corev1.ResourceCPU] = *resource.NewMilliQuantity(defaultMilliCPURequest, resource.DecimalSI)
-	}
-
-	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.cpu_limit") {
-		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.cpu_limit"))
-		if err != nil {
-			return resources, err
-		}
-		resources.Limits[corev1.ResourceCPU] = quantity
+		conf[corev1.ResourceCPU] = quantity
 	}
 
 	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.memory") {
 		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.memory"))
 		if err != nil {
-			return resources, err
+			return conf, err
 		}
-		resources.Requests[corev1.ResourceMemory] = quantity
-	} else {
-		resources.Requests[corev1.ResourceMemory] = *resource.NewQuantity(defaultMemoryRequest, resource.DecimalSI)
+		conf[corev1.ResourceMemory] = quantity
 	}
 
-	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.memory_limit") {
-		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.memory_limit"))
-		if err != nil {
-			return resources, err
-		}
-		resources.Limits[corev1.ResourceMemory] = quantity
-	}
-
-	return resources, nil
+	return conf, nil
 }
 
 func parseInitSecurityContext() (*corev1.SecurityContext, error) {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -595,8 +595,7 @@ func podSumRessourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
 		Requests: corev1.ResourceList{},
 	}
 
-	keys := []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU}
-	for _, k := range keys {
+	for _, k := range [2]corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
 		// Take max(initContainer ressource)
 		for i := range pod.Spec.InitContainers {
 			c := &pod.Spec.InitContainers[i]

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -651,7 +651,7 @@ func podSumRessourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
 //     the maximum amount of the resource requested by the original pod wihtout changing how much of
 //     this resource is necessary.
 //     In particular, for the QoS Guaranteed Limits and Requests have to be equal for every container.
-//     wich means that the max amount of request/limits that we compute is going to be equal to each other
+//     which means that the max amount of request/limits that we compute is going to be equal to each other
 //     so our init container will also have request == limit.
 //
 //     In the 2nd case, of we wouldn't have enough memory, we bail on injection

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -39,7 +39,7 @@ const (
 	volumeName = "datadog-auto-instrumentation"
 	mountPath  = "/datadog-lib"
 
-	minimumCpuLimit    float64 = 50                // 0.05 core, otherwise copying + library initialization is going to take forever
+	minimumCPULimit    float64 = 50                // 0.05 core, otherwise copying + library initialization is going to take forever
 	minimumMemoryLimit float64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
 
 	webhookName = "lib_injection"
@@ -693,7 +693,7 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 		} else {
 			if maxPodLim, ok := podRequirements.Limits[k]; ok {
 				if (k == corev1.ResourceMemory && maxPodLim.AsApproximateFloat64() < minimumMemoryLimit) ||
-					(k == corev1.ResourceCPU && maxPodLim.AsApproximateFloat64() < minimumCpuLimit) {
+					(k == corev1.ResourceCPU && maxPodLim.AsApproximateFloat64() < minimumCPULimit) {
 					// If the pod before adding instrumentation init containers would have had a limits smaller than
 					// a certain amount, we just don't do anything, for two reasons:
 					// 1. The init containers need quite a lot of memory/CPU in order to not OOM or initialize in reasonnable time

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1419,6 +1419,59 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wantCPU:           "100",
 			wantMem:           "51Mi",
 		},
+		{
+			name: "sidecar_container",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "java-pod",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container-1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("501"),
+									corev1.ResourceMemory: resource.MustParse("101Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("501"),
+									corev1.ResourceMemory: resource.MustParse("101Mi"),
+								},
+							},
+						}, {
+							Name:          "sidecar-container-1",
+							RestartPolicy: pointer.Ptr(corev1.ContainerRestartPolicyAlways),
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200"),
+							corev1.ResourceMemory: resource.MustParse("101Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200"),
+							corev1.ResourceMemory: resource.MustParse("101Mi"),
+						},
+					}}},
+				},
+			},
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:    java,
+			wantErr: false,
+			wantCPU: "700",
+			wantMem: "151Mi",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1099,7 +1099,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "300m",
+			wantCPU: "50m",
 			wantMem: "100Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
@@ -1134,7 +1134,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:     java,
 			wantErr:  false,
-			wantCPU:  "300m",
+			wantCPU:  "50m",
 			wantMem:  "100Mi",
 			secCtx:   &corev1.SecurityContext{},
 		},
@@ -1145,7 +1145,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "300m",
+			wantCPU: "50m",
 			wantMem: "512Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
@@ -1156,7 +1156,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: true,
-			wantCPU: "300m",
+			wantCPU: "50m",
 			wantMem: "100Mi",
 			secCtx:  &corev1.SecurityContext{},
 		},
@@ -1166,7 +1166,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "300m",
+			wantCPU: "50m",
 			wantMem: "100Mi",
 			secCtx: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -1204,7 +1204,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "300m",
+			wantCPU: "50m",
 			wantMem: "100Mi",
 			secCtx: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1382,7 +1382,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wantMem: "256Mi",
 		},
 		{
-			name: "low_limit_skip",
+			name: "low_memory_skip",
 			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("499"),
@@ -1391,6 +1391,21 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("499"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			}}),
+			image:             "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:              java,
+			wantErr:           false,
+			wantSkipInjection: true,
+		},
+		{
+			name: "low_cpu_skip",
+			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("25"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("25"),
 				},
 			}}),
 			image:             "gcr.io/datadoghq/dd-lib-java-init:v1",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestVolumeMount(t *testing.T) {
@@ -55,8 +56,16 @@ func TestVolumeMount(t *testing.T) {
 }
 
 func TestInitContainer(t *testing.T) {
-	resources, err := initResources()
-	require.NoError(t, err)
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("500Mib"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("500Mib"),
+		},
+	}
 
 	c := initContainer{
 		Container: corev1.Container{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
@@ -59,11 +59,11 @@ func TestInitContainer(t *testing.T) {
 	resources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500Mib"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
 		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("500Mib"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
 		},
 	}
 

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -239,6 +239,11 @@ func FakePod(name string) *corev1.Pod {
 	return FakePodWithContainer(name, corev1.Container{Name: name + "-container"})
 }
 
+// FakePodWithResources with resource requirements
+func FakePodWithResources(name string, reqs corev1.ResourceRequirements) *corev1.Pod {
+	return FakePodWithContainer(name, corev1.Container{Name: name + "-container", Resources: reqs})
+}
+
 func withContainer(pod *corev1.Pod, nameSuffix string) *corev1.Pod {
 	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: pod.Name + nameSuffix})
 	return pod

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3116,7 +3116,7 @@ api_key:
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU_LIMIT - string - optional
       ## Configures the CPU limit for the init containers.
       #
-      # cpu:
+      # cpu_limit:
 
       ## @param memory - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY - string - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3108,15 +3108,27 @@ api_key:
 
       ## @param cpu - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU - string - optional
-      ## Configures the CPU request and limit for the init containers.
+      ## Configures the CPU request for the init containers.
+      #
+      # cpu:
+
+      ## @param cpu_limit - string - optional
+      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU_LIMIT - string - optional
+      ## Configures the CPU limit for the init containers.
       #
       # cpu:
 
       ## @param memory - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY - string - optional
-      ## Configures the memory request and limit for the init containers.
+      ## Configures the memory request for the init containers.
       #
       # memory:
+
+      ## @param memory_limit - string - optional
+      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY_LIMIT - string - optional
+      ## Configures the memory limit for the init containers.
+      #
+      # memory_limit:
 
     ## @param init_security_context - json - optional
     ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_SECURITY_CONTEXT - json - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3112,23 +3112,11 @@ api_key:
       #
       # cpu:
 
-      ## @param cpu_limit - string - optional
-      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU_LIMIT - string - optional
-      ## Configures the CPU limit for the init containers.
-      #
-      # cpu_limit:
-
       ## @param memory - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY - string - optional
       ## Configures the memory request for the init containers.
       #
       # memory:
-
-      ## @param memory_limit - string - optional
-      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY_LIMIT - string - optional
-      ## Configures the memory limit for the init containers.
-      #
-      # memory_limit:
 
     ## @param init_security_context - json - optional
     ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_SECURITY_CONTEXT - json - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3108,13 +3108,13 @@ api_key:
 
       ## @param cpu - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU - string - optional
-      ## Configures the CPU request for the init containers.
+      ## Configures the CPU request that will be applied for the init container's CPU request and limit.
       #
       # cpu:
 
       ## @param memory - string - optional
       ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY - string - optional
-      ## Configures the memory request for the init containers.
+      ## Configures the memory request that will be applied for the init container's memory request and limit.
       #
       # memory:
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -761,7 +761,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", false)                                   // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu_limit")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory_limit")
 	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")
 	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")          // config for ASM which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")           // config for IAST which is implemented in the client libraries

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -761,9 +761,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", false)                                   // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu_limit")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory_limit")
 	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")
 	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")          // config for ASM which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")           // config for IAST which is implemented in the client libraries


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

+ Set the CPU/memory limits and requests for the init container to the maximum that will be used for the pod
+ Block injection if the memory would have been too low and cause OOMs on init containers

### Motivation

The current limits are too low for the SSI init container.
Customer pods will usually allocate a lot more than we are requiring. Since init containers are run sequentially, adding limits/requirements set to what the pod would have needed wihtout us doesn't change the way it is scheduled and gives us a lot more of resources to work with (in most cases at least). 

### Describe how to test/QA your changes

How to test:
* Enable SSI on the cluster agent
Case 1:
* Deploy a new pod with combinations of init-containers/sidecar containers/containers.
* Verify that the resource limits and requests on injected init containers are set to the effective request/limit for the pod

Case 2:
* Set auto_instrumentation.init_resources.(cpu|memory)
* Verify that the value is applied to injected init container resources, regardless of the pod limits and requests

Case 3:
* Deploy a pod with a container with a very small memory footprint (<100Mi)
* Verify that we are not injecting anything into it

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Associated documentation PR: https://github.com/DataDog/documentation/pull/25873