### PR TITLE
Add tasks to handle AMI in agent-qa

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -9,6 +9,7 @@ from invoke import Collection, Task
 
 from tasks import (
     agent,
+    ami,
     bench,
     buildimages,
     cluster_agent,
@@ -155,6 +156,7 @@ ns.add_task(lint_go)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)
+ns.add_collection(ami)
 ns.add_collection(buildimages)
 ns.add_collection(cluster_agent)
 ns.add_collection(cluster_agent_cloudfoundry)

--- a/tasks/ami.py
+++ b/tasks/ami.py
@@ -1,0 +1,92 @@
+import os
+
+import boto3
+from invoke import task
+
+ec2 = boto3.client('ec2')
+
+
+@task
+def launch_instance(_ctx, ami_id, key_name, instance_type='t2.medium'):
+    """
+    Launch an instance from an AMI.
+
+    Example:
+    Run: aws-vault exec sso-agent-qa-account-admin -- deva ami.launch-instance --ami-id ami-0eef9d92ec044bc94 --key-name your-key-name
+    Then: ssh -i ~/.ssh/your-key.pem user@ip
+    """
+    response = ec2.run_instances(
+        ImageId=ami_id,
+        InstanceType=instance_type,
+        KeyName=key_name,
+        MaxCount=1,
+        MinCount=1,
+        NetworkInterfaces=[
+            {
+                "SubnetId": "subnet-0f1ca3e929eb3fb8b",
+                "DeviceIndex": 0,
+                "AssociatePublicIpAddress": False,
+                "Groups": ["sg-070023ab71cadf760"],
+            },
+        ],
+        TagSpecifications=[
+            {
+                'ResourceType': 'instance',
+                'Tags': [
+                    {'Key': 'Name', 'Value': f"dd-agent-{os.environ.get('USER', os.environ.get('USERNAME'))}-{ami_id}"},
+                ],
+            },
+        ],
+    )
+
+    instance_id = response['Instances'][0]['InstanceId']
+    print(f"Instance {instance_id} launched from AMI {ami_id}")
+    print(f"IP address: {response['Instances'][0]['PrivateIpAddress']}")
+
+
+@task
+def create_ami(_ctx, instance_id, ami_name, origin_ami, os, usage="test-ami"):
+    """
+    Create an AMI from a running instance.
+
+    Example: aws-vault exec sso-agent-qa-account-admin -- deva ami.create-ami --instance-id i-054d463dee21bd56f --ami-name test-ami --origin-ami ami-0eef9d92ec044bc94 --os debian-12-x86_64
+    """
+    response = ec2.create_image(
+        InstanceId=instance_id,
+        Name=ami_name,
+        TagSpecifications=[
+            {
+                'ResourceType': 'image',
+                'Tags': [
+                    {
+                        'Key': 'Usage',
+                        'Value': usage,
+                    },
+                    {
+                        'Key': 'OriginAmi',
+                        'Value': origin_ami,
+                    },
+                    {
+                        'Key': 'OS',
+                        'Value': os,  # <os-version>-<architecture>, ie: debian-12-x86_64
+                    },
+                ],
+            },
+        ],
+    )
+
+    ami_id = response['ImageId']
+    print(f"AMI {ami_id} created from instance {instance_id}")
+
+
+@task
+def delete_ami(_ctx, ami_id):
+    """
+    Delete an AMI.
+
+    Example: aws-vault exec sso-agent-qa-account-admin -- deva ami.delete-ami --ami-id ami-0890dd73c014b3a84
+    """
+    ec2.deregister_image(
+        ImageId=ami_id,
+    )
+    print(f"AMI {ami_id} deleted")

--- a/tasks/ami.py
+++ b/tasks/ami.py
@@ -1,9 +1,6 @@
 import os
 
-import boto3
 from invoke import task
-
-ec2 = boto3.client('ec2')
 
 
 @task
@@ -15,6 +12,9 @@ def launch_instance(_ctx, ami_id, key_name, instance_type='t2.medium'):
     Run: aws-vault exec sso-agent-qa-account-admin -- deva ami.launch-instance --ami-id ami-0eef9d92ec044bc94 --key-name your-key-name
     Then: ssh -i ~/.ssh/your-key.pem user@ip
     """
+    import boto3
+
+    ec2 = boto3.client('ec2')
     response = ec2.run_instances(
         ImageId=ami_id,
         InstanceType=instance_type,
@@ -51,6 +51,9 @@ def create_ami(_ctx, instance_id, ami_name, origin_ami, os, usage="test-ami"):
 
     Example: aws-vault exec sso-agent-qa-account-admin -- deva ami.create-ami --instance-id i-054d463dee21bd56f --ami-name test-ami --origin-ami ami-0eef9d92ec044bc94 --os debian-12-x86_64
     """
+    import boto3
+
+    ec2 = boto3.client('ec2')
     response = ec2.create_image(
         InstanceId=instance_id,
         Name=ami_name,
@@ -86,6 +89,9 @@ def delete_ami(_ctx, ami_id):
 
     Example: aws-vault exec sso-agent-qa-account-admin -- deva ami.delete-ami --ami-id ami-0890dd73c014b3a84
     """
+    import boto3
+
+    ec2 = boto3.client('ec2')
     ec2.deregister_image(
         ImageId=ami_id,
     )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add tasks to handle AMI in agent-qa.
- Start an instance with a specific AMI
- Create an AMI from a running instance with the correct tags
- Delete an AMI

We need aws-vault to make it work for now.

### Motivation

We currently have to use the UI to update some AMI, which is not very convenient and time-consuming. I'm having a look at better ways to manage AMI, but in the meantime we can use these tasks.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Examples

Launch an instance: 

```
❯ aws-vault exec sso-agent-qa-account-admin -- deva ami.launch-instance --ami-id ami-0eef9d92ec044bc94 --key-name florentclarret-aws-agent-qa
Instance i-054d463dee21bd56f launched from AMI ami-0eef9d92ec044bc94
IP address: 10.1.53.5
❯ ssh -i ~/.ssh/florentclarret-aws-agent-qa.pem admin@10.1.53.5
Warning: Permanently added '10.1.53.5' (ED25519) to the list of known hosts.
Linux ip-10-1-53-5 6.1.0-10-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.37-1 (2023-07-03) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Thu Oct 17 08:19:33 2024 from 10.1.54.49
admin@ip-10-1-53-5:~$ pwd
/home/admin
```

Create an AMI from this instance:

```
❯ aws-vault exec sso-agent-qa-account-admin -- deva ami.create-ami --instance-id i-054d463dee21bd56f --ami-name test-florent --origin-ami ami-0eef9d92ec044bc94 --os debian-12-x86_64
AMI ami-0890dd73c014b3a84 created from instance i-054d463dee21bd56f
```

Delete this AMI:

```
❯ aws-vault exec sso-agent-qa-account-admin -- deva ami.delete-ami --ami-id ami-0890dd73c014b3a84
AMI ami-0890dd73c014b3a84 deleted
```
