### PR TITLE
[CWS] split iterator test in 2 rules working on 2 files

### DIFF
--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -237,7 +237,7 @@ func TestEventIteratorRegister(t *testing.T) {
 		},
 		{
 			ID:         "test_register_2",
-			Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-register" && process.ancestors[A].file.path == "%s" && process.ancestors[A].pid == 1`, pid1Path),
+			Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-register-2" && process.ancestors[A].file.path == "%s" && process.ancestors[A].pid == 1`, pid1Path),
 		},
 	}
 
@@ -252,6 +252,12 @@ func TestEventIteratorRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(testFile)
+
+	testFile2, _, err := test.Path("test-register-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testFile2)
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 	if err != nil {
@@ -268,7 +274,7 @@ func TestEventIteratorRegister(t *testing.T) {
 
 	t.Run("pid1", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			f, err := os.Create(testFile)
+			f, err := os.Create(testFile2)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`TestEventIteratorRegister` is quite flaky, with the std test often failing because the second rule matched. This PR improves this by ensuring you can't trigger both rules at the same time.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->