### PR TITLE
[NPM] use config to size conn_close_flushed map

### DIFF
--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -7,8 +7,9 @@
 
 /* redefinition of some error values */
 #ifdef COMPILE_CORE
-#define EEXIST 17
+#define E2BIG 7
 #define EBUSY 16
+#define EEXIST 17
 #endif
 
 #define STR(x) #x

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -286,7 +286,7 @@ int BPF_BYPASSABLE_KPROBE(kprobe__tcp_close, struct sock *sk) {
     // upsert the timestamp to the map and delete if it already exists, flush connection otherwise
     // skip EEXIST errors for telemetry since it is an expected error
     __u64 timestamp = bpf_ktime_get_ns();
-    if (bpf_map_update_with_telemetry(conn_close_flushed, &t, &timestamp, BPF_NOEXIST, -EEXIST) == 0) {
+    if (bpf_map_update_with_telemetry(conn_close_flushed, &t, &timestamp, BPF_NOEXIST, -EEXIST, -E2BIG) == 0) {
         cleanup_conn(ctx, &t, sk);
         increment_telemetry_count(tcp_close_connection_flush);
         int err = 0;

--- a/pkg/network/ebpf/c/tracer/maps.h
+++ b/pkg/network/ebpf/c/tracer/maps.h
@@ -27,7 +27,7 @@ BPF_HASH_MAP(tcp_retransmits, conn_tuple_t, __u32, 0)
 BPF_HASH_MAP(tcp_ongoing_connect_pid, skp_conn_tuple_t, pid_ts_t, 0)
 
 /* Will hold a flag to indicate that closed connections have already been flushed */
-BPF_HASH_MAP(conn_close_flushed, conn_tuple_t, __u64, 16384)
+BPF_HASH_MAP(conn_close_flushed, conn_tuple_t, __u64, 0)
 
 /* Will hold the tcp/udp close events
  * The keys are the cpu number and the values a perf file descriptor for a perf event

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -193,6 +193,7 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 			probes.ConnectionProtocolMap:             {MaxEntries: config.MaxTrackedConnections, EditorFlag: manager.EditMaxEntries},
 			probes.ConnectionTupleToSocketSKBConnMap: {MaxEntries: config.MaxTrackedConnections, EditorFlag: manager.EditMaxEntries},
 			probes.TCPOngoingConnectPid:              {MaxEntries: config.MaxTrackedConnections, EditorFlag: manager.EditMaxEntries},
+			probes.ConnCloseFlushed:                  {MaxEntries: config.MaxTrackedConnections / 4, EditorFlag: manager.EditMaxEntries},
 		},
 		ConstantEditors: []manager.ConstantEditor{
 			boolConst("tcpv6_enabled", config.CollectTCPv6Conns),

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -174,14 +174,12 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	if err := initManager(m, connCloseEventHandler, failedConnsHandler, runtimeTracer, config); err != nil {
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
-	ringbufferEnabled := false
 	switch connCloseEventHandler.(type) {
 	case *ddebpf.RingBufferHandler:
-		ringbufferEnabled = true
-	}
-	util.AddBoolConst(&mgrOpts, "ringbuffers_enabled", ringbufferEnabled)
-	if ringbufferEnabled {
-		util.EnableRingbuffersViaMapEditor(&mgrOpts)
+		{
+			util.AddBoolConst(&mgrOpts, "ringbuffers_enabled", true)
+			util.EnableRingbuffersViaMapEditor(&mgrOpts)
+		}
 	}
 
 	var undefinedProbes []manager.ProbeIdentificationPair


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Instead of hardcoding the allocated max entry count of `conn_close_flushed`, set it as a function of the max connections tracked. With defaults this is a no-op as the current size of the map is 1/4 the default `max_connections_tracked`.

Also stop inserting into `conn_close_flushed` in `tcp_close` as there is no mechanism for `tcp_done` to flush connections after `tcp_close` executes for a connection anyway

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->