### PR TITLE
usm: pclntab: Fix bug with finding exact symbols

### DIFF
--- a/pkg/network/go/bininspect/pclntab.go
+++ b/pkg/network/go/bininspect/pclntab.go
@@ -106,7 +106,8 @@ func GetPCLNTABSymbolParser(f *elf.File, symbolFilter symbolFilter) (map[string]
 	}
 	// Late initialization, to prevent allocation if the binary is not supported.
 	_, maxSymbolsSize := symbolFilter.getMinMaxLength()
-	parser.funcNameHelper = make([]byte, maxSymbolsSize)
+	// Adding additional byte for null terminator.
+	parser.funcNameHelper = make([]byte, maxSymbolsSize+1)
 	parser.funcTableFieldSize = getFuncTableFieldSize(parser.cachedVersion, int(parser.ptrSize))
 	// Allocate the buffer for reading the function table.
 	// TODO: Do we need 2*funcTableFieldSize?

--- a/pkg/network/go/bininspect/pclntab_test.go
+++ b/pkg/network/go/bininspect/pclntab_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package bininspect
+
+import (
+	"debug/elf"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	// Info is composed of the type and binding of the symbol. Type is the lower 4 bits and binding is the upper 4 bits.
+	// We are only interested in functions, which binding STB_GLOBAL (1) and type STT_FUNC (2).
+	// Hence, we are interested in symbols with Info 18.
+	infoFunction = byte(elf.STB_GLOBAL)<<4 | byte(elf.STT_FUNC)
+)
+
+// TestGetPCLNTABSymbolParser tests the GetPCLNTABSymbolParser function with strings set symbol filter.
+// We are looking to find all symbols of the current process executable and check if they are found in the PCLNTAB.
+func TestGetPCLNTABSymbolParser(t *testing.T) {
+	currentPid := os.Getpid()
+	f, err := elf.Open("/proc/" + strconv.Itoa(currentPid) + "/exe")
+	require.NoError(t, err)
+	symbolSet := make(common.StringSet)
+	staticSymbols, _ := f.Symbols()
+	dynamicSymbols, _ := f.DynamicSymbols()
+	for _, symbols := range [][]elf.Symbol{staticSymbols, dynamicSymbols} {
+		for _, sym := range symbols {
+			if sym.Info != infoFunction {
+				continue
+			}
+			// Skipping types, runtime functions and ABI0 functions
+			if strings.HasPrefix(sym.Name, "type:") || strings.HasPrefix(sym.Name, "runtime") || strings.HasSuffix(sym.Name, ".abi0") {
+				continue
+			}
+			symbolSet[sym.Name] = struct{}{}
+		}
+	}
+	if len(symbolSet) == 0 {
+		t.Skip("No symbols found")
+	}
+
+	got, err := GetPCLNTABSymbolParser(f, newStringSetSymbolFilter(symbolSet))
+	assert.NoError(t, err)
+	if err != nil {
+		for sym := range symbolSet {
+			if _, ok := got[sym]; !ok {
+				t.Log("Missing symbol:", sym)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

n case we were provided with symbolSetFilter, we didn't consider null byte in our size of funcNameHelper thus, we would filter out symbols with length equals to the max symbol.

The bug was missed as currently the code works with prefixSymbolFilter, which has high maxLength setting.

We're also introducing a UT to ensure the code won't break again

### Motivation

Discovered while working to support symbol location and size.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->