### PR TITLE
usm: process monitor: Increase channel size

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -30,7 +30,7 @@ const (
 	// The size of the process events queue of netlink.
 	processMonitorEventQueueSize = 2048
 	// The size of the callbacks queue for pending tasks.
-	pendingCallbacksQueueSize = 1000
+	pendingCallbacksQueueSize = 5000
 )
 
 var (
@@ -532,7 +532,7 @@ func NewProcessMonitorEventConsumer(em *eventmonitor.EventMonitor) (*EventConsum
 
 // ChanSize returns the channel size used by this consumer
 func (ec *EventConsumer) ChanSize() int {
-	return 100
+	return 500
 }
 
 // ID returns the ID of this consumer


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increase the channels sizes in the process monitor since there are many dropped events reported in both local testing and on staging due to these sizes.  With the new sizes no hits were seen in the debug metrics on one staging cluster.

The metrics used to tracked it are the following (the latter is not relevant unless event stream is enabled).

 datadog.system_probe.usm.process.monitor.process_exec_channel_is_full
 datadog.runtime_security.event_monitoring.events.dropped{consumer_id:process_monitor}

### Motivation

https://datadoghq.atlassian.net/browse/USMON-694
https://datadoghq.atlassian.net/wiki/spaces/UT/pages/4218553435

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->