### PR TITLE
Mark Go DI e2e tests as flaky

### DIFF
--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diconfig"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/rlimit"
@@ -31,6 +32,7 @@ import (
 )
 
 func TestGoDI(t *testing.T) {
+	flake.Mark(t)
 	if err := rlimit.RemoveMemlock(); err != nil {
 		require.NoError(t, rlimit.RemoveMemlock())
 	}


### PR DESCRIPTION
### What does this PR do?

This PR marks the Go DI e2e tests as flaky to prevent them from blocking other features.

### Motivation

Test runs fail sporadically, reported to us by other teams.

### Describe how to test/QA your changes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->