### PR TITLE
usm: Do not block file on environment errors

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -606,9 +606,9 @@ func isBuildKit(procRoot string, pid uint32) bool {
 func addHooks(m *manager.Manager, procRoot string, probes []manager.ProbesSelector) func(utils.FilePath) error {
 	return func(fpath utils.FilePath) error {
 		if isBuildKit(procRoot, fpath.PID) {
-			return fmt.Errorf("process %d is buildkitd, skipping", fpath.PID)
+			return fmt.Errorf("%w: process %d is buildkitd, skipping", utils.ErrEnvironment, fpath.PID)
 		} else if isContainerdTmpMount(fpath.HostPath) {
-			return fmt.Errorf("path %s from process %d is tempmount of containerd, skipping", fpath.HostPath, fpath.PID)
+			return fmt.Errorf("%w: path %s from process %d is tempmount of containerd, skipping", utils.ErrEnvironment, fpath.HostPath, fpath.PID)
 		}
 
 		uid := getUID(fpath.ID)

--- a/pkg/network/usm/ebpf_ssl_test.go
+++ b/pkg/network/usm/ebpf_ssl_test.go
@@ -9,16 +9,18 @@ package usm
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	fileopener "github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/stretchr/testify/require"
 )
 
 func testArch(t *testing.T, arch string) {
@@ -55,4 +57,11 @@ func TestArchAmd64(t *testing.T) {
 
 func TestArchArm64(t *testing.T) {
 	testArch(t, "arm64")
+}
+
+func TestContainerdTmpErrEnvironment(t *testing.T) {
+	hookFunction := addHooks(nil, "foo", nil)
+	path := utils.FilePath{PID: uint32(os.Getpid()), HostPath: "/foo/tmpmounts/containerd-mount/bar"}
+	err := hookFunction(path)
+	require.ErrorIs(t, err, utils.ErrEnvironment)
 }

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -85,6 +85,10 @@ type Callback func(FilePath) error
 // Meant for testing purposes
 var IgnoreCB = func(FilePath) error { return nil }
 
+// ErrEnvironment indicates that the error is not with the path itself, so the
+// path itself should not be blocked from further attempts at hooking.
+var ErrEnvironment = errors.New("Environment error, path will not be blocked")
+
 // NewFileRegistry creates a new `FileRegistry` instance
 func NewFileRegistry(programName string) *FileRegistry {
 	blocklistByID, err := simplelru.NewLRU[PathIdentifier, string](2000, nil)
@@ -169,6 +173,10 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 		// indicate that the process is gone, since the process could disappear
 		// between two uprobe registrations.
 		_ = deactivationCB(FilePath{ID: pathID})
+
+		if errors.Is(err, ErrEnvironment) {
+			return err
+		}
 
 		// short living process would be hard to catch and will failed when we try to open the library
 		// so let's failed silently

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -287,6 +287,42 @@ func TestShortLivedProcess(t *testing.T) {
 	assert.Contains(t, r.GetRegisteredProcesses(), pid)
 }
 
+func TestNoBlockErrEnvironment(t *testing.T) {
+	registerRecorder := new(CallbackRecorder)
+	registerRecorder.ReturnError = fmt.Errorf("%w: failed registration", ErrEnvironment)
+	registerCallback := registerRecorder.Callback()
+
+	unregisterRecorder := new(CallbackRecorder)
+	unregisterCallback := unregisterRecorder.Callback()
+
+	r := newFileRegistry()
+	path, pathID := createTempTestFile(t, "foobar")
+	cmd, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
+	pid := uint32(cmd.Process.Pid)
+
+	err = r.Register(path, pid, registerCallback, unregisterCallback, IgnoreCB)
+	require.ErrorIs(t, err, registerRecorder.ReturnError)
+
+	// First let's assert that the callback was executed once, but there are no
+	// registered processes because the registration should have failed
+	assert.Equal(t, 1, registerRecorder.CallsForPathID(pathID))
+	assert.Empty(t, r.GetRegisteredProcesses())
+
+	// The unregister callback should have been called to clean up the failed registration.
+	assert.Equal(t, 1, unregisterRecorder.CallsForPathID(pathID))
+
+	registerRecorder.ReturnError = nil
+
+	// Now let's try to register the same path again
+	require.Nil(t, r.Register(path, pid, registerCallback, IgnoreCB, IgnoreCB))
+
+	// Assert that the path is successfully registered since it shouldn't have
+	// been blocked since we retruned an error wrapping ErrEnvironment.
+	assert.Equal(t, 2, registerRecorder.CallsForPathID(pathID))
+	assert.Contains(t, r.GetRegisteredProcesses(), pid)
+}
+
 func TestFilePathInCallbackArgument(t *testing.T) {
 	var capturedPath string
 	callback := func(f FilePath) error {


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If an attachment failure has to do with something other than the file itself, such as the mount path or the process name, do not permanently block the file from being attached later.

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1293

### Describe how to test/QA your changes

Tests included.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->