### PR TITLE
[CWS] migrate fentry, activity dump and ebpfless jobs to KMT

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -32,7 +32,7 @@ kmt_setup_env_secagent_arm64:
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
     TEST_COMPONENT: security-agent
-    TEST_SETS: cws_host,cws_docker
+    TEST_SETS: cws_host,cws_docker,cws_ad,cws_el,cws_el_ns,cws_fentry
 
 kmt_setup_env_secagent_x64:
   extends:
@@ -281,6 +281,66 @@ kmt_run_secagent_tests_arm64:
           - "rocky_9.3"
           - "opensuse_15.5"
         TEST_SET: [cws_host]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_arm64_ad:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs:
+    - kmt_setup_env_secagent_arm64
+    - upload_dependencies_secagent_arm64
+    - upload_secagent_tests_arm64
+  variables:
+    ARCH: "arm64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+        TEST_SET: [cws_ad]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_arm64_ebpfless:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs:
+    - kmt_setup_env_secagent_arm64
+    - upload_dependencies_secagent_arm64
+    - upload_secagent_tests_arm64
+  variables:
+    ARCH: "arm64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+        TEST_SET: [cws_el,cws_el_ns]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_arm64_fentry:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs:
+    - kmt_setup_env_secagent_arm64
+    - upload_dependencies_secagent_arm64
+    - upload_secagent_tests_arm64
+  variables:
+    ARCH: "arm64"
+  parallel:
+    matrix:
+      - TAG:
+          - "amazon_2023"
+        TEST_SET: [cws_fentry]
   after_script:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -45,7 +45,7 @@ kmt_setup_env_secagent_x64:
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
     TEST_COMPONENT: security-agent
-    TEST_SETS: cws_host,cws_docker
+    TEST_SETS: cws_host,cws_docker,cws_ad,cws_el,cws_el_ns,cws_fentry
 
 .upload_secagent_tests:
   stage: kernel_matrix_testing_prepare
@@ -153,6 +153,66 @@ kmt_run_secagent_tests_x64:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]
 
+kmt_run_secagent_tests_x64_ad:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs:
+    - kmt_setup_env_secagent_x64
+    - upload_dependencies_secagent_x64
+    - upload_secagent_tests_x64
+  variables:
+    ARCH: "x86_64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+        TEST_SET: [cws_ad]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_x64_ebpfless:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs:
+    - kmt_setup_env_secagent_x64
+    - upload_dependencies_secagent_x64
+    - upload_secagent_tests_x64
+  variables:
+    ARCH: "x86_64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+        TEST_SET: [cws_el,cws_el_ns]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
+kmt_run_secagent_tests_x64_fentry:
+  extends:
+    - .kmt_run_secagent_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs:
+    - kmt_setup_env_secagent_x64
+    - upload_dependencies_secagent_x64
+    - upload_secagent_tests_x64
+  variables:
+    ARCH: "x86_64"
+  parallel:
+    matrix:
+      - TAG:
+          - "amazon_2023"
+        TEST_SET: [cws_fentry]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
 kmt_run_secagent_tests_x64_docker:
   extends:
     - .kmt_run_secagent_tests
@@ -220,7 +280,7 @@ kmt_run_secagent_tests_arm64:
           - "rocky_8.5"
           - "rocky_9.3"
           - "opensuse_15.5"
-        TEST_SET: ["cws_host"]
+        TEST_SET: [cws_host]
   after_script:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]

--- a/test/new-e2e/system-probe/test-runner/files/cws_ad.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_ad.json
@@ -1,0 +1,14 @@
+{
+	"filters": {
+		"*": {
+			"exclude": false,
+			"run-only": [
+				"TestActivityDump",
+				"TestSecurityProfile"
+			]
+		}
+	},
+	"additional_env_vars": [
+		"DEDICATED_ACTIVITY_DUMP_NODE=1"
+	]
+}

--- a/test/new-e2e/system-probe/test-runner/files/cws_ad.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_ad.json
@@ -1,6 +1,6 @@
 {
 	"filters": {
-		"*": {
+		"pkg/security": {
 			"exclude": false,
 			"run-only": [
 				"TestActivityDump",

--- a/test/new-e2e/system-probe/test-runner/files/cws_el.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_el.json
@@ -1,0 +1,10 @@
+{
+    "filters": {
+        "*": {
+            "exclude": false
+        }
+    },
+    "additional_test_args": [
+        "-trace"
+    ]
+}

--- a/test/new-e2e/system-probe/test-runner/files/cws_el_ns.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_el_ns.json
@@ -1,0 +1,11 @@
+{
+    "filters": {
+        "*": {
+            "exclude": false
+        }
+    },
+    "additional_test_args": [
+        "-trace",
+        "-disable-seccomp"
+    ]
+}

--- a/test/new-e2e/system-probe/test-runner/files/cws_fentry.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_fentry.json
@@ -1,0 +1,10 @@
+{
+	"filters": {
+		"*": {
+			"exclude": false
+		}
+	},
+	"additional_env_vars": [
+		"DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY=true"
+	]
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR migrates the remaining CWS kitchen tests to KMT. The distributions were chosen to match the ones used in kitchen, the only functional change is the disabling of `docker-fentry` (i.e. fentry version of the probe running on docker) because it doesn't bring a lot of value. The main risk of fentry is that probes won't load and this is already tested by the host version.

The removal of old kitchen tests will come in a follow-up PR.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->