### PR TITLE
[EBPF-601] gpu: add function to retrieve visible devices for a process

### DIFF
--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package cuda
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+type WithUUID interface {
+	GetUUID() (string, nvml.Return)
+}
+
+// getVisibleDevices processes the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable
+// Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
+func getVisibleDevices[T WithUUID](systemDevices []T, cudaVisibleDevices string) ([]T, error) {
+	if cudaVisibleDevices == "" {
+		return systemDevices, nil
+	}
+
+	var filteredDevices []T
+	visibleDevicesList := strings.Split(cudaVisibleDevices, ",")
+
+	for _, visibleDevice := range visibleDevicesList {
+		if strings.HasPrefix(visibleDevice, "GPU-") {
+			for _, device := range systemDevices {
+				uuid, ret := device.GetUUID()
+				if ret != nvml.SUCCESS {
+					return nil, fmt.Errorf("cannot get UUID for device: %w", WrapNvmlError(ret))
+				}
+
+				if strings.HasPrefix(uuid, visibleDevice) {
+					filteredDevices = append(filteredDevices, device)
+					break
+				}
+			}
+		} else if strings.HasPrefix(visibleDevice, "MIG-GPU") {
+			return nil, fmt.Errorf("MIG devices are not supported")
+		} else {
+			idx, err := strconv.Atoi(visibleDevice)
+			if err != nil {
+				return nil, fmt.Errorf("invalid device index %s: %w", visibleDevice, err)
+			}
+
+			if idx < 0 || idx >= len(systemDevices) {
+				return nil, fmt.Errorf("device index %d is out of range", idx)
+			}
+
+			filteredDevices = append(filteredDevices, systemDevices[idx])
+		}
+	}
+
+	return filteredDevices, nil
+}
+
+func getCudaVisibleDevicesEnvVar(pid int, procfs string) (string, error) {
+	return kernel.GetProcessEnvVariable(pid, "CUDA_VISIBLE_DEVICES", procfs)
+}
+
+func GetVisibleDevicesForProcess[T WithUUID](systemDevices []T, pid int, procfs string) ([]T, error) {
+	cudaVisibleDevices, err := getCudaVisibleDevicesEnvVar(pid, procfs)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get CUDA_VISIBLE_DEVICES for process %d: %w", pid, err)
+	}
+
+	return getVisibleDevices(systemDevices, cudaVisibleDevices)
+}

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -17,19 +17,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-// WithUUID is an interface for objects that have a GetUUID function,
-type WithUUID interface {
-	GetUUID() (string, nvml.Return)
-}
-
 // getVisibleDevices processes the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable
 // Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
-func getVisibleDevices[T WithUUID](systemDevices []T, cudaVisibleDevices string) ([]T, error) {
+func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) ([]nvml.Device, error) {
 	if cudaVisibleDevices == "" {
 		return systemDevices, nil
 	}
 
-	var filteredDevices []T
+	var filteredDevices []nvml.Device
 	visibleDevicesList := strings.Split(cudaVisibleDevices, ",")
 
 	for _, visibleDevice := range visibleDevicesList {
@@ -70,7 +65,7 @@ func getCudaVisibleDevicesEnvVar(pid int, procfs string) (string, error) {
 }
 
 // GetVisibleDevicesForProcess modifies the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable for the specified process
-func GetVisibleDevicesForProcess[T WithUUID](systemDevices []T, pid int, procfs string) ([]T, error) {
+func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs string) ([]nvml.Device, error) {
 	cudaVisibleDevices, err := getCudaVisibleDevicesEnvVar(pid, procfs)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get CUDA_VISIBLE_DEVICES for process %d: %w", pid, err)

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -58,16 +58,17 @@ func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) (
 	for _, visibleDevice := range visibleDevicesList {
 		var matchingDevice nvml.Device
 		var err error
-		if strings.HasPrefix(visibleDevice, "GPU-") {
+		switch {
+		case strings.HasPrefix(visibleDevice, "GPU-"):
 			matchingDevice, err = getDeviceWithMatchingUUIDPrefix(systemDevices, visibleDevice)
 			if err != nil {
 				return filteredDevices, err
 			}
-		} else if strings.HasPrefix(visibleDevice, "MIG-GPU") {
+		case strings.HasPrefix(visibleDevice, "MIG-GPU"):
 			// MIG (Multi Instance GPUs) devices require extra parsing and data
 			// about the MIG instance assignment, which is not supported yet.
 			return filteredDevices, fmt.Errorf("MIG devices are not supported")
-		} else {
+		default:
 			matchingDevice, err = getDeviceWithIndex(systemDevices, visibleDevice)
 			if err != nil {
 				return filteredDevices, err

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -19,7 +19,15 @@ import (
 
 const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 
-// GetVisibleDevicesForProcess modifies the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable for the specified process
+// GetVisibleDevicesForProcess modifies the list of GPU devices according to the
+// value of the CUDA_VISIBLE_DEVICES environment variable for the specified
+// process. Reference:
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
+// Invalid device indexes are ignored, and anything that comes after that is
+// invisible, following the spec: "If one of the indices is invalid, only the
+// devices whose index precedes the invalid index are visible to CUDA
+// applications." If an invalid index is found, an error is returned together
+// with the list of valid devices found up until that point.
 func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs string) ([]nvml.Device, error) {
 	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, cudaVisibleDevicesEnvVar, procfs)
 	if err != nil {
@@ -29,11 +37,8 @@ func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs st
 	return getVisibleDevices(systemDevices, cudaVisibleDevices)
 }
 
-// getVisibleDevices processes the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable
-// Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
-// Invalid device indexes are ignored, and anything that comes after that is invisible, following the spec:
-// "If one of the indices is invalid, only the devices whose index precedes the invalid index are visible to CUDA applications."
-// If an invalid index is found, an error is returned together with the list of valid devices found up until that point.
+// getVisibleDevices processes the list of GPU devices according to the value of
+// the CUDA_VISIBLE_DEVICES environment variable
 func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) ([]nvml.Device, error) {
 	if cudaVisibleDevices == "" {
 		return systemDevices, nil

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -22,7 +22,15 @@ const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 // GetVisibleDevicesForProcess modifies the list of GPU devices according to the
 // value of the CUDA_VISIBLE_DEVICES environment variable for the specified
 // process. Reference:
-// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars.
+//
+// As a summary, the CUDA_VISIBLE_DEVICES environment variable should be a comma
+// separated list of GPU identifiers. These can be either the index of the GPU
+// (0, 1, 2) or the UUID of the GPU (GPU-<UUID>, or
+// MIG-GPU-<UUID>/<instance-index>/<compute-index for multi-instance GPUs). UUID
+// identifiers do not need to be the full UUID, it is enough with specifying the
+// prefix that uniquely identifies the GPU.
+//
 // Invalid device indexes are ignored, and anything that comes after that is
 // invisible, following the spec: "If one of the indices is invalid, only the
 // devices whose index precedes the invalid index are visible to CUDA

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
+
 // getVisibleDevices processes the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable
 // Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
 func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) ([]nvml.Device, error) {
@@ -59,14 +61,9 @@ func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) (
 	return filteredDevices, nil
 }
 
-// getCudaVisibleDevicesEnvVar retrieves the value of the CUDA_VISIBLE_DEVICES environment variable for the specified process
-func getCudaVisibleDevicesEnvVar(pid int, procfs string) (string, error) {
-	return kernel.GetProcessEnvVariable(pid, "CUDA_VISIBLE_DEVICES", procfs)
-}
-
 // GetVisibleDevicesForProcess modifies the list of GPU devices according to the value of the CUDA_VISIBLE_DEVICES environment variable for the specified process
 func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs string) ([]nvml.Device, error) {
-	cudaVisibleDevices, err := getCudaVisibleDevicesEnvVar(pid, procfs)
+	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, cudaVisibleDevicesEnvVar, procfs)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get CUDA_VISIBLE_DEVICES for process %d: %w", pid, err)
 	}

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -51,6 +51,8 @@ func getVisibleDevices(systemDevices []nvml.Device, cudaVisibleDevices string) (
 				return filteredDevices, err
 			}
 		} else if strings.HasPrefix(visibleDevice, "MIG-GPU") {
+			// MIG (Multi Instance GPUs) devices require extra parsing and data
+			// about the MIG instance assignment, which is not supported yet.
 			return filteredDevices, fmt.Errorf("MIG devices are not supported")
 		} else {
 			matchingDevice, err = getDeviceWithIndex(systemDevices, visibleDevice)

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -31,7 +31,7 @@ const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs string) ([]nvml.Device, error) {
 	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, cudaVisibleDevicesEnvVar, procfs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get CUDA_VISIBLE_DEVICES for process %d: %w", pid, err)
+		return nil, fmt.Errorf("cannot get env var %s for process %d: %w", cudaVisibleDevicesEnvVar, pid, err)
 	}
 
 	return getVisibleDevices(systemDevices, cudaVisibleDevices)

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -37,7 +37,7 @@ const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 // applications." If an invalid index is found, an error is returned together
 // with the list of valid devices found up until that point.
 func GetVisibleDevicesForProcess(systemDevices []nvml.Device, pid int, procfs string) ([]nvml.Device, error) {
-	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, cudaVisibleDevicesEnvVar, procfs)
+	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, procfs, cudaVisibleDevicesEnvVar)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get env var %s for process %d: %w", cudaVisibleDevicesEnvVar, pid, err)
 	}

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -28,7 +28,7 @@ func TestGetVisibleDevices(t *testing.T) {
 
 	dev2 := &nvmlmock.Device{
 		GetUUIDFunc: func() (string, nvml.Return) {
-			return uuid1, nvml.SUCCESS
+			return uuid2, nvml.SUCCESS
 		},
 	}
 

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetVisibleDevices(t *testing.T) {
-	uuid1 := "GPU-8932f937-d72c-4106-c12f-20bd9faed9f6"
-	uuid2 := "GPU-1902f078-a8da-4036-a78f-4032bbddeaf2"
+	commonPrefix := "GPU-89"
+	uuid1 := commonPrefix + "32f937-d72c-4106-c12f-20bd9faed9f6"
+	uuid2 := commonPrefix + "02f078-a8da-4036-a78f-4032bbddeaf2"
 
 	dev1 := &nvmlmock.Device{
 		GetUUIDFunc: func() (string, nvml.Return) {
@@ -26,7 +26,7 @@ func TestGetVisibleDevices(t *testing.T) {
 		},
 	}
 
-	dev2 := nvmlmock.Device{
+	dev2 := &nvmlmock.Device{
 		GetUUIDFunc: func() (string, nvml.Return) {
 			return uuid1, nvml.SUCCESS
 		},
@@ -85,6 +85,18 @@ func TestGetVisibleDevices(t *testing.T) {
 			visibleDevices:  "0," + uuid2,
 			expectedDevices: []nvml.Device{devList[0], devList[1]},
 			expectsError:    false,
+		},
+		{
+			name:            "InvalidIndexInMiddle",
+			visibleDevices:  "0,235,1",
+			expectedDevices: []nvml.Device{devList[0]},
+			expectsError:    true,
+		},
+		{
+			name:            "SharedPrefix",
+			visibleDevices:  commonPrefix,
+			expectedDevices: nil,
+			expectsError:    true,
 		},
 	}
 

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package cuda
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockGpuDevice struct {
+	mock.Mock
+}
+
+func (m *mockGpuDevice) GetUUID() (string, nvml.Return) {
+	args := m.Called()
+	return args.String(0), args.Get(1).(nvml.Return)
+}
+
+func TestGetVisibleDevices(t *testing.T) {
+	uuid1 := "GPU-8932f937-d72c-4106-c12f-20bd9faed9f6"
+	uuid2 := "GPU-1902f078-a8da-4036-a78f-4032bbddeaf2"
+
+	devList := []WithUUID{
+		&mockGpuDevice{},
+		&mockGpuDevice{},
+	}
+
+	devList[0].(*mockGpuDevice).On("GetUUID").Return(uuid1, nvml.SUCCESS)
+	devList[1].(*mockGpuDevice).On("GetUUID").Return(uuid2, nvml.SUCCESS)
+
+	cases := []struct {
+		name            string
+		visibleDevices  string
+		expectedDevices []WithUUID
+		expectsError    bool
+	}{
+		{
+			name:            "no visible devices",
+			visibleDevices:  "",
+			expectedDevices: devList,
+			expectsError:    false,
+		},
+		{
+			name:            "UUIDs",
+			visibleDevices:  uuid1,
+			expectedDevices: []WithUUID{devList[0]},
+			expectsError:    false,
+		},
+		{
+			name:            "Index",
+			visibleDevices:  "1",
+			expectedDevices: []WithUUID{devList[1]},
+			expectsError:    false,
+		},
+		{
+			name:            "IndexOutOfRange",
+			visibleDevices:  "2",
+			expectedDevices: nil,
+			expectsError:    true,
+		},
+		{
+			name:            "InvalidIndex",
+			visibleDevices:  "a",
+			expectedDevices: nil,
+			expectsError:    true,
+		},
+		{
+			name:            "MIGDevices",
+			visibleDevices:  "MIG-GPU-1",
+			expectedDevices: nil,
+			expectsError:    true,
+		},
+		{name: "UnorderedIndexes",
+			visibleDevices:  "1,0",
+			expectedDevices: []WithUUID{devList[1], devList[0]},
+			expectsError:    false,
+		},
+		{
+			name:            "MixedIndexesAndUUIDs",
+			visibleDevices:  "0," + uuid2,
+			expectedDevices: []WithUUID{devList[0], devList[1]},
+			expectsError:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			devices, err := getVisibleDevices(devList, tc.visibleDevices)
+			if tc.expectsError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedDevices, devices)
+		})
+	}
+}

--- a/pkg/util/kernel/proc.go
+++ b/pkg/util/kernel/proc.go
@@ -56,7 +56,12 @@ func WithAllProcs(procRoot string, fn func(int) error) error {
 	return nil
 }
 
-// scanNullString is a SplitFunc for a Scanner that returns each null-terminated string as a token
+// scanNullString is a SplitFunc for a Scanner that returns each null-terminated
+// string as a token. Receives the data from the scanner that's yet to be
+// processed into tokens, and whether the scanner has reached EOF.
+//
+// Returns the number of bytes to advance the scanner, the token that was
+// detected and an error in case of failure
 func scanNullStrings(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil

--- a/pkg/util/kernel/proc.go
+++ b/pkg/util/kernel/proc.go
@@ -90,6 +90,8 @@ func getEnvVariableFromBuffer(reader io.Reader, envVar string) string {
 	return ""
 }
 
+// GetProcessEnvVariable retrieves the given environment variable for the specified process ID, without
+// loading the entire environment into memory. Will return an empty string if the variable is not found.
 func GetProcessEnvVariable(pid int, procRoot string, envVar string) (string, error) {
 	envPath := filepath.Join(procRoot, strconv.Itoa(pid), "environ")
 	envFile, err := os.Open(envPath)

--- a/pkg/util/kernel/proc.go
+++ b/pkg/util/kernel/proc.go
@@ -8,8 +8,14 @@
 package kernel
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // AllPidsProcs will return all pids under procRoot
@@ -48,4 +54,49 @@ func WithAllProcs(procRoot string, fn func(int) error) error {
 		}
 	}
 	return nil
+}
+
+// scanNullString is a SplitFunc for a Scanner that returns each null-terminated string as a token
+func scanNullStrings(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\x00'); i >= 0 {
+		// We have a full null-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+func getEnvVariableFromBuffer(reader io.Reader, envVar string) string {
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(scanNullStrings)
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		if parts[0] == envVar {
+			return parts[1]
+		}
+	}
+
+	return ""
+}
+
+func GetProcessEnvVariable(pid int, procRoot string, envVar string) (string, error) {
+	envPath := filepath.Join(procRoot, strconv.Itoa(pid), "environ")
+	envFile, err := os.Open(envPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot open %s: %w", envPath, err)
+	}
+	defer envFile.Close()
+
+	return getEnvVariableFromBuffer(envFile, envVar), nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds code to the `pkg/gpu/cuda` package to filter the visible GPU devices for a process, using the value of the `CUDA_VISIBLE_DEVICES` environment variable. This is needed to enable correct multi-gpu support, as the process selects a device based on its index in the list of GPUs visible to it. 

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->