### PR TITLE
[e2e] recreate stack on ssh handshake failure

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -50,5 +50,9 @@ func getKnownErrors() []knownError {
 			errorMessage: `error while waiting for fakeintake`,
 			retryType:    ReCreate,
 		},
+		{
+			errorMessage: `ssh: handshake failed: ssh: unable to authenticate`,
+			retryType:    ReCreate,
+		},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Recreate e2e stack on ssh handshake failure error

### Motivation

ADXT-558

The following error impacted one job:

```
command:remote:Command remote-aws-vm-cmd-wait-cloud-init **creating failed** error: after 100 failed attempts: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
            pulumi:pulumi:Stack e2eci-ci-656730910-4670-upgrade-from-6-to-6-test-datadog-agent-debian-9-x86-64 running error: update failed
            pulumi:pulumi:Stack e2eci-ci-656730910-4670-upgrade-from-6-to-6-test-datadog-agent-debian-9-x86-64 **failed** 1 error
        Diagnostics:
          command:remote:Command (remote-aws-vm-cmd-wait-cloud-init):
            error: after 100 failed attempts: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
        
          pulumi:pulumi:Stack (e2eci-ci-656730910-4670-upgrade-from-6-to-6-test-datadog-agent-debian-9-x86-64):
            error: update failed
```

This is similar to another error reported on the same test, where the error happened at cloud init, with a different output 

```
Process exited with status 2: running \" sudo cloud-init status --wait\"
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->