### PR TITLE
Only launch VM specified in test set in the CI

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -154,7 +154,7 @@
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
       # Each VM gets 12GB of memory. We have set 8GB as base for the system, and upto 4GB can be used
       # by a ram backed filesystem holding the system-probe test packages
-    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --sets=$TEST_SETS --vmconfig-template=$TEST_COMPONENT --memory=12288
+    - inv -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --vmconfig-template=$TEST_COMPONENT --memory=12288
     - inv -e system-probe.start-microvms --provision-instance --provision-microvms --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-${TEST_COMPONENT}-${ARCH}-${CI_PIPELINE_ID} --run-agent
     - jq "." $CI_PROJECT_DIR/stack.output
     - pulumi logout

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -32,7 +32,6 @@ kmt_setup_env_secagent_arm64:
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
     TEST_COMPONENT: security-agent
-    TEST_SETS: cws_host,cws_docker,cws_ad,cws_el,cws_el_ns,cws_fentry
 
 kmt_setup_env_secagent_x64:
   extends:
@@ -45,7 +44,6 @@ kmt_setup_env_secagent_x64:
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
     TEST_COMPONENT: security-agent
-    TEST_SETS: cws_host,cws_docker,cws_ad,cws_el,cws_el_ns,cws_fentry
 
 .upload_secagent_tests:
   stage: kernel_matrix_testing_prepare

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -122,7 +122,6 @@ kmt_setup_env_sysprobe_arm64:
     AMI_ID_ARG: "--arm-ami-id=$KERNEL_MATRIX_TESTING_ARM_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-arm
     TEST_COMPONENT: system-probe
-    TEST_SETS: "only_usm,no_usm"
 
 kmt_setup_env_sysprobe_x64:
   extends:
@@ -135,7 +134,6 @@ kmt_setup_env_sysprobe_x64:
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
     LibvirtSSHKey: $CI_PROJECT_DIR/libvirt_rsa-x86
     TEST_COMPONENT: system-probe
-    TEST_SETS: "only_usm,no_usm"
 
 .upload_sysprobe_tests:
   stage: kernel_matrix_testing_prepare

--- a/tasks/kernel_matrix_testing/platforms.py
+++ b/tasks/kernel_matrix_testing/platforms.py
@@ -9,6 +9,7 @@ import yaml
 from tasks.kernel_matrix_testing.tool import Exit
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
+from tasks.libs.types.arch import Arch
 
 if TYPE_CHECKING:
     from tasks.kernel_matrix_testing.types import (
@@ -27,7 +28,7 @@ def get_platforms():
 
 
 class KMTTestJob:
-    def __init__(self, name, arch, test_set, kernels):
+    def __init__(self, name: str, arch: KMTArchName, test_set: str, kernels: set[str]):
         self.name = name
         self.arch = arch
         self.test_set = test_set
@@ -65,7 +66,7 @@ def filter_by_ci_component(platforms: Platforms, component: Component) -> dict[s
             sets = ci_config[job]["parallel"]["matrix"][0]["TEST_SET"]
             kernels = ci_config[job]["parallel"]["matrix"][0]["TAG"]
 
-            test_jobs.append(KMTTestJob(job, arch, sets, set(kernels)))
+            test_jobs.append(KMTTestJob(job, Arch.from_str(arch).kmt_arch, sets, set(kernels)))
 
     new_platforms_by_set = {}
     for job in test_jobs:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -488,7 +488,7 @@ def start_compiler(ctx: Context):
 
 
 def filter_target_domains(vms: str, infra: dict[KMTArchNameOrLocal, HostInstance], arch: Arch | None = None):
-    vmsets = vmconfig.build_vmsets(vmconfig.build_normalized_vm_def_by_set(vms))
+    vmsets = vmconfig.build_vmsets(vmconfig.build_normalized_vm_def_by_set(vms, []))
     domains: list[LibvirtDomain] = []
     for vmset in vmsets:
         if arch is not None and Arch.from_str(vmset.arch) != arch:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -488,7 +488,7 @@ def start_compiler(ctx: Context):
 
 
 def filter_target_domains(vms: str, infra: dict[KMTArchNameOrLocal, HostInstance], arch: Arch | None = None):
-    vmsets = vmconfig.build_vmsets(vmconfig.build_normalized_vm_def_set(vms), [])
+    vmsets = vmconfig.build_vmsets(vmconfig.build_normalized_vm_def_by_set(vms))
     domains: list[LibvirtDomain] = []
     for vmset in vmsets:
         if arch is not None and Arch.from_str(vmset.arch) != arch:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR makes the configuration generation test set aware. This means we only launch VMs required by a test set as specified in the Gitlab yaml. This allows us to reduce resource usage by unused VMs.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->