### PR TITLE
init commit debug utils

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -19,6 +19,7 @@ from tasks import (
     coverage,
     cws_instrumentation,
     debug,
+    debugging,
     devcontainer,
     diff,
     docker_tasks,
@@ -162,6 +163,7 @@ ns.add_collection(cluster_agent)
 ns.add_collection(cluster_agent_cloudfoundry)
 ns.add_collection(components)
 ns.add_collection(coverage)
+ns.add_collection(debugging)
 ns.add_collection(docs)
 ns.add_collection(bench)
 ns.add_collection(trace_agent)

--- a/tasks/debugging/__init__.py
+++ b/tasks/debugging/__init__.py
@@ -1,4 +1,4 @@
-from invoke import Collection
+from invoke.collection import Collection
 
 from . import dump
 

--- a/tasks/debugging/__init__.py
+++ b/tasks/debugging/__init__.py
@@ -1,6 +1,3 @@
-from invoke.collection import Collection
-
-from . import dump
-
-ns = Collection()
-ns.add_collection(dump)
+from tasks.debugging.dump import debug_job_dump  # noqa
+from tasks.debugging.dump import get_debug_symbols  # noqa
+from tasks.debugging.dump import get_job_dump  # noqa

--- a/tasks/debugging/__init__.py
+++ b/tasks/debugging/__init__.py
@@ -1,0 +1,6 @@
+from invoke import Collection
+
+from . import dump
+
+ns = Collection()
+ns.add_collection(dump)

--- a/tasks/debugging/delve.py
+++ b/tasks/debugging/delve.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from pathlib import Path
+
+
+class Delve:
+    dlv_cmd: Path | str
+
+    def __init__(self):
+        if sys.platform == 'win32':
+            self.dlv_cmd = 'dlv.exe'
+        else:
+            self.dlv_cmd = 'dlv'
+
+    def __interactive_cmd(self, cmd):
+        os.system(f'{self.dlv_cmd} {cmd}')
+
+    def core(self, binary: Path | str, core: Path | str):
+        return self.__interactive_cmd(f'core "{binary}" "{core}"')

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -183,18 +183,6 @@ def get_debug_symbols_for_version(version: str, output_dir=None) -> None:
         extract_agent_symbols(zip_path, output_dir)
 
 
-def get_debug_symbols_for_job_pipeline(job_id: str, output_dir=None) -> None:
-    package_job_id = get_package_job_id(job_id)
-    print(f"Downloading debug symbols from package job {package_job_id}")
-    # TODO: gitlab API doesn't let us download just one artifact
-    #       so we have to get them all, and they are big :(
-    #       we could start uploading the .debug.zip to mstesting bucket
-    package_out = Path(output_dir, f'{package_job_id}-artifacts')
-    download_job_artifacts(package_job_id, package_out)
-    debug_zip = find_debug_zip(package_out)
-    extract_agent_symbols(debug_zip, output_dir)
-
-
 def extract_agent_symbols(zip_path: str, output_dir: str) -> None:
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for info in zip_ref.infolist():

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -99,6 +99,7 @@ class CrashAnalyzerCli:
 
 
 def get_crash_analyzer(platform=None, arch=None):
+    # TODO: configuration file would be nice
     env = Path.home() / '.agent-crash-analyzer'
     ca = CrashAnalyzer(env=env, platform=platform, arch=arch)
     print(f"Using environment: {ca.env}")
@@ -245,6 +246,7 @@ def get_symbols_for_job_id(ca: CrashAnalyzer, job_id: str) -> tuple[str | None, 
         if syms:
             return artifact.version, syms
     # Need to get the symbols from the package build job in the pipeline
+    # TODO: Linux platforms could get symbols from the testing repos
     package_job_id = get_package_job_id(ca.active_project, job_id, ca.target_platform, ca.target_arch)
     if not package_job_id:
         raise Exception(f"Could not find package job for job {job_id}")
@@ -465,6 +467,7 @@ def get_package_job_id(project: Project, job_id: str, platform: str, arch: str) 
     else:
         raise NotImplementedError(f"Unsupported platform {platform}")
 
+    # TODO: there may be a name lookup option soon https://gitlab.com/gitlab-org/gitlab/-/issues/22027
     job = project.jobs.get(job_id)
     pipeline_id = str(job.pipeline["id"])
     pipeline = project.pipelines.get(pipeline_id)

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -1,7 +1,7 @@
 import glob
 import os
-import platform
 import shutil
+import sys
 import tempfile
 import zipfile
 from pathlib import Path, PurePath
@@ -79,7 +79,7 @@ class CrashAnalyzerCli:
 def get_crash_analyzer():
     env = Path.home() / '.agent-crash-analyzer'
     ca = CrashAnalyzer(env=env)
-    if platform.platform() == 'Windows':
+    if sys.platform == 'win32':
         ca.target_platform = 'windows'
         ca.target_arch = 'x86_64'
     else:

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -135,13 +135,13 @@ def add_gitlab_job_artifacts_to_artifact_store(
 ) -> Artifacts:
     with tempfile.TemporaryDirectory() as temp_dir:
         download_job_artifacts(project, job_id, temp_dir)
-        project_id = "datadog-agent"  # TODO: get from project
+        project_id = project.name
         job_id = str(job_id)
         return artifact_store.add(project_id, job_id, temp_dir)
 
 
 def get_symbols_for_job_id(cli: CrashAnalyzerCLI, job_id: str) -> Path:
-    project_id = "datadog-agent"  # TODO: get from project
+    project_id = cli.active_project.name
     # check if we already have the symbols for this job
     artifact = cli.artifact_store.get(project_id, job_id)
     if artifact and artifact.version:
@@ -169,7 +169,7 @@ def get_symbols_for_job_id(cli: CrashAnalyzerCLI, job_id: str) -> Path:
 
 
 def get_or_fetch_artifacts(artifact_store: ArtifactStore, project: Project, job_id: str) -> Artifacts:
-    project_id = "datadog-agent"  # TODO: get from project
+    project_id = project.name
     artifacts = artifact_store.get(project_id, job_id)
     if not artifacts:
         artifacts = add_gitlab_job_artifacts_to_artifact_store(artifact_store, project, job_id)

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -1,0 +1,177 @@
+import glob
+import os
+import tempfile
+import zipfile
+from pathlib import Path, PurePath
+
+from invoke import task
+
+from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
+from tasks.libs.common.utils import download_to_tempfile
+
+
+@task(
+    help={
+        "job_id": "The job ID to download the dump from",
+        "output_dir": "The directory to save the dump to",
+    },
+)
+def debug_job_dump(ctx, job_id=None, output_dir=None):
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp()
+
+    if job_id:
+        get_job_dump(ctx, job_id, with_symbols=True, output_dir=output_dir)
+    else:
+        print("Dump files:")
+        for dmp_file in find_dmp_files(output_dir):
+            print('\t', Path(dmp_file).resolve())
+        print("Symbols:")
+        for symbol_file in find_symbol_files(output_dir):
+            print('\t', Path(symbol_file).resolve())
+
+    # prompt user to select a dump file
+    dump_file = input("Select a dump file to analyze: ")
+    symbol_file = input("Select a symbol file to use: ")
+
+    # launch windbg and delve
+    windbg_cmd = f'cmd.exe /c start "" "{dump_file}"'
+    print(f"Running command: {windbg_cmd}")
+    dlv_cmd = f'dlv.exe core "{symbol_file}" "{dump_file}"'
+    print(f"Running command: {dlv_cmd}")
+    os.system(windbg_cmd)
+    os.system(dlv_cmd)
+
+
+@task(
+    help={
+        "job_id": "The job ID to download the dump from",
+        "with_symbols": "Whether to download debug symbols",
+        "output_dir": "The directory to save the dump to",
+    },
+)
+def get_job_dump(ctx, job_id, with_symbols=False, output_dir=None):
+    """
+    Download a dump from a job and save it to the output directory.
+    """
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp()
+
+    artifacts_dir = Path(output_dir, 'artifacts')
+
+    download_job_artifacts(job_id, artifacts_dir)
+    dmp_files = find_dmp_files(artifacts_dir)
+    if not dmp_files:
+        print("No dump files found")
+        return
+    print("Dump files:")
+    for dmp_file in dmp_files:
+        print('\t', dmp_file)
+
+    if with_symbols:
+        get_debug_symbols(ctx, job_id=job_id, output_dir=output_dir)
+        print("Symbols:")
+        for symbol_file in find_symbol_files(output_dir):
+            print('\t', Path(symbol_file).resolve())
+
+
+@task
+def get_debug_symbols(ctx, job_id=None, version=None, output_dir=None):
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp()
+
+    symbol_out = Path(output_dir, 'symbols')
+
+    if version:
+        get_debug_symbols_for_version(version, symbol_out)
+    elif job_id:
+        get_debug_symbols_for_job_pipeline(job_id, symbol_out)
+
+    print(f"Downloaded debug symbols to {symbol_out}")
+
+
+def get_debug_symbols_for_version(version: str, output_dir=None) -> None:
+    url = get_debug_symbol_url_for_version(version)
+    print(f"Downloading symbols for {version} from {url}")
+    with download_to_tempfile(url) as zip_path:
+        extract_agent_symbols(zip_path, output_dir)
+
+
+def get_debug_symbols_for_job_pipeline(job_id: str, output_dir=None) -> None:
+    package_job_id = get_package_job_id(job_id)
+    print(f"Downloading debug symbols from package job {package_job_id}")
+    # TODO: gitlab API doesn't let us download just one artifact
+    #       so we have to get them all, and they are big :(
+    #       we could start uploading the .debug.zip to mstesting bucket
+    package_out = Path(output_dir, f'{package_job_id}-artifacts')
+    download_job_artifacts(package_job_id, package_out)
+    debug_zip = find_debug_zip(package_out)
+    extract_agent_symbols(debug_zip, output_dir)
+
+
+def extract_agent_symbols(zip_path: str, output_dir: str) -> None:
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        for info in zip_ref.infolist():
+            if info.filename.endswith('.exe.debug'):
+                info.filename = PurePath(info.filename).name
+                zip_ref.extract(info, output_dir)
+
+
+def get_debug_symbol_url_for_version(version: str) -> str:
+    if 'rc' in version:
+        base = 'https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-'
+    else:
+        base = 'https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-'
+    url = f'{base}{version}.debug.zip'
+    return url
+
+
+def download_job_artifacts(job_id: str, output_dir: str) -> None:
+    """
+    Download the artifacts for a job to the output directory.
+    """
+    gitlab = get_gitlab_repo()
+    job = gitlab.jobs.get(job_id)
+    print(f"Downloading artifacts for job {job.name} to {output_dir}")
+    fd, tmp_path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, "wb") as f:
+            # fd will be closed by context manager, so we no longer need it
+            fd = None
+            job.artifacts(streamed=True, action=f.write)
+        with zipfile.ZipFile(tmp_path, "r") as zip_ref:
+            zip_ref.extractall(output_dir)
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def find_dmp_files(output_dir: str) -> list[str]:
+    return list(glob.glob(f"{output_dir}/**/*.dmp", recursive=True))
+
+
+def find_debug_zip(output_dir: str) -> str:
+    return glob.glob(f"{output_dir}/**/*.debug.zip", recursive=True)[0]
+
+
+def find_symbol_files(output_dir: str) -> list[str]:
+    return list(glob.glob(f"{output_dir}/**/*.exe.debug", recursive=True))
+
+
+def get_package_job_id(job_id: str, package_job_name=None) -> str | None:
+    """
+    Get the package job ID for the pipeline of the given job.
+    """
+    if package_job_name is None:
+        package_job_name = "windows_msi_and_bosh_zip_x64-a7"
+
+    gitlab = get_gitlab_repo()
+    job = gitlab.jobs.get(job_id)
+    pipeline_id = job.pipeline["id"]
+    pipeline = gitlab.pipelines.get(pipeline_id)
+    jobs = pipeline.jobs.list(iterator=True)
+    for job in jobs:
+        if job.name == package_job_name:
+            return job.id

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -113,7 +113,7 @@ def debug_job_dump(ctx, job_id):
     if not syms:
         print("No symbols found")
         return
-    syms = find_symbol_files(syms)
+    syms = find_symbol_files_for_platform(ca.target_platform, syms)
     if not syms:
         print("No symbols found")
         return
@@ -156,7 +156,7 @@ def get_job_dump(ctx, job_id, with_symbols=False):
             print("No symbols found")
             return
         print("Symbols:")
-        for symbol_file in find_symbol_files(syms):
+        for symbol_file in find_symbol_files_for_platform(ca.target_platform, syms):
             print('\t', Path(symbol_file).resolve())
 
 
@@ -193,29 +193,38 @@ def get_symbols_for_job_id(ca: CrashAnalyzer, job_id: str) -> Path | None:
     project_id = ca.active_project.name
     # check if we already have the symbols for this job
     artifact = ca.artifact_store.get(project_id, job_id)
+    syms = None
     if artifact and artifact.version:
-        version = artifact.version
-        syms = ca.symbol_store.get(version, ca.target_platform, ca.target_arch)
-    else:
-        # Need to get the symbols from the package build job in the pipeline
-        package_job_id = get_package_job_id(ca.active_project, job_id)
-        if not package_job_id:
-            raise Exception(f"Could not find package job for job {job_id}")
-        package_artifacts = get_or_fetch_artifacts(ca.artifact_store, ca.active_project, package_job_id)
-        for path in find_debug_zip(package_artifacts.get()):
-            debug_zip = Path(path)
-            version = debug_zip.name.removesuffix('.debug.zip')
-            # add a version ref so we can look it up faster next time
-            package_artifacts.version = version
-            if not artifact:
-                artifact = ca.artifact_store.add(project_id, job_id)
-            artifact.version = version
-            # add the symbols to the symbol store
-            syms = ca.symbol_store.get(version, ca.target_platform, ca.target_arch)
-            if not syms:
-                with tempfile.TemporaryDirectory() as tmp_dir:
-                    _windows_extract_agent_symbols(debug_zip, tmp_dir)
-                    syms = ca.symbol_store.add(version, ca.target_platform, ca.target_arch, tmp_dir)
+        syms = ca.symbol_store.get(artifact.version, ca.target_platform, ca.target_arch)
+        if syms:
+            return syms
+    # Need to get the symbols from the package build job in the pipeline
+    package_job_id = get_package_job_id(ca.active_project, job_id, ca.target_platform, ca.target_arch)
+    if not package_job_id:
+        raise Exception(f"Could not find package job for job {job_id}")
+    package_artifacts = get_or_fetch_artifacts(ca.artifact_store, ca.active_project, package_job_id)
+    archives = find_platform_debug_artifacts(ca.target_platform, package_artifacts.get())
+    # TODO: hacky way to get the version from the archive name
+    version = Path(archives[0]).name
+    for s in ['.debug.zip', '.tar.xz', '-amd64', '-x86_64', '-arm64', '-1']:
+        version = version.removesuffix(s)
+    for p in ['datadog-agent-dbg-', 'datadog-agent-']:
+        version = version.removeprefix(p)
+    # add a version ref so we can look it up faster next time
+    package_artifacts.version = version
+    if not artifact:
+        artifact = ca.artifact_store.add(project_id, job_id)
+    artifact.version = version
+    syms = ca.symbol_store.get(version, ca.target_platform, ca.target_arch)
+    if not syms:
+        # add the symbols to the symbol store
+        for path in archives:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                if ca.target_platform == 'windows':
+                    _windows_extract_agent_symbols(path, tmp_dir)
+                elif ca.target_platform in ['suse', 'linux']:
+                    _linux_extract_agent_symbols(path, tmp_dir)
+                syms = ca.symbol_store.add(version, ca.target_platform, ca.target_arch, tmp_dir)
 
     return syms
 
@@ -243,10 +252,10 @@ def _suse_get_debug_symbols_for_version(version: str, arch: str, output_dir: Pat
     url = f'{base}stable/{major_version}/{arch}/datadog-agent-dbg-{version}-1.{arch}.rpm'
     print(f"Downloading symbols for {version} from {url}")
     with download_to_tempfile(url) as rpm_path:
-        _suse_extract_agent_symbols(rpm_path, output_dir)
+        _suse_extract_agent_symbols_from_rpm(rpm_path, output_dir)
 
 
-def _suse_extract_agent_symbols(rpm_path: Path | str, output_dir: Path | str) -> None:
+def _suse_extract_agent_symbols_from_rpm(rpm_path: Path | str, output_dir: Path | str) -> None:
     assert shutil.which('rpm2cpio'), "rpm2cpio is required to extract symbols from RPMs"
     assert shutil.which('cpio'), "cpio is required to extract symbols from RPMs"
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -254,6 +263,13 @@ def _suse_extract_agent_symbols(rpm_path: Path | str, output_dir: Path | str) ->
         agent_root = 'opt/datadog-agent/.debug/opt/datadog-agent'
         os.system(f'rpm2cpio {rpm_path} | cpio -idm -D {tmp_dir}')
         shutil.copytree(f"{tmp_dir}/{agent_root}", output_dir, dirs_exist_ok=True)
+
+
+def _linux_extract_agent_symbols(archive_path: Path | str, output_dir: Path | str) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        shutil.unpack_archive(archive_path, tmp_dir)
+        agent_root = Path(tmp_dir) / 'opt/datadog-agent/.debug/opt/datadog-agent'
+        shutil.copytree(agent_root, output_dir, dirs_exist_ok=True)
 
 
 def _windows_extract_agent_symbols(zip_path: Path | str, output_dir: Path | str) -> None:
@@ -301,20 +317,39 @@ def find_dmp_files(output_dir: Path | str) -> list[str]:
     return list(glob.glob(f"{output_dir}/**/*.dmp", recursive=True))
 
 
-def find_debug_zip(output_dir: Path | str) -> list[str]:
-    return list(glob.glob(f"{output_dir}/**/*.debug.zip", recursive=True))
+def find_symbol_files_for_platform(platform: str, output_dir: Path | str) -> list[str]:
+    if platform == 'windows':
+        return list(glob.glob(f"{output_dir}/**/*.exe.debug", recursive=True))
+    elif platform in ['suse', 'linux']:
+        return list(glob.glob(f"{output_dir}/**/*.dbg", recursive=True))
+    else:
+        raise NotImplementedError(f"Unsupported platform {platform}")
 
 
-def find_symbol_files(output_dir: Path | str) -> list[str]:
-    return list(glob.glob(f"{output_dir}/**/*.exe.debug", recursive=True))
+def find_platform_debug_artifacts(platform: str, path: Path | str) -> list[str]:
+    if platform == 'windows':
+        return list(glob.glob(f"{path}/**/*.debug.zip", recursive=True))
+    elif platform in ['suse', 'linux']:
+        return list(glob.glob(f"{path}/**/datadog-agent-dbg-*.tar.xz", recursive=True))
+    else:
+        raise NotImplementedError(f"Unsupported platform {platform}")
 
 
-def get_package_job_id(project: Project, job_id: str, package_job_name=None) -> str | None:
+def get_package_job_id(project: Project, job_id: str, platform: str, arch: str) -> str | None:
     """
     Get the package job ID for the pipeline of the given job.
     """
-    if package_job_name is None:
+    if platform == 'windows':
         package_job_name = "windows_msi_and_bosh_zip_x64-a7"
+    elif platform in ['suse', 'linux']:
+        if arch == 'x86_64':
+            package_job_name = "datadog-agent-7-x64"
+        elif arch == 'arm64':
+            package_job_name = "datadog-agent-7-arm64"
+        else:
+            raise NotImplementedError(f"Unsupported arch {arch}")
+    else:
+        raise NotImplementedError(f"Unsupported platform {platform}")
 
     job = project.jobs.get(job_id)
     pipeline_id = str(job.pipeline["id"])

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -259,17 +259,18 @@ def _suse_extract_agent_symbols_from_rpm(rpm_path: Path | str, output_dir: Path 
     assert shutil.which('rpm2cpio'), "rpm2cpio is required to extract symbols from RPMs"
     assert shutil.which('cpio'), "cpio is required to extract symbols from RPMs"
     with tempfile.TemporaryDirectory() as tmp_dir:
-        # directory layout opt/datadog-agent/.debug/opt/datadog-agent/
-        agent_root = 'opt/datadog-agent/.debug/opt/datadog-agent'
+        # example: opt/datadog-agent/.debug/opt/datadog-agent/bin/agent/agent.dbg
+        debug_root = 'opt/datadog-agent/.debug'
         os.system(f'rpm2cpio {rpm_path} | cpio -idm -D {tmp_dir}')
-        shutil.copytree(f"{tmp_dir}/{agent_root}", output_dir, dirs_exist_ok=True)
+        shutil.copytree(f"{tmp_dir}/{debug_root}", output_dir, dirs_exist_ok=True)
 
 
 def _linux_extract_agent_symbols(archive_path: Path | str, output_dir: Path | str) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         shutil.unpack_archive(archive_path, tmp_dir)
-        agent_root = Path(tmp_dir) / 'opt/datadog-agent/.debug/opt/datadog-agent'
-        shutil.copytree(agent_root, output_dir, dirs_exist_ok=True)
+        # example: opt/datadog-agent/.debug/opt/datadog-agent/bin/agent/agent.dbg
+        debug_root = Path(tmp_dir) / 'opt/datadog-agent/.debug'
+        shutil.copytree(debug_root, output_dir, dirs_exist_ok=True)
 
 
 def _windows_extract_agent_symbols(zip_path: Path | str, output_dir: Path | str) -> None:

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -5,7 +5,7 @@ import zipfile
 from pathlib import Path, PurePath
 
 from gitlab.v4.objects import Project
-from invoke import task
+from invoke.tasks import task
 
 from tasks.debugging.gitlab_artifacts import Artifacts, ArtifactStore
 from tasks.debugging.symbols import SymbolStore
@@ -13,14 +13,14 @@ from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.utils import download_to_tempfile
 
 
-class CrashAnalyzerCLI:
+class CrashAnalyzer:
     env: Path
 
-    active_dump: Path
+    active_dump: Path | None
     symbol_store: SymbolStore
-    active_symbol: Path
+    active_symbol: Path | None
     artifact_store: ArtifactStore
-    active_project: Project
+    active_project: Project | None
 
     def __init__(self, env=None):
         if env is None:
@@ -35,22 +35,47 @@ class CrashAnalyzerCLI:
         self.artifact_store = ArtifactStore(Path(env, 'artifacts'))
 
     def select_dump(self, path: str | Path):
-        path = Path(path)
-        self.active_dump = path
+        self.active_dump = Path(path)
 
     def select_symbol(self, path: str | Path):
-        assert path in self.symbol_files
-        self.active_symbol = path
+        self.active_symbol = Path(path)
 
     def select_project(self, project: Project):
         self.active_project = project
 
 
-def get_cli():
+class CrashAnalyzerCli:
+    ca: CrashAnalyzer
+
+    def __init__(self, crash_analyzer):
+        self.ca = crash_analyzer
+
+    def prompt_select_dump(self, choices: list[Path] | list[str]):
+        print("Dump files:")
+        for choice in choices:
+            print('\t', choice)
+        if len(choices) > 1:
+            choice = ""
+            while not choice:
+                choice = input("Select a dump file: ")
+        self.ca.select_dump(choice)
+
+    def prompt_select_symbol_file(self, choices: list[Path] | list[str]):
+        print("Symbol files:")
+        for choice in choices:
+            print('\t', choice)
+        if len(choices) > 1:
+            choice = ""
+            while not choice:
+                choice = input("Select a symbol file: ")
+        self.ca.select_symbol(choice)
+
+
+def get_crash_analyzer():
     env = Path.home() / '.agent-crash-analyzer'
-    cli = CrashAnalyzerCLI(env=env)
-    print(f"Using environment: {cli.env}")
-    return cli
+    ca = CrashAnalyzer(env=env)
+    print(f"Using environment: {ca.env}")
+    return ca
 
 
 @task(
@@ -59,29 +84,34 @@ def get_cli():
     },
 )
 def debug_job_dump(ctx, job_id):
-    cli = get_cli()
-    cli.select_project(get_gitlab_repo())
+    ca = get_crash_analyzer()
+    ca.select_project(get_gitlab_repo())
+
+    cli = CrashAnalyzerCli(ca)
 
     # select dump file
-    package_artifacts = get_or_fetch_artifacts(cli.artifact_store, cli.active_project, job_id)
-    print("Dump files:")
+    package_artifacts = get_or_fetch_artifacts(ca.artifact_store, ca.active_project, job_id)
     dmp_files = find_dmp_files(package_artifacts.get())
-    for dmp_file in dmp_files:
-        print('\t', Path(dmp_file).resolve())
-    if len(dmp_files) > 1:
-        dmp_file = input("Select a dump file to analyze: ")
+    if not dmp_files:
+        print("No dump files found")
+        return
+    cli.prompt_select_dump(dmp_files)
 
     # select symbol file
-    syms = get_symbols_for_job_id(cli, job_id)
-    print("Symbols:")
-    for symbol_file in find_symbol_files(syms):
-        print('\t', Path(symbol_file).resolve())
-    symbol_file = input("Select a symbol file to use: ")
+    syms = get_symbols_for_job_id(ca, job_id)
+    if not syms:
+        print("No symbols found")
+        return
+    syms = find_symbol_files(syms)
+    if not syms:
+        print("No symbols found")
+        return
+    cli.prompt_select_symbol_file(syms)
 
     # launch windbg and delve
-    windbg_cmd = f'cmd.exe /c start "" "{dmp_file}"'
+    windbg_cmd = f'cmd.exe /c start "" "{ca.active_dump}"'
     print(f"Running command: {windbg_cmd}")
-    dlv_cmd = f'dlv.exe core "{symbol_file}" "{dmp_file}"'
+    dlv_cmd = f'dlv.exe core "{ca.active_symbol}" "{ca.active_dump}"'
     print(f"Running command: {dlv_cmd}")
     os.system(windbg_cmd)
     os.system(dlv_cmd)
@@ -97,10 +127,10 @@ def get_job_dump(ctx, job_id, with_symbols=False):
     """
     Download a dump from a job and save it to the output directory.
     """
-    cli = get_cli()
-    cli.select_project(get_gitlab_repo())
+    ca = get_crash_analyzer()
+    ca.select_project(get_gitlab_repo())
 
-    package_artifacts = get_or_fetch_artifacts(cli.artifact_store, cli.active_project, job_id)
+    package_artifacts = get_or_fetch_artifacts(ca.artifact_store, ca.active_project, job_id)
     dmp_files = find_dmp_files(package_artifacts.get())
     if not dmp_files:
         print("No dump files found")
@@ -110,7 +140,10 @@ def get_job_dump(ctx, job_id, with_symbols=False):
         print('\t', dmp_file)
 
     if with_symbols:
-        syms = get_symbols_for_job_id(cli, job_id)
+        syms = get_symbols_for_job_id(ca, job_id)
+        if not syms:
+            print("No symbols found")
+            return
         print("Symbols:")
         for symbol_file in find_symbol_files(syms):
             print('\t', Path(symbol_file).resolve())
@@ -118,7 +151,7 @@ def get_job_dump(ctx, job_id, with_symbols=False):
 
 @task
 def get_debug_symbols(ctx, job_id=None, version=None):
-    cli = get_cli()
+    cli = get_crash_analyzer()
     if version:
         with tempfile.TemporaryDirectory() as tmp_dir:
             get_debug_symbols_for_version(version, tmp_dir)
@@ -140,30 +173,33 @@ def add_gitlab_job_artifacts_to_artifact_store(
         return artifact_store.add(project_id, job_id, temp_dir)
 
 
-def get_symbols_for_job_id(cli: CrashAnalyzerCLI, job_id: str) -> Path:
-    project_id = cli.active_project.name
+def get_symbols_for_job_id(ca: CrashAnalyzer, job_id: str) -> Path | None:
+    project_id = ca.active_project.name
     # check if we already have the symbols for this job
-    artifact = cli.artifact_store.get(project_id, job_id)
+    artifact = ca.artifact_store.get(project_id, job_id)
     if artifact and artifact.version:
         version = artifact.version
+        syms = ca.symbol_store.get(version)
     else:
         # Need to get the symbols from the package build job in the pipeline
-        package_job_id = get_package_job_id(cli.active_project, job_id)
-        package_artifacts = get_or_fetch_artifacts(cli.artifact_store, cli.active_project, package_job_id)
-        for debug_zip in find_debug_zip(package_artifacts.get()):
-            debug_zip = Path(debug_zip)
+        package_job_id = get_package_job_id(ca.active_project, job_id)
+        if not package_job_id:
+            raise Exception(f"Could not find package job for job {job_id}")
+        package_artifacts = get_or_fetch_artifacts(ca.artifact_store, ca.active_project, package_job_id)
+        for path in find_debug_zip(package_artifacts.get()):
+            debug_zip = Path(path)
             version = debug_zip.name.removesuffix('.debug.zip')
             # add a version ref so we can look it up faster next time
             package_artifacts.version = version
             if not artifact:
-                artifact = cli.artifact_store.add(project_id, job_id)
+                artifact = ca.artifact_store.add(project_id, job_id)
             artifact.version = version
-            break
-    syms = cli.symbol_store.get(version)
-    if not syms:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            extract_agent_symbols(debug_zip, tmp_dir)
-            syms = cli.symbol_store.add(version, tmp_dir)
+            # add the symbols to the symbol store
+            syms = ca.symbol_store.get(version)
+            if not syms:
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    extract_agent_symbols(debug_zip, tmp_dir)
+                    syms = ca.symbol_store.add(version, tmp_dir)
 
     return syms
 
@@ -176,14 +212,14 @@ def get_or_fetch_artifacts(artifact_store: ArtifactStore, project: Project, job_
     return artifacts
 
 
-def get_debug_symbols_for_version(version: str, output_dir=None) -> None:
+def get_debug_symbols_for_version(version: str, output_dir: Path | str) -> None:
     url = get_debug_symbol_url_for_version(version)
     print(f"Downloading symbols for {version} from {url}")
     with download_to_tempfile(url) as zip_path:
         extract_agent_symbols(zip_path, output_dir)
 
 
-def extract_agent_symbols(zip_path: str, output_dir: str) -> None:
+def extract_agent_symbols(zip_path: Path | str, output_dir: Path | str) -> None:
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for info in zip_ref.infolist():
             if info.filename.endswith('.exe.debug'):
@@ -221,15 +257,15 @@ def download_job_artifacts(project: Project, job_id: str, output_dir: str) -> No
             os.remove(tmp_path)
 
 
-def find_dmp_files(output_dir: str) -> list[str]:
+def find_dmp_files(output_dir: Path | str) -> list[str]:
     return list(glob.glob(f"{output_dir}/**/*.dmp", recursive=True))
 
 
-def find_debug_zip(output_dir: str) -> list[str]:
+def find_debug_zip(output_dir: Path | str) -> list[str]:
     return list(glob.glob(f"{output_dir}/**/*.debug.zip", recursive=True))
 
 
-def find_symbol_files(output_dir: str) -> list[str]:
+def find_symbol_files(output_dir: Path | str) -> list[str]:
     return list(glob.glob(f"{output_dir}/**/*.exe.debug", recursive=True))
 
 
@@ -247,3 +283,4 @@ def get_package_job_id(project: Project, job_id: str, package_job_name=None) -> 
     for job in jobs:
         if job.name == package_job_name:
             return str(job.id)
+    return None

--- a/tasks/debugging/dump.py
+++ b/tasks/debugging/dump.py
@@ -255,7 +255,8 @@ def get_symbols_for_job_id(ca: CrashAnalyzer, job_id: str) -> tuple[str | None, 
     if not path:
         raise FileNotFoundError(f"No artifacts found for job {package_job_id}")
     archives = find_platform_debug_artifacts(ca.target_platform, path)
-    # TODO: hacky way to get the version from the archive name
+    # TODO: hacky way to get the version from the archive name, is there a better way?
+    #       the setup-agent-version job stores the version in a private bucket.
     version = Path(archives[0]).name
     for s in ['.debug.zip', '.tar.xz', '-amd64', '-x86_64', '-arm64', '-1']:
         version = version.removesuffix(s)

--- a/tasks/debugging/gitlab_artifacts.py
+++ b/tasks/debugging/gitlab_artifacts.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from tasks.debugging.path_store import PathStore
+
+
+class Artifacts:
+    def __init__(self, project: str, job: str, path_store: PathStore):
+        self.__path_store = path_store
+        self._project = project
+        self._job = job
+        self._version = None
+        self._pipeline = None
+
+    def get(self) -> Path:
+        return self.__path_store.get_directory(f"{self.key()}/artifacts")
+
+    def add(self, path: str | Path) -> None:
+        self.__path_store.add_directory(f"{self.key()}/artifacts", Path(path))
+
+    def _get_text_property(self, attr: str) -> str | None:
+        value = getattr(self, f"_{attr}")
+        if value is None:
+            data = self.__path_store.get(f"{self.key()}/{attr}.txt")
+            if not data:
+                return None
+            value = data.decode('utf-8').strip()
+            setattr(self, f"_{attr}", value)
+        return value
+
+    def _set_text_property(self, attr: str, value: str) -> None:
+        self.__path_store.add(f"{self.key()}/{attr}.txt", value.encode('utf-8'))
+        setattr(self, f"_{attr}", value)
+
+    @property
+    def version(self) -> str | None:
+        return self._get_text_property("version")
+
+    @version.setter
+    def version(self, value: str) -> None:
+        self._set_text_property("version", value)
+
+    @property
+    def pipeline(self) -> str | None:
+        return self._get_text_property("pipeline")
+
+    @pipeline.setter
+    def pipeline(self, value: str) -> None:
+        self._set_text_property("pipeline", value)
+
+    @property
+    def project(self) -> str | None:
+        return self._get_text_property("project")
+
+    @project.setter
+    def project(self, value: str) -> None:
+        self._set_text_property("project", value)
+
+    def key(self) -> str:
+        return self.makekey(self._project, self._job)
+
+    @classmethod
+    def makekey(cls, project: str, job: str) -> str:
+        return f"{project}/{job}"
+
+
+class ArtifactStore:
+    def __init__(self, path: str | Path):
+        self.path_store = PathStore(Path(path))
+
+    def add(self, project_id: str, job_id: str, artifacts_path: str | Path = None) -> Artifacts:
+        artifacts = Artifacts(project_id, job_id, self.path_store)
+        if artifacts_path:
+            artifacts.add(artifacts_path)
+        return artifacts
+
+    def get(self, project_id: str, job_id: str) -> Artifacts | None:
+        key = Artifacts.makekey(project_id, job_id)
+        if self.path_store.get_directory(key):
+            return Artifacts(project_id, job_id, self.path_store)
+        return None

--- a/tasks/debugging/gitlab_artifacts.py
+++ b/tasks/debugging/gitlab_artifacts.py
@@ -8,10 +8,10 @@ class Artifacts:
         self.__path_store = path_store
         self._project = project
         self._job = job
-        self._version = None
-        self._pipeline = None
+        self._version = None  # noqa
+        self._pipeline = None  # noqa
 
-    def get(self) -> Path:
+    def get(self) -> Path | None:
         return self.__path_store.get_directory(f"{self.key()}/artifacts")
 
     def add(self, path: str | Path) -> None:
@@ -67,7 +67,7 @@ class ArtifactStore:
     def __init__(self, path: str | Path):
         self.path_store = PathStore(Path(path))
 
-    def add(self, project_id: str, job_id: str, artifacts_path: str | Path = None) -> Artifacts:
+    def add(self, project_id: str, job_id: str, artifacts_path: str | Path | None = None) -> Artifacts:
         artifacts = Artifacts(project_id, job_id, self.path_store)
         if artifacts_path:
             artifacts.add(artifacts_path)

--- a/tasks/debugging/gitlab_artifacts.py
+++ b/tasks/debugging/gitlab_artifacts.py
@@ -15,7 +15,12 @@ class Artifacts:
         return self.__path_store.get_directory(f"{self.key()}/artifacts")
 
     def add(self, path: str | Path) -> None:
-        self.__path_store.add_directory(f"{self.key()}/artifacts", Path(path))
+        path = Path(path)
+        if not path.is_dir():
+            raise ValueError(f"{path} is not a directory")
+        if not list(path.iterdir()):
+            return
+        self.__path_store.add_directory(f"{self.key()}/artifacts", path)
 
     def _get_text_property(self, attr: str) -> str | None:
         value = getattr(self, f"_{attr}")

--- a/tasks/debugging/path_store.py
+++ b/tasks/debugging/path_store.py
@@ -1,0 +1,29 @@
+import shutil
+from pathlib import Path
+
+
+class PathStore:
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+
+    def add(self, key: str, data: bytes) -> None:
+        file_path = self.path / key
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(data)
+
+    def get(self, key: str) -> bytes | None:
+        file_path = self.path / key
+        if file_path.exists():
+            return file_path.read_bytes()
+        return None
+
+    def add_directory(self, key: str, src: Path) -> None:
+        dst = self.path / key
+        dst.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+
+    def get_directory(self, key: str) -> Path | None:
+        dir_path = self.path / key
+        if dir_path.exists():
+            return dir_path
+        return None

--- a/tasks/debugging/symbols.py
+++ b/tasks/debugging/symbols.py
@@ -3,12 +3,15 @@ from pathlib import Path
 from tasks.debugging.path_store import PathStore
 
 
-class SymbolStore(PathStore):
+class SymbolStore:
+    def __init__(self, path: Path | str):
+        self.path_store = PathStore(path)
+
     def add(self, version: str, path: str | Path) -> Path:
-        dst = Path(self.path, version, 'symbols')
-        self.add_directory(str(dst), path)
-        return dst
+        k = f'{version}/symbols'
+        self.path_store.add_directory(k, Path(path))
+        return Path(self.path_store.path, k)
 
     def get(self, version: str) -> Path | None:
-        p = Path(self.path, version, 'symbols')
-        return self.get_directory(str(p))
+        k = f'{version}/symbols'
+        return self.path_store.get_directory(k)

--- a/tasks/debugging/symbols.py
+++ b/tasks/debugging/symbols.py
@@ -7,11 +7,11 @@ class SymbolStore:
     def __init__(self, path: Path | str):
         self.path_store = PathStore(path)
 
-    def add(self, version: str, path: str | Path) -> Path:
-        k = f'{version}/symbols'
+    def add(self, version: str, platform: str, arch: str, path: str | Path) -> Path:
+        k = f'{version}/{platform}/{arch}/symbols'
         self.path_store.add_directory(k, Path(path))
         return Path(self.path_store.path, k)
 
-    def get(self, version: str) -> Path | None:
-        k = f'{version}/symbols'
+    def get(self, version: str, platform: str, arch: str) -> Path | None:
+        k = f'{version}/{platform}/{arch}/symbols'
         return self.path_store.get_directory(k)

--- a/tasks/debugging/symbols.py
+++ b/tasks/debugging/symbols.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from tasks.debugging.path_store import PathStore
+
+
+class SymbolStore(PathStore):
+    def add(self, version: str, path: str | Path) -> Path:
+        dst = Path(self.path, version, 'symbols')
+        self.add_directory(str(dst), path)
+        return dst
+
+    def get(self, version: str) -> Path | None:
+        p = Path(self.path, version, 'symbols')
+        return self.get_directory(str(p))

--- a/tasks/debugging/unit_tests/crash_analyzer_tests.py
+++ b/tasks/debugging/unit_tests/crash_analyzer_tests.py
@@ -1,0 +1,78 @@
+import shutil
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tasks.debugging.gitlab_artifacts import Artifacts
+
+
+class TestCrashAnalyzer(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix='test-store-'))
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+    def test_get_symbols_for_job_id(self):
+        """
+        Test that we can get symbols for a job id from a (mock) pipeline
+        """
+        from tasks.debugging.dump import CrashAnalyzer, get_symbols_for_job_id
+
+        AGENT_VERSION = '7.56.0.git.123.123.pipeline.123'
+
+        def _patched_download_job_artifacts(project, jobid, path):
+            """
+            Mock/patch to "download" artifacts without involving gitlab api
+            """
+            if jobid == 'package-job-id':
+                p = Path(path, f'datadog-agent-{AGENT_VERSION}-1-x86_64.debug.zip')
+                with zipfile.ZipFile(p, 'w') as z:
+                    z.writestr('agent.exe.debug', 'fake symbols')
+            else:
+                Path(path, 'test.txt').write_text('fake artifacts')
+
+        def _patched_get_package_job_id(*args):
+            """
+            Mock/patch to return a static job id as the package job without involving gitlab api
+            """
+            return 'package-job-id'
+
+        project = MagicMock()
+        project.name = 'project'
+        ca = CrashAnalyzer(self.root, 'windows', 'x86_64')
+        ca.select_project(project)
+
+        with (
+            patch('tasks.debugging.dump.download_job_artifacts', side_effect=_patched_download_job_artifacts),
+            patch('tasks.debugging.dump.get_package_job_id', side_effect=_patched_get_package_job_id),
+        ):
+            version, syms = get_symbols_for_job_id(ca, 'jobid')
+
+        self.assertEqual(version, '7.56.0.git.123.123.pipeline.123')
+        # check that we got the symbols
+        self.assertIsInstance(syms, Path)
+        assert syms is not None
+        self.assertTrue(syms.exists())
+        dbg_path = Path(syms, 'agent.exe.debug')
+        self.assertTrue(dbg_path.exists())
+        self.assertEqual(dbg_path.read_text(), 'fake symbols')
+        # check that we got the artifacts for the package job
+        artifact = ca.artifact_store.get(project.name, 'package-job-id')
+        self.assertIsInstance(artifact, Artifacts)
+        assert artifact is not None
+        path = artifact.get()
+        assert path is not None
+        self.assertTrue(path.exists())
+        dbg_path = Path(path, f'datadog-agent-{AGENT_VERSION}-1-x86_64.debug.zip')
+        self.assertTrue(dbg_path.exists())
+        # check that we set the version property
+        self.assertEqual(artifact.version, AGENT_VERSION)
+        # check that we didn't download artifacts for jobid, only package-job-id
+        artifact = ca.artifact_store.get(project.name, 'jobid')
+        self.assertIsInstance(artifact, Artifacts)
+        assert artifact is not None
+        self.assertEqual(artifact.version, AGENT_VERSION)
+        self.assertIsNone(artifact.get())

--- a/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
+++ b/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
@@ -45,8 +45,7 @@ class TestArtifactStore(unittest.TestCase):
         artifact.version = '1.0'
         version_path = Path(self.root, 'artifacts', 'project', 'jobid', 'version.txt')
         self.assertTrue(version_path.exists())
-        with version_path.open() as f:
-            self.assertEqual(f.read(), '1.0')
+        self.assertEqual('1.0', version_path.read_text())
         # fetch artifact and check version property
         artifact = self.artifact_store.get('project', 'jobid')
         self.assertIsInstance(artifact, Artifacts)

--- a/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
+++ b/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
@@ -78,9 +78,22 @@ class TestArtifactStore(unittest.TestCase):
         self.assertTrue(artifact_path.exists())
         self.assertEqual('fake artifacts', artifact_path.read_text())
 
+        # add test case that ensures download_job_artifacts is not called now that the artifacts exist
+        with patch('tasks.debugging.dump.download_job_artifacts') as download_job_artifacts:
+            artifact = get_or_fetch_artifacts(self.artifact_store, project, 'jobid')
+            download_job_artifacts.assert_not_called()
+        self.assertIsInstance(artifact, Artifacts)
+        path = artifact.get()
+        self.assertIsInstance(path, Path)
+        assert path is not None
+        artifact_path = Path(path, 'test.txt')
+        self.assertEqual('fake artifacts', artifact_path.read_text())
+
     def test_get_or_fetch_artifacts_when_job_has_no_artifacts(self):
         """
-        Test that get_or_fetch_artifacts will fetch artifacts if they don't exist
+        Test that get_or_fetch_artifacts still returns an Artifacts object when the job has no artifacts
+
+        We may still want to get the version property, to find symbols, for example
         """
         from tasks.debugging.dump import get_or_fetch_artifacts
 

--- a/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
+++ b/tasks/debugging/unit_tests/gitlab_artifacts_tests.py
@@ -1,0 +1,96 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tasks.debugging.gitlab_artifacts import Artifacts, ArtifactStore
+
+
+class TestArtifactStore(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix='test-store-'))
+        self.artifact_store = ArtifactStore(Path(self.root, 'artifacts'))
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+    # Test that we can add an artifact to the store
+    def test_add_artifacts(self):
+        """
+        Test that we can add artifacts to the store
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, 'test.txt').touch()
+            artifact = self.artifact_store.add('project', 'jobid', tmpdir)
+        self.assertIsInstance(artifact, Artifacts)
+        # artifacts organized by project/jobid
+        self.assertTrue(Path(self.root, 'artifacts', 'project', 'jobid', 'artifacts', 'test.txt').exists())
+        self.assertEqual(None, artifact.version)
+        # get artifacts
+        artifact = self.artifact_store.get('project', 'jobid')
+        self.assertIsInstance(artifact, Artifacts)
+        assert artifact is not None
+        path = artifact.get()
+        assert path is not None
+        self.assertTrue(path.exists())
+        self.assertEqual(None, artifact.version)
+
+    def test_add_job_properties_without_artifacts(self):
+        """
+        Test that we can add job properties without artifacts
+        """
+        # add artifact with version property
+        artifact = self.artifact_store.add('project', 'jobid')
+        artifact.version = '1.0'
+        version_path = Path(self.root, 'artifacts', 'project', 'jobid', 'version.txt')
+        self.assertTrue(version_path.exists())
+        with version_path.open() as f:
+            self.assertEqual(f.read(), '1.0')
+        # fetch artifact and check version property
+        artifact = self.artifact_store.get('project', 'jobid')
+        self.assertIsInstance(artifact, Artifacts)
+        assert artifact is not None
+        self.assertEqual(artifact.version, '1.0')
+
+    def test_get_or_fetch_artifacts(self):
+        """
+        Test that get_or_fetch_artifacts will fetch artifacts if they don't exist
+        """
+        from tasks.debugging.dump import get_or_fetch_artifacts
+
+        def _patched_download_job_artifacts(project, jobid, path):
+            Path(path, 'test.txt').write_text('fake artifacts')
+
+        project = MagicMock()
+        project.name = 'project'
+        with patch('tasks.debugging.dump.download_job_artifacts', side_effect=_patched_download_job_artifacts):
+            artifact = get_or_fetch_artifacts(self.artifact_store, project, 'jobid')
+        self.assertIsInstance(artifact, Artifacts)
+        self.assertEqual(None, artifact.version)
+        expected_path = Path(self.root, 'artifacts', 'project', 'jobid', 'artifacts')
+        self.assertTrue(expected_path.exists())
+        path = artifact.get()
+        self.assertIsInstance(path, Path)
+        self.assertEqual(expected_path, path)
+        assert path is not None
+        artifact_path = Path(path, 'test.txt')
+        self.assertTrue(artifact_path.exists())
+        self.assertEqual('fake artifacts', artifact_path.read_text())
+
+    def test_get_or_fetch_artifacts_when_job_has_no_artifacts(self):
+        """
+        Test that get_or_fetch_artifacts will fetch artifacts if they don't exist
+        """
+        from tasks.debugging.dump import get_or_fetch_artifacts
+
+        def _patched_download_job_artifacts(project, jobid, path):
+            pass
+
+        project = MagicMock()
+        project.name = 'project'
+        with patch('tasks.debugging.dump.download_job_artifacts', side_effect=_patched_download_job_artifacts):
+            artifact = get_or_fetch_artifacts(self.artifact_store, project, 'jobid')
+        self.assertIsInstance(artifact, Artifacts)
+        path = artifact.get()
+        self.assertIsNone(path)

--- a/tasks/debugging/unit_tests/symbols_tests.py
+++ b/tasks/debugging/unit_tests/symbols_tests.py
@@ -1,0 +1,35 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from tasks.debugging.symbols import SymbolStore
+
+
+class TestSymbolStore(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix='test-store-'))
+        self.symbol_store = SymbolStore(Path(self.root, 'symbols'))
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+    def test_add_symbols(self):
+        """
+        Test that we can add symbols to the store
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # pretend symbols in directory
+            Path(tmpdir, 'agent.dbg').write_text('fake symbols')
+            # add to store
+            self.symbol_store.add('1.0', 'linux', 'x86_64', tmpdir)
+        # symbols organized by version/platform/arch
+        symbol_path = Path(self.root, 'symbols', '1.0', 'linux', 'x86_64', 'symbols', 'agent.dbg')
+        self.assertTrue(symbol_path.exists())
+        with symbol_path.open() as f:
+            self.assertEqual(f.read(), 'fake symbols')
+        # get symbols from store
+        symbols = self.symbol_store.get('1.0', 'linux', 'x86_64')
+        assert symbols is not None
+        self.assertTrue(symbols.exists())
+        self.assertTrue(Path(symbols, 'agent.dbg').exists())

--- a/tasks/debugging/unit_tests/symbols_tests.py
+++ b/tasks/debugging/unit_tests/symbols_tests.py
@@ -26,8 +26,7 @@ class TestSymbolStore(unittest.TestCase):
         # symbols organized by version/platform/arch
         symbol_path = Path(self.root, 'symbols', '1.0', 'linux', 'x86_64', 'symbols', 'agent.dbg')
         self.assertTrue(symbol_path.exists())
-        with symbol_path.open() as f:
-            self.assertEqual(f.read(), 'fake symbols')
+        self.assertEqual('fake symbols', symbol_path.read_text())
         # get symbols from store
         symbols = self.symbol_store.get('1.0', 'linux', 'x86_64')
         assert symbols is not None

--- a/tasks/debugging/windbg.py
+++ b/tasks/debugging/windbg.py
@@ -1,0 +1,15 @@
+import os
+import shutil
+from pathlib import Path
+
+
+class Windbg:
+    def __init__(self):
+        # prefer newer windbg if available
+        if shutil.which('windbgx.exe'):
+            self.windbg_cmd = 'windbgx.exe'
+        else:
+            self.windbg_cmd = 'windbg.exe'
+
+    def open_dump(self, path: Path | str):
+        os.system(f'cmd.exe /c start {self.windbg_cmd} -z "{path}"')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add invoke tasks (and helpers) to
- download coredump file from Gitlab job artifacts
  - e.g. from an [E2E test](https://github.com/DataDog/datadog-agent/blob/55c6a18d88679080b23363441f7ac5a5b8417cdb/test/new-e2e/tests/windows/service-test/startstop_test.go#L368-L375)
- download Agent debug symbols from Gitlab job artifacts (auto-finds the package build job in the pipeline)
- download Agent debug symbols for released versions

implemented fetch/extract for windows, suse, and debian debug packages.
- some tools may be required, such as `rpm2cpio` and `dpkg-deb`


```bash
# download dump from 681900370 and symbols from pipeline and launch delve
inv debugging.debug-job-dump --job-id 681900370 --platform windows
# download symbols from pipeline
inv debugging.get-debug-symbols --job-id 681900370 --platform debian
# download symbols for version
inv debugging.dump.get-debug-symbols --version 7.57.0 --platform windows
```
persists/caches downloaded files into `~/.agent-crash-analyzer/`
```
/home/brandenclark/.agent-crash-analyzer
├── artifacts
│   └── datadog-agent
│       ├── 681900223
│       ├── 681900226
│       ├── 681900227
│       └── 681900370
└── symbols
    ├── 7.57.0
    │   ├── debian
    │   │   ├── arm64
    │   │   └── x86_64
    │   ├── suse
    │   │   └── x86_64
    │   └── windows
    │       └── x86_64
    └── 7.58.0-installer-0.6.0.git.119.b718ef8.pipeline.47264433
        ├── debian
        │   └── x86_64
        ├── suse
        │   ├── arm64
        │   └── x86_64
        └── windows
            └── x86_64
```
### Motivation
automation
- very clicky to get artifacts/symbols/dumps
- debug packages for different platforms are in different places, jobs, can be hard to find

based on info from https://datadoghq.atlassian.net/wiki/spaces/agent/pages/3777987099/Loading+an+agent+core+dump

### Describe how to test/QA your changes
run unit tests
```
cd tasks/debugging; inv invoke-unit-tests.run -v 2
```

run some of the invoke tasks and see if you get symbols/dumps

### Possible Drawbacks / Trade-offs
there doesn't seem to be a way to list artifacts or download a specific artifact, so all the artifacts get downloaded.
This is nice for e2e test artifacts because you get the dump and the agent logs
but is not nice for package build artifacts when we only care about the debug symbol archive and the other artifacts are large. maybe we could upload the debug packages to the mstesting bucket, too.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Not sure where to get debug symbols for release candidate builds for Linux platforms