### PR TITLE
fix(installer): Enforce CGO when building if --no-cgo isn't set

### DIFF
--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -66,6 +66,8 @@ def build(
 
     if no_cgo:
         env["CGO_ENABLED"] = "0"
+    else:
+        env["CGO_ENABLED"] = "1"
 
     cmd = f"go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
     cmd += f"-o {installer_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags} {strip_flags}\" {REPO_PATH}/cmd/installer"


### PR DESCRIPTION
### What does this PR do?
Don't rely on the machine cgo settings when building the installer through an invoke task

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->