### PR TITLE
kmt: adds support for additional test args and env vars to be passed to the testsuite

### DIFF
--- a/test/new-e2e/system-probe/test-runner/files/cws_docker.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_docker.json
@@ -4,5 +4,9 @@
             "exclude": false
         }
     },
-    "testcontainer": "ghcr.io/datadog/apps-cws-centos7:main"
+    "testcontainer": "ghcr.io/datadog/apps-cws-centos7:main",
+    "additional_test_args": [
+        "--env",
+        "docker"
+    ]
 }

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -152,6 +152,7 @@ func buildCommandArgs(pkg string, xmlpath string, jsonpath string, testArgs []st
 	if testConfig.extraParams != "" {
 		args = append(args, strings.Split(testConfig.extraParams, " ")...)
 	}
+	args = append(args, testConfig.AdditionalTestArgs...)
 
 	packagesRunConfig := testConfig.PackagesRunConfig
 	if config, ok := packagesRunConfig[pkg]; ok && config.RunOnly != nil {
@@ -269,9 +270,9 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 		xmlpath := filepath.Join(xmlDir, fmt.Sprintf("%s.xml", junitfilePrefix))
 		jsonpath := filepath.Join(jsonDir, fmt.Sprintf("%s.json", junitfilePrefix))
 
-		testsuiteArgs := append([]string{testsuite}, testConfig.AdditionalTestArgs...)
+		testsuiteArgs := []string{testsuite}
 		if testContainer != nil {
-			testsuiteArgs = testContainer.buildDockerExecArgs(testsuiteArgs, envVars)
+			testsuiteArgs = testContainer.buildDockerExecArgs(testsuite, envVars)
 		}
 
 		args := buildCommandArgs(pkg, xmlpath, jsonpath, testsuiteArgs, testConfig)

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -52,8 +52,9 @@ type testConfig struct {
 }
 
 type userProvidedConfig struct {
-	PackagesRunConfig map[string]packageRunConfiguration `json:"filters"`
-	InContainerImage  string                             `json:"testcontainer"`
+	PackagesRunConfig  map[string]packageRunConfiguration `json:"filters"`
+	InContainerImage   string                             `json:"testcontainer"`
+	AdditionalTestArgs []string                           `json:"additional_test_args"`
 }
 
 const ciVisibility = "/ci-visibility"
@@ -248,9 +249,11 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 		xmlpath := filepath.Join(xmlDir, fmt.Sprintf("%s.xml", junitfilePrefix))
 		jsonpath := filepath.Join(jsonDir, fmt.Sprintf("%s.json", junitfilePrefix))
 
-		testsuiteArgs := []string{testsuite}
+		var testsuiteArgs []string
 		if testContainer != nil {
-			testsuiteArgs = testContainer.buildDockerExecArgs(testsuite, "--env", "docker")
+			testsuiteArgs = testContainer.buildDockerExecArgs(testsuite, testConfig.AdditionalTestArgs)
+		} else {
+			testsuiteArgs = append([]string{testsuite}, testConfig.AdditionalTestArgs...)
 		}
 
 		args := buildCommandArgs(pkg, xmlpath, jsonpath, testsuiteArgs, testConfig)

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -55,6 +55,7 @@ type userProvidedConfig struct {
 	PackagesRunConfig  map[string]packageRunConfiguration `json:"filters"`
 	InContainerImage   string                             `json:"testcontainer"`
 	AdditionalTestArgs []string                           `json:"additional_test_args"`
+	AdditionalEnvVars  []string                           `json:"additional_env_vars"`
 }
 
 const ciVisibility = "/ci-visibility"
@@ -210,6 +211,8 @@ func collectEnvVars(testConfig *testConfig, bpfDir string) []string {
 	if testConfig.extraEnv != "" {
 		env = append(env, strings.Split(testConfig.extraEnv, " ")...)
 	}
+
+	env = append(env, testConfig.AdditionalEnvVars...)
 
 	return env
 }

--- a/test/new-e2e/system-probe/test-runner/testcontainer.go
+++ b/test/new-e2e/system-probe/test-runner/testcontainer.go
@@ -89,12 +89,11 @@ func (ctc *testContainer) start() error {
 	return nil
 }
 
-func (ctc *testContainer) buildDockerExecArgs(args []string, envVars []string) []string {
-	dockerargs := []string{"docker", "exec"}
+func (ctc *testContainer) buildDockerExecArgs(testSuite string, envVars []string) []string {
+	args := []string{"docker", "exec"}
 	for _, envVar := range envVars {
-		dockerargs = append(dockerargs, "-e", envVar)
+		args = append(args, "-e", envVar)
 	}
-	dockerargs = append(dockerargs, containerName)
-	dockerargs = append(dockerargs, args...)
-	return dockerargs
+	args = append(args, containerName, testSuite)
+	return args
 }

--- a/test/new-e2e/system-probe/test-runner/testcontainer.go
+++ b/test/new-e2e/system-probe/test-runner/testcontainer.go
@@ -90,6 +90,6 @@ func (ctc *testContainer) start() error {
 	return nil
 }
 
-func (ctc *testContainer) buildDockerExecArgs(args ...string) []string {
+func (ctc *testContainer) buildDockerExecArgs(args []string) []string {
 	return append([]string{"docker", "exec", containerName}, args...)
 }

--- a/test/new-e2e/system-probe/test-runner/testcontainer.go
+++ b/test/new-e2e/system-probe/test-runner/testcontainer.go
@@ -95,6 +95,6 @@ func (ctc *testContainer) buildDockerExecArgs(args []string, envVars []string) [
 		dockerargs = append(dockerargs, "-e", envVar)
 	}
 	dockerargs = append(dockerargs, containerName)
-	dockerargs = append(dockerargs, dockerargs...)
+	dockerargs = append(dockerargs, args...)
 	return dockerargs
 }

--- a/test/new-e2e/system-probe/test-runner/testcontainer.go
+++ b/test/new-e2e/system-probe/test-runner/testcontainer.go
@@ -68,7 +68,6 @@ func (ctc *testContainer) start() error {
 		"HOST_PROC=/host/proc",
 		"HOST_ETC=/host/etc",
 		"HOST_SYS=/host/sys",
-		"DD_SYSTEM_PROBE_BPF_DIR=/opt/bpf",
 	}
 	for _, env := range envs {
 		args = append(args, "-e", env)
@@ -90,6 +89,12 @@ func (ctc *testContainer) start() error {
 	return nil
 }
 
-func (ctc *testContainer) buildDockerExecArgs(args []string) []string {
-	return append([]string{"docker", "exec", containerName}, args...)
+func (ctc *testContainer) buildDockerExecArgs(args []string, envVars []string) []string {
+	dockerargs := []string{"docker", "exec"}
+	for _, envVar := range envVars {
+		dockerargs = append(dockerargs, "-e", envVar)
+	}
+	dockerargs = append(dockerargs, containerName)
+	dockerargs = append(dockerargs, dockerargs...)
+	return dockerargs
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the missing pieces in the KMT test runner to migrate the remaining CWS functional tests off kitchen. This PR:
- adds support to pass arguments and env vars to the testsuite through the json config (already possible through the CLI interface)
- fixes an issue with env vars to being passed through `docker exec` when running in a test container

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->