### PR TITLE
usm: consumer: Reduce Counter.Add runtime by 95% if v == 0

### DIFF
--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -28,14 +28,12 @@ func NewCounter(name string, tagsAndOptions ...string) *Counter {
 
 // Add value atomically
 func (c *Counter) Add(v int64) {
-	if v < 0 {
-		// Counters are always monotonic so we don't allow negative numbers. We
+	if v > 0 {
+		// Counters are always monotonic so we don't allow non-positive numbers. We
 		// could enforce this by using an unsigned type, but that would make the
 		// API a little bit more cumbersome to use.
-		return
+		c.value.Add(v)
 	}
-
-	c.value.Add(v)
 }
 
 func (c *Counter) base() *metricBase {

--- a/pkg/network/protocols/telemetry/metric_test.go
+++ b/pkg/network/protocols/telemetry/metric_test.go
@@ -11,6 +11,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkAddPositive(b *testing.B) {
+	m := NewCounter("foo")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Add(1)
+	}
+}
+
+func BenchmarkAddZero(b *testing.B) {
+	m := NewCounter("foo")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Add(0)
+	}
+}
+
 func TestNewMetric(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reduce 95% of the cpu consumption of `(*Counter).Add` when the value is zero.

### Motivation

I noticed the [cpu consumption](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20&agg_m=count&agg_m_source=base&agg_t=count&my_code=disabled&op_filter=focus_on%28function%3A%22%28%2AConsumer%5B...%5D%29.Start.func1%22%29&refresh_mode=paused&viz=flame_graph&from_ts=1729409943937&to_ts=1729413543937&live=false) of Counter.Add is weird
While the function is strictly a wrapper for atomic.Int64.Add the proportion of `(*Int64).Add` is only 25% of `(*Counter).Add`
The original code of `(*Counter).Add` is:

```go
func (c *Counter) Add(v int64) {
	if v < 0 {
		// Counters are always monotonic so we don't allow negative numbers. We
		// could enforce this by using an unsigned type, but that would make the
		// API a little bit more cumbersome to use.
		return
	}

	c.value.Add(v)
}
```

It means that if `v` is zero, we perform redundant operations.

Implemented 2 benchmarks:

```go
func BenchmarkAddPositive(b *testing.B) {
	m := NewCounter("foo")
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		m.Add(1)
	}
}

func BenchmarkAddZero(b *testing.B) {
	m := NewCounter("foo")
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		m.Add(0)
	}
}
```

On main the results are:

```
BenchmarkAddPositive
BenchmarkAddPositive-16    	266800626	         4.211 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddZero
BenchmarkAddZero-16        	281880972	         4.279 ns/op	       0 B/op	       0 allocs/op
```

If we change `(*Counter).Add` to:

```go
func (c *Counter) Add(v int64) {
	if v > 0 {
		// Counters are always monotonic so we don't allow non-positive numbers. We
		// could enforce this by using an unsigned type, but that would make the
		// API a little bit more cumbersome to use.
		c.value.Add(v)
	}
}
```

And the benchmark changed to:

```
BenchmarkAddPositive
BenchmarkAddPositive-16    	281561790	         4.520 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddZero
BenchmarkAddZero-16        	1000000000	         0.2158 ns/op	       0 B/op	       0 allocs/op
```

Which means we reduce 95% of the cpu usage for the case `v == 0` which is frequent in the path of `(*Consumer[V]).Start`

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->