### PR TITLE
[SBOM] Sanitize paths when using overlayfs direct scanning on docker

### DIFF
--- a/pkg/util/containers/image/image.go
+++ b/pkg/util/containers/image/image.go
@@ -8,6 +8,7 @@ package image
 
 import (
 	"errors"
+	"os"
 	"strings"
 )
 
@@ -59,4 +60,18 @@ func SplitImageName(image string) (string, string, string, string, error) {
 		registry = long[:firstSlash]
 	}
 	return long, registry, short, tag, nil
+}
+
+// SanitizeHostPath changes the specified path by prepending the mount point of the host's filesystem
+func SanitizeHostPath(path string) string {
+	hostPath := os.Getenv("HOST_ROOT")
+	if hostPath == "" {
+		hostPath = "/host"
+	}
+
+	if index := strings.Index(path, "/var/lib"); index != -1 {
+		return hostPath + path[index:]
+	}
+
+	return hostPath + path
 }

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	containersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
@@ -280,7 +281,7 @@ func (c *Collector) ScanDockerImageFromGraphDriver(ctx context.Context, imgMeta 
 
 		if env.IsContainerized() {
 			for i, layer := range layers {
-				layers[i] = sanitizeHostPath(layer)
+				layers[i] = containersimage.SanitizeHostPath(layer)
 			}
 		}
 
@@ -500,17 +501,4 @@ func extractLayersFromOverlayFSMounts(mounts []mount.Mount) []string {
 		}
 	}
 	return layers
-}
-
-func sanitizeHostPath(path string) string {
-	hostPath := os.Getenv("HOST_ROOT")
-	if hostPath == "" {
-		hostPath = "/host"
-	}
-
-	if index := strings.Index(path, "/var/lib"); index != -1 {
-		return hostPath + path[index:]
-	}
-
-	return hostPath + path
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Sanitifize overlayfs paths when using overlayfs direct scanning on docker.

### Motivation

When using Docker and overlayfs direct scanning (sbom.container_image.overlayfs_direct_scan),
dirs for the overlay were not prefix with the host root bind mount.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->