### PR TITLE
Set and enforce fleet data permissions

### DIFF
--- a/cmd/installer/subcommands/daemon/run_windows_test.go
+++ b/cmd/installer/subcommands/daemon/run_windows_test.go
@@ -8,6 +8,7 @@
 package daemon
 
 import (
+	"golang.org/x/sys/windows"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
@@ -38,8 +39,8 @@ func (s *daemonTestSuite) TestRunCommand() {
 // Note: this actually instantiates the components, so it will actually start
 // the remote config service etc...
 func (s *daemonTestSuite) TestAppStartsAndStops() {
-	tmpDir := s.T().TempDir()
-	s.T().Setenv("DD_INSTALLER_DEBUG_CDN_LOCAL_DIR_PATH", tmpDir)
+	// TODO: This test currently tries to start the daemon using the system paths
+	createConfigDir(s.T())
 	tempfile, err := os.CreateTemp("", "test-*.yaml")
 	require.NoError(s.T(), err, "failed to create temporary file")
 	defer os.Remove(tempfile.Name())
@@ -50,4 +51,22 @@ func (s *daemonTestSuite) TestAppStartsAndStops() {
 	}
 	s.Require().NoError(testApp.Start())
 	s.Require().NoError(testApp.Stop())
+}
+
+// createConfigDir creates the C:\ProgramData\Datadog Installer directory with the correct permissions.
+func createConfigDir(t *testing.T) {
+	t.Cleanup(func() {
+		// only cleanup the dir in the CI, to protect local testers while
+		// this test still uses the real filesystem
+		if os.Getenv("CI") != "" || os.Getenv("CI_JOB_ID") != "" {
+			_ = os.RemoveAll("C:\\ProgramData\\Datadog Installer")
+		}
+	})
+	err := os.MkdirAll("C:\\ProgramData\\Datadog Installer", 0)
+	require.NoError(t, err)
+	owner, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	require.NoError(t, err)
+	err = windows.SetNamedSecurityInfo("C:\\ProgramData\\Datadog Installer", windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION, owner, nil, nil, nil)
+	require.NoError(t, err)
 }

--- a/cmd/installer/subcommands/daemon/run_windows_test.go
+++ b/cmd/installer/subcommands/daemon/run_windows_test.go
@@ -8,10 +8,10 @@
 package daemon
 
 import (
-	"golang.org/x/sys/windows"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
+	"golang.org/x/sys/windows"
 	"os"
 	"testing"
 

--- a/cmd/installer/subcommands/daemon/run_windows_test.go
+++ b/cmd/installer/subcommands/daemon/run_windows_test.go
@@ -38,6 +38,8 @@ func (s *daemonTestSuite) TestRunCommand() {
 // Note: this actually instantiates the components, so it will actually start
 // the remote config service etc...
 func (s *daemonTestSuite) TestAppStartsAndStops() {
+	tmpDir := s.T().TempDir()
+	s.T().Setenv("DD_INSTALLER_DEBUG_CDN_LOCAL_DIR_PATH", tmpDir)
 	tempfile, err := os.CreateTemp("", "test-*.yaml")
 	require.NoError(s.T(), err, "failed to create temporary file")
 	defer os.Remove(tempfile.Name())

--- a/pkg/fleet/daemon/local_api_windows.go
+++ b/pkg/fleet/daemon/local_api_windows.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Microsoft/go-winio"
 	"net"
 	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
 )
 
 const (
@@ -20,6 +22,11 @@ const (
 
 // NewLocalAPI returns a new LocalAPI.
 func NewLocalAPI(daemon Daemon, _ string) (LocalAPI, error) {
+	// Prevent daemon from running in insecure directories
+	err := paths.IsInstallerDataDirSecure()
+	if err != nil {
+		return nil, err
+	}
 	listener, err := winio.ListenPipe(namedPipePath, &winio.PipeConfig{
 		SecurityDescriptor: "D:P(A;;GA;;;SY)(A;;GA;;;BA)",
 		MessageMode:        false,

--- a/pkg/fleet/internal/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/internal/bootstrap/bootstrap_windows.go
@@ -23,7 +23,11 @@ import (
 )
 
 func install(ctx context.Context, env *env.Env, url string, experiment bool) error {
-	err := os.MkdirAll(paths.RootTmpDir, 0755)
+	err := paths.CreateInstallerDataDir()
+	if err != nil {
+		return fmt.Errorf("failed to create installer data directory: %w", err)
+	}
+	err = os.MkdirAll(paths.RootTmpDir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}

--- a/pkg/fleet/internal/paths/installer_paths_windows.go
+++ b/pkg/fleet/internal/paths/installer_paths_windows.go
@@ -68,8 +68,9 @@ func CreateInstallerDataDir() error {
 	// - GROUP: Administrators
 	// - SYSTEM: Full Control (propagates to children)
 	// - Administrators: Full Control (propagates to children)
+	// - Everyone: 0x1200a9 List folder contents (propagates to container children only, so no access to file content)
 	// - PROTECTED: does not inherit permissions from parent
-	sddl := "O:BAGBA:D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+	sddl := "O:BAGBA:D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;0x1200a9;;;WD)"
 
 	// The following privileges are required to modify the security descriptor,
 	// and are granted to Administrators by default:

--- a/pkg/fleet/internal/paths/installer_paths_windows.go
+++ b/pkg/fleet/internal/paths/installer_paths_windows.go
@@ -9,6 +9,7 @@
 package paths
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -86,9 +87,11 @@ func secureCreateDirectory(path string, sddl string) error {
 	// We avoid TOCTOU issues because CreateDirectory fails if the directory already exists.
 	// This is of concern because Windows by default grants Users write access to ProgramData.
 	err := createDirectoryWithSDDL(path, sddl)
-	if err != nil && err != windows.ERROR_ALREADY_EXISTS {
-		// return other errors, ERROR_ALREADY_EXISTS is handled below
-		return err
+	if err != nil {
+		if !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			// return other errors, ERROR_ALREADY_EXISTS is handled below
+			return err
+		}
 	}
 	if err == nil {
 		// directory securely created, we're done

--- a/pkg/fleet/internal/paths/installer_paths_windows.go
+++ b/pkg/fleet/internal/paths/installer_paths_windows.go
@@ -10,12 +10,21 @@ package paths
 
 import (
 	"path/filepath"
+	"syscall"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/winregistry"
 	"golang.org/x/sys/windows"
 )
 
 var (
+	advapi32                        = syscall.NewLazyDLL("advapi32.dll")
+	procTreeResetNamedSecurityInfoW = advapi32.NewProc("TreeResetNamedSecurityInfoW")
+)
+
+var (
+	// datadogInstallerData is the path to the Datadog Installer data directory, by default C:\\ProgramData\\Datadog Installer.
+	datadogInstallerData string
 	// PackagesPath is the path to the packages directory.
 	PackagesPath string
 	// ConfigsPath is the path to the Fleet-managed configuration directory
@@ -33,7 +42,7 @@ var (
 )
 
 func init() {
-	datadogInstallerData, _ := winregistry.GetProgramDataDirForProduct("Datadog Installer")
+	datadogInstallerData, _ = winregistry.GetProgramDataDirForProduct("Datadog Installer")
 	PackagesPath = filepath.Join(datadogInstallerData, "packages")
 	ConfigsPath = filepath.Join(datadogInstallerData, "configs")
 	LocksPath = filepath.Join(datadogInstallerData, "locks")
@@ -42,4 +51,169 @@ func init() {
 	StableInstallerPath = filepath.Join(datadogInstallerPath, "datadog-installer.exe")
 	DefaultUserConfigsDir, _ = windows.KnownFolderPath(windows.FOLDERID_ProgramData, 0)
 	RunPath = filepath.Join(PackagesPath, "run")
+}
+
+// CreateInstallerDataDir creates the root directory for the installer data and sets permissions
+// to ensure that only Administrators have write access to the directory tree.
+func CreateInstallerDataDir() error {
+	// Since bootstrap can run and use this path before the Installer MSI creates it
+	// we need to make sure the path is created with the correct permissions.
+	// This is of concern because Windows by default grants Users write access to ProgramData.
+	// Permissions:
+	// - OWNER: Administrators
+	// - GROUP: Administrators
+	// - SYSTEM: Full Control (propagates to children)
+	// - Administrators: Full Control (propagates to children)
+	// - PROTECTED: does not inherit permissions from parent
+	sddl := "O:BAGBA:D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+	err := createDirectoryAndResetTreeWithSDDL(datadogInstallerData, sddl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createDirectoryAndResetTreeWithSDDL(path string, sddl string) error {
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	sa := &windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: sd,
+		InheritHandle:      0,
+	}
+
+	// create directory with security descriptor
+	err = windows.CreateDirectory(windows.StringToUTF16Ptr(path), sa)
+	if err != nil && err != windows.ERROR_ALREADY_EXISTS {
+		return err
+	}
+	// CreateDirectory does NOT apply the security descriptor if the directory already exists
+	// so we need to set it explicitly.
+	// Additionally, if the directory/tree already exists, we need to reset the children, too.
+	err = treeResetNamedSecurityInfoFromSecurityDescriptor(path, sd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func treeResetNamedSecurityInfoWithSDDL(root string, sddl string) error {
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	return treeResetNamedSecurityInfoFromSecurityDescriptor(root, sd)
+}
+
+func treeResetNamedSecurityInfoFromSecurityDescriptor(root string, sd *windows.SECURITY_DESCRIPTOR) error {
+	var flags windows.SECURITY_INFORMATION
+	control, _, err := sd.Control()
+	if err != nil {
+		return err
+	}
+	flags |= securityInformationFromControlFlags(control)
+
+	owner, _, err := sd.Owner()
+	if err != nil {
+		return err
+	}
+	if owner != nil {
+		flags |= windows.OWNER_SECURITY_INFORMATION
+	}
+	group, _, err := sd.Group()
+	if err != nil {
+		return err
+	}
+	if group != nil {
+		flags |= windows.GROUP_SECURITY_INFORMATION
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		if err != windows.ERROR_OBJECT_NOT_FOUND {
+			return err
+		}
+	} else {
+		flags |= windows.DACL_SECURITY_INFORMATION
+	}
+	sacl, _, err := sd.SACL()
+	if err != nil {
+		if err != windows.ERROR_OBJECT_NOT_FOUND {
+			return err
+		}
+	} else {
+		flags |= windows.SACL_SECURITY_INFORMATION
+	}
+	err = TreeResetNamedSecurityInfo(
+		root,
+		windows.SE_FILE_OBJECT,
+		flags,
+		owner,
+		group,
+		dacl,
+		sacl,
+		// Set to false to remove explicit ACEs from the subtree
+		false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func securityInformationFromControlFlags(control windows.SECURITY_DESCRIPTOR_CONTROL) windows.SECURITY_INFORMATION {
+	var flags windows.SECURITY_INFORMATION
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		flags |= windows.UNPROTECTED_DACL_SECURITY_INFORMATION
+	} else {
+		flags |= windows.PROTECTED_DACL_SECURITY_INFORMATION
+	}
+	if control&windows.SE_SACL_PROTECTED == 0 {
+		flags |= windows.UNPROTECTED_SACL_SECURITY_INFORMATION
+	} else {
+		flags |= windows.PROTECTED_SACL_SECURITY_INFORMATION
+	}
+	return flags
+}
+
+// TreeResetNamedSecurityInfo wraps the TreeResetNamedSecurityInfoW Windows API function
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-treeresetnamedsecurityinfow
+func TreeResetNamedSecurityInfo(
+	objectName string,
+	objectType windows.SE_OBJECT_TYPE,
+	securityInfo windows.SECURITY_INFORMATION,
+	owner *windows.SID,
+	group *windows.SID,
+	dacl *windows.ACL,
+	sacl *windows.ACL,
+	keepExplicitDacl bool) error {
+
+	utf16ObjectName, err := windows.UTF16PtrFromString(objectName)
+	if err != nil {
+		return err
+	}
+
+	keepExplicitDaclInt := uintptr(0)
+	if keepExplicitDacl {
+		keepExplicitDaclInt = 1
+	}
+
+	r0, _, _ := procTreeResetNamedSecurityInfoW.Call(
+		uintptr(unsafe.Pointer(utf16ObjectName)),
+		uintptr(objectType),
+		uintptr(securityInfo),
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(group)),
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(sacl)),
+		keepExplicitDaclInt,
+		// don't use a progress callback
+		0, 0, 0)
+	if r0 != 0 {
+		return syscall.Errno(r0)
+	}
+	return nil
 }

--- a/pkg/fleet/internal/paths/installer_paths_windows.go
+++ b/pkg/fleet/internal/paths/installer_paths_windows.go
@@ -70,7 +70,7 @@ func CreateInstallerDataDir() error {
 	// - Administrators: Full Control (propagates to children)
 	// - Everyone: 0x1200a9 List folder contents (propagates to container children only, so no access to file content)
 	// - PROTECTED: does not inherit permissions from parent
-	sddl := "O:BAGBA:D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;0x1200a9;;;WD)"
+	sddl := "O:BAG:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;0x1200a9;;;WD)"
 
 	// The following privileges are required to modify the security descriptor,
 	// and are granted to Administrators by default:
@@ -173,7 +173,7 @@ func isDirSecure(targetDir string) error {
 func createDirectoryWithSDDL(path string, sddl string) error {
 	sd, err := windows.SecurityDescriptorFromString(sddl)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create security descriptor from sddl %s: %w", sddl, err)
 	}
 	sa := &windows.SecurityAttributes{
 		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
@@ -186,7 +186,7 @@ func createDirectoryWithSDDL(path string, sddl string) error {
 	if err != nil {
 		// CreateDirectory does not apply the security descriptor if the directory already exists
 		// so treat it as an error if the directory already exists.
-		return err
+		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
 	return nil

--- a/pkg/fleet/internal/paths/paths_windows_test.go
+++ b/pkg/fleet/internal/paths/paths_windows_test.go
@@ -68,7 +68,7 @@ func TestSecureCreateDirectory(t *testing.T) {
 func skipIfDontHavePrivileges(t *testing.T, privilegesRequired []string) {
 	user, err := user.Current()
 	require.NoError(t, err)
-	if os.Getenv("CI") != "" || strings.Contains(user.Name, "ContainerAdministrator") {
+	if os.Getenv("CI") != "" || os.Getenv("CI_JOB_ID") != "" || strings.Contains(user.Name, "ContainerAdministrator") {
 		// never skip in CI, we should always have the required privileges and we
 		// want the test to run
 		return

--- a/pkg/fleet/internal/paths/paths_windows_test.go
+++ b/pkg/fleet/internal/paths/paths_windows_test.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package paths
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSecureCreateDirectory(t *testing.T) {
+	t.Run("new directory", func(t *testing.T) {
+		root := t.TempDir()
+		subdir := filepath.Join(root, "A")
+		sddl := "D:PAI(A;OICI;FA;;;AU)"
+		err := secureCreateDirectory(subdir, sddl)
+		require.NoError(t, err)
+		sd, err := getSecurityDescriptor(subdir)
+		require.NoError(t, err)
+		assertDACLProtected(t, sd)
+	})
+
+	t.Run("directory exists", func(t *testing.T) {
+		t.Run("unknown owner", func(t *testing.T) {
+			root := t.TempDir()
+			subdir := filepath.Join(root, "A")
+			err := os.Mkdir(subdir, 0)
+			require.NoError(t, err)
+			sddl := "O:BAG:BAD:PAI(A;OICI;FA;;;AU)"
+			err = secureCreateDirectory(subdir, sddl)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "installer data directory has unexpected owner")
+		})
+		t.Run("known owner", func(t *testing.T) {
+			// required to set owner to another user
+			privilegesRequired := []string{"SeRestorePrivilege"}
+			skipIfDontHavePrivileges(t, privilegesRequired)
+			root := t.TempDir()
+			subdir := filepath.Join(root, "A")
+			sddl := "O:SYG:SYD:PAI(A;OICI;FA;;;AU)"
+			err := winio.RunWithPrivileges(privilegesRequired, func() error {
+				return createDirectoryWithSDDL(subdir, sddl)
+			})
+			require.NoError(t, err)
+			sddl = "O:BAG:BAD:PAI(A;OICI;FA;;;AU)"
+			err = secureCreateDirectory(subdir, sddl)
+			require.NoError(t, err)
+			sd, err := getSecurityDescriptor(subdir)
+			require.NoError(t, err)
+			assertDACLProtected(t, sd)
+		})
+	})
+}
+
+func skipIfDontHavePrivileges(t *testing.T, privilegesRequired []string) {
+	user, err := user.Current()
+	require.NoError(t, err)
+	if os.Getenv("CI") != "" || strings.Contains(user.Name, "ContainerAdministrator") {
+		// never skip in CI, we should always have the required privileges and we
+		// want the test to run
+		return
+	}
+	hasPrivs := false
+	err = winio.RunWithPrivileges(privilegesRequired, func() error {
+		hasPrivs = true
+		return nil
+	})
+	if err != nil || !hasPrivs {
+		t.Skipf("test requires %v", strings.Join(privilegesRequired, ","))
+	}
+}
+
+func getSecurityDescriptor(path string) (*windows.SECURITY_DESCRIPTOR, error) {
+	return windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+}
+
+func assertDACLProtected(t *testing.T, sd *windows.SECURITY_DESCRIPTOR) {
+	t.Helper()
+	control, _, err := sd.Control()
+	require.NoError(t, err)
+	assert.NotZero(t, control&windows.SE_DACL_PROTECTED)
+}

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -405,6 +405,19 @@ def validate_msi_createfolder_table(db, allowlist):
           this behavior was also present in the original installer so leave them for now.
     """
 
+    # Skip if CreateFolder table does not exist
+    with MsiClosing(db.OpenView("Select `Name` From `_Tables`")) as view:
+        view.Execute(None)
+        record = view.Fetch()
+        tables = set()
+        while record:
+            tables.add(record.GetString(1))
+            record = view.Fetch()
+        if "CreateFolder" not in tables:
+            print("skipping validation, CreateFolder table not found in MSI")
+            return
+
+    print("Validating MSI CreateFolder table")
     with MsiClosing(db.OpenView("Select Directory_ FROM CreateFolder")) as view:
         view.Execute(None)
         record = view.Fetch()

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Installer/DatadogInstaller.cs
@@ -84,14 +84,8 @@ namespace WixSetup.Datadog_Installer
                             Account = "LocalSystem",
                             Vital = true
                         })
-                ),
-                // This is where the installer will store its data
-                new Dir(new Id("DatadogInstallerData"), @"%CommonAppDataFolder%\Datadog Installer",
-                    new Dir("packages"),
-                    new Dir("temp"),
-                    new Dir("locks")
-                    )
-                );
+                )
+            );
 
             // Always generate a new GUID otherwise WixSharp will generate one based on
             // the version


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
fleet bootstrap configures permissions on its data directory
- admin/system - full control
- everyone - list directory 
  - done to avoid unnecessary ACE additions when navigating directory in explorer

since Windows lets arbitrary users create folders in ProgramData, fleet uses the Owner of the data directory as an indicator of whether to trust the directory tree or not, as only Admins can set the owner to Admins
- bootstrap will fail if the data directory already exists and is not owned by Administrators or SYSTEM
- fleet daemon will refuse to start if the data directory is not owned by Administrators or SYSTEM
- If the data directory already exists and is owned by Administrators or System, bootstrap resets the permissions on the entire tree, to inherit from the root data directory, similar to `icacls.exe /reset`

add unit tests for the new/existing directory/owner cases

### Motivation
data security
https://datadoghq.atlassian.net/browse/WINA-1134

### Describe how to test/QA your changes

#### scenario 1 
install installer MSI from pipeline
configure datadog.yaml
```yaml
api_key: your_api_key
remote_updates: true
```
manually run bootstrap command
```PowerShell
$env:DD_API_KEY = '<YOUR_API_KEY>';
$env:DD_SITE = 'datadoghq.com';
$env:DD_REMOTE_UPDATES = 'true';
$env:DD_AGENT_MAJOR_VERSION = '7';
$env:DD_AGENT_MINOR_VERSION = '55.0';
cp 'C:\Program Files\Datadog\Datadog Installer\datadog-installer.exe' 'C:\datadog-bootstrap.exe'
& 'C:\datadog-bootstrap.exe' bootstrap
```
ensure bootstrap succeeds and Agent is installed
ensure data directory is protected, children inherit from parent
```PowerShell
get-acl 'C:\ProgramData\Datadog Installer\' | fl
get-acl 'C:\ProgramData\Datadog Installer\packages' | fl
```

#### scenario 2
install previous versions with install script as normal
install installer MSI from pipeline
manually run bootstrap command
```PowerShell
$env:DD_API_KEY = '<YOUR_API_KEY>';
$env:DD_SITE = 'datadoghq.com';
$env:DD_REMOTE_UPDATES = 'true';
$env:DD_AGENT_MAJOR_VERSION = '7';
$env:DD_AGENT_MINOR_VERSION = '55.0';
cp 'C:\Program Files\Datadog\Datadog Installer\datadog-installer.exe' 'C:\datadog-bootstrap.exe'
& ''C:\datadog-bootstrap.exe' bootstrap
```
ensure bootstrap succeeds and Agent is installed
ensure data directory is protected, children inherit from parent
```PowerShell
get-acl 'C:\ProgramData\Datadog Installer\' | fl
get-acl 'C:\ProgramData\Datadog Installer\packages' | fl
```

#### scenario 3
create `C:\ProgramData\Datadog Installer` and set its owner to something like `BUILTIN\Users`
install installer MSI from pipeline
manually run bootstrap command
```PowerShell
& 'C:\Program Files\Datadog\Datadog Installer\datadog-installer.exe' bootstrap
```
it should fail with
```
Error: failed to bootstrap the installer: failed to create installer data directory: installer data directory has unexpected owner: S-1-5-32-545
```
daemon service should fail to start

### Possible Drawbacks / Trade-offs
Added a hack to `daemonTestSuite.TestAppStartsAndStops`, since there's currently no way to configure the daemon to use a different directory tree for the test it uses standard dir, and creates it via the [cdn code](https://github.com/DataDog/datadog-agent/blob/9c9fdc7d566df34e2c8eeee2f7d90fad7a158715/pkg/fleet/daemon/daemon.go#L101). This triggers the "is owner Administrators" check and fails the test. So now the test sets the owner of that dir to Administrators before starting. It would be better for the test to configure the daemon to use a test-specific temp dir.

> fleet uses the Owner of the data directory as an indicator of whether to trust the directory tree or not

This doesn't prevent Admins from setting open permissions

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Permissions are set in bootstrap rather than the MSI because bootstrap will run, and use those dirs, before the MSI is run