### PR TITLE
Remove flake mark from process/TestK8sTestSuite

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeClient "k8s.io/client-go/kubernetes"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -122,8 +121,7 @@ func (s *K8sSuite) TestManualContainerCheck() {
 
 func (s *K8sSuite) TestProcessDiscoveryCheck() {
 	t := s.T()
-	// PROCS-4327: Unexpected errors trying to get agent status
-	flake.Mark(t)
+
 	helmValues, err := createHelmValues(helmConfig{
 		ProcessDiscoveryCollection: true,
 	})
@@ -160,8 +158,7 @@ func (s *K8sSuite) TestProcessDiscoveryCheck() {
 
 func (s *K8sSuite) TestProcessCheckInCoreAgent() {
 	t := s.T()
-	// PROCS-4327: Unexpected errors trying to get agent status
-	flake.Mark(t)
+
 	helmValues, err := createHelmValues(helmConfig{
 		ProcessCollection: true,
 		RunInCoreAgent:    true,
@@ -212,9 +209,6 @@ func (s *K8sSuite) TestProcessCheckInCoreAgent() {
 
 func (s *K8sSuite) TestProcessCheckInCoreAgentWithNPM() {
 	t := s.T()
-	// PROCS-4327: The process-agent container either fails to start or
-	// does not seem to run the connections check as expected.
-	flake.Mark(t)
 
 	helmValues, err := createHelmValues(helmConfig{
 		ProcessCollection:            true,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Removes flake mark from process/TestK8sTestSuite as it has not failed since https://github.com/DataDog/datadog-agent/pull/30528 was merged when it was very frequent before.
<img width="1375" alt="image" src="https://github.com/user-attachments/assets/a1bf0fd1-9291-47aa-9d72-5c1716d596f0">

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->