### PR TITLE
[CWS] Rework TestEventRaleLimiters to use variable based token limiter

### DIFF
--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -107,12 +107,19 @@ func TestEventRaleLimiters(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_unique_id",
-			Expression: `open.file.path == "{{.Root}}/test-unique-id"`,
-			Every: &rules.HumanReadableDuration{
-				Duration: 5 * time.Second,
-			},
-			RateLimiterToken: []string{"process.file.name"},
-		},
+			Expression: `open.file.path == "{{.Root}}/test-unique-id" && process.file.name not in ${test_unique_id_services}`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Name:  "test_unique_id_services",
+						Field: "process.file.name",
+						TTL: &rules.HumanReadableDuration{
+							Duration: 5 * time.Second,
+						},
+						Append: true,
+					},
+				},
+			}},
 		{
 			ID:         "test_std",
 			Expression: `open.file.path == "{{.Root}}/test-std"`,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use variables for rate limiting in TestEventRateLimiters.

### Motivation

The `rate_limiter_token` attribute can be replaced by the generic variable mechanism.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->