### PR TITLE
[usm] service discovery add bypassed processes

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package module
+
+import (
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// ignoreComms is a list of process names that should not be reported as a service.
+var ignoreComms = map[string]struct{}{
+	"sshd":                     {}, // a daemon that handles secure communication
+	"dhclient":                 {}, // utility that uses the DHCP to configure network interfaces
+	"systemd":                  {}, // manages system and service components for Linux
+	"systemd-resolved":         {}, // a system service that provides network name resolution for local applications
+	"systemd-networkd":         {}, // manages network configurations for Linux system
+	"datadog-agent":            {}, // datadog core agent
+	"livenessprobe":            {}, // Kubernetes tool that monitors a container's health
+	"docker-proxy":             {}, // forwards traffic to containers
+	"cilium-agent":             {}, // accepts configuration for networking, load balancing etc.
+	"kubelet":                  {}, // Kubernetes agent
+	"chronyd":                  {}, // a daemon that implements the Network Time Protocol (NTP)
+	"containerd":               {}, // engine to run containers
+	"dockerd":                  {}, // engine to run containers
+	"local-volume-provisioner": {}, // manages the lifecycle of Persistent Volumes
+}
+
+// ignoreComm returns true if process should be ignored
+func ignoreComm(proc *process.Process) bool {
+	comm, err := proc.Name()
+	if err != nil {
+		return false
+	}
+
+	if _, found := ignoreComms[comm]; found {
+		return true
+	}
+	return false
+}

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -13,20 +13,20 @@ import (
 
 // ignoreComms is a list of process names that should not be reported as a service.
 var ignoreComms = map[string]struct{}{
-	"sshd":                     {}, // a daemon that handles secure communication
-	"dhclient":                 {}, // utility that uses the DHCP to configure network interfaces
-	"systemd":                  {}, // manages system and service components for Linux
-	"systemd-resolved":         {}, // a system service that provides network name resolution for local applications
-	"systemd-networkd":         {}, // manages network configurations for Linux system
-	"datadog-agent":            {}, // datadog core agent
-	"livenessprobe":            {}, // Kubernetes tool that monitors a container's health
-	"docker-proxy":             {}, // forwards traffic to containers
-	"cilium-agent":             {}, // accepts configuration for networking, load balancing etc.
-	"kubelet":                  {}, // Kubernetes agent
-	"chronyd":                  {}, // a daemon that implements the Network Time Protocol (NTP)
-	"containerd":               {}, // engine to run containers
-	"dockerd":                  {}, // engine to run containers
-	"local-volume-provisioner": {}, // manages the lifecycle of Persistent Volumes
+	"sshd":           {}, // a daemon that handles secure communication
+	"dhclient":       {}, // utility that uses the DHCP to configure network interfaces
+	"systemd":        {}, // manages system and service components for Linux
+	"systemd-resolv": {}, // 'systemd-resolved' a system service that provides network name resolution for local applications
+	"systemd-networ": {}, // 'systemd-networkd' manages network configurations for Linux system
+	"datadog-agent":  {}, // datadog core agent
+	"livenessprobe":  {}, // Kubernetes tool that monitors a container's health
+	"docker-proxy":   {}, // forwards traffic to containers
+	"cilium-agent":   {}, // accepts configuration for networking, load balancing etc.
+	"kubelet":        {}, // Kubernetes agent
+	"chronyd":        {}, // a daemon that implements the Network Time Protocol (NTP)
+	"containerd":     {}, // engine to run containers
+	"dockerd":        {}, // engine to run containers
+	"local-volume-p": {}, // 'local-volume-provisioner' manages the lifecycle of Persistent Volumes
 }
 
 // ignoreComm returns true if process should be ignored
@@ -35,9 +35,17 @@ func ignoreComm(proc *process.Process) bool {
 	if err != nil {
 		return false
 	}
+	// The proc.Name() function returns an unpredictable length string when command name is long.
+	// It most likely returns the full command name, taken from /proc/<pid>/cmdline,
+	// but it may occasionally return a 15-byte name, maybe /proc/<pid>/cmdline is not ready yet.
+	// search first 15 bytes of returned command.
+	found := func(comm string, m map[string]struct{}) bool {
+		if len(comm) > 15 {
+			comm = comm[:15]
+		}
+		_, found := m[comm]
+		return found
+	}(comm, ignoreComms)
 
-	if _, found := ignoreComms[comm]; found {
-		return true
-	}
-	return false
+	return found
 }

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -37,14 +37,11 @@ var ignoreFamily = map[string]struct{}{
 	"systemd":    {}, // 'systemd-networkd', 'systemd-resolved' etc
 	"datadog":    {}, // datadog processes
 	"containerd": {}, // 'containerd-shim...'
-	"dockerd":    {}, // 'docker-proxy'
+	"docker":     {}, // 'docker-proxy'
 }
 
 // shouldIgnoreComm returns true if process should be ignored
 func shouldIgnoreComm(proc *process.Process) bool {
-	if shouldIgnoreKernelThread(proc) {
-		return true
-	}
 	commPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "comm")
 	contents, err := os.ReadFile(commPath)
 	if err != nil {
@@ -63,15 +60,4 @@ func shouldIgnoreComm(proc *process.Process) bool {
 	_, found := ignoreComms[comm]
 
 	return found
-}
-
-// shouldIgnoreKernelThread returns true if process is kernel thread
-func shouldIgnoreKernelThread(proc *process.Process) bool {
-	exePath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "exe")
-	_, err := os.Stat(exePath)
-	if err != nil {
-		// this is a kernel thread if /proc/<pid>/exe could not be found
-		return true
-	}
-	return false
 }

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -63,21 +62,6 @@ func TestIgnoreCommsLengths(t *testing.T) {
 	}
 }
 
-// TestIgnoreKernelThread check that kernel thread is ignored
-func TestIgnoreKernelThread(t *testing.T) {
-	proc := &process.Process{
-		Pid: 1,
-	}
-	// Pid=1 is not kernel thread and should not be ignored
-	ignore := shouldIgnoreKernelThread(proc)
-	require.Equal(t, ignore, false)
-
-	// Pid=2 is kernel thread [kthreadd] and should be ignored
-	proc.Pid = 2
-	ignore = shouldIgnoreKernelThread(proc)
-	require.Equal(t, ignore, true)
-}
-
 // buildTestBin returns the path to a binary file
 func buildTestBin(t *testing.T) string {
 	curDir, err := httptestutil.CurDir()
@@ -97,8 +81,8 @@ func TestShouldIgnoreComm(t *testing.T) {
 		ignore bool
 	}{
 		{
-			name:   "should ignore command dockerd-1234",
-			comm:   "dockerd-1234",
+			name:   "should ignore command docker-proxy",
+			comm:   "docker-proxy",
 			ignore: true,
 		},
 		{

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && linux
+
+package module
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	httptestutil "github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+const (
+	longComm = "this_is_command_name_longer_than_sixteen_bytes"
+)
+
+// TestIgnoreComm checks that the 'sshd' command is ignored and the 'node' command is not
+func TestIgnoreComm(t *testing.T) {
+	serverDir := buildFakeServer(t)
+	url := setupDiscoveryModule(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
+	badBin := filepath.Join(serverDir, "sshd")
+	badCmd := exec.CommandContext(ctx, badBin)
+	require.NoError(t, badCmd.Start())
+
+	// Also run a non-ignored server so that we can use it in the eventually
+	// loop below so that we don't have to wait a long time to be sure that we
+	// really ignored badBin and just didn't miss it because of a race.
+	goodBin := filepath.Join(serverDir, "node")
+	goodCmd := exec.CommandContext(ctx, goodBin)
+	require.NoError(t, goodCmd.Start())
+
+	goodPid := goodCmd.Process.Pid
+	badPid := badCmd.Process.Pid
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		svcMap := getServicesMap(t, url)
+		assert.Contains(collect, svcMap, goodPid)
+		require.NotContains(t, svcMap, badPid)
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+// buildLongProc returns the path of a symbolic link to a binary file
+func buildLongProc(t *testing.T) string {
+	curDir, err := httptestutil.CurDir()
+	require.NoError(t, err)
+
+	serverBin, err := testutil.BuildGoBinaryWrapper(filepath.Join(curDir, "testutil"), "fake_server")
+	require.NoError(t, err)
+
+	makeAlias(t, longComm, serverBin)
+
+	return filepath.Join(filepath.Dir(serverBin), longComm)
+}
+
+// TestLongComm checks that the long command name of process is fetched completely.
+func TestLongComm(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
+	bin := buildLongProc(t)
+	cmd := exec.CommandContext(ctx, bin)
+	require.NoError(t, cmd.Start())
+
+	proc, err := process.NewProcess(int32(cmd.Process.Pid))
+	require.NoError(t, err)
+
+	comm, err := proc.Name()
+	require.NoError(t, err)
+	require.Equal(t, len(comm), len(longComm))
+	require.False(t, ignoreComm(proc))
+}
+
+func makeSymLink(b *testing.B, src string, dst string) {
+	target, err := os.Readlink(dst)
+	if err == nil && target == dst {
+		return
+	}
+
+	err = os.Symlink(src, dst)
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func startBenchLongCommProcess(b *testing.B) *process.Process {
+	b.Helper()
+
+	dstPath := filepath.Join(b.TempDir(), longComm)
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(func() {
+		cancel()
+		os.Remove(dstPath)
+	})
+	makeSymLink(b, "/bin/sleep", dstPath)
+
+	cmd := exec.CommandContext(ctx, dstPath, "49")
+	err := cmd.Start()
+	if err != nil {
+		b.Fatal(err)
+	}
+	proc, err := customNewProcess(int32(cmd.Process.Pid))
+	if err != nil {
+		b.Fatal(err)
+	}
+	return proc
+}
+
+// BenchmarkProcName benchmarks reading of entire command name from /proc.
+func BenchmarkProcName(b *testing.B) {
+	proc := startBenchLongCommProcess(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		comm, err := proc.Name()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(comm) != len(longComm) {
+			b.Fatalf("wrong comm length, expected: %d, got: %d", len(longComm), len(comm))
+		}
+	}
+}
+
+// getComm reads /rpc/<pid>/comm and returns process command.
+func getComm(proc *process.Process) (string, error) {
+	commPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "comm")
+	contents, err := os.ReadFile(commPath)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(string(contents), "\n"), nil
+}
+
+// BenchmarkProcComm benchmarks reading of command name from /proc/<pid>/comm.
+func BenchmarkProcComm(b *testing.B) {
+	proc := startBenchLongCommProcess(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		comm, err := getComm(proc)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(comm) != 15 {
+			b.Fatalf("wrong comm length, expected: 15, got: %d", len(comm))
+		}
+	}
+}

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build test && linux
+//go:build test && linux_bpf
 
 package module
 

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build test && linux
+// This doesn't need BPF, but it's built with this tag to only run with system-probe tests.
+//go:build test && linux_bpf
 
 package module
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -395,7 +395,8 @@ func (s *discovery) getService(context parsingContext, pid int32) *model.Service
 	if err != nil {
 		return nil
 	}
-	if ignoreComm(proc) {
+
+	if shouldIgnoreComm(proc) {
 		return nil
 	}
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -385,19 +385,6 @@ func customNewProcess(pid int32) (*process.Process, error) {
 	return p, nil
 }
 
-// ignoreComms is a list of process names (matched against /proc/PID/comm) to
-// never report as a service. Note that comm is limited to 16 characters.
-var ignoreComms = map[string]struct{}{
-	"sshd":             {},
-	"dhclient":         {},
-	"systemd":          {},
-	"systemd-resolved": {},
-	"systemd-networkd": {},
-	"datadog-agent":    {},
-	"livenessprobe":    {},
-	"docker-proxy":     {},
-}
-
 // maxNumberOfPorts is the maximum number of listening ports which we report per
 // service.
 const maxNumberOfPorts = 50
@@ -408,13 +395,7 @@ func (s *discovery) getService(context parsingContext, pid int32) *model.Service
 	if err != nil {
 		return nil
 	}
-
-	comm, err := proc.Name()
-	if err != nil {
-		return nil
-	}
-
-	if _, found := ignoreComms[comm]; found {
+	if ignoreComm(proc) {
 		return nil
 	}
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-// This doesn't need BPF but it's built with this tag to only run with
+// This doesn't need BPF, but it's built with this tag to only run with
 // system-probe tests.
-//go:build linux_bpf
+//go:build test && linux_bpf
 
 package module
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add more system processes and container engines to the list of ignored processes.

### Motivation
Service discovery of system-probe detects non-instrumented processes and reports them to back-end. 
Many of such processes are initiated by operating system, the are of no interest and can be ignored.
With this code change the following processes will be excluded from processing

```
"systemd"
"dhclient"
"local-volume-pr"
"sshd"
"cilium-agent"
"kubelet"
"chronyd"
"containerd"
"dockerd"
"livenessprobe"
```

Following families of processes are ignored

```
"systemd-..."
"datadog-...”
"containerd-..."
"dockerd-..."
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Benchmark below compares usage of package proc.Name() function and implemented direct read of /proc/<pid>/comm

```
BenchmarkProcName-4           	   75009	     15820 ns/op	   10696 B/op	     119 allocs/op
BenchmarkShouldIgnoreComm-4   	  220056	      5335 ns/op	    1896 B/op	      26 allocs/op
```
