### PR TITLE
[CI] Remove template injection vulnerable bits from Agent Security GHA Workflows

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -81,8 +81,11 @@ jobs:
           echo "ARTIFACT_NAME=constants-${{ matrix.cone }}" | tr '/' '-' >> $GITHUB_OUTPUT
 
       - name: Sync constants
+        env:
+          ARTIFACT_NAME: ${{ steps.artifact-name.outputs.ARTIFACT_NAME }}
+          FORCE_REFRESH: ${{ inputs.force_refresh && '--force-refresh' || '' }}
         run: |
-          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive --output-path=./${{ steps.artifact-name.outputs.ARTIFACT_NAME }}.json ${{ inputs.force_refresh && '--force-refresh' || '' }}
+          inv -e security-agent.generate-btfhub-constants --archive-path=./dev/dist/archive --output-path=./"$ARTIFACT_NAME".json "$FORCE_REFRESH"
 
       - name: Upload artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
@@ -140,6 +143,9 @@ jobs:
           skip_checkout: true
 
       - name: Create Pull Request
+        env:
+          BRANCH_NAME: ${{ steps.branch-name.outputs.BRANCH_NAME }}
+          BASE_BRANCH: ${{ inputs.base_branch || 'main' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: steps.commit-creator.outputs.changes_detected == 'true'
         with:
@@ -149,8 +155,8 @@ jobs:
               title: 'CWS: sync BTFHub constants',
               owner,
               repo,
-              head: '${{ steps.branch-name.outputs.BRANCH_NAME }}',
-              base: '${{ inputs.base_branch || 'main' }}',
+              head: "$BRANCH_NAME",
+              base: "$BASE_BRANCH",
               body: [
                 '### What does this PR do?',
                 'This PR syncs the BTFHub constants used by CWS',


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the template injection vulnerable bits from Agent Security GHA Workflows.

### Motivation

TL; DR: [From this remediation security post from Gitlab](https://securitylab.github.com/resources/github-actions-untrusted-input/):
The best practice to avoid code and command injection vulnerabilities in GitHub workflows is to set the untrusted input value of the expression to an intermediate environment variable:
```
- name: print title
  env:
    TITLE: ${{ github.event.issue.title }}
  run: echo "$TITLE"
```
This way, the value of the ${{ github.event.issue.title }} expression is stored in memory and used as variable instead of influencing the generation of script. As a side note, it is a good idea to double quote shell variables to avoid [word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086), but this is [one](https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow) of [many](https://mywiki.wooledge.org/BashPitfalls) general recommendations for writing shell scripts, not specific to GitHub Actions.


### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->