### PR TITLE
[CWS] add option to parsing context to cache rule parsing

### DIFF
--- a/pkg/security/secl/compiler/ast/secl_test.go
+++ b/pkg/security/secl/compiler/ast/secl_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func parseRule(rule string) (*Rule, error) {
-	pc := NewParsingContext()
+	pc := NewParsingContext(false)
 	return pc.ParseRule(rule)
 }
 
 func parseMacro(macro string) (*Macro, error) {
-	pc := NewParsingContext()
+	pc := NewParsingContext(false)
 	return pc.ParseMacro(macro)
 }
 

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -41,7 +41,7 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 func parseRule(expr string, model Model, opts *Opts) (*Rule, error) {
 	rule := NewRule("id1", expr, opts)
 
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 
 	if err := rule.Parse(pc); err != nil {
 		return nil, fmt.Errorf("parsing error: %v", err)
@@ -608,7 +608,7 @@ func TestConstants(t *testing.T) {
 
 func TestMacroList(t *testing.T) {
 	model := &testModel{}
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 	opts := newOptsWithParams(make(map[string]interface{}), nil)
 
 	macro, err := NewMacro(
@@ -638,7 +638,7 @@ func TestMacroList(t *testing.T) {
 
 func TestMacroExpression(t *testing.T) {
 	model := &testModel{}
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 	opts := newOptsWithParams(make(map[string]interface{}), nil)
 
 	macro, err := NewMacro(
@@ -677,7 +677,7 @@ func TestMacroExpression(t *testing.T) {
 
 func TestMacroPartial(t *testing.T) {
 	model := &testModel{}
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 	opts := newOptsWithParams(make(map[string]interface{}), nil)
 
 	macro, err := NewMacro(
@@ -738,7 +738,7 @@ func TestNestedMacros(t *testing.T) {
 	}
 
 	model := &testModel{}
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 	opts := newOptsWithParams(make(map[string]interface{}), nil)
 
 	macro1, err := NewMacro(
@@ -1559,7 +1559,7 @@ func BenchmarkPartial(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 	if err := rule.GenEvaluator(model, pc); err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -89,7 +89,7 @@ type SECLRuleFilter struct {
 func NewSECLRuleFilter(model eval.Model) *SECLRuleFilter {
 	return &SECLRuleFilter{
 		model:          model,
-		parsingContext: ast.NewParsingContext(),
+		parsingContext: ast.NewParsingContext(false),
 	}
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -743,7 +743,7 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 		rulesIndex = make(map[string]*PolicyRule)
 	)
 
-	parsingContext := ast.NewParsingContext()
+	parsingContext := ast.NewParsingContext(false)
 
 	policies, err := loader.LoadPolicies(opts)
 	if err != nil {

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -1067,7 +1067,7 @@ func TestGetRuleEventType(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		rule := eval.NewRule("aaa", `open.file.name == "test"`, &eval.Opts{})
 
-		pc := ast.NewParsingContext()
+		pc := ast.NewParsingContext(false)
 
 		if err := rule.GenEvaluator(&model.Model{}, pc); err != nil {
 			t.Fatal(err)
@@ -1092,7 +1092,7 @@ func TestGetRuleEventType(t *testing.T) {
 	t.Run("ko", func(t *testing.T) {
 		rule := eval.NewRule("aaa", `open.file.name == "test" && unlink.file.name == "123"`, &eval.Opts{})
 
-		pc := ast.NewParsingContext()
+		pc := ast.NewParsingContext(false)
 
 		if err := rule.GenEvaluator(&model.Model{}, pc); err == nil {
 			t.Fatalf("shouldn't get an evaluator, multiple event types: %s", err)

--- a/pkg/security/secl/rules/testutil.go
+++ b/pkg/security/secl/rules/testutil.go
@@ -30,7 +30,7 @@ func AddTestRuleExpr(t testing.TB, rs *RuleSet, exprs ...string) {
 		rules = append(rules, rule)
 	}
 
-	pc := ast.NewParsingContext()
+	pc := ast.NewParsingContext(false)
 
 	if err := rs.AddRules(pc, rules); err != nil {
 		t.Fatal(err)

--- a/pkg/security/secl/validators/rule_structure.go
+++ b/pkg/security/secl/validators/rule_structure.go
@@ -14,7 +14,7 @@ import (
 
 // HasBareWildcardInField checks whether a rule has a bare wildcard
 func HasBareWildcardInField(rule *eval.Rule) (bool, error) {
-	parsingContext := ast.NewParsingContext()
+	parsingContext := ast.NewParsingContext(false)
 	localModel := &model.Model{}
 	if err := rule.GenEvaluator(localModel, parsingContext); err != nil {
 		return false, err


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to the parsing context to cache the rule compilation (in one given parsing context). This is not very useful in the agent, but this will be interesting backend side where this caching will allow to skip the compilation of a lot of rules with the same expression (a result of some tests that always generate the same rule, with a different ID).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->