### PR TITLE
add `aws-sdk-go-v2` dependabot group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,6 +37,9 @@ updates:
       bun:
         patterns:
           - "github.com/uptrace/bun*"
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: gomod
     directory: /pkg/trace
     labels:


### PR DESCRIPTION
### What does this PR do?

We currently have dozens of aws sdk go v2 dependabot PRs open, merging them is tedious. The goal of this PR is to group all of those into a big bump PR automatically. Which should make it easier to merge them frequently.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->