### PR TITLE
Make remote tagger grpc max message size cofigurable with default of 2MB

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -132,8 +132,10 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 	}
 
 	grpcSrv := grpc.NewServer(opts...)
+	// event size should be small enough to fit within the grpc max message size
+	maxEventSize := maxMessageSize / 2
 	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
-		taggerServer: taggerserver.NewServer(taggerComp, maxMessageSize/2),
+		taggerServer: taggerserver.NewServer(taggerComp, maxEventSize),
 	})
 
 	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -53,8 +53,6 @@ var (
 	apiRouter *mux.Router
 )
 
-const maxMessageSize = 4 * 1024 * 1024 // 4 MB
-
 // StartServer creates the router and starts the HTTP server
 func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component) error {
 	// create the root HTTP router
@@ -125,6 +123,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 		return struct{}{}, nil
 	})
 
+	maxMessageSize := cfg.GetInt("cluster_agent.cluster_tagger.grpc_max_message_size")
 	opts := []grpc.ServerOption{
 		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(authInterceptor)),
 		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(authInterceptor)),
@@ -134,7 +133,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 
 	grpcSrv := grpc.NewServer(opts...)
 	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
-		taggerServer: taggerserver.NewServer(taggerComp, maxMessageSize),
+		taggerServer: taggerserver.NewServer(taggerComp, maxMessageSize/2),
 	})
 
 	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -40,6 +41,7 @@ func Module() fxutil.Module {
 type apiServer struct {
 	dogstatsdServer   dogstatsdServer.Component
 	capture           replay.Component
+	cfg               config.Component
 	pidMap            pidmap.Component
 	secretResolver    secrets.Component
 	rcService         optional.Option[rcservice.Component]
@@ -69,6 +71,7 @@ type dependencies struct {
 	RcServiceMRF          optional.Option[rcservicemrf.Component]
 	AuthToken             authtoken.Component
 	Tagger                tagger.Component
+	Cfg                   config.Component
 	AutoConfig            autodiscovery.Component
 	LogsAgentComp         optional.Option[logsAgent.Component]
 	WorkloadMeta          workloadmeta.Component
@@ -91,6 +94,7 @@ func newAPIServer(deps dependencies) api.Component {
 		rcServiceMRF:      deps.RcServiceMRF,
 		authToken:         deps.AuthToken,
 		taggerComp:        deps.Tagger,
+		cfg:               deps.Cfg,
 		autoConfig:        deps.AutoConfig,
 		logsAgentComp:     deps.LogsAgentComp,
 		wmeta:             deps.WorkloadMeta,

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -79,6 +79,7 @@ func (server *apiServer) startServers() error {
 		tlsConfig(),
 		tlsCertPool,
 		tmf,
+		server.cfg,
 	); err != nil {
 		return fmt.Errorf("unable to start CMD API server: %v", err)
 	}

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -61,12 +61,14 @@ func (server *apiServer) startCMDServer(
 		grpc.MaxSendMsgSize(maxMessageSize),
 	}
 
+	// event size should be small enough to fit within the grpc max message size
+	maxEventSize := maxMessageSize / 2
 	s := grpc.NewServer(opts...)
 	pb.RegisterAgentServer(s, &grpcServer{})
 	pb.RegisterAgentSecureServer(s, &serverSecure{
 		configService:    server.rcService,
 		configServiceMRF: server.rcServiceMRF,
-		taggerServer:     taggerserver.NewServer(server.taggerComp, maxMessageSize/2),
+		taggerServer:     taggerserver.NewServer(server.taggerComp, maxEventSize),
 		taggerComp:       server.taggerComp,
 		// TODO(components): decide if workloadmetaServer should be componentized itself
 		workloadmetaServer: workloadmetaServer.NewServer(server.wmeta),

--- a/comp/core/tagger/taggerimpl/server/server.go
+++ b/comp/core/tagger/taggerimpl/server/server.go
@@ -30,14 +30,14 @@ const (
 // Server is a grpc server that streams tagger entities
 type Server struct {
 	taggerComponent tagger.Component
-	maxMessageSize  int
+	maxEventSize    int
 }
 
 // NewServer returns a new Server
-func NewServer(t tagger.Component, maxMessageSize int) *Server {
+func NewServer(t tagger.Component, maxEventSize int) *Server {
 	return &Server{
 		taggerComponent: t,
-		maxMessageSize:  maxMessageSize,
+		maxEventSize:    maxEventSize,
 	}
 }
 
@@ -89,7 +89,7 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 			}
 
 			// Split events into chunks and send each one
-			chunks := splitEvents(responseEvents, s.maxMessageSize)
+			chunks := splitEvents(responseEvents, s.maxEventSize)
 			for _, chunk := range chunks {
 				err = grpc.DoWithTimeout(func() error {
 					return out.Send(&pb.StreamTagsResponse{

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -537,6 +537,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// - nodes
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resources", []string{})
 	config.BindEnvAndSetDefault("cluster_agent.kube_metadata_collection.resource_annotations_exclude", []string{})
+	config.BindEnvAndSetDefault("cluster_agent.cluster_tagger.grpc_max_message_size", 4<<20) // 4 MB
 
 	// Metadata endpoints
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes the cluster remote tagger grpc stream max message size configurable with default of 2MB.

### Motivation

Be able to control the max message size using env var. 

Recently, [we did a change](https://github.com/DataDog/datadog-agent/pull/30192) to ensure the message is cut into chunks of 4MB each, however the communication still failed because the size slightly exceeded the 4MB limit due to extra headers added to the message, that's why now we make this parameter configurable with an env var and we use the default value of 2MB to give a sufficient margin for headers.

```
2024-10-22 08:47:22 UTC | CORE | INFO | (comp/core/tagger/taggerimpl/remote/tagger.go:403 in func1) | tagger stream established successfully
2024-10-22 08:47:22 UTC | CORE | WARN | (comp/core/tagger/taggerimpl/remote/tagger.go:307 in run) | error received from remote tagger: rpc error: code = ResourceExhausted desc = trying to send message larger than max (4209972 vs. 4194304)
```

### Describe how to test/QA your changes

No need for QA, E2E tests should be sufficient. (CLC runners should still be able to use remote tagger)

### Possible Drawbacks / Trade-offs


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->