### PR TITLE
Fix kmt error

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -880,9 +880,9 @@ def build_run_config(run: str | None, packages: list[str]):
         if p[:2] == "./":
             p = p[2:]
         if run is not None:
-            c["filters"][p] = {"run-only": [run]}
+            c["filters"] = {p: {"run-only": [run]}}
         else:
-            c["filters"][p] = {"exclude": False}
+            c["filters"] = {p: {"exclude": False}}
 
     return c
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes this error (when specifying `-p` with the `kmt.test` command):
```
Traceback (most recent call last):
  File "/home/hasan.mahmood/.local/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/home/hasan.mahmood/.local/lib/python3.10/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/home/hasan.mahmood/.local/lib/python3.10/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/home/hasan.mahmood/.local/lib/python3.10/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
  File "/home/hasan.mahmood/go/src/github.com/DataDog/datadog-agent/tasks/custom_task/custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
  File "/home/hasan.mahmood/go/src/github.com/DataDog/datadog-agent/tasks/kmt.py", line 1212, in test
    run_config = build_run_config(run, pkgs)
  File "/home/hasan.mahmood/go/src/github.com/DataDog/datadog-agent/tasks/kmt.py", line 885, in build_run_config
    c["filters"][p] = {"exclude": False}
KeyError: 'filters'

```

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->