### PR TITLE
[CI] Use prod AMI for the macOS Gitlab runners

### DIFF
--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,7 +13,7 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:monterey-amd64-test", "specific:true"]
+  tags: ["macos:monterey-amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -24,4 +24,4 @@ lint_macos_gitlab_arm64:
   rules:
     - !reference [.on_main]
     - !reference [.manual]
-  tags: ["macos:monterey-arm64-test", "specific:true"]
+  tags: ["macos:monterey-arm64", "specific:true"]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -71,7 +71,7 @@ tests_macos:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:monterey-amd64-test", "specific:true"]
+  tags: ["macos:monterey-amd64", "specific:true"]
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
@@ -80,7 +80,7 @@ tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   rules:
     !reference [.manual]
-  tags: ["macos:monterey-arm64-test", "specific:true"]
+  tags: ["macos:monterey-arm64", "specific:true"]
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR puts back the prod macOS Gitlab runners for the CI.

### Motivation

#30329 mistakenly left the test runners.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->