### PR TITLE
feat(util): Don't use CGO for fqdn_windows

### DIFF
--- a/pkg/util/hostname/fqdn_windows.go
+++ b/pkg/util/hostname/fqdn_windows.go
@@ -6,9 +6,7 @@
 package hostname
 
 import (
-	"C"
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -23,7 +21,7 @@ func getSystemFQDN() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	namestring := C.GoString((*C.char)(unsafe.Pointer(he.Name)))
+	namestring := windows.BytePtrToString(he.Name)
 
 	return namestring, nil
 }


### PR DESCRIPTION
### What does this PR do?
Removes CGO dependency on `pkg/util/hostname` for future usage in statically-linked datadog-installer 

### Motivation

### Describe how to test/QA your changes
No functional change expected -- make sure the agent does report properly its hostname on Windows

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->