### PR TITLE
[networks] Scan for AncillaryPktType in packet capture

### DIFF
--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -155,8 +155,7 @@ func (p *AFPacketSource) VisitPackets(exit <-chan struct{}, visit func(data []by
 			return err
 		}
 
-		foo := append([]interface{}{afpacket.AncillaryVLAN{VLAN: 0}}, stats.AncillaryData...)
-		for _, data := range foo {
+		for _, data := range stats.AncillaryData {
 			// if addPktType = true, AncillaryData will contain an AncillaryPktType element;
 			// however, it might not be the first element, so scan through.
 			pktType, ok := data.(afpacket.AncillaryPktType)

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -129,9 +129,6 @@ func (p *AFPacketSource) SetBPF(filter []bpf.RawInstruction) error {
 	return p.TPacket.SetBPF(filter)
 }
 
-// NoPacketType is what getPktType returns when addPktType is not turned on.
-const NoPacketType = 0xff
-
 // VisitPackets starts reading packets from the source
 func (p *AFPacketSource) VisitPackets(exit <-chan struct{}, visit func(data []byte, info PacketInfo, t time.Time) error) error {
 	pktInfo := &AFPacketInfo{}
@@ -158,7 +155,8 @@ func (p *AFPacketSource) VisitPackets(exit <-chan struct{}, visit func(data []by
 			return err
 		}
 
-		for _, data := range stats.AncillaryData {
+		foo := append([]interface{}{afpacket.AncillaryVLAN{VLAN: 0}}, stats.AncillaryData...)
+		for _, data := range foo {
 			// if addPktType = true, AncillaryData will contain an AncillaryPktType element;
 			// however, it might not be the first element, so scan through.
 			pktType, ok := data.(afpacket.AncillaryPktType)

--- a/releasenotes/notes/system-probe-vlan-2aea22b74ae91c32.yaml
+++ b/releasenotes/notes/system-probe-vlan-2aea22b74ae91c32.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an error in system-probe triggered by packet capture in environments with multiple VLANs.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This fixes a crash from a support ticket where `AncillaryData[0]` contains VLAN data instead of PktType info.

With our config, `AncillaryData` should always contain `AncillaryPktType` but it might not be the first element:
<img width="868" alt="Screenshot 2024-10-22 at 5 06 21 PM" src="https://github.com/user-attachments/assets/15ec5b04-9d9c-455b-ad33-fb7e1d54dcea">

This PR changes it to scan the slice instead of taking the first element.

### Motivation

Customer wants to upgrade the agent version from 7.55 but ran into this issue. 

### Describe how to test/QA your changes

Mocked up the VLAN data with `mockData := append([]interface{}{afpacket.AncillaryVLAN{VLAN: 0}}, stats.AncillaryData...)`, expect it not to crash when capturing packets.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->