### PR TITLE
Populate env in span Meta in ReceiveResourceSpansV2

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -208,7 +208,6 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 	otelres := rspans.Resource()
 	resourceAttributes := otelres.Attributes()
 
-	topLevelByKind := o.conf.HasFeature("enable_otlp_compute_top_level_by_span_kind")
 	tracesByID := make(map[uint64]pb.Trace)
 	priorityByID := make(map[uint64]sampler.SamplingPriority)
 	var spancount int64
@@ -225,7 +224,7 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 			if tracesByID[traceID] == nil {
 				tracesByID[traceID] = pb.Trace{}
 			}
-			ddspan := transform.OtelSpanToDDSpan(otelspan, otelres, libspans.Scope(), topLevelByKind, o.conf, nil)
+			ddspan := transform.OtelSpanToDDSpan(otelspan, otelres, libspans.Scope(), o.conf, nil)
 
 			if p, ok := ddspan.Metrics["_sampling_priority_v1"]; ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1733,7 +1733,16 @@ func testOTLPConvertSpan(enableReceiveResourceSpansV2 bool, t *testing.T) {
 			lib.SetVersion(tt.libver)
 			assert := assert.New(t)
 			want := tt.out
-			got := o.convertSpan(tt.rattr, lib, tt.in)
+			res := pcommon.NewResource()
+			for k, v := range tt.rattr {
+				res.Attributes().PutStr(k, v)
+			}
+			var got *pb.Span
+			if enableReceiveResourceSpansV2 {
+				got = transform.OtelSpanToDDSpan(tt.in, res, lib, o.conf, nil)
+			} else {
+				got = o.convertSpan(tt.rattr, lib, tt.in)
+			}
 			if len(want.Meta) != len(got.Meta) {
 				t.Fatalf("(%d) Meta count mismatch:\n%#v", i, got.Meta)
 			}
@@ -1779,7 +1788,11 @@ func testOTLPConvertSpan(enableReceiveResourceSpansV2 bool, t *testing.T) {
 
 			// test new top-level identification feature flag
 			o.conf.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
-			got = o.convertSpan(tt.rattr, lib, tt.in)
+			if enableReceiveResourceSpansV2 {
+				got = transform.OtelSpanToDDSpan(tt.in, res, lib, o.conf, nil)
+			} else {
+				got = o.convertSpan(tt.rattr, lib, tt.in)
+			}
 			wantMetrics := tt.topLevelOutMetrics
 			if len(wantMetrics) != len(got.Metrics) {
 				t.Fatalf("(%d) Metrics count mismatch:\n\n%v\n\n%v", i, wantMetrics, got.Metrics)
@@ -2156,7 +2169,17 @@ func testOTLPConvertSpanSetPeerService(enableReceiveResourceSpansV2 bool, t *tes
 			lib.SetName(tt.libname)
 			lib.SetVersion(tt.libver)
 			assert := assert.New(t)
-			assert.Equal(tt.out, o.convertSpan(tt.rattr, lib, tt.in), i)
+			res := pcommon.NewResource()
+			for k, v := range tt.rattr {
+				res.Attributes().PutStr(k, v)
+			}
+			var got *pb.Span
+			if enableReceiveResourceSpansV2 {
+				got = transform.OtelSpanToDDSpan(tt.in, res, lib, o.conf, nil)
+			} else {
+				got = o.convertSpan(tt.rattr, lib, tt.in)
+			}
+			assert.Equal(tt.out, got, i)
 		})
 	}
 }

--- a/pkg/trace/traceutil/otel_util.go
+++ b/pkg/trace/traceutil/otel_util.go
@@ -106,6 +106,7 @@ func GetOTelAttrVal(attrs pcommon.Map, normalize bool, keys ...string) string {
 		attrval, exists := attrs.Get(key)
 		if exists {
 			val = attrval.AsString()
+			break
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In refactored OTLPReceiver in trace agent, the env attribute was only being populated in the output at trace level. In this PR, populate it at span level as well. Also, modify tests to ensure this code path is tested, and fix minor bugs that came up during this testing.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->