### PR TITLE
Fix broken activity sampling with external Oracle client (DBMON-4709)

### DIFF
--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -66,8 +66,8 @@ const activityQueryOnView12 = `SELECT /* DD_ACTIVITY_SAMPLING */
 		'CPU'
 	END wait_class,
 	wait_time_micro,
-	dbms_lob.substr(sql_fulltext, :sql_substr_length, 1) sql_fulltext,
-	dbms_lob.substr(prev_sql_fulltext, :sql_substr_length, 1) prev_sql_fulltext,
+	dbms_lob.substr(sql_fulltext, :sql_substr_length_1, 1) sql_fulltext,
+	dbms_lob.substr(prev_sql_fulltext, :sql_substr_length_2, 1) prev_sql_fulltext,
 	pdb_name,
 	command_name
 FROM sys.dd_session
@@ -133,8 +133,8 @@ const activityQueryOnView11 = `SELECT /* DD_ACTIVITY_SAMPLING */
 		'CPU'
 	END wait_class,
 	wait_time_micro,
-	dbms_lob.substr(sql_fulltext, :sql_substr_length, 1) sql_fulltext,
-	dbms_lob.substr(prev_sql_fulltext, :sql_substr_length, 1) prev_sql_fulltext,
+	dbms_lob.substr(sql_fulltext, :sql_substr_length_1, 1) sql_fulltext,
+	dbms_lob.substr(prev_sql_fulltext, :sql_substr_length_2, 1) prev_sql_fulltext,
 	command_name
 FROM sys.dd_session
 WHERE
@@ -199,8 +199,8 @@ ELSE
 END wait_class,
 s.wait_time_micro,
 c.name as pdb_name,
-dbms_lob.substr(sq.sql_fulltext, :sql_substr_length, 1) sql_fulltext,
-dbms_lob.substr(sq_prev.sql_fulltext, :sql_substr_length, 1) prev_sql_fulltext,
+dbms_lob.substr(sq.sql_fulltext, :sql_substr_length_1, 1) sql_fulltext,
+dbms_lob.substr(sq_prev.sql_fulltext, :sql_substr_length_2, 1) prev_sql_fulltext,
 comm.command_name
 FROM
 v$session s,

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -153,6 +153,11 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 		assert.Contains(t, c.configTags, dbmsTag, "c.configTags doesn't contain static tags")
 	}
 
+	if oracleLibDir := os.Getenv("ORACLE_TEST_ORACLE_CLIENT_LIB_DIR"); oracleLibDir != "" {
+		c.config.InstanceConfig.OracleClientLibDir = oracleLibDir
+		c.config.InstanceConfig.OracleClient = true
+	}
+
 	return c, sender
 }
 

--- a/releasenotes/notes/oracle-activity-bug-external-client-12d1da009d5bf628.yaml
+++ b/releasenotes/notes/oracle-activity-bug-external-client-12d1da009d5bf628.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle] Fix broken activity sampling with an external Oracle client.


### PR DESCRIPTION
### What does this PR do?

Fix broken activity sampling with an external Oracle client. 

Added tests for external client.

### Motivation

The agent encountered this error with an external Oracle client:

`failed to collect session samples failed to collect session sampling activity: sql: expected 1 arguments, got 2`

The query references the `:sql_substr_length` parameter twice. `go-ora` requires the parameter twice, while `godror` only requires it once, causing a conflict with `godror`. The solution is to rename the parameter, creating two distinct parameters for the same value.

### Describe how to test/QA your changes

Set up connections with both external and native clients and verify that the agent works without errors. Check the activity samples in the console.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->