### PR TITLE
[usm] discovery, check ignored command names defined in system-probe config file.

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	// maximum command name length to process when checking for non-reportable commands
-	// file /proc/<pid>/comm stores a length of up to 16 bytes, where the last byte is the end of the line.
+	// maximum command name length to process when checking for non-reportable commands,
+	// is one byte less (excludes end of line) than the maximum of /proc/<pid>/comm
+	// defined in https://man7.org/linux/man-pages/man5/proc.5.html.
 	maxCommLen = 15
 )
 

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ignoreComms is a list of process names that should not be reported as a service.
@@ -60,4 +61,21 @@ func shouldIgnoreComm(proc *process.Process) bool {
 	_, found := ignoreComms[comm]
 
 	return found
+}
+
+// LoadIgnoredComms expands the list of ignored commands by adding commands from the configuration
+func LoadIgnoredComms(config *discoveryConfig) {
+	if config == nil {
+		log.Errorf("unexpected nil configuration")
+		return
+	}
+	comms := strings.Split(strings.ReplaceAll(config.ignoreComms, " ", ""), ",")
+
+	for _, comm := range comms {
+		if len(comm) > 15 {
+			ignoreComms[comm[:15]] = struct{}{}
+		} else if len(comm) > 0 {
+			ignoreComms[comm] = struct{}{}
+		}
+	}
 }

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -33,8 +33,7 @@ var ignoreFamily = map[string]struct{}{
 
 // shouldIgnoreComm returns true if process should be ignored
 func (s *discovery) shouldIgnoreComm(proc *process.Process) bool {
-	ignoreComms := s.config.ignoreComms
-	if ignoreComms == nil {
+	if s.config.ignoreComms == nil {
 		return false
 	}
 	commPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "comm")
@@ -52,7 +51,7 @@ func (s *discovery) shouldIgnoreComm(proc *process.Process) bool {
 	}
 
 	comm := strings.TrimSuffix(string(contents), "\n")
-	_, found := ignoreComms[comm]
+	_, found := s.config.ignoreComms[comm]
 
 	return found
 }

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -19,7 +19,9 @@ import (
 )
 
 const (
-	maxCommLen = 15 // maximum command name length to process when checking for non-reportable commands
+	// maximum command name length to process when checking for non-reportable commands
+	// file /proc/<pid>/comm stores a length of up to 16 bytes, where the last byte is the end of the line.
+	maxCommLen = 15
 )
 
 // ignoreFamily list of processes with hyphens in their names,

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -144,8 +144,8 @@ func TestShouldIgnoreComm(t *testing.T) {
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				ignore := discovery.shouldIgnoreComm(proc)
-				assert.Equal(t, test.ignore, ignore)
-			}, 200*time.Millisecond, 100*time.Millisecond)
+				assert.Equal(collect, test.ignore, ignore)
+			}, 500*time.Millisecond, 100*time.Millisecond)
 		})
 	}
 }

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -61,6 +61,7 @@ func TestIgnoreComm(t *testing.T) {
 func TestIgnoreCommsLengths(t *testing.T) {
 	discovery := newDiscovery()
 	require.NotEmpty(t, discovery)
+	require.Equal(t, len(discovery.config.ignoreComms), 10)
 
 	for comm := range discovery.config.ignoreComms {
 		assert.LessOrEqual(t, len(comm), maxCommLen, "Process name %q too big", comm)

--- a/pkg/collector/corechecks/servicediscovery/module/config.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config.go
@@ -30,14 +30,14 @@ func newConfig() *discoveryConfig {
 	conf := &discoveryConfig{
 		cpuUsageUpdateDelay: cfg.GetDuration(join(discoveryNS, "cpu_usage_update_delay")),
 	}
-	conf.loadIgnoredComms(cfg.GetString(join(discoveryNS, "ignored_command_names")))
+
+	conf.loadIgnoredComms(cfg.GetStringSlice(join(discoveryNS, "ignored_command_names")))
 
 	return conf
 }
 
 // loadIgnoredComms read process names that should not be reported as a service from input string
-func (config *discoveryConfig) loadIgnoredComms(commsList string) {
-	comms := strings.Split(strings.ReplaceAll(commsList, " ", ""), ",")
+func (config *discoveryConfig) loadIgnoredComms(comms []string) {
 	if len(comms) == 0 {
 		log.Warn("loading ignored commands found empty commands list")
 		return

--- a/pkg/collector/corechecks/servicediscovery/module/config.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config.go
@@ -47,7 +47,7 @@ func (config *discoveryConfig) loadIgnoredComms(comms []string) {
 	for _, comm := range comms {
 		if len(comm) > maxCommLen {
 			config.ignoreComms[comm[:maxCommLen]] = struct{}{}
-			log.Warnf("the command name %d bytes long in config is truncated to maximum %d.", len(comm), maxCommLen)
+			log.Warnf("truncating command name %q has %d bytes to %d", comm, len(comm), maxCommLen)
 		} else if len(comm) > 0 {
 			config.ignoreComms[comm] = struct{}{}
 		}

--- a/pkg/collector/corechecks/servicediscovery/module/config.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config.go
@@ -19,6 +19,7 @@ const discoveryNS = "discovery"
 
 type discoveryConfig struct {
 	cpuUsageUpdateDelay time.Duration
+	ignoreComms         string
 }
 
 func newConfig() *discoveryConfig {
@@ -27,6 +28,7 @@ func newConfig() *discoveryConfig {
 
 	return &discoveryConfig{
 		cpuUsageUpdateDelay: cfg.GetDuration(join(discoveryNS, "cpu_usage_update_delay")),
+		ignoreComms:         cfg.GetString(join(discoveryNS, "ignore_comms")),
 	}
 }
 

--- a/pkg/collector/corechecks/servicediscovery/module/config_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test && linux_bpf
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestConfigIgnoredComms(t *testing.T) {
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("discovery.ignored_command_names", "dummy1 dummy2")
+
+		discovery := newDiscovery()
+		require.NotEmpty(t, discovery)
+
+		assert.Equal(t, len(discovery.config.ignoreComms), 2)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_DISCOVERY_IGNORED_COMMAND_NAMES", "dummy1 dummy2")
+
+		discovery := newDiscovery()
+		require.NotEmpty(t, discovery)
+
+		assert.Equal(t, len(discovery.config.ignoreComms), 2)
+	})
+
+	t.Run("default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		discovery := newDiscovery()
+		require.NotEmpty(t, discovery)
+
+		assert.Equal(t, len(discovery.config.ignoreComms), 10)
+	})
+}

--- a/pkg/collector/corechecks/servicediscovery/module/config_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build test && linux_bpf
+//go:build linux_bpf
 
 package module
 

--- a/pkg/collector/corechecks/servicediscovery/module/config_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config_test.go
@@ -8,6 +8,7 @@
 package module
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,31 +18,78 @@ import (
 )
 
 func TestConfigIgnoredComms(t *testing.T) {
-	t.Run("via YAML", func(t *testing.T) {
-		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("discovery.ignored_command_names", "dummy1 dummy2")
+	tests := []struct {
+		name  string   // The name of the test.
+		comms []string // list of command names to test
+	}{
+		{
+			name:  "empty list of commands",
+			comms: []string{},
+		},
+		{
+			name: "short commands in config list",
+			comms: []string{
+				"cron",
+				"polkitd",
+				"rsyslogd",
+				"bash",
+				"sshd",
+			},
+		},
+		{
+			name: "long commands in config list",
+			comms: []string{
+				"containerd-shim-runc-v2",
+				"calico-node",
+				"unattended-upgrade-shutdown",
+				"bash",
+				"kube-controller-manager",
+			},
+		},
+	}
 
+	// test with custom command names of different lengths
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockSystemProbe := mock.NewSystemProbe(t)
+			require.NotEmpty(t, mockSystemProbe)
+
+			commsStr := strings.Join(test.comms, "   ") // intentionally multiple spaces for sensitivity testing
+			mockSystemProbe.SetWithoutSource("discovery.ignored_command_names", commsStr)
+
+			discovery := newDiscovery()
+			require.NotEmpty(t, discovery)
+
+			require.Equal(t, len(discovery.config.ignoreComms), len(test.comms))
+
+			for _, cmd := range test.comms {
+				if len(cmd) > maxCommLen {
+					cmd = cmd[:maxCommLen]
+				}
+				_, found := discovery.config.ignoreComms[cmd]
+				assert.True(t, found)
+			}
+		})
+	}
+
+	t.Run("check default config length", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		discovery := newDiscovery()
 		require.NotEmpty(t, discovery)
 
-		assert.Equal(t, len(discovery.config.ignoreComms), 2)
+		assert.Equal(t, len(discovery.config.ignoreComms), 10)
 	})
 
-	t.Run("via ENV variable", func(t *testing.T) {
+	t.Run("check command names in env variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
 		t.Setenv("DD_DISCOVERY_IGNORED_COMMAND_NAMES", "dummy1 dummy2")
 
 		discovery := newDiscovery()
 		require.NotEmpty(t, discovery)
 
-		assert.Equal(t, len(discovery.config.ignoreComms), 2)
-	})
-
-	t.Run("default", func(t *testing.T) {
-		mock.NewSystemProbe(t)
-		discovery := newDiscovery()
-		require.NotEmpty(t, discovery)
-
-		assert.Equal(t, len(discovery.config.ignoreComms), 10)
+		_, found := discovery.config.ignoreComms["dummy1"]
+		assert.True(t, found)
+		_, found = discovery.config.ignoreComms["dummy2"]
+		assert.True(t, found)
 	})
 }

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -82,8 +82,11 @@ type discovery struct {
 
 // NewDiscoveryModule creates a new discovery system probe module.
 func NewDiscoveryModule(*sysconfigtypes.Config, module.FactoryDependencies) (module.Module, error) {
+	config := newConfig()
+	LoadIgnoredComms(config)
+
 	return &discovery{
-		config:             newConfig(),
+		config:             config,
 		mux:                &sync.RWMutex{},
 		cache:              make(map[int32]*serviceInfo),
 		privilegedDetector: privileged.NewLanguageDetector(),

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -80,18 +80,19 @@ type discovery struct {
 	lastCPUTimeUpdate time.Time
 }
 
-// NewDiscoveryModule creates a new discovery system probe module.
-func NewDiscoveryModule(*sysconfigtypes.Config, module.FactoryDependencies) (module.Module, error) {
-	config := newConfig()
-	LoadIgnoredComms(config)
-
+func newDiscovery() *discovery {
 	return &discovery{
-		config:             config,
+		config:             newConfig(),
 		mux:                &sync.RWMutex{},
 		cache:              make(map[int32]*serviceInfo),
 		privilegedDetector: privileged.NewLanguageDetector(),
 		scrubber:           procutil.NewDefaultDataScrubber(),
-	}, nil
+	}
+}
+
+// NewDiscoveryModule creates a new discovery system probe module.
+func NewDiscoveryModule(*sysconfigtypes.Config, module.FactoryDependencies) (module.Module, error) {
+	return newDiscovery(), nil
 }
 
 // GetStats returns the stats of the discovery module.
@@ -405,7 +406,7 @@ func (s *discovery) getService(context parsingContext, pid int32) *model.Service
 		return nil
 	}
 
-	if shouldIgnoreComm(proc) {
+	if s.shouldIgnoreComm(proc) {
 		return nil
 	}
 

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -402,7 +402,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// Discovery config
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignore_comms"), "")
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), "chronyd,cilium-agent,containerd,dhclient,dockerd,kubelet,livenessprobe,local-volume-pr,sshd,systemd")
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir")

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -402,7 +402,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// Discovery config
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), "chronyd,cilium-agent,containerd,dhclient,dockerd,kubelet,livenessprobe,local-volume-pr,sshd,systemd")
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir")

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -402,6 +402,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// Discovery config
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignore_comms"), "")
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir")


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow adding process command names skipped during service discovery to the system-probe configuration file.

### Motivation

[USMON-1291](https://datadoghq.atlassian.net/browse/USMON-1291)
The service discovery skips processing of a certain predefined process based on the command name. 
This code allows to add other command names to the list of bypassed processes using the system-probe configuration file.

### Describe how to test/QA your changes

A new unit test verifies the extraction of various process command names from a system probe-configuration file.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The system-probe only considers the first 15 bytes of the process command name, which is the maximum command name length taken from /proc/<pid>/comm for user-mode processes.


[USMON-1291]: https://datadoghq.atlassian.net/browse/USMON-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ