### PR TITLE
[Backport 7.59] increase memory request for minimize BTF jobs

### DIFF
--- a/.gitlab/package_deps_build/package_deps_build.yml
+++ b/.gitlab/package_deps_build/package_deps_build.yml
@@ -32,8 +32,8 @@
     - tar -cJf $CI_PROJECT_DIR/minimized-btfs.tar.xz *
     - $S3_CP_CMD $CI_PROJECT_DIR/minimized-btfs.tar.xz $S3_PROJECT_ARTIFACTS_URI/btfs/$MIN_BTFS_FILENAME
   variables:
-    KUBERNETES_MEMORY_REQUEST: "32Gi"
-    KUBERNETES_MEMORY_LIMIT: "32Gi"
+    KUBERNETES_MEMORY_REQUEST: "64Gi"
+    KUBERNETES_MEMORY_LIMIT: "64Gi"
     KUBERNETES_CPU_REQUEST: 24
   artifacts:
     expire_in: 2 weeks


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increases memory limits in BTF jobs to avoid job failures, backport to 7.59 https://github.com/DataDog/datadog-agent/pull/30210

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->