### PR TITLE
[CI] Remove template injection vulnerable bits from Serverless GHA Workflows

### DIFF
--- a/.github/workflows/serverless-benchmarks.yml
+++ b/.github/workflows/serverless-benchmarks.yml
@@ -40,9 +40,11 @@ jobs:
           go get ./...
 
       - name: Run benchmark
+        env:
+          TEMP_RUNNER: ${{runner.temp}}
         run: |
           go test -tags=test -run='^$' -bench=StartEndInvocation -count=10 -benchtime=500ms -timeout=60m \
-              ./pkg/serverless/... | tee ${{runner.temp}}/benchmark.log
+              ./pkg/serverless/... | tee "$TEMP_RUNNER"/benchmark.log
 
       - name: Upload result artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
@@ -76,9 +78,11 @@ jobs:
           go get ./...
 
       - name: Run benchmark
+        env:
+          TEMP_RUNNER: ${{runner.temp}}
         run: |
           go test -tags=test -run='^$' -bench=StartEndInvocation -count=10 -benchtime=500ms -timeout=60m \
-              ./pkg/serverless/... | tee ${{runner.temp}}/benchmark.log
+              ./pkg/serverless/... | tee "$TEMP_RUNNER"/benchmark.log
 
       - name: Upload result artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -72,9 +72,12 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Compare sizes
+        env:
+          PREVIOUS_SIZE: ${{ steps.previous.outputs.result }}
+          CURRENT_SIZE: ${{ steps.current.outputs.result }}
         id: compare
         run: |
-          OUTPUT=$(( ${{ steps.current.outputs.result }} - ${{ steps.previous.outputs.result }} ))
+          OUTPUT=$(( $CURRENT_SIZE - $PREVIOUS_SIZE ))
           echo "binary size changed by $OUTPUT bytes"
           echo "diff=$OUTPUT" >> $GITHUB_OUTPUT
 
@@ -83,6 +86,8 @@ jobs:
           echo "coldstart=$OUTPUT" >> $GITHUB_OUTPUT
 
       - name: Should post comment
+        env:
+          GIT_DIFF: ${{ steps.compare.outputs.diff }}
         id: should
         run: |
           cd go/src/github.com/DataDog/datadog-agent
@@ -93,7 +98,7 @@ jobs:
           ); then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "dependencies list changed"
-          elif [[ ${{ steps.compare.outputs.diff }} > env.SIZE_ALLOWANCE ]]; then
+          elif [[ $GIT_DIFF > env.SIZE_ALLOWANCE ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "binary size changed"
           else
@@ -113,24 +118,29 @@ jobs:
           GOPATH=$(pwd)/go go install golang.org/x/tools/cmd/digraph@latest
 
       - name: List new dependencies
+        env:
+          PREVIOUS_DEPS: ${{ steps.previous.outputs.deps }}
+          CURRENT_DEPS: ${{ steps.current.outputs.deps }}
         id: deps
         if: steps.should.outputs.should_run == 'true'
         run: |
           echo "deps<<EOF" >> $GITHUB_OUTPUT
-          for dep in $(echo "${{ steps.current.outputs.deps }}"); do
-            if ! echo "${{ steps.previous.outputs.deps }}" | grep -w -q "$dep"; then
+          for dep in $(echo "$CURRENT_DEPS"); do
+            if ! echo "$PREVIOUS_DEPS" | grep -w -q "$dep"; then
               echo "$dep" >> $GITHUB_OUTPUT
             fi
           done
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create dependency graphs
+        env:
+          DEPS: ${{ steps.deps.outputs.deps }}
         if: steps.should.outputs.should_run == 'true'
         run: |
           export PATH=$(pwd)/go/bin:$PATH
           cd go/src/github.com/DataDog/datadog-lambda-extension
           mkdir graphs
-          for dep in $(echo "${{ steps.deps.outputs.deps }}"); do
+          for dep in $(echo "$DEPS"); do
             PACKAGE=$dep ./scripts/visualize_size.sh graph
             mv .layers/output.svg graphs/$(echo $dep | tr '/' '-').svg
           done


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the template injection vulnerable bits from Serverless GHA Workflows.

### Motivation

TL; DR: [From this remediation security post from Gitlab](https://securitylab.github.com/resources/github-actions-untrusted-input/):
The best practice to avoid code and command injection vulnerabilities in GitHub workflows is to set the untrusted input value of the expression to an intermediate environment variable:
```
- name: print title
  env:
    TITLE: ${{ github.event.issue.title }}
  run: echo "$TITLE"
```
This way, the value of the ${{ github.event.issue.title }} expression is stored in memory and used as variable instead of influencing the generation of script. As a side note, it is a good idea to double quote shell variables to avoid [word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086), but this is [one](https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow) of [many](https://mywiki.wooledge.org/BashPitfalls) general recommendations for writing shell scripts, not specific to GitHub Actions.


### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->