### PR TITLE
[CWS] remove now unrequired docker (and remaining host) kitchen tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -38,24 +38,9 @@ kitchen_test_security_agent_x64:
     - tasks/kitchen_setup.sh
   parallel:
     matrix:
-      - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-77"
-        KITCHEN_CWS_PLATFORM: [docker]
-      - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-18-04-0,ubuntu-18-04,ubuntu-18-04-3"
-        KITCHEN_CWS_PLATFORM: [docker]
-      - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-20-04,ubuntu-20-04-2,ubuntu-22-04"
-        KITCHEN_CWS_PLATFORM: [docker]
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-22-04"
         KITCHEN_CWS_PLATFORM: [ad, ebpfless, ebpfless-no-seccomp]
-      - KITCHEN_PLATFORM: "debian"
-        KITCHEN_OSVERS: "debian-10,debian-11"
-        KITCHEN_CWS_PLATFORM: [docker]
-      - KITCHEN_PLATFORM: "oracle"
-        KITCHEN_OSVERS: "oracle-7-9"
-        KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_test_security_agent_arm64:
   extends:
@@ -77,9 +62,9 @@ kitchen_test_security_agent_arm64:
     matrix:
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-20-04-2,ubuntu-22-04"
-        KITCHEN_CWS_PLATFORM: [docker, ad, ebpfless, ebpfless-no-seccomp]
+        KITCHEN_CWS_PLATFORM: [ad, ebpfless, ebpfless-no-seccomp]
 
-kitchen_test_security_agent_amazonlinux_x64:
+kitchen_test_security_agent_amazonlinux_x64_fentry:
   extends:
     - .kitchen_test_security_agent_linux
     - .kitchen_ec2_location_us_east_1
@@ -95,42 +80,6 @@ kitchen_test_security_agent_amazonlinux_x64:
   before_script:
     - pushd $DD_AGENT_TESTING_DIR
     - tasks/kitchen_setup.sh
-  parallel:
-    matrix:
-      - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10"
-        KITCHEN_CWS_PLATFORM: [docker]
-      - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2023"
-        KITCHEN_CWS_PLATFORM: [docker]
-      - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2022-5-15"
-        KITCHEN_CWS_PLATFORM: [host, docker]
-
-kitchen_test_security_agent_x64_ec2:
-  extends:
-    - .kitchen_test_security_agent_linux
-    - .kitchen_ec2_location_us_east_1
-    - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "prepare_secagent_ebpf_functional_tests_x64" ]
-  variables:
-    KITCHEN_ARCH: x86_64
-    KITCHEN_EC2_INSTANCE_TYPE: "t3.medium"
-    KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
-    KITCHEN_CI_ROOT_PATH: "/tmp/ci"
-  before_script:
-    - pushd $DD_AGENT_TESTING_DIR
-    - tasks/kitchen_setup.sh
-  parallel:
-    matrix:
-      - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-23-10"
-        KITCHEN_CWS_PLATFORM: [docker]
-        KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
-
-kitchen_test_security_agent_amazonlinux_x64_fentry:
-  extends:
-    - kitchen_test_security_agent_amazonlinux_x64
   allow_failure: true
   parallel:
     matrix:


### PR DESCRIPTION
### What does this PR do?

Now that both host and docker versions of our functional tests are available on KMT, we can remove the legacy jobs using kitchen. The set of kernels that is validated is slightly different, but we can work on adding those that are really important to KMT at a later time (those jobs were manual anyway, and very rarely run).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->