### PR TITLE
ci: cache libpcap build in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,6 +233,10 @@ variables:
   # skip known flaky tests by default
   GO_TEST_SKIP_FLAKE: "true"
 
+  # system-probe deps
+  LIBPCAP_VERSION: 1.10.5
+  LIBPCAP_SHA256SUM: 84fa89ac6d303028c1c5b754abff77224f45eca0a94eb1a34ff0aa9ceece3925
+
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
   AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile  # agent-devx-infra

--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -13,6 +13,8 @@ needs-rules:
     - build_clang_arm64
     - build_clang_x64
     - build_dogstatsd_static-binary_x64
+    - build_libpcap_arm64
+    - build_libpcap_x64
     - build_processed_btfhub_archive
     - check_already_deployed_version_7
     - cleanup_kitchen_functional_test

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -12,6 +12,7 @@ create_release_qa_cards              @DataDog/agent-devx-infra
 # Deps build
 build_clang_*                        @DataDog/ebpf-platform
 build_processed_btfhub_archive       @DataDog/ebpf-platform
+build_libpcap_*                      @DataDog/agent-security
 
 # Source test
 # Notifications are handled separately for more fine-grained control on go tests

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -20,6 +20,13 @@
     KUBERNETES_MEMORY_REQUEST: "6Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
     KUBERNETES_CPU_REQUEST: 6
+  cache:
+    policy: pull
+    key: libpcap-$LIBPCAP_VERSION-$ARCH
+    paths:
+      - $CI_PROJECT_DIR/dev/lib/libpcap.a
+      - $CI_PROJECT_DIR/dev/include/pcap*.h
+      - $CI_PROJECT_DIR/dev/include/pcap/*.h
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -30,7 +37,7 @@ build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["go_deps"]
+  needs: ["go_deps", "build_libpcap_x64"]
   extends: .system-probe_build_common
   variables:
     ARCH: amd64
@@ -38,7 +45,7 @@ build_system-probe-x64:
 build_system-probe-arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  needs: ["go_deps"]
+  needs: ["go_deps", "build_libpcap_arm64"]
   tags: ["arch:arm64"]
   extends: .system-probe_build_common
   variables:

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -94,3 +94,36 @@ build_processed_btfhub_archive:
     - inv -e system-probe.process-btfhub-archive --branch $BTFHUB_ARCHIVE_BRANCH
     - $S3_CP_CMD btfs-x86_64.tar $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-x86_64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     - $S3_CP_CMD btfs-arm64.tar $S3_DD_AGENT_OMNIBUS_BTFS_URI/$BTFHUB_ARCHIVE_BRANCH/btfs-arm64.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+
+.build_libpcap_common:
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  stage: deps_build
+  variables:
+    KUBERNETES_CPU_REQUEST: 2
+  script:
+    - inv -e system-probe.build-libpcap --version=$LIBPCAP_VERSION --sha256sum=$LIBPCAP_SHA256SUM
+    - strings $CI_PROJECT_DIR/dev/lib/libpcap.a | grep -E "^libpcap version $LIBPCAP_VERSION" || exit 1 # ensure we're able to match the expected version
+  timeout: 10m
+  cache:
+    policy: pull-push
+    key: libpcap-$LIBPCAP_VERSION-$ARCH
+    paths:
+      - $CI_PROJECT_DIR/dev/lib/libpcap.a
+      - $CI_PROJECT_DIR/dev/include/pcap*.h
+      - $CI_PROJECT_DIR/dev/include/pcap/*.h
+
+build_libpcap_x64:
+  extends: .build_libpcap_common
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:amd64"]
+  variables:
+    ARCH: amd64
+
+build_libpcap_arm64:
+  extends: .build_libpcap_common
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  variables:
+    ARCH: arm64

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -78,7 +78,13 @@ prepare_sysprobe_ebpf_functional_tests_x64:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  needs: ["go_deps", "go_tools_deps"]
+  cache:
+    policy: pull
+    key: libpcap-$LIBPCAP_VERSION-$ARCH
+    paths:
+      - $CI_PROJECT_DIR/dev/lib/libpcap.a
+      - $CI_PROJECT_DIR/dev/include/pcap*.h
+      - $CI_PROJECT_DIR/dev/include/pcap/*.h
   artifacts:
     when: always
     paths:
@@ -97,6 +103,7 @@ prepare_sysprobe_ebpf_functional_tests_x64:
 
 prepare_secagent_ebpf_functional_tests_arm64:
   extends: .prepare_secagent_ebpf_functional_tests
+  needs: ["go_deps", "go_tools_deps", "build_libpcap_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:arm64"]
   variables:
@@ -104,6 +111,7 @@ prepare_secagent_ebpf_functional_tests_arm64:
 
 prepare_secagent_ebpf_functional_tests_x64:
   extends: .prepare_secagent_ebpf_functional_tests
+  needs: ["go_deps", "go_tools_deps", "build_libpcap_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds: 
- `build_libpcap_x64`/`build_libpcap_arm64` jobs responsible for fetching `libpcap` sources and building the library (in case its artifacts don't exist in the gitlab cache)
- a gitlab cache for the artifacts built from these jobs (the `libpcap` static library and its headers)

### Motivation

This avoids fetching and building the library in every `build_system-probe-*` and `prepare_secagent_ebpf_functional_tests_*` jobs. This also allows the library artifacts to be reused across multiple CI pipelines.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->