### PR TITLE
[PROCS-4403][PROCS-4404] Add Processes e2e tests for ECS Fargate

### DIFF
--- a/test/new-e2e/pkg/environments/aws/ecs/ecs.go
+++ b/test/new-e2e/pkg/environments/aws/ecs/ecs.go
@@ -46,6 +46,7 @@ type ProvisionerParams struct {
 	ecsWindowsNodeGroup               bool
 	infraShouldDeployFakeintakeWithLB bool
 	workloadAppFuncs                  []WorkloadAppFunc
+	fargateWorkloadAppFuncs           []FargateWorkloadAppFunc
 	awsEnv                            *aws.Environment
 }
 
@@ -186,6 +187,17 @@ func WithWorkloadApp(appFunc WorkloadAppFunc) ProvisionerOption {
 	}
 }
 
+// FargateWorkloadAppFunc is a function that deploys a Fargate workload app to an ECS cluster
+type FargateWorkloadAppFunc func(e aws.Environment, clusterArn pulumi.StringInput, apiKeySSMParamName pulumi.StringInput, fakeIntake *fakeintakeComp.Fakeintake) (*ecsComp.Workload, error)
+
+// WithFargateWorkloadApp adds a Fargate workload app to the environment
+func WithFargateWorkloadApp(appFunc FargateWorkloadAppFunc) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.fargateWorkloadAppFuncs = append(params.fargateWorkloadAppFuncs, appFunc)
+		return nil
+	}
+}
+
 // Run deploys a ECS environment given a pulumi.Context
 func Run(ctx *pulumi.Context, env *environments.ECS, params *ProvisionerParams) error {
 	var awsEnv aws.Environment
@@ -298,6 +310,16 @@ func Run(ctx *pulumi.Context, env *environments.ECS, params *ProvisionerParams) 
 			ctx.Export("agent-ec2-linux-task-arn", agentDaemon.TaskDefinition.Arn())
 			ctx.Export("agent-ec2-linux-task-family", agentDaemon.TaskDefinition.Family())
 			ctx.Export("agent-ec2-linux-task-version", agentDaemon.TaskDefinition.Revision())
+		}
+
+		// Deploy Fargate Apps
+		if params.ecsFargate {
+			for _, fargateAppFunc := range params.fargateWorkloadAppFuncs {
+				_, err := fargateAppFunc(awsEnv, ecsCluster.Arn, apiKeyParam.Name, fakeIntake)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -63,7 +63,7 @@ func TestECSFargateTestSuite(t *testing.T) {
 	s := ECSFargateSuite{}
 	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
 		e2e.NewTypedPulumiProvisioner("ecsFargateCPUStress", ecsFargateCPUStressProvisioner(), nil),
-	), e2e.WithDevMode(),
+	),
 	}
 
 	e2e.Run(t, &s, e2eParams...)

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package process
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+
+	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
+	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/ecs"
+)
+
+type ECSFargateSuite struct {
+	e2e.BaseSuite[fargateCPUStressEnv]
+}
+
+type fargateCPUStressEnv struct {
+	environments.ECS
+}
+
+func ecsFargateCPUStressProvisioner() e2e.PulumiEnvRunFunc[fargateCPUStressEnv] {
+	return func(ctx *pulumi.Context, env *fargateCPUStressEnv) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		params := ecs.GetProvisionerParams(
+			ecs.WithAwsEnv(&awsEnv),
+			ecs.WithECSFargateCapacityProvider(),
+			ecs.WithFargateWorkloadApp(func(e aws.Environment, clusterArn pulumi.StringInput, apiKeySSMParamName pulumi.StringInput, fakeIntake *fakeintakeComp.Fakeintake) (*ecsComp.Workload, error) {
+				return cpustress.FargateAppDefinition(e, clusterArn, apiKeySSMParamName, fakeIntake)
+			}),
+		)
+
+		if err := ecs.Run(ctx, &env.ECS, params); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func TestECSFargateTestSuite(t *testing.T) {
+	t.Parallel()
+	s := ECSFargateSuite{}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
+		e2e.NewTypedPulumiProvisioner("ecsFargateCPUStress", ecsFargateCPUStressProvisioner(), nil),
+	), e2e.WithDevMode(),
+	}
+
+	e2e.Run(t, &s, e2eParams...)
+}
+
+func (s *ECSFargateSuite) TestProcessCheck() {
+	t := s.T()
+	// PROCS-4219
+	flake.Mark(t)
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 5*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
+	assertContainersCollected(t, payloads, []string{"stress-ng"})
+}
+
+func (s *ECSFargateSuite) TestProcessCheckInCoreAgent() {
+	t := s.T()
+	// PROCS-4219
+	flake.Mark(t)
+
+	extraConfig := runner.ConfigMap{
+		"ddagent:extraEnvVars": auto.ConfigValue{Value: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED=true"},
+	}
+
+	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsFargateCPUStress", ecsFargateCPUStressProvisioner(), extraConfig))
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
+	requireProcessNotCollected(t, payloads, "process-agent")
+	assertContainersCollected(t, payloads, []string{"stress-ng"})
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds e2e tests for the Process checks in ECS Fargate and an accompanying option for adding fargate workloads to the environment. 

### Motivation

### Describe how to test/QA your changes
Ran the tests locally
```
--- PASS: TestECSFargateTestSuite (48.35s)
    --- PASS: TestECSFargateTestSuite/TestProcessCheck (20.13s)
    --- PASS: TestECSFargateTestSuite/TestProcessCheckInCoreAgent (22.70s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	51.415s

DONE 3 tests in 82.071s
All tests passed
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->