### PR TITLE
continue on enrichEvent error

### DIFF
--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -257,7 +257,7 @@ func (t *Tailer) handleEvent(eventRecordHandle evtapi.EventRecordHandle) {
 	err = t.enrichEvent(m, eventRecordHandle)
 	if err != nil {
 		log.Warnf("%v", err)
-		return
+		// continue to submit the event even if we failed to enrich it
 	}
 
 	err = t.bookmark.Update(eventRecordHandle)

--- a/releasenotes/notes/eventlog-tailer-enrichevent-error-308d6c9730684067.yaml
+++ b/releasenotes/notes/eventlog-tailer-enrichevent-error-308d6c9730684067.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue added in 7.50 that causes the Windows event log tailer to drop
+    events if it cannot open their publisher metadata.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Restore pre-7.50 windows event log tailer behavior that continues to submit events when the publisher metadata cannot be opened.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is also the behavior in the event log check
https://github.com/DataDog/datadog-agent/blob/5a7faf8f4ed206f4a88120a32c2cc09d65b3c44e/comp/checks/windowseventlog/windowseventlogimpl/check/message_filter.go#L68-L72
https://github.com/DataDog/datadog-agent/blob/5a7faf8f4ed206f4a88120a32c2cc09d65b3c44e/comp/checks/windowseventlog/windowseventlogimpl/check/ddlog_submitter.go#L77-L81