### PR TITLE
[CWS] use BTF to derive the argument structure of `vfs_rename`

### DIFF
--- a/pkg/security/probe/constantfetch/available.go
+++ b/pkg/security/probe/constantfetch/available.go
@@ -90,12 +90,13 @@ func GetHasVFSRenameStructArgs() (bool, error) {
 		return false, err
 	}
 
-	switch len(proto.Params) {
-	case 0: // error
+	if len(proto.Params) == 0 {
 		return false, errors.New("vfs_rename has no parameters")
-	case 1: // int vfs_rename(struct renamedata *rd)
-		return true, nil
-	default: // int vfs_rename(struct inode *old_dir, struct dentry *old_dentry, struct inode *new_dir, struct dentry *new_dentry, struct inode **delegated_inode, unsigned int flags)
-		return false, nil
 	}
+
+	if len(proto.Params) == 1 && proto.Params[0].Name == "rd" {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/security/probe/constantfetch/available.go
+++ b/pkg/security/probe/constantfetch/available.go
@@ -10,6 +10,7 @@ package constantfetch
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cilium/ebpf/btf"
@@ -49,21 +50,30 @@ func GetAvailableConstantFetchers(config *config.Config, kv *kernel.Version, sta
 	return fetchers
 }
 
-// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
-func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
+func getBTFFuncProto(funcName string) (*btf.FuncProto, error) {
 	spec, err := pkgebpf.GetKernelSpec()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	var function *btf.Func
-	if err := spec.TypeByName("security_inode_setattr", &function); err != nil {
-		return false, err
+	if err := spec.TypeByName(funcName, &function); err != nil {
+		return nil, err
 	}
 
 	proto, ok := function.Type.(*btf.FuncProto)
 	if !ok {
-		return false, errors.New("security_inode_setattr has no prototype")
+		return nil, fmt.Errorf("%s has no prototype", funcName)
+	}
+
+	return proto, nil
+}
+
+// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
+func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
+	proto, err := getBTFFuncProto("security_inode_setattr")
+	if err != nil {
+		return false, err
 	}
 
 	if len(proto.Params) == 0 {
@@ -71,4 +81,21 @@ func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
 	}
 
 	return proto.Params[0].Name != "dentry", nil
+}
+
+// GetHasVFSRenameStructArgs uses BTF to check if the vfs_rename function has a struct renamedata as its only argument
+func GetHasVFSRenameStructArgs() (bool, error) {
+	proto, err := getBTFFuncProto("vfs_rename")
+	if err != nil {
+		return false, err
+	}
+
+	switch len(proto.Params) {
+	case 0: // error
+		return false, errors.New("vfs_rename has no parameters")
+	case 1: // int vfs_rename(struct renamedata *rd)
+		return true, nil
+	default: // int vfs_rename(struct inode *old_dir, struct dentry *old_dentry, struct inode *new_dir, struct dentry *new_dentry, struct inode **delegated_inode, unsigned int flags)
+		return false, nil
+	}
 }

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -35,7 +35,12 @@ func GetAvailableConstantFetchers(_ *config.Config, kv *kernel.Version, _ statsd
 	return fetchers
 }
 
-// GetHasUsernamespaceFirstArgWithBtf uses BTF to check if the security_inode_setattr function has a user namespace as its first argument
+// GetHasUsernamespaceFirstArgWithBtf not available
 func GetHasUsernamespaceFirstArgWithBtf() (bool, error) {
+	return false, errors.New("unsupported BTF request")
+}
+
+// GetHasVFSRenameStructArgs not available
+func GetHasVFSRenameStructArgs() (bool, error) {
 	return false, errors.New("unsupported BTF request")
 }

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -30,6 +30,10 @@ const (
 	OffsetNameFileFpath                 = "file_f_path_offset"
 	OffsetNameMountMntID                = "mount_id_offset"
 
+	// rename
+	OffsetNameRenameStructOldDentry = "vfs_rename_src_dentry_offset"
+	OffsetNameRenameStructNewDentry = "vfs_rename_target_dentry_offset"
+
 	// tracepoints
 	OffsetNameSchedProcessForkParentPid = "sched_process_fork_parent_pid_offset"
 	OffsetNameSchedProcessForkChildPid  = "sched_process_fork_child_pid_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -141,6 +141,10 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getFileFpathOffset(f.kernelVersion)
 	case OffsetNameMountMntID:
 		value = getMountIDOffset(f.kernelVersion)
+	case OffsetNameRenameStructOldDentry:
+		value = getRenameStructOldDentryOffset(f.kernelVersion)
+	case OffsetNameRenameStructNewDentry:
+		value = getRenameStructNewDentryOffset(f.kernelVersion)
 	}
 	f.res[id] = value
 }
@@ -1022,4 +1026,12 @@ func getMountIDOffset(kv *kernel.Version) uint64 {
 
 func getNetDeviceNameOffset(_ *kernel.Version) uint64 {
 	return 0
+}
+
+func getRenameStructOldDentryOffset(_ *kernel.Version) uint64 {
+	return 16
+}
+
+func getRenameStructNewDentryOffset(_ *kernel.Version) uint64 {
+	return 40
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2176,8 +2176,10 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	}
 
 	// rename offsets
-	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructOldDentry, "struct renamedata", "old_dentry", "linux/fs.h")
-	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructNewDentry, "struct renamedata", "new_dentry", "linux/fs.h")
+	if kv.Code >= kernel.Kernel5_12 || (kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11) && kv.Code.Patch() >= 220) {
+		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructOldDentry, "struct renamedata", "old_dentry", "linux/fs.h")
+		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructNewDentry, "struct renamedata", "new_dentry", "linux/fs.h")
+	}
 
 	// bpf offsets
 	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameBPFMapStructID, "struct bpf_map", "id", "linux/bpf.h")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2175,6 +2175,10 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameKernelCloneArgsExitSignal, "struct kernel_clone_args", "exit_signal", "linux/sched/task.h")
 	}
 
+	// rename offsets
+	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructOldDentry, "struct renamedata", "old_dentry", "linux/fs.h")
+	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameRenameStructNewDentry, "struct renamedata", "new_dentry", "linux/fs.h")
+
 	// bpf offsets
 	constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameBPFMapStructID, "struct bpf_map", "id", "linux/bpf.h")
 	if kv.Code != 0 && (kv.Code >= kernel.Kernel4_15 || kv.IsRH7Kernel()) {

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -571,17 +571,6 @@ func GetVFSRemovexattrDentryPosition(kernelVersion *skernel.Version) uint64 {
 	return position
 }
 
-// GetVFSRenameInputType gets VFS rename input type
-func GetVFSRenameInputType(kernelVersion *skernel.Version) uint64 {
-	inputType := uint64(1)
-
-	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
-		inputType = 2
-	}
-
-	return inputType
-}
-
 // SendStats sends metrics about the current state of the mount resolver
 func (mr *Resolver) SendStats() error {
 	mr.lock.RLock()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes use of BTF data to select the argument structure of `vfs_rename` (one big struct, or multiple args). And fixes the fallback code to support kernel where the change was backported (5.10.220 and up).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->