### PR TITLE
Rename some e2e tests so easier to see which ones fail and what the test suite is testing

### DIFF
--- a/test/new-e2e/examples/agentenv_logs_test.go
+++ b/test/new-e2e/examples/agentenv_logs_test.go
@@ -20,15 +20,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type vmFakeintakeSuite struct {
+type vmLogsExampleSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
 //go:embed testfixtures/custom_logs.yaml
 var customLogsConfig string
 
-func TestE2EVMFakeintakeSuite(t *testing.T) {
-	e2e.Run(t, &vmFakeintakeSuite{}, e2e.WithProvisioner(
+func TestVMLogsExampleSuite(t *testing.T) {
+	e2e.Run(t, &vmLogsExampleSuite{}, e2e.WithProvisioner(
 		awshost.Provisioner(
 			awshost.WithAgentOptions(
 				agentparams.WithIntegration("custom_logs.d", customLogsConfig),
@@ -38,7 +38,7 @@ func TestE2EVMFakeintakeSuite(t *testing.T) {
 	))
 }
 
-func (s *vmFakeintakeSuite) TestLogs() {
+func (s *vmLogsExampleSuite) TestLogs() {
 	fakeintake := s.Env().FakeIntake.Client()
 	// part 1: no logs
 	s.EventuallyWithT(func(c *assert.CollectT) {

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing/file_tailing_test.go
@@ -35,8 +35,8 @@ const (
 	logFilePath = utils.LinuxLogsFolderPath + "/" + logFileName
 )
 
-// TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
-func TestE2EVMFakeintakeSuite(t *testing.T) {
+// TestLinuxVMFileTailingSuite runs the E2E test suite for the log agent with a Linux VM and fake intake.
+func TestLinuxVMFileTailingSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(
 			awshost.Provisioner(

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/journald/journald_tailing_test.go
@@ -44,8 +44,8 @@ var pythonScript []byte
 //go:embed log-config/logger-service.sh
 var randomLogger []byte
 
-// TestE2EVMFakeintakeSuite returns the stack definition required for the log agent test suite.
-func TestE2EVMFakeintakeSuite(t *testing.T) {
+// TestVMJournaldTailingSuite returns the stack definition required for the log agent test suite.
+func TestVMJournaldTailingSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(
 			awshost.WithAgentOptions(

--- a/test/new-e2e/tests/agent-metrics-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/log-agent/windows-log/file-tailing/file_tailing_test.go
@@ -37,8 +37,8 @@ const (
 	logFilePath = utils.WindowsLogsFolderPath + "\\" + logFileName
 )
 
-// TestE2EVMFakeintakeSuite runs the E2E test suite for the log agent with a VM and fake intake.
-func TestE2EVMFakeintakeSuite(t *testing.T) {
+// TestWindowsVMFileTailingSuite runs the E2E test suite for the log agent with a VM and fake intake.
+func TestWindowsVMFileTailingSuite(t *testing.T) {
 	s := &WindowsFakeintakeSuite{}
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(


### PR DESCRIPTION
### What does this PR do?

Renames some test suites in the new-e2e package.

### Motivation

Currently we have four test suites named the same so hard to understand which one failed at a glance. Also the names of the test suite did not really explain what the test suite was testing.
