### PR TITLE
AMLII-2114: truncated logs are tagged consistently

### DIFF
--- a/pkg/logs/internal/decoder/single_line_handler_test.go
+++ b/pkg/logs/internal/decoder/single_line_handler_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+package decoder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+func TestSingleLineHandlerProcess(t *testing.T) {
+	truncateTag := message.TruncatedReasonTag("single_line")
+	tagTrunLogsFlag := pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs")
+	defer pkgconfigsetup.Datadog().SetWithoutSource("logs_config.tag_truncated_logs", tagTrunLogsFlag)
+
+	scenarios := []struct {
+		name             string
+		input            []string
+		expected         []string
+		expTags          [][]string
+		tagTruncatedLogs bool
+	}{
+		{
+			name:             "Base case",
+			input:            []string{"This is a", "normal set  ", " of messages"},
+			expected:         []string{"This is a", "normal set", "of messages"},
+			expTags:          [][]string{nil, nil, nil},
+			tagTruncatedLogs: true,
+		},
+		{
+			name:  "Truncation base case",
+			input: []string{"aaaaaaaaaaaaaaaaaaaa", "aaaaaaaa", "wait, how many a's?"},
+			expected: []string{
+				"aaaaaaaaaaaaaaaaaaaa" + string(message.TruncatedFlag),
+				string(message.TruncatedFlag) + "aaaaaaaa",
+				"wait, how many a's?",
+			},
+			expTags:          [][]string{{truncateTag}, {truncateTag}, nil},
+			tagTruncatedLogs: true,
+		},
+		{
+			name:  "Truncation with whitespace",
+			input: []string{"aaaaaaaaaaaaaaaa    ", "  aaaaaa", "wait, how many a's?"},
+			expected: []string{
+				"aaaaaaaaaaaaaaaa" + string(message.TruncatedFlag),
+				string(message.TruncatedFlag) + "aaaaaa",
+				"wait, how many a's?",
+			},
+			expTags:          [][]string{{truncateTag}, {truncateTag}, nil},
+			tagTruncatedLogs: true,
+		},
+		{
+			name:  "Triple trunc",
+			input: []string{"aaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaa", "wait, how many a's?"},
+			expected: []string{
+				"aaaaaaaaaaaaaaaaaaaa" + string(message.TruncatedFlag),
+				string(message.TruncatedFlag) + "aaaaaaaaaaaaaaaaaaaa" + string(message.TruncatedFlag),
+				string(message.TruncatedFlag) + "wait, how many a's?",
+			},
+			expTags:          [][]string{{truncateTag}, {truncateTag, truncateTag}, {truncateTag}},
+			tagTruncatedLogs: true,
+		},
+		{
+			name:  "Truncate tag disabled",
+			input: []string{"aaaaaaaaaaaaaaaaaaaa", "aaaaaaaa", "wait, how many a's?"},
+			expected: []string{
+				"aaaaaaaaaaaaaaaaaaaa" + string(message.TruncatedFlag),
+				string(message.TruncatedFlag) + "aaaaaaaa",
+				"wait, how many a's?",
+			},
+			expTags:          [][]string{nil, nil, nil},
+			tagTruncatedLogs: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			var processedMessage *message.Message
+			pkgconfigsetup.Datadog().SetWithoutSource("logs_config.tag_truncated_logs", scenario.tagTruncatedLogs)
+			h := NewSingleLineHandler(func(m *message.Message) { processedMessage = m }, 20)
+
+			for idx, input := range scenario.input {
+				msg := message.NewMessage([]byte(input), nil, "", time.Now().UnixNano())
+				h.process(msg)
+				assert.Equal(t, []byte(scenario.expected[idx]), processedMessage.GetContent(), "Unexpected message content for run %d", idx)
+				assert.Equal(t, scenario.expTags[idx], processedMessage.ParsingExtra.Tags, "Unexpected tag content for run %d", idx)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/truncated-logs-tagged-inconsistently-13edd805a166f33e.yaml
+++ b/releasenotes/notes/truncated-logs-tagged-inconsistently-13edd805a166f33e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix bug wherein single line truncated logs ended with whitespace characters were not being tagged as truncated.
+    Fix issue with the truncation message occasionally causing subsequent logs to think they were truncated when they were not (single line logs only).


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix bug wherein single line truncated logs ended with whitespace characters avoided being tagged as truncated.
Fix issue with the truncation message occasionally causing subsequent logs to think they were truncated when they were not (single line logs only). 

### Motivation

### Describe how to test/QA your changes
Testing this change involves crafting single line logs below and above the logs_config.max_message_size_bytes config size, so set that value to something reasonably small and configure log ingestion for a file. The stream-logs agent command will be quite helpful when identifying when logs have been truncated, as the output message field will contain a "...TRUNCATED..." value prepended and appended to the log where appropriate. 

Previous (bugged) behavior: a too-large log message that contains whitespace at the max_bytes cutoff point wouldn't be correctly identified as truncated. For example, if the max bytes is set to 6 then the message "hello world" would be output as "hello" and "world" rather than correctly as "hello...TRUNCATED..." and "...TRUNCATED...world".

Test steps:
Generate a number of variable sized logs above and below the max bytes size. Confirm that all of them are correctly marked as truncated or not, especially when they are in the edge case identified above. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->