### PR TITLE
Daily Job Summaries: Add tests link

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -133,28 +133,26 @@ notify_failure_summary_on_pipeline:
 # Send failure summary notifications daily and weekly
 notify_failure_summary_daily:
   extends: .failure_summary_job
-  # rules:
-  #   - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
-  #     when: never
-  #   - !reference [.on_deploy_nightly_repo_branch_always]
-  needs: []
+  rules:
+    - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
+      when: never
+    - !reference [.on_deploy_nightly_repo_branch_always]
   script:
     - !reference [.failure_summary_setup]
-    - inv -e notify.failure-summary-send-notifications --daily-summary --dry-run
-    # - weekday="$(date --utc '+%A')"
-    # - |
-    #   if [ "$weekday" = "Sunday" ] || [ "$weekday" = "Monday" ]; then
-    #     echo "Skipping daily summary on $weekday"
-    #     exit
-    #   fi
-    # # Daily
-    # - inv -e notify.failure-summary-send-notifications --daily-summary
-    # # Send weekly if necessary (note that this workflow is usually triggered early in the morning)
-    # - |
-    #   if [ "$weekday" = "Friday" ]; then
-    #     echo 'Sending weekly summary'
-    #     inv -e notify.failure-summary-send-notifications --weekly-summary
-    #   fi
+    - weekday="$(date --utc '+%A')"
+    - |
+      if [ "$weekday" = "Sunday" ] || [ "$weekday" = "Monday" ]; then
+        echo "Skipping daily summary on $weekday"
+        exit
+      fi
+    # Daily
+    - inv -e notify.failure-summary-send-notifications --daily-summary
+    # Send weekly if necessary (note that this workflow is usually triggered early in the morning)
+    - |
+      if [ "$weekday" = "Friday" ]; then
+        echo 'Sending weekly summary'
+        inv -e notify.failure-summary-send-notifications --weekly-summary
+      fi
 
 close_failing_tests_stale_issues:
   stage: notify

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -133,26 +133,28 @@ notify_failure_summary_on_pipeline:
 # Send failure summary notifications daily and weekly
 notify_failure_summary_daily:
   extends: .failure_summary_job
-  rules:
-    - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
-      when: never
-    - !reference [.on_deploy_nightly_repo_branch_always]
+  # rules:
+  #   - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
+  #     when: never
+  #   - !reference [.on_deploy_nightly_repo_branch_always]
+  needs: []
   script:
     - !reference [.failure_summary_setup]
-    - weekday="$(date --utc '+%A')"
-    - |
-      if [ "$weekday" = "Sunday" ] || [ "$weekday" = "Monday" ]; then
-        echo "Skipping daily summary on $weekday"
-        exit
-      fi
-    # Daily
-    - inv -e notify.failure-summary-send-notifications --daily-summary
-    # Send weekly if necessary (note that this workflow is usually triggered early in the morning)
-    - |
-      if [ "$weekday" = "Friday" ]; then
-        echo 'Sending weekly summary'
-        inv -e notify.failure-summary-send-notifications --weekly-summary
-      fi
+    - inv -e notify.failure-summary-send-notifications --daily-summary --dry-run
+    # - weekday="$(date --utc '+%A')"
+    # - |
+    #   if [ "$weekday" = "Sunday" ] || [ "$weekday" = "Monday" ]; then
+    #     echo "Skipping daily summary on $weekday"
+    #     exit
+    #   fi
+    # # Daily
+    # - inv -e notify.failure-summary-send-notifications --daily-summary
+    # # Send weekly if necessary (note that this workflow is usually triggered early in the morning)
+    # - |
+    #   if [ "$weekday" = "Friday" ]; then
+    #     echo 'Sending weekly summary'
+    #     inv -e notify.failure-summary-send-notifications --weekly-summary
+    #   fi
 
 close_failing_tests_stale_issues:
   stage: notify

--- a/tasks/libs/notify/failure_summary.py
+++ b/tasks/libs/notify/failure_summary.py
@@ -267,13 +267,15 @@ def send_summary_slack_notification(
     for stat in stats:
         name = stat['name']
         fail = stat['failures']
-        link = get_ci_visibility_job_url(
-            name,
-            prefix=False,
-            extra_flags=['status:error', '-@error.domain:provider'],
-            extra_args={'start': timestamp_start, 'end': timestamp_end, 'paused': 'true'},
-        )
-        message.append(f"- <{link}|{name}>: *{fail} failures*")
+        url_args = {
+            'name': name,
+            'prefix': False,
+            'extra_flags': ['status:error', '-@error.domain:provider'],
+            'extra_args': {'start': timestamp_start, 'end': timestamp_end, 'paused': 'true'},
+        }
+        link = get_ci_visibility_job_url(**url_args)
+        link_tests = get_ci_visibility_job_url(**url_args, show_tests=True)
+        message.append(f"- <{link}|{name}>: *{fail} failures* (<{link_tests}|tests>)")
 
     header = f'{period} Job Failure Report'
     if allow_failure:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR updates the daily job summary by providing an additional link to each job for their respective failing tests.

[Discussion](https://dd.slack.com/archives/C06PBHLD4DQ/p1729671455242219).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Report before this change:

<img width="659" alt="Screenshot 2024-10-23 at 11 06 59" src="https://github.com/user-attachments/assets/ac87902c-adb2-4a42-932d-d6dc959d94a6">

- Example [failing job](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-discovery%22%20status%3Aerror%20-%40error.domain%3Aprovider&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1729587881577&end=1729674281577&paused=true) and its [failing tests](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-discovery%22%20status%3Aerror%20-%40error.domain%3Aprovider&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1729587881577&end=1729674281577&paused=true)