### PR TITLE
Add the ability to manually deploy the cluster-agent image on PR pipelines

### DIFF
--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -94,7 +94,7 @@ docker_trigger_internal-ot:
 
 docker_trigger_cluster_agent_internal:
   stage: internal_image_deploy
-  rules: !reference [.on_deploy]
+  rules: !reference [.on_deploy_internal_or_manual]
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

Add a manual job on PR GitLab pipelines to manually deploy an internal image of the cluster agent.

### Motivation

It’s already possible to manually deploy an internal image of the agent from a PR GitLab pipeline.
So, why not for the cluster agent?

### Describe how to test/QA your changes

Check that, on PR pipelines, the `docker_trigger_cluster_agent_internal` job is accessible for manual launch.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->