### PR TITLE
small optimization to IP quantization

### DIFF
--- a/pkg/obfuscate/ip_address.go
+++ b/pkg/obfuscate/ip_address.go
@@ -6,6 +6,7 @@
 package obfuscate
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
 	"regexp"
@@ -30,7 +31,8 @@ func QuantizePeerIPAddresses(raw string) string {
 	return strings.Join(uniq, ",")
 }
 
-var protocolRegex = regexp.MustCompile(`((?:dnspoll|ftp|file|http|https):/{2,3}).*`)
+var schemes = []string{"dnspoll", "ftp", "file", "http", "https"}
+var protocolRegex = regexp.MustCompile(fmt.Sprintf(`((?:%s):/{2,3}).*`, strings.Join(schemes, "|")))
 
 var allowedIPAddresses = map[string]bool{
 	// localhost
@@ -49,7 +51,7 @@ func splitPrefix(raw string) (prefix, after string) {
 	}
 
 	isHintFound := false
-	for _, hint := range []string{"dnspoll", "ftp", "file", "http"} {
+	for _, hint := range schemes {
 		if strings.Contains(raw, hint) {
 			isHintFound = true
 			break

--- a/pkg/obfuscate/ip_address.go
+++ b/pkg/obfuscate/ip_address.go
@@ -47,10 +47,22 @@ func splitPrefix(raw string) (prefix, after string) {
 	if after, ok := strings.CutPrefix(raw, "ip-"); ok { // AWS EC2 hostnames e.g. ip-10-123-4-567.ec2.internal
 		return "ip-", after
 	}
-	subMatches := protocolRegex.FindStringSubmatch(raw)
-	if len(subMatches) >= 2 {
-		prefix = subMatches[1]
+
+	isHintFound := false
+	for _, hint := range []string{"dnspoll", "ftp", "file", "http"} {
+		if strings.Contains(raw, hint) {
+			isHintFound = true
+			break
+		}
 	}
+
+	if isHintFound {
+		subMatches := protocolRegex.FindStringSubmatch(raw)
+		if len(subMatches) >= 2 {
+			prefix = subMatches[1]
+		}
+	}
+
 	return prefix, raw[len(prefix):]
 }
 

--- a/pkg/obfuscate/ip_address_test.go
+++ b/pkg/obfuscate/ip_address_test.go
@@ -61,3 +61,23 @@ func TestQuantizePeerIpAddresses(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSplitPrefix(b *testing.B) {
+	b.Run("matching", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			prefix, after := splitPrefix("dnspoll:///abc.cluster.local:50051")
+			if prefix != "dnspoll:///" || after != "abc.cluster.local:50051" {
+				b.Error("unexpected result")
+			}
+		}
+	})
+
+	b.Run("not matching", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			prefix, after := splitPrefix("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF")
+			if prefix != "" || after != "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF" {
+				b.Error("unexpected result")
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR improves the performance of the IP quantization operation by skipping the regex call in most cases: when the hints are not present in the given text. [Example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Atrace-agent&agg_m=count&agg_m_source=base&agg_t=count&event=AgAAAZLTzNMqkdMaLQAAAAAAAAAYAAAAAEFaTFR6TlNvQUFDVzBTTFZSVjN2ZGdBQQAAACQAAAAAMDE5MmQzY2MtZjc0My00ZjQzLWExMjktMjU3YTVlY2M1NDUz&my_code=disabled&profileId=AZLTzNSoAACW0SLVRV3vdgAA&refresh_mode=paused&viz=stream&from_ts=1730126668534&to_ts=1730130268534&live=false) showing that this code path was quite present.

Benchmark (CPU only, allocations are the same):
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/obfuscate
cpu: Apple M1 Max
                            │  before.txt   │              after.txt              │
                            │    sec/op     │   sec/op     vs base                │
SplitPrefix/matching-10         342.6n ± 9%   351.9n ± 2%        ~ (p=0.078 n=10)
SplitPrefix/not_matching-10   1378.00n ± 1%   37.22n ± 1%  -97.30% (p=0.000 n=10)
geomean                         687.1n        114.4n       -83.34%
```


### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->