### PR TITLE
Enable ReceiveResourceSpansV2 by default in OTel Agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -176,30 +175,6 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	}
 	if addr := ddc.Traces.Endpoint; addr != "" {
 		pkgconfig.Set("apm_config.apm_dd_url", addr, pkgconfigmodel.SourceFile)
-	}
-
-	if apmConfigFeaturesEnv, found := os.LookupEnv("DD_APM_FEATURES"); found {
-		pkgconfig.Set("apm_config.features", strings.Split(apmConfigFeaturesEnv, ","), pkgconfigmodel.SourceEnvVar)
-	} else if acfg := cfg.Get("apm_config"); acfg != nil {
-		if acfgmap, ok := acfg.(map[string]any); ok {
-			if v, ok := acfgmap["features"]; ok {
-				if features, ok := v.([]interface{}); ok {
-					success := true
-					var featuresStrings []string
-					for _, feature := range features {
-						if fstr, ok := feature.(string); ok {
-							featuresStrings = append(featuresStrings, fstr)
-						} else {
-							success = false
-							break
-						}
-					}
-					if success {
-						pkgconfig.Set("apm_config.features", featuresStrings, pkgconfigmodel.SourceFile)
-					}
-				}
-			}
-		}
 	}
 
 	if pkgconfig.Get("apm_config.features") == nil {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -55,7 +55,7 @@ func (suite *ConfigTestSuite) TestAgentConfig() {
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, 10, c.Get("apm_config.trace_buffer"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, nil, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2"}, c.Get("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
@@ -77,7 +77,8 @@ func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, true, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"},
+		c.Get("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
@@ -102,7 +103,7 @@ func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, true, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
 
 	// log_level from datadog.yaml takes precedence -> more verbose
 	assert.Equal(t, "debug", c.Get("log_level"))
@@ -123,6 +124,38 @@ func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlKeysAvailable() {
 	assert.Equal(t, "https://localhost:7777", c.GetString("otelcollector.extension_url"))
 	assert.Equal(t, 5009, c.GetInt("agent_ipc.port"))
 	assert.Equal(t, 60, c.GetInt("agent_ipc.config_refresh_interval"))
+}
+
+func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromDatadogYaml() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_apm_config_features.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	assert.Equal(t, []string{"test1", "test2"}, c.GetStringSlice("apm_config.features"))
+}
+
+func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromEnv() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	oldval, exists := os.LookupEnv("DD_APM_FEATURES")
+	os.Setenv("DD_APM_FEATURES", "test1,test2")
+	defer func() {
+		if !exists {
+			os.Unsetenv("DD_APM_FEATURES")
+		} else {
+			os.Setenv("DD_APM_FEATURES", oldval)
+		}
+	}()
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	assert.Equal(t, []string{"test1", "test2"}, c.GetStringSlice("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestLogLevelPrecedence() {

--- a/cmd/otel-agent/config/testdata/datadog_apm_config_features.yaml
+++ b/cmd/otel-agent/config/testdata/datadog_apm_config_features.yaml
@@ -1,0 +1,11 @@
+api_key: deadbeef
+
+log_level: debug
+
+otelcollector:
+  enabled: true
+  extension_url: "https://localhost:7777"
+
+apm_config:
+  features: ["test1", "test2"]
+

--- a/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-a63e15dd6c002599.yaml
+++ b/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-a63e15dd6c002599.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    The `enable_receive_resource_spans_v2` flag now defaults to true in Converged Agent. This enables the refactored
+    version of the span receiver in trace agent, which gives a 10% performance and deprecates some functionality:
+    - No longer check for information about the resource in HTTP headers (ContainerID, Lang, LangVersion, Interpreter, LangVendor).
+    - No longer check for resource-related values (container, env, hostname) in span attributes - behaviour which did not follow OTel spec


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set `enable_receive_resource_spans_v2` flag by default in Converged Agent. This enables the refactor of the span receiver in trace agent, from https://github.com/DataDog/datadog-agent/pull/29435.

Also, honour the `DD_APM_FEATURES` env variable and the `apm_config.features` core config option if either of them is set. The former takes precedence over the latter. 

### Motivation

### Describe how to test/QA your changes

1. Run the otel agent with no APM features set, and verify that the V2 Receiver logic is correctly used (e.g. "resource-related values (container, env, hostname) [aren't checked for] in span attributes")
     - e.g., send a span with `deployment.environment` set in span attributes and not in resource attributes. It should not get set in "env" in the output log in DD

2. Run the otel agent with `DD_APM_FEATURES=""` and verify that the V1 receiver logic is used.

### Possible Drawbacks / Trade-offs

Users may be trying to set other DD_APM_FEATURES (e.g. they set `DD_APM_FEATURES=sql_cache`) and disable enable_receive_resource_spans_v2 without realizing. Open to suggestions for how we should address this while retaining the option for users to disable `enable_receive_resource_spans_v2` intentionally.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->