### PR TITLE
[EBPF-577] gpu: re-enable e2e tests

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
@@ -51,9 +50,6 @@ const gpuEnabledAMI = "ami-0f71e237bb2ba34be" // Ubuntu 22.04 with GPU drivers
 
 // TestGPUSuite runs tests for the VM interface to ensure its implementation is correct.
 func TestGPUSuite(t *testing.T) {
-	// Marked as flaky pending removal of unattended-upgrades in the AMI
-	flake.Mark(t)
-
 	provisioner := awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(
 			ec2.WithInstanceType("g4dn.xlarge"),

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -108,9 +108,13 @@ func (v *gpuSuite) TestGPUCheckIsEnabled() {
 func (v *gpuSuite) TestVectorAddProgramDetected() {
 	vm := v.Env().RemoteHost
 
-	out, err := vm.Execute(fmt.Sprintf("docker run --rm --gpus all %s", vectorAddDockerImg))
-	v.Require().NoError(err)
-	v.Require().NotEmpty(out)
+	// The vectorAdd program is quite short, so we might
+	numStarts := 3
+	for i := 0; i < numStarts; i++ {
+		out, err := vm.Execute(fmt.Sprintf("docker run --rm --gpus all %s", vectorAddDockerImg))
+		v.Require().NoError(err)
+		v.Require().NotEmpty(out)
+	}
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		metricNames := []string{"gpu.memory", "gpu.utilization", "gpu.memory.max"}

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var devMode = flag.Bool("devmode", false, "enable dev mode")
-var imageTag = flag.String("image-tag", "pr-1226", "Docker image tag to use")
+var imageTag = flag.String("image-tag", "main", "Docker image tag to use")
 
 type gpuSuite struct {
 	e2e.BaseSuite[environments.Host]

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -141,7 +141,9 @@ func (v *gpuSuite) TestVectorAddProgramDetected() {
 	v.runCudaDockerWorkload()
 
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		metricNames := []string{"gpu.memory", "gpu.utilization", "gpu.memory.max"}
+		// We are not including "gpu.memory", as that represents the "current
+		// memory usage" and that might be zero at the time it's checked
+		metricNames := []string{"gpu.utilization", "gpu.memory.max"}
 		for _, metricName := range metricNames {
 			metrics, err := v.Env().FakeIntake.Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
 			assert.NoError(c, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Re-enables the GPU e2e tests after they were marked as flaky due to possible problems with `unattended-upgrades` (this setting was disabled at the infra level).

It also includes some fixes to make the tests themselves more reliable, including a custom workload image.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->