### PR TITLE
Revert "[CI] Select the right Python virtualenv on the macOS Gitlab runners (#30329)"

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -1,49 +1,27 @@
 ---
 # This is the scripts to be executed on the Gitlab macOS runners before every job.
 # We don't have virtualization now so we need to clean the environment and install the proper dependencies before every job.
-.list_go_versions_commands: &list_go_versions_commands
-  - |
-    echo "Don't forget to regularly delete Go unused versions. Here are the installed Go versions and their disk space on the runner:"
-    echo "Go:"
-    du -sh $HOME/.gimme/versions/*
-    echo "To remove a Go version please run:"
-    echo "gimme uninstall <version>"
-
-.list_python_versions_commands: &list_python_versions_commands
-  - |
-    echo "Don't forget to regularly delete Python unused versions. Here are the installed Python versions and their disk space on the runner:"
-    echo "Python:"
-    du -sh $(pyenv root)/versions/*
-    echo "To remove a Python version please run:"
-    echo "pyenv uninstall -f <version>"
-
-.select_python_env_commands: &select_python_env_commands
-  # Print a warning if the current Python version is different from the one in .python-version
-  # Select the virtualenv using the current Python version. Create it if it doesn't exist.
-  - |
-    PYTHON_REPO_VERSION=$(cat .python-version)
-    PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
-    VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
-    if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
-      echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
-      echo "Installing Python $PYTHON_REPO_VERSION..."
-    fi
-    if ! pyenv virtualenvs --bare | grep -q "^${VENV_NAME}$"; then
-      pyenv virtualenv $PYTHON_VERSION $VENV_NAME
-    fi
-    pyenv activate $VENV_NAME
-
 .macos_gitlab:
   before_script:
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))
       export GOPATH=$GOROOT
-    # Selecting the current Python version
-    - *select_python_env_commands
-    # List Python and Go existing environments and their disk space
-    - *list_go_versions_commands
-    - *list_python_versions_commands
+      echo "Don't forget to regularly delete unused versions. Here are the installed versions and their memory usage on the runner:"
+      du -sh $HOME/.gimme/versions/*
+    # Remove the Python cache and env if the Python version changed
+    - |
+      PYTHON_REPO_VERSION=$(cat .python-version)
+      PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
+      if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
+        echo "Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version. Cleaning the environment."
+        pyenv uninstall -f datadog-agent
+        echo "Installing Python $PYTHON_REPO_VERSION..."
+        pyenv virtualenv 3.11.8 datadog-agent
+        pyenv activate datadog-agent
+      else
+        echo "Python current version $PYTHON_VERSION is the same as .python-version. Keeping the existing environment."
+      fi
     # Installing the job dependencies
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-github.txt
     - pyenv rehash


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reverts #30329.

### Motivation

It broke the venv management with:
```
pyenv-virtualenv: `/Users/ec2-user/.pyenv/versions/datadog-agent-python-3.11' already exists.
```
All the jobs in the macOS Gitlab runners will fail without it.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->