### PR TITLE
[CWS] skip alloc in filepath.Clean in `ProcRootFilePath`

### DIFF
--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -120,6 +120,14 @@ func ProcRootPath(pid uint32) string {
 
 // ProcRootFilePath returns the path to the input file after prepending the proc root path of the given pid
 func ProcRootFilePath(pid uint32, file string) string {
+	// if file starts with /, the result of filepath.Join will look, before cleaning, like
+	//   /proc/$PID/root//file
+	// and this will require a re-allocation in filepath.Clean
+	// to prevent this, we remove the leading / from the file if it's there. In most cases
+	// it will be enough
+	if file != "" && file[0] == os.PathSeparator {
+		file = file[1:]
+	}
 	return procPidPath2(pid, "root", file)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`filepath.Join` is basically `strings.Join` + `filepath.Clean`. `strings.Join` allocates obviously, but `filepath.Clean` doesn't if the path is already clean. The way we call `filepath.Join` currently looks like
```
filepath.Join("/host/proc", "123", "root", "/usr/a/b/c")
```

which always result in something like `/host/proc/123/root//usr/a/b/c` after the first join. Something like that always go down the slow path of `filepath.Clean` which allocates.

The goal of this PR is to call it like:
```
filepath.Join("/host/proc", "123", "root", "usr/a/b/c")
```
if possible, which returns a path that is already clean in most cases, thus removing a lot of allocation.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->