### PR TITLE
[CWS] fix `minProcEntries` to be an actual power of 2

### DIFF
--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -24,7 +24,7 @@ const (
 	minPathnamesEntries = 64000 // ~27 MB
 	maxPathnamesEntries = 96000
 
-	minProcEntries = 16394
+	minProcEntries = 16384
 	maxProcEntries = 131072
 )
 


### PR DESCRIPTION
### What does this PR do?

The max size is `131072` which is a power of 2, 16394 is very close to being one. This PR fixes this small issue and sets the min to 16384 which is actually one.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->