### PR TITLE
change eBPF helper replace instruction to r0 = 0

### DIFF
--- a/pkg/ebpf/helper_call_patcher.go
+++ b/pkg/ebpf/helper_call_patcher.go
@@ -14,16 +14,12 @@ import (
 	"github.com/cilium/ebpf/asm"
 )
 
-// noopIns is used in place of the eBPF helpers we wish to remove from
+// replaceIns is used in place of the eBPF helpers we wish to remove from
 // the bytecode.
 //
-// note we're using here the same noop instruction used internally by the
-// verifier:
-// https://elixir.bootlin.com/linux/v6.7/source/kernel/bpf/verifier.c#L18582
-var noopIns = asm.Instruction{
-	OpCode:   asm.Ja.Op(asm.ImmSource),
-	Constant: 0,
-}
+// Helper calls clobber r1-r5 and the return value is expected in r0.
+// We are replacing with `r0 = 0` so code which checks the return value works as expected.
+var replaceIns = asm.Mov.Imm(asm.R0, 0)
 
 // NewHelperCallRemover provides a `Modifier` that patches eBPF bytecode
 // such that calls to the functions given by `helpers` are replaced by
@@ -70,7 +66,7 @@ func (h *helperCallRemover) BeforeInit(m *manager.Manager, _ *manager.Options) e
 
 				for _, fn := range h.helpers {
 					if ins.Constant == int64(fn) {
-						*ins = noopIns.WithMetadata(ins.Metadata)
+						*ins = replaceIns.WithMetadata(ins.Metadata)
 						break
 					}
 				}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the instruction used in the helper replacer to `r0 = 0`

### Motivation

Helper calls clobber `r1-r5` and the return value is expected in `r0`.
We are replacing with `r0 = 0` so code which checks the return value works as expected.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->