### PR TITLE
move pkg/network/usm/tests to only_usm KMT set

### DIFF
--- a/test/new-e2e/system-probe/test-runner/files/no_usm.json
+++ b/test/new-e2e/system-probe/test-runner/files/no_usm.json
@@ -3,6 +3,9 @@
         "pkg/network/usm": {
             "exclude": true
         },
+        "pkg/network/usm/tests": {
+            "exclude": true
+        },
         "*": {
             "exclude": false
         }

--- a/test/new-e2e/system-probe/test-runner/files/only_usm.json
+++ b/test/new-e2e/system-probe/test-runner/files/only_usm.json
@@ -2,6 +2,9 @@
     "filters": {
         "pkg/network/usm": {
             "exclude": false
+        },
+        "pkg/network/usm/tests": {
+            "exclude": false
         }
     }
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

move `pkg/network/usm/tests` to `only_usm` KMT set

### Motivation

More even distribution of test runtime between sets. `no_usm` takes quite a bit longer.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->