### PR TITLE
refactor(buildimages): Move and rename `get-gitlab-config-image-tag`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -560,6 +560,7 @@
 /tasks/windows_resources.py             @DataDog/windows-agent
 /tasks/components.py                    @DataDog/agent-shared-components
 /tasks/components_templates             @DataDog/agent-shared-components
+/tasks/libs/ciproviders/                @DataDog/agent-devx-infra
 /tasks/libs/common/omnibus.py           @DataDog/agent-delivery
 /tasks/omnibus.py                       @DataDog/agent-delivery
 /tasks/unit_tests/components_tests.py   @DataDog/agent-shared-components

--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Get current buildimage tag
         id: current_buildimage_tag
         run: |
-            echo "BUILDIMAGE_TAG=$(inv pipeline.get-gitlab-config-image-tag)" >> $GITHUB_OUTPUT
+            echo "BUILDIMAGE_TAG=$(inv buildimages.get-tag)" >> $GITHUB_OUTPUT
 
       - name: Update buildimages IDs and Go version
         id: update_build_images

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 
-from invoke import Context, task
+import yaml
+from invoke import Context, Exit, task
 
 from tasks.libs.ciproviders.circleci import update_circleci_config
-from tasks.libs.ciproviders.gitlab_api import update_gitlab_config, update_test_infra_def
+from tasks.libs.ciproviders.gitlab_api import ReferenceTag, update_gitlab_config, update_test_infra_def
+from tasks.libs.common.color import color_message
 
 
 @task(
@@ -75,3 +77,24 @@ This PR updates the current buildimages (`{old_build_image_tag}`) to `{new_build
 This PR updates the current Golang version ([`{old_go_version}`]({old_go_version_url})) to [`{new_go_version}`]({new_go_version_url}).
 """
     return pr_body
+
+
+@task(
+    help={
+        "file_path": "path of the Gitlab configuration YAML file",
+    },
+    autoprint=True,
+)
+def get_tag(_, file_path=".gitlab-ci.yml"):
+    """
+    Print the current image tag of the given Gitlab configuration file (default: ".gitlab-ci.yml")
+    """
+    yaml.SafeLoader.add_constructor(ReferenceTag.yaml_tag, ReferenceTag.from_yaml)
+    with open(file_path) as gl:
+        gitlab_ci = yaml.safe_load(gl)
+    if "variables" not in gitlab_ci or "DATADOG_AGENT_BUILDIMAGES" not in gitlab_ci["variables"]:
+        raise Exit(
+            color_message(f"Impossible to find the version of image in {file_path} configuration file", "red"),
+            code=1,
+        )
+    return gitlab_ci["variables"]["DATADOG_AGENT_BUILDIMAGES"]

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -11,7 +11,7 @@ from invoke.context import Context
 from invoke.runners import Result
 
 from tasks.kernel_matrix_testing.tool import Exit, info, warn
-from tasks.libs.ciproviders.gitlab_api import GitlabYamlLoader
+from tasks.libs.ciproviders.gitlab_api import ReferenceTag
 from tasks.libs.types.arch import ARCH_AMD64, ARCH_ARM64, Arch
 
 if TYPE_CHECKING:
@@ -29,8 +29,9 @@ DOCKER_IMAGE_BASE = f"{DOCKER_REGISTRY}/ci/datadog-agent-buildimages/system-prob
 
 def get_build_image_suffix_and_version() -> tuple[str, str]:
     gitlab_ci_file = Path(__file__).parent.parent.parent / ".gitlab-ci.yml"
+    yaml.SafeLoader.add_constructor(ReferenceTag.yaml_tag, ReferenceTag.from_yaml)
     with open(gitlab_ci_file) as f:
-        ci_config = yaml.load(f, Loader=GitlabYamlLoader())
+        ci_config = yaml.safe_load(f)
 
     ci_vars = ci_config['variables']
     return ci_vars['DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX'], ci_vars['DATADOG_AGENT_SYSPROBE_BUILDIMAGES']

--- a/tasks/kernel_matrix_testing/platforms.py
+++ b/tasks/kernel_matrix_testing/platforms.py
@@ -8,7 +8,7 @@ import yaml
 
 from tasks.kernel_matrix_testing.tool import Exit
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS
-from tasks.libs.ciproviders.gitlab_api import GitlabYamlLoader
+from tasks.libs.ciproviders.gitlab_api import ReferenceTag
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import (
@@ -40,8 +40,9 @@ def filter_by_ci_component(platforms: Platforms, component: Component) -> Platfo
     target_file = (
         Path(__file__).parent.parent.parent / ".gitlab" / "kernel_matrix_testing" / f"{component.replace('-', '_')}.yml"
     )
+    yaml.SafeLoader.add_constructor(ReferenceTag.yaml_tag, ReferenceTag.from_yaml)
     with open(target_file) as f:
-        ci_config = yaml.load(f, Loader=GitlabYamlLoader())
+        ci_config = yaml.safe_load(f)
 
     for arch in KMT_SUPPORTED_ARCHS:
         job_name = f"kmt_run_{job_component_mapping[component]}_tests_{job_arch_mapping[arch]}"

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -120,24 +120,6 @@ def refresh_pipeline(pipeline: ProjectPipeline):
     pipeline.refresh()
 
 
-class GitlabReference(yaml.YAMLObject):
-    def __init__(self, refs):
-        self.refs = refs
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}=(refs={self.refs}'
-
-
-def reference_constructor(loader, node):
-    return GitlabReference(loader.construct_sequence(node))
-
-
-def GitlabYamlLoader():
-    loader = yaml.SafeLoader
-    loader.add_constructor('!reference', reference_constructor)
-    return loader
-
-
 class GitlabCIDiff:
     def __init__(
         self,
@@ -1291,7 +1273,8 @@ def update_gitlab_config(file_path, image_tag, test_version):
     """
     with open(file_path) as gl:
         file_content = gl.readlines()
-    gitlab_ci = yaml.load("".join(file_content), Loader=GitlabYamlLoader())
+    yaml.SafeLoader.add_constructor(ReferenceTag.yaml_tag, ReferenceTag.from_yaml)
+    gitlab_ci = yaml.safe_load("".join(file_content))
     # TEST_INFRA_DEFINITION_BUILDIMAGE label format differs from other buildimages
     suffixes = [
         name

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -13,7 +13,6 @@ from invoke.exceptions import Exit
 
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.ciproviders.gitlab_api import (
-    GitlabYamlLoader,
     get_gitlab_bot_token,
     get_gitlab_repo,
     gitlab_configuration_is_modified,
@@ -740,27 +739,6 @@ def update_buildimages(ctx, image_tag, test_version=True, branch_name=None):
     Use --no-test-version to commit without the _test_only suffixes
     """
     raise Exit(f"This invoke task is {color_message('deprecated', 'red')}, please use inv buildimages.update instead.")
-
-
-@task(
-    help={
-        "file_path": "path of the Gitlab configuration YAML file",
-    },
-    autoprint=True,
-)
-def get_gitlab_config_image_tag(_, file_path=".gitlab-ci.yml"):
-    """
-    Print the current image tag of the given Gitlab configuration file (default: ".gitlab-ci.yml")
-    """
-    with open(file_path) as gl:
-        file_content = gl.readlines()
-    gitlab_ci = yaml.load("".join(file_content), Loader=GitlabYamlLoader())
-    if "variables" not in gitlab_ci or "DATADOG_AGENT_BUILDIMAGES" not in gitlab_ci["variables"]:
-        raise Exit(
-            color_message(f"Impossible to find the version of image in {file_path} configuration file", "red"),
-            code=1,
-        )
-    return gitlab_ci["variables"]["DATADOG_AGENT_BUILDIMAGES"]
 
 
 @task(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Move the `get-gitlab-config-image-tag` from `pipelines.py` to `buildimages.py`
- Rename in `get-image-tag`
- Replace occurrences of `GitlabYamlLoader` by `ReferenceTag`

### Motivation
Refactoring

### Describe how to test/QA your changes
Invoke unit tests + manually ran the new task

### Possible Drawbacks / Trade-offs

### Additional Notes
Based on #30365
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->