### PR TITLE
[CWS] switch http version to 1.0 in `simpleHTTPRequest`

### DIFF
--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -132,7 +132,7 @@ func simpleHTTPRequest(uri string) ([]byte, error) {
 		path = "/"
 	}
 
-	req := fmt.Sprintf("GET %s?%s HTTP/1.1\nHost: %s\nConnection: close\n\n", path, u.RawQuery, u.Hostname())
+	req := fmt.Sprintf("GET %s?%s HTTP/1.0\nHost: %s\nConnection: close\n\n", path, u.RawQuery, u.Hostname())
 
 	_, err = client.Write([]byte(req))
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Switching to http 1.0 will allow us to communicate to the server that we do not support http 1.1 special features, especially chunked encoding.

### Motivation

### Describe how to test/QA your changes

Deploy the CWS in ebpfless/fargate mode on ECS:
- make sure the container context of events is correct (this is filled with data fetched from `ECS_CONTAINER_METADATA_URI_V4`)
- look at the logs, and make sure there is no error there (at least none related to fetching the container metadata)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->