### PR TITLE
[CI] Select the right Python virtualenv on the macOS Gitlab runners

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -1,6 +1,31 @@
 ---
 # This is the scripts to be executed on the Gitlab macOS runners before every job.
 # We don't have virtualization now so we need to clean the environment and install the proper dependencies before every job.
+.list_go_versions_commands: &list_go_versions_commands
+  - |
+    echo "Don't forget to regularly delete Go unused versions. Here are the installed Go versions and their disk space on the runner:"
+    echo "Go:"
+    du -sh $HOME/.gimme/versions/*
+    echo "To remove a Go version please run:"
+    echo "gimme uninstall <version>"
+
+.list_python_versions_commands: &list_python_versions_commands
+  - |
+    echo "Don't forget to regularly delete Python unused versions. Here are the installed Python versions and their disk space on the runner:"
+    echo "Python:"
+    du -sh $(pyenv root)/versions/*
+    echo "To remove a Python version please run:"
+    echo "pyenv uninstall -f <version>"
+
+.check_python_version_commands: &check_python_version_commands
+  - |
+    PYTHON_REPO_VERSION=$(cat .python-version)
+    PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
+    if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
+      echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
+      echo "Installing Python $PYTHON_REPO_VERSION..."
+    fi
+
 .macos_gitlab:
   variables:
     PYTHON_RUNTIMES: "3"
@@ -13,40 +38,12 @@
     - |
       pyenv virtualenv $PYTHON_VERSION datadog-agent-python-$PYTHON_VERSION
       pyenv activate datadog-agent-python-$PYTHON_VERSION
-    - !reference [.check_right_python_version]
-    - !reference [.list_go_versions]
-    - !reference [.list_python_versions]
+    - *check_python_version_commands
+    - *list_go_versions_commands
+    - *list_python_versions_commands
     # Installing the job dependencies
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-github.txt
     - pyenv rehash
     - inv -e rtloader.make
     - inv -e rtloader.install
     - inv -e install-tools
-
-.list_go_versions:
-  script:
-    - |
-      echo "Don't forget to regularly delete Go unused versions. Here are the installed Go versions and their disk space on the runner:"
-      echo "Go:"
-      du -sh $HOME/.gimme/versions/*
-      echo "To remove a Go version please run:"
-      echo "gimme uninstall <version>"
-
-.list_python_versions:
-  script:
-    - |
-      echo "Don't forget to regularly delete Python unused versions. Here are the installed Python versions and their disk space on the runner:"
-      echo "Python:"
-      du -sh $(pyenv root)/versions/*
-      echo "To remove a Python version please run:"
-      echo "pyenv uninstall -f <version>"
-
-.check_right_python_version:
-  script:
-    - |
-      PYTHON_REPO_VERSION=$(cat .python-version)
-      PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
-      if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
-        echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
-        echo "Installing Python $PYTHON_REPO_VERSION..."
-      fi

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -8,13 +8,14 @@
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))
-      export GOPATH=$GOROOT`
+      export GOPATH=$GOROOT
     # Selecting the current Python version
     - |
       pyenv virtualenv $PYTHON_VERSION datadog-agent-python-$PYTHON_VERSION
       pyenv activate datadog-agent-python-$PYTHON_VERSION
     - !reference [.check_right_python_version]
-    - !reference [.list_go_versions, .list_python_versions]
+    - !reference [.list_go_versions]
+    - !reference [.list_python_versions]
     # Installing the job dependencies
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-github.txt
     - pyenv rehash

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -35,10 +35,10 @@
       eval $(gimme $(cat .go-version))
       export GOPATH=$GOROOT
     # Selecting the current Python version
+    - *check_python_version_commands
     - |
       pyenv virtualenv $PYTHON_VERSION datadog-agent-python-$PYTHON_VERSION
       pyenv activate datadog-agent-python-$PYTHON_VERSION
-    - *check_python_version_commands
     - *list_go_versions_commands
     - *list_python_versions_commands
     # Installing the job dependencies

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -17,14 +17,21 @@
     echo "To remove a Python version please run:"
     echo "pyenv uninstall -f <version>"
 
-.check_python_version_commands: &check_python_version_commands
+.select_python_env_commands: &select_python_env_commands
+  # Print a warning if the current Python version is different from the one in .python-version
+  # Select the virtualenv using the current Python version. Create it if it doesn't exist.
   - |
     PYTHON_REPO_VERSION=$(cat .python-version)
     PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
+    VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
     if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
       echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
       echo "Installing Python $PYTHON_REPO_VERSION..."
     fi
+    if ! pyenv virtualenvs --bare | grep -q "^${VENV_NAME}$"; then
+      pyenv virtualenv $PYTHON_VERSION $VENV_NAME
+    fi
+    pyenv activate $VENV_NAME
 
 .macos_gitlab:
   variables:
@@ -35,10 +42,8 @@
       eval $(gimme $(cat .go-version))
       export GOPATH=$GOROOT
     # Selecting the current Python version
-    - *check_python_version_commands
-    - |
-      pyenv virtualenv $PYTHON_VERSION datadog-agent-python-$PYTHON_VERSION
-      pyenv activate datadog-agent-python-$PYTHON_VERSION
+    - *select_python_env_commands
+    # List Python and Go existing environments and their disk space
     - *list_go_versions_commands
     - *list_python_versions_commands
     # Installing the job dependencies

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -8,25 +8,44 @@
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))
-      export GOPATH=$GOROOT
-      echo "Don't forget to regularly delete unused versions. Here are the installed versions and their memory usage on the runner:"
-      du -sh $HOME/.gimme/versions/*
-    # Remove the Python cache and env if the Python version changed
+      export GOPATH=$GOROOT`
+    # Selecting the current Python version
     - |
-      PYTHON_REPO_VERSION=$(cat .python-version)
-      PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
-      if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
-        echo "Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version. Cleaning the environment."
-        pyenv uninstall -f datadog-agent
-        echo "Installing Python $PYTHON_REPO_VERSION..."
-        pyenv virtualenv 3.11.8 datadog-agent
-        pyenv activate datadog-agent
-      else
-        echo "Python current version $PYTHON_VERSION is the same as .python-version. Keeping the existing environment."
-      fi
+      pyenv virtualenv $PYTHON_VERSION datadog-agent-python-$PYTHON_VERSION
+      pyenv activate datadog-agent-python-$PYTHON_VERSION
+    - !reference [.check_right_python_version]
+    - !reference [.list_go_versions, .list_python_versions]
     # Installing the job dependencies
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-github.txt
     - pyenv rehash
     - inv -e rtloader.make
     - inv -e rtloader.install
     - inv -e install-tools
+
+.list_go_versions:
+  script:
+    - |
+      echo "Don't forget to regularly delete Go unused versions. Here are the installed Go versions and their disk space on the runner:"
+      echo "Go:"
+      du -sh $HOME/.gimme/versions/*
+      echo "To remove a Go version please run:"
+      echo "gimme uninstall <version>"
+
+.list_python_versions:
+  script:
+    - |
+      echo "Don't forget to regularly delete Python unused versions. Here are the installed Python versions and their disk space on the runner:"
+      echo "Python:"
+      du -sh $(pyenv root)/versions/*
+      echo "To remove a Python version please run:"
+      echo "pyenv uninstall -f <version>"
+
+.check_right_python_version:
+  script:
+    - |
+      PYTHON_REPO_VERSION=$(cat .python-version)
+      PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
+      if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
+        echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
+        echo "Installing Python $PYTHON_REPO_VERSION..."
+      fi

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,7 +13,7 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:monterey-amd64", "specific:true"]
+  tags: ["macos:monterey-amd64-test", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -24,4 +24,4 @@ lint_macos_gitlab_arm64:
   rules:
     - !reference [.on_main]
     - !reference [.manual]
-  tags: ["macos:monterey-arm64", "specific:true"]
+  tags: ["macos:monterey-arm64-test", "specific:true"]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -73,7 +73,7 @@ tests_macos:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:monterey-amd64", "specific:true"]
+  tags: ["macos:monterey-amd64-test", "specific:true"]
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -82,7 +82,7 @@ tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   rules:
     !reference [.manual]
-  tags: ["macos:monterey-arm64", "specific:true"]
+  tags: ["macos:monterey-arm64-test", "specific:true"]
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR:
- changes the way we deal with Python cache depending: there's now one virtual env per Python version. The jobs now use `datadog-agent-python-$PYTHON_VERSION` as the virtualenv.
- refactors a bit the warning echo-ed in the CI about the Go and Python versions already installed on the runners 

### Motivation

- There's no need to remove the virtualenv directly for every job. It slows the job down.
- Readability

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->