### PR TITLE
[CONTP-430][dca] apm-ssi admission controller migration to config.Component

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -94,7 +94,9 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	// Note: the auto_instrumentation pod injection filter is used across
 	// multiple mutating webhooks, so we add it as a hard dependency to each
 	// of the components that use it via the injectionFilter parameter.
-	injectionFilter := autoinstrumentation.GetInjectionFilter()
+	// TODO: for now we ignore the error returned by NewInjectionFilter, but we should not and surface it
+	//       in the admission controller section in agent status.
+	injectionFilter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
 
 	var webhooks []Webhook
 	var validatingWebhooks []Webhook
@@ -118,14 +120,14 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 		webhooks = append(webhooks, mutatingWebhooks...)
 
 		// APM Instrumentation webhook needs to be registered after the configWebhook webhook.
-		apm, err := autoinstrumentation.NewWebhook(wmeta, injectionFilter)
+		apm, err := autoinstrumentation.NewWebhook(wmeta, datadogConfig, injectionFilter)
 		if err == nil {
 			webhooks = append(webhooks, apm)
 		} else {
 			log.Errorf("failed to register APM Instrumentation webhook: %v", err)
 		}
 
-		cws, err := cwsinstrumentation.NewCWSInstrumentation(wmeta)
+		cws, err := cwsinstrumentation.NewCWSInstrumentation(wmeta, datadogConfig)
 		if err == nil {
 			webhooks = append(webhooks, cws.WebhookForPods(), cws.WebhookForCommands())
 		} else {

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -72,7 +72,7 @@ type Webhook struct {
 func NewWebhook(datadogConfig config.Component) *Webhook {
 	nsSelector, objSelector := labelSelectors(datadogConfig)
 
-	containerRegistry := mutatecommon.ContainerRegistry("admission_controller.agent_sidecar.container_registry")
+	containerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.agent_sidecar.container_registry")
 
 	return &Webhook{
 		name:              webhookName,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -39,6 +39,9 @@ const (
 	mountPath  = "/datadog-lib"
 
 	webhookName = "lib_injection"
+
+	// apmInjectionErrorAnnotationKey this annotation is added when the apm auto-instrumentation admission controller failed to mutate the Pod.
+	apmInjectionErrorAnnotationKey = "apm.datadoghq.com/injection-error"
 )
 
 // Webhook is the auto instrumentation webhook
@@ -670,6 +673,10 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 	}
 	requirements, skipInjection := initContainerResourceRequirements(pod, w.config.defaultResourceRequirements)
 	if skipInjection {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		pod.Annotations[apmInjectionErrorAnnotationKey] = "The overall pod's containers memory limit is too low to acceptable for the datadog library init-container"
 		return nil
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -10,7 +10,6 @@
 package autoinstrumentation
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -26,11 +25,11 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -39,80 +38,55 @@ const (
 	volumeName = "datadog-auto-instrumentation"
 	mountPath  = "/datadog-lib"
 
-	minimumCPULimit    float64 = 50                // 0.05 core, otherwise copying + library initialization is going to take forever
-	minimumMemoryLimit float64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
-
 	webhookName = "lib_injection"
 )
 
 // Webhook is the auto instrumentation webhook
 type Webhook struct {
-	name                     string
-	isEnabled                bool
-	endpoint                 string
-	resources                []string
-	operations               []admissionregistrationv1.OperationType
-	initSecurityContext      *corev1.SecurityContext
-	initResourceRequirements initResourceRequirementConfiguration
-	containerRegistry        string
-	injectorImageTag         string
-	injectionFilter          mutatecommon.InjectionFilter
-	pinnedLibraries          []libInfo
-	version                  version
-	wmeta                    workloadmeta.Component
+	name       string
+	resources  []string
+	operations []admissionregistrationv1.OperationType
+
+	wmeta workloadmeta.Component
+
+	// use to store all the config option from the config component to avoid costly lookups in the admission webhook hot path.
+	config webhookConfig
+
+	// precomputed mutators for the security and profiling products
+	securityClientLibraryPodMutators  []podMutator
+	profilingClientLibraryPodMutators []podMutator
 }
 
 // NewWebhook returns a new Webhook dependent on the injection filter.
-func NewWebhook(wmeta workloadmeta.Component, filter mutatecommon.InjectionFilter) (*Webhook, error) {
+func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, filter mutatecommon.InjectionFilter) (*Webhook, error) {
 	// Note: the webhook is not functional with the filter being disabled--
 	//       and the filter is _global_! so we need to make sure that it was
 	//       initialized as it validates the configuration itself.
-	if filter.NSFilter == nil {
+	if filter == nil {
 		return nil, errors.New("filter required for auto_instrumentation webhook")
-	} else if err := filter.NSFilter.Err(); err != nil {
-		return nil, err
+	} else if err := filter.InitError(); err != nil {
+		return nil, fmt.Errorf("filter error: %w", err)
 	}
 
-	initSecurityContext, err := parseInitSecurityContext()
+	config, err := retrieveConfig(datadogConfig, filter)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to retrieve autoinstrumentation config, err: %w", err)
 	}
 
-	initResource, err := getInitResourceConfiguration()
-	if err != nil {
-		return nil, err
+	webhook := &Webhook{
+		name: webhookName,
+
+		resources:  []string{"pods"},
+		operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+		wmeta:      wmeta,
+
+		config: config,
 	}
 
-	v, err := instrumentationVersion(pkgconfigsetup.Datadog().GetString("apm_config.instrumentation.version"))
-	if err != nil {
-		return nil, fmt.Errorf("invalid version for key apm_config.instrumentation.version: %w", err)
-	}
+	webhook.securityClientLibraryPodMutators = securityClientLibraryConfigMutators(&webhook.config)
+	webhook.profilingClientLibraryPodMutators = profilingClientLibraryConfigMutators(&webhook.config)
 
-	var (
-		isEnabled         = pkgconfigsetup.Datadog().GetBool("admission_controller.auto_instrumentation.enabled")
-		containerRegistry = mutatecommon.ContainerRegistry("admission_controller.auto_instrumentation.container_registry")
-		pinnedLibraries   []libInfo
-	)
-
-	if isEnabled {
-		pinnedLibraries = getPinnedLibraries(containerRegistry)
-	}
-
-	return &Webhook{
-		name:                     webhookName,
-		isEnabled:                isEnabled,
-		endpoint:                 pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.endpoint"),
-		resources:                []string{"pods"},
-		operations:               []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-		initSecurityContext:      initSecurityContext,
-		initResourceRequirements: initResource,
-		injectionFilter:          filter,
-		containerRegistry:        containerRegistry,
-		injectorImageTag:         pkgconfigsetup.Datadog().GetString("apm_config.instrumentation.injector_image_tag"),
-		pinnedLibraries:          pinnedLibraries,
-		version:                  v,
-		wmeta:                    wmeta,
-	}, nil
+	return webhook, nil
 }
 
 // Name returns the name of the webhook
@@ -127,12 +101,12 @@ func (w *Webhook) WebhookType() common.WebhookType {
 
 // IsEnabled returns whether the webhook is enabled
 func (w *Webhook) IsEnabled() bool {
-	return w.isEnabled
+	return w.config.isEnabled
 }
 
 // Endpoint returns the endpoint of the webhook
 func (w *Webhook) Endpoint() string {
-	return w.endpoint
+	return w.config.endpoint
 }
 
 // Resources returns the kubernetes resources for which the webhook should
@@ -160,19 +134,9 @@ func (w *Webhook) WebhookFunc() admission.WebhookFunc {
 	}
 }
 
-func initContainerName(lang language) string {
-	return fmt.Sprintf("datadog-lib-%s-init", lang)
-}
-
 // isPodEligible checks whether we are allowed to inject in this pod.
 func (w *Webhook) isPodEligible(pod *corev1.Pod) bool {
-	return w.injectionFilter.ShouldMutatePod(pod)
-}
-
-// isEnabledInNamespace checks whether this namespace is opted into or out of
-// single step (auto_instrumentation) outside pod-specific annotations.
-func (w *Webhook) isEnabledInNamespace(namespace string) bool {
-	return w.injectionFilter.NSFilter.IsNamespaceEligible(namespace)
+	return w.config.injectionFilter.ShouldMutatePod(pod)
 }
 
 func (w *Webhook) inject(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool, error) {
@@ -202,13 +166,13 @@ func (w *Webhook) inject(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool,
 		return false, nil
 	}
 
-	for _, mutator := range securityClientLibraryConfigMutators() {
+	for _, mutator := range w.securityClientLibraryPodMutators {
 		if err := mutator.mutatePod(pod); err != nil {
 			return false, fmt.Errorf("error mutating pod for security client: %w", err)
 		}
 	}
 
-	for _, mutator := range profilingClientLibraryConfigMutators() {
+	for _, mutator := range w.profilingClientLibraryPodMutators {
 		if err := mutator.mutatePod(pod); err != nil {
 			return false, fmt.Errorf("error mutating pod for profiling client: %w", err)
 		}
@@ -222,32 +186,28 @@ func (w *Webhook) inject(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool,
 	return true, nil
 }
 
+func initContainerName(lang language) string {
+	return fmt.Sprintf("datadog-lib-%s-init", lang)
+}
+
 // The config for the security products has three states: <unset> | true | false.
 // This is because the products themselves have treat these cases differently:
 // * <unset> - product disactivated but can be activated remotely
 // * true - product activated, not overridable remotely
 // * false - product disactivated, not overridable remotely
-func securityClientLibraryConfigMutators() []podMutator {
-	boolVal := func(key string) string {
-		return strconv.FormatBool(pkgconfigsetup.Datadog().GetBool(key))
+func securityClientLibraryConfigMutators(config *webhookConfig) []podMutator {
+	var podMutators []podMutator
+	if config.asmEnabled != nil {
+		podMutators = append(podMutators, newConfigEnvVarFromBoolMutator("DD_APPSEC_ENABLED", config.asmEnabled))
 	}
-	return []podMutator{
-		configKeyEnvVarMutator{
-			envKey:    "DD_APPSEC_ENABLED",
-			configKey: "admission_controller.auto_instrumentation.asm.enabled",
-			getVal:    boolVal,
-		},
-		configKeyEnvVarMutator{
-			envKey:    "DD_IAST_ENABLED",
-			configKey: "admission_controller.auto_instrumentation.iast.enabled",
-			getVal:    boolVal,
-		},
-		configKeyEnvVarMutator{
-			envKey:    "DD_APPSEC_SCA_ENABLED",
-			configKey: "admission_controller.auto_instrumentation.asm_sca.enabled",
-			getVal:    boolVal,
-		},
+	if config.iastEnabled != nil {
+		podMutators = append(podMutators, newConfigEnvVarFromBoolMutator("DD_IAST_ENABLED", config.iastEnabled))
 	}
+	if config.asmScaEnabled != nil {
+		podMutators = append(podMutators, newConfigEnvVarFromBoolMutator("DD_APPSEC_SCA_ENABLED", config.asmScaEnabled))
+	}
+
+	return podMutators
 }
 
 // The config for profiling has four states: <unset> | "auto" | "true" | "false".
@@ -255,14 +215,13 @@ func securityClientLibraryConfigMutators() []podMutator {
 // * "true" - profiling activated unconditionally, not overridable remotely
 // * "false" - profiling deactivated, not overridable remotely
 // * "auto" - profiling activates per-process heuristically, not overridable remotely
-func profilingClientLibraryConfigMutators() []podMutator {
-	return []podMutator{
-		configKeyEnvVarMutator{
-			envKey:    "DD_PROFILING_ENABLED",
-			configKey: "admission_controller.auto_instrumentation.profiling.enabled",
-			getVal:    pkgconfigsetup.Datadog().GetString,
-		},
+func profilingClientLibraryConfigMutators(config *webhookConfig) []podMutator {
+	var podMutators []podMutator
+
+	if config.profilingEnabled != nil {
+		podMutators = append(podMutators, newConfigEnvVarFromStringlMutator("DD_PROFILING_ENABLED", config.profilingEnabled))
 	}
+	return podMutators
 }
 
 func injectApmTelemetryConfig(pod *corev1.Pod) {
@@ -283,29 +242,6 @@ func injectApmTelemetryConfig(pod *corev1.Pod) {
 		Value: os.Getenv(instrumentationInstallIDEnvVarName),
 	}
 	_ = mutatecommon.InjectEnv(pod, instrumentationInstallIDEnvVar)
-}
-
-// getPinnedLibraries returns tracing libraries to inject as configured by apm_config.instrumentation.lib_versions
-// given a registry.
-func getPinnedLibraries(registry string) []libInfo {
-	// If APM Instrumentation is enabled and configuration apm_config.instrumentation.lib_versions specified,
-	// inject only the libraries from the configuration
-	singleStepLibraryVersions := pkgconfigsetup.Datadog().
-		GetStringMapString("apm_config.instrumentation.lib_versions")
-
-	var res []libInfo
-	for lang, version := range singleStepLibraryVersions {
-		l := language(lang)
-		if !l.isSupported() {
-			log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)
-			continue
-		}
-
-		log.Infof("Library version %s is specified for language %s", version, lang)
-		res = append(res, l.libInfo("", l.libImageName(registry, version)))
-	}
-
-	return res
 }
 
 type libInfoLanguageDetection struct {
@@ -352,14 +288,14 @@ func (l *libInfoLanguageDetection) containerMutator(v version) containerMutator 
 // The languages information is available in workloadmeta-store
 // and attached on the pod's owner.
 func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) *libInfoLanguageDetection {
-	if !pkgconfigsetup.Datadog().GetBool("language_detection.enabled") ||
-		!pkgconfigsetup.Datadog().GetBool("language_detection.reporting.enabled") {
+	if !w.config.languageDetectionEnabled ||
+		!w.config.languageDetectionReportingEnabled {
 		return nil
 	}
 
 	return &libInfoLanguageDetection{
 		libs:             w.getAutoDetectedLibraries(pod),
-		injectionEnabled: pkgconfigsetup.Datadog().GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries"),
+		injectionEnabled: w.config.injectAutoDetectedLibraries,
 	}
 }
 
@@ -367,7 +303,7 @@ func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) *libInfoLanguag
 func (w *Webhook) getAllLatestLibraries() []libInfo {
 	var libsToInject []libInfo
 	for _, lang := range supportedLanguages {
-		libsToInject = append(libsToInject, lang.defaultLibInfo(w.containerRegistry, ""))
+		libsToInject = append(libsToInject, lang.defaultLibInfo(w.config.containerRegistry, ""))
 	}
 
 	return libsToInject
@@ -455,7 +391,7 @@ func (w *Webhook) initExtractedLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 		languageDetection *libInfoLanguageDetection
 	)
 
-	if w.isEnabledInNamespace(pod.Namespace) {
+	if w.config.injectionFilter.IsNamespaceEligible(pod.Namespace) {
 		source = libInfoSourceSingleStepInstrumentation
 		languageDetection = w.getLibrariesLanguageDetection(pod)
 	}
@@ -480,8 +416,8 @@ func (w *Webhook) extractLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 	// we prefer to use these and not override their behavior.
 	//
 	// N.B. this is empty if auto-instrumentation is disabled.
-	if len(w.pinnedLibraries) > 0 {
-		return extracted.withLibs(w.pinnedLibraries)
+	if len(w.config.pinnedLibraries) > 0 {
+		return extracted.withLibs(w.config.pinnedLibraries)
 	}
 
 	// if the language_detection injection is enabled
@@ -528,7 +464,7 @@ func (w *Webhook) getAutoDetectedLibraries(pod *corev1.Pod) []libInfo {
 	// Currently we only support deployments
 	switch ownerKind {
 	case "Deployment":
-		return getLibListFromDeploymentAnnotations(store, ownerName, pod.Namespace, w.containerRegistry)
+		return getLibListFromDeploymentAnnotations(store, ownerName, pod.Namespace, w.config.containerRegistry)
 	default:
 		log.Debugf("This ownerKind:%s is not yet supported by the process language auto-detection feature", ownerKind)
 		return nil
@@ -552,20 +488,20 @@ func (w *Webhook) extractLibrariesFromAnnotations(pod *corev1.Pod) []libInfo {
 
 	for _, l := range supportedLanguages {
 		extractLibInfo(l.customLibAnnotationExtractor())
-		extractLibInfo(l.libVersionAnnotationExtractor(w.containerRegistry))
+		extractLibInfo(l.libVersionAnnotationExtractor(w.config.containerRegistry))
 		for _, ctr := range pod.Spec.Containers {
 			extractLibInfo(l.ctrCustomLibAnnotationExtractor(ctr.Name))
-			extractLibInfo(l.ctrLibVersionAnnotationExtractor(ctr.Name, w.containerRegistry))
+			extractLibInfo(l.ctrLibVersionAnnotationExtractor(ctr.Name, w.config.containerRegistry))
 		}
 	}
 
 	return libList
 }
 
-func (w *Webhook) initContainerMutators(requirements corev1.ResourceRequirements) containerMutators {
+func (w *Webhook) newContainerMutators(requirements corev1.ResourceRequirements) containerMutators {
 	return containerMutators{
 		containerResourceRequirements{requirements},
-		containerSecurityContext{w.initSecurityContext},
+		containerSecurityContext{w.config.initSecurityContext},
 	}
 }
 
@@ -584,8 +520,8 @@ func (w *Webhook) newInjector(startTime time.Time, pod *corev1.Pod, opts ...inje
 		opts = append(opts, opt)
 	}
 
-	return newInjector(startTime, w.containerRegistry, w.injectorImageTag, opts...).
-		podMutator(w.version)
+	return newInjector(startTime, w.config.containerRegistry, w.config.injectorImageTag, opts...).
+		podMutator(w.config.version)
 }
 
 func initContainerIsSidecar(container *corev1.Container) bool {
@@ -685,22 +621,35 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 		Requests: corev1.ResourceList{},
 	}
 	podRequirements := podSumRessourceRequirements(pod)
-
+	var shouldSkipInjection bool
 	for _, k := range [2]corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		if q, ok := conf[k]; ok {
 			requirements.Limits[k] = q
 			requirements.Requests[k] = q
 		} else {
 			if maxPodLim, ok := podRequirements.Limits[k]; ok {
-				if (k == corev1.ResourceMemory && maxPodLim.AsApproximateFloat64() < minimumMemoryLimit) ||
-					(k == corev1.ResourceCPU && maxPodLim.AsApproximateFloat64() < minimumCPULimit) {
-					// If the pod before adding instrumentation init containers would have had a limits smaller than
-					// a certain amount, we just don't do anything, for two reasons:
-					// 1. The init containers need quite a lot of memory/CPU in order to not OOM or initialize in reasonnable time
-					// 2. The APM libraries themselves will increase footprint of the container by a
-					//   non trivial amount, and we don't want to cause issues for constrained apps
-					return corev1.ResourceRequirements{}, true
-
+				val, ok := maxPodLim.AsInt64()
+				if !ok {
+					log.Debugf("Unable do convert resource value to int64, raw value: %v", maxPodLim)
+				}
+				// If the pod before adding instrumentation init containers would have had a limits smaller than
+				// a certain amount, we just don't do anything, for two reasons:
+				// 1. The init containers need quite a lot of memory/CPU in order to not OOM or initialize in reasonnable time
+				// 2. The APM libraries themselves will increase footprint of the container by a
+				//   non trivial amount, and we don't want to cause issues for constrained apps
+				switch k {
+				case corev1.ResourceMemory:
+					if val < minimumMemoryLimit {
+						log.Debugf("The memory limit is too low to acceptable for the datadog library init-container: %v", val)
+						shouldSkipInjection = true
+					}
+				case corev1.ResourceCPU:
+					if val < minimumCPULimit {
+						log.Debugf("The cpu limit is too low to acceptable for the datadog library init-container: %v", val)
+						shouldSkipInjection = true
+					}
+				default:
+					// We don't support other resources
 				}
 				requirements.Limits[k] = maxPodLim
 			}
@@ -709,6 +658,9 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 			}
 		}
 	}
+	if shouldSkipInjection {
+		return corev1.ResourceRequirements{}, shouldSkipInjection
+	}
 	return requirements, false
 }
 
@@ -716,7 +668,7 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 	if len(config.libs) == 0 {
 		return nil
 	}
-	requirements, skipInjection := initContainerResourceRequirements(pod, w.initResourceRequirements)
+	requirements, skipInjection := initContainerResourceRequirements(pod, w.config.defaultResourceRequirements)
 	if skipInjection {
 		return nil
 	}
@@ -727,12 +679,12 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
-		initContainerMutators = w.initContainerMutators(requirements)
+		initContainerMutators = w.newContainerMutators(requirements)
 		injector              = w.newInjector(time.Now(), pod, injectorWithLibRequirementOptions(libRequirementOptions{
 			initContainerMutators: initContainerMutators,
 		}))
 		containerMutators = containerMutators{
-			config.languageDetection.containerMutator(w.version),
+			config.languageDetection.containerMutator(w.config.version),
 		}
 	)
 
@@ -750,7 +702,7 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
 		}()
 
-		if err := lib.podMutator(w.version, libRequirementOptions{
+		if err := lib.podMutator(w.config.version, libRequirementOptions{
 			containerMutators:     containerMutators,
 			initContainerMutators: initContainerMutators,
 			podMutators:           []podMutator{configInjector.podMutator(lib.lang), injector},
@@ -769,50 +721,11 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 		log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
 	}
 
-	if w.isEnabledInNamespace(pod.Namespace) {
+	if w.config.injectionFilter.IsNamespaceEligible(pod.Namespace) {
 		_ = basicLibConfigInjector{}.mutatePod(pod)
 	}
 
 	return lastError
-}
-
-type initResourceRequirementConfiguration map[corev1.ResourceName]resource.Quantity
-
-func getInitResourceConfiguration() (initResourceRequirementConfiguration, error) {
-	conf := initResourceRequirementConfiguration{}
-
-	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.cpu") {
-		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.cpu"))
-		if err != nil {
-			return conf, err
-		}
-		conf[corev1.ResourceCPU] = quantity
-	}
-
-	if pkgconfigsetup.Datadog().IsSet("admission_controller.auto_instrumentation.init_resources.memory") {
-		quantity, err := resource.ParseQuantity(pkgconfigsetup.Datadog().GetString("admission_controller.auto_instrumentation.init_resources.memory"))
-		if err != nil {
-			return conf, err
-		}
-		conf[corev1.ResourceMemory] = quantity
-	}
-
-	return conf, nil
-}
-
-func parseInitSecurityContext() (*corev1.SecurityContext, error) {
-	securityContext := corev1.SecurityContext{}
-	confKey := "admission_controller.auto_instrumentation.init_security_context"
-
-	if pkgconfigsetup.Datadog().IsSet(confKey) {
-		confValue := pkgconfigsetup.Datadog().GetString(confKey)
-		err := json.Unmarshal([]byte(confValue), &securityContext)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get init security context from configuration, %s=`%s`: %v", confKey, confValue, err)
-		}
-	}
-
-	return &securityContext, nil
 }
 
 // Returns the name of Kubernetes resource that owns the pod

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/DataDog/datadog-agent/comp/core"
-	configComp "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -208,11 +207,11 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				tt.config(c)
 			}
 
-			webhook := mustWebhook(t, wmeta)
-			require.Equal(t, instrumentationV2, webhook.version)
-			require.True(t, webhook.version.usesInjector())
+			webhook := mustWebhook(t, wmeta, c)
+			require.Equal(t, instrumentationV2, webhook.config.version)
+			require.True(t, webhook.config.version.usesInjector())
 
-			webhook.initSecurityContext = tt.expectedSecurityContext
+			webhook.config.initSecurityContext = tt.expectedSecurityContext
 
 			if tt.libInfo.source == libInfoSourceNone {
 				tt.libInfo.source = libInfoSourceSingleStepInstrumentation
@@ -562,7 +561,7 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 			c := configmock.New(t)
 			c.SetWithoutSource("apm_config.instrumentation.version", "v1")
 
-			webhook := mustWebhook(t, wmeta)
+			webhook := mustWebhook(t, wmeta, c)
 			err := webhook.injectAutoInstruConfig(tt.pod, extractedPodLibInfo{
 				libs:   tt.libsToInject,
 				source: libInfoSourceLibInjection,
@@ -971,8 +970,6 @@ func TestExtractLibInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Fix me: since comp-config and pkg-config don't work together,
-			// we have to set settings twice
 			overrides := map[string]interface{}{
 				"admission_controller.mutate_unlabelled":  true,
 				"admission_controller.container_registry": commonRegistry,
@@ -980,10 +977,13 @@ func TestExtractLibInfo(t *testing.T) {
 			if tt.containerRegistry != "" {
 				overrides["admission_controller.auto_instrumentation.container_registry"] = tt.containerRegistry
 			}
+			mockConfig = configmock.New(t)
+			for k, v := range overrides {
+				mockConfig.SetWithoutSource(k, v)
+			}
 
 			wmeta := fxutil.Test[workloadmeta.Component](t,
 				core.MockBundle(),
-				fx.Replace(configComp.MockParams{Overrides: overrides}),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 			)
 			mockConfig = configmock.New(t)
@@ -995,7 +995,7 @@ func TestExtractLibInfo(t *testing.T) {
 				tt.setupConfig()
 			}
 
-			webhook := mustWebhook(t, wmeta)
+			webhook := mustWebhook(t, wmeta, mockConfig)
 
 			if tt.expectedPodEligible != nil {
 				require.Equal(t, *tt.expectedPodEligible, webhook.isPodEligible(tt.pod))
@@ -1503,8 +1503,8 @@ func TestInjectLibInitContainer(t *testing.T) {
 			if tt.mem != "" {
 				conf.SetWithoutSource("admission_controller.auto_instrumentation.init_resources.memory", tt.mem)
 			}
-
-			wh, err := NewWebhook(wmeta, GetInjectionFilter())
+			filter, _ := NewInjectionFilter(conf)
+			wh, err := NewWebhook(wmeta, conf, filter)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("injectLibInitContainer() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1513,15 +1513,15 @@ func TestInjectLibInitContainer(t *testing.T) {
 			}
 
 			// N.B. this is a bit hacky but consistent.
-			wh.initSecurityContext = tt.secCtx
+			wh.config.initSecurityContext = tt.secCtx
 
-			c := tt.lang.libInfo("", tt.image).initContainers(wh.version)[0]
-			requirements, skipInjection := initContainerResourceRequirements(tt.pod, wh.initResourceRequirements)
+			c := tt.lang.libInfo("", tt.image).initContainers(wh.config.version)[0]
+			requirements, skipInjection := initContainerResourceRequirements(tt.pod, wh.config.defaultResourceRequirements)
 			require.Equal(t, tt.wantSkipInjection, skipInjection)
 			if tt.wantSkipInjection {
 				return
 			}
-			c.Mutators = wh.initContainerMutators(requirements)
+			c.Mutators = wh.newContainerMutators(requirements)
 			initalInitContainerCount := len(tt.pod.Spec.InitContainers)
 			err = c.mutatePod(tt.pod)
 			if (err != nil) != tt.wantErr {
@@ -3207,7 +3207,8 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 				}
 			}
 
-			webhook, errInitAPMInstrumentation := NewWebhook(wmeta, GetInjectionFilter())
+			filter, _ := NewInjectionFilter(mockConfig)
+			webhook, errInitAPMInstrumentation := NewWebhook(wmeta, mockConfig, filter)
 			if tt.wantWebhookInitErr {
 				require.Error(t, errInitAPMInstrumentation)
 				return
@@ -3249,7 +3250,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			for _, contEnv := range container.Env {
 				for _, expectEnv := range tt.expectedEnvs {
 					if expectEnv.Name == contEnv.Name {
-						require.Equal(t, expectEnv.Value, contEnv.Value)
+						require.Equalf(t, expectEnv.Value, contEnv.Value, "for envvar %s", expectEnv.Name)
 						envCount++
 						break
 					}
@@ -3463,14 +3464,15 @@ func TestShouldInject(t *testing.T) {
 			mockConfig = configmock.New(t)
 			tt.setupConfig()
 
-			webhook := mustWebhook(t, wmeta)
+			webhook := mustWebhook(t, wmeta, mockConfig)
 			require.Equal(t, tt.want, webhook.isPodEligible(tt.pod), "expected webhook.isPodEligible() to be %t", tt.want)
 		})
 	}
 }
 
-func mustWebhook(t *testing.T, wmeta workloadmeta.Component) *Webhook {
-	webhook, err := NewWebhook(wmeta, GetInjectionFilter())
+func mustWebhook(t *testing.T, wmeta workloadmeta.Component, ddConfig config.Component) *Webhook {
+	filter, _ := NewInjectionFilter(ddConfig)
+	webhook, err := NewWebhook(wmeta, ddConfig, filter)
 	require.NoError(t, err)
 	return webhook
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	minimumCPULimit    int64 = 50                // 0.05 core, otherwise copying + library initialization is going to take forever
+	minimumMemoryLimit int64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
+)
+
+// webhookConfig use to store options from the config.Component for the autoinstrumentation webhook
+type webhookConfig struct {
+	// isEnabled is the flag to enable the autoinstrumentation webhook
+	isEnabled bool
+	endpoint  string
+	version   version // autoinstrumentation logic version
+
+	// optional features
+	languageDetectionEnabled          bool
+	languageDetectionReportingEnabled bool
+	injectAutoDetectedLibraries       bool
+	// keep pointers to bool to differentiate between unset and false
+	// for backward compatibility with the previous implementation.
+	// TODO: remove the pointers when the backward compatibility is not needed anymore.
+	asmEnabled       *bool
+	iastEnabled      *bool
+	asmScaEnabled    *bool
+	profilingEnabled *string
+
+	// configuration for the libraries init-containers to inject.
+	containerRegistry           string
+	injectorImageTag            string
+	injectionFilter             mutatecommon.InjectionFilter
+	pinnedLibraries             []libInfo
+	initSecurityContext         *corev1.SecurityContext
+	defaultResourceRequirements initResourceRequirementConfiguration
+}
+
+type initResourceRequirementConfiguration map[corev1.ResourceName]resource.Quantity
+
+// retrieveConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config
+func retrieveConfig(datadogConfig config.Component, injectionFilter mutatecommon.InjectionFilter) (webhookConfig, error) {
+
+	webhookConfig := webhookConfig{
+		isEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
+		endpoint:  datadogConfig.GetString("admission_controller.auto_instrumentation.endpoint"),
+
+		languageDetectionEnabled:          datadogConfig.GetBool("language_detection.enabled"),
+		languageDetectionReportingEnabled: datadogConfig.GetBool("language_detection.reporting.enabled"),
+		injectAutoDetectedLibraries:       datadogConfig.GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries"),
+
+		asmEnabled:       getOptionalBoolValue(datadogConfig, "admission_controller.auto_instrumentation.asm.enabled"),
+		iastEnabled:      getOptionalBoolValue(datadogConfig, "admission_controller.auto_instrumentation.iast.enabled"),
+		asmScaEnabled:    getOptionalBoolValue(datadogConfig, "admission_controller.auto_instrumentation.asm_sca.enabled"),
+		profilingEnabled: getOptionalStringValue(datadogConfig, "admission_controller.auto_instrumentation.profiling.enabled"),
+
+		containerRegistry: mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry"),
+		injectorImageTag:  datadogConfig.GetString("apm_config.instrumentation.injector_image_tag"),
+		injectionFilter:   injectionFilter,
+	}
+	webhookConfig.pinnedLibraries = getPinnedLibraries(datadogConfig, webhookConfig.containerRegistry)
+
+	var err error
+	if webhookConfig.version, err = instrumentationVersion(datadogConfig.GetString("apm_config.instrumentation.version")); err != nil {
+		return webhookConfig, fmt.Errorf("invalid version for key apm_config.instrumentation.version: %w", err)
+	}
+
+	webhookConfig.initSecurityContext, err = parseInitSecurityContext(datadogConfig)
+	if err != nil {
+		return webhookConfig, fmt.Errorf("unable to parse init-container's SecurityContext from configuration: %w", err)
+	}
+
+	webhookConfig.defaultResourceRequirements, err = initDefaultResources(datadogConfig)
+	if err != nil {
+		return webhookConfig, fmt.Errorf("unable to parse init-container's resources from configuration: %w", err)
+	}
+
+	return webhookConfig, nil
+}
+
+// getOptionalBoolValue returns a pointer to a bool corresponding to the config value if the key is set in the config
+func getOptionalBoolValue(datadogConfig config.Component, key string) *bool {
+	var value *bool
+	if datadogConfig.IsSet(key) {
+		tmp := datadogConfig.GetBool(key)
+		value = &tmp
+	}
+
+	return value
+}
+
+// getOptionalBoolValue returns a pointer to a bool corresponding to the config value if the key is set in the config
+func getOptionalStringValue(datadogConfig config.Component, key string) *string {
+	var value *string
+	if datadogConfig.IsSet(key) {
+		tmp := datadogConfig.GetString(key)
+		value = &tmp
+	}
+
+	return value
+}
+
+// getPinnedLibraries returns tracing libraries to inject as configured by apm_config.instrumentation.lib_versions
+// given a registry.
+func getPinnedLibraries(datadogConfig config.Component, registry string) []libInfo {
+	// If APM Instrumentation is enabled and configuration apm_config.instrumentation.lib_versions specified,
+	// inject only the libraries from the configuration
+	singleStepLibraryVersions := datadogConfig.GetStringMapString("apm_config.instrumentation.lib_versions")
+
+	var res []libInfo
+	for lang, version := range singleStepLibraryVersions {
+		l := language(lang)
+		if !l.isSupported() {
+			log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)
+			continue
+		}
+
+		log.Infof("Library version %s is specified for language %s", version, lang)
+		res = append(res, l.libInfo("", l.libImageName(registry, version)))
+	}
+
+	return res
+}
+
+func initDefaultResources(datadogConfig config.Component) (initResourceRequirementConfiguration, error) {
+
+	var conf = initResourceRequirementConfiguration{}
+
+	if datadogConfig.IsSet("admission_controller.auto_instrumentation.init_resources.cpu") {
+		quantity, err := resource.ParseQuantity(datadogConfig.GetString("admission_controller.auto_instrumentation.init_resources.cpu"))
+		if err != nil {
+			return conf, err
+		}
+		conf[corev1.ResourceCPU] = quantity
+	} /* else {
+		conf[corev1.ResourceCPU] = *resource.NewMilliQuantity(minimumCPULimit, resource.DecimalSI)
+	}*/
+
+	if datadogConfig.IsSet("admission_controller.auto_instrumentation.init_resources.memory") {
+		quantity, err := resource.ParseQuantity(datadogConfig.GetString("admission_controller.auto_instrumentation.init_resources.memory"))
+		if err != nil {
+			return conf, err
+		}
+		conf[corev1.ResourceMemory] = quantity
+	} /*else {
+		conf[corev1.ResourceCPU] = *resource.NewMilliQuantity(minimumMemoryLimit, resource.DecimalSI)
+	}*/
+
+	return conf, nil
+}
+
+func parseInitSecurityContext(datadogConfig config.Component) (*corev1.SecurityContext, error) {
+	securityContext := corev1.SecurityContext{}
+	confKey := "admission_controller.auto_instrumentation.init_security_context"
+
+	if datadogConfig.IsSet(confKey) {
+		confValue := datadogConfig.GetString(confKey)
+		err := json.Unmarshal([]byte(confValue), &securityContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get init security context from configuration, %s=`%s`: %v", confKey, confValue, err)
+		}
+	}
+
+	return &securityContext, nil
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter_test.go
@@ -10,9 +10,10 @@ package autoinstrumentation
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	mockconfig "github.com/DataDog/datadog-agent/pkg/config/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFailingInjectionConfig(t *testing.T) {
@@ -87,10 +88,10 @@ func TestFailingInjectionConfig(t *testing.T) {
 			c.SetWithoutSource("apm_config.instrumentation.enabled_namespaces", tt.enabledNamespaces)
 			c.SetWithoutSource("apm_config.instrumentation.disabled_namespaces", tt.disabledNamespaces)
 
-			nsFilter := GetNamespaceInjectionFilter()
+			nsFilter, _ := NewInjectionFilter(c)
 			require.NotNil(t, nsFilter, "we should always get a filter")
 
-			_, err := NewWebhook(wmeta, common.InjectionFilter{NSFilter: nsFilter})
+			_, err := NewWebhook(wmeta, c, nsFilter)
 			if tt.expectedWebhookError {
 				require.Error(t, err)
 			} else {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
@@ -10,11 +10,12 @@ package autoinstrumentation
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestVolumeMount(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -19,8 +19,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -180,12 +180,12 @@ func containsVolumeMount(volumeMounts []corev1.VolumeMount, element corev1.Volum
 // ContainerRegistry gets the container registry config using the specified
 // config option, and falls back to the default container registry if no
 // webhook-specific container registry is set.
-func ContainerRegistry(specificConfigOpt string) string {
-	if pkgconfigsetup.Datadog().IsSet(specificConfigOpt) {
-		return pkgconfigsetup.Datadog().GetString(specificConfigOpt)
+func ContainerRegistry(datadogConfig config.Component, specificConfigOpt string) string {
+	if datadogConfig.IsSet(specificConfigOpt) {
+		return datadogConfig.GetString(specificConfigOpt)
 	}
 
-	return pkgconfigsetup.Datadog().GetString("admission_controller.container_registry")
+	return datadogConfig.GetString("admission_controller.container_registry")
 }
 
 // MarkVolumeAsSafeToEvictForAutoscaler adds the Kubernetes cluster-autoscaler

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -79,7 +79,8 @@ func TestInjectHostIP(t *testing.T) {
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -91,7 +92,8 @@ func TestInjectService(t *testing.T) {
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "service"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -121,7 +123,8 @@ func TestInjectEntityID(t *testing.T) {
 				fx.Replace(config.MockParams{Overrides: tt.configOverrides}),
 			)
 			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+			filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+			webhook := NewWebhook(wmeta, filter, datadogConfig)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -309,7 +312,8 @@ func TestInjectSocket(t *testing.T) {
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -337,7 +341,8 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 		}),
 	)
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -433,7 +438,8 @@ func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
 
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.True(t, injected)
 	assert.Nil(t, err)
@@ -473,7 +479,8 @@ func TestJSONPatchCorrectness(t *testing.T) {
 				fx.Replace(config.MockParams{Overrides: tt.overrides}),
 			)
 			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-			webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+			filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+			webhook := NewWebhook(wmeta, filter, datadogConfig)
 			request := admission.Request{
 				Raw:       podJSON,
 				Namespace: "bar",
@@ -504,7 +511,8 @@ func BenchmarkJSONPatch(b *testing.B) {
 
 	wmeta := fxutil.Test[workloadmeta.Component](b, core.MockBundle())
 	datadogConfig := fxutil.Test[config.Component](b, core.MockBundle())
-	webhook := NewWebhook(wmeta, autoinstrumentation.GetInjectionFilter(), datadogConfig)
+	filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+	webhook := NewWebhook(wmeta, filter, datadogConfig)
 	podJSON := obj.(*admiv1.AdmissionReview).Request.Object.Raw
 
 	b.ResetTimer()

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
@@ -293,7 +294,7 @@ type CWSInstrumentation struct {
 }
 
 // NewCWSInstrumentation parses the webhook config and returns a new instance of CWSInstrumentation
-func NewCWSInstrumentation(wmeta workloadmeta.Component) (*CWSInstrumentation, error) {
+func NewCWSInstrumentation(wmeta workloadmeta.Component, datadogConfig config.Component) (*CWSInstrumentation, error) {
 	ci := CWSInstrumentation{
 		wmeta: wmeta,
 	}
@@ -313,7 +314,7 @@ func NewCWSInstrumentation(wmeta workloadmeta.Component) (*CWSInstrumentation, e
 	cwsInjectorImageName := pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_name")
 	cwsInjectorImageTag := pkgconfigsetup.Datadog().GetString("admission_controller.cws_instrumentation.image_tag")
 
-	cwsInjectorContainerRegistry := mutatecommon.ContainerRegistry("admission_controller.cws_instrumentation.container_registry")
+	cwsInjectorContainerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.cws_instrumentation.container_registry")
 
 	if len(cwsInjectorImageName) == 0 {
 		return nil, fmt.Errorf("can't initialize CWS Instrumentation without an image_name")

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -489,7 +489,7 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 				initialCommand = strings.Join(tt.args.exec.Command, " ")
 			}
 
-			ci, err := NewCWSInstrumentation(wmeta)
+			ci, err := NewCWSInstrumentation(wmeta, mockConfig)
 			if err != nil {
 				require.Fail(t, "couldn't instantiate CWS Instrumentation", "%v", err)
 			} else {
@@ -846,7 +846,7 @@ func Test_injectCWSPodInstrumentation(t *testing.T) {
 			mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.remote_copy.mount_volume", tt.args.cwsInjectorMountVolumeForRemoteCopy)
 			mockConfig.SetWithoutSource("cluster_agent.service_account_name", tt.args.cwsInjectorServiceAccountName)
 
-			ci, err := NewCWSInstrumentation(wmeta)
+			ci, err := NewCWSInstrumentation(wmeta, mockConfig)
 			if err != nil {
 				require.Fail(t, "couldn't instantiate CWS Instrumentation", "%v", err)
 			} else {

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
@@ -175,7 +175,8 @@ func Test_injectTags(t *testing.T) {
 	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			webhook := NewWebhook(wmeta, datadogConfig, autoinstrumentation.GetInjectionFilter())
+			filter, _ := autoinstrumentation.NewInjectionFilter(datadogConfig)
+			webhook := NewWebhook(wmeta, datadogConfig, filter)
 			_, err := webhook.injectTags(tt.pod, "ns", nil)
 			assert.NoError(t, err)
 			assert.Len(t, tt.pod.Spec.Containers, 1)
@@ -275,8 +276,9 @@ func TestGetAndCacheOwner(t *testing.T) {
 	kubeObj := newUnstructuredWithSpec(map[string]interface{}{"foo": "bar"})
 	owner := newOwner(kubeObj)
 	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	webhook := NewWebhook(wmeta, datadogConfig, autoinstrumentation.GetInjectionFilter())
+	config := fxutil.Test[config.Component](t, core.MockBundle())
+	filter, _ := autoinstrumentation.NewInjectionFilter(config)
+	webhook := NewWebhook(wmeta, config, filter)
 
 	// Cache hit
 	cache.Cache.Set(ownerInfo.buildID(testNamespace), owner, webhook.ownerCacheTTL)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* remove config retrieval from the web hook hot execution path.
* centralise all config retrieval in one struct.

### Motivation

* improve APM SSI performance
* simplify code base
* continue component migration

### Describe how to test/QA your changes

* All unit-test and e2e tests should continue to work

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->