### PR TITLE
Set another endpoint to forward logs to DDDev

### DIFF
--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -63,15 +63,16 @@ type Option func(*Server)
 
 // Server is a struct implementing a fakeintake server
 type Server struct {
-	uuid            uuid.UUID
-	server          http.Server
-	ready           chan bool
-	clock           clock.Clock
-	retention       time.Duration
-	shutdown        chan struct{}
-	dddevForward    bool
-	forwardEndpoint string
-	apiKey          string
+	uuid               uuid.UUID
+	server             http.Server
+	ready              chan bool
+	clock              clock.Clock
+	retention          time.Duration
+	shutdown           chan struct{}
+	dddevForward       bool
+	forwardEndpoint    string
+	logForwardEndpoint string
+	apiKey             string
 
 	urlMutex sync.RWMutex
 	url      string
@@ -97,8 +98,9 @@ func NewServer(options ...Option) *Server {
 		server: http.Server{
 			Addr: "0.0.0.0:0",
 		},
-		storeDriver:     "memory",
-		forwardEndpoint: "https://app.datadoghq.com",
+		storeDriver:        "memory",
+		forwardEndpoint:    "https://app.datadoghq.com",
+		logForwardEndpoint: "https://agent-http-intake.logs.datadoghq.com",
 	}
 
 	for _, opt := range options {
@@ -246,6 +248,15 @@ func withForwardEndpoint(endpoint string) Option {
 	}
 }
 
+// withLogForwardEndpoint sets the endpoint to forward the log payload to, useful for testing
+//
+//nolint:unused // this function is used in the tests
+func withLogForwardEndpoint(endpoint string) Option {
+	return func(fi *Server) {
+		fi.logForwardEndpoint = endpoint
+	}
+}
+
 // Start Starts a fake intake server in a separate go-routine
 // Notifies when ready to the ready channel
 func (fi *Server) Start() {
@@ -368,7 +379,13 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 }
 
 func (fi *Server) forwardRequestToDDDev(req *http.Request, payload []byte) error {
-	url := fi.forwardEndpoint + req.URL.Path
+	forwardEndpoint := fi.forwardEndpoint
+
+	if req.URL.Path == "/api/v2/logs" {
+		forwardEndpoint = fi.logForwardEndpoint
+	}
+
+	url := forwardEndpoint + req.URL.Path
 
 	proxyReq, err := http.NewRequest(req.Method, url, bytes.NewReader(payload))
 	if err != nil {
@@ -413,7 +430,7 @@ func (fi *Server) handleDatadogPostRequest(w http.ResponseWriter, req *http.Requ
 	if fi.dddevForward {
 		err := fi.forwardRequestToDDDev(req, payload)
 		if err != nil {
-			log.Printf("Error forwarding request to DDDev: %v", err)
+			log.Printf("Error forwarding request on endpoint %v to DDDev: %v", req.URL.Path, err)
 		}
 	}
 	encoding := req.Header.Get("Content-Encoding")

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -98,8 +98,8 @@ func NewServer(options ...Option) *Server {
 		server: http.Server{
 			Addr: "0.0.0.0:0",
 		},
-		storeDriver:        "memory",
-		forwardEndpoint:    "https://app.datadoghq.com",
+		storeDriver:     "memory",
+		forwardEndpoint: "https://app.datadoghq.com",
 		// Source: https://docs.datadoghq.com/api/latest/logs/
 		logForwardEndpoint: "https://agent-http-intake.logs.datadoghq.com",
 	}

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -100,6 +100,7 @@ func NewServer(options ...Option) *Server {
 		},
 		storeDriver:        "memory",
 		forwardEndpoint:    "https://app.datadoghq.com",
+		// Source: https://docs.datadoghq.com/api/latest/logs/
 		logForwardEndpoint: "https://agent-http-intake.logs.datadoghq.com",
 	}
 

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -381,7 +381,7 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 func (fi *Server) forwardRequestToDDDev(req *http.Request, payload []byte) error {
 	forwardEndpoint := fi.forwardEndpoint
 
-	if req.URL.Path == "/api/v2/logs" {
+	if req.URL.Path == "/api/v2/logs" || req.URL.Path == "/v1/input" {
 		forwardEndpoint = fi.logForwardEndpoint
 	}
 

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -629,6 +629,31 @@ func testServer(t *testing.T, opts ...Option) {
 		assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected code")
 
 	})
+	t.Run("should forward logs to dddev using logforwardendpoint", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Logf("Received request in test %+v", r)
+			responseBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err, "Error reading request body")
+			assert.Equal(t, "totoro|5|tag:log,owner:toto", string(responseBody))
+			assert.Equal(t, r.Header.Get("DD-API-KEY"), "thisisatestapikey")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+
+		defer testServer.Close()
+		testOpts := append(opts, withLogForwardEndpoint(testServer.URL), withDDDevAPIKey("thisisatestapikey"), WithDDDevForward())
+		fi, _ := InitialiseForTests(t, testOpts...)
+		defer fi.Stop()
+		res, err := http.Post(fi.URL()+"/api/v2/logs", "text/plain", strings.NewReader("totoro|5|tag:log,owner:toto"))
+		require.NoError(t, err, "Error on POST request")
+		defer res.Body.Close()
+		t.Logf("Response: %v", res)
+		assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected code")
+		res, err = http.Post(fi.URL()+"/api/v2/series", "text/plain", strings.NewReader("totoro|5|tag:series,owner:toto"))
+		require.NoError(t, err, "Error on POST request")
+		defer res.Body.Close()
+		t.Logf("Response: %v", res)
+		assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected code")
+	})
 }
 
 type TestTextPayload struct {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Logs cannot be sent to the `app.datadoghq.com` endpoint, `app.datadoghq.com/api/v2/logs` sends a `404` error. Instead we need to forward the logs to `http-agent-intake.logs.datadoghq.com`. This PR update forwarding to forward calls to `/api/v2/logs` to the correct endpoint.

### Motivation

Make sure the payload forwarding works with logs

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->