### PR TITLE
Split NDM team

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -57,12 +57,20 @@ jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "universal-service-monitoring"
 github_labels = ["team/usm"]
 
-[teams."Network Device Monitoring"]
+[teams."Network Device Monitoring - Core"]
 jira_project = "NDMII"
 jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]
-github_team = "network-device-monitoring"
-github_labels = ["team/network-device-monitoring"]
+github_team = "ndm-core"
+github_labels = ["team/ndm-core", "team/network-device-monitoring"]
+exclude_members = ["leeavital", "heyronhay"]
+
+[teams."Network Device Monitoring - Integrations"]
+jira_project = "NDINT"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "ndm-integrations"
+github_labels = ["team/ndm-integrations"]
 exclude_members = ["leeavital", "heyronhay"]
 
 [teams."Network Performance Monitoring"]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -190,7 +190,7 @@
 /cmd/agent/subcommands/dogstatsd*       @DataDog/agent-metrics-logs
 /cmd/agent/subcommands/integrations     @DataDog/agent-integrations @DataDog/agent-shared-components
 /cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
-/cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring
+/cmd/agent/subcommands/snmp             @DataDog/ndm-core
 /cmd/agent/subcommands/streamlogs       @DataDog/agent-metrics-logs
 /cmd/agent/subcommands/streamep         @DataDog/container-integrations
 /cmd/agent/subcommands/taggerlist       @DataDog/container-platform
@@ -207,7 +207,7 @@
 /cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/network_path.d/  @DataDog/Networks @DataDog/network-device-monitoring
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/container-integrations
-/cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring
+/cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-agent
 /cmd/agent/install*.sh                  @DataDog/container-ecosystems @DataDog/agent-delivery
 /cmd/cluster-agent/                     @DataDog/container-platform
@@ -230,7 +230,7 @@
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
 /cmd/system-probe/modules/traceroute*   @DataDog/network-device-monitoring @Datadog/Networks
-/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring
+/cmd/system-probe/modules/ping*         @DataDog/ndm-core
 /cmd/system-probe/modules/language_detection* @DataDog/processes @DataDog/universal-service-monitoring
 /cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger
 /cmd/system-probe/windows_resources/    @DataDog/windows-kernel-integrations
@@ -274,7 +274,7 @@
 /omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-delivery
 /omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
 /omnibus/config/software/sds.rb                           @DataDog/agent-processing-and-routing
-/omnibus/config/software/snmp-traps.rb                    @DataDog/network-device-monitoring
+/omnibus/config/software/snmp-traps.rb                    @DataDog/ndm-core
 /omnibus/resources/*/msi/                                 @DataDog/windows-agent
 
 # The following is managed by `inv lint-components` -- DO NOT EDIT
@@ -290,13 +290,13 @@
 /comp/forwarder @DataDog/agent-processing-and-routing
 /comp/logs @DataDog/agent-metrics-logs
 /comp/metadata @DataDog/agent-shared-components
-/comp/ndmtmp @DataDog/network-device-monitoring
-/comp/netflow @DataDog/network-device-monitoring
+/comp/ndmtmp @DataDog/ndm-core
+/comp/netflow @DataDog/ndm-integrations
 /comp/networkpath @DataDog/Networks @DataDog/network-device-monitoring
 /comp/otelcol @DataDog/opentelemetry
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config
-/comp/snmptraps @DataDog/network-device-monitoring
+/comp/snmptraps @DataDog/ndm-core
 /comp/systray @DataDog/windows-agent
 /comp/trace @DataDog/agent-apm
 /comp/updater @DataDog/fleet @DataDog/windows-agent
@@ -316,9 +316,9 @@
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/etw @DataDog/windows-agent
 /comp/languagedetection/client @DataDog/container-platform
-/comp/rdnsquerier @DataDog/network-device-monitoring
+/comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/compression @DataDog/agent-metrics-logs
-/comp/snmpscan @DataDog/network-device-monitoring
+/comp/snmpscan @DataDog/ndm-core
 # END COMPONENTS
 
 # pkg
@@ -354,7 +354,7 @@
 /pkg/trace/transform/                   @DataDog/opentelemetry
 /comp/core/autodiscovery/listeners/           @DataDog/container-platform
 /comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/platform-integrations
-/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/network-device-monitoring
+/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/ndm-core
 /comp/core/autodiscovery/providers/           @DataDog/container-platform
 /comp/core/autodiscovery/providers/file*.go   @DataDog/agent-metrics-logs
 /comp/core/autodiscovery/providers/config_reader*.go @DataDog/container-platform @DataDog/agent-metrics-logs
@@ -381,13 +381,13 @@
 /pkg/collector/corechecks/embed/apm/               @DataDog/agent-apm
 /pkg/collector/corechecks/embed/process/           @DataDog/processes
 /pkg/collector/corechecks/gpu/                     @DataDog/ebpf-platform
-/pkg/collector/corechecks/network-devices/         @DataDog/network-device-monitoring
+/pkg/collector/corechecks/network-devices/         @DataDog/ndm-integrations
 /pkg/collector/corechecks/orchestrator/   @DataDog/container-app
 /pkg/collector/corechecks/net/          @DataDog/platform-integrations
 /pkg/collector/corechecks/oracle        @DataDog/database-monitoring
 /pkg/collector/corechecks/sbom/         @DataDog/container-integrations
 /pkg/collector/corechecks/servicediscovery/ @DataDog/universal-service-monitoring
-/pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring
+/pkg/collector/corechecks/snmp/         @DataDog/ndm-core
 /pkg/collector/corechecks/system/                 @DataDog/platform-integrations
 /pkg/collector/corechecks/system/**/*_windows*.go @DataDog/platform-integrations @DataDog/windows-agent
 /pkg/collector/corechecks/system/wincrashdetect/  @DataDog/windows-kernel-integrations
@@ -520,8 +520,8 @@
 /pkg/databasemonitoring                 @DataDog/database-monitoring
 /pkg/kubestatemetrics                   @DataDog/container-integrations
 /pkg/security/                          @DataDog/agent-security
-/pkg/networkdevice/                     @DataDog/network-device-monitoring
-/pkg/snmp/                              @DataDog/network-device-monitoring
+/pkg/networkdevice/                     @DataDog/ndm-core
+/pkg/snmp/                              @DataDog/ndm-core
 /pkg/tagger/                            @DataDog/container-platform
 /pkg/windowsdriver/                     @DataDog/windows-kernel-integrations
 /comp/core/workloadmeta/collectors/internal/cloudfoundry @DataDog/platform-integrations
@@ -586,8 +586,8 @@
 /test/kitchen/test/integration/win-repair/ @DataDog/windows-agent
 /test/kitchen/test/integration/win-user/ @DataDog/windows-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx-loops
-/test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/network-device-monitoring
-/test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/network-device-monitoring
+/test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
+/test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/servicediscovery* @DataDog/universal-service-monitoring
 /test/new-e2e/                                @DataDog/agent-e2e-testing @DataDog/agent-devx-loops
 /test/new-e2e/pkg/components/datadog-installer @DataDog/windows-agent
@@ -600,7 +600,8 @@
 /test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
 /test/new-e2e/tests/discovery                 @DataDog/universal-service-monitoring
 /test/new-e2e/tests/language-detection        @DataDog/processes
-/test/new-e2e/tests/ndm                       @DataDog/network-device-monitoring
+/test/new-e2e/tests/ndm                       @DataDog/ndm-core
+/test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
 /test/new-e2e/tests/npm                       @DataDog/Networks
 /test/new-e2e/tests/npm/ec2_1host_wkit_test.go @DataDog/Networks @DataDog/windows-kernel-integrations
 /test/new-e2e/tests/orchestrator              @DataDog/container-app

--- a/comp/README.md
+++ b/comp/README.md
@@ -322,7 +322,7 @@ Package systemprobe is the metadata provider for system-probe process
 
 ## [comp/ndmtmp](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/ndmtmp) (Component Bundle)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-core
 
 Package ndmtmp implements the "ndmtmp" bundle, which exposes the default
 sender.Sender and the event platform forwarder. This is a temporary module
@@ -334,7 +334,7 @@ Package forwarder exposes the event platform forwarder for netflow.
 
 ## [comp/netflow](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/netflow) (Component Bundle)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-integrations
 
 Package netflow implements the "netflow" bundle, which listens for netflow
 packets, processes them, and forwards relevant data to the backend.
@@ -482,7 +482,7 @@ Package rctelemetryreporter provides a component that sends RC-specific metrics 
 
 ## [comp/snmptraps](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmptraps) (Component Bundle)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-core
 
 Package snmptraps implements the a server that listens for SNMP trap data
 and sends it to the backend.
@@ -602,7 +602,7 @@ Package client implements a component to send process metadata to the Cluster-Ag
 
 ### [comp/rdnsquerier](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/rdnsquerier)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-integrations
 
 Package rdnsquerier provides the reverse DNS querier component.
 
@@ -614,6 +614,6 @@ Package compression provides a compression implementation based on the configura
 
 ### [comp/snmpscan](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmpscan)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-core
 
 Package snmpscan is a light component that can be used to perform a scan or a walk of a particular device

--- a/comp/ndmtmp/bundle.go
+++ b/comp/ndmtmp/bundle.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // TODO: (components) Delete this module when the sender and event platform forwarder are fully componentized.
 

--- a/comp/ndmtmp/bundle_mock.go
+++ b/comp/ndmtmp/bundle_mock.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // MockBundle defines the fx options for mock versions of everything in this bundle.
 func MockBundle() fxutil.BundleOptions {

--- a/comp/ndmtmp/forwarder/component.go
+++ b/comp/ndmtmp/forwarder/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/netflow/bundle.go
+++ b/comp/netflow/bundle.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-integrations
 
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {

--- a/comp/netflow/config/component.go
+++ b/comp/netflow/config/component.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-integrations
 
 // Component is the component type.
 type Component interface {

--- a/comp/netflow/server/component.go
+++ b/comp/netflow/server/component.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-integrations
 
 // Component is the component type. It has no exposed methods.
 type Component interface{}

--- a/comp/rdnsquerier/def/component.go
+++ b/comp/rdnsquerier/def/component.go
@@ -10,7 +10,7 @@ import (
 	"context"
 )
 
-// team: network-device-monitoring
+// team: ndm-integrations
 
 // ReverseDNSResult is the result of a reverse DNS lookup
 type ReverseDNSResult struct {

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/bundle.go
+++ b/comp/snmptraps/bundle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {

--- a/comp/snmptraps/config/component.go
+++ b/comp/snmptraps/config/component.go
@@ -7,7 +7,7 @@
 // a component that provides it.
 package config
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/formatter/component.go
+++ b/comp/snmptraps/formatter/component.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/forwarder/component.go
+++ b/comp/snmptraps/forwarder/component.go
@@ -7,7 +7,7 @@
 // listener component, formats it properly, and sends it to the backend.
 package forwarder
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface{}

--- a/comp/snmptraps/listener/component.go
+++ b/comp/snmptraps/listener/component.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps/packet"
 )
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/snmptraps/oidresolver/component.go
+++ b/comp/snmptraps/oidresolver/component.go
@@ -6,7 +6,7 @@
 // Package oidresolver resolves OIDs
 package oidresolver
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is a interface to get Trap and Variable metadata from OIDs
 type Component interface {

--- a/comp/snmptraps/server/component.go
+++ b/comp/snmptraps/server/component.go
@@ -8,7 +8,7 @@
 // reformats them, and sends the resulting data to the backend.
 package server
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the SNMP traps server. It listens for SNMP traps messages and
 // sends traps data to the DD backend.

--- a/comp/snmptraps/status/component.go
+++ b/comp/snmptraps/status/component.go
@@ -7,7 +7,7 @@
 // component system.
 package status
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -10,6 +10,8 @@
 '@datadog/agent-security': CWS
 '@datadog/agent-apm': APMSP
 '@datadog/network-device-monitoring': NDMII
+'@datadog/ndm-core': NDMII
+'@datadog/ndm-integrations': NDINT
 '@datadog/processes': PROCS
 '@datadog/agent-metrics-logs': AMLII
 '@datadog/agent-shared-components': ASCII

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -12,6 +12,8 @@
 '@datadog/agent-security': '#security-and-compliance-agent-ops'
 '@datadog/agent-apm': '#apm-agent'
 '@datadog/network-device-monitoring': '#network-device-monitoring'
+'@datadog/ndm-core': '#ndm-core'
+'@datadog/ndm-integrations': '#ndm-integrations'
 '@datadog/processes': '#process-agent-ops'
 '@datadog/agent-metrics-logs': '#agent-metrics-logs'
 '@datadog/agent-processing-and-routing': '#agent-processing-and-routing'

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -55,7 +55,7 @@ class TestSplitJUnitXML(unittest.TestCase):
     def test_with_split(self):
         xml_file = Path("./tasks/unit_tests/testdata/secret.tar.gz/-go-src-datadog-agent-junit-out-base.xml")
         owners = read_owners(".github/CODEOWNERS")
-        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, []), 27)
+        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, []), 29)
 
 
 class TestGroupPerTag(unittest.TestCase):
@@ -129,4 +129,4 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
         mock_popen.return_value = mock_instance
         junit.junit_upload_from_tgz("tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz")
         mock_popen.assert_called()
-        self.assertEqual(mock_popen.call_count, 29)
+        self.assertEqual(mock_popen.call_count, 31)


### PR DESCRIPTION
The `Network Device Monitoring` team is splitting into `ndm-core` and `ndm-integrations`.
I searched for `network-device-monitoring` in the agent codebase and replaced it appropriately.

Only place where it's remaining is for network path which doesn't have a real home yet. But the `Network Device Monitoring` team will continue to exist as a github "parent" team as a parent of core and integrations