### PR TITLE
[CWS-3196] allow disabling env vars resolution when using event process stream

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -32,6 +32,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	}
 
 	opts := eventmonitor.Opts{}
+	opts.ProbeOpts.EnvsVarResolutionEnabled = emconfig.EnvVarsResolutionEnabled
 	secmoduleOpts := secmodule.Opts{}
 
 	// adapt options

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -380,6 +380,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "syscalls_monitor.enabled"), false)
 	cfg.BindEnvAndSetDefault(join(evNS, "socket"), defaultEventMonitorAddress)
 	cfg.BindEnvAndSetDefault(join(evNS, "event_server.burst"), 40)
+	cfg.BindEnvAndSetDefault(join(evNS, "env_vars_resolution.enabled"), true)
 
 	// process event monitoring data limits for network tracer
 	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))

--- a/pkg/eventmonitor/config/config.go
+++ b/pkg/eventmonitor/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	// ProcessConsumerEnabled defines if the process-agent wants to receive kernel events
 	ProcessConsumerEnabled bool
+
+	EnvVarsResolutionEnabled bool
 }
 
 // NewConfig creates a config for the event monitoring module
@@ -38,6 +40,9 @@ func NewConfig() *Config {
 
 		// consumers
 		ProcessConsumerEnabled: getBool("process.enabled"),
+
+		// options
+		EnvVarsResolutionEnabled: pkgconfigsetup.SystemProbe().GetBool(sysconfig.FullKeyPath(evNS, "env_vars_resolution.enabled")),
 	}
 }
 

--- a/pkg/eventmonitor/examples/consumer.go
+++ b/pkg/eventmonitor/examples/consumer.go
@@ -17,7 +17,9 @@ import (
 
 // SimpleEvent defines a simple event
 type SimpleEvent struct {
-	Type uint32 `copy:"GetEventType;event:*;cast:uint32"`
+	Type         uint32   `copy:"GetEventType;event:*;cast:uint32"`
+	ExecFilePath string   `copy:"GetExecFilePath;event:ExecEventType"`
+	Envp         []string `copy:"GetProcessEnvp;event:ExecEventType"`
 }
 
 // SimpleEventConsumer defines a simple event consumer
@@ -26,6 +28,8 @@ type SimpleEventConsumer struct {
 	exec int
 	fork int
 	exit int
+
+	handlers []func(evt *SimpleEvent)
 }
 
 // NewSimpleEventConsumer returns a new simple event consumer
@@ -33,6 +37,14 @@ func NewSimpleEventConsumer(em *eventmonitor.EventMonitor) *SimpleEventConsumer 
 	fc := &SimpleEventConsumer{}
 	_ = em.AddEventConsumer(fc)
 	return fc
+}
+
+// AddHandler adds a handler to this consumer
+func (fc *SimpleEventConsumer) AddHandler(handler func(evt *SimpleEvent)) {
+	fc.Lock()
+	defer fc.Unlock()
+
+	fc.handlers = append(fc.handlers, handler)
 }
 
 // ID returns the ID of this consumer
@@ -86,6 +98,10 @@ func (fc *SimpleEventConsumer) HandleEvent(event any) {
 		fc.fork++
 	case uint32(model.ExitEventType):
 		fc.exit++
+	}
+
+	for _, handler := range fc.handlers {
+		handler(sevent)
 	}
 }
 

--- a/pkg/eventmonitor/examples/event_copy.go
+++ b/pkg/eventmonitor/examples/event_copy.go
@@ -19,5 +19,15 @@ func (fc *SimpleEventConsumer) Copy(event *smodel.Event) any {
 
 	valueType := uint32(event.GetEventType())
 	result.Type = valueType
+
+	if event.GetEventType() == smodel.ExecEventType {
+		valueExecFilePath := event.GetExecFilePath()
+		result.ExecFilePath = valueExecFilePath
+	}
+
+	if event.GetEventType() == smodel.ExecEventType {
+		valueEnvp := event.GetProcessEnvp()
+		result.Envp = valueEnvp
+	}
 	return &result
 }

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -14,6 +14,7 @@ import (
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
 	opts.ProbeOpts.PathResolutionEnabled = true
+	opts.ProbeOpts.EnvsVarResolutionEnabled = true
 	opts.ProbeOpts.TTYFallbackEnabled = true
 	opts.ProbeOpts.SyscallsMonitorEnabled = config.Probe.SyscallsMonitorEnabled
 	opts.ProbeOpts.EBPFLessEnabled = config.RuntimeSecurity.EBPFLessEnabled

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -14,7 +14,6 @@ import (
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
 	opts.ProbeOpts.PathResolutionEnabled = true
-	opts.ProbeOpts.EnvsVarResolutionEnabled = true
 	opts.ProbeOpts.TTYFallbackEnabled = true
 	opts.ProbeOpts.SyscallsMonitorEnabled = config.Probe.SyscallsMonitorEnabled
 	opts.ProbeOpts.EBPFLessEnabled = config.RuntimeSecurity.EBPFLessEnabled

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -31,7 +31,7 @@ func TestProcessArgsFlags(t *testing.T) {
 	}
 
 	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
+		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{
@@ -94,7 +94,7 @@ func TestProcessArgsOptions(t *testing.T) {
 	}
 
 	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
+		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{

--- a/pkg/security/probe/opts_linux.go
+++ b/pkg/security/probe/opts_linux.go
@@ -21,6 +21,8 @@ type Opts struct {
 	StatsdClient statsd.ClientInterface
 	// PathResolutionEnabled defines if the path resolution is enabled
 	PathResolutionEnabled bool
+	// EnvsVarResolutionEnabled defines if environment variables resolution is enabled
+	EnvsVarResolutionEnabled bool
 	// TagsResolver will override the default one. Mainly here for tests.
 	TagsResolver tags.Resolver
 	// SyscallsMonitorEnabled enable syscalls map monitor

--- a/pkg/security/probe/opts_windows.go
+++ b/pkg/security/probe/opts_windows.go
@@ -20,6 +20,9 @@ type Opts struct {
 	// StatsdClient to be used for probe stats
 	StatsdClient statsd.ClientInterface
 
+	// EnvsVarResolutionEnabled defines if environment variables resolution is enabled
+	EnvsVarResolutionEnabled bool
+
 	// this option for test purposes only; should never be true in main code
 	disableProcmon bool
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1963,10 +1963,11 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts, telemetry tele
 	}
 
 	resolversOpts := resolvers.Opts{
-		PathResolutionEnabled: probe.Opts.PathResolutionEnabled,
-		TagsResolver:          probe.Opts.TagsResolver,
-		UseRingBuffer:         useRingBuffers,
-		TTYFallbackEnabled:    probe.Opts.TTYFallbackEnabled,
+		PathResolutionEnabled:    probe.Opts.PathResolutionEnabled,
+		EnvVarsResolutionEnabled: probe.Opts.EnvsVarResolutionEnabled,
+		TagsResolver:             probe.Opts.TagsResolver,
+		UseRingBuffer:            useRingBuffers,
+		TTYFallbackEnabled:       probe.Opts.TTYFallbackEnabled,
 	}
 
 	p.Resolvers, err = resolvers.NewEBPFResolvers(config, p.Manager, probe.StatsdClient, probe.scrubber, p.Erpc, resolversOpts, telemetry)

--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -37,5 +37,9 @@ func NewEnvVarsResolver(cfg *config.Config) *Resolver {
 
 // ResolveEnvVars resolves a pid
 func (r *Resolver) ResolveEnvVars(pid uint32) ([]string, bool, error) {
+	// we support the r == nil, for when env vars resolution is disabled
+	if r == nil {
+		return nil, false, nil
+	}
 	return utils.EnvVars(r.priorityEnvs, pid, model.MaxArgsEnvsSize)
 }

--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -39,7 +39,8 @@ func NewEnvVarsResolver(cfg *config.Config) *Resolver {
 func (r *Resolver) ResolveEnvVars(pid uint32) ([]string, bool, error) {
 	// we support the r == nil, for when env vars resolution is disabled
 	if r == nil {
-		return nil, false, nil
+		// communicate the fact that it was truncated
+		return nil, true, nil
 	}
 	return utils.EnvVars(r.priorityEnvs, pid, model.MaxArgsEnvsSize)
 }

--- a/pkg/security/resolvers/opts_linux.go
+++ b/pkg/security/resolvers/opts_linux.go
@@ -10,8 +10,9 @@ import "github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 
 // Opts defines common options
 type Opts struct {
-	PathResolutionEnabled bool
-	TagsResolver          tags.Resolver
-	UseRingBuffer         bool
-	TTYFallbackEnabled    bool
+	PathResolutionEnabled    bool
+	EnvVarsResolutionEnabled bool
+	TagsResolver             tags.Resolver
+	UseRingBuffer            bool
+	TTYFallbackEnabled       bool
 }

--- a/pkg/security/resolvers/process/opts_linux.go
+++ b/pkg/security/resolvers/process/opts_linux.go
@@ -8,8 +8,9 @@ package process
 
 // ResolverOpts options of resolver
 type ResolverOpts struct {
-	ttyFallbackEnabled bool
-	envsWithValue      map[string]bool
+	ttyFallbackEnabled    bool
+	envsResolutionEnabled bool
+	envsWithValue         map[string]bool
 }
 
 // WithEnvsValue specifies envs with value
@@ -23,6 +24,12 @@ func (o *ResolverOpts) WithEnvsValue(envsWithValue []string) *ResolverOpts {
 // WithTTYFallbackEnabled enables the TTY fallback
 func (o *ResolverOpts) WithTTYFallbackEnabled() *ResolverOpts {
 	o.ttyFallbackEnabled = true
+	return o
+}
+
+// WithEnvsResolutionEnabled enables the envs resolution
+func (o *ResolverOpts) WithEnvsResolutionEnabled() *ResolverOpts {
+	o.envsResolutionEnabled = true
 	return o
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -987,6 +987,10 @@ func (p *EBPFResolver) GetProcessArgvScrubbed(pr *model.Process) ([]string, bool
 
 // SetProcessEnvs set envs to cache entry
 func (p *EBPFResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
+	if !p.opts.envsResolutionEnabled {
+		return
+	}
+
 	if entry, found := p.argsEnvsCache.Get(pce.EnvsID); found {
 		if pce.EnvsTruncated {
 			p.envsTruncated.Inc()

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1436,7 +1436,7 @@ func (p *EBPFResolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 func NewEBPFResolver(manager *manager.Manager, config *config.Config, statsdClient statsd.ClientInterface,
 	scrubber *procutil.DataScrubber, containerResolver *container.Resolver, mountResolver mount.ResolverInterface,
 	cgroupResolver *cgroup.Resolver, userGroupResolver *usergroup.Resolver, timeResolver *stime.Resolver,
-	pathResolver spath.ResolverInterface, opts *ResolverOpts) (*EBPFResolver, error) {
+	pathResolver spath.ResolverInterface, envVarsResolver *envvars.Resolver, opts *ResolverOpts) (*EBPFResolver, error) {
 	argsEnvsCache, err := simplelru.NewLRU[uint64, *argsEnvsCacheEntry](maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err
@@ -1471,7 +1471,7 @@ func NewEBPFResolver(manager *manager.Manager, config *config.Config, statsdClie
 		userGroupResolver:         userGroupResolver,
 		timeResolver:              timeResolver,
 		pathResolver:              pathResolver,
-		envVarsResolver:           envvars.NewEnvVarsResolver(config),
+		envVarsResolver:           envVarsResolver,
 	}
 	for _, t := range metrics.AllTypesTags {
 		p.hitsStats[t] = atomic.NewInt64(0)

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -34,7 +34,7 @@ func testCacheSize(t *testing.T, resolver *EBPFResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestForkForkExec(t *testing.T) {
 }
 
 func TestExecBomb(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func TestExecBomb(t *testing.T) {
 }
 
 func TestExecLostFork(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestExecLostFork(t *testing.T) {
 }
 
 func TestExecLostExec(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -622,7 +622,7 @@ func TestExecLostExec(t *testing.T) {
 }
 
 func TestIsExecExecRuntime(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +683,7 @@ func TestIsExecExecRuntime(t *testing.T) {
 }
 
 func TestIsExecExecSnapshot(t *testing.T) {
-	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -143,6 +143,9 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	if opts.TTYFallbackEnabled {
 		processOpts.WithTTYFallbackEnabled()
 	}
+	if opts.EnvVarsResolutionEnabled {
+		processOpts.WithEnvsResolutionEnabled()
+	}
 
 	var envVarsResolver *envvars.Resolver
 	if opts.EnvVarsResolutionEnabled {

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/container"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/envvars"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/hash"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/netns"
@@ -143,8 +144,13 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		processOpts.WithTTYFallbackEnabled()
 	}
 
+	var envVarsResolver *envvars.Resolver
+	if opts.EnvVarsResolutionEnabled {
+		envVarsResolver = envvars.NewEnvVarsResolver(config.Probe)
+	}
+
 	processResolver, err := process.NewEBPFResolver(manager, config.Probe, statsdClient,
-		scrubber, containerResolver, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, processOpts)
+		scrubber, containerResolver, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, envVarsResolver, processOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/examples"
 	"github.com/avast/retry-go/v4"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 )
 
 func TestEventMonitor(t *testing.T) {
@@ -72,4 +73,49 @@ func TestEventMonitor(t *testing.T) {
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
 		assert.NoError(t, err)
 	})
+}
+
+func TestEventMonitorNoEnvs(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	var sec *examples.SimpleEventConsumer
+	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{
+		disableRuntimeSecurity:   true,
+		disableEnvVarsResolution: true,
+		preStartCallback: func(test *testModule) {
+			sec = examples.NewSimpleEventConsumer(test.eventMonitor)
+			test.eventMonitor.RegisterEventConsumer(sec)
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	lsExecutable := which(t, "ls")
+
+	foundLs := atomic.NewBool(false)
+
+	sec.AddHandler(func(evt *examples.SimpleEvent) {
+		if len(evt.Envp) != 0 {
+			t.Errorf("unexpected envp: %+v", evt)
+		}
+
+		if evt.ExecFilePath == lsExecutable {
+			foundLs.Store(true)
+		}
+	})
+
+	cmd := exec.Command(lsExecutable, "-l")
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	err = retry.Do(func() error {
+		if foundLs.Load() {
+			return nil
+		}
+		return errors.New("event not received")
+	}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
+	assert.NoError(t, err)
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -734,12 +734,13 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 	emopts := eventmonitor.Opts{
 		StatsdClient: statsdClient,
 		ProbeOpts: sprobe.Opts{
-			StatsdClient:           statsdClient,
-			DontDiscardRuntime:     true,
-			PathResolutionEnabled:  true,
-			SyscallsMonitorEnabled: true,
-			TTYFallbackEnabled:     true,
-			EBPFLessEnabled:        ebpfLessEnabled,
+			StatsdClient:             statsdClient,
+			DontDiscardRuntime:       true,
+			PathResolutionEnabled:    true,
+			EnvsVarResolutionEnabled: true,
+			SyscallsMonitorEnabled:   true,
+			TTYFallbackEnabled:       true,
+			EBPFLessEnabled:          ebpfLessEnabled,
 		},
 	}
 	if opts.staticOpts.tagsResolver != nil {

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -737,7 +737,7 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 			StatsdClient:             statsdClient,
 			DontDiscardRuntime:       true,
 			PathResolutionEnabled:    true,
-			EnvsVarResolutionEnabled: true,
+			EnvsVarResolutionEnabled: !opts.staticOpts.disableEnvVarsResolution,
 			SyscallsMonitorEnabled:   true,
 			TTYFallbackEnabled:       true,
 			EBPFLessEnabled:          ebpfLessEnabled,

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -21,6 +21,7 @@ import (
 type testOpts struct {
 	disableFilters                             bool
 	disableApprovers                           bool
+	disableEnvVarsResolution                   bool
 	enableActivityDump                         bool
 	activityDumpRateLimiter                    int
 	activityDumpTagRules                       bool
@@ -108,6 +109,7 @@ func withForceReload() optFunc {
 
 func (to testOpts) Equal(opts testOpts) bool {
 	return to.disableApprovers == opts.disableApprovers &&
+		to.disableEnvVarsResolution == opts.disableEnvVarsResolution &&
 		to.enableActivityDump == opts.enableActivityDump &&
 		to.activityDumpRateLimiter == opts.activityDumpRateLimiter &&
 		to.activityDumpTagRules == opts.activityDumpTagRules &&


### PR DESCRIPTION
### What does this PR do?

This PR allows to disable env vars resolution when using the event process data stream. This will allow USM and NPM team to receive a process stream without env variables. Something that some clients might want/require.

New config:
```
event_monitoring_config:
  env_vars_resolution:
    enabled: true|false
```

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->