### PR TITLE
usm: tests: Support ssl package on python 3.12

### DIFF
--- a/pkg/network/protocols/http/testutil/pythonserver.go
+++ b/pkg/network/protocols/http/testutil/pythonserver.go
@@ -45,11 +45,9 @@ server_address = ('%s', %s)
 httpd = http.server.HTTPServer(server_address, RequestHandler)
 
 if len(sys.argv) >= 2 and sys.argv[1].lower() in YES:
-    httpd.socket = ssl.wrap_socket(httpd.socket,
-                                   server_side=True,
-                                   certfile='%s',
-                                   keyfile='%s',
-                                   ssl_version=ssl.PROTOCOL_TLS)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile='%s', keyfile='%s')
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 try:
     httpd.serve_forever()
 finally:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes deprecation of wrap_socket from ssl package.

### Motivation

Trying to add ubuntu 24 for kmt, which uses python 3.12 by default
python 3.12 deprecates wrap_socket

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->