### PR TITLE
Fix bug where incorrect timestamp would be used for unbundled Kubernetes events

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -104,10 +104,10 @@ func (c *unbundledTransformer) Transform(events []*v1.Event) ([]event.Event, []e
 		)
 
 		var timestamp int64
-		if ev.FirstTimestamp.IsZero() {
+		if ev.LastTimestamp.IsZero() {
 			timestamp = int64(ev.EventTime.Unix())
 		} else {
-			timestamp = int64(ev.FirstTimestamp.Unix())
+			timestamp = int64(ev.LastTimestamp.Unix())
 		}
 
 		event := event.Event{

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestUnbundledEventsTransform(t *testing.T) {
 	ts := metav1.Time{Time: time.Date(2024, 5, 29, 6, 0, 51, 0, time.Now().Location())}
+	oldTs := metav1.Time{Time: ts.Add(-3 * time.Hour)}
 
 	incomingEvents := []*v1.Event{
 		{
@@ -58,7 +59,7 @@ func TestUnbundledEventsTransform(t *testing.T) {
 				Component: "kubelet",
 				Host:      "test-host",
 			},
-			FirstTimestamp: ts,
+			FirstTimestamp: oldTs,
 			LastTimestamp:  ts,
 			Count:          1,
 		},
@@ -375,9 +376,9 @@ func TestUnbundledEventsTransform(t *testing.T) {
 					Text: fmt.Sprintf(`%%%%%%%[1]s
 1 **Pulled**: Successfully pulled image "pokemon/squirtle:latest" in 1.263s (1.263s including waiting)
 %[1]s
- _Events emitted by the kubelet seen at %[2]s since %[2]s_%[1]s
+ _Events emitted by the kubelet seen at %[2]s since %[3]s_%[1]s
 
- %%%%%%`, " ", ts.String()),
+ %%%%%%`, " ", ts.String(), oldTs.String()),
 					Ts:       ts.Time.Unix(),
 					Priority: event.PriorityNormal,
 					Tags: []string{

--- a/releasenotes-dca/notes/apiserver-unbundle-events-wrong-timestamp-f41dbb55a76f41ff.yaml
+++ b/releasenotes-dca/notes/apiserver-unbundle-events-wrong-timestamp-f41dbb55a76f41ff.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes bug where incorrect timestamp would be used for unbundled Kubernetes events.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug with unbundled Kubernetes events where the timestamp an event first happened would be used by default, instead of the timestamp of the most recent occurrence.

### Motivation

See [this slack thread](https://dd.slack.com/archives/C06QGASN1A4/p1729626132818029) for more info

Fixes bug introduced by [this PR](https://github.com/DataDog/datadog-agent/pull/28342)

### Describe how to test/QA your changes

Enable unbundled events, deploy a workload that keeps crashlooping (either because of OOM or because unexpected exit code), validate that the Back-Off events are being associated with the correct timestamp as time passes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->