### PR TITLE
Propagate agent tags for oracle integration

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -6,6 +6,12 @@ init_config:
   ## Active session sampling interval in seconds
   # min_collection_interval: <interval_in_seconds>
 
+  ## @param propagate_agent_tags - boolean - optional - default: false
+  ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+  ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
+  #
+  # propagate_agent_tags: false
+
   ## @param global_custom_queries - list of mappings - optional
   ## See `custom_queries` defined below.
   ##
@@ -113,6 +119,13 @@ instances:
     ## Set to `true` to enable Database Monitoring.
     #
     # dbm: false
+
+    ## @param propagate_agent_tags - boolean - optional - default: false
+    ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+    ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
+    ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
+    #
+    # propagate_agent_tags: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -9,12 +9,15 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/hosttags"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"gopkg.in/yaml.v3"
@@ -25,6 +28,7 @@ const defaultLoader = "core"
 // InitConfig is used to deserialize integration init config.
 type InitConfig struct {
 	MinCollectionInterval int           `yaml:"min_collection_interval"`
+	PropagateAgentTags    *bool         `yaml:"propagate_agent_tags"`
 	CustomQueries         []CustomQuery `yaml:"global_custom_queries"`
 	UseInstantClient      bool          `yaml:"use_instant_client"`
 	Service               string        `yaml:"service"`
@@ -144,6 +148,7 @@ type InstanceConfig struct {
 	ConnectionConfig                   `yaml:",inline"`
 	User                               string                 `yaml:"user"`
 	DBM                                bool                   `yaml:"dbm"`
+	PropagateAgentTags                 *bool                  `yaml:"propagate_agent_tags"`
 	Tags                               []string               `yaml:"tags"`
 	LogUnobfuscatedQueries             bool                   `yaml:"log_unobfuscated_queries"`
 	ObfuscatorOptions                  obfuscate.SQLConfig    `yaml:"obfuscator_options"`
@@ -300,6 +305,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		instance.Tags = append(instance.Tags, fmt.Sprintf("service:%s", service))
 	}
 
+	if shouldPropagateAgentTags(instance.PropagateAgentTags, initCfg.PropagateAgentTags) {
+		agentTags := hosttags.Get(context.Background(), true, pkgconfigsetup.Datadog())
+		instance.Tags = append(instance.Tags, agentTags.System...)
+		instance.Tags = append(instance.Tags, agentTags.GoogleCloudPlatform...)
+	}
+
 	c := &CheckConfig{
 		InstanceConfig: instance,
 		InitConfig:     initCfg,
@@ -335,6 +346,20 @@ func GetConnectData(c InstanceConfig) string {
 		p = fmt.Sprintf("%s/%s", p, c.ServiceName)
 	}
 	return p
+}
+
+// shouldPropagateAgentTags returns true if the agent tags should be propagated to the check
+func shouldPropagateAgentTags(instancePropagateTags, initConfigPropagateTags *bool) bool {
+	if instancePropagateTags != nil {
+		// if the instance has explicitly set the value, return the boolean
+		return *instancePropagateTags
+	}
+	if initConfigPropagateTags != nil {
+		// if the init config has explicitly set the value, return the boolean
+		return *initConfigPropagateTags
+	}
+	// if neither the instance nor the init_config has set the value, return False
+	return false
 }
 
 func warnDeprecated(old string, new string) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the agent host tags that we use in the oracle integration. This change only affects DBM customers with the `propagate_agent_tags` flag set to true. By getting host tags, we not only use the tags in the conf.yaml file but also other tags on the agent host. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Metrics emitted by DBM integrations are tagged with the tags from the database instance host. We would like to update the `propagate_agent_tags` option (default false) that allows us to also consider the tags of the agent host. If this setting is enabled, we will propagate all agent host tags. This allows user to opt-in to having their postgres metrics tagged with the agent host tags.

