### PR TITLE
Reduce flakiness of agent check CLI e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -324,7 +324,7 @@ func (suite *k8sSuite) testAgentCLI() {
 	suite.Run("agent check -r container", func() {
 		var stdout string
 		suite.EventuallyWithT(func(c *assert.CollectT) {
-			stdout, _, err = suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "check", "-r", "container", "--table", "--delay", "1000"})
+			stdout, _, err = suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "check", "-t", "3", "container", "--table", "--delay", "1000", "--pause", "5000"})
 			// Can be replaced by require.NoError(…) once https://github.com/stretchr/testify/pull/1481 is merged
 			if !assert.NoError(c, err) {
 				return


### PR DESCRIPTION
### What does this PR do?

Reduces flakiness of agent check CLI e2e test

### Motivation

[Test is flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40ci.job.name%3Anew-e2e-containers%2A%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent%20%40test.name%3A%2A%2FTestCLI%2Fagent_CLI%2Fagent_check_-r_container%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&top_n=250&top_o=top&viz=stream&x_missing=true&start=1727279689110&end=1729871689110&paused=false)

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

The test was originally running the following command:
```
agent check -r container --table --delay 1000
```

Setting `-r` [causes the check to run twice](https://github.com/DataDog/datadog-agent/blob/85241c6eefbad6e363eb0b54eb323488512d3613/pkg/cli/subcommands/check/command.go#L631), with 1 second in between each run. The problem we are running into is that the container metrics provider is not ready by the time the second check finishes running. Setting `--delay` [has no affect](https://github.com/DataDog/datadog-agent/blob/85241c6eefbad6e363eb0b54eb323488512d3613/pkg/cli/subcommands/check/command.go#L495) on the time it takes for the agent to become ready, it is only the amount of time between when the check finishes running and when we look at the aggregator

Instead, the check now runs:
```
agent check -t 3 container --table --delay 1000 --pause 5000
```

So, instead of running the check twice, it runs it 3 times, but more crucially it will wait 5 seconds in between check runs, allowing the agent more time to become fully ready before the final check run is executed