### PR TITLE
Allow rc_kubernetes_deploy to be manual

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -6,6 +6,9 @@ rc_kubernetes_deploy:
   stage: internal_kubernetes_deploy
   rules:
     - if: $RC_K8S_DEPLOYMENTS == "true"
+      when: on_success
+    - if: $RC_BUILD == "true"
+      when: manual
   needs:
     - job: docker_trigger_internal
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

This PR allows the job `rc_kubernetes_deploy` to be run manually when there is no particular flag passed to the Agent RC build task.

### Motivation

Starting from Agent 7.60.0 release we begin the code freeze on Thursday and dedicate Friday for the RC1 creation. At first we want to avoid deploying RC1 to staging before the weekend, so we can verify how the process will look like,

Currently we start the RC build by running `inv release.build-rc -k` where `-k` adds and automatically runs the staging deployment job to the build pipeline. We still want to have the job added, but we want to run it manually on Monday morning. 

### Describe how to test/QA your changes

This will be tested properly only when `7.60.0-rc.1` build will be created.