### PR TITLE
[gitlab] move new e2e to multiple owners

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -147,31 +147,9 @@ k8s-e2e-otlp-*                    @DataDog/opentelemetry
 k8s-e2e-cspm-*                    @DataDog/agent-security
 
 # New E2E
-new-e2e-containers*                    @DataDog/container-integrations
-new-e2e-agent-subcommands*             @DataDog/agent-shared-components
-new-e2e-agent-shared-components*       @DataDog/agent-shared-components
-new-e2e-language-detection*            @DataDog/processes
-new-e2e-process*                       @DataDog/processes
-new-e2e-agent-platform*                @DataDog/container-ecosystems @DataDog/agent-delivery
-new-e2e-platform-integrations*         @DataDog/agent-delivery @DataDog/platform-integrations
-new-e2e-aml*                           @DataDog/agent-metrics-logs
-new-e2e-apm*                           @DataDog/agent-apm
-new-e2e-discovery*                     @Datadog/universal-service-monitoring
-new-e2e-ndm*                           @DataDog/network-device-monitoring
-new-e2e-npm*                           @DataDog/Networks
-new-e2e-cws*                           @DataDog/agent-security
-new-e2e-orchestrator*                  @DataDog/container-app
-new-e2e-otel*                          @DataDog/opentelemetry
-e2e_pre_test*                          @DataDog/agent-devx-loops
-new-e2e-remote-config*                 @DataDog/remote-config
-new-e2e-installer*                     @DataDog/fleet
-new-e2e-installer-windows              @DataDog/windows-agent
-new-e2e-windows*                       @DataDog/windows-agent
-new-e2e-windows-systemprobe            @DataDog/windows-kernel-integrations
-new-e2e-windows-security-agent         @DataDog/windows-kernel-integrations
-new-e2e_windows_powershell_module_test @DataDog/windows-kernel-integrations
-new-e2e-eks-cleanup-on-failure         @DataDog/agent-devx-loops
-new-e2e-gpu*                           @DataDog/ebpf-platform
+e2e_pre_test*                     @DataDog/agent-devx-loops
+new-e2e*                          @DataDog/multiple
+
 
 # Kernel matrix testing
 upload_dependencies*              @DataDog/ebpf-platform


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Move ownership of new e2e tests to multiple owners

### Motivation

Similarly to unit tests, teams own tests as defined in `CODEOWNERS`, while job ownership is shared. The supply chain team would be notified on job failures on main during the CI rotation, while teams still receives notifications on failing tests.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->