### PR TITLE
Remove useless init already done by the mock

### DIFF
--- a/pkg/config/utils/metadata_as_tags_test.go
+++ b/pkg/config/utils/metadata_as_tags_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestGetMetadataAsTagsNoError(t *testing.T) {
@@ -101,7 +100,6 @@ func TestGetMetadataAsTagsNoError(t *testing.T) {
 
 		t.Run(test.name, func(tt *testing.T) {
 			mockConfig := configmock.New(t)
-			pkgconfigsetup.InitConfig(mockConfig)
 
 			mockConfig.SetWithoutSource("kubernetes_pod_labels_as_tags", test.podLabelsAsTags)
 			mockConfig.SetWithoutSource("kubernetes_pod_annotations_as_tags", test.podAnnotationsAsTags)

--- a/pkg/config/utils/tags_test.go
+++ b/pkg/config/utils/tags_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetConfiguredaTags(t *testing.T) {
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.InitConfig(mockConfig)
 
 	set1 := []string{"1", "2", "3"}
 
@@ -25,7 +23,6 @@ func TestGetConfiguredaTags(t *testing.T) {
 
 func TestGetConfiguredaTagsExtraTags(t *testing.T) {
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.InitConfig(mockConfig)
 
 	set1 := []string{"1", "2", "3"}
 
@@ -35,7 +32,6 @@ func TestGetConfiguredaTagsExtraTags(t *testing.T) {
 
 func TestGetConfiguredaTagsDSD(t *testing.T) {
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.InitConfig(mockConfig)
 
 	set1 := []string{"1", "2", "3"}
 
@@ -46,7 +42,6 @@ func TestGetConfiguredaTagsDSD(t *testing.T) {
 
 func TestGetConfiguredaTagsCombined(t *testing.T) {
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.InitConfig(mockConfig)
 
 	set1 := []string{"1", "2", "3"}
 	set2 := []string{"4", "5", "6"}

--- a/pkg/config/utils/telemetry_test.go
+++ b/pkg/config/utils/telemetry_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +16,6 @@ func TestIsCheckTelemetryEnabled(t *testing.T) {
 	assert := assert.New(t)
 
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.InitConfig(mockConfig)
 	mockConfig.SetWithoutSource("agent_telemetry.enabled", false)
 	mockConfig.SetWithoutSource("telemetry.enabled", false)
 


### PR DESCRIPTION
### What does this PR do?

Remove useless init already done by the mock

### Possible Drawbacks / Trade-offs

Running the CI is enough