### PR TITLE
Mark ECS Windows Fargate e2e tests as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,3 +11,5 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
+  - TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready
+  - TestECSSuite/TestWindowsFargate


### PR DESCRIPTION
### What does this PR do?

Mark
* `TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` and
* `TestECSSuite/TestWindowsFargate`
tests as flaky.

### Motivation

They became flaky since last Friday: https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%28%22TestECSSuite%2FTest00UpAndRunning%2FECS_tasks_are_ready%22%20OR%20%22TestECSSuite%2FTestWindowsFargate%22%29&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&mode=sliding&saved-view-id=2236559&start=1728909838229&end=1729514638229&paused=false

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
