### PR TITLE
Add ConnectionTuple to replace ByteKey

### DIFF
--- a/cmd/system-probe/modules/network_tracer_test.go
+++ b/cmd/system-probe/modules/network_tracer_test.go
@@ -27,9 +27,16 @@ func TestDecode(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.1.1.1"),
 					Dest:   util.AddressFromString("10.2.2.2"),
+					Pid:    6000,
+					NetNS:  7,
+					SPort:  1000,
+					DPort:  9000,
+					Type:   network.UDP,
+					Family: network.AFINET6,
+				},
 					Monotonic: network.StatCounters{
 						SentBytes:   1,
 						RecvBytes:   100,
@@ -41,19 +48,12 @@ func TestDecode(t *testing.T) {
 						Retransmits: 201,
 					},
 					LastUpdateEpoch: 50,
-					Pid:             6000,
-					NetNS:           7,
-					SPort:           1000,
-					DPort:           9000,
 					IPTranslation: &network.IPTranslation{
 						ReplSrcIP:   util.AddressFromString("20.1.1.1"),
 						ReplDstIP:   util.AddressFromString("20.1.1.1"),
 						ReplSrcPort: 40,
 						ReplDstPort: 70,
 					},
-
-					Type:      network.UDP,
-					Family:    network.AFINET6,
 					Direction: network.LOCAL,
 				},
 			},

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -191,9 +191,16 @@ func TestSerialization(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.1.1.1"),
 					Dest:   util.AddressFromString("10.2.2.2"),
+					Pid:    6000,
+					NetNS:  7,
+					SPort:  1000,
+					DPort:  9000,
+					Type:   network.TCP,
+					Family: network.AFINET6,
+				},
 					Monotonic: network.StatCounters{
 						SentBytes:   1,
 						RecvBytes:   100,
@@ -207,10 +214,7 @@ func TestSerialization(t *testing.T) {
 						Retransmits:    201,
 					},
 					LastUpdateEpoch: 50,
-					Pid:             6000,
-					NetNS:           7,
-					SPort:           1000,
-					DPort:           9000,
+
 					IPTranslation: &network.IPTranslation{
 						ReplSrcIP:   util.AddressFromString("20.1.1.1"),
 						ReplDstIP:   util.AddressFromString("20.1.1.1"),
@@ -218,8 +222,6 @@ func TestSerialization(t *testing.T) {
 						ReplDstPort: 80,
 					},
 
-					Type:      network.TCP,
-					Family:    network.AFINET6,
 					Direction: network.LOCAL,
 					Via: &network.Via{
 						Subnet: network.Subnet{
@@ -228,13 +230,14 @@ func TestSerialization(t *testing.T) {
 					},
 					ProtocolStack: protocols.Stack{Application: protocols.HTTP},
 				},
-				{
-					Source:        util.AddressFromString("10.1.1.1"),
-					Dest:          util.AddressFromString("8.8.8.8"),
-					SPort:         1000,
-					DPort:         53,
-					Type:          network.UDP,
-					Family:        network.AFINET6,
+				{ConnectionTuple: network.ConnectionTuple{
+					Source: util.AddressFromString("10.1.1.1"),
+					Dest:   util.AddressFromString("8.8.8.8"),
+					SPort:  1000,
+					DPort:  53,
+					Type:   network.UDP,
+					Family: network.AFINET6,
+				},
 					Direction:     network.LOCAL,
 					StaticTags:    tagOpenSSL | tagTLS,
 					ProtocolStack: protocols.Stack{Application: protocols.HTTP2},
@@ -491,18 +494,18 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  clientPort,
 					DPort:  serverPort,
-				},
-				{
+				}},
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  serverPort,
 					DPort:  clientPort,
-				},
+				}},
 			},
 		},
 		HTTP: map[http.Key]*http.RequestStats{
@@ -651,18 +654,18 @@ func TestHTTP2SerializationWithLocalhostTraffic(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  clientPort,
 					DPort:  serverPort,
-				},
-				{
+				}},
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  serverPort,
 					DPort:  clientPort,
-				},
+				}},
 			},
 		},
 		HTTP2: map[http.Key]*http.RequestStats{
@@ -758,12 +761,12 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.0.15.1"),
 					SPort:  uint16(60000),
 					Dest:   util.AddressFromString("172.217.10.45"),
 					DPort:  uint16(8080),
-				},
+				}},
 			},
 		},
 	}
@@ -824,12 +827,12 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.0.15.1"),
 					SPort:  uint16(60000),
 					Dest:   util.AddressFromString("172.217.10.45"),
 					DPort:  uint16(8080),
-				},
+				}},
 			},
 		},
 	}
@@ -913,20 +916,20 @@ func TestKafkaSerializationWithLocalhostTraffic(t *testing.T) {
 	)
 
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  clientPort,
 			Dest:   localhost,
 			DPort:  serverPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  serverPort,
 			Dest:   localhost,
 			DPort:  clientPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	const topicName = "TopicName"

--- a/pkg/network/encoding/marshal/dns_test.go
+++ b/pkg/network/encoding/marshal/dns_test.go
@@ -26,13 +26,14 @@ func TestFormatConnectionDNS(t *testing.T) {
 	payload := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
-					Source:    util.AddressFromString("10.1.1.1"),
-					Dest:      util.AddressFromString("8.8.8.8"),
-					SPort:     1000,
-					DPort:     53,
-					Type:      network.UDP,
-					Family:    network.AFINET6,
+				{ConnectionTuple: network.ConnectionTuple{
+					Source: util.AddressFromString("10.1.1.1"),
+					Dest:   util.AddressFromString("8.8.8.8"),
+					SPort:  1000,
+					DPort:  53,
+					Type:   network.UDP,
+					Family: network.AFINET6,
+				},
 					Direction: network.LOCAL,
 					DNSStats: map[dns.Hostname]map[dns.QueryType]dns.Stats{
 						dns.ToHostname("foo.com"): {

--- a/pkg/network/encoding/marshal/usm_http2_test.go
+++ b/pkg/network/encoding/marshal/usm_http2_test.go
@@ -78,12 +78,12 @@ func (s *HTTP2Suite) TestFormatHTTP2Stats() {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  clientPort,
 					DPort:  serverPort,
-				},
+				}},
 			},
 		},
 		HTTP2: map[http.Key]*http.RequestStats{
@@ -155,12 +155,12 @@ func (s *HTTP2Suite) TestFormatHTTP2StatsByPath() {
 	payload := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.1.1.1"),
 					Dest:   util.AddressFromString("10.2.2.2"),
 					SPort:  60000,
 					DPort:  80,
-				},
+				}},
 			},
 		},
 		HTTP2: map[http.Key]*http.RequestStats{
@@ -202,20 +202,20 @@ func (s *HTTP2Suite) TestHTTP2IDCollisionRegression() {
 	http2Stats := http.NewRequestStats()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			SPort:  60000,
 			Dest:   util.AddressFromString("2.2.2.2"),
 			DPort:  80,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			SPort:  60000,
 			Dest:   util.AddressFromString("2.2.2.2"),
 			DPort:  80,
 			Pid:    2,
-		},
+		}},
 	}
 
 	httpKey := http.NewKey(
@@ -264,20 +264,20 @@ func (s *HTTP2Suite) TestHTTP2LocalhostScenario() {
 	cliport := uint16(6000)
 	serverport := uint16(80)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("127.0.0.1"),
 			SPort:  cliport,
 			Dest:   util.AddressFromString("127.0.0.1"),
 			DPort:  serverport,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("127.0.0.1"),
 			SPort:  serverport,
 			Dest:   util.AddressFromString("127.0.0.1"),
 			DPort:  cliport,
 			Pid:    2,
-		},
+		}},
 	}
 
 	http2Stats := http.NewRequestStats()

--- a/pkg/network/encoding/marshal/usm_http_test.go
+++ b/pkg/network/encoding/marshal/usm_http_test.go
@@ -57,12 +57,12 @@ func TestFormatHTTPStats(t *testing.T) {
 	in := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: localhost,
 					Dest:   localhost,
 					SPort:  clientPort,
 					DPort:  serverPort,
-				},
+				}},
 			},
 		},
 		HTTP: map[http.Key]*http.RequestStats{
@@ -135,12 +135,12 @@ func TestFormatHTTPStatsByPath(t *testing.T) {
 	payload := &network.Connections{
 		BufferedData: network.BufferedData{
 			Conns: []network.ConnectionStats{
-				{
+				{ConnectionTuple: network.ConnectionTuple{
 					Source: util.AddressFromString("10.1.1.1"),
 					Dest:   util.AddressFromString("10.2.2.2"),
 					SPort:  60000,
 					DPort:  80,
-				},
+				}},
 			},
 		},
 		HTTP: map[http.Key]*http.RequestStats{
@@ -180,20 +180,20 @@ func TestIDCollisionRegression(t *testing.T) {
 	httpStats := http.NewRequestStats()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			SPort:  60000,
 			Dest:   util.AddressFromString("2.2.2.2"),
 			DPort:  80,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			SPort:  60000,
 			Dest:   util.AddressFromString("2.2.2.2"),
 			DPort:  80,
 			Pid:    2,
-		},
+		}},
 	}
 
 	httpKey := http.NewKey(
@@ -238,20 +238,20 @@ func TestIDCollisionRegression(t *testing.T) {
 func TestLocalhostScenario(t *testing.T) {
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("127.0.0.1"),
 			SPort:  60000,
 			Dest:   util.AddressFromString("127.0.0.1"),
 			DPort:  80,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("127.0.0.1"),
 			SPort:  80,
 			Dest:   util.AddressFromString("127.0.0.1"),
 			DPort:  60000,
 			Pid:    2,
-		},
+		}},
 	}
 
 	httpStats := http.NewRequestStats()

--- a/pkg/network/encoding/marshal/usm_kafka_test.go
+++ b/pkg/network/encoding/marshal/usm_kafka_test.go
@@ -38,12 +38,12 @@ const (
 
 var (
 	localhost         = util.AddressFromString("127.0.0.1")
-	defaultConnection = network.ConnectionStats{
+	defaultConnection = network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: localhost,
 		Dest:   localhost,
 		SPort:  clientPort,
 		DPort:  serverPort,
-	}
+	}}
 )
 
 type KafkaSuite struct {
@@ -132,20 +132,20 @@ func (s *KafkaSuite) TestKafkaIDCollisionRegression() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  clientPort,
 			Dest:   localhost,
 			DPort:  serverPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  clientPort,
 			Dest:   localhost,
 			DPort:  serverPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	kafkaKey := kafka.NewKey(
@@ -193,20 +193,20 @@ func (s *KafkaSuite) TestKafkaLocalhostScenario() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  clientPort,
 			Dest:   localhost,
 			DPort:  serverPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  serverPort,
 			Dest:   localhost,
 			DPort:  clientPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	kafkaKey := kafka.NewKey(

--- a/pkg/network/encoding/marshal/usm_lookup_test.go
+++ b/pkg/network/encoding/marshal/usm_lookup_test.go
@@ -34,20 +34,20 @@ func TestUSMLookup(t *testing.T) {
 		data[key] = val
 
 		// Assert that c1 and c2 (which are symmetrical) "link" to the same aggregation
-		c1 := network.ConnectionStats{
+		c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			Dest:   util.AddressFromString("2.2.2.2"),
 			SPort:  60000,
 			DPort:  80,
-		}
+		}}
 		assert.Equal(t, val, USMLookup(c1, data))
 
-		c2 := network.ConnectionStats{
+		c2 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("2.2.2.2"),
 			Dest:   util.AddressFromString("1.1.1.1"),
 			SPort:  80,
 			DPort:  60000,
-		}
+		}}
 		assert.Equal(t, val, USMLookup(c2, data))
 	})
 
@@ -64,11 +64,12 @@ func TestUSMLookup(t *testing.T) {
 		data[key] = val
 
 		// Assert that c1 and c2 (which are symmetrical) "link" to the same aggregation
-		c1 := network.ConnectionStats{
+		c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("1.1.1.1"),
 			Dest:   util.AddressFromString("2.2.2.2"),
 			SPort:  60000,
 			DPort:  80,
+		},
 			IPTranslation: &network.IPTranslation{
 				ReplSrcIP:   util.AddressFromString("3.3.3.3"),
 				ReplDstIP:   util.AddressFromString("4.4.4.4"),
@@ -78,11 +79,12 @@ func TestUSMLookup(t *testing.T) {
 		}
 		assert.Equal(t, val, USMLookup(c1, data))
 
-		c2 := network.ConnectionStats{
+		c2 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("2.2.2.2"),
 			Dest:   util.AddressFromString("1.1.1.1"),
 			SPort:  80,
 			DPort:  60000,
+		},
 			IPTranslation: &network.IPTranslation{
 				ReplSrcIP:   util.AddressFromString("4.4.4.4"),
 				ReplDstIP:   util.AddressFromString("3.3.3.3"),

--- a/pkg/network/encoding/marshal/usm_lookup_windows_test.go
+++ b/pkg/network/encoding/marshal/usm_lookup_windows_test.go
@@ -31,19 +31,19 @@ func TestUSMLookup(t *testing.T) {
 
 	// In windows the USMLookup operation is done only once and using the
 	// original tuple order, so in the case below only c1 should match the data
-	c1 := network.ConnectionStats{
+	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("2.2.2.2"),
 		SPort:  60000,
 		DPort:  80,
-	}
+	}}
 
-	c2 := network.ConnectionStats{
+	c2 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: util.AddressFromString("2.2.2.2"),
 		Dest:   util.AddressFromString("1.1.1.1"),
 		SPort:  80,
 		DPort:  60000,
-	}
+	}}
 
 	assert.Equal(t, val, USMLookup(c1, data))
 	assert.Equal(t, (*USMConnectionData[struct{}, any])(nil), USMLookup(c2, data))

--- a/pkg/network/encoding/marshal/usm_postgres_test.go
+++ b/pkg/network/encoding/marshal/usm_postgres_test.go
@@ -27,12 +27,12 @@ const (
 )
 
 var (
-	postgresDefaultConnection = network.ConnectionStats{
+	postgresDefaultConnection = network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: localhost,
 		Dest:   localhost,
 		SPort:  postgresClientPort,
 		DPort:  postgresServerPort,
-	}
+	}}
 )
 
 type PostgresSuite struct {
@@ -251,20 +251,20 @@ func (s *PostgresSuite) TestPostgresIDCollisionRegression() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  postgresClientPort,
 			Dest:   localhost,
 			DPort:  postgresServerPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  postgresClientPort,
 			Dest:   localhost,
 			DPort:  postgresServerPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	postgresKey := postgres.NewKey(
@@ -311,20 +311,20 @@ func (s *PostgresSuite) TestPostgresLocalhostScenario() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  postgresClientPort,
 			Dest:   localhost,
 			DPort:  postgresServerPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  postgresServerPort,
 			Dest:   localhost,
 			DPort:  postgresClientPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	postgresKey := postgres.NewKey(

--- a/pkg/network/encoding/marshal/usm_redis_test.go
+++ b/pkg/network/encoding/marshal/usm_redis_test.go
@@ -26,12 +26,12 @@ const (
 )
 
 var (
-	redisDefaultConnection = network.ConnectionStats{
+	redisDefaultConnection = network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: localhost,
 		Dest:   localhost,
 		SPort:  redisClientPort,
 		DPort:  redisServerPort,
-	}
+	}}
 )
 
 type RedisSuite struct {
@@ -87,20 +87,20 @@ func (s *RedisSuite) TestRedisIDCollisionRegression() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  redisClientPort,
 			Dest:   localhost,
 			DPort:  redisServerPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  redisClientPort,
 			Dest:   localhost,
 			DPort:  redisServerPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	redisKey := redis.NewKey(
@@ -138,20 +138,20 @@ func (s *RedisSuite) TestRedisLocalhostScenario() {
 	t := s.T()
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
-		{
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  redisClientPort,
 			Dest:   localhost,
 			DPort:  redisServerPort,
 			Pid:    1,
-		},
-		{
+		}},
+		{ConnectionTuple: network.ConnectionTuple{
 			Source: localhost,
 			SPort:  redisServerPort,
 			Dest:   localhost,
 			DPort:  redisClientPort,
 			Pid:    2,
-		},
+		}},
 	}
 
 	redisKey := redis.NewKey(

--- a/pkg/network/encoding/marshal/usm_test.go
+++ b/pkg/network/encoding/marshal/usm_test.go
@@ -80,12 +80,12 @@ func TestGroupByConnection(t *testing.T) {
 
 	// Connection 1
 	// Assert that (key1, val1) and (key2, val2) were grouped together
-	connection1 := network.ConnectionStats{
+	connection1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("2.2.2.2"),
 		SPort:  60000,
 		DPort:  80,
-	}
+	}}
 	connectionData1 := byConnection.Find(connection1)
 	assert.NotNil(t, connectionData1)
 	assert.Len(t, connectionData1.Data, 2)
@@ -94,12 +94,12 @@ func TestGroupByConnection(t *testing.T) {
 
 	// Connection 2
 	// Assert that (key3, val3) and (key4, val4) were grouped together
-	connection2 := network.ConnectionStats{
+	connection2 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: util.AddressFromString("3.3.3.3"),
 		Dest:   util.AddressFromString("4.4.4.4"),
 		SPort:  60000,
 		DPort:  80,
-	}
+	}}
 	connectionData2 := byConnection.Find(connection2)
 	assert.NotNil(t, connectionData2)
 	assert.Len(t, connectionData1.Data, 2)

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -260,43 +260,36 @@ func (c ConnectionTuple) String() string {
 
 // ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned
 type ConnectionStats struct {
-	ConnectionTuple
-
+	// move pointer fields first to reduce number of bytes GC has to scan
 	IPTranslation *IPTranslation
 	Via           *Via
-
-	Monotonic StatCounters
-
-	Last StatCounters
-
-	Cookie StatCookie
-
-	// Last time the stats for this connection were updated
-	LastUpdateEpoch uint64
-	Duration        time.Duration
-
-	RTT    uint32 // Stored in µs
-	RTTVar uint32
-
-	Direction        ConnectionDirection
-	SPortIsEphemeral EphemeralPortType
-	StaticTags       uint64
-	Tags             []*intern.Value
-
-	IntraHost bool
-	IsAssured bool
-	IsClosed  bool
-
-	ContainerID struct {
+	Tags          []*intern.Value
+	ContainerID   struct {
 		Source, Dest *intern.Value
 	}
-
-	ProtocolStack protocols.Stack
-
 	DNSStats map[dns.Hostname]map[dns.QueryType]dns.Stats
-
 	// TCPFailures stores the number of failures for a POSIX error code
 	TCPFailures map[uint32]uint32
+
+	ConnectionTuple
+
+	Monotonic StatCounters
+	Last      StatCounters
+	Cookie    StatCookie
+	// LastUpdateEpoch is the last time the stats for this connection were updated
+	LastUpdateEpoch uint64
+	Duration        time.Duration
+	RTT             uint32 // Stored in µs
+	RTTVar          uint32
+	StaticTags      uint64
+	ProtocolStack   protocols.Stack
+
+	// keep these fields last because they are 1 byte each and otherwise inflate the struct size due to alignment
+	Direction        ConnectionDirection
+	SPortIsEphemeral EphemeralPortType
+	IntraHost        bool
+	IsAssured        bool
+	IsClosed         bool
 }
 
 // Via has info about the routing decision for a flow

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -232,10 +232,35 @@ func (s StatCounters) IsZero() bool {
 // reduce collisions; see PR #17197 for more info.
 type StatCookie = uint64
 
-// ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned
-type ConnectionStats struct {
+// ConnectionTuple represents the unique network key for a connection
+type ConnectionTuple struct {
 	Source util.Address
 	Dest   util.Address
+	Pid    uint32
+	NetNS  uint32
+	SPort  uint16
+	DPort  uint16
+	Type   ConnectionType
+	Family ConnectionFamily
+}
+
+func (c ConnectionTuple) String() string {
+	return fmt.Sprintf(
+		"[%s%s] [PID: %d] [ns: %d] [%s:%d ⇄ %s:%d] ",
+		c.Type,
+		c.Family,
+		c.Pid,
+		c.NetNS,
+		c.Source,
+		c.SPort,
+		c.Dest,
+		c.DPort,
+	)
+}
+
+// ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned
+type ConnectionStats struct {
+	ConnectionTuple
 
 	IPTranslation *IPTranslation
 	Via           *Via
@@ -253,13 +278,6 @@ type ConnectionStats struct {
 	RTT    uint32 // Stored in µs
 	RTTVar uint32
 
-	Pid   uint32
-	NetNS uint32
-
-	SPort            uint16
-	DPort            uint16
-	Type             ConnectionType
-	Family           ConnectionFamily
 	Direction        ConnectionDirection
 	SPortIsEphemeral EphemeralPortType
 	StaticTags       uint64

--- a/pkg/network/event_linux_test.go
+++ b/pkg/network/event_linux_test.go
@@ -29,12 +29,12 @@ func TestKeyTuplesFromConn(t *testing.T) {
 	destinationAddress := util.AddressFromString("5.6.7.8")
 	destinationPort := uint16(5678)
 
-	connectionStats := ConnectionStats{
+	connectionStats := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: sourceAddress,
 		SPort:  sourcePort,
 		Dest:   destinationAddress,
 		DPort:  destinationPort,
-	}
+	}}
 	keyTuples := ConnectionKeysFromConnectionStats(connectionStats)
 
 	assert.Len(t, keyTuples, 2, "Expected different number of key tuples")
@@ -65,11 +65,12 @@ func TestKeyTuplesFromConnNAT(t *testing.T) {
 	natDestinationAddress := util.AddressFromString("50.60.70.80")
 	natDestinationPort := uint16(8765)
 
-	connectionStats := ConnectionStats{
+	connectionStats := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: sourceAddress,
 		Dest:   destinationAddress,
 		SPort:  sourcePort,
 		DPort:  destinationPort,
+	},
 		IPTranslation: &IPTranslation{
 			ReplSrcIP:   natSourceAddress,
 			ReplDstIP:   natDestinationAddress,

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -18,13 +18,15 @@ import (
 
 var (
 	testConn = ConnectionStats{
-		Pid:    123,
-		Type:   1,
-		Family: AFINET,
-		Source: util.AddressFromString("192.168.0.1"),
-		Dest:   util.AddressFromString("192.168.0.103"),
-		SPort:  123,
-		DPort:  35000,
+		ConnectionTuple: ConnectionTuple{
+			Pid:    123,
+			Type:   1,
+			Family: AFINET,
+			Source: util.AddressFromString("192.168.0.1"),
+			Dest:   util.AddressFromString("192.168.0.103"),
+			SPort:  123,
+			DPort:  35000,
+		},
 		Monotonic: StatCounters{
 			SentBytes: 123123,
 			RecvBytes: 312312,
@@ -37,24 +39,28 @@ func TestBeautifyKey(t *testing.T) {
 	for _, c := range []ConnectionStats{
 		testConn,
 		{
-			Pid:    345,
-			Type:   0,
-			Family: AFINET6,
-			Source: util.AddressFromNetIP(net.ParseIP("::7f00:35:0:1")),
-			Dest:   util.AddressFromNetIP(net.ParseIP("2001:db8::2:1")),
-			SPort:  4444,
-			DPort:  8888,
+			ConnectionTuple: ConnectionTuple{
+				Pid:    345,
+				Type:   0,
+				Family: AFINET6,
+				Source: util.AddressFromNetIP(net.ParseIP("::7f00:35:0:1")),
+				Dest:   util.AddressFromNetIP(net.ParseIP("2001:db8::2:1")),
+				SPort:  4444,
+				DPort:  8888,
+			},
 			Cookie: 1,
 		},
 		{
-			Pid:       32065,
-			Type:      0,
-			Family:    AFINET,
+			ConnectionTuple: ConnectionTuple{
+				Pid:    32065,
+				Type:   0,
+				Family: AFINET,
+				Source: util.AddressFromString("172.21.148.124"),
+				Dest:   util.AddressFromString("130.211.21.187"),
+				SPort:  52012,
+				DPort:  443,
+			},
 			Direction: 2,
-			Source:    util.AddressFromString("172.21.148.124"),
-			Dest:      util.AddressFromString("130.211.21.187"),
-			SPort:     52012,
-			DPort:     443,
 			Cookie:    2,
 		},
 	} {
@@ -74,44 +80,44 @@ func TestConnStatsByteKey(t *testing.T) {
 		b ConnectionStats
 	}{
 		{ // Port is different
-			a: ConnectionStats{Source: addrA, Dest: addrB, Pid: 1},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB, Pid: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Family is different
-			a: ConnectionStats{Source: addrA, Dest: addrB, Family: 1},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB, Family: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Type is different
-			a: ConnectionStats{Source: addrA, Dest: addrB, Type: 1},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB, Type: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Source is different
-			a: ConnectionStats{Source: util.AddressFromString("123.255.123.0"), Dest: addrB},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("123.255.123.0"), Dest: addrB}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Dest is different
-			a: ConnectionStats{Source: addrA, Dest: util.AddressFromString("129.0.1.2")},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: util.AddressFromString("129.0.1.2")}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Source port is different
-			a: ConnectionStats{Source: addrA, Dest: addrB, SPort: 1},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB, SPort: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Dest port is different
-			a: ConnectionStats{Source: addrA, Dest: addrB, DPort: 1},
-			b: ConnectionStats{Source: addrA, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB, DPort: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addrA, Dest: addrB}},
 		},
 		{ // Fields set, but sources are different
-			a: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: addrA, Dest: addrB},
-			b: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: addrB, Dest: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Family: 0, Type: 1, Source: addrA, Dest: addrB}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Family: 0, Type: 1, Source: addrB, Dest: addrB}},
 		},
 		{ // Both sources and dest are different
-			a: ConnectionStats{Pid: 1, Dest: addrB, Family: 0, Type: 1, Source: addrA},
-			b: ConnectionStats{Pid: 1, Dest: addrA, Family: 0, Type: 1, Source: addrB},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Dest: addrB, Family: 0, Type: 1, Source: addrA}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Dest: addrA, Family: 0, Type: 1, Source: addrB}},
 		},
 		{ // Family and Type are different
-			a: ConnectionStats{Pid: 1, Source: addrA, Dest: addrB, Family: 1},
-			b: ConnectionStats{Pid: 1, Source: addrA, Dest: addrB, Type: 1},
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Source: addrA, Dest: addrB, Family: 1}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Source: addrA, Dest: addrB, Type: 1}},
 		},
 	} {
 		var keyA, keyB string
@@ -129,35 +135,36 @@ func TestByteKeyNAT(t *testing.T) {
 		shouldMatch bool
 	}{
 		{
-			a: ConnectionStats{
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
-			},
-			b: ConnectionStats{
+			}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
-			},
+			}},
 			shouldMatch: true,
 		},
 		{
-			a: ConnectionStats{
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
-			},
-			b: ConnectionStats{
+			}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.3"),
 				Dest:   util.AddressFromString("127.0.0.4"),
-			},
+			}},
 			shouldMatch: false,
 		},
 		{
-			a: ConnectionStats{
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("127.0.0.1"),
+				Dest:   util.AddressFromString("127.0.0.2"),
+			}},
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
 			},
-			b: ConnectionStats{
-				Source: util.AddressFromString("127.0.0.1"),
-				Dest:   util.AddressFromString("127.0.0.2"),
 				IPTranslation: &IPTranslation{
 					ReplSrcIP: util.AddressFromString("1.1.1.1"),
 					ReplDstIP: util.AddressFromString("2.2.2.2"),
@@ -166,17 +173,19 @@ func TestByteKeyNAT(t *testing.T) {
 			shouldMatch: false,
 		},
 		{
-			a: ConnectionStats{
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
+			},
 				IPTranslation: &IPTranslation{
 					ReplSrcIP: util.AddressFromString("1.1.1.1"),
 					ReplDstIP: util.AddressFromString("2.2.2.2"),
 				},
 			},
-			b: ConnectionStats{
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
+			},
 				IPTranslation: &IPTranslation{
 					ReplSrcIP: util.AddressFromString("3.3.3.3"),
 					ReplDstIP: util.AddressFromString("4.4.4.4"),
@@ -185,17 +194,19 @@ func TestByteKeyNAT(t *testing.T) {
 			shouldMatch: false,
 		},
 		{
-			a: ConnectionStats{
+			a: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.2"),
+			},
 				IPTranslation: &IPTranslation{
 					ReplSrcIP: util.AddressFromString("1.1.1.1"),
 					ReplDstIP: util.AddressFromString("2.2.2.2"),
 				},
 			},
-			b: ConnectionStats{
+			b: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.3"),
 				Dest:   util.AddressFromString("127.0.0.4"),
+			},
 				IPTranslation: &IPTranslation{
 					ReplSrcIP: util.AddressFromString("1.1.1.1"),
 					ReplDstIP: util.AddressFromString("2.2.2.2"),
@@ -246,7 +257,7 @@ func BenchmarkByteKey(b *testing.B) {
 	buf := make([]byte, ConnectionByteKeyMaxLen)
 	addrA := util.AddressFromString("127.0.0.1")
 	addrB := util.AddressFromString("127.0.0.2")
-	c := ConnectionStats{Pid: 1, Dest: addrB, Family: 0, Type: 1, Source: addrA}
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{Pid: 1, Dest: addrB, Family: 0, Type: 1, Source: addrA}}
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -51,12 +51,12 @@ func TestKeyTuplesFromConn(t *testing.T) {
 	destinationAddress := util.AddressFromString("5.6.7.8")
 	destinationPort := uint16(5678)
 
-	connectionStats := ConnectionStats{
+	connectionStats := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: sourceAddress,
 		SPort:  sourcePort,
 		Dest:   destinationAddress,
 		DPort:  destinationPort,
-	}
+	}}
 	keyTuples := ConnectionKeysFromConnectionStats(connectionStats)
 
 	assert.Len(t, keyTuples, 1, "Expected different number of key tuples")

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -49,10 +49,10 @@ type Conntracker interface {
 	Describe(descs chan<- *prometheus.Desc)
 	// Collect returns the current state of all metrics of the collector
 	Collect(metrics chan<- prometheus.Metric)
-	GetTranslationForConn(*network.ConnectionStats) *network.IPTranslation
+	GetTranslationForConn(*network.ConnectionTuple) *network.IPTranslation
 	// GetType returns a string describing whether the conntracker is "ebpf" or "netlink"
 	GetType() string
-	DeleteTranslation(*network.ConnectionStats)
+	DeleteTranslation(*network.ConnectionTuple)
 	DumpCachedTable(context.Context) (map[uint32][]DebugConntrackEntry, error)
 	Close()
 }
@@ -192,7 +192,7 @@ func (ctr *realConntracker) GetType() string {
 	return "netlink"
 }
 
-func (ctr *realConntracker) GetTranslationForConn(c *network.ConnectionStats) *network.IPTranslation {
+func (ctr *realConntracker) GetTranslationForConn(c *network.ConnectionTuple) *network.IPTranslation {
 	then := time.Now()
 	defer func() {
 		conntrackerTelemetry.getsDuration.Observe(float64(time.Since(then).Nanoseconds()))
@@ -228,7 +228,7 @@ func (ctr *realConntracker) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(conntrackerTelemetry.orphanSize, prometheus.CounterValue, float64(ctr.cache.orphans.Len()))
 }
 
-func (ctr *realConntracker) DeleteTranslation(c *network.ConnectionStats) {
+func (ctr *realConntracker) DeleteTranslation(c *network.ConnectionTuple) {
 	then := time.Now()
 
 	ctr.Lock()

--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -59,7 +59,7 @@ func TestConnTrackerCrossNamespaceAllNsDisabled(t *testing.T) {
 
 	time.Sleep(time.Second)
 	trans := ct.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromNetIP(laddr.IP),
 			SPort:  uint16(laddr.Port),
 			Dest:   util.AddressFromString("2.2.2.4"),

--- a/pkg/network/netlink/conntracker_test.go
+++ b/pkg/network/netlink/conntracker_test.go
@@ -74,7 +74,7 @@ func TestRegisterNonNat(t *testing.T) {
 
 	rt.register(c)
 	translation := rt.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.0"),
 			SPort:  8080,
 			Dest:   util.AddressFromString("50.30.40.10"),
@@ -91,7 +91,7 @@ func TestRegisterNat(t *testing.T) {
 
 	rt.register(c)
 	translation := rt.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.0"),
 			SPort:  12345,
 			Dest:   util.AddressFromString("50.30.40.10"),
@@ -108,7 +108,7 @@ func TestRegisterNat(t *testing.T) {
 	}, translation)
 
 	udpTranslation := rt.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.0"),
 			SPort:  12345,
 			Dest:   util.AddressFromString("50.30.40.10"),
@@ -126,7 +126,7 @@ func TestRegisterNatUDP(t *testing.T) {
 
 	rt.register(c)
 	translation := rt.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.0"),
 			SPort:  12345,
 			Dest:   util.AddressFromString("50.30.40.10"),
@@ -143,7 +143,7 @@ func TestRegisterNatUDP(t *testing.T) {
 	}, translation)
 
 	translation = rt.GetTranslationForConn(
-		&network.ConnectionStats{
+		&network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.0"),
 			SPort:  12345,
 			Dest:   util.AddressFromString("50.30.40.10"),
@@ -158,7 +158,7 @@ func TestTooManyEntries(t *testing.T) {
 	rt := newConntracker(2)
 
 	rt.register(makeTranslatedConn(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("20.0.0.0"), netip.MustParseAddr("50.30.40.10"), 6, 12345, 80, 80))
-	tr := rt.GetTranslationForConn(&network.ConnectionStats{
+	tr := rt.GetTranslationForConn(&network.ConnectionTuple{
 		Source: util.AddressFromString("10.0.0.0"),
 		SPort:  12345,
 		Dest:   util.AddressFromString("50.30.40.10"),
@@ -171,7 +171,7 @@ func TestTooManyEntries(t *testing.T) {
 
 	rt.register(makeTranslatedConn(netip.MustParseAddr("10.0.0.1"), netip.MustParseAddr("20.0.0.1"), netip.MustParseAddr("50.30.40.20"), 6, 12345, 80, 80))
 	// old entry should be gone
-	tr = rt.GetTranslationForConn(&network.ConnectionStats{
+	tr = rt.GetTranslationForConn(&network.ConnectionTuple{
 		Source: util.AddressFromString("10.0.0.0"),
 		SPort:  12345,
 		Dest:   util.AddressFromString("50.30.40.10"),
@@ -181,7 +181,7 @@ func TestTooManyEntries(t *testing.T) {
 	require.Nil(t, tr)
 
 	// check new entry
-	tr = rt.GetTranslationForConn(&network.ConnectionStats{
+	tr = rt.GetTranslationForConn(&network.ConnectionTuple{
 		Source: util.AddressFromString("10.0.0.1"),
 		SPort:  12345,
 		Dest:   util.AddressFromString("50.30.40.20"),

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -25,11 +25,11 @@ func NewNoOpConntracker() Conntracker {
 // GetType returns a string describing whether the conntracker is "ebpf" or "netlink"
 func (*noOpConntracker) GetType() string { return "" }
 
-func (*noOpConntracker) GetTranslationForConn(_c *network.ConnectionStats) *network.IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(_c *network.ConnectionTuple) *network.IPTranslation {
 	return nil
 }
 
-func (*noOpConntracker) DeleteTranslation(_c *network.ConnectionStats) {
+func (*noOpConntracker) DeleteTranslation(_c *network.ConnectionTuple) {
 
 }
 

--- a/pkg/network/network_filter_test.go
+++ b/pkg/network/network_filter_test.go
@@ -50,39 +50,39 @@ func TestParseConnectionFilters(t *testing.T) {
 	destList := ParseConnectionFilters(testDestinationFilters)
 
 	// source
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("172.0.0.1"), SPort: uint16(10), Type: TCP}))
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("*"), SPort: uint16(9000), Type: TCP})) // only port 9000
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.1.24"), SPort: uint16(9000), Type: TCP}))
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("::7f00:35:0:0"), SPort: uint16(443), Type: TCP})) // ipv6
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("::"), SPort: uint16(443), Type: TCP}))            // 0 == ::7f00:35:0:0
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.10"), SPort: uint16(6666), Type: TCP}))    // port wildcard
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.10"), SPort: uint16(33), Type: TCP}))
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.25"), SPort: uint16(30), Type: TCP})) // bad config
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("123.ABCD"), SPort: uint16(30), Type: TCP}))  // bad IP config
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("172.0.0.1"), SPort: uint16(10), Type: TCP}}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("*"), SPort: uint16(9000), Type: TCP}})) // only port 9000
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.1.24"), SPort: uint16(9000), Type: TCP}}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("::7f00:35:0:0"), SPort: uint16(443), Type: TCP}})) // ipv6
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("::"), SPort: uint16(443), Type: TCP}}))            // 0 == ::7f00:35:0:0
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.10"), SPort: uint16(6666), Type: TCP}}))    // port wildcard
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.10"), SPort: uint16(33), Type: TCP}}))
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.25"), SPort: uint16(30), Type: TCP}})) // bad config
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("123.ABCD"), SPort: uint16(30), Type: TCP}}))  // bad IP config
 
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("172.0.0.2"), SPort: uint16(100), Type: TCP}))
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("::7f00:35:0:1"), SPort: uint16(100), Type: TCP})) // invalid port
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.11"), SPort: uint16(6666), Type: TCP}))     // port wildcard
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.26"), SPort: uint16(30), Type: TCP}))      // invalid port range
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.1"), SPort: uint16(100), Type: TCP}))       // tcp wildcard
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53363), Type: UDP}))
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53361), Type: TCP}))
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53361), Type: UDP}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("172.0.0.2"), SPort: uint16(100), Type: TCP}}))
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("::7f00:35:0:1"), SPort: uint16(100), Type: TCP}})) // invalid port
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.11"), SPort: uint16(6666), Type: TCP}}))     // port wildcard
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.26"), SPort: uint16(30), Type: TCP}}))      // invalid port range
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.1"), SPort: uint16(100), Type: TCP}}))       // tcp wildcard
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53363), Type: UDP}}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53361), Type: TCP}}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: util.AddressFromString("10.0.0.2"), SPort: uint16(53361), Type: UDP}}))
 
 	// destination
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(8080), Type: TCP}))
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(80), Type: TCP}))
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString(""), DPort: uint16(1234), Type: TCP}))
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("2001:db8::2:1"), DPort: uint16(5001), Type: TCP})) // ipv6
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("2001:db8::5:1"), DPort: uint16(80), Type: TCP}))   // ipv6 CIDR
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("1.1.1.1"), DPort: uint16(11211), Type: TCP}))
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("*"), DPort: uint16(30), Type: TCP}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(8080), Type: TCP}}))
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(80), Type: TCP}}))
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString(""), DPort: uint16(1234), Type: TCP}}))
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("2001:db8::2:1"), DPort: uint16(5001), Type: TCP}})) // ipv6
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("2001:db8::5:1"), DPort: uint16(80), Type: TCP}}))   // ipv6 CIDR
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("1.1.1.1"), DPort: uint16(11211), Type: TCP}}))
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("*"), DPort: uint16(30), Type: TCP}}))
 
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("2001:db8::2:2"), DPort: uint16(3333), Type: UDP})) // invalid config
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("10.0.0.3/24"), DPort: uint16(80), Type: TCP}))     // invalid config
-	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("10.0.0.4"), DPort: uint16(1234), Type: TCP}))       // port wildcard
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("2001:db8::2:2"), DPort: uint16(8082), Type: TCP})) // invalid config
-	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(0), Type: TCP}))         // invalid port
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("2001:db8::2:2"), DPort: uint16(3333), Type: UDP}})) // invalid config
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("10.0.0.3/24"), DPort: uint16(80), Type: TCP}}))     // invalid config
+	assert.True(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("10.0.0.4"), DPort: uint16(1234), Type: TCP}}))       // port wildcard
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("2001:db8::2:2"), DPort: uint16(8082), Type: TCP}})) // invalid config
+	assert.False(t, IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: util.AddressFromString("10.0.0.5"), DPort: uint16(0), Type: TCP}}))         // invalid port
 }
 
 var sink bool
@@ -96,8 +96,8 @@ func BenchmarkIsBlacklistedConnectionIPv4(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for _, addr := range addrs {
-			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: addr, SPort: uint16(rand.Intn(9999)), Type: TCP})
-			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: addr, DPort: uint16(rand.Intn(9999)), Type: TCP})
+			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addr, SPort: uint16(rand.Intn(9999)), Type: TCP}})
+			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: addr, DPort: uint16(rand.Intn(9999)), Type: TCP}})
 		}
 	}
 
@@ -112,8 +112,8 @@ func BenchmarkIsBlacklistedConnectionIPv6(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for _, addr := range addrs {
-			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{Source: addr, SPort: uint16(rand.Intn(9999)), Type: TCP})
-			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{Dest: addr, DPort: uint16(rand.Intn(9999)), Type: TCP})
+			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Source: addr, SPort: uint16(rand.Intn(9999)), Type: TCP}})
+			sink = IsExcludedConnection(sourceList, destList, &ConnectionStats{ConnectionTuple: ConnectionTuple{Dest: addr, DPort: uint16(rand.Intn(9999)), Type: TCP}})
 		}
 	}
 }

--- a/pkg/network/resolver_test.go
+++ b/pkg/network/resolver_test.go
@@ -18,13 +18,15 @@ import (
 
 func TestResolveLocalConnections(t *testing.T) {
 	conns := []ConnectionStats{
-		{
-			Pid:       8579,
-			Source:    util.AddressFromString("172.29.132.189"),
-			SPort:     37432,
-			Dest:      util.AddressFromString("172.29.168.124"),
-			DPort:     8080,
-			NetNS:     4026533024,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    8579,
+			Source: util.AddressFromString("172.29.132.189"),
+			SPort:  37432,
+			Dest:   util.AddressFromString("172.29.168.124"),
+			DPort:  8080,
+			NetNS:  4026533024,
+			Type:   TCP,
+		},
 			Direction: OUTGOING,
 			ContainerID: struct {
 				Source *intern.Value
@@ -32,16 +34,17 @@ func TestResolveLocalConnections(t *testing.T) {
 			}{
 				Source: intern.GetByString("6254f6bc5dc03a50440268c2c0771c476fb9a7230c510afef6114c4498b2a4f8"),
 			},
-			Type:      TCP,
 			IntraHost: true,
 		},
-		{
-			Pid:       8576,
-			Source:    util.AddressFromString("172.29.132.189"),
-			SPort:     46822,
-			Dest:      util.AddressFromString("172.29.168.124"),
-			DPort:     8080,
-			NetNS:     4026533024,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    8576,
+			Source: util.AddressFromString("172.29.132.189"),
+			SPort:  46822,
+			Dest:   util.AddressFromString("172.29.168.124"),
+			DPort:  8080,
+			NetNS:  4026533024,
+			Type:   TCP,
+		},
 			Direction: OUTGOING,
 			ContainerID: struct {
 				Source *intern.Value
@@ -49,16 +52,17 @@ func TestResolveLocalConnections(t *testing.T) {
 			}{
 				Source: intern.GetByString("6254f6bc5dc03a50440268c2c0771c476fb9a7230c510afef6114c4498b2a4f8"),
 			},
-			Type:      TCP,
 			IntraHost: true,
 		},
-		{
-			Pid:       1342852,
-			Source:    util.AddressFromString("172.29.168.124"),
-			SPort:     8080,
-			Dest:      util.AddressFromString("172.29.132.189"),
-			DPort:     46822,
-			NetNS:     4026533176,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    1342852,
+			Source: util.AddressFromString("172.29.168.124"),
+			SPort:  8080,
+			Dest:   util.AddressFromString("172.29.132.189"),
+			DPort:  46822,
+			NetNS:  4026533176,
+			Type:   TCP,
+		},
 			Direction: INCOMING,
 			ContainerID: struct {
 				Source *intern.Value
@@ -66,16 +70,17 @@ func TestResolveLocalConnections(t *testing.T) {
 			}{
 				Source: intern.GetByString("7e999c2c2349713e27cecf87ef8e0cf496aec08b06b6a8b8c988dd42a3839a98"),
 			},
-			Type:      TCP,
 			IntraHost: true,
 		},
-		{
-			Pid:       1344818,
-			Source:    util.AddressFromString("172.29.168.124"),
-			SPort:     8080,
-			Dest:      util.AddressFromString("172.29.132.189"),
-			DPort:     37432,
-			NetNS:     4026533176,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    1344818,
+			Source: util.AddressFromString("172.29.168.124"),
+			SPort:  8080,
+			Dest:   util.AddressFromString("172.29.132.189"),
+			DPort:  37432,
+			NetNS:  4026533176,
+			Type:   TCP,
+		},
 			Direction: INCOMING,
 			ContainerID: struct {
 				Source *intern.Value
@@ -83,7 +88,6 @@ func TestResolveLocalConnections(t *testing.T) {
 			}{
 				Source: intern.GetByString("7e999c2c2349713e27cecf87ef8e0cf496aec08b06b6a8b8c988dd42a3839a98"),
 			},
-			Type:      TCP,
 			IntraHost: true,
 		},
 	}
@@ -111,19 +115,20 @@ func TestResolveLoopbackConnections(t *testing.T) {
 	}{
 		{
 			name: "raddr resolution with nat",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Pid:    1,
 				Source: util.AddressFromString("127.0.0.1"),
 				SPort:  1234,
 				Dest:   util.AddressFromString("10.1.1.2"),
 				DPort:  1234,
+				NetNS:  1,
+			},
 				IPTranslation: &IPTranslation{
 					ReplDstIP:   util.AddressFromString("127.0.0.1"),
 					ReplDstPort: 1234,
 					ReplSrcIP:   util.AddressFromString("10.1.1.2"),
 					ReplSrcPort: 1234,
 				},
-				NetNS:     1,
 				Direction: INCOMING,
 				IntraHost: true,
 				ContainerID: struct {
@@ -137,13 +142,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr resolution with nat to localhost",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Pid:    2,
 				NetNS:  1,
 				Source: util.AddressFromString("10.1.1.2"),
 				SPort:  1234,
 				Dest:   util.AddressFromString("10.1.1.1"),
 				DPort:  1234,
+			},
 				IPTranslation: &IPTranslation{
 					ReplDstIP:   util.AddressFromString("10.1.1.2"),
 					ReplDstPort: 1234,
@@ -163,13 +169,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr failed localhost resolution",
-			conn: ConnectionStats{
-				Pid:       3,
-				NetNS:     3,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1235,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1234,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    3,
+				NetNS:  3,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1235,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1234,
+			},
 				IntraHost: true,
 				Direction: INCOMING,
 				ContainerID: struct {
@@ -183,13 +190,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr resolution within same netns (3)",
-			conn: ConnectionStats{
-				Pid:       5,
-				NetNS:     3,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1240,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1235,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    5,
+				NetNS:  3,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1240,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1235,
+			},
 				IntraHost: true,
 				Direction: OUTGOING,
 				ContainerID: struct {
@@ -203,13 +211,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr resolution within same netns (1)",
-			conn: ConnectionStats{
-				Pid:       3,
-				NetNS:     3,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1235,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1240,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    3,
+				NetNS:  3,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1235,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1240,
+			},
 				IntraHost: true,
 				Direction: INCOMING,
 				ContainerID: struct {
@@ -223,13 +232,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr resolution within same netns (2)",
-			conn: ConnectionStats{
-				Pid:       5,
-				NetNS:     3,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1240,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1235,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    5,
+				NetNS:  3,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1240,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1235,
+			},
 				IntraHost: true,
 				Direction: OUTGOING,
 				ContainerID: struct {
@@ -243,13 +253,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "raddr failed resolution, known address in different netns",
-			conn: ConnectionStats{
-				Pid:       5,
-				NetNS:     4,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1240,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1235,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    5,
+				NetNS:  4,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1240,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1235,
+			},
 				IntraHost: true,
 				Direction: OUTGOING,
 				ContainerID: struct {
@@ -263,13 +274,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "failed laddr and raddr resolution",
-			conn: ConnectionStats{
-				Pid:       10,
-				NetNS:     10,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1234,
-				Dest:      util.AddressFromString("10.1.1.1"),
-				DPort:     1235,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    10,
+				NetNS:  10,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1234,
+				Dest:   util.AddressFromString("10.1.1.1"),
+				DPort:  1235,
+			},
 				Direction: OUTGOING,
 				IntraHost: false,
 			},
@@ -277,13 +289,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "failed resolution: unknown pid for laddr, raddr address in different netns from known address",
-			conn: ConnectionStats{
-				Pid:       11,
-				NetNS:     10,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1250,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1240,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    11,
+				NetNS:  10,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1250,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1240,
+			},
 				Direction: OUTGOING,
 				IntraHost: true,
 			},
@@ -291,13 +304,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "localhost resolution within same netns 1/2",
-			conn: ConnectionStats{
-				Pid:       6,
-				NetNS:     7,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1260,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1250,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    6,
+				NetNS:  7,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1260,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1250,
+			},
 				Direction: OUTGOING,
 				IntraHost: true,
 				ContainerID: struct {
@@ -311,13 +325,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "localhost resolution within same netns 2/2",
-			conn: ConnectionStats{
-				Pid:       7,
-				NetNS:     7,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     1250,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1260,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    7,
+				NetNS:  7,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  1250,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1260,
+			},
 				Direction: INCOMING,
 				IntraHost: true,
 				ContainerID: struct {
@@ -331,13 +346,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "zero src netns failed resolution",
-			conn: ConnectionStats{
-				Pid:       22,
-				NetNS:     0,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     8282,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     1250,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    22,
+				NetNS:  0,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  8282,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  1250,
+			},
 				Direction: OUTGOING,
 				ContainerID: struct {
 					Source *intern.Value
@@ -350,13 +366,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		},
 		{
 			name: "zero src and dst netns failed resolution",
-			conn: ConnectionStats{
-				Pid:       21,
-				NetNS:     0,
-				Source:    util.AddressFromString("127.0.0.1"),
-				SPort:     8181,
-				Dest:      util.AddressFromString("127.0.0.1"),
-				DPort:     8282,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Pid:    21,
+				NetNS:  0,
+				Source: util.AddressFromString("127.0.0.1"),
+				SPort:  8181,
+				Dest:   util.AddressFromString("127.0.0.1"),
+				DPort:  8282,
+			},
 				Direction: OUTGOING,
 				ContainerID: struct {
 					Source *intern.Value

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -6,7 +6,6 @@
 package network
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 	"sync"
@@ -285,28 +284,22 @@ type networkState struct {
 	enableConnectionRollup      bool
 	processEventConsumerEnabled bool
 
-	mergeStatsBuffers [2][]byte
-
 	localResolver LocalResolver
 }
 
 // NewState creates a new network state
 func NewState(_ telemetryComponent.Component, clientExpiry time.Duration, maxClosedConns uint32, maxClientStats, maxDNSStats, maxHTTPStats, maxKafkaStats, maxPostgresStats, maxRedisStats int, enableConnectionRollup bool, processEventConsumerEnabled bool) State {
 	ns := &networkState{
-		clients:                map[string]*client{},
-		clientExpiry:           clientExpiry,
-		maxClosedConns:         maxClosedConns,
-		maxClientStats:         maxClientStats,
-		maxDNSStats:            maxDNSStats,
-		maxHTTPStats:           maxHTTPStats,
-		maxKafkaStats:          maxKafkaStats,
-		maxPostgresStats:       maxPostgresStats,
-		maxRedisStats:          maxRedisStats,
-		enableConnectionRollup: enableConnectionRollup,
-		mergeStatsBuffers: [2][]byte{
-			make([]byte, ConnectionByteKeyMaxLen),
-			make([]byte, ConnectionByteKeyMaxLen),
-		},
+		clients:                     map[string]*client{},
+		clientExpiry:                clientExpiry,
+		maxClosedConns:              maxClosedConns,
+		maxClientStats:              maxClientStats,
+		maxDNSStats:                 maxDNSStats,
+		maxHTTPStats:                maxHTTPStats,
+		maxKafkaStats:               maxKafkaStats,
+		maxPostgresStats:            maxPostgresStats,
+		maxRedisStats:               maxRedisStats,
+		enableConnectionRollup:      enableConnectionRollup,
 		localResolver:               NewLocalResolver(processEventConsumerEnabled),
 		processEventConsumerEnabled: processEventConsumerEnabled,
 	}
@@ -1222,8 +1215,7 @@ type aggregateConnection struct {
 }
 
 type aggregationKey struct {
-	// connKey is the key returned by ConnectionStats.ByteKey()
-	connKey    string
+	connKey    ConnectionTuple
 	direction  ConnectionDirection
 	containers struct {
 		source, dest *intern.Value
@@ -1232,7 +1224,6 @@ type aggregationKey struct {
 
 type connectionAggregator struct {
 	conns                       map[aggregationKey][]*aggregateConnection
-	buf                         []byte
 	dnsStats                    dns.StatsByKeyByNameByType
 	enablePortRollups           bool
 	processEventConsumerEnabled bool
@@ -1241,7 +1232,6 @@ type connectionAggregator struct {
 func newConnectionAggregator(size int, enablePortRollups, processEventConsumerEnabled bool, dnsStats dns.StatsByKeyByNameByType) *connectionAggregator {
 	return &connectionAggregator{
 		conns:                       make(map[aggregationKey][]*aggregateConnection, size),
-		buf:                         make([]byte, ConnectionByteKeyMaxLen),
 		dnsStats:                    dnsStats,
 		enablePortRollups:           enablePortRollups,
 		processEventConsumerEnabled: processEventConsumerEnabled,
@@ -1249,7 +1239,7 @@ func newConnectionAggregator(size int, enablePortRollups, processEventConsumerEn
 }
 
 func (a *connectionAggregator) key(c *ConnectionStats) (key aggregationKey, sportRolledUp, dportRolledUp bool) {
-	key.connKey = string(c.ByteKey(a.buf))
+	key.connKey = c.ConnectionTuple
 	key.direction = c.Direction
 	if a.processEventConsumerEnabled {
 		key.containers.source = c.ContainerID.Source
@@ -1297,7 +1287,7 @@ func (a *connectionAggregator) key(c *ConnectionStats) (key aggregationKey, spor
 		}()
 	}
 
-	key.connKey = string(c.ByteKey(a.buf))
+	key.connKey = c.ConnectionTuple
 	return key, sportRolledUp, dportRolledUp
 }
 
@@ -1477,7 +1467,7 @@ func (ns *networkState) mergeConnectionStats(a, b *ConnectionStats) (collision b
 		return false
 	}
 
-	if !bytes.Equal(a.ByteKey(ns.mergeStatsBuffers[0]), b.ByteKey(ns.mergeStatsBuffers[1])) {
+	if a.ConnectionTuple != b.ConnectionTuple {
 		log.Debugf("cookie collision for connections %+v and %+v", a, b)
 		// cookie collision
 		return true

--- a/pkg/network/state_intrahost_test.go
+++ b/pkg/network/state_intrahost_test.go
@@ -37,13 +37,13 @@ func TestSNATIntraHost(t *testing.T) {
 }
 
 func CreateConnectionStat(source string, dest string, SPort uint16, DPort uint16, connType ConnectionType) ConnectionStats {
-	return ConnectionStats{
+	return ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString(source),
 		Dest:   util.AddressFromString(dest),
 		SPort:  SPort,
 		DPort:  DPort,
 		Type:   connType,
-	}
+	}}
 }
 
 func AddIPTranslationToConnection(conn *ConnectionStats, ReplSrcIP string, ReplDstIP string, ReplSrcPort uint16, ReplDstPort uint16) {

--- a/pkg/network/state_linux_test.go
+++ b/pkg/network/state_linux_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 func TestStatsOverflow(t *testing.T) {
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentPackets: math.MaxUint32 - 1, RecvPackets: math.MaxUint32 - 2},
 		IntraHost: true,
 	}

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -109,7 +109,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 }
 
 func TestRemoveConnections(t *testing.T) {
-	conn := ConnectionStats{
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   UDP,
 		Family: AFINET,
@@ -117,6 +117,7 @@ func TestRemoveConnections(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  31890,
 		DPort:  80,
+	},
 		Monotonic: StatCounters{
 			SentBytes:   12345,
 			RecvBytes:   6789,
@@ -148,7 +149,7 @@ func TestRemoveConnections(t *testing.T) {
 }
 
 func TestRetrieveClosedConnection(t *testing.T) {
-	conn := ConnectionStats{
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -156,6 +157,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  31890,
 		DPort:  80,
+	},
 		Monotonic: StatCounters{
 			SentBytes:   12345,
 			RecvBytes:   6789,
@@ -202,7 +204,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 }
 
 func TestDropActiveConnections(t *testing.T) {
-	conn := ConnectionStats{
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -210,6 +212,7 @@ func TestDropActiveConnections(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  31890,
 		DPort:  80,
+	},
 		Monotonic: StatCounters{
 			SentBytes:   12345,
 			RecvBytes:   6789,
@@ -245,7 +248,7 @@ func TestDropActiveConnections(t *testing.T) {
 }
 
 func TestDropEmptyConnections(t *testing.T) {
-	conn := ConnectionStats{
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -253,6 +256,7 @@ func TestDropEmptyConnections(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  31890,
 		DPort:  80,
+	},
 		Monotonic: StatCounters{
 			SentBytes:   12345,
 			RecvBytes:   6789,
@@ -565,7 +569,7 @@ func TestTelemetryDiffing(t *testing.T) {
 func TestNoPriorRegistrationActiveConnections(t *testing.T) {
 	clientID := "1"
 	state := newDefaultState()
-	conn := ConnectionStats{
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -573,6 +577,7 @@ func TestNoPriorRegistrationActiveConnections(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  9000,
 		DPort:  1234,
+	},
 		Monotonic: StatCounters{
 			SentBytes: 1,
 		},
@@ -622,14 +627,15 @@ func TestLastStats(t *testing.T) {
 		Retransmits: 2,
 	}
 
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
-		SPort:     31890,
-		DPort:     80,
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  31890,
+		DPort:  80,
+	},
 		Monotonic: m,
 	}
 
@@ -710,14 +716,15 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 		Retransmits: 1,
 	}
 
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
-		SPort:     31890,
-		DPort:     80,
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+		SPort:  31890,
+		DPort:  80,
+	},
 		Monotonic: m,
 	}
 
@@ -763,7 +770,7 @@ func TestRaceConditions(_ *testing.T) {
 	genConns := func(n uint32) []ConnectionStats {
 		conns := make([]ConnectionStats, 0, n)
 		for i := uint32(0); i < n; i++ {
-			conns = append(conns, ConnectionStats{
+			conns = append(conns, ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Pid:    1 + i,
 				Type:   TCP,
 				Family: AFINET,
@@ -771,6 +778,7 @@ func TestRaceConditions(_ *testing.T) {
 				Dest:   util.AddressFromString("127.0.0.1"),
 				SPort:  uint16(rand.Int()),
 				DPort:  uint16(rand.Int()),
+			},
 				Monotonic: StatCounters{
 					SentBytes:   uint64(rand.Int()),
 					RecvBytes:   uint64(rand.Int()),
@@ -813,12 +821,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 	// Each horizontal bar represents a connection lifespan (from start to end with the number of sent bytes written on top of the line)
 
 	client := "c"
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentBytes: 3},
 		Cookie:    1,
 	}
@@ -923,14 +932,15 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Conns
 		assert.Len(t, conns, 0)
 
-		conn := ConnectionStats{
-			Pid:       123,
-			Type:      TCP,
-			Family:    AFINET,
-			Source:    util.AddressFromString("127.0.0.1"),
-			Dest:      util.AddressFromString("127.0.0.1"),
-			SPort:     9000,
-			DPort:     1234,
+		conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+			Pid:    123,
+			Type:   TCP,
+			Family: AFINET,
+			Source: util.AddressFromString("127.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			SPort:  9000,
+			DPort:  1234,
+		},
 			Monotonic: StatCounters{SentBytes: 1},
 			Cookie:    1,
 		}
@@ -1444,12 +1454,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 }
 
 func TestStatsResetOnUnderflow(t *testing.T) {
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentBytes: 3},
 		IntraHost: true,
 	}
@@ -1477,12 +1488,13 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 }
 
 func TestDoubleCloseOnTwoClients(t *testing.T) {
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentBytes: 3},
 		Last:      StatCounters{SentBytes: 3},
 		IntraHost: true,
@@ -1515,12 +1527,13 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 
 func TestUnorderedCloseEvent(t *testing.T) {
 	stateTelemetry.statsUnderflows.Delete()
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentBytes: 3},
 	}
 
@@ -1567,12 +1580,13 @@ func TestUnorderedCloseEvent(t *testing.T) {
 }
 
 func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
-	conn := ConnectionStats{
-		Pid:       123,
-		Type:      TCP,
-		Family:    AFINET,
-		Source:    util.AddressFromString("127.0.0.1"),
-		Dest:      util.AddressFromString("127.0.0.1"),
+	conn := ConnectionStats{ConnectionTuple: ConnectionTuple{
+		Pid:    123,
+		Type:   TCP,
+		Family: AFINET,
+		Source: util.AddressFromString("127.0.0.1"),
+		Dest:   util.AddressFromString("127.0.0.1"),
+	},
 		Monotonic: StatCounters{SentBytes: 3},
 	}
 
@@ -1597,7 +1611,7 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 }
 
 func TestDNSStatsWithMultipleClients(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -1605,7 +1619,7 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  1000,
 		DPort:  53,
-	}
+	}}
 
 	dKey := dns.Key{ClientIP: c.Source, ClientPort: c.SPort, ServerIP: c.Dest, Protocol: getIPProtocol(c.Type)}
 
@@ -1673,12 +1687,12 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 }
 
 func TestHTTPStats(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte("/testpath"), true, http.MethodGet)
 
@@ -1701,12 +1715,12 @@ func TestHTTPStats(t *testing.T) {
 }
 
 func TestHTTP2Stats(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
 		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte(path), true, http.MethodGet)
@@ -1733,12 +1747,12 @@ func TestHTTP2Stats(t *testing.T) {
 }
 
 func TestHTTPStatsWithMultipleClients(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
 		httpStats := make(map[http.Key]*http.RequestStats)
@@ -1796,12 +1810,12 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 }
 
 func TestHTTP2StatsWithMultipleClients(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
 		http2Stats := make(map[http.Key]*http.RequestStats)
@@ -1866,31 +1880,32 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 	}{
 		{
 			name: "equal source/dest",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("1.1.1.1"),
 				Dest:   util.AddressFromString("1.1.1.1"),
 				SPort:  123,
 				DPort:  456,
-			},
+			}},
 			intraHost: true,
 		},
 		{
 			name: "source/dest loopback",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("127.0.0.1"),
 				Dest:   util.AddressFromString("127.0.0.1"),
 				SPort:  123,
 				DPort:  456,
-			},
+			}},
 			intraHost: true,
 		},
 		{
 			name: "dest nat'ed to loopback",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
 				Source: util.AddressFromString("1.1.1.1"),
 				Dest:   util.AddressFromString("2.2.2.2"),
 				SPort:  123,
 				DPort:  456,
+			},
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("127.0.0.1"),
 					ReplDstIP:   util.AddressFromString("1.1.1.1"),
@@ -1902,13 +1917,14 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 		},
 		{
 			name: "local connection with nat on both sides (outgoing)",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("169.254.169.254"),
-				SPort:     12345,
-				DPort:     80,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("169.254.169.254"),
+				SPort:  12345,
+				DPort:  80,
+				NetNS:  1212,
+			},
 				Direction: OUTGOING,
-				NetNS:     1212,
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("127.0.0.1"),
 					ReplDstIP:   util.AddressFromString("1.1.1.1"),
@@ -1920,13 +1936,14 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 		},
 		{
 			name: "local connection with nat on both sides (incoming)",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("127.0.0.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     8181,
-				DPort:     12345,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("127.0.0.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  8181,
+				DPort:  12345,
+				NetNS:  1233,
+			},
 				Direction: INCOMING,
-				NetNS:     1233,
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("1.1.1.1"),
 					ReplDstIP:   util.AddressFromString("169.254.169.254"),
@@ -1938,13 +1955,14 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 		},
 		{
 			name: "remote connection with source translation (redirect)",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("4.4.4.4"),
-				Dest:      util.AddressFromString("2.2.2.2"),
-				SPort:     12345,
-				DPort:     80,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("4.4.4.4"),
+				Dest:   util.AddressFromString("2.2.2.2"),
+				SPort:  12345,
+				DPort:  80,
+				NetNS:  2,
+			},
 				Direction: INCOMING,
-				NetNS:     2,
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("2.2.2.2"),
 					ReplDstIP:   util.AddressFromString("127.0.0.1"),
@@ -1956,61 +1974,66 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 		},
 		{
 			name: "local connection, same network ns",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("2.2.2.2"),
-				SPort:     12345,
-				DPort:     80,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("2.2.2.2"),
+				SPort:  12345,
+				DPort:  80,
+				NetNS:  1,
+			},
 				Direction: OUTGOING,
-				NetNS:     1,
 			},
 			intraHost: true,
 		},
 		{
 			name: "local connection, same network ns",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("2.2.2.2"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     80,
-				DPort:     12345,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("2.2.2.2"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  80,
+				DPort:  12345,
+				NetNS:  1,
+			},
 				Direction: INCOMING,
-				NetNS:     1,
 			},
 			intraHost: true,
 		},
 		{
 			name: "local connection, different network ns",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("2.2.2.2"),
-				SPort:     12345,
-				DPort:     80,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("2.2.2.2"),
+				SPort:  12345,
+				DPort:  80,
+				NetNS:  1,
+			},
 				Direction: OUTGOING,
-				NetNS:     1,
 			},
 			intraHost: true,
 		},
 		{
 			name: "local connection, different network ns",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("2.2.2.2"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     80,
-				DPort:     12345,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("2.2.2.2"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  80,
+				DPort:  12345,
+				NetNS:  2,
+			},
 				Direction: INCOMING,
-				NetNS:     2,
 			},
 			intraHost: true,
 		},
 		{
 			name: "remote connection",
-			conn: ConnectionStats{
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("3.3.3.3"),
-				SPort:     12345,
-				DPort:     80,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("3.3.3.3"),
+				SPort:  12345,
+				DPort:  80,
+				NetNS:  1,
+			},
 				Direction: OUTGOING,
-				NetNS:     1,
 			},
 			intraHost: false,
 		},
@@ -2047,75 +2070,81 @@ func TestIntraHostFixDirection(t *testing.T) {
 	}{
 		{
 			name: "outgoing both non-ephemeral",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  123,
+				DPort:  456,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     123,
-				DPort:     456,
 				Direction: OUTGOING,
 			},
 			direction: OUTGOING,
 		},
 		{
 			name: "outgoing non ephemeral to ephemeral",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  123,
+				DPort:  49612,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     123,
-				DPort:     49612,
 				Direction: OUTGOING,
 			},
 			direction: INCOMING,
 		},
 		{
 			name: "outgoing ephemeral to non ephemeral",
-			conn: ConnectionStats{
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  49612,
+				DPort:  123,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     49612,
-				DPort:     123,
 				Direction: OUTGOING,
 			},
 			direction: OUTGOING,
 		},
 		{
 			name: "incoming udp non ephemeral to ephemeral",
-			conn: ConnectionStats{
-				Type:      UDP,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Type:   UDP,
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  49612,
+				DPort:  123,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     49612,
-				DPort:     123,
 				Direction: INCOMING,
 			},
 			direction: OUTGOING,
 		},
 		{
 			name: "incoming udp ephemeral to non ephemeral",
-			conn: ConnectionStats{
-				Type:      UDP,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Type:   UDP,
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  123,
+				DPort:  49612,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     123,
-				DPort:     49612,
 				Direction: INCOMING,
 			},
 			direction: INCOMING,
 		},
 		{
 			name: "incoming tcp non ephemeral to ephemeral",
-			conn: ConnectionStats{
-				Type:      TCP,
+			conn: ConnectionStats{ConnectionTuple: ConnectionTuple{
+				Type:   TCP,
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  49612,
+				DPort:  123,
+			},
 				IntraHost: true,
-				Source:    util.AddressFromString("1.1.1.1"),
-				Dest:      util.AddressFromString("1.1.1.1"),
-				SPort:     49612,
-				DPort:     123,
 				Direction: INCOMING,
 			},
 			direction: INCOMING,
@@ -2137,7 +2166,7 @@ func TestIntraHostFixDirection(t *testing.T) {
 func TestClosedMergingWithAddressCollision(t *testing.T) {
 	const client = "foo"
 
-	c1 := ConnectionStats{
+	c1 := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -2145,6 +2174,7 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  1000,
 		DPort:  8080,
+	},
 		Monotonic: StatCounters{
 			SentBytes: 100,
 		},
@@ -2156,7 +2186,7 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 			ReplDstPort: 456,
 		},
 	}
-	c2 := ConnectionStats{
+	c2 := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Pid:    123,
 		Type:   TCP,
 		Family: AFINET,
@@ -2164,6 +2194,7 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 		Dest:   util.AddressFromString("127.0.0.1"),
 		SPort:  1000,
 		DPort:  8080,
+	},
 		Monotonic: StatCounters{
 			SentBytes: 150,
 		},
@@ -2191,7 +2222,7 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 		state.StoreClosedConnection(&c1)
 		state.StoreClosedConnection(&c2)
 
-		active := ConnectionStats{
+		active := ConnectionStats{ConnectionTuple: ConnectionTuple{
 			Pid:    123,
 			Type:   TCP,
 			Family: AFINET,
@@ -2199,6 +2230,7 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  1000,
 			DPort:  8080,
+		},
 			Monotonic: StatCounters{
 				SentBytes: 150,
 			},
@@ -2263,12 +2295,12 @@ func TestClosedMergingWithAddressCollision(t *testing.T) {
 }
 
 func TestKafkaStats(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	key := kafka.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "my-topic", kafka.ProduceAPIKey, 1)
 
@@ -2294,12 +2326,12 @@ func TestKafkaStats(t *testing.T) {
 }
 
 func TestKafkaStatsWithMultipleClients(t *testing.T) {
-	c := ConnectionStats{
+	c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("0.0.0.0"),
 		SPort:  1000,
 		DPort:  80,
-	}
+	}}
 
 	getStats := func(topicName string) map[protocols.ProtocolType]interface{} {
 		kafkaStats := make(map[kafka.Key]*kafka.RequestStats)
@@ -2362,10 +2394,18 @@ func TestKafkaStatsWithMultipleClients(t *testing.T) {
 
 func TestConnectionRollup(t *testing.T) {
 	conns := []ConnectionStats{
-		{
+		{ConnectionTuple: ConnectionTuple{
+			Source: util.AddressFromString("172.29.141.26"),
+			SPort:  50010,
+			Family: AFINET,
+			NetNS:  4026532341,
+			Pid:    28385,
+			Dest:   util.AddressFromString("10.100.0.10"),
+			DPort:  53,
+			Type:   UDP,
+		},
 			// should be rolled up with next connection
 			Direction: OUTGOING,
-			Family:    AFINET,
 			IntraHost: false,
 			IPTranslation: &IPTranslation{
 				ReplDstIP:   util.AddressFromString("172.29.141.26"),
@@ -2374,8 +2414,6 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcPort: 53,
 			},
 			SPortIsEphemeral: EphemeralTrue,
-			Source:           util.AddressFromString("172.29.141.26"),
-			SPort:            50010,
 			ContainerID:      struct{ Source, Dest *intern.Value }{intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f"), nil},
 			Monotonic: StatCounters{
 				RecvBytes:      342,
@@ -2386,19 +2424,22 @@ func TestConnectionRollup(t *testing.T) {
 				TCPClosed:      0,
 				TCPEstablished: 0,
 			},
-			NetNS:    4026532341,
-			Pid:      28385,
-			Dest:     util.AddressFromString("10.100.0.10"),
-			DPort:    53,
-			Type:     UDP,
 			Cookie:   1,
 			Duration: time.Second,
 			IsClosed: true,
 		},
-		{
+		{ConnectionTuple: ConnectionTuple{
+			Source: util.AddressFromString("172.29.141.26"),
+			SPort:  49155,
+			Family: AFINET,
+			NetNS:  4026532341,
+			Pid:    28385,
+			Dest:   util.AddressFromString("10.100.0.10"),
+			DPort:  53,
+			Type:   UDP,
+		},
 			// should be rolled up with previous connection
 			Direction: OUTGOING,
-			Family:    AFINET,
 			IntraHost: false,
 			IPTranslation: &IPTranslation{
 				ReplDstIP:   util.AddressFromString("172.29.141.26"),
@@ -2407,8 +2448,6 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcPort: 53,
 			},
 			SPortIsEphemeral: EphemeralTrue,
-			Source:           util.AddressFromString("172.29.141.26"),
-			SPort:            49155,
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      314,
@@ -2419,19 +2458,22 @@ func TestConnectionRollup(t *testing.T) {
 				TCPClosed:      0,
 				TCPEstablished: 0,
 			},
-			NetNS:    4026532341,
-			Pid:      28385,
-			Dest:     util.AddressFromString("10.100.0.10"),
-			DPort:    53,
-			Type:     UDP,
 			Cookie:   2,
 			Duration: time.Second,
 			IsClosed: true,
 		},
-		{
+		{ConnectionTuple: ConnectionTuple{
+			Family: AFINET,
+			Source: util.AddressFromString("172.29.141.26"),
+			SPort:  52907,
+			NetNS:  4026532341,
+			Pid:    28385,
+			Dest:   util.AddressFromString("10.100.0.10"),
+			DPort:  53,
+			Type:   UDP,
+		},
 			// should be rolled up with next connection
 			Direction: OUTGOING,
-			Family:    AFINET,
 			IntraHost: false,
 			IPTranslation: &IPTranslation{
 				ReplDstIP:   util.AddressFromString("172.29.141.26"),
@@ -2440,8 +2482,6 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcPort: 53,
 			},
 			SPortIsEphemeral: EphemeralTrue,
-			Source:           util.AddressFromString("172.29.141.26"),
-			SPort:            52907,
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      306,
@@ -2452,19 +2492,22 @@ func TestConnectionRollup(t *testing.T) {
 				TCPClosed:      0,
 				TCPEstablished: 0,
 			},
-			NetNS:    4026532341,
-			Pid:      28385,
-			Dest:     util.AddressFromString("10.100.0.10"),
-			DPort:    53,
-			Type:     UDP,
 			Cookie:   3,
 			Duration: time.Second,
 			IsClosed: true,
 		},
-		{
+		{ConnectionTuple: ConnectionTuple{
+			Family: AFINET,
+			Source: util.AddressFromString("172.29.141.26"),
+			SPort:  52904,
+			NetNS:  4026532341,
+			Pid:    28385,
+			Dest:   util.AddressFromString("10.100.0.10"),
+			DPort:  53,
+			Type:   UDP,
+		},
 			// should be rolled up with previous connection
 			Direction: OUTGOING,
-			Family:    AFINET,
 			IntraHost: false,
 			IPTranslation: &IPTranslation{
 				ReplDstIP:   util.AddressFromString("172.29.141.26"),
@@ -2473,8 +2516,6 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcPort: 53,
 			},
 			SPortIsEphemeral: EphemeralTrue,
-			Source:           util.AddressFromString("172.29.141.26"),
-			SPort:            52904,
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      288,
@@ -2485,19 +2526,22 @@ func TestConnectionRollup(t *testing.T) {
 				TCPClosed:      0,
 				TCPEstablished: 0,
 			},
-			NetNS:    4026532341,
-			Pid:      28385,
-			Dest:     util.AddressFromString("10.100.0.10"),
-			DPort:    53,
-			Type:     UDP,
 			Cookie:   4,
 			Duration: time.Second,
 			IsClosed: true,
 		},
-		{
+		{ConnectionTuple: ConnectionTuple{
+			Family: AFINET,
+			Source: util.AddressFromString("172.29.141.26"),
+			SPort:  37240,
+			NetNS:  4026532341,
+			Pid:    28385,
+			Dest:   util.AddressFromString("10.100.0.10"),
+			DPort:  53,
+			Type:   UDP,
+		},
 			// this should not be rolled up as the duration is > 2 mins
 			Direction: OUTGOING,
-			Family:    AFINET,
 			IntraHost: false,
 			IPTranslation: &IPTranslation{
 				ReplDstIP:   util.AddressFromString("172.29.141.26"),
@@ -2506,8 +2550,6 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcPort: 53,
 			},
 			SPortIsEphemeral: EphemeralTrue,
-			Source:           util.AddressFromString("172.29.141.26"),
-			SPort:            37240,
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      594,
@@ -2518,24 +2560,21 @@ func TestConnectionRollup(t *testing.T) {
 				TCPClosed:      0,
 				TCPEstablished: 0,
 			},
-			NetNS:    4026532341,
-			Pid:      28385,
-			Dest:     util.AddressFromString("10.100.0.10"),
-			DPort:    53,
-			Type:     UDP,
 			Cookie:   5,
 			Duration: 3 * time.Minute,
 			IsClosed: true,
 		},
-		{
-			Pid:              5652,
-			Source:           util.AddressFromString("172.29.160.125"),
-			SPort:            8443,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    5652,
+			Source: util.AddressFromString("172.29.160.125"),
+			SPort:  8443,
+			Dest:   util.AddressFromString("172.29.166.243"),
+			DPort:  38633,
+			Family: AFINET,
+			Type:   TCP,
+			NetNS:  4026531992,
+		},
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
-			Dest:             util.AddressFromString("172.29.166.243"),
-			DPort:            38633,
-			Family:           AFINET,
-			Type:             TCP,
 			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      0,
@@ -2546,7 +2585,6 @@ func TestConnectionRollup(t *testing.T) {
 				TCPEstablished: 1,
 			},
 			Direction: INCOMING,
-			NetNS:     4026531992,
 			RTT:       262,
 			RTTVar:    131,
 			IntraHost: false,
@@ -2554,15 +2592,17 @@ func TestConnectionRollup(t *testing.T) {
 			Duration:  time.Second,
 			IsClosed:  true,
 		},
-		{
-			Pid:              5652,
-			Source:           util.AddressFromString("172.29.160.125"),
-			SPort:            8443,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    5652,
+			Source: util.AddressFromString("172.29.160.125"),
+			SPort:  8443,
+			Dest:   util.AddressFromString("172.29.154.189"),
+			DPort:  60509,
+			Family: AFINET,
+			Type:   TCP,
+			NetNS:  4026531992,
+		},
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
-			Dest:             util.AddressFromString("172.29.154.189"),
-			DPort:            60509,
-			Family:           AFINET,
-			Type:             TCP,
 			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      0,
@@ -2573,7 +2613,6 @@ func TestConnectionRollup(t *testing.T) {
 				TCPEstablished: 1,
 			},
 			Direction: INCOMING,
-			NetNS:     4026531992,
 			RTT:       254,
 			RTTVar:    127,
 			IntraHost: false,
@@ -2581,15 +2620,17 @@ func TestConnectionRollup(t *testing.T) {
 			Duration:  time.Second,
 			IsClosed:  true,
 		},
-		{
-			Pid:              5652,
-			Source:           util.AddressFromString("172.29.160.125"),
-			SPort:            8443,
+		{ConnectionTuple: ConnectionTuple{
+			Pid:    5652,
+			Source: util.AddressFromString("172.29.160.125"),
+			SPort:  8443,
+			Dest:   util.AddressFromString("172.29.166.243"),
+			DPort:  34715,
+			Family: AFINET,
+			Type:   TCP,
+			NetNS:  4026531992,
+		},
 			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
-			Dest:             util.AddressFromString("172.29.166.243"),
-			DPort:            34715,
-			Family:           AFINET,
-			Type:             TCP,
 			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      2392,
@@ -2600,7 +2641,6 @@ func TestConnectionRollup(t *testing.T) {
 				TCPEstablished: 1,
 			},
 			Direction: INCOMING,
-			NetNS:     4026531992,
 			RTT:       250,
 			RTTVar:    66,
 			IntraHost: false,
@@ -2775,28 +2815,30 @@ func TestFilterConnections(t *testing.T) {
 
 func TestDNSPIDCollision(t *testing.T) {
 	conns := []ConnectionStats{
-		{
-			Source:    util.AddressFromString("10.1.1.1"),
-			Dest:      util.AddressFromString("8.8.8.8"),
-			Pid:       1,
-			SPort:     1000,
-			DPort:     53,
-			Type:      UDP,
-			Family:    AFINET,
+		{ConnectionTuple: ConnectionTuple{
+			Source: util.AddressFromString("10.1.1.1"),
+			Dest:   util.AddressFromString("8.8.8.8"),
+			Pid:    1,
+			SPort:  1000,
+			DPort:  53,
+			Type:   UDP,
+			Family: AFINET,
+		},
 			Direction: LOCAL,
 			Cookie:    1,
 			Monotonic: StatCounters{
 				RecvBytes: 2,
 			},
 		},
-		{
-			Source:    util.AddressFromString("10.1.1.1"),
-			Dest:      util.AddressFromString("8.8.8.8"),
-			Pid:       2,
-			SPort:     1000,
-			DPort:     53,
-			Type:      UDP,
-			Family:    AFINET,
+		{ConnectionTuple: ConnectionTuple{
+			Source: util.AddressFromString("10.1.1.1"),
+			Dest:   util.AddressFromString("8.8.8.8"),
+			Pid:    2,
+			SPort:  1000,
+			DPort:  53,
+			Type:   UDP,
+			Family: AFINET,
+		},
 			Direction: LOCAL,
 			Cookie:    2,
 			Monotonic: StatCounters{
@@ -2838,7 +2880,7 @@ func TestDNSPIDCollision(t *testing.T) {
 func generateRandConnections(n int) []ConnectionStats {
 	cs := make([]ConnectionStats, 0, n)
 	for i := 0; i < n; i++ {
-		cs = append(cs, ConnectionStats{
+		cs = append(cs, ConnectionStats{ConnectionTuple: ConnectionTuple{
 			Pid:    123,
 			Type:   TCP,
 			Family: AFINET,
@@ -2846,6 +2888,7 @@ func generateRandConnections(n int) []ConnectionStats {
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  uint16(rand.Intn(math.MaxUint16)),
 			DPort:  uint16(rand.Intn(math.MaxUint16)),
+		},
 			Monotonic: StatCounters{
 				RecvBytes:   rand.Uint64(),
 				SentBytes:   rand.Uint64(),

--- a/pkg/network/tracer/cached_conntrack_test.go
+++ b/pkg/network/tracer/cached_conntrack_test.go
@@ -144,7 +144,7 @@ func TestCachedConntrackExists(t *testing.T) {
 	daddr := util.AddressFromString("2.3.4.5")
 	var sport uint16 = 23
 	var dport uint16 = 223
-	ct := &network.ConnectionStats{
+	ct := &network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Pid:    uint32(os.Getpid()),
 		NetNS:  1234,
 		Source: saddr,
@@ -153,7 +153,7 @@ func TestCachedConntrackExists(t *testing.T) {
 		DPort:  dport,
 		Type:   network.TCP,
 		Family: network.AFINET,
-	}
+	}}
 
 	m.EXPECT().Exists(gomock.Not(gomock.Nil())).Times(1).DoAndReturn(func(c *netlink.Con) (bool, error) {
 		require.Equal(t, saddr.String(), c.Origin.Src.Addr().String())

--- a/pkg/network/tracer/cached_conntrack_test.go
+++ b/pkg/network/tracer/cached_conntrack_test.go
@@ -87,10 +87,10 @@ func TestCachedConntrackIgnoreErrNotPermitted(t *testing.T) {
 
 	t.Cleanup(func() { cache.Close() })
 
-	c := &network.ConnectionStats{
+	c := &network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		NetNS: 123455,
 		Pid:   1,
-	}
+	}}
 
 	exists, err := cache.Exists(c)
 	require.True(t, createCalled, "conntrack creator not called")
@@ -107,10 +107,10 @@ func TestCachedConntrackCacheCreatorError(t *testing.T) {
 
 	t.Cleanup(func() { cache.Close() })
 
-	c := &network.ConnectionStats{
+	c := &network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		NetNS: 123455,
 		Pid:   1,
-	}
+	}}
 
 	exists, err := cache.Exists(c)
 	require.True(t, createCalled, "conntrack creator not called")

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -314,15 +314,12 @@ func (t *ebpfTracer) Start(callback func(*network.ConnectionStats)) (err error) 
 		return fmt.Errorf("error initializing port binding maps: %s", err)
 	}
 
-	t.closeConsumer.Start(callback)
-	t.failedConnConsumer.Start()
-
 	if err := t.m.Start(); err != nil {
-		t.closeConsumer.Stop()
-		t.failedConnConsumer.Stop()
 		return fmt.Errorf("could not start ebpf manager: %s", err)
 	}
 
+	t.closeConsumer.Start(callback)
+	t.failedConnConsumer.Start()
 	return nil
 }
 

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -54,14 +54,13 @@ type ebpfLessTracer struct {
 
 	packetSrc   *filter.AFPacketSource
 	exit        chan struct{}
-	keyBuf      []byte
 	scratchConn *network.ConnectionStats
 
 	udp *udpProcessor
 	tcp *tcpProcessor
 
 	// connection maps
-	conns        map[string]*network.ConnectionStats
+	conns        map[network.ConnectionTuple]*network.ConnectionStats
 	boundPorts   *ebpfless.BoundPorts
 	cookieHasher *cookieHasher
 
@@ -81,11 +80,10 @@ func newEbpfLessTracer(cfg *config.Config) (*ebpfLessTracer, error) {
 		config:       cfg,
 		packetSrc:    packetSrc,
 		exit:         make(chan struct{}),
-		keyBuf:       make([]byte, network.ConnectionByteKeyMaxLen),
 		scratchConn:  &network.ConnectionStats{},
 		udp:          &udpProcessor{},
 		tcp:          newTCPProcessor(),
-		conns:        make(map[string]*network.ConnectionStats, cfg.MaxTrackedConnections),
+		conns:        make(map[network.ConnectionTuple]*network.ConnectionStats, cfg.MaxTrackedConnections),
 		boundPorts:   ebpfless.NewBoundPorts(cfg),
 		cookieHasher: newCookieHasher(),
 	}
@@ -99,7 +97,7 @@ func newEbpfLessTracer(cfg *config.Config) (*ebpfLessTracer, error) {
 }
 
 // Start begins collecting network connection data.
-func (t *ebpfLessTracer) Start(func(*network.ConnectionStats)) error {
+func (t *ebpfLessTracer) Start(_ func(*network.ConnectionStats)) error {
 	if err := t.boundPorts.Start(); err != nil {
 		return fmt.Errorf("could not update bound ports: %w", err)
 	}
@@ -190,8 +188,7 @@ func (t *ebpfLessTracer) processConnection(
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	key := string(t.scratchConn.ByteKey(t.keyBuf))
-	conn := t.conns[key]
+	conn := t.conns[t.scratchConn.ConnectionTuple]
 	if conn == nil {
 		conn = &network.ConnectionStats{}
 		*conn = *t.scratchConn
@@ -219,7 +216,7 @@ func (t *ebpfLessTracer) processConnection(
 			return fmt.Errorf("error getting last updated timestamp for connection: %w", err)
 		}
 		conn.LastUpdateEpoch = uint64(ts)
-		t.conns[key] = conn
+		t.conns[t.scratchConn.ConnectionTuple] = conn
 	}
 
 	log.TraceFunc(func() string {
@@ -300,7 +297,7 @@ func (t *ebpfLessTracer) Remove(conn *network.ConnectionStats) error {
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	delete(t.conns, string(conn.ByteKey(t.keyBuf)))
+	delete(t.conns, conn.ConnectionTuple)
 	return nil
 }
 
@@ -359,8 +356,7 @@ func (u *udpProcessor) process(conn *network.ConnectionStats, pktType uint8, udp
 }
 
 type tcpProcessor struct {
-	buf   []byte
-	conns map[string]struct {
+	conns map[network.ConnectionTuple]struct {
 		established bool
 		closed      bool
 	}
@@ -368,8 +364,7 @@ type tcpProcessor struct {
 
 func newTCPProcessor() *tcpProcessor {
 	return &tcpProcessor{
-		buf: make([]byte, network.ConnectionByteKeyMaxLen),
-		conns: map[string]struct {
+		conns: map[network.ConnectionTuple]struct {
 			established bool
 			closed      bool
 		}{},
@@ -385,8 +380,7 @@ func (t *tcpProcessor) process(conn *network.ConnectionStats, pktType uint8, ip4
 	log.TraceFunc(func() string {
 		return fmt.Sprintf("tcp processor: pktType=%+v seq=%+v ack=%+v fin=%+v rst=%+v syn=%+v ack=%+v", pktType, tcp.Seq, tcp.Ack, tcp.FIN, tcp.RST, tcp.SYN, tcp.ACK)
 	})
-	key := string(conn.ByteKey(t.buf))
-	c := t.conns[key]
+	c := t.conns[conn.ConnectionTuple]
 	log.TraceFunc(func() string {
 		return fmt.Sprintf("pre ack_seq=%+v", c)
 	})
@@ -405,7 +399,7 @@ func (t *tcpProcessor) process(conn *network.ConnectionStats, pktType uint8, ip4
 			conn.Monotonic.TCPClosed++
 			conn.Duration = time.Duration(time.Now().UnixNano() - int64(conn.Duration))
 		}
-		delete(t.conns, key)
+		delete(t.conns, conn.ConnectionTuple)
 		return nil
 	}
 
@@ -417,6 +411,6 @@ func (t *tcpProcessor) process(conn *network.ConnectionStats, pktType uint8, ip4
 	log.TraceFunc(func() string {
 		return fmt.Sprintf("ack_seq=%+v", c)
 	})
-	t.conns[key] = c
+	t.conns[conn.ConnectionTuple] = c
 	return nil
 }

--- a/pkg/network/tracer/connection/failure/failed_conn_consumer.go
+++ b/pkg/network/tracer/connection/failure/failed_conn_consumer.go
@@ -61,10 +61,10 @@ func (c *TCPFailedConnConsumer) Stop() {
 }
 
 func (c *TCPFailedConnConsumer) extractConn(data []byte) {
-	failedConn := (*netebpf.FailedConn)(unsafe.Pointer(&data[0]))
+	failedConn := (*Conn)(unsafe.Pointer(&data[0]))
 	failedConnConsumerTelemetry.eventsReceived.Inc()
 
-	c.FailedConns.upsertConn(failedConn)
+	c.FailedConns.UpsertConn(failedConn)
 }
 
 // Start starts the consumer

--- a/pkg/network/tracer/connection/failure/types.go
+++ b/pkg/network/tracer/connection/failure/types.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package failure
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
+)
+
+// Conn represents a failed connection
+type Conn ebpf.FailedConn
+
+// Tuple returns a network.ConnectionTuple
+func (c Conn) Tuple() network.ConnectionTuple {
+	ct := network.ConnectionTuple{
+		Source: c.Tup.SourceAddress(),
+		Dest:   c.Tup.DestAddress(),
+		Pid:    c.Tup.Pid,
+		NetNS:  c.Tup.Netns,
+		SPort:  c.Tup.Sport,
+		DPort:  c.Tup.Dport,
+	}
+
+	if c.Tup.Type() == ebpf.TCP {
+		ct.Type = network.TCP
+	} else {
+		ct.Type = network.UDP
+	}
+
+	switch c.Tup.Family() {
+	case ebpf.IPv4:
+		ct.Family = network.AFINET
+	case ebpf.IPv6:
+		ct.Family = network.AFINET6
+	}
+
+	return ct
+}

--- a/pkg/network/tracer/connection/util/conn_tracer.go
+++ b/pkg/network/tracer/connection/util/conn_tracer.go
@@ -147,8 +147,8 @@ func AddBoolConst(options *manager.Options, name string, flag bool) {
 	)
 }
 
-// ConnStatsToTuple converts a ConnectionStats to a ConnTuple
-func ConnStatsToTuple(c *network.ConnectionStats, tup *netebpf.ConnTuple) {
+// ConnTupleToEBPFTuple converts a ConnectionTuple to an eBPF ConnTuple
+func ConnTupleToEBPFTuple(c *network.ConnectionTuple, tup *netebpf.ConnTuple) {
 	tup.Sport = c.SPort
 	tup.Dport = c.DPort
 	tup.Netns = c.NetNS

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -147,7 +147,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 
 		localAddr := nettestutil.MustPingTCP(t, clientIP, natPort).LocalAddr().(*net.TCPAddr)
 		var trans *network.IPTranslation
-		cs := network.ConnectionStats{
+		cs := network.ConnectionTuple{
 			Source: util.AddressFromNetIP(localAddr.IP),
 			SPort:  uint16(localAddr.Port),
 			Dest:   util.AddressFromNetIP(clientIP),
@@ -165,7 +165,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 		// now dial TCP directly
 		localAddr = nettestutil.MustPingTCP(t, serverIP, nonNatPort).LocalAddr().(*net.TCPAddr)
 
-		cs = network.ConnectionStats{
+		cs = network.ConnectionTuple{
 			Source: util.AddressFromNetIP(localAddr.IP),
 			SPort:  uint16(localAddr.Port),
 			Dest:   util.AddressFromNetIP(serverIP),
@@ -189,7 +189,7 @@ func testConntracker(t *testing.T, serverIP, clientIP net.IP, ct netlink.Conntra
 
 		localAddrUDP := nettestutil.MustPingUDP(t, clientIP, natPort).LocalAddr().(*net.UDPAddr)
 		var trans *network.IPTranslation
-		cs := network.ConnectionStats{
+		cs := network.ConnectionTuple{
 			Source: util.AddressFromNetIP(localAddrUDP.IP),
 			SPort:  uint16(localAddrUDP.Port),
 			Dest:   util.AddressFromNetIP(clientIP),
@@ -221,7 +221,7 @@ func testConntrackerCrossNamespace(t *testing.T, ct netlink.Conntracker) {
 	t.Logf("test ns: %d", testIno)
 
 	var trans *network.IPTranslation
-	cs := network.ConnectionStats{
+	cs := network.ConnectionTuple{
 		Source: util.AddressFromNetIP(laddr.IP),
 		SPort:  uint16(laddr.Port),
 		Dest:   util.AddressFromString("2.2.2.4"),
@@ -277,7 +277,7 @@ func testConntrackerCrossNamespaceNATonRoot(t *testing.T, ct netlink.Conntracker
 	require.NotNil(t, laddr)
 
 	var trans *network.IPTranslation
-	cs := network.ConnectionStats{
+	cs := network.ConnectionTuple{
 		Source: util.AddressFromNetIP(laddr.IP),
 		SPort:  uint16(laddr.Port),
 		Dest:   util.AddressFromString("3.3.3.3"),

--- a/pkg/network/tracer/testutil/conntrack.go
+++ b/pkg/network/tracer/testutil/conntrack.go
@@ -19,7 +19,7 @@ type delayedConntracker struct {
 
 	mux          sync.Mutex
 	numDelays    int
-	delayPerConn map[string]int
+	delayPerConn map[network.ConnectionTuple]int
 }
 
 // NewDelayedConntracker returns a netlink.Conntracker that returns `nil` for `numDelays`
@@ -28,18 +28,17 @@ func NewDelayedConntracker(ctr netlink.Conntracker, numDelays int) netlink.Connt
 	return &delayedConntracker{
 		Conntracker:  ctr,
 		numDelays:    numDelays,
-		delayPerConn: make(map[string]int),
+		delayPerConn: make(map[network.ConnectionTuple]int),
 	}
 }
 
-func (ctr *delayedConntracker) GetTranslationForConn(c *network.ConnectionStats) *network.IPTranslation {
+func (ctr *delayedConntracker) GetTranslationForConn(c *network.ConnectionTuple) *network.IPTranslation {
 	ctr.mux.Lock()
 	defer ctr.mux.Unlock()
 
-	key := c.ByteKey(make([]byte, 64))
-	delays := ctr.delayPerConn[string(key)]
+	delays := ctr.delayPerConn[*c]
 	if delays < ctr.numDelays {
-		ctr.delayPerConn[string(key)]++
+		ctr.delayPerConn[*c]++
 		return nil
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -304,10 +304,10 @@ func (t *Tracer) storeClosedConnection(cs *network.ConnectionStats) {
 		return
 	}
 
-	cs.IPTranslation = t.conntracker.GetTranslationForConn(cs)
+	cs.IPTranslation = t.conntracker.GetTranslationForConn(&cs.ConnectionTuple)
 	t.connVia(cs)
 	if cs.IPTranslation != nil {
-		t.conntracker.DeleteTranslation(cs)
+		t.conntracker.DeleteTranslation(&cs.ConnectionTuple)
 	}
 
 	t.addProcessInfo(cs)
@@ -537,7 +537,7 @@ func (t *Tracer) getConnections(activeBuffer *network.ConnectionBuffer) (latestU
 
 	activeConnections = activeBuffer.Connections()
 	for i := range activeConnections {
-		activeConnections[i].IPTranslation = t.conntracker.GetTranslationForConn(&activeConnections[i])
+		activeConnections[i].IPTranslation = t.conntracker.GetTranslationForConn(&activeConnections[i].ConnectionTuple)
 		// do gateway resolution only on active connections outside
 		// the map iteration loop to not add to connections while
 		// iterating (leads to ever-increasing connections in the map,
@@ -590,7 +590,7 @@ func (t *Tracer) removeEntries(entries []network.ConnectionStats) {
 		}
 
 		// Delete conntrack entry for this connection
-		t.conntracker.DeleteTranslation(entry)
+		t.conntracker.DeleteTranslation(&entry.ConnectionTuple)
 
 		// Append the connection key to the keys to remove from the userspace state
 		toRemove = append(toRemove, entry)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -443,7 +443,7 @@ func (s *TracerSuite) TestConntrackExpiration() {
 		if !assert.True(collect, ok, "connection not found") {
 			return
 		}
-		assert.NotNil(collect, tr.conntracker.GetTranslationForConn(conn), "connection does not have NAT translation")
+		assert.NotNil(collect, tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple), "connection does not have NAT translation")
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection translation")
 
 	// This will force the connection to be expired next time we call getConnections, but
@@ -452,7 +452,7 @@ func (s *TracerSuite) TestConntrackExpiration() {
 	tr.config.TCPConnTimeout = time.Duration(-1)
 	_ = getConnections(t, tr)
 
-	assert.NotNil(t, tr.conntracker.GetTranslationForConn(conn), "translation should not have been deleted")
+	assert.NotNil(t, tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple), "translation should not have been deleted")
 
 	// delete the connection from system conntrack
 	cmd := exec.Command("conntrack", "-D", "-s", c.LocalAddr().(*net.TCPAddr).IP.String(), "-d", c.RemoteAddr().(*net.TCPAddr).IP.String(), "-p", "tcp")
@@ -460,7 +460,7 @@ func (s *TracerSuite) TestConntrackExpiration() {
 	require.NoError(t, err, "conntrack delete failed, output: %s", out)
 	_ = getConnections(t, tr)
 
-	assert.Nil(t, tr.conntracker.GetTranslationForConn(conn), "translation should have been deleted")
+	assert.Nil(t, tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple), "translation should have been deleted")
 
 	// write newline so server connections will exit
 	_, err = c.Write([]byte("\n"))
@@ -502,7 +502,7 @@ func (s *TracerSuite) TestConntrackDelays() {
 	require.Eventually(t, func() bool {
 		connections := getConnections(t, tr)
 		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		return ok && tr.conntracker.GetTranslationForConn(conn) != nil
+		return ok && tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple) != nil
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection with translation")
 
 	// write newline so server connections will exit
@@ -542,16 +542,16 @@ func (s *TracerSuite) TestTranslationBindingRegression() {
 	// wait for conntrack update
 	laddr := c.LocalAddr().(*net.TCPAddr)
 	raddr := c.RemoteAddr().(*net.TCPAddr)
-	cs := network.ConnectionStats{
+	cs := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		DPort:  uint16(raddr.Port),
 		Dest:   util.AddressFromNetIP(raddr.IP),
 		Family: network.AFINET,
 		SPort:  uint16(laddr.Port),
 		Source: util.AddressFromNetIP(laddr.IP),
 		Type:   network.TCP,
-	}
+	}}
 	require.Eventually(t, func() bool {
-		return tr.conntracker.GetTranslationForConn(&cs) != nil
+		return tr.conntracker.GetTranslationForConn(&cs.ConnectionTuple) != nil
 	}, 3*time.Second, 100*time.Millisecond, "timed out waiting for conntrack update")
 
 	// Assert that the connection to 2.2.2.2 has an IPTranslation object bound to it
@@ -1353,8 +1353,7 @@ func (s *TracerSuite) TestUDPPythonReusePort() {
 
 	t.Logf("port is %d", port)
 
-	conns := map[string]network.ConnectionStats{}
-	buf := make([]byte, network.ConnectionByteKeyMaxLen)
+	conns := map[network.ConnectionTuple]network.ConnectionStats{}
 	require.Eventually(t, func() bool {
 		_conns := network.FilterConnections(getConnections(t, tr), func(cs network.ConnectionStats) bool {
 			return cs.Type == network.UDP &&
@@ -1364,7 +1363,7 @@ func (s *TracerSuite) TestUDPPythonReusePort() {
 		})
 
 		for _, c := range _conns {
-			conns[string(c.ByteKey(buf))] = c
+			conns[c.ConnectionTuple] = c
 		}
 
 		t.Log(conns)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -660,57 +660,57 @@ func (s *TracerSuite) TestShouldExcludeEmptyStatsConnection() {
 func TestSkipConnectionDNS(t *testing.T) {
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
 		tr := &Tracer{config: &config.Config{CollectLocalDNS: false}}
-		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  1000, DPort: 53,
-		}))
+		}}))
 
-		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  1000, DPort: 8080,
-		}))
+		}}))
 
-		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
 			SPort:  53, DPort: 1000,
-		}))
+		}}))
 
-		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
 			SPort:  53, DPort: 1000,
-		}))
+		}}))
 	})
 
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
 		tr := &Tracer{config: &config.Config{CollectLocalDNS: true}}
 
-		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  1000, DPort: 53,
-		}))
+		}}))
 
-		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
 			SPort:  1000, DPort: 8080,
-		}))
+		}}))
 
-		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
 			SPort:  53, DPort: 1000,
-		}))
+		}}))
 
-		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{
+		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
 			SPort:  53, DPort: 1000,
-		}))
+		}}))
 	})
 }
 

--- a/pkg/network/usm_connection_keys_test.go
+++ b/pkg/network/usm_connection_keys_test.go
@@ -10,19 +10,20 @@ package network
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWithKey(t *testing.T) {
 	t.Run("without NAT", func(t *testing.T) {
-		c := ConnectionStats{
+		c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 			Source: util.AddressFromString("10.1.1.1"),
 			Dest:   util.AddressFromString("10.2.2.2"),
 			SPort:  60000,
 			DPort:  80,
-		}
+		}}
 
 		shouldGenerateKeys(t, c,
 			types.NewConnectionKey(c.Source, c.Dest, c.SPort, c.DPort),
@@ -31,11 +32,12 @@ func TestWithKey(t *testing.T) {
 	})
 
 	t.Run("with NAT", func(t *testing.T) {
-		c := ConnectionStats{
+		c := ConnectionStats{ConnectionTuple: ConnectionTuple{
 			Source: util.AddressFromString("10.1.1.1"),
 			Dest:   util.AddressFromString("10.2.2.2"),
 			SPort:  60000,
 			DPort:  80,
+		},
 			IPTranslation: &IPTranslation{
 				ReplSrcIP:   util.AddressFromString("3.3.3.3"),
 				ReplDstIP:   util.AddressFromString("4.4.4.4"),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds an embedded `network.ConnectionTuple` type that is comparable. 

### Motivation

1. This can be used in place of the `ByteKey` function, which created a byte slice.
2. This lays the groundwork to fix a race condition with how failed TCP connections are handled (coming in a future PR soon).

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->