### PR TITLE
Add a task to create the GitHub release

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -370,6 +370,14 @@ class GithubAPI:
         """
         return self._repository.create_label(name, color, description)
 
+    def create_release(self, tag, message, draft=True):
+        return self._repository.create_git_release(
+            tag=tag,
+            name=tag,
+            message=message,
+            draft=draft,
+        )
+
 
 def get_github_teams(users):
     for user in users:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1066,7 +1066,7 @@ def create_github_release(_ctx, version, draft=True):
     notes = []
 
     for section, filename in sections:
-        text = pandoc.write(pandoc.read(file=filename), format="markdown_strict")
+        text = pandoc.write(pandoc.read(file=filename), format="markdown_strict", options=["--wrap=none"])
 
         header_found = False
         lines = []

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1049,3 +1049,55 @@ def create_qa_cards(ctx, tag):
         return
     setup_ddqa(ctx)
     ctx.run(f"ddqa --auto create {version.previous_rc_version()} {tag} {get_labels(version)}")
+
+
+@task
+def create_github_release(_ctx, version, draft=True):
+    """
+    Create a GitHub release for the given tag.
+    """
+    import pandoc
+
+    sections = (
+        ("Agent", "CHANGELOG.rst"),
+        ("Datadog Cluster Agent", "CHANGELOG-DCA.rst"),
+    )
+
+    notes = []
+
+    for section, filename in sections:
+        text = pandoc.write(pandoc.read(file=filename), format="markdown_strict")
+
+        header_found = False
+        lines = []
+
+        # Extract the section for the given version
+        for line in text.splitlines():
+            # Move to the right section
+            if line.startswith("## " + version):
+                header_found = True
+                continue
+
+            if header_found:
+                # Next version found, stop
+                if line.startswith("## "):
+                    break
+                lines.append(line)
+
+        # if we found the header, add the section to the final release note
+        if header_found:
+            notes.append(f"# {section}")
+            notes.extend(lines)
+
+    if not notes:
+        print(f"No release notes found for {version}")
+        raise Exit(code=1)
+
+    github = GithubAPI()
+    release = github.create_release(
+        version,
+        "\n".join(notes),
+        draft=draft,
+    )
+
+    print(f"Link to the release note: {release.html_url}")

--- a/tasks/requirements_release_tasks.txt
+++ b/tasks/requirements_release_tasks.txt
@@ -1,3 +1,4 @@
 atlassian-python-api==3.41.3
 yattag==1.15.2
 reno==3.5.0
+pandoc==2.4


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a task to create the GitHub release

### Motivation

We currently do this manually and copy/paste it in the UI. 

We could include this in the CI one day if we think it makes sense. For now let's use it directly.

By default the release is a draft and not public so we can create it in advance and publish it only when we push the artefacts to the various registries

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Usage: `inv/deva release.create-github-release 7.XX.Y`