### PR TITLE
[EBPF] kmt: avoid races when generating helper binaries

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1063,10 +1063,15 @@ def kmt_sysprobe_prepare(
             for cbin in TEST_HELPER_CBINS:
                 source = Path(pkg) / "testdata" / f"{cbin}.c"
                 if source.is_file():
-                    binary_path = os.path.join(target_path, "testdata", cbin)
+                    testdata_folder = os.path.join(target_path, "testdata")
+                    binary_path = os.path.join(testdata_folder, cbin)
                     nw.build(
                         inputs=[os.fspath(source)],
                         outputs=[binary_path],
+                        # Ensure that the testdata folder is created before the
+                        # binary, to avoid races between this command and the
+                        # copy command
+                        implicit=[testdata_folder],
                         rule="cbin",
                         variables={
                             "cc": "clang",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds an implicit dependency on the testdata folder to avoid a race between the command that copies the files and the one that generates helper binaries.

### Motivation

Avoid sporadic failures in the prepare job.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->