### PR TITLE
[CWS] reduce max size of `proc_cache` and `pid_cache` LRU maps

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -40,6 +40,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.compliance_module.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.on_demand.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.on_demand.rate_limiter.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.reduced_proc_pid_cache_size", false)
 
 	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
 	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -80,6 +80,8 @@ type RuntimeSecurityConfig struct {
 	OnDemandEnabled bool
 	// OnDemandRateLimiterEnabled defines whether the on-demand probes rate limit getting hit disabled the on demand probes
 	OnDemandRateLimiterEnabled bool
+	// ReducedProcPidCacheSize defines whether the `proc_cache` and `pid_cache` map should use reduced size
+	ReducedProcPidCacheSize bool
 
 	// InternalMonitoringEnabled determines if the monitoring events of the agent should be sent to Datadog
 	InternalMonitoringEnabled bool
@@ -342,6 +344,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 		OnDemandEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.on_demand.enabled"),
 		OnDemandRateLimiterEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.on_demand.rate_limiter.enabled"),
+		ReducedProcPidCacheSize:    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.reduced_proc_pid_cache_size"),
 
 		// policy & ruleset
 		PoliciesDir:                         pkgconfigsetup.SystemProbe().GetString("runtime_security_config.policies.dir"),

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -25,7 +25,7 @@ const (
 	maxPathnamesEntries = 96000
 
 	minProcEntries = 16384
-	maxProcEntries = 65536
+	maxProcEntries = 131072
 )
 
 var (
@@ -151,11 +151,17 @@ type MapSpecEditorOpts struct {
 	RingBufferSize          uint32
 	PathResolutionEnabled   bool
 	SecurityProfileMaxCount int
+	ReducedProcPidCacheSize bool
 }
 
 // AllMapSpecEditors returns the list of map editors
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
-	procPidCacheMaxEntries := getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+	var procPidCacheMaxEntries uint32
+	if opts.ReducedProcPidCacheSize {
+		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries/2)
+	} else {
+		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+	}
 
 	editors := map[string]manager.MapSpecEditor{
 		"syscalls": {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -155,17 +155,19 @@ type MapSpecEditorOpts struct {
 
 // AllMapSpecEditors returns the list of map editors
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
+	procPidCacheMaxEntries := getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+
 	editors := map[string]manager.MapSpecEditor{
 		"syscalls": {
 			MaxEntries: 8192,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"proc_cache": {
-			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
+			MaxEntries: procPidCacheMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"pid_cache": {
-			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
+			MaxEntries: procPidCacheMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
 

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -25,7 +25,7 @@ const (
 	maxPathnamesEntries = 96000
 
 	minProcEntries = 16384
-	maxProcEntries = 131072
+	maxProcEntries = 65536
 )
 
 var (

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -24,7 +24,7 @@ const (
 	minPathnamesEntries = 64000 // ~27 MB
 	maxPathnamesEntries = 96000
 
-	minProcEntries = 16394
+	minProcEntries = 16384
 	maxProcEntries = 131072
 )
 


### PR DESCRIPTION
### What does this PR do?

Those maps (`proc_cache` and `pid_cache`) have a very low utilization percentage on some clusters, never being even half full. This PR adds an option to reduce the maximum `max_entries` value of those 2 LRUs. Ensuring those maps are more correctly sized one.

The end goal is to turn on this config flag slowly internally to monitor the absence of issues caused by this, and then to make it the default (and remove the config flag after that).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->