### PR TITLE
[CWS] remove dependabot entry for `/test/e2e/cws-tests`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -157,18 +157,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
-  - package-ecosystem: pip
-    directory: /test/e2e/cws-tests
-    labels:
-      - dependencies
-      - python
-      - team/agent-security
-      - changelog/no-changelog
-      - qa/no-code-change
-      - dev/tooling
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 100
   - package-ecosystem: docker
     directory: /test/fakeintake
     labels:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This file doesn't exist anymore, since cws e2e tests were migrated to the new e2e system.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->