### PR TITLE
[Backport 7.58.x] Fix duplicate tags in TCP/UDP logs (again)

### DIFF
--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -98,9 +98,8 @@ func (t *Tailer) readForever() {
 				log.Warnf("Couldn't read message from connection: %v", err)
 				return
 			}
-			copiedTags := make([]string, len(t.source.Config.Tags))
-			copy(copiedTags, t.source.Config.Tags)
-			if ipAddress != "" && coreConfig.Datadog().GetBool("logs_config.use_sourcehost_tag") {
+			msg := decoder.NewInput(data)
+			if ipAddress != "" && pkgconfigsetup.Datadog().GetBool("logs_config.use_sourcehost_tag") {
 				lastColonIndex := strings.LastIndex(ipAddress, ":")
 				var ipAddressWithoutPort string
 				if lastColonIndex != -1 {
@@ -109,10 +108,8 @@ func (t *Tailer) readForever() {
 					ipAddressWithoutPort = ipAddress
 				}
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
-				copiedTags = append(copiedTags, sourceHostTag)
+				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, sourceHostTag)
 			}
-			msg := decoder.NewInput(data)
-			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, copiedTags...)
 			t.decoder.InputChan <- msg
 		}
 	}

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -12,7 +12,7 @@ import (
 	"net"
 	"strings"
 
-	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"

--- a/releasenotes/notes/fix-duplicate-tags-e97e8eeb6492235f.yaml
+++ b/releasenotes/notes/fix-duplicate-tags-e97e8eeb6492235f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix duplicate tags in UDP/TCP logs.
+

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/utils/file_tailing_utils.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/utils/file_tailing_utils.go
@@ -149,7 +149,7 @@ func FetchAndFilterLogs(t *testing.T, fakeIntake *components.FakeIntake, service
 	return logs, nil
 }
 
-// CheckLogsExpected verifies the presence of expected logs.
+// CheckLogsExpected verifies the presence of expected logs, and verifies that there are no duplicate tags.
 func CheckLogsExpected(t *testing.T, fakeIntake *components.FakeIntake, service, content string, expectedTags ddtags) {
 	t.Helper()
 
@@ -160,6 +160,14 @@ func CheckLogsExpected(t *testing.T, fakeIntake *components.FakeIntake, service,
 			if assert.NotEmpty(c, logs, "Expected logs with content: '%s' not found. Instead, found: %s", content, intakeLog) {
 				t.Logf("Logs from service: '%s' with content: '%s' collected", service, content)
 				log := logs[0]
+				// Use a map to check for duplicate tags
+				seenTags := make(map[string]struct{})
+				for _, tag := range log.Tags {
+					if _, exists := seenTags[tag]; exists {
+						t.Errorf("Duplicate tag found: %s", tag)
+					}
+					seenTags[tag] = struct{}{} // Mark the tag as seen
+				}
 				for _, expectedTag := range expectedTags {
 					assert.Contains(t, log.Tags, expectedTag)
 				}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Backports commit #29780 into 7.58.x

The previous backport [PR](https://github.com/DataDog/datadog-agent/pull/29996) was reverted due to merging before 7.58.1 was ready

Below is copied from previous PR.

Fixes bug where duplicate tags occur in UDP/TCP logs

### Motivation
[Issue](https://datadoghq.atlassian.net/browse/AGENT-12428)
### Describe how to test/QA your changes

Inside `conf.yaml`, add the following
Create the file if needed `dev/dist/conf.d/test.d/conf.yaml`

```
logs:
  - type: udp
    port: 10518
    service: "test_app"
    source: "test_app_src"
    tags:
      - "name:integrationtag"

```
Inside Datadog.yaml, enable logs and have tags as well
```
logs_enabled: true
tags:
  - "name:hosttag"
```

Run the agent
`./bin/agent/agent run -c bin/agent/dist/datadog.yaml
`
In a different terminal, get the logs from the agent
`./bin/agent/agent stream-logs -c bin/agent/dist/datadog.yaml
`
In a different terminal, send logs to the agent
`echo -n "this is my log" | nc -u -w 1 127.0.0.1 10518
`
Ensure that the tags are not duplicated in the terminal that gets the logs

Different QA steps are also provided in the [ticket](https://datadoghq.atlassian.net/browse/AGENT-12428) if needed

