### PR TITLE
Update OTLP span -> DD span logic for operation and resource name

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -81,9 +81,9 @@ func NewOTLPReceiver(out chan<- *Payload, cfg *config.AgentConfig, statsd statsd
 	spanNameRemappingsEnabledVal := 0.0
 	if cfg.OTLPReceiver.SpanNameRemappings != nil && len(cfg.OTLPReceiver.SpanNameRemappings) > 0 {
 		if operationAndResourceNamesV2GateEnabled {
-			log.Warnf("Detected SpanNameRemappings in config - this feature will be deprecated in a future version. Please remove it to access functionality from feature gate \"enable_operation_and_resource_name_logic_v22\".")
+			log.Warnf("Detected SpanNameRemappings in config - this feature will be deprecated in a future version. Please remove it to access functionality from feature gate \"enable_operation_and_resource_name_logic_v2\".")
 		} else {
-			log.Warnf("Detected SpanNameRemappings in config - this feature will be deprecated in a future version. Please remove it and enable feature gate \"enable_operation_and_resource_name_logic_v22\"")
+			log.Warnf("Detected SpanNameRemappings in config - this feature will be deprecated in a future version. Please remove it and enable feature gate \"enable_operation_and_resource_name_logic_v2\"")
 		}
 		spanNameRemappingsEnabledVal = 1.0
 	}

--- a/pkg/trace/stats/otel_util.go
+++ b/pkg/trace/stats/otel_util.go
@@ -46,7 +46,13 @@ func OTLPTracesToConcentratorInputs(
 	containerTagsByID := make(map[string][]string)
 	for spanID, otelspan := range spanByID {
 		otelres := resByID[spanID]
-		if _, exists := ignoreResNames[traceutil.GetOTelResource(otelspan, otelres)]; exists {
+		var resourceName string
+		if transform.OperationAndResourceNameV2Enabled(conf) {
+			resourceName = traceutil.GetOTelResourceV2(otelspan, otelres)
+		} else {
+			resourceName = traceutil.GetOTelResourceV1(otelspan, otelres)
+		}
+		if _, exists := ignoreResNames[resourceName]; exists {
 			continue
 		}
 		// TODO(songy23): use AttributeDeploymentEnvironmentName once collector version upgrade is unblocked

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -214,6 +214,10 @@ func TestProcessOTLPTraces(t *testing.T) {
 			conf.PeerTagsAggregation = tt.peerTagsAggr
 			conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 			conf.OTLPReceiver.SpanNameAsResourceName = tt.spanNameAsResourceName
+			if conf.OTLPReceiver.SpanNameAsResourceName {
+				// Verify that while EnableOperationAndResourceNamesV2 is in alpha, SpanNameAsResourceName overrides it
+				conf.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
+			}
 			conf.OTLPReceiver.SpanNameRemappings = tt.spanNameRemappings
 			conf.Ignore["resource"] = tt.ignoreRes
 			if !tt.legacyTopLevel {

--- a/pkg/trace/traceutil/otel_util.go
+++ b/pkg/trace/traceutil/otel_util.go
@@ -206,8 +206,8 @@ func GetOTelResourceV1(span ptrace.Span, res pcommon.Resource) (resName string) 
 }
 
 // GetOTelResourceV2 returns the DD resource name based on OTel span and resource attributes.
-func GetOTelResourceV2(span ptrace.Span, res pcommon.Resource) (resName string) {
-	resName = GetOTelAttrValInResAndSpanAttrs(span, res, false, "resource.name")
+func GetOTelResourceV2(span ptrace.Span, res pcommon.Resource) string {
+	resName := GetOTelAttrValInResAndSpanAttrs(span, res, false, "resource.name")
 	if resName == "" {
 		if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, "http.request.method", semconv.AttributeHTTPMethod); m != "" {
 			if m == "_OTHER" {
@@ -220,27 +220,37 @@ func GetOTelResourceV2(span ptrace.Span, res pcommon.Resource) (resName string) 
 					resName = resName + " " + route
 				}
 			}
-		} else if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeMessagingOperation); m != "" {
+		}
+	}
+
+	if resName == "" {
+		if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeMessagingOperation); m != "" {
 			resName = m
 			// use the messaging operation
 			if dest := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeMessagingDestination, semconv117.AttributeMessagingDestinationName); dest != "" {
 				resName = resName + " " + dest
 			}
-		} else if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeRPCMethod); m != "" {
+		}
+	}
+
+	if resName == "" {
+		if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeRPCMethod); m != "" {
 			resName = m
 			// use the RPC method
 			if svc := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeRPCService); m != "" {
 				// ...and service if available
 				resName = resName + " " + svc
 			}
-		} else {
-			resName = span.Name()
 		}
+	}
+
+	if resName == "" {
+		resName = span.Name()
 	}
 	if len(resName) > MaxResourceLen {
 		resName = resName[:MaxResourceLen]
 	}
-	return
+	return resName
 }
 
 // GetOTelOperationNameV2 returns the DD operation name based on OTel span and resource attributes and given configs.

--- a/pkg/trace/traceutil/otel_util_test.go
+++ b/pkg/trace/traceutil/otel_util_test.go
@@ -257,36 +257,42 @@ func TestGetOTelService(t *testing.T) {
 
 func TestGetOTelResource(t *testing.T) {
 	for _, tt := range []struct {
-		name      string
-		rattrs    map[string]string
-		sattrs    map[string]string
-		normalize bool
-		expected  string
+		name       string
+		rattrs     map[string]string
+		sattrs     map[string]string
+		normalize  bool
+		expectedV1 string
+		expectedV2 string
 	}{
 		{
-			name:     "resource not set",
-			expected: "span_name",
+			name:       "resource not set",
+			expectedV1: "span_name",
+			expectedV2: "span_name",
 		},
 		{
-			name:     "normal resource",
-			sattrs:   map[string]string{"resource.name": "res"},
-			expected: "res",
+			name:       "normal resource",
+			sattrs:     map[string]string{"resource.name": "res"},
+			expectedV1: "res",
+			expectedV2: "res",
 		},
 		{
-			name:     "HTTP request method resource",
-			sattrs:   map[string]string{"http.request.method": "GET"},
-			expected: "GET",
+			name:       "HTTP request method resource",
+			sattrs:     map[string]string{"http.request.method": "GET"},
+			expectedV1: "GET",
+			expectedV2: "GET",
 		},
 		{
-			name:     "HTTP method and route resource",
-			sattrs:   map[string]string{semconv.AttributeHTTPMethod: "GET", semconv.AttributeHTTPRoute: "/"},
-			expected: "GET /",
+			name:       "HTTP method and route resource",
+			sattrs:     map[string]string{semconv.AttributeHTTPMethod: "GET", semconv.AttributeHTTPRoute: "/"},
+			expectedV1: "GET /",
+			expectedV2: "GET",
 		},
 		{
-			name:      "truncate long resource",
-			sattrs:    map[string]string{"resource.name": strings.Repeat("a", MaxResourceLen+1)},
-			normalize: true,
-			expected:  strings.Repeat("a", MaxResourceLen),
+			name:       "truncate long resource",
+			sattrs:     map[string]string{"resource.name": strings.Repeat("a", MaxResourceLen+1)},
+			normalize:  true,
+			expectedV1: strings.Repeat("a", MaxResourceLen),
+			expectedV2: strings.Repeat("a", MaxResourceLen),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -299,8 +305,8 @@ func TestGetOTelResource(t *testing.T) {
 			for k, v := range tt.rattrs {
 				res.Attributes().PutStr(k, v)
 			}
-			actual := GetOTelResource(span, res)
-			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expectedV1, GetOTelResourceV1(span, res))
+			assert.Equal(t, tt.expectedV2, GetOTelResourceV2(span, res))
 		})
 	}
 }
@@ -384,7 +390,7 @@ func TestGetOTelOperationName(t *testing.T) {
 			}
 			lib := pcommon.NewInstrumentationScope()
 			lib.SetName(tt.libname)
-			actual := GetOTelOperationName(span, res, lib, tt.spanNameAsResourceName, tt.spanNameRemappings, tt.normalize)
+			actual := GetOTelOperationNameV1(span, res, lib, tt.spanNameAsResourceName, tt.spanNameRemappings, tt.normalize)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -23,6 +23,11 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
+// OperationAndResourceNameV2Enabled checks if the new operation and resource name logic should be used
+func OperationAndResourceNameV2Enabled(conf *config.AgentConfig) bool {
+	return !conf.OTLPReceiver.SpanNameAsResourceName && (conf.OTLPReceiver.SpanNameRemappings == nil || len(conf.OTLPReceiver.SpanNameRemappings) == 0) && conf.HasFeature("enable_operation_and_resource_name_logic_v2")
+}
+
 // OtelSpanToDDSpanMinimal otelSpanToDDSpan converts an OTel span to a DD span.
 // The converted DD span only has the minimal number of fields for APM stats calculation and is only meant
 // to be used in OTLPTracesToConcentratorInputs. Do not use them for other purposes.
@@ -34,10 +39,20 @@ func OtelSpanToDDSpanMinimal(
 	conf *config.AgentConfig,
 	peerTagKeys []string,
 ) *pb.Span {
+	var operationName string
+	var resourceName string
+	if OperationAndResourceNameV2Enabled(conf) {
+		operationName = traceutil.GetOTelOperationNameV2(otelspan)
+		resourceName = traceutil.GetOTelResourceV2(otelspan, otelres)
+	} else {
+		operationName = traceutil.GetOTelOperationNameV1(otelspan, otelres, lib, conf.OTLPReceiver.SpanNameAsResourceName, conf.OTLPReceiver.SpanNameRemappings, true)
+		resourceName = traceutil.GetOTelResourceV1(otelspan, otelres)
+	}
+
 	ddspan := &pb.Span{
 		Service:  traceutil.GetOTelService(otelspan, otelres, true),
-		Name:     traceutil.GetOTelOperationName(otelspan, otelres, lib, conf.OTLPReceiver.SpanNameAsResourceName, conf.OTLPReceiver.SpanNameRemappings, true),
-		Resource: traceutil.GetOTelResource(otelspan, otelres),
+		Name:     operationName,
+		Resource: resourceName,
 		TraceID:  traceutil.OTelTraceIDToUint64(otelspan.TraceID()),
 		SpanID:   traceutil.OTelSpanIDToUint64(otelspan.SpanID()),
 		ParentID: traceutil.OTelSpanIDToUint64(otelspan.ParentSpanID()),

--- a/releasenotes/notes/operation-and-resource-name-logic-v2-75929121247f2059.yaml
+++ b/releasenotes/notes/operation-and-resource-name-logic-v2-75929121247f2059.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - Added a new feature flag `enable_operation_and_resource_name_logic_v2` in DD_APM_FEATURES. When this flag is enabled, the logic for computing operation and resource names from OTLP spans is modified to create shorter and more readable names and to better align with OpenTelemetry specifications.

--- a/releasenotes/notes/operation-and-resource-name-logic-v2-75929121247f2059.yaml
+++ b/releasenotes/notes/operation-and-resource-name-logic-v2-75929121247f2059.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 ---
 features:
-  - Added a new feature flag `enable_operation_and_resource_name_logic_v2` in DD_APM_FEATURES. When this flag is enabled, the logic for computing operation and resource names from OTLP spans is modified to create shorter and more readable names and to better align with OpenTelemetry specifications.
+  - Added a new feature flag `enable_operation_and_resource_name_logic_v2` in DD_APM_FEATURES. Enabling this flag modifies the logic for computing operation and resource names from OTLP spans to produce shorter, more readable names and improve alignment with OpenTelemetry specifications.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update the logic for determining DD span operation name and resource name from OTLP spans to produce shorter names and better align with the OTel spec.

The operation name logic is based on the logic used in [dd-trace-go](https://github.com/DataDog/dd-trace-go/blob/6b5e01ab247b70c5e4e39a5e97ae27ac99fff4de/ddtrace/opentelemetry/span.go#L257)

Minor changes are made to resource name to bring the resource name closer in line with the [OTel specification for span name](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name), since we would like the two concepts to be equivalent.

This is a breaking change, so it is gated for now - users can enable the new logic by setting `enable_operation_and_resource_name_logic_v2` in `apm_config.features`.  In this first version, if a user has the new logic enabled along with `SpanNameAsResourceName` and `SpanNameRemappings`, the latter will override the former and revert to the v1 logic. This is intended to make sure users know what they're doing by enabling the new breaking logic.

If a user hasn't enabled the new logic or has overridden it with another config option, surface a warning encouraging them to switch and informing them how. In a future PR, these will be cleaned up and `enable_operation_and_resource_name_logic_v2` will become the default.

Once we merge this and update the agent version in opentelemetry-collector-contrib, it will be available for `datadogexporter` as well. So, I'll create an issue in that repo to explain the utility of the update and encourage users to enable it. 

[The RFC with more information can be found here](https://docs.google.com/document/d/1Olq7ZSljlOJYwgqMeW9Sh16Cj4P2Rh0cHhyk25LtsSo/edit?tab=t.0)

### Describe how to test/QA your changes

Set `enable_operation_and_resource_name_logic_v2` in `apm_config.features` and run the agent + trace-agent. Send some spans and verify that the resource name and operation name are set in the new way (e.g., there is no `io.opentelemetry...` prefix on operation name, an HTTP server request from the OTel java calendar app would have operation name `http.server.request`.)
