### PR TITLE
feat(ci): Add a new workflow to label a PR wrt review duration

### DIFF
--- a/.github/workflows/code_review_complexity.yml
+++ b/.github/workflows/code_review_complexity.yml
@@ -1,0 +1,34 @@
+---
+name: "PR complexity label"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - "[0-9]+.[0-9]+.x"
+  pull_request_review_comment:
+    types: [created, deleted]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions: {}
+jobs:
+  codereview-complexity:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Setup python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: 3.12
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r tasks/requirements.txt
+      - name: Check code review complexity
+        run: inv -e github.assign-codereview-label --pr-id='${{ github.event.pull_request.number }}'

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -409,3 +409,15 @@ def pr_commenter(
 
     if verbose:
         print(f"{action} comment on PR #{pr.number} - {pr.title}")
+
+
+@task
+def assign_codereview_label(_, pr_id=-1):
+    """
+    Assigns a code review complexity label based on PR attributes (files changed, additions, deletions, comments)
+    """
+    from tasks.libs.ciproviders.github_api import GithubAPI
+
+    gh = GithubAPI('DataDog/datadog-agent')
+    complexity = gh.get_codereview_complexity(pr_id)
+    gh.add_pr_label(pr_id, complexity)

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -420,4 +420,4 @@ def assign_codereview_label(_, pr_id=-1):
 
     gh = GithubAPI('DataDog/datadog-agent')
     complexity = gh.get_codereview_complexity(pr_id)
-    gh.add_pr_label(pr_id, complexity)
+    gh.update_review_complexity_labels(pr_id, complexity)

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -378,6 +378,26 @@ class GithubAPI:
             draft=draft,
         )
 
+    def get_codereview_complexity(self, pr_id):
+        pr = self._repository.get_pull(pr_id)
+        criteria = {
+            'easy': {'files': 4, 'lines': 150, 'comments': 1},
+            'hard': {'files': 12, 'lines': 650, 'comments': 9},
+        }
+        if (
+            pr.changed_files < criteria['easy']['files']
+            and pr.additions + pr.deletions < criteria['easy']['lines']
+            and pr.review_comments < criteria['easy']['comments']
+        ):
+            return 'short review'
+        elif (
+            pr.changed_files > criteria['hard']['files']
+            or pr.additions + pr.deletions > criteria['hard']['lines']
+            or pr.review_comments > criteria['hard']['comments']
+        ):
+            return 'long review'
+        return 'medium review'
+
 
 def get_github_teams(users):
     for user in users:

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -399,6 +399,10 @@ class GithubAPI:
         Get the complexity of the code review for a given PR, taking into account the number of files, lines and comments.
         """
         pr = self._repository.get_pull(pr_id)
+        # Criteria are defined with the average of PR attributes (files, lines, comments) so that:
+        # - easy PRs are merged in less than 1 day
+        # - hard PRs are merged in more than 1 week
+        # More details about criteria definition: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4271079846/Code+Review+Experience+Improvement#Complexity-label
         criteria = {
             'easy': {'files': 4, 'lines': 150, 'comments': 1},
             'hard': {'files': 12, 'lines': 650, 'comments': 9},

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -271,6 +271,22 @@ class GithubAPI:
 
         return [label.name for label in pr.get_labels()]
 
+    def update_review_complexity_labels(self, pr_id: int, new_label: str) -> None:
+        """
+        Updates the review complexity label of a pull request
+        """
+        pr = self.get_pr(pr_id)
+        already_there = False
+        for label in pr.get_labels():
+            if label.name.endswith(" review"):
+                if label.name == new_label:
+                    already_there = True
+                else:
+                    pr.remove_from_labels(label.name)
+
+        if not already_there:
+            pr.add_to_labels(new_label)
+
     def get_pr_files(self, pr_id: int) -> list[str]:
         """
         Returns the files involved in the PR
@@ -378,7 +394,10 @@ class GithubAPI:
             draft=draft,
         )
 
-    def get_codereview_complexity(self, pr_id):
+    def get_codereview_complexity(self, pr_id: int) -> str:
+        """
+        Get the complexity of the code review for a given PR, taking into account the number of files, lines and comments.
+        """
         pr = self._repository.get_pull(pr_id)
         criteria = {
             'easy': {'files': 4, 'lines': 150, 'comments': 1},

--- a/tasks/unit_tests/github_api_tests.py
+++ b/tasks/unit_tests/github_api_tests.py
@@ -56,3 +56,35 @@ class TestContainsReleaseNote(unittest.TestCase):
 
         github = GithubAPI(repository="org/test", public_repo=True)
         self.assertEqual(github._organization, "org")
+
+
+class TestUpdateReviewComplexityLabel(unittest.TestCase):
+    @patch("tasks.libs.ciproviders.github_api.Github", autospec=True)
+    def test_add_label(self, _):
+        github = GithubAPI(repository="test", public_repo=True)
+        with patch.object(github, '_repository') as mock_repo:
+            mock_pr = mock_repo.get_pull.return_value
+            mock_pr.get_labels.return_value = [Label("changelog/no-changelog")]
+            github.update_review_complexity_labels(1, "short review")
+            mock_pr.remove_from_labels.assert_not_called()
+            mock_pr.add_to_labels.assert_called_with("short review")
+
+    @patch("tasks.libs.ciproviders.github_api.Github", autospec=True)
+    def test_add_same_label(self, _):
+        github = GithubAPI(repository="test", public_repo=True)
+        with patch.object(github, '_repository') as mock_repo:
+            mock_pr = mock_repo.get_pull.return_value
+            mock_pr.get_labels.return_value = [Label("changelog/no-changelog"), Label("short review")]
+            github.update_review_complexity_labels(1, "short review")
+            mock_pr.remove_from_labels.assert_not_called()
+            mock_pr.add_to_labels.assert_not_called()
+
+    @patch("tasks.libs.ciproviders.github_api.Github", autospec=True)
+    def test_add_new_label(self, _):
+        github = GithubAPI(repository="test", public_repo=True)
+        with patch.object(github, '_repository') as mock_repo:
+            mock_pr = mock_repo.get_pull.return_value
+            mock_pr.get_labels.return_value = [Label("changelog/no-changelog"), Label("short review")]
+            github.update_review_complexity_labels(1, "medium review")
+            mock_pr.remove_from_labels.assert_called_with("short review")
+            mock_pr.add_to_labels.assert_called_with("medium review")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a new workflow `PR complexity label` to add a code review duration estimation label to a PR, based on PR attributes (files changed, additions, deletions, comments)

### Motivation
Better inform PR author and reviewers about the complexity of the PR.
With the [chosen criteria](https://github.com/DataDog/datadog-agent/blob/nschweitzer/codereview_label/tasks/libs/ciproviders/github_api.py#L384-L385)
- `easy PR` (short review) are merged in an average time of `3 days, 2:49:10`
- `medium PR` (medium review) are merged in an average time of `7 days, 22:14:08`
- `hard PR` (short review) are merged in an average time of `26 days, 22:13:15`

From the ~30k PR merged in `datadog-agent`, we have the following distribution:
|complexity|percentage|
|--|--|
|easy|43%|
|medium|54%|
|hard|3%|

The objective is to increase the number of PR merged in less than 1week

### Describe how to test/QA your changes
n/a

### Possible Drawbacks / Trade-offs

### Additional Notes
It would be nice to have this label automatically posted when a PR review is required, to give an hint to reviewers.
If you want more details about the choice of criteria, you an have a look to a [detailed document](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4271079846/Code+Review+Experience+Improvement#Complexity-label).
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->