### PR TITLE
fix(buildimage): Deprecate the old buildimages update task

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -11,12 +11,12 @@ This image is now built alongside other images in [agent-buildimages](https://gi
 Once you have created a new image by building a new version of agent-buildimages, you can test your modification with the associated invoke task:
 
 ```bash
-invoke -e pipeline.update-buildimages --image-tag v12345678-c0mm1t5
+invoke -e buildimages.update --image-tag v12345678-c0mm1t5
 ```
 This will update the configuration of circleci and gitlab to use the __test version__ of these images.
 Once your test is successful, you can either move the `_test_version` from files or invoke
 ```bash
-invoke -e pipeline.update-buildimages --image-tag v12345678-c0mm1t5 --no-test-version
+invoke -e buildimages.update --image-tag v12345678-c0mm1t5 --no-test-version
 ```
 
 If everything is green, get a review and merge the PR.

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -4,7 +4,8 @@ import os
 
 from invoke import Context, task
 
-from tasks.pipeline import update_circleci_config, update_gitlab_config, update_test_infra_def
+from tasks.libs.ciproviders.circleci import update_circleci_config
+from tasks.libs.ciproviders.gitlab_api import update_gitlab_config, update_test_infra_def
 
 
 @task(

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -11,8 +11,8 @@ from invoke.context import Context
 from invoke.runners import Result
 
 from tasks.kernel_matrix_testing.tool import Exit, info, warn
+from tasks.libs.ciproviders.gitlab_api import GitlabYamlLoader
 from tasks.libs.types.arch import ARCH_AMD64, ARCH_ARM64, Arch
-from tasks.pipeline import GitlabYamlLoader
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import PathOrStr

--- a/tasks/kernel_matrix_testing/platforms.py
+++ b/tasks/kernel_matrix_testing/platforms.py
@@ -8,7 +8,7 @@ import yaml
 
 from tasks.kernel_matrix_testing.tool import Exit
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS
-from tasks.pipeline import GitlabYamlLoader
+from tasks.libs.ciproviders.gitlab_api import GitlabYamlLoader
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import (

--- a/tasks/libs/ciproviders/circleci.py
+++ b/tasks/libs/ciproviders/circleci.py
@@ -1,0 +1,16 @@
+import re
+
+
+def update_circleci_config(file_path, image_tag, test_version):
+    """
+    Override variables in .gitlab-ci.yml file
+    """
+    image_name = "gcr.io/datadoghq/agent-circleci-runner"
+    with open(file_path) as circle:
+        circle_ci = circle.read()
+    match = re.search(rf"({image_name}(_test_only)?):([a-zA-Z0-9_-]+)\n", circle_ci)
+    if not match:
+        raise RuntimeError(f"Impossible to find the version of image {image_name} in circleci configuration file")
+    image = f"{image_name}_test_only" if test_version else image_name
+    with open(file_path, "w") as circle:
+        circle.write(circle_ci.replace(f"{match.group(0)}", f"{image}:{image_tag}\n"))

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -120,6 +120,24 @@ def refresh_pipeline(pipeline: ProjectPipeline):
     pipeline.refresh()
 
 
+class GitlabReference(yaml.YAMLObject):
+    def __init__(self, refs):
+        self.refs = refs
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}=(refs={self.refs}'
+
+
+def reference_constructor(loader, node):
+    return GitlabReference(loader.construct_sequence(node))
+
+
+def GitlabYamlLoader():
+    loader = yaml.SafeLoader
+    loader.add_constructor('!reference', reference_constructor)
+    return loader
+
+
 class GitlabCIDiff:
     def __init__(
         self,
@@ -1250,3 +1268,51 @@ def full_config_get_all_stages(full_config: dict) -> set[str]:
         all_stages.update(config.get("stages", []))
 
     return all_stages
+
+
+def update_test_infra_def(file_path, image_tag):
+    """
+    Override TEST_INFRA_DEFINITIONS_BUILDIMAGES in `.gitlab/common/test_infra_version.yml` file
+    """
+    with open(file_path) as gl:
+        file_content = gl.readlines()
+    with open(file_path, "w") as gl:
+        for line in file_content:
+            test_infra_def = re.search(r"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
+            if test_infra_def:
+                gl.write(line.replace(test_infra_def.group(1), image_tag))
+            else:
+                gl.write(line)
+
+
+def update_gitlab_config(file_path, image_tag, test_version):
+    """
+    Override variables in .gitlab-ci.yml file
+    """
+    with open(file_path) as gl:
+        file_content = gl.readlines()
+    gitlab_ci = yaml.load("".join(file_content), Loader=GitlabYamlLoader())
+    # TEST_INFRA_DEFINITION_BUILDIMAGE label format differs from other buildimages
+    suffixes = [
+        name
+        for name in gitlab_ci["variables"]
+        if name.endswith("SUFFIX") and not name.startswith("TEST_INFRA_DEFINITION")
+    ]
+    images = [name.replace("_SUFFIX", "") for name in suffixes]
+    with open(file_path, "w") as gl:
+        for line in file_content:
+            if any(re.search(rf"{suffix}:", line) for suffix in suffixes):
+                if test_version:
+                    gl.write(line.replace('""', '"_test_only"'))
+                else:
+                    gl.write(line.replace('"_test_only"', '""'))
+            elif any(re.search(rf"{image}:", line) for image in images):
+                current_version = re.search(r"v\d+-\w+", line)
+                if current_version:
+                    gl.write(line.replace(current_version.group(0), image_tag))
+                else:
+                    raise RuntimeError(
+                        f"Unable to find a version matching the v<pipelineId>-<commitId> pattern in line {line}"
+                    )
+            else:
+                gl.write(line)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -13,14 +13,15 @@ from invoke.exceptions import Exit
 
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.ciproviders.gitlab_api import (
+    GitlabYamlLoader,
     get_gitlab_bot_token,
     get_gitlab_repo,
     gitlab_configuration_is_modified,
     refresh_pipeline,
 )
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.constants import DEFAULT_BRANCH, GITHUB_REPO_NAME
-from tasks.libs.common.git import check_clean_branch_state, get_commit_sha, get_current_branch
+from tasks.libs.common.constants import DEFAULT_BRANCH
+from tasks.libs.common.git import get_commit_sha, get_current_branch
 from tasks.libs.common.utils import (
     get_all_allowed_repo_branches,
     is_allowed_repo_branch,
@@ -38,24 +39,6 @@ from tasks.libs.pipeline.tools import (
 from tasks.libs.releasing.documentation import nightly_entry_for, release_entry_for
 
 BOT_NAME = "github-actions[bot]"
-
-
-class GitlabReference(yaml.YAMLObject):
-    def __init__(self, refs):
-        self.refs = refs
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}=(refs={self.refs}'
-
-
-def reference_constructor(loader, node):
-    return GitlabReference(loader.construct_sequence(node))
-
-
-def GitlabYamlLoader():
-    loader = yaml.SafeLoader
-    loader.add_constructor('!reference', reference_constructor)
-    return loader
 
 
 # Tasks to trigger pipelines
@@ -756,86 +739,7 @@ def update_buildimages(ctx, image_tag, test_version=True, branch_name=None):
     Update local files to run with new image_tag from agent-buildimages and launch a full pipeline
     Use --no-test-version to commit without the _test_only suffixes
     """
-    create_branch = branch_name is None
-    branch_name = verify_workspace(ctx, branch_name=branch_name)
-    update_gitlab_config(".gitlab-ci.yml", image_tag, test_version=test_version)
-    update_circleci_config(".circleci/config.yml", image_tag, test_version=test_version)
-    trigger_build(ctx, branch_name=branch_name, create_branch=create_branch)
-
-
-def verify_workspace(ctx, branch_name=None):
-    """
-    Assess we can modify files and commit without risk of local or upstream conflicts
-    """
-    if branch_name is None:
-        user_name = ctx.run("whoami", hide="out")
-        branch_name = f"{user_name.stdout.rstrip()}/test_buildimages"
-        github = GithubAPI(repository=GITHUB_REPO_NAME)
-        check_clean_branch_state(ctx, github, branch_name)
-    return branch_name
-
-
-def update_test_infra_def(file_path, image_tag):
-    """
-    Override TEST_INFRA_DEFINITIONS_BUILDIMAGES in `.gitlab/common/test_infra_version.yml` file
-    """
-    with open(file_path) as gl:
-        file_content = gl.readlines()
-    with open(file_path, "w") as gl:
-        for line in file_content:
-            test_infra_def = re.search(r"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
-            if test_infra_def:
-                gl.write(line.replace(test_infra_def.group(1), image_tag))
-            else:
-                gl.write(line)
-
-
-def update_gitlab_config(file_path, image_tag, test_version):
-    """
-    Override variables in .gitlab-ci.yml file
-    """
-    with open(file_path) as gl:
-        file_content = gl.readlines()
-    gitlab_ci = yaml.load("".join(file_content), Loader=GitlabYamlLoader())
-    # TEST_INFRA_DEFINITION_BUILDIMAGE label format differs from other buildimages
-    suffixes = [
-        name
-        for name in gitlab_ci["variables"]
-        if name.endswith("SUFFIX") and not name.startswith("TEST_INFRA_DEFINITION")
-    ]
-    images = [name.replace("_SUFFIX", "") for name in suffixes]
-    with open(file_path, "w") as gl:
-        for line in file_content:
-            if any(re.search(rf"{suffix}:", line) for suffix in suffixes):
-                if test_version:
-                    gl.write(line.replace('""', '"_test_only"'))
-                else:
-                    gl.write(line.replace('"_test_only"', '""'))
-            elif any(re.search(rf"{image}:", line) for image in images):
-                current_version = re.search(r"v\d+-\w+", line)
-                if current_version:
-                    gl.write(line.replace(current_version.group(0), image_tag))
-                else:
-                    raise RuntimeError(
-                        f"Unable to find a version matching the v<pipelineId>-<commitId> pattern in line {line}"
-                    )
-            else:
-                gl.write(line)
-
-
-def update_circleci_config(file_path, image_tag, test_version):
-    """
-    Override variables in .gitlab-ci.yml file
-    """
-    image_name = "gcr.io/datadoghq/agent-circleci-runner"
-    with open(file_path) as circle:
-        circle_ci = circle.read()
-    match = re.search(rf"({image_name}(_test_only)?):([a-zA-Z0-9_-]+)\n", circle_ci)
-    if not match:
-        raise RuntimeError(f"Impossible to find the version of image {image_name} in circleci configuration file")
-    image = f"{image_name}_test_only" if test_version else image_name
-    with open(file_path, "w") as circle:
-        circle.write(circle_ci.replace(f"{match.group(0)}", f"{image}:{image_tag}\n"))
+    raise Exit(f"This invoke task is {color_message('deprecated', 'red')}, please use inv buildimages.update instead.")
 
 
 @task(
@@ -857,22 +761,6 @@ def get_gitlab_config_image_tag(_, file_path=".gitlab-ci.yml"):
             code=1,
         )
     return gitlab_ci["variables"]["DATADOG_AGENT_BUILDIMAGES"]
-
-
-def trigger_build(ctx, branch_name=None, create_branch=False):
-    """
-    Trigger a pipeline from current branch on-demand (useful for test image)
-    """
-    if create_branch:
-        ctx.run(f"git checkout -b {branch_name}")
-    answer = input("Do you want to trigger a pipeline (will also commit and push)? [Y/n]\n")
-    if len(answer) == 0 or answer.casefold() == "y":
-        ctx.run("git add .gitlab-ci.yml .circleci/config.yml")
-        ctx.run("git commit -m 'Update buildimages version'")
-        ctx.run(f"git push origin {branch_name}")
-        print("Wait 10s to let Gitlab create the first events before triggering a new pipeline")
-        time.sleep(10)
-        run(ctx, here=True)
 
 
 @task(

--- a/tasks/unit_tests/circleci_tests.py
+++ b/tasks/unit_tests/circleci_tests.py
@@ -1,0 +1,45 @@
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+from tasks.libs.ciproviders.circleci import update_circleci_config
+
+
+class TestUpdateCircleCI(unittest.TestCase):
+    circleci_file = ".circleci/config.yml"
+    circleci_test = ".circleci/config-test.yml"
+    erroneous_file = "tasks/unit_tests/testdata/erroneous_circleci_config.yml"
+
+    def setUp(self) -> None:
+        shutil.copy(self.circleci_file, self.circleci_test)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        subprocess.run(f"git checkout -- {self.erroneous_file}".split())
+        Path(self.circleci_test).unlink()
+        return super().tearDown()
+
+    def test_nominal(self):
+        update_circleci_config(self.circleci_test, "1m4g3", test_version=True)
+        with open(self.circleci_test) as gl:
+            circle_ci = yaml.safe_load(gl)
+        full_image = circle_ci['templates']['job_template']['docker'][0]['image']
+        image, version = full_image.split(":")
+        self.assertTrue(image.endswith("_test_only"))
+        self.assertEqual("1m4g3", version)
+
+    def test_update_no_test(self):
+        update_circleci_config(self.circleci_test, "1m4g3", test_version=False)
+        with open(self.circleci_test) as gl:
+            circle_ci = yaml.safe_load(gl)
+        full_image = circle_ci['templates']['job_template']['docker'][0]['image']
+        image, version = full_image.split(":")
+        self.assertFalse(image.endswith("_test_only"))
+        self.assertEqual("1m4g3", version)
+
+    def test_raise(self):
+        with self.assertRaises(RuntimeError):
+            update_circleci_config(self.erroneous_file, "1m4g3", test_version=False)

--- a/tasks/unit_tests/gitlab_api_tests.py
+++ b/tasks/unit_tests/gitlab_api_tests.py
@@ -1,7 +1,9 @@
+import subprocess
 import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock, patch
 
+import yaml
 from invoke import MockContext, Result
 
 from tasks.libs.ciproviders.gitlab_api import (
@@ -13,6 +15,7 @@ from tasks.libs.ciproviders.gitlab_api import (
     gitlab_configuration_is_modified,
     read_includes,
     retrieve_all_paths,
+    update_gitlab_config,
 )
 
 
@@ -478,3 +481,33 @@ class TestGitlabConfigurationIsModified(unittest.TestCase):
         diff = f'diff --git a/{file} b/{file}\nindex 561eb1a201..5e43218090 100644\n--- a/{file}\n+++ b/{file}\n@@ -1,4 +1,11 @@\n ---\n+rtloader_tests:\n+  stage: source_test\n+  needs: ["go_deps"]\n+  before_script:\n+    - source /root/.bashrc && conda activate $CONDA_ENV\n+  script: ["# Skipping go tests"]\n+\n nerd_tests\n   stage: source_test\n   needs: ["go_deps"]\ndiff --git a/{yaml} b/{yaml}\nindex 561eb1a201..5e43218090 100644\n--- a/{yaml}\n+++ b/{yaml}\n@@ -1,4 +1,11 @@\n ---\n+rtloader_tests:\n+  stage: source_test\n+  noods: ["go_deps"]\n+  before_script:\n+    - source /root/.bashrc && conda activate $CONDA_ENV\n+  script: ["# Skipping go tests"]\n+\n nerd_tests\n   stage: source_test\n   needs: ["go_deps"]'
         c = MockContext(run={"git diff HEAD^1..HEAD": Result(diff)})
         self.assertTrue(gitlab_configuration_is_modified(c))
+
+
+class TestUpdateGitlabCI(unittest.TestCase):
+    gitlabci_file = "tasks/unit_tests/testdata/fake_gitlab-ci.yml"
+    erroneous_file = "tasks/unit_tests/testdata/erroneous_gitlab-ci.yml"
+
+    def tearDown(self) -> None:
+        subprocess.run(f"git checkout -- {self.gitlabci_file} {self.erroneous_file}".split())
+        return super().tearDown()
+
+    def test_nominal(self):
+        update_gitlab_config(self.gitlabci_file, "1mageV3rsi0n", test_version=True)
+        with open(self.gitlabci_file) as gl:
+            gitlab_ci = yaml.safe_load(gl)
+        for variable, value in gitlab_ci["variables"].items():
+            # TEST_INFRA_DEFINITION_BUILDIMAGE label format differs from other buildimages
+            if variable.endswith("_SUFFIX") and not variable.startswith("TEST_INFRA_DEFINITION"):
+                self.assertEqual("_test_only", value)
+
+    def test_update_no_test(self):
+        update_gitlab_config(self.gitlabci_file, "1mageV3rsi0n", test_version=False)
+        with open(self.gitlabci_file) as gl:
+            gitlab_ci = yaml.safe_load(gl)
+        for variable, value in gitlab_ci["variables"].items():
+            if variable.endswith("_SUFFIX"):
+                self.assertEqual("", value)
+
+    def test_raise(self):
+        with self.assertRaises(RuntimeError):
+            update_gitlab_config(self.erroneous_file, "1mageV3rsi0n", test_version=False)

--- a/tasks/unit_tests/pipeline_tests.py
+++ b/tasks/unit_tests/pipeline_tests.py
@@ -1,102 +1,11 @@
-import subprocess
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import yaml
 from invoke import MockContext, Result
 from invoke.exceptions import Exit
 
 from tasks import pipeline
-
-
-class TestVerifyWorkspace(unittest.TestCase):
-    @patch('tasks.pipeline.GithubAPI', autospec=True)
-    @patch('tasks.pipeline.check_clean_branch_state', new=MagicMock())
-    def test_with_branch(self, mock_gh):
-        branch_test_name = "tryphon_tournesol"
-        context_mock = MockContext(run=Result("haddock"))
-        branch = pipeline.verify_workspace(context_mock, branch_test_name)
-        self.assertEqual(branch_test_name, branch)
-        mock_gh.assert_not_called()
-
-    @patch('tasks.pipeline.GithubAPI', autospec=True)
-    @patch('tasks.pipeline.check_clean_branch_state', new=MagicMock())
-    def test_without_branch(self, mock_gh):
-        context_mock = MockContext(run=Result("haddock"))
-        branch = pipeline.verify_workspace(context_mock, None)
-        self.assertEqual("haddock/test_buildimages", branch)
-        mock_gh.assert_called()
-
-    @patch('tasks.pipeline.GithubAPI', autospec=True)
-    def test_bad_workspace(self, _):
-        with open(".gitignore", "a") as f:
-            f.write("# test comment")
-        with self.assertRaises(Exit):
-            context_mock = MockContext(run=Result("haddock"))
-            _ = pipeline.verify_workspace(context_mock)
-        subprocess.run("git checkout -- .gitignore".split())
-
-
-class TestUpdateGitlabCI(unittest.TestCase):
-    gitlabci_file = "tasks/unit_tests/testdata/fake_gitlab-ci.yml"
-    erroneous_file = "tasks/unit_tests/testdata/erroneous_gitlab-ci.yml"
-
-    def tearDown(self) -> None:
-        subprocess.run(f"git checkout -- {self.gitlabci_file} {self.erroneous_file}".split())
-        return super().tearDown()
-
-    def test_nominal(self):
-        pipeline.update_gitlab_config(self.gitlabci_file, "1mageV3rsi0n", test_version=True)
-        with open(self.gitlabci_file) as gl:
-            gitlab_ci = yaml.safe_load(gl)
-        for variable, value in gitlab_ci["variables"].items():
-            # TEST_INFRA_DEFINITION_BUILDIMAGE label format differs from other buildimages
-            if variable.endswith("_SUFFIX") and not variable.startswith("TEST_INFRA_DEFINITION"):
-                self.assertEqual("_test_only", value)
-
-    def test_update_no_test(self):
-        pipeline.update_gitlab_config(self.gitlabci_file, "1mageV3rsi0n", test_version=False)
-        with open(self.gitlabci_file) as gl:
-            gitlab_ci = yaml.safe_load(gl)
-        for variable, value in gitlab_ci["variables"].items():
-            if variable.endswith("_SUFFIX"):
-                self.assertEqual("", value)
-
-    def test_raise(self):
-        with self.assertRaises(RuntimeError):
-            pipeline.update_gitlab_config(self.erroneous_file, "1mageV3rsi0n", test_version=False)
-
-
-class TestUpdateCircleCI(unittest.TestCase):
-    circleci_file = "tasks/unit_tests/testdata/fake_circleci_config.yml"
-    erroneous_file = "tasks/unit_tests/testdata/erroneous_circleci_config.yml"
-
-    def tearDown(self) -> None:
-        subprocess.run(f"git checkout -- {self.circleci_file} {self.erroneous_file}".split())
-        return super().tearDown()
-
-    def test_nominal(self):
-        pipeline.update_circleci_config(self.circleci_file, "1m4g3", test_version=True)
-        with open(self.circleci_file) as gl:
-            circle_ci = yaml.safe_load(gl)
-        full_image = circle_ci['templates']['job_template']['docker'][0]['image']
-        image, version = full_image.split(":")
-        self.assertTrue(image.endswith("_test_only"))
-        self.assertEqual("1m4g3", version)
-
-    def test_update_no_test(self):
-        pipeline.update_circleci_config(self.circleci_file, "1m4g3", test_version=False)
-        with open(self.circleci_file) as gl:
-            circle_ci = yaml.safe_load(gl)
-        full_image = circle_ci['templates']['job_template']['docker'][0]['image']
-        image, version = full_image.split(":")
-        self.assertFalse(image.endswith("_test_only"))
-        self.assertEqual("1m4g3", version)
-
-    def test_raise(self):
-        with self.assertRaises(RuntimeError):
-            pipeline.update_circleci_config(self.erroneous_file, "1m4g3", test_version=False)
 
 
 class TestCompareToItself(unittest.TestCase):

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -7,9 +7,10 @@ from invoke.context import Context
 from invoke.tasks import task
 
 from tasks.go import tidy
+from tasks.libs.ciproviders.circleci import update_circleci_config
+from tasks.libs.ciproviders.gitlab_api import update_gitlab_config
 from tasks.libs.common.color import color_message
 from tasks.modules import DEFAULT_MODULES
-from tasks.pipeline import update_circleci_config, update_gitlab_config
 
 GO_VERSION_FILE = "./.go-version"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Deprecate the `pipeline.update-buildimages` task to use the `buildimages.update` one

### Motivation
Remove a duplicated task and refactoring (moved gitlab related tasks to the gitlab modules)

### Describe how to test/QA your changes
Invoke unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
The [last reference](https://github.com/search?q=org%3ADataDog+update-buildimages&type=code) of old task is on the buildimage repo readme. I will fix this with a follow-up PR
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->