### PR TITLE
[PROCS-4327] Reduce flakiness in `process/TestK8sTestSuite`

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -147,9 +147,6 @@ func (s *K8sSuite) TestProcessDiscoveryCheck() {
 		assert.ElementsMatch(c, []string{"process_discovery"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
 	}, 5*time.Minute, 10*time.Second)
 
-	// Flush fake intake to remove any payloads which may have
-	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-
 	var payloads []*aggregator.ProcessDiscoveryPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
@@ -239,10 +236,7 @@ func (s *K8sSuite) TestProcessCheckInCoreAgentWithNPM() {
 			t.Logf("status: %+v\n", status)
 		}
 	}()
-	var tick int
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		t.Logf("tick %d", tick)
-		tick++
 		status = k8sAgentStatus(c, s.Env().KubernetesCluster)
 		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
 		assert.ElementsMatch(c, []string{"connections"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -77,7 +77,7 @@ func TestK8sTestSuite(t *testing.T) {
 				return cpustress.K8sAppDefinition(e, kubeProvider, "workload-stress")
 			}),
 			awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
-		)), e2e.WithDevMode(),
+		)),
 	}
 
 	e2e.Run(t, &K8sSuite{}, options...)

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -77,7 +77,7 @@ func TestK8sTestSuite(t *testing.T) {
 				return cpustress.K8sAppDefinition(e, kubeProvider, "workload-stress")
 			}),
 			awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
-		)),
+		)), e2e.WithDevMode(),
 	}
 
 	e2e.Run(t, &K8sSuite{}, options...)
@@ -86,10 +86,10 @@ func TestK8sTestSuite(t *testing.T) {
 func (s *K8sSuite) TestProcessCheck() {
 	t := s.T()
 
-	assert.EventuallyWithT(t, func(*assert.CollectT) {
-		status := k8sAgentStatus(t, s.Env().KubernetesCluster)
-		assert.ElementsMatch(t, []string{"process", "rtprocess"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
-	}, 4*time.Minute, 10*time.Second)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status := k8sAgentStatus(c, s.Env().KubernetesCluster)
+		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
+	}, 5*time.Minute, 10*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -99,7 +99,7 @@ func (s *K8sSuite) TestProcessCheck() {
 
 		// Wait for two payloads, as processes must be detected in two check runs to be returned
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 
 	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
@@ -142,10 +142,10 @@ func (s *K8sSuite) TestProcessDiscoveryCheck() {
 			t.Logf("status: %+v\n", status)
 		}
 	}()
-	assert.EventuallyWithT(t, func(*assert.CollectT) {
-		status = k8sAgentStatus(t, s.Env().KubernetesCluster)
-		assert.ElementsMatch(t, []string{"process_discovery"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
-	}, 4*time.Minute, 10*time.Second)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status = k8sAgentStatus(c, s.Env().KubernetesCluster)
+		assert.ElementsMatch(c, []string{"process_discovery"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
+	}, 5*time.Minute, 10*time.Second)
 
 	// Flush fake intake to remove any payloads which may have
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
@@ -156,7 +156,7 @@ func (s *K8sSuite) TestProcessDiscoveryCheck() {
 		payloads, err = s.Env().FakeIntake.Client().GetProcessDiscoveries()
 		assert.NoError(c, err, "failed to get process discovery payloads from fakeintake")
 		assert.NotEmpty(c, payloads, "no process discovery payloads returned")
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 
 	assertProcessDiscoveryCollected(t, payloads, "stress-ng-cpu [run]")
 }
@@ -184,16 +184,16 @@ func (s *K8sSuite) TestProcessCheckInCoreAgent() {
 			t.Logf("status: %+v\n", status)
 		}
 	}()
-	assert.EventuallyWithT(t, func(*assert.CollectT) {
-		status = k8sAgentStatus(t, s.Env().KubernetesCluster)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status = k8sAgentStatus(c, s.Env().KubernetesCluster)
 
 		// verify the standalone process-agent is not running
-		assert.NotEmpty(t, status.ProcessAgentStatus.Error, "status: %+v", status)
-		assert.Empty(t, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
+		assert.NotEmpty(c, status.ProcessAgentStatus.Error, "status: %+v", status)
+		assert.Empty(c, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
 
 		// Verify the process component is running in the core agent
-		assert.ElementsMatch(t, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
-	}, 4*time.Minute, 10*time.Second)
+		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
+	}, 5*time.Minute, 10*time.Second)
 
 	// Flush fake intake to remove any payloads which may have
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
@@ -205,7 +205,7 @@ func (s *K8sSuite) TestProcessCheckInCoreAgent() {
 		assert.NoError(c, err, "failed to get process payloads from fakeintake")
 		// Wait for two payloads, as processes must be detected in two check runs to be returned
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 
 	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
@@ -239,11 +239,14 @@ func (s *K8sSuite) TestProcessCheckInCoreAgentWithNPM() {
 			t.Logf("status: %+v\n", status)
 		}
 	}()
-	assert.EventuallyWithT(t, func(*assert.CollectT) {
-		status = k8sAgentStatus(t, s.Env().KubernetesCluster)
-		assert.ElementsMatch(t, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
-		assert.ElementsMatch(t, []string{"connections"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
-	}, 4*time.Minute, 10*time.Second)
+	var tick int
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		t.Logf("tick %d", tick)
+		tick++
+		status = k8sAgentStatus(c, s.Env().KubernetesCluster)
+		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
+		assert.ElementsMatch(c, []string{"connections"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
+	}, 5*time.Minute, 10*time.Second)
 
 	// Flush fake intake to remove any payloads which may have
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
@@ -256,7 +259,7 @@ func (s *K8sSuite) TestProcessCheckInCoreAgentWithNPM() {
 
 		// Wait for two payloads, as processes must be detected in two check runs to be returned
 		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 
 	assertProcessCollected(t, payloads, false, "stress-ng-cpu [run]")
 	assertProcessCollected(t, payloads, false, "process-agent")
@@ -279,13 +282,13 @@ func execProcessAgentCheck(t *testing.T, cluster *components.KubernetesCluster, 
 	return stdout
 }
 
-func k8sAgentStatus(t *testing.T, cluster *components.KubernetesCluster) AgentStatus {
+func k8sAgentStatus(t assert.TestingT, cluster *components.KubernetesCluster) AgentStatus {
 	agent := getAgentPod(t, cluster.Client())
 
 	stdout, stderr, err := cluster.KubernetesClient.
 		PodExec(agent.Namespace, agent.Name, "agent",
 			[]string{"bash", "-c", "DD_LOG_LEVEL=OFF agent status --json"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, stderr)
 	assert.NotNil(t, stdout, "failed to get agent status")
 
@@ -296,11 +299,11 @@ func k8sAgentStatus(t *testing.T, cluster *components.KubernetesCluster) AgentSt
 	return statusMap
 }
 
-func getAgentPod(t *testing.T, client kubeClient.Interface) corev1.Pod {
+func getAgentPod(t assert.TestingT, client kubeClient.Interface) corev1.Pod {
 	res, err := client.CoreV1().Pods("datadog").
 		List(context.Background(), v1.ListOptions{LabelSelector: "app=dda-linux-datadog"})
-	require.NoError(t, err)
-	require.NotEmpty(t, res.Items)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, res.Items)
 
 	return res.Items[0]
 }

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -116,9 +116,9 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
 	}, 1*time.Minute, 5*time.Second)
 
 	// Verify that the process agent is not running
-	assert.EventuallyWithT(t, func(*assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		status := s.Env().RemoteHost.MustExecute("/opt/datadog-agent/embedded/bin/process-agent status")
-		assert.Contains(t, status, "The Process Agent is not running")
+		assert.Contains(c, status, "The Process Agent is not running")
 	}, 1*time.Minute, 5*time.Second)
 
 	// Flush fake intake to remove any payloads which may have


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR addresses flakiness in the `process/TestK8sTestSuite` e2e suite. Particularly with `TestProcessCheckInCoreAgentWithNPM` and `TestProcessDiscovery` tests.

The following fixes were made:
* Fix incorrect usage of `testing.T` instead of `assert.CollectT` in `assert.EventuallyWithT` calls. This would cause the function to exit on immediately on any failed assertion as the parent `T` was mistakenly used.
* Remove any use of `require` within `assert.EventuallyWithT` calls.`assert.TestingT` and `require.TestingT` are not interchangeable interfaces, so using them together can be inconvenient in helper functions unless using`assert.CollectT` which implements both. Since some helpers are used outside of  `assert.EventuallyWithT`, it seemed to simpler to stick with just `assert`.  The downside being that `require` calls immediately ends ticks while asserts don't.
* Remove the fake intake flush for process discovery payloads. It's likely that the payloads were being removed before having a chance to be received and because the default check run interval is 4hrs, no other payloads would be produced before the test would time out.

### Motivation
PROCS-4327

### Describe how to test/QA your changes
The tests are still marked as flaky and are skipped on branches so they were locally run for correctness.
```
--- PASS: TestK8sTestSuite (1065.67s)
    --- PASS: TestK8sTestSuite/TestManualContainerCheck (16.97s)
    --- PASS: TestK8sTestSuite/TestManualProcessCheck (17.49s)
    --- PASS: TestK8sTestSuite/TestManualProcessDiscoveryCheck (11.92s)
    --- PASS: TestK8sTestSuite/TestProcessCheck (20.92s)
    --- PASS: TestK8sTestSuite/TestProcessCheckInCoreAgent (63.57s)
    --- PASS: TestK8sTestSuite/TestProcessCheckInCoreAgentWithNPM (82.25s)
    --- PASS: TestK8sTestSuite/TestProcessDiscoveryCheck (69.70s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	1068.595s

DONE 8 tests in 1092.222s
All tests passed
```
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The tests are still marked as flaky just in case the fixes don't work. The flakes were fairly [frequent](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fprocess.TestK8sTestSuite%2FTestProcessCheckInCoreAgentWithNPM%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%3A338%2C%40duration%3A96%2C%40test.service%2C%40git.branch&fromUser=false&index=citest&start=1729715006971&end=1729887806971&paused=false), so if there are no more failures on main in the following days, we can remove the mark.