### PR TITLE
[CWS] do not replay snapshot for all consumers

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -461,8 +461,3 @@ func (p *Probe) IsSecurityProfileEnabled() bool {
 func (p *Probe) EnableEnforcement(state bool) {
 	p.PlatformProbe.EnableEnforcement(state)
 }
-
-// PlaySnapshot plays the snapshot
-func (p *Probe) PlaySnapshot() {
-	p.PlatformProbe.PlaySnapshot()
-}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -57,7 +57,6 @@ type PlatformProbe interface {
 	GetEventTags(_ string) []string
 	GetProfileManager() interface{}
 	EnableEnforcement(bool)
-	PlaySnapshot()
 }
 
 // EventHandler represents a handler for events sent by the probe that needs access to all the fields in the SECL model

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -448,11 +448,6 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 	}
 }
 
-// PlaySnapshot plays a snapshot
-func (p *EBPFProbe) PlaySnapshot() {
-	p.playSnapshot(true)
-}
-
 func (p *EBPFProbe) sendAnomalyDetection(event *model.Event) {
 	tags := p.probe.GetEventTags(string(event.ContainerContext.ContainerID))
 	if service := p.probe.GetService(event); service != "" {

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -703,8 +703,3 @@ func NewEBPFLessProbe(probe *Probe, config *config.Config, opts Opts, telemetry 
 
 	return p, nil
 }
-
-// PlaySnapshot plays a snapshot
-func (p *EBPFLessProbe) PlaySnapshot() {
-	// TODO: Implement this method if needed.
-}

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -120,8 +120,3 @@ func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {}
 
 // EnableEnforcement sets the enforcement mode
 func (p *Probe) EnableEnforcement(_ bool) {}
-
-// PlaySnapshot plays the snapshot
-func (p *Probe) PlaySnapshot() {
-	// TODO: Implement this method if needed.
-}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1444,8 +1444,3 @@ func (p *WindowsProbe) setApprovers(_ eval.EventType, approvers rules.Approvers)
 
 	return nil
 }
-
-// PlaySnapshot plays a snapshot
-func (p *WindowsProbe) PlaySnapshot() {
-	// TODO: Implement this method if needed.
-}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -168,7 +168,6 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 			if err := e.ReloadPolicies(); err != nil {
 				seclog.Errorf("failed to reload policies: %s", err)
 			}
-			e.probe.PlaySnapshot()
 		}
 	}()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replay snapshot on ruleset_loaded event only for CWS. Before this PR, every ruleset_loaded was triggering a replay of the snapshot causing the consumer to be notified.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->