### PR TITLE
[e2e] recreate stack on cloud init errors, error code independent

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -39,7 +39,8 @@ func getKnownErrors() []knownError {
 		},
 		{
 			// https://datadoghq.atlassian.net/browse/ADXT-558
-			errorMessage: `Process exited with status 2: running " sudo cloud-init status --wait"`,
+			// https://datadoghq.atlassian.net/browse/ADXT-713
+			errorMessage: `Process exited with status \d+: running " sudo cloud-init status --wait"`,
 			retryType:    ReCreate,
 		},
 		{

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -259,6 +259,11 @@ func TestStackManager(t *testing.T) {
 				expectedRetryType: ReCreate,
 			},
 			{
+				name:              "cloud-init-timeout",
+				errMessage:        "Process exited with status 6: running \" sudo cloud-init status --wait\"",
+				expectedRetryType: ReCreate,
+			},
+			{
 				name:              "ecs-fakeintake-timeout",
 				errMessage:        "waiting for ECS Service (arn:aws:ecs:us-east-1:669783387624:service/fakeintake-ecs/ci-633219896-4670-e2e-dockersuite-80f62edf7bcc6194-aws-fakeintake-dockervm-srv) create: timeout while waiting for state to become 'tfSTABLE' (last state: 'tfPENDING', timeout: 20m0s)",
 				expectedRetryType: ReCreate,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* recreate stack on any digit error code from `cloud init`

### Motivation

ADXT-713

We recreated on error code: 2, in ADXT-713 stack creation failed with error code 1. Let's recreate on any error code

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->