### PR TITLE
usm: Add debug endpoint to clear blocked list

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -295,6 +295,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/debug/usm_telemetry", telemetry.Handler)
 	httpMux.HandleFunc("/debug/usm/traced_programs", usm.TracedProgramsEndpoint)
 	httpMux.HandleFunc("/debug/usm/blocked_processes", usm.BlockedPathIDEndpoint)
+	httpMux.HandleFunc("/debug/usm/clear_blocked", usm.ClearBlockedEndpoint)
 	httpMux.HandleFunc("/debug/usm/attach-pid", usm.AttachPIDEndpoint)
 	httpMux.HandleFunc("/debug/usm/detach-pid", usm.DetachPIDEndpoint)
 

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -174,9 +174,8 @@ func (d *tlsDebugger) ClearBlocked() {
 
 	for _, registry := range d.registries {
 		registry.m.Lock()
-		defer registry.m.Unlock()
-
 		registry.blocklistByID.Purge()
+		registry.m.Unlock()
 	}
 }
 

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -60,6 +60,11 @@ func BlockedPathIDEndpoint(w http.ResponseWriter, _ *http.Request) {
 	otherutils.WriteAsJSON(w, debugger.GetAllBlockedPathIDs())
 }
 
+// ClearBlockedEndpoint clears the lists of blocked paths.
+func ClearBlockedEndpoint(_ http.ResponseWriter, _ *http.Request) {
+	debugger.ClearBlocked()
+}
+
 var debugger *tlsDebugger
 
 type tlsDebugger struct {
@@ -160,6 +165,19 @@ func (d *tlsDebugger) GetBlockedPathIDs(programType string) []PathIdentifier {
 	}
 
 	return nil
+}
+
+// ClearBlocked clears the list of blocked paths for all registries.
+func (d *tlsDebugger) ClearBlocked() {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	for _, registry := range d.registries {
+		registry.m.Lock()
+		defer registry.m.Unlock()
+
+		registry.blocklistByID.Purge()
+	}
 }
 
 // GetBlockedPathIDsWithSamplePath returns a list of PathIdentifiers with a matching sample path blocked in the

--- a/pkg/network/usm/utils/debugger_windows.go
+++ b/pkg/network/usm/utils/debugger_windows.go
@@ -20,6 +20,11 @@ func BlockedPathIDEndpoint(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(404)
 }
 
+// ClearBlockedEndpoint is not supported on Windows
+func ClearBlockedEndpoint(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(404)
+}
+
 // AttachPIDEndpoint is not supported on Windows
 func AttachPIDEndpoint(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(404)

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -238,6 +238,10 @@ func TestFailedRegistration(t *testing.T) {
 	// Assert that the number of callback executions hasn't changed for this pathID
 	// This is because we have block-listed this file
 	assert.Equal(t, 1, registerRecorder.CallsForPathID(pathID))
+
+	assert.Contains(t, debugger.GetBlockedPathIDs(""), pathID)
+	debugger.ClearBlocked()
+	assert.Empty(t, debugger.GetBlockedPathIDs(""))
 }
 
 func TestShortLivedProcess(t *testing.T) {
@@ -398,5 +402,6 @@ func createSymlink(t *testing.T, old, new string) {
 func newFileRegistry() *FileRegistry {
 	// Ensure that tests relying on telemetry data will always have a clean slate
 	telemetry.Clear()
+	ResetDebugger()
 	return NewFileRegistry("")
 }


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a debug endpoint to clear the list of blocked paths from the file registry.  This is useful in combination with attach-pid to try to re-attach to processes which have previously been blocked.

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1294

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->