### PR TITLE
[CWS] fix fileless handling code

### DIFF
--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -55,7 +55,7 @@ func (r *Resolver) ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDC
 	}
 
 	if e.IsFileless() {
-		return pathStr, "", model.MountSourceUnknown, model.MountOriginUnknown, nil
+		return pathStr, "", model.MountSourceMountID, model.MountOriginEvent, nil
 	}
 
 	mountPath, source, origin, err := r.mountResolver.ResolveMountPath(e.MountID, e.Device, pidCtx.Pid, string(ctrCtx.ContainerID))

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -8,9 +8,12 @@ package process
 
 import (
 	"path"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
+
+const memfdPrefix = "memfd:"
 
 // IsKThread returns whether given pids are from kthreads
 func IsKThread(ppid, pid uint32) bool {
@@ -23,12 +26,16 @@ func IsBusybox(pathname string) bool {
 }
 
 func setPathname(fileEvent *model.FileEvent, pathnameStr string) {
+	baseName := path.Base(pathnameStr)
 	if fileEvent.FileFields.IsFileless() {
 		fileEvent.SetPathnameStr("")
+		if !strings.HasPrefix(baseName, memfdPrefix) {
+			baseName = memfdPrefix + baseName
+		}
 	} else {
 		fileEvent.SetPathnameStr(pathnameStr)
 	}
-	fileEvent.SetBasenameStr(path.Base(pathnameStr))
+	fileEvent.SetBasenameStr(baseName)
 }
 
 // GetProcessArgv returns the unscrubbed args of the event as an array. Use with caution.

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -451,7 +451,6 @@ func validateProcessContextSECL(tb testing.TB, event *model.Event) {
 	if event.Origin != "ebpfless" {
 		nameFields = append(nameFields,
 			"process.ancestors.file.name",
-			"process.parent.file.path",
 			"process.parent.file.name",
 		)
 	}
@@ -463,7 +462,10 @@ func validateProcessContextSECL(tb testing.TB, event *model.Event) {
 		"process.file.path",
 	}
 	if event.Origin != "ebpfless" {
-		pathFields = append(pathFields, "process.ancestors.file.path")
+		pathFields = append(pathFields,
+			"process.parent.file.path",
+			"process.ancestors.file.path",
+		)
 	}
 
 	pathFieldValid := true

--- a/pkg/security/tests/schemas/process.json
+++ b/pkg/security/tests/schemas/process.json
@@ -96,6 +96,9 @@
                 "fsgroup": {
                     "type": "string"
                 },
+                "auid": {
+                    "type": "integer"
+                },
                 "cap_effective": {
                     "type": "array",
                     "items": {

--- a/pkg/security/tests/schemas/process.json
+++ b/pkg/security/tests/schemas/process.json
@@ -160,25 +160,46 @@
                 },
                 "mount_source": {
                     "type": "string",
-                    "enum": ["device", "mount_id", "snapshot"]
+                    "enum": [
+                        "device",
+                        "mount_id",
+                        "snapshot"
+                    ]
                 },
                 "mount_origin": {
                     "type": "string",
-                    "enum": ["procfs", "event", "unshare"]
+                    "enum": [
+                        "procfs",
+                        "event",
+                        "unshare"
+                    ]
                 }
             },
             "required": [
-                "path",
                 "name",
                 "inode",
                 "mode",
-                "mount_id",
                 "filesystem",
                 "uid",
                 "gid",
                 "modification_time",
                 "change_time"
-            ]
+            ],
+            "if": {
+                "not": {
+                    "properties": {
+                        "filesystem": {
+                            "const": "tmpfs"
+                        }
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "path",
+                    "mount_id"
+                ]
+            }
         },
         "container": {
             "$ref": "/schemas/container.json"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The main goal of this PR is to fix openSUSE 15.5 host KMT tests. This version is using a runc version when creating docker container that goes through a memfd file ([more info on this here](https://github.com/opencontainers/runc/blob/main/contrib/cmd/memfd-bind/README.md)) and the handling of those fileless execs was not perfect on multiple layers.

This PR:
- makes sure the mount origin and source of a fileless exec are not unknown (changed to source=MountID, origin=Event)
- makes sure that a fileless exec has a correct `memfd:` prefix on it's basename
- makes sure that the json schema validated in the test accepts `memfd:` files when the filesystem is tmpfs (this is kind of a hack, but should be good enough for now).

This PR also fixes a few things here and there:
- adds missing auid in the json schema
- fix an empty path check in the tests that was done in the empty basename check

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->