### PR TITLE
[Backport 7.58.x] [cloudproviders/azure] Revert using cloud-provided hostname as default in AKS

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -29,36 +29,6 @@ var (
 )
 
 const hostnameStyleSetting = "azure_hostname_style"
-const aksManagedOrchestratorTag = "aks-managed-orchestrator"
-const kubernetesTagValue = "Kubernetes"
-
-type metadata struct {
-	VMID              string
-	Name              string
-	ResourceGroupName string
-	SubscriptionID    string
-	TagsList          []map[string]string
-	OsProfile         struct {
-		ComputerName string
-	}
-}
-
-func (metadata metadata) GetFromStyle(style string) (string, error) {
-	switch style {
-	case "vmid":
-		return metadata.VMID, nil
-	case "name":
-		return metadata.Name, nil
-	case "name_and_resource_group":
-		return fmt.Sprintf("%s.%s", metadata.Name, metadata.ResourceGroupName), nil
-	case "full":
-		return fmt.Sprintf("%s.%s.%s", metadata.Name, metadata.ResourceGroupName, metadata.SubscriptionID), nil
-	case "os_computer_name":
-		return strings.ToLower(metadata.OsProfile.ComputerName), nil
-	default:
-		return "", fmt.Errorf("invalid azure_hostname_style value: %s", style)
-	}
-}
 
 // IsRunningOn returns true if the agent is running on Azure
 func IsRunningOn(ctx context.Context) bool {
@@ -75,7 +45,7 @@ var vmIDFetcher = cachedfetch.Fetcher{
 			metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text",
 			config.Datadog().GetInt("metadata_endpoints_max_hostname_size"))
 		if err != nil {
-			return nil, fmt.Errorf("Azure HostAliases: unable to query metadata VM ID endpoint: %s", err)
+			return nil, fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
 		}
 		return []string{res}, nil
 	},
@@ -83,21 +53,7 @@ var vmIDFetcher = cachedfetch.Fetcher{
 
 // GetHostAliases returns the VM ID from the Azure Metadata api
 func GetHostAliases(ctx context.Context) ([]string, error) {
-	aliases := []string{}
-	vm, err := vmIDFetcher.FetchStringSlice(ctx)
-	if err == nil {
-		aliases = append(aliases, vm...)
-	}
-
-	metadata, err := getMetadata(ctx)
-	if err != nil {
-		return aliases, fmt.Errorf("Azure GetHostAliases: unable to query metadata endpoint: %s", err)
-	}
-
-	if isKubernetesTag(metadata.TagsList) {
-		aliases = append(aliases, metadata.OsProfile.ComputerName)
-	}
-	return aliases, err
+	return vmIDFetcher.FetchStringSlice(ctx)
 }
 
 var resourceGroupNameFetcher = cachedfetch.Fetcher{
@@ -166,7 +122,7 @@ var instanceMetaFetcher = cachedfetch.Fetcher{
 	Name: "Azure Instance Metadata",
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		metadataJSON, err := getResponse(ctx,
-			metadataURL+"/metadata/instance/compute?api-version=2021-02-01")
+			metadataURL+"/metadata/instance/compute?api-version=2017-08-01")
 		if err != nil {
 			return "", fmt.Errorf("failed to get Azure instance metadata: %s", err)
 		}
@@ -174,49 +130,40 @@ var instanceMetaFetcher = cachedfetch.Fetcher{
 	},
 }
 
-func isKubernetesTag(tagsList []map[string]string) bool {
-	for _, tag := range tagsList {
-		if tag["name"] == aksManagedOrchestratorTag && strings.Contains(tag["value"], kubernetesTagValue) {
-			return true
-		}
-	}
-	return false
-}
-
-func getMetadata(ctx context.Context) (metadata, error) {
-	metadataInfo := metadata{}
-	metadataJSON, err := instanceMetaFetcher.FetchString(ctx)
-	if err != nil {
-		return metadataInfo, err
-	}
-
-	if err := json.Unmarshal([]byte(metadataJSON), &metadataInfo); err != nil {
-		return metadataInfo, fmt.Errorf("failed to parse Azure instance metadata: %s", err)
-	}
-	return metadataInfo, nil
-}
-
 func getHostnameWithConfig(ctx context.Context, config config.Config) (string, error) {
 	style := config.GetString(hostnameStyleSetting)
-	metadata, err := getMetadata(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	isKubernetes := isKubernetesTag(metadata.TagsList)
 
 	if style == "os" {
-		if isKubernetes {
-			// If running in AKS, use the node name as the hostname
-			style = "os_computer_name"
-		} else {
-			return "", fmt.Errorf("azure_hostname_style is set to 'os'")
-		}
+		return "", fmt.Errorf("azure_hostname_style is set to 'os'")
 	}
 
-	name, err := metadata.GetFromStyle(style)
+	metadataJSON, err := instanceMetaFetcher.FetchString(ctx)
 	if err != nil {
 		return "", err
+	}
+
+	var metadata struct {
+		VMID              string
+		Name              string
+		ResourceGroupName string
+		SubscriptionID    string
+	}
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		return "", fmt.Errorf("failed to parse Azure instance metadata: %s", err)
+	}
+
+	var name string
+	switch style {
+	case "vmid":
+		name = metadata.VMID
+	case "name":
+		name = metadata.Name
+	case "name_and_resource_group":
+		name = fmt.Sprintf("%s.%s", metadata.Name, metadata.ResourceGroupName)
+	case "full":
+		name = fmt.Sprintf("%s.%s.%s", metadata.Name, metadata.ResourceGroupName, metadata.SubscriptionID)
+	default:
+		return "", fmt.Errorf("invalid azure_hostname_style value: %s", style)
 	}
 
 	if err := validate.ValidHostname(name); err != nil {

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -23,43 +23,23 @@ import (
 
 func TestGetAlias(t *testing.T) {
 	ctx := context.Background()
-	expectedNodeName := "node-name-A"
-	expectedVM := "5d33a910-a7a0-4443-9f01-6a807801b29b"
-	responseIdx := 0
-	responses := []func(w http.ResponseWriter, r *http.Request){
-		func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "text/plain")
-			io.WriteString(w, expectedVM)
-		},
-		func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, fmt.Sprintf(`{
-				"name": "vm-name",
-				"resourceGroupName": "my-resource-group",
-				"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
-				"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
-				"osProfile": {"computerName":"%s"},
-				"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
-			}`, expectedNodeName))
-		},
-	}
+	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		responses[responseIdx](w, r)
-		responseIdx++
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
 		lastRequest = r
 	}))
-
 	defer ts.Close()
 	metadataURL = ts.URL
 
 	aliases, err := GetHostAliases(ctx)
 	assert.NoError(t, err)
-	require.Len(t, aliases, 2)
-	assert.Equal(t, expectedVM, aliases[0])
-	assert.Equal(t, expectedNodeName, aliases[1])
-	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute")
-	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2021-02-01")
+	require.Len(t, aliases, 1)
+	assert.Equal(t, expected, aliases[0])
+	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
+	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-04-02&format=text")
 }
 
 func TestGetClusterName(t *testing.T) {
@@ -112,27 +92,9 @@ func TestGetNTPHosts(t *testing.T) {
 	ctx := context.Background()
 	expectedHosts := []string{"time.windows.com"}
 
-	responseIdx := 0
-	responses := []func(w http.ResponseWriter, r *http.Request){
-		func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "text/plain")
-			io.WriteString(w, "test")
-		},
-		func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, fmt.Sprintf(`{
-				"name": "vm-name",
-				"resourceGroupName": "my-resource-group",
-				"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
-				"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
-				"osProfile": {"computerName":"%s"},
-				"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
-			}`, "node-name-a"))
-		},
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		responses[responseIdx](w, r)
-		responseIdx++
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, "test")
 	}))
 	defer ts.Close()
 
@@ -162,44 +124,6 @@ func TestGetHostname(t *testing.T) {
 		err          bool
 	}{
 		{"os", "", true},
-		{"vmid", "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d", false},
-		{"name", "vm-name", false},
-		{"name_and_resource_group", "vm-name.my-resource-group", false},
-		{"full", "vm-name.my-resource-group.2370ac56-5683-45f8-a2d4-d1054292facb", false},
-		{"invalid", "", true},
-	}
-
-	mockConfig := configmock.New(t)
-
-	for _, tt := range cases {
-		mockConfig.SetWithoutSource(hostnameStyleSetting, tt.style)
-		hostname, err := getHostnameWithConfig(ctx, mockConfig)
-		assert.Equal(t, tt.value, hostname)
-		assert.Equal(t, tt.err, (err != nil))
-	}
-}
-
-func TestGetHostnameKubernetesTag(t *testing.T) {
-	ctx := context.Background()
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{
-			"name": "vm-name",
-			"resourceGroupName": "my-resource-group",
-			"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
-			"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d",
-			"osProfile": {"computerName":"node-name-A"},
-			"tagsList": [{"name":"aks-managed-orchestrator","value":"Kubernetes"}]
-		}`)
-	}))
-	defer ts.Close()
-	metadataURL = ts.URL
-
-	cases := []struct {
-		style, value string
-		err          bool
-	}{
-		{"os", "node-name-a", false}, // use osProfile.computerName when running in AKS
 		{"vmid", "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d", false},
 		{"name", "vm-name", false},
 		{"name_and_resource_group", "vm-name.my-resource-group", false},

--- a/releasenotes/notes/revert-using-aks-provided-hostname-6b4e793809533b6f.yaml
+++ b/releasenotes/notes/revert-using-aks-provided-hostname-6b4e793809533b6f.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Use of cloud-provided hostname as default when running the Agent
+    in AKS introduced in `7.56.0` is reverted due to cases where the
+    hostname returned is non-unique. This feature will be fixed and
+    added again in a future release.


### PR DESCRIPTION
Backport 52edd70d042e66c596f03d2c4c3cc343c7d0459b from #30331.

___

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Revert change to use cloud-provided hostname as default for agents running in AKS. https://github.com/DataDog/datadog-agent/pull/26860

### Motivation

Hostname returned by Azure API is non-unique. Once we consider all scenarios/edge cases, the feature will be re-implemented in a future release.

### Describe how to test/QA your changes

Check that when `azure_hostname_style` is not set, the default hostname is `[node]-[cluster name]` and there is no hostname alias with just the `[node]` (i.e. behavior is the same as before `7.56.0`).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
Should the original release note be removed?
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->