### PR TITLE
usm: Wrap debug logs with shouldLog

### DIFF
--- a/pkg/network/protocols/events/consumer.go
+++ b/pkg/network/protocols/events/consumer.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/cihub/seelog"
+
 	manager "github.com/DataDog/ebpf-manager"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -162,7 +164,9 @@ func (c *Consumer[V]) Start() {
 				c.batchReader.ReadAll(func(_ int, b *batch) {
 					c.process(b, true)
 				})
-				log.Debugf("usm events summary: name=%q %s", c.proto, c.metricGroup.Summary())
+				if log.ShouldLog(seelog.DebugLvl) {
+					log.Debugf("usm events summary: name=%q %s", c.proto, c.metricGroup.Summary())
+				}
 				close(done)
 			}
 		}

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -10,6 +10,8 @@ package http
 import (
 	"fmt"
 
+	"github.com/cihub/seelog"
+
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -97,5 +99,7 @@ func (t *Telemetry) Count(tx Transaction) {
 
 // Log logs the telemetry.
 func (t *Telemetry) Log() {
-	log.Debugf("%s stats summary: %s", t.protocol, t.metricGroup.Summary())
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("%s stats summary: %s", t.protocol, t.metricGroup.Summary())
+	}
 }

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -10,6 +10,8 @@ package http2
 import (
 	"strconv"
 
+	"github.com/cihub/seelog"
+
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -89,7 +91,9 @@ func (t *kernelTelemetry) update(tel *HTTP2Telemetry, isTLS bool) {
 }
 
 func (t *kernelTelemetry) Log() {
-	log.Debugf("http2 kernel telemetry summary: %s", t.metricGroup.Summary())
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("http2 kernel telemetry summary: %s", t.metricGroup.Summary())
+	}
 }
 
 // Sub generates a new HTTP2Telemetry object by subtracting the values of this HTTP2Telemetry object from the other

--- a/pkg/network/protocols/kafka/telemetry.go
+++ b/pkg/network/protocols/kafka/telemetry.go
@@ -8,6 +8,8 @@
 package kafka
 
 import (
+	"github.com/cihub/seelog"
+
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -49,5 +51,7 @@ func (t *Telemetry) Count(tx *KafkaTransaction) {
 
 // Log logs the kafka stats summary
 func (t *Telemetry) Log() {
-	log.Debugf("kafka stats summary: %s", t.metricGroup.Summary())
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("kafka stats summary: %s", t.metricGroup.Summary())
+	}
 }

--- a/pkg/network/protocols/postgres/telemetry.go
+++ b/pkg/network/protocols/postgres/telemetry.go
@@ -10,6 +10,8 @@ package postgres
 import (
 	"fmt"
 
+	"github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres/ebpf"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -172,5 +174,7 @@ func (t *Telemetry) Count(tx *ebpf.EbpfEvent, eventWrapper *EventWrapper) {
 
 // Log logs the postgres stats summary
 func (t *Telemetry) Log() {
-	log.Debugf("postgres stats summary: %s", t.metricGroup.Summary())
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("postgres stats summary: %s", t.metricGroup.Summary())
+	}
 }

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"sync"
 
+	"github.com/cihub/seelog"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
-
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -244,7 +244,9 @@ func (r *FileRegistry) GetRegisteredProcesses() map[uint32]struct{} {
 
 // Log state of `FileRegistry`
 func (r *FileRegistry) Log() {
-	log.Debugf("file_registry summary: program=%s %s", r.telemetry.programName, r.telemetry.metricGroup.Summary())
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("file_registry summary: program=%s %s", r.telemetry.programName, r.telemetry.metricGroup.Summary())
+	}
 }
 
 // Clear removes all registrations calling their deactivation callbacks


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Wraps hot-path calls for log.Debug with `log.ShouldLog` to prevent redundant allocations and waste of CPU

### Motivation

Profiles show 5-11% cpu consumption in critical paths due to debug logs.
Since debug logs are not the default level, it means waste of resources for the default deployment of system probe.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

Implemented the following benchmarks
```go
func BenchmarkLogSummaryFast(b *testing.B) {
	metricGroup := libtelemetry.NewMetricGroup("usm.http")
	counter := metricGroup.NewCounter("counter", "tag1", "tag2")
	counter.Add(5)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if log.ShouldLog(seelog.DebugLvl) {
			log.Debugf("BenchmarkCountSameTag: %s", metricGroup.Summary())
		}
	}
}

func BenchmarkLogSummary(b *testing.B) {
	metricGroup := libtelemetry.NewMetricGroup("usm.http")
	counter := metricGroup.NewCounter("counter", "tag1", "tag2")
	counter.Add(5)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		log.Debugf("BenchmarkCountSameTag: %s", metricGroup.Summary())
	}
}
```

The results:

```
BenchmarkLogSummaryFast
BenchmarkLogSummaryFast-16             	100000000	        11.55 ns/op	       0 B/op	       0 allocs/op
BenchmarkLogSummary
BenchmarkLogSummary-16                 	  902073	      1271 ns/op	     640 B/op	      19 allocs/op
```

Which means 99% cut of runtime, 100% in bytes and allocations if debug log is not enabled.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->