### PR TITLE
Fix agent internal profiling version tag

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -346,8 +346,6 @@ func StopAgent(log log.Component) {
 
 func setupInternalProfiling(config config.Component) error {
 	if config.GetBool(secAgentKey("internal_profiling.enabled")) {
-		v, _ := version.Agent()
-
 		cfgSite := config.GetString(secAgentKey("internal_profiling.site"))
 		cfgURL := config.GetString(secAgentKey("internal_profiling.profile_dd_url"))
 
@@ -363,7 +361,7 @@ func setupInternalProfiling(config config.Component) error {
 		}
 
 		tags := config.GetStringSlice(secAgentKey("internal_profiling.extra_tags"))
-		tags = append(tags, fmt.Sprintf("version:%v", v))
+		tags = append(tags, fmt.Sprintf("version:%v", version.AgentVersion))
 
 		profSettings := profiling.Settings{
 			ProfilingURL:         site,

--- a/comp/process/profiler/profilerimpl/profiler.go
+++ b/comp/process/profiler/profilerimpl/profiler.go
@@ -76,10 +76,8 @@ func getProfilingSettings(cfg config.Component) profiling.Settings {
 		site = fmt.Sprintf(profiling.ProfilingURLTemplate, s)
 	}
 
-	v, _ := version.Agent()
-
 	tags := cfg.GetStringSlice("internal_profiling.extra_tags")
-	tags = append(tags, fmt.Sprintf("version:%v", v))
+	tags = append(tags, fmt.Sprintf("version:%v", version.AgentVersion))
 
 	return profiling.Settings{
 		ProfilingURL:         site,

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -85,10 +85,9 @@ func (l *ProfilingRuntimeSetting) Set(config config.Component, v interface{}, so
 
 		// Note that we must derive a new profiling.Settings on every
 		// invocation, as many of these settings may have changed at runtime.
-		v, _ := version.Agent()
 
 		tags := config.GetStringSlice(l.ConfigPrefix + "internal_profiling.extra_tags")
-		tags = append(tags, fmt.Sprintf("version:%v", v))
+		tags = append(tags, fmt.Sprintf("version:%v", version.AgentVersion))
 
 		settings := profiling.Settings{
 			ProfilingURL:         site,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the version used to tag internal profiles on core-agent, process-agent, security-agent, system-probe, and cluster-agent (all but trace-agent).

All these process currently tag the version using `pkg/version.Agent()` (which returns a structured version), then formatting that with `%v`, which gives something like `{7 58 0 rc.10  1f5f2cc}`, then spaces and brackets are replaced with underscores in the final tag, resulting in `_7_58_0_rc.10__1f5f2cc_`.

The trace-agent on the other hand uses `pkg/version.AgentVersion`, which is `7.58.0-rc.10` (the expected version, which is also much more readable).

### Motivation
Have the version tagged the same way for all agent processes, and have the expected version format used as tag.

If we start using [datadog-pgo](https://github.com/DataDog/datadog-pgo) to get profiles automatically in the CI then having a unified version would be much more convenient.

### Describe how to test/QA your changes
Checked manually for each process that they are now correctly tagged.

### Possible Drawbacks / Trade-offs
It is unclear if anything could be relying on the "odd" version format.

This feature is only used internally so at least no external user will be impacted.
This is only used to help with debugging and inspecting performance of the agents, and to the best of my knowledge there is no automation related to it, so I don't expect anything to break.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->