### PR TITLE
discovery: improve e2e test output in case of failures

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -91,54 +91,51 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			}
 		}
 
-		found := foundMap["json-server"]
-		if assert.NotNil(c, found) {
-			assert.Equal(c, "none", found.Payload.APMInstrumentation)
-			assert.Equal(c, "json-server", found.Payload.ServiceName)
-			assert.Equal(c, "json-server", found.Payload.GeneratedServiceName)
-			assert.Empty(c, found.Payload.DDService)
-			assert.Empty(c, found.Payload.ServiceNameSource)
-			assert.NotZero(c, found.Payload.RSSMemory)
-		}
-
-		found = foundMap["node-instrumented"]
-		if assert.NotNil(c, found) {
-			assert.Equal(c, "provided", found.Payload.APMInstrumentation)
-			assert.Equal(c, "node-instrumented", found.Payload.ServiceName)
-			assert.Equal(c, "node-instrumented", found.Payload.GeneratedServiceName)
-			assert.Empty(c, found.Payload.DDService)
-			assert.Empty(c, found.Payload.ServiceNameSource)
-			assert.NotZero(c, found.Payload.RSSMemory)
-		}
-
-		found = foundMap["python-svc-dd"]
-		if assert.NotNil(c, found) {
-			assert.Equal(c, "none", found.Payload.APMInstrumentation)
-			assert.Equal(c, "python-svc-dd", found.Payload.ServiceName)
-			assert.Equal(c, "python.server", found.Payload.GeneratedServiceName)
-			assert.Equal(c, "python-svc-dd", found.Payload.DDService)
-			assert.Equal(c, "provided", found.Payload.ServiceNameSource)
-			assert.NotZero(c, found.Payload.RSSMemory)
-		}
-
-		found = foundMap["python.instrumented"]
-		if assert.NotNil(c, found) {
-			assert.Equal(c, "provided", found.Payload.APMInstrumentation)
-			assert.Equal(c, "python.instrumented", found.Payload.ServiceName)
-			assert.Equal(c, "python.instrumented", found.Payload.GeneratedServiceName)
-			assert.Empty(c, found.Payload.DDService)
-			assert.Empty(c, found.Payload.ServiceNameSource)
-			assert.NotZero(c, found.Payload.RSSMemory)
-		}
-
-		found = foundMap["rails_hello"]
-		if assert.NotNil(c, found) {
-			assert.Equal(c, "rails_hello", found.Payload.ServiceName)
-			assert.Equal(c, "rails_hello", found.Payload.GeneratedServiceName)
-			assert.Empty(c, found.Payload.DDService)
-			assert.Empty(c, found.Payload.ServiceNameSource)
-			assert.NotZero(c, found.Payload.RSSMemory)
-		}
+		s.assertService(t, foundMap, serviceExpectedPayload{
+			name:                 "json-server",
+			systemdServiceName:   "node-json-server",
+			instrumentation:      "none",
+			serviceName:          "json-server",
+			generatedServiceName: "json-server",
+			ddService:            "",
+			serviceNameSource:    "",
+		})
+		s.assertService(t, foundMap, serviceExpectedPayload{
+			name:                 "node-instrumented",
+			systemdServiceName:   "node-instrumented",
+			instrumentation:      "provided",
+			serviceName:          "node-instrumented",
+			generatedServiceName: "node-instrumented",
+			ddService:            "",
+			serviceNameSource:    "",
+		})
+		s.assertService(t, foundMap, serviceExpectedPayload{
+			name:                 "python-svc-dd",
+			systemdServiceName:   "python-svc",
+			instrumentation:      "none",
+			serviceName:          "python-svc-dd",
+			generatedServiceName: "python.server",
+			ddService:            "python-svc-dd",
+			serviceNameSource:    "provided",
+		})
+		s.assertService(t, foundMap, serviceExpectedPayload{
+			name:                 "python.instrumented",
+			systemdServiceName:   "python-instrumented",
+			instrumentation:      "provided",
+			serviceName:          "python.instrumented",
+			generatedServiceName: "python.instrumented",
+			ddService:            "",
+			serviceNameSource:    "",
+		})
+		s.assertService(t, foundMap, serviceExpectedPayload{
+			name:                 "rails_hello",
+			systemdServiceName:   "rails-svc",
+			instrumentation:      "none",
+			serviceName:          "rails_hello",
+			generatedServiceName: "rails_hello",
+			ddService:            "",
+			serviceNameSource:    "",
+		})
 
 		assert.Contains(c, foundMap, "json-server")
 	}, 3*time.Minute, 10*time.Second)
@@ -186,5 +183,35 @@ func (s *linuxTestSuite) stopServices() {
 	for i := len(services) - 1; i >= 0; i-- {
 		service := services[i]
 		s.Env().RemoteHost.MustExecute("sudo systemctl stop " + service)
+	}
+}
+
+type serviceExpectedPayload struct {
+	name                 string
+	systemdServiceName   string
+	instrumentation      string
+	serviceName          string
+	generatedServiceName string
+	ddService            string
+	serviceNameSource    string
+}
+
+func (s *linuxTestSuite) assertService(t *testing.T, foundMap map[string]*aggregator.ServiceDiscoveryPayload, expected serviceExpectedPayload) {
+	t.Helper()
+
+	found := foundMap[expected.name]
+	if assert.NotNil(t, found, "could not find service %q", expected.name) {
+		assert.Equal(t, expected.instrumentation, found.Payload.APMInstrumentation, "service %q: APM instrumentation", expected.name)
+		assert.Equal(t, expected.serviceName, found.Payload.ServiceName, "service %q: service name", expected.name)
+		assert.Equal(t, expected.generatedServiceName, found.Payload.GeneratedServiceName, "service %q: generated service name", expected.name)
+		assert.Equal(t, expected.ddService, found.Payload.DDService, "service %q: DD service", expected.name)
+		assert.Equal(t, expected.serviceNameSource, found.Payload.ServiceNameSource, "service %q: service name source", expected.name)
+		assert.NotZero(t, found.Payload.RSSMemory, "service %q: expected non-zero memory usage", expected.name)
+	} else {
+		status := s.Env().RemoteHost.MustExecute("sudo systemctl status " + expected.systemdServiceName)
+		logs := s.Env().RemoteHost.MustExecute("sudo journalctl -u " + expected.systemdServiceName)
+
+		t.Logf("Service %q status:\n:%s", expected.systemdServiceName, status)
+		t.Logf("Service %q logs:\n:%s", expected.systemdServiceName, logs)
 	}
 }

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -91,7 +91,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			}
 		}
 
-		s.assertService(t, foundMap, serviceExpectedPayload{
+		s.assertService(t, c, foundMap, serviceExpectedPayload{
 			name:                 "json-server",
 			systemdServiceName:   "node-json-server",
 			instrumentation:      "none",
@@ -100,7 +100,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			ddService:            "",
 			serviceNameSource:    "",
 		})
-		s.assertService(t, foundMap, serviceExpectedPayload{
+		s.assertService(t, c, foundMap, serviceExpectedPayload{
 			name:                 "node-instrumented",
 			systemdServiceName:   "node-instrumented",
 			instrumentation:      "provided",
@@ -109,7 +109,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			ddService:            "",
 			serviceNameSource:    "",
 		})
-		s.assertService(t, foundMap, serviceExpectedPayload{
+		s.assertService(t, c, foundMap, serviceExpectedPayload{
 			name:                 "python-svc-dd",
 			systemdServiceName:   "python-svc",
 			instrumentation:      "none",
@@ -118,7 +118,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			ddService:            "python-svc-dd",
 			serviceNameSource:    "provided",
 		})
-		s.assertService(t, foundMap, serviceExpectedPayload{
+		s.assertService(t, c, foundMap, serviceExpectedPayload{
 			name:                 "python.instrumented",
 			systemdServiceName:   "python-instrumented",
 			instrumentation:      "provided",
@@ -127,7 +127,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 			ddService:            "",
 			serviceNameSource:    "",
 		})
-		s.assertService(t, foundMap, serviceExpectedPayload{
+		s.assertService(t, c, foundMap, serviceExpectedPayload{
 			name:                 "rails_hello",
 			systemdServiceName:   "rails-svc",
 			instrumentation:      "none",
@@ -196,17 +196,17 @@ type serviceExpectedPayload struct {
 	serviceNameSource    string
 }
 
-func (s *linuxTestSuite) assertService(t *testing.T, foundMap map[string]*aggregator.ServiceDiscoveryPayload, expected serviceExpectedPayload) {
+func (s *linuxTestSuite) assertService(t *testing.T, c *assert.CollectT, foundMap map[string]*aggregator.ServiceDiscoveryPayload, expected serviceExpectedPayload) {
 	t.Helper()
 
 	found := foundMap[expected.name]
-	if assert.NotNil(t, found, "could not find service %q", expected.name) {
-		assert.Equal(t, expected.instrumentation, found.Payload.APMInstrumentation, "service %q: APM instrumentation", expected.name)
-		assert.Equal(t, expected.serviceName, found.Payload.ServiceName, "service %q: service name", expected.name)
-		assert.Equal(t, expected.generatedServiceName, found.Payload.GeneratedServiceName, "service %q: generated service name", expected.name)
-		assert.Equal(t, expected.ddService, found.Payload.DDService, "service %q: DD service", expected.name)
-		assert.Equal(t, expected.serviceNameSource, found.Payload.ServiceNameSource, "service %q: service name source", expected.name)
-		assert.NotZero(t, found.Payload.RSSMemory, "service %q: expected non-zero memory usage", expected.name)
+	if assert.NotNil(c, found, "could not find service %q", expected.name) {
+		assert.Equal(c, expected.instrumentation, found.Payload.APMInstrumentation, "service %q: APM instrumentation", expected.name)
+		assert.Equal(c, expected.serviceName, found.Payload.ServiceName, "service %q: service name", expected.name)
+		assert.Equal(c, expected.generatedServiceName, found.Payload.GeneratedServiceName, "service %q: generated service name", expected.name)
+		assert.Equal(c, expected.ddService, found.Payload.DDService, "service %q: DD service", expected.name)
+		assert.Equal(c, expected.serviceNameSource, found.Payload.ServiceNameSource, "service %q: service name source", expected.name)
+		assert.NotZero(c, found.Payload.RSSMemory, "service %q: expected non-zero memory usage", expected.name)
 	} else {
 		status := s.Env().RemoteHost.MustExecute("sudo systemctl status " + expected.systemdServiceName)
 		logs := s.Env().RemoteHost.MustExecute("sudo journalctl -u " + expected.systemdServiceName)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes the E2E test output for service discovery show more information about the running services, as well as being more precise as to what the actual issue is, and for which services.

Here are some examples:
#### Service not found

##### Before
```
Error:      	Expected value not to be nil.
```

#### After
```
	Error:      	Expected value not to be nil.
        	Test:       	TestLinuxTestSuite/TestServiceDiscoveryCheck
        	Messages:   	could not find service "rails_hello"
    host.go:131: 23-10-2024 16:32:46 - TestLinuxTestSuite/TestServiceDiscoveryCheck - Executing command `sudo systemctl status rails-svc`
    host.go:131: 23-10-2024 16:32:47 - TestLinuxTestSuite/TestServiceDiscoveryCheck - Executing command `sudo journalctl -u rails-svc`
    linux_test.go:130: Service "rails-svc" status:
        :● rails-svc.service - rails-svc
             Loaded: loaded (/etc/systemd/system/rails-svc.service; disabled; vendor preset: enabled)
             Active: active (running) since Wed 2024-10-23 14:31:34 UTC; 1min 12s ago
           Main PID: 27339 (ruby3.0)
              Tasks: 15 (limit: 4586)
             Memory: 66.0M
                CPU: 2.537s
             CGroup: /system.slice/rails-svc.service
                     └─27339 "puma 5.6.9 (tcp://localhost:7777) [rails-hello]"
        
        Oct 23 14:31:37 ip-10-1-59-25 rails[27339]: => Run `bin/rails server --help` for more startup options
        Oct 23 14:31:37 ip-10-1-59-25 rails[27339]: Puma starting in single mode...
        Oct 23 14:31:37 ip-10-1-59-25 rails[27339]: * Puma version: 5.6.9 (ruby 3.0.2-p107) ("Birdie's Version")
```

#### Field with unexpected value
##### Before
```
	Error:      	Not equal: 
        	           	expected: "python.intrumented"
        	           	actual  : "python.instrumented"
        	           	
        	           	Diff:
        	           	--- Expected
        	           	+++ Actual
        	           	@@ -1 +1 @@
        	           	-python.intrumented
        	           	+python.instrumented
        	Test:       	TestLinuxTestSuite/TestServiceDiscoveryCheck
```

##### After
```
	Error:      	Not equal: 
        	           	expected: "python.intrumented"
        	           	actual  : "python.instrumented"
        	           	
        	           	Diff:
        	           	--- Expected
        	           	+++ Actual
        	           	@@ -1 +1 @@
        	           	-python.intrumented
        	           	+python.instrumented
        	Test:       	TestLinuxTestSuite/TestServiceDiscoveryCheck
        	Messages:   	service "python.instrumented": service name
```

### Motivation

USMON-1297

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->