### PR TITLE
[CONTP-472] Configure gpu tagging to search for names using prefixes

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -421,7 +421,7 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 func extractGPUVendor(gpuNamePrefix kubelet.ResourceName) string {
 	gpuVendor := ""
 	switch gpuNamePrefix {
-	case kubelet.ResourcePrefixNvidiaGPU:
+	case kubelet.ResourcePrefixNvidiaMIG, kubelet.ResourceGenericNvidiaGPU:
 		gpuVendor = "nvidia"
 	case kubelet.ResourcePrefixAMDGPU:
 		gpuVendor = "amd"
@@ -451,12 +451,13 @@ func extractResources(spec *kubelet.ContainerSpec) workloadmeta.ContainerResourc
 		resourceKeys = append(resourceKeys, resourceName)
 	}
 
-	for _, gpuResourcePrefix := range kubelet.GetGPUResourcePrefixes() {
+	for _, gpuResourceName := range kubelet.GetGPUResourceNames() {
 		for _, resourceKey := range resourceKeys {
-			if strings.HasPrefix(string(resourceKey), string(gpuResourcePrefix)) {
+			if strings.HasPrefix(string(resourceKey), string(gpuResourceName)) {
 				if gpuReq, found := spec.Resources.Requests[resourceKey]; found {
 					resources.GPURequest = pointer.Ptr(uint64(gpuReq.Value()))
-					uniqueGPUVendor[extractGPUVendor(gpuResourcePrefix)] = true
+					uniqueGPUVendor[extractGPUVendor(gpuResourceName)] = true
+					break
 				}
 			}
 		}

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -418,20 +418,19 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 	return env
 }
 
-func extractSimpleGPUName(gpuName kubelet.ResourceName) string {
-	simpleName := ""
-	switch gpuName {
-	case kubelet.ResourceNvidiaGPU:
-		simpleName = "nvidia"
-	case kubelet.ResourceAMDGPU:
-		simpleName = "amd"
-	case kubelet.ResourceIntelGPUxe, kubelet.ResourceIntelGPUi915:
-		simpleName = "intel"
+func extractGPUVendor(gpuNamePrefix kubelet.ResourceName) string {
+	gpuVendor := ""
+	switch gpuNamePrefix {
+	case kubelet.ResourcePrefixNvidiaGPU:
+		gpuVendor = "nvidia"
+	case kubelet.ResourcePrefixAMDGPU:
+		gpuVendor = "amd"
+	case kubelet.ResourcePrefixIntelGPU:
+		gpuVendor = "intel"
 	default:
-		simpleName = string(gpuName)
+		gpuVendor = string(gpuNamePrefix)
 	}
-
-	return simpleName
+	return gpuVendor
 }
 
 func extractResources(spec *kubelet.ContainerSpec) workloadmeta.ContainerResources {
@@ -446,10 +445,20 @@ func extractResources(spec *kubelet.ContainerSpec) workloadmeta.ContainerResourc
 
 	// extract GPU resource info from the possible GPU sources
 	uniqueGPUVendor := make(map[string]bool)
-	for _, gpuResource := range kubelet.GetGPUResourceNames() {
-		if gpuReq, found := spec.Resources.Requests[gpuResource]; found {
-			resources.GPURequest = pointer.Ptr(uint64(gpuReq.Value()))
-			uniqueGPUVendor[extractSimpleGPUName(gpuResource)] = true
+
+	resourceKeys := make([]kubelet.ResourceName, 0, len(spec.Resources.Requests))
+	for resourceName := range spec.Resources.Requests {
+		resourceKeys = append(resourceKeys, resourceName)
+	}
+
+	for _, gpuResourcePrefix := range kubelet.GetGPUResourcePrefixes() {
+		for _, resourceKey := range resourceKeys {
+			if strings.HasPrefix(string(resourceKey), string(gpuResourcePrefix)) {
+				if gpuReq, found := spec.Resources.Requests[resourceKey]; found {
+					resources.GPURequest = pointer.Ptr(uint64(gpuReq.Value()))
+					uniqueGPUVendor[extractGPUVendor(gpuResourcePrefix)] = true
+				}
+			}
 		}
 	}
 	gpuVendorList := make([]string, 0, len(uniqueGPUVendor))

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -93,9 +93,10 @@ type ResourceName string
 const (
 	// Kubernetes GPU resource types by vendor as shown below
 	// https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
-	ResourcePrefixNvidiaGPU ResourceName = "nvidia.com/"
-	ResourcePrefixIntelGPU  ResourceName = "gpu.intel.com/"
-	ResourcePrefixAMDGPU    ResourceName = "amd.com/"
+	ResourceGenericNvidiaGPU ResourceName = "nvidia.com/gpu"
+	ResourcePrefixNvidiaMIG  ResourceName = "nvidia.com/mig"
+	ResourcePrefixIntelGPU   ResourceName = "gpu.intel.com/"
+	ResourcePrefixAMDGPU     ResourceName = "amd.com/"
 
 	ResourceCPU              ResourceName = "cpu"
 	ResourceMemory           ResourceName = "memory"
@@ -103,9 +104,9 @@ const (
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
 )
 
-// GetGPUResourcePrefixes returns the list of GPU resource prefixes
-func GetGPUResourcePrefixes() []ResourceName {
-	return []ResourceName{ResourcePrefixNvidiaGPU, ResourcePrefixIntelGPU, ResourcePrefixAMDGPU}
+// GetGPUResourceNames returns the list of GPU resource names
+func GetGPUResourceNames() []ResourceName {
+	return []ResourceName{ResourcePrefixNvidiaMIG, ResourceGenericNvidiaGPU, ResourcePrefixIntelGPU, ResourcePrefixAMDGPU}
 }
 
 // ResourceList is the type of fields in Pod.Spec.Containers.Resources

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -91,21 +91,21 @@ type ResourceName string
 
 // Resources name
 const (
-	ResourceCPU ResourceName = "cpu"
 	// Kubernetes GPU resource types by vendor as shown below
 	// https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
-	ResourceNvidiaGPU        ResourceName = "nvidia.com/gpu"
-	ResourceAMDGPU           ResourceName = "amd.com/gpu"
-	ResourceIntelGPUi915     ResourceName = "gpu.intel.com/i915"
-	ResourceIntelGPUxe       ResourceName = "gpu.intel.com/xe"
+	ResourcePrefixNvidiaGPU ResourceName = "nvidia.com/"
+	ResourcePrefixIntelGPU  ResourceName = "gpu.intel.com/"
+	ResourcePrefixAMDGPU    ResourceName = "amd.com/"
+
+	ResourceCPU              ResourceName = "cpu"
 	ResourceMemory           ResourceName = "memory"
 	ResourceStorage          ResourceName = "storage"
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"
 )
 
-// GetGPUResourceNames returns the list of GPU resource names
-func GetGPUResourceNames() []ResourceName {
-	return []ResourceName{ResourceNvidiaGPU, ResourceAMDGPU, ResourceIntelGPUi915, ResourceIntelGPUxe}
+// GetGPUResourcePrefixes returns the list of GPU resource prefixes
+func GetGPUResourcePrefixes() []ResourceName {
+	return []ResourceName{ResourcePrefixNvidiaGPU, ResourcePrefixIntelGPU, ResourcePrefixAMDGPU}
 }
 
 // ResourceList is the type of fields in Pod.Spec.Containers.Resources


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Agent GPU Tagging to search for GPU resources using prefixes.

### Motivation

Support different types of kubernetes resource request definitions. For example, nvidia.com/gpu and nvidia.com/mig-1g.10gb

### Describe how to test/QA your changes

Deploy the agent with a default configuration such as:
```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: "INSERT_CLUSTER_NAME"
agents:
  image:
    repository: INSERT_REPO_NAME
    tag: INSERT_TAG_NAME
    pullPolicy: Always
```
Deploy a dummy workload requesting GPU resources. Note, the values must be zero for kubernetes to schedule the pods since you probably don't have GPU resources on your cluster.
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-nginx-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-nginx-app
  template:
    metadata:
      labels:
        app: dummy-nginx-app
    spec:
      containers:
        - name: dummy-nginx-app
          image: nginx
          resources:
            requests:
              memory: "64Mi"
              cpu: "250m"
              nvidia.com/mig-something: "0"
              nvidia.com/gpu: "0"
              amd.com/gpu: "0"
              gpu.intel.com/xe: "0"
            limits:
              memory: "128Mi"
              cpu: "500m"
              nvidia.com/mig-something: "0"
              nvidia.com/gpu: "0"
              amd.com/gpu: "0"
              gpu.intel.com/xe: "0"
```

Then execute the following command and search for the gpu tags on the pod and container

```
k exec -it datadog-agent-linux-h6vkz -n datadog-agent-helm -- agent tagger-list
=== Entity container_id://173f2c6b8102d6ebf76bbbc6ee1ad8126d70f24950e0cff0c77f5d6b6d192414 ===
== Source workloadmeta-container =
=Tags: [container_id:173f2c6b8102d6ebf76bbbc6ee1ad8126d70f24950e0cff0c77f5d6b6d192414 container_name:dummy-nginx-app docker_image:nginx:latest gpu_vendor:amd gpu_vendor:intel gpu_vendor:nvidia image_id:nginx@sha256:28402db69fec7c17e179ea87882667f1e054391138f77ffaf0c3eb388efc3ffb image_name:nginx image_tag:latest short_image:nginx]
== Source workloadmeta-kubernetes_pod =
=Tags: [container_id:173f2c6b8102d6ebf76bbbc6ee1ad8126d70f24950e0cff0c77f5d6b6d192414 display_container_name:dummy-nginx-app_dummy-nginx-app-6d47fbbbc5-mvmqk gpu_vendor:amd gpu_vendor:intel gpu_vendor:nvidia image_id:nginx@sha256:28402db69fec7c17e179ea87882667f1e054391138f77ffaf0c3eb388efc3ffb image_name:nginx image_tag:latest kube_container_name:dummy-nginx-app kube_deployment:dummy-nginx-app kube_namespace:default kube_ownerref_kind:replicaset kube_ownerref_name:dummy-nginx-app-6d47fbbbc5 kube_qos:Burstable kube_replica_set:dummy-nginx-app-6d47fbbbc5 pod_name:dummy-nginx-app-6d47fbbbc5-mvmqk pod_phase:running short_image:nginx]
===
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A