### PR TITLE
Replace clang format with dotnet format for C# files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,8 +70,16 @@ repos:
       description: clang-format
       entry: 'inv pre-commit.check-winclang-format'
       language: system
-      types_or: [c, c++, c#]
+      types_or: [c, c++]
       pass_filenames: false
+    - # dotnet format is available on Linux, see https://learn.microsoft.com/en-us/dotnet/core/install/linux
+      id: dotnet-format-win-installer
+      name: dotnet-format-win-installer
+      description: Format .net file of the MSI installer
+      language: system
+      # The dotnet format tool requires a solution file to operate.
+      entry: dotnet format ./tools/windows/DatadogAgentInstaller --include 
+      types: [c#]
     - id: go-mod-tidy
       name: go-mod-tidy
       description: check that all go.mod files are tidy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,8 +73,8 @@ repos:
       types_or: [c, c++]
       pass_filenames: false
     - # dotnet format is available on Linux, see https://learn.microsoft.com/en-us/dotnet/core/install/linux
-      id: dotnet-format-win-installer
-      name: dotnet-format-win-installer
+      id: dotnet-format-installer
+      name: dotnet-format-installer
       description: Format .net file of the MSI installer
       language: system
       # The dotnet format tool requires a solution file to operate.

--- a/tools/windows/DatadogAgentInstaller/.editorconfig
+++ b/tools/windows/DatadogAgentInstaller/.editorconfig
@@ -6,7 +6,13 @@
 indent_style = space
 tab_width = 4
 indent_size = 4
-end_of_line = crlf
+
+# unset = native (let the platform decide)
+# see https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#end_of_line
+#   > 'if you want to use native line endings between different operating systems it is better not to set this option and leave that task to the VCS'
+# and
+# https://github.com/editorconfig/editorconfig/issues/226
+# end_of_line = crlf
 
 #### .NET Coding Conventions ####
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR replaces the `clang-format` tool with `dotnet format` tool in the pre-commit hook.

### Motivation
The pre-commit hook `clang-format` doesn't work on C# files.

### Describe how to test/QA your changes
Mess up some C# file and try to commit it. It should fail.

### Possible Drawbacks / Trade-offs

### Additional Notes
The dotnet tool works on Linux as well.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->