### PR TITLE
ci(runners): Move to k8s runners

### DIFF
--- a/.gitlab/functional_test/oracle.yml
+++ b/.gitlab/functional_test/oracle.yml
@@ -1,6 +1,6 @@
 oracle:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   stage: functional_test
   needs: ["go_deps"]
   rules:

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -76,7 +76,7 @@ single-machine-performance-regression_detector:
     - echo "Commit ${BASELINE_SHA} is recent enough"
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     - |
-      while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]
+      while [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]
       do
           echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"
           BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^)

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -5,7 +5,7 @@ single-machine-performance-regression_detector:
     - !reference [.except_main_or_release_branch]
     - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   needs:
     - job: single_machine_performance-amd64-a7
       artifacts: false

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -4,7 +4,7 @@ serverless_cold_start_performance-deb_x64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   needs: ["go_deps", "build_serverless-deb_x64"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -4,7 +4,7 @@ serverless_cold_start_performance-deb_x64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["runner:docker"]  # Still required as compute.sh is doing a container run
   needs: ["go_deps", "build_serverless-deb_x64"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -27,7 +27,7 @@ docker_image_build_otel:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   needs: ["go_deps","integration_tests_otel"]
-  tags: ["arch:amd64"]
+  tags: ["runner:docker"]  # Still required because the otel_agent_build_tests.py is doing a container run
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p /tmp/otel-ci

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -27,7 +27,7 @@ docker_image_build_otel:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   needs: ["go_deps","integration_tests_otel"]
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p /tmp/otel-ci


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move 2 jobs which were still using `runner:docker` to k8s gitlab runners

### Motivation
Relates to #30229: I wanted to perform the vault migration of SMP credentials, and SMP was running on old runners, so not possible to use the k8s vault. So I'm doing this first step to migrate jobs that could use another runner

### Describe how to test/QA your changes
Validate the CI is green for these jobs

### Possible Drawbacks / Trade-offs
I had to force the region of `aws ecr describe` for the SMP, as it might be set in the runner default configuration. There is maybe an other way to fix this.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->