### PR TITLE
[CWS] use regular http client instead of rolling our own

### DIFF
--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -103,7 +103,7 @@ func getNSID() uint64 {
 	return stat.Ino
 }
 
-// simpleHTTPRequest used to avoid importing the crypto golang package
+// simpleHTTPRequest simply performs an HTTP GET request and returns the body
 func simpleHTTPRequest(uri string) ([]byte, error) {
 	resp, err := http.Get(uri)
 	if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently we use a simple hand written http client in `cws-instrumentation` to query the ECS metadata endpoint. The main goal of this was the size (no need to import the crypto package). Sadly we have no guarantee that the ECS metadata endpoint will continue to not use compression, and we already know that it uses "chunked encoding".
This is not really feasible to maintain this in the long run, and the added binary size is not that catastrophic:
```
on my arm64 laptop
# before = 7.6M
# after = 9.5M
```

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->