### PR TITLE
[NETPATH-329]  Use reverse DNS resolution for Network Traffic (dynamic) paths (with cache)

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -49,6 +49,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/profiler"
 	"github.com/DataDog/datadog-agent/comp/process/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	remoteconfig "github.com/DataDog/datadog-agent/comp/remote-config"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
@@ -131,6 +132,9 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 
 		eventplatformreceiverimpl.Module(),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
+
+		// Provides the rdnssquerier module
+		rdnsquerierfx.Module(),
 
 		// Provide network path bundle
 		networkpath.Bundle(),

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -39,6 +39,7 @@ import (
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -124,6 +125,11 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 				// Provide eventplatformimpl module
 				eventplatformreceiverimpl.Module(),
 				eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
+
+				// Provide rdnsquerier module
+				rdnsquerierfx.Module(),
+
+				// Provide npcollector module
 				npcollectorimpl.Module(),
 				// Provide the corresponding workloadmeta Params to configure the catalog
 				wmcatalog.GetCatalog(),

--- a/comp/networkpath/bundle_test.go
+++ b/comp/networkpath/bundle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -17,5 +18,6 @@ func TestBundleDependencies(t *testing.T) {
 	fxutil.TestBundle(t, Bundle(),
 		core.MockBundle(),
 		eventplatformimpl.MockModule(),
+		rdnsquerier.MockModule(),
 	)
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -22,7 +22,7 @@ type collectorConfigs struct {
 	pathtestTTL                  time.Duration
 	pathtestInterval             time.Duration
 	flushInterval                time.Duration
-	reverseDNSCacheEnabled       bool
+	reverseDNSEnabled            bool
 	reverseDNSTimeout            time.Duration
 	networkDevicesNamespace      string
 }
@@ -40,8 +40,8 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		pathtestTTL:                  agentConfig.GetDuration("network_path.collector.pathtest_ttl"),
 		pathtestInterval:             agentConfig.GetDuration("network_path.collector.pathtest_interval"),
 		flushInterval:                agentConfig.GetDuration("network_path.collector.flush_interval"),
-		reverseDNSCacheEnabled:       agentConfig.GetBool("network_path.collector.reverse_dns_cache.enabled"),
-		reverseDNSTimeout:            agentConfig.GetDuration("network_path.collector.reverse_dns_cache.timeout") * time.Millisecond,
+		reverseDNSEnabled:            agentConfig.GetBool("network_path.collector.reverse_dns_enrichment.enabled"),
+		reverseDNSTimeout:            agentConfig.GetDuration("network_path.collector.reverse_dns_enrichment.timeout") * time.Millisecond,
 		networkDevicesNamespace:      agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -22,6 +22,8 @@ type collectorConfigs struct {
 	pathtestTTL                  time.Duration
 	pathtestInterval             time.Duration
 	flushInterval                time.Duration
+	reverseDNSCacheEnabled       bool
+	reverseDNSTimeout            time.Duration
 	networkDevicesNamespace      string
 }
 
@@ -38,6 +40,8 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		pathtestTTL:                  agentConfig.GetDuration("network_path.collector.pathtest_ttl"),
 		pathtestInterval:             agentConfig.GetDuration("network_path.collector.pathtest_interval"),
 		flushInterval:                agentConfig.GetDuration("network_path.collector.flush_interval"),
+		reverseDNSCacheEnabled:       agentConfig.GetBool("network_path.collector.reverse_dns_cache.enabled"),
+		reverseDNSTimeout:            agentConfig.GetDuration("network_path.collector.reverse_dns_cache.timeout") * time.Millisecond,
 		networkDevicesNamespace:      agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -353,7 +353,7 @@ func (s *npCollectorImpl) enrichPathWithRDNS(path *payload.NetworkPath) {
 	hostname := s.getReverseDNSResult(path.Destination.IPAddress, results)
 	// if hostname is blank, use what's given by traceroute
 	// TODO: would it be better to move the logic up from the traceroute command?
-	// benefit to this approach is having consistent behavior for all paths
+	// benefit to the current approach is having consistent behavior for all paths
 	// both static and dynamic
 	if hostname != "" {
 		path.Destination.ReverseDNSHostname = hostname
@@ -375,10 +375,12 @@ func (s *npCollectorImpl) getReverseDNSResult(ipAddr string, results map[string]
 	if !ok {
 		s.statsdClient.Incr(reverseDNSLookupFailuresMetricName, []string{"reason:absent"}, 1) //nolint:errcheck
 		s.logger.Tracef("Reverse DNS lookup failed for IP %s", ipAddr)
+		return ""
 	}
 	if result.Err != nil {
 		s.statsdClient.Incr(reverseDNSLookupFailuresMetricName, []string{"reason:error"}, 1) //nolint:errcheck
 		s.logger.Tracef("Reverse lookup failed for hop IP %s: %s", ipAddr, result.Err)
+		return ""
 	}
 	if result.Hostname == "" {
 		s.statsdClient.Incr(reverseDNSLookupSuccessesMetricName, []string{"status:empty"}, 1) //nolint:errcheck

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -34,9 +34,9 @@ import (
 const (
 	networkPathCollectorMetricPrefix          = "datadog.network_path.collector."
 	reverseDNSLookupMetricPrefix              = networkPathCollectorMetricPrefix + "reverse_dns_lookup."
-	ReverseDNSResultsLengthMismatchMetricName = "datadog.network_path.collector.reverse_dns_lookup.results_length_mismatch"
-	ReverseDNSLookupFailedMetricName          = "datadog.network_path.collector.reverse_dns_lookup.failed"
-	ReverseDNSLookupSucceededMetricName       = "datadog.network_path.collector.reverse_dns_lookup.success"
+	reverseDNSResultsLengthMismatchMetricName = reverseDNSLookupMetricPrefix + "results_length_mismatch"
+	reverseDNSLookupFailedMetricName          = reverseDNSLookupMetricPrefix + "failed"
+	reverseDNSLookupSucceededMetricName       = reverseDNSLookupMetricPrefix + "success"
 )
 
 type npCollectorImpl struct {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -145,7 +145,8 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
     "destination": {
         "hostname": "abc",
         "ip_address": "10.0.0.2",
-        "port": 80
+        "port": 80,
+		"reverse_dns_hostname": "hostname-10.0.0.2"
     },
     "hops": [
         {
@@ -179,7 +180,8 @@ func Test_NpCollector_runningAndProcessing(t *testing.T) {
     "destination": {
         "hostname": "abc",
         "ip_address": "10.0.0.4",
-        "port": 80
+        "port": 80,
+		"reverse_dns_hostname": "hostname-10.0.0.4"
     },
     "hops": [
         {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_testutils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder/forwarderimpl"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector"
+	rdnsqueriermock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
@@ -43,6 +44,7 @@ var testOptions = fx.Options(
 	defaultforwarder.MockModule(),
 	core.MockBundle(),
 	eventplatformimpl.MockModule(),
+	rdnsqueriermock.MockModule(),
 )
 
 func newTestNpCollector(t fxtest.TB, agentConfigs map[string]any) (*fxtest.App, *npCollectorImpl) {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollectorcomp.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollectorcomp.go
@@ -15,6 +15,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector"
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+	nooprdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/impl-none"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -25,6 +27,7 @@ type dependencies struct {
 	Logger      log.Component
 	AgentConfig config.Component
 	Telemetry   telemetry.Component
+	RDNSQuerier rdnsquerier.Component
 }
 
 type provides struct {
@@ -46,12 +49,25 @@ func newNpCollector(deps dependencies) provides {
 	configs := newConfig(deps.AgentConfig)
 	if configs.networkPathCollectorEnabled() {
 		deps.Logger.Debugf("Network Path Collector enabled")
+
+		// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
+		// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
+		// active instance.  However, we also need to check here whether the netflow component has
+		// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
+		// it with a noop implementation.
+		rdnsQuerier := deps.RDNSQuerier
+		if !configs.reverseDNSCacheEnabled {
+			// TODO: is this necessary? When wouldn't we want to use the reverse DNS querier?
+			deps.Logger.Infof("Reverse DNS Cache is disabled for Network Path Collector")
+			rdnsQuerier = nooprdnsquerier.NewNone().Comp
+		}
+
 		epForwarder, ok := deps.EpForwarder.Get()
 		if !ok {
 			deps.Logger.Errorf("Error getting EpForwarder")
 			collector = newNoopNpCollectorImpl()
 		} else {
-			collector = newNpCollectorImpl(epForwarder, configs, deps.Logger, deps.Telemetry)
+			collector = newNpCollectorImpl(epForwarder, configs, deps.Logger, deps.Telemetry, rdnsQuerier)
 			deps.Lc.Append(fx.Hook{
 				// No need for OnStart hook since NpCollector.Init() will be called by clients when needed.
 				OnStart: func(context.Context) error {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollectorcomp.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollectorcomp.go
@@ -52,13 +52,12 @@ func newNpCollector(deps dependencies) provides {
 
 		// Note that multiple components can share the same rdnsQuerier instance.  If any of them have
 		// reverse DNS enrichment enabled then the deps.RDNSQuerier component passed here will be an
-		// active instance.  However, we also need to check here whether the netflow component has
+		// active instance.  However, we also need to check here whether the network path component has
 		// reverse DNS enrichment enabled to decide whether to use the passed instance or to override
 		// it with a noop implementation.
 		rdnsQuerier := deps.RDNSQuerier
-		if !configs.reverseDNSCacheEnabled {
-			// TODO: is this necessary? When wouldn't we want to use the reverse DNS querier?
-			deps.Logger.Infof("Reverse DNS Cache is disabled for Network Path Collector")
+		if !configs.reverseDNSEnabled {
+			deps.Logger.Infof("Reverse DNS enrichment is disabled for Network Path Collector")
 			rdnsQuerier = nooprdnsquerier.NewNone().Comp
 		}
 

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/runner"
 	"github.com/DataDog/datadog-agent/comp/process/status/statusimpl"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -53,6 +54,7 @@ func TestBundleDependencies(t *testing.T) {
 			},
 		),
 		fx.Provide(func() context.Context { return context.TODO() }),
+		rdnsquerier.MockModule(),
 		npcollectorimpl.MockModule(),
 		statsd.MockModule(),
 	)
@@ -92,6 +94,7 @@ func TestBundleOneShot(t *testing.T) {
 		workloadmetafx.Module(workloadmeta.NewParams()),
 		eventplatformreceiverimpl.Module(),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
+		rdnsquerier.MockModule(),
 		npcollectorimpl.Module(),
 		statsd.MockModule(),
 		Bundle(),

--- a/comp/rdnsquerier/impl/config.go
+++ b/comp/rdnsquerier/impl/config.go
@@ -56,11 +56,11 @@ const (
 )
 
 func newConfig(agentConfig config.Component) *rdnsQuerierConfig {
-	netflowRDNSEnrichmentEnabled := agentConfig.GetBool("network_devices.netflow.reverse_dns_enrichment_enabled") ||
-		(agentConfig.GetBool("network_path.collector.reverse_dns_enrichment.enabled") && agentConfig.GetBool("network_path.connections_monitoring.enabled"))
+	netflowRDNSEnrichmentEnabled := agentConfig.GetBool("network_devices.netflow.reverse_dns_enrichment_enabled")
+	networkPathRDNSEnrichmentEnabled := agentConfig.GetBool("network_path.collector.reverse_dns_enrichment.enabled") && agentConfig.GetBool("network_path.connections_monitoring.enabled")
 
 	c := &rdnsQuerierConfig{
-		enabled:  netflowRDNSEnrichmentEnabled,
+		enabled:  netflowRDNSEnrichmentEnabled || networkPathRDNSEnrichmentEnabled,
 		workers:  agentConfig.GetInt("reverse_dns_enrichment.workers"),
 		chanSize: agentConfig.GetInt("reverse_dns_enrichment.chan_size"),
 

--- a/comp/rdnsquerier/impl/config.go
+++ b/comp/rdnsquerier/impl/config.go
@@ -56,7 +56,8 @@ const (
 )
 
 func newConfig(agentConfig config.Component) *rdnsQuerierConfig {
-	netflowRDNSEnrichmentEnabled := agentConfig.GetBool("network_devices.netflow.reverse_dns_enrichment_enabled")
+	netflowRDNSEnrichmentEnabled := agentConfig.GetBool("network_devices.netflow.reverse_dns_enrichment_enabled") ||
+		(agentConfig.GetBool("network_path.collector.reverse_dns_enrichment.enabled") && agentConfig.GetBool("network_path.connections_monitoring.enabled"))
 
 	c := &rdnsQuerierConfig{
 		enabled:  netflowRDNSEnrichmentEnabled,

--- a/comp/rdnsquerier/impl/config_test.go
+++ b/comp/rdnsquerier/impl/config_test.go
@@ -45,11 +45,72 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "default config when enabled",
+			name: "disabled when Network Path Collector is enabled, reverse DNS enrichment is disabled",
+			configYaml: `
+network_path:
+  connections_monitoring:
+    enabled: true
+  collector:
+    reverse_dns_enrichment:
+      enabled: false
+`,
+			expectedConfig: rdnsQuerierConfig{
+				enabled:  false,
+				workers:  0,
+				chanSize: 0,
+				cache: cacheConfig{
+					enabled:         true,
+					entryTTL:        0,
+					cleanInterval:   0,
+					persistInterval: 0,
+					maxRetries:      -1,
+					maxSize:         0,
+				},
+				rateLimiter: rateLimiterConfig{
+					enabled:                true,
+					limitPerSec:            0,
+					limitThrottledPerSec:   0,
+					throttleErrorThreshold: 0,
+					recoveryIntervals:      0,
+					recoveryInterval:       0,
+				},
+			},
+		},
+		{
+			name: "default config when enabled through netflow",
 			configYaml: `
 network_devices:
   netflow:
     reverse_dns_enrichment_enabled: true
+`,
+			expectedConfig: rdnsQuerierConfig{
+				enabled:  true,
+				workers:  defaultWorkers,
+				chanSize: defaultChanSize,
+				cache: cacheConfig{
+					enabled:         true,
+					entryTTL:        defaultCacheEntryTTL,
+					cleanInterval:   defaultCacheCleanInterval,
+					persistInterval: defaultCachePersistInterval,
+					maxRetries:      defaultCacheMaxRetries,
+					maxSize:         defaultCacheMaxSize,
+				},
+				rateLimiter: rateLimiterConfig{
+					enabled:                true,
+					limitPerSec:            defaultRateLimitPerSec,
+					limitThrottledPerSec:   defaultRateLimitThrottledPerSec,
+					throttleErrorThreshold: defaultRateLimitThrottleErrorThreshold,
+					recoveryIntervals:      defaultRateLimitRecoveryIntervals,
+					recoveryInterval:       defaultRateLimitRecoveryInterval,
+				},
+			},
+		},
+		{
+			name: "default config when Network Path Collector is enabled",
+			configYaml: `
+network_path:
+  connections_monitoring:
+    enabled: true
 `,
 			expectedConfig: rdnsQuerierConfig{
 				enabled:  true,

--- a/comp/rdnsquerier/mock/mock.go
+++ b/comp/rdnsquerier/mock/mock.go
@@ -76,10 +76,12 @@ func (q *rdnsQuerierMock) GetHostnames(_ context.Context, ipAddrs []string) map[
 		netipAddr, err := netip.ParseAddr(ipAddr)
 		if err != nil {
 			results[ipAddr] = rdnsquerier.ReverseDNSResult{IP: ipAddr, Err: fmt.Errorf("invalid IP address %v", ipAddr)}
+			continue
 		}
 
 		if !netipAddr.IsPrivate() {
 			results[ipAddr] = rdnsquerier.ReverseDNSResult{IP: ipAddr}
+			continue
 		}
 
 		results[ipAddr] = rdnsquerier.ReverseDNSResult{IP: ipAddr, Hostname: "hostname-" + netipAddr.String()}

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -74,6 +74,12 @@ func (c *Check) Run() error {
 	path.Destination.Service = c.config.DestinationService
 	path.Tags = c.config.Tags
 
+	// Perform reverse DNS lookup
+	path.Destination.ReverseDNSHostname = traceroute.GetHostname(path.Destination.IPAddress)
+	for i := range path.Hops {
+		path.Hops[i].Hostname = traceroute.GetHostname(path.Hops[i].IPAddress)
+	}
+
 	// send to EP
 	err = c.SendNetPathMDToEP(senderInstance, path)
 	if err != nil {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -470,7 +470,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "5m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")
 	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.enabled", true)
-	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.timeout", 1000)
+	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.timeout", 5000)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// Kube ApiServer

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -469,8 +469,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "15m")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "5m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")
-	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_cache.enabled", true)
-	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_cache.timeout", 1000)
+	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.enabled", true)
+	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.timeout", 1000)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// Kube ApiServer

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -469,6 +469,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "15m")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "5m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")
+	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_cache.enabled", true)
+	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_cache.timeout", 1000)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// Kube ApiServer

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -673,7 +673,7 @@ func TestNetworkPathDefaults(t *testing.T) {
 	assert.Equal(t, 15*time.Minute, config.GetDuration("network_path.collector.pathtest_ttl"))
 	assert.Equal(t, 5*time.Minute, config.GetDuration("network_path.collector.pathtest_interval"))
 	assert.Equal(t, 10*time.Second, config.GetDuration("network_path.collector.flush_interval"))
-	assert.Equal(t, true, config.GetDuration("network_path.collector.reverse_dns_cache.enabled"))
+	assert.Equal(t, true, config.GetBool("network_path.collector.reverse_dns_cache.enabled"))
 	assert.Equal(t, 1000, config.GetInt("network_path.collector.reverse_dns_cache.timeout"))
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -673,6 +673,8 @@ func TestNetworkPathDefaults(t *testing.T) {
 	assert.Equal(t, 15*time.Minute, config.GetDuration("network_path.collector.pathtest_ttl"))
 	assert.Equal(t, 5*time.Minute, config.GetDuration("network_path.collector.pathtest_interval"))
 	assert.Equal(t, 10*time.Second, config.GetDuration("network_path.collector.flush_interval"))
+	assert.Equal(t, true, config.GetDuration("network_path.collector.reverse_dns_cache.enabled"))
+	assert.Equal(t, 1000, config.GetInt("network_path.collector.reverse_dns_cache.timeout"))
 }
 
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -673,8 +673,8 @@ func TestNetworkPathDefaults(t *testing.T) {
 	assert.Equal(t, 15*time.Minute, config.GetDuration("network_path.collector.pathtest_ttl"))
 	assert.Equal(t, 5*time.Minute, config.GetDuration("network_path.collector.pathtest_interval"))
 	assert.Equal(t, 10*time.Second, config.GetDuration("network_path.collector.flush_interval"))
-	assert.Equal(t, true, config.GetBool("network_path.collector.reverse_dns_cache.enabled"))
-	assert.Equal(t, 1000, config.GetInt("network_path.collector.reverse_dns_cache.timeout"))
+	assert.Equal(t, true, config.GetBool("network_path.collector.reverse_dns_enrichment.enabled"))
+	assert.Equal(t, 1000, config.GetInt("network_path.collector.reverse_dns_enrichment.timeout"))
 }
 
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -674,7 +674,7 @@ func TestNetworkPathDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, config.GetDuration("network_path.collector.pathtest_interval"))
 	assert.Equal(t, 10*time.Second, config.GetDuration("network_path.collector.flush_interval"))
 	assert.Equal(t, true, config.GetBool("network_path.collector.reverse_dns_enrichment.enabled"))
-	assert.Equal(t, 1000, config.GetInt("network_path.collector.reverse_dns_enrichment.timeout"))
+	assert.Equal(t, 5000, config.GetInt("network_path.collector.reverse_dns_enrichment.timeout"))
 }
 
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -235,10 +235,9 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 			NetworkID: r.networkID,
 		},
 		Destination: payload.NetworkPathDestination{
-			Hostname:           destinationHost,
-			Port:               destinationPort,
-			IPAddress:          destinationIP.String(),
-			ReverseDNSHostname: getReverseDNSForIP(destinationIP),
+			Hostname:  destinationHost,
+			Port:      destinationPort,
+			IPAddress: destinationIP.String(),
 		},
 	}
 
@@ -267,7 +266,6 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
 			hopname = hop.IP.String()
-			hostname = getHostname(hop.IP.String())
 		}
 
 		npHop := payload.NetworkPathHop{
@@ -299,10 +297,9 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 			NetworkID: r.networkID,
 		},
 		Destination: payload.NetworkPathDestination{
-			Hostname:           destinationHost,
-			Port:               destinationPort,
-			IPAddress:          destinationIP.String(),
-			ReverseDNSHostname: getReverseDNSForIP(destinationIP),
+			Hostname:  destinationHost,
+			Port:      destinationPort,
+			IPAddress: destinationIP.String(),
 		},
 	}
 
@@ -381,7 +378,6 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 			hop := payload.NetworkPathHop{
 				TTL:       idx,
 				IPAddress: ip,
-				Hostname:  getHostname(cur.node),
 				RTT:       durationMs,
 				Reachable: isReachable,
 			}

--- a/pkg/networkpath/traceroute/utils.go
+++ b/pkg/networkpath/traceroute/utils.go
@@ -15,14 +15,14 @@ import (
 
 var lookupAddrFn = net.DefaultResolver.LookupAddr
 
-func getReverseDNSForIP(destIP net.IP) string {
+func GetReverseDNSForIP(destIP net.IP) string {
 	if destIP == nil {
 		return ""
 	}
-	return getHostname(destIP.String())
+	return GetHostname(destIP.String())
 }
 
-func getHostname(ipAddr string) string {
+func GetHostname(ipAddr string) string {
 	currHost := ""
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/networkpath/traceroute/utils.go
+++ b/pkg/networkpath/traceroute/utils.go
@@ -15,6 +15,7 @@ import (
 
 var lookupAddrFn = net.DefaultResolver.LookupAddr
 
+// GetReverseDNSForIP returns the reverse DNS for the given IP address as a net.IP.
 func GetReverseDNSForIP(destIP net.IP) string {
 	if destIP == nil {
 		return ""
@@ -22,6 +23,7 @@ func GetReverseDNSForIP(destIP net.IP) string {
 	return GetHostname(destIP.String())
 }
 
+// GetHostname returns the hostname for the given IP address as a string.
 func GetHostname(ipAddr string) string {
 	currHost := ""
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/networkpath/traceroute/utils_test.go
+++ b/pkg/networkpath/traceroute/utils_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_getReverseDnsForIP(t *testing.T) {
+func Test_GetReverseDnsForIP(t *testing.T) {
 	t.Run("reverse dns lookup successful", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
 			return []string{"domain-a.com", "domain-b.com"}, nil
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "domain-a.com", getReverseDNSForIP(net.ParseIP("1.2.3.4")))
-		assert.Equal(t, "", getReverseDNSForIP(nil))
+		assert.Equal(t, "domain-a.com", GetReverseDNSForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", GetReverseDNSForIP(nil))
 	})
 	t.Run("reverse dns lookup failure", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
@@ -30,8 +30,8 @@ func Test_getReverseDnsForIP(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "1.2.3.4", getReverseDNSForIP(net.ParseIP("1.2.3.4")))
-		assert.Equal(t, "", getReverseDNSForIP(nil))
+		assert.Equal(t, "1.2.3.4", GetReverseDNSForIP(net.ParseIP("1.2.3.4")))
+		assert.Equal(t, "", GetReverseDNSForIP(nil))
 	})
 }
 
@@ -42,7 +42,7 @@ func Test_getHostname(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "domain-a.com", getHostname("1.2.3.4"))
+		assert.Equal(t, "domain-a.com", GetHostname("1.2.3.4"))
 	})
 	t.Run("reverse dns lookup failure", func(t *testing.T) {
 		lookupAddrFn = func(_ context.Context, _ string) ([]string, error) {
@@ -50,6 +50,6 @@ func Test_getHostname(t *testing.T) {
 		}
 		defer func() { lookupAddrFn = net.DefaultResolver.LookupAddr }()
 
-		assert.Equal(t, "1.2.3.4", getHostname("1.2.3.4"))
+		assert.Equal(t, "1.2.3.4", GetHostname("1.2.3.4"))
 	})
 }

--- a/releasenotes/notes/network-path-use-reverse-dns-cache-2dc3dec296cabb01.yaml
+++ b/releasenotes/notes/network-path-use-reverse-dns-cache-2dc3dec296cabb01.yaml
@@ -8,7 +8,8 @@
 ---
 enhancements:
   - |
-    This change reduces the number of DNS queries made by Network Path.
+    This change reduces the number of DNS queries made by Network Traffic
+    based paths in Network Path.
     A cache of reverse DNS lookups is used to reduce the number of DNS
     queries. Additionally, reverse DNS lookups are now performed only
     for private IPs and not for public IPs. 

--- a/releasenotes/notes/network-path-use-reverse-dns-cache-2dc3dec296cabb01.yaml
+++ b/releasenotes/notes/network-path-use-reverse-dns-cache-2dc3dec296cabb01.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    This change reduces the number of DNS queries made by Network Path.
+    A cache of reverse DNS lookups is used to reduce the number of DNS
+    queries. Additionally, reverse DNS lookups are now performed only
+    for private IPs and not for public IPs. 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR leverages the updated reverse DNS querier component's synchronous interface for Network Path's queries. Rather than query for every hop directly, we use this additional cache to store common IPs and filter out public IPs from being queried at all.

This also adds a flag to enable or disable reverse DNS enrichment. If Network Traffic paths are enabled, reverse DNS enrichment is enabled by default, but can be disabled with: `network_path.collector.reverse_dns_enrichment.enabled`

### Motivation
Internally, we've noticed that with Network Traffic paths we can end up pounding our k8s cluster DNS servers with a ton PTR requests. It seems that the caching done by the host in general is not enough to prevent Network Path from querying too much especially at scale.

### Describe how to test/QA your changes
These changes can be tested locally by running dynamic paths.

By default it is enabled, however, it can be disabled using: `network_path.collector.reverse_dns_enrichment.enabled`. Disabling this should result in no reverse DNS lookups being performed

In my local testing, my router gets resolved to `_gateway`, but your milage may vary and no hops may actually be resolved with local testing.

As long as paths are running, you should be able to see metrics such as:
```yaml
datadog.network_path.collector.reverse_dns_lookup.successes
```

This metric should be getting incremented. It gets incremented regardless of whether an IP is public or private. If the IP is public or simply not found, it will be tagged with `empty`.

```yaml
datadog.network_path.collector.reverse_dns_lookup.failures
```

If you see this metric, there's likely something wrong and it's worth checking the `trace` level logs to see more details.

These metrics will also be present on staging once this build is deployed there.

### Possible Drawbacks / Trade-offs
Prior to this change, we attempted a reverse DNS lookup for ALL hops regardless of whether the IP of the hop was a public address or private address. With this change, we now ONLY perform reverse lookups for private IPs.

This trade off was made both in an attempt to reduce the number of calls, but also because in many cases, the geoIP data we provide in the back end is more useful.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->