### PR TITLE
[usm] service discovery, use pool of [15]byte slices to read up to 15 bytes from /proc/<pid>/comm

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -16,13 +16,15 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
 const (
 	// maximum command name length to process when checking for non-reportable commands,
 	// is one byte less (excludes end of line) than the maximum of /proc/<pid>/comm
 	// defined in https://man7.org/linux/man-pages/man5/proc.5.html.
-	maxCommLen = 15
+	maxCommLen   = 15
+	poolCapacity = 100
 )
 
 // ignoreFamily list of processes with hyphens in their names,
@@ -34,26 +36,38 @@ var ignoreFamily = map[string]struct{}{
 	"docker":     {}, // 'docker-proxy'
 }
 
+var (
+	procCommBufferPool = ddsync.NewSlicePool[byte](maxCommLen, poolCapacity)
+)
+
 // shouldIgnoreComm returns true if process should be ignored
 func (s *discovery) shouldIgnoreComm(proc *process.Process) bool {
 	if s.config.ignoreComms == nil {
 		return false
 	}
 	commPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "comm")
-	contents, err := os.ReadFile(commPath)
+	file, err := os.Open(commPath)
 	if err != nil {
 		return true
 	}
+	defer file.Close()
 
-	dash := bytes.IndexByte(contents, '-')
+	buf := procCommBufferPool.Get()
+	defer procCommBufferPool.Put(buf)
+
+	n, err := file.Read(*buf)
+	if err != nil {
+		return true
+	}
+	dash := bytes.IndexByte((*buf)[:n], '-')
 	if dash > 0 {
-		_, found := ignoreFamily[string(contents[:dash])]
+		_, found := ignoreFamily[string((*buf)[:dash])]
 		if found {
 			return true
 		}
 	}
 
-	comm := strings.TrimSuffix(string(contents), "\n")
+	comm := strings.TrimSuffix(string((*buf)[:n]), "\n")
 	_, found := s.config.ignoreComms[comm]
 
 	return found

--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// maximum command name length to process when checking for non-reportable commands,
+	// maxCommLen is maximum command name length to process when checking for non-reportable commands,
 	// is one byte less (excludes end of line) than the maximum of /proc/<pid>/comm
 	// defined in https://man7.org/linux/man-pages/man5/proc.5.html.
 	maxCommLen   = 15


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
system-probe, service discovery, use pre-allocated 15 byte buffers for reading /proc/pid/comm

### Motivation
Reduce the memory allocation used by the system-probe process when discovering services and reading all of /proc
Compare benchmark before and after code change:

Time per Operation (ns/op): 20% less
Bytes Allocated per Operation (B/op): 6.8 times less
Allocations per Operation (allocs/op): 40% less

```
BenchmarkProcCommReadFile-4   	  457720	      2609 ns/op	     824 B/op	       5 allocs/op
BenchmarkProcCommReadLen-4    	  585106	      2108 ns/op	     120 B/op	       3 allocs/op

```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->