### PR TITLE
[gitlab] release OTel to public facing repos on relevant tags + protections

### DIFF
--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -28,6 +28,30 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
+.manual_on_deploy_auto_on_rc-ot:
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL != "true"
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL == "true"
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 # Rule for job that are triggered on_success on RC pipelines
 .on_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
@@ -42,6 +66,20 @@
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
+# Rule for job that are triggered on_success on RC pipelines for OTel Beta
+.on_rc-ot:
+  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
 # Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
@@ -62,19 +100,51 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
+# Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
+# For OTel Beta builds
+.on_final-ot:
+  - if: $BUCKET_BRANCH == "beta"
+    when: never
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 # Rule to deploy to our internal repository, on stable branch deploy
 .on_internal_final:
   - if: $BUCKET_BRANCH == "beta"
     when: never
   - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
     when: never
-  - when: manual
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
     allow_failure: true
     variables:
       AGENT_REPOSITORY: ci/datadog-agent/agent-release
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+
+# Rule to deploy to our internal repository, on stable branch deploy
+.on_internal_final-ot:
+  - if: $BUCKET_BRANCH == "beta"
+    when: never
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
+    when: never
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
 # Rule to deploy to our internal repository on RC
@@ -95,4 +165,18 @@
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+
+# Rule to deploy to our internal repository on RC for OTel Agent Beta
+.on_internal_rc-ot:
+  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild

--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -1,5 +1,19 @@
 
 # Rule to make job manual when running deploy pipelines, or automatic and on success on RC pipelines
+#
+## Note on CI_COMMIT_TAGS
+#
+# The standard(vanilla) agent builds expect COMMIT TAGS that match the following
+# patterns:
+#    - RC: ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ (eg. 7.60.0-rc.2)
+#    - FINAL: ^[0-9]+\.[0-9]+\.[0-9]$ (eg. 7.60.0)
+#
+#
+# The OTel beta agent builds expect COMMIT TAGS that match the following
+# patterns. These tags will eventually be unrequired once GA is offered:
+#    - RC: ^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ (eg. 7.60.0-v1.1.0-rc.2)
+#    - FINAL: ^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$ (eg.
+#    7.60.0-v1.1.0)
 .manual_on_deploy_auto_on_rc:
   - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
     when: manual

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -48,12 +48,6 @@ include:
 .deploy_containers-a7-base-ot:
   extends: .docker_publish_job_definition
   stage: deploy_containers
-  rules:
-    - when: manual
-      allow_failure: true
-  variables:
-    AGENT_REPOSITORY: agent
-    IMG_REGISTRIES: public
   dependencies: []
 
 deploy_containers-a7:
@@ -61,12 +55,24 @@ deploy_containers-a7:
   rules:
     !reference [.manual_on_deploy_auto_on_rc]
 
+deploy_containers-a7-ot:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.manual_on_deploy_auto_on_rc-ot]
+
 deploy_containers-a7-rc:
   extends: .deploy_containers-a7_external
   rules:
     !reference [.on_rc]
   variables:
     VERSION: 7-rc
+
+deploy_containers-a7-ot-rc:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_rc-ot]
+  variables:
+    VERSION: 7-ot-beta-rc
 
 deploy_containers-dogstatsd:
   extends: .docker_publish_job_definition
@@ -95,8 +101,24 @@ deploy_containers-a7_internal-rc:
     VERSION: 7-rc
 
 
-deploy_containers-ot:
+deploy_containers-a7-ot_internal:
   extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_internal_final-ot]
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
+
+deploy_containers-a7-ot_internal-rc:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_internal_rc-ot]
   before_script:
     - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
@@ -155,8 +177,10 @@ deploy_containers_latest-dogstatsd:
     IMG_SOURCES: ${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
 
-deploy_containers_latest-ot:
+deploy_containers_latest-a7-ot:
   extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_final-ot]
   variables:
     VERSION: 7
   parallel:

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -106,7 +106,7 @@ deploy_containers-a7-ot_internal:
   rules:
     !reference [.on_internal_final-ot]
   before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
   parallel:
@@ -120,7 +120,7 @@ deploy_containers-a7-ot_internal-rc:
   rules:
     !reference [.on_internal_rc-ot]
   before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
   parallel:

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -39,6 +39,8 @@ trigger_auto_staging_release:
   rules:
     - if: $DDR == "true"
       when: never
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
     - !reference [.on_deploy]
 
 trigger_manual_prod_release:
@@ -49,4 +51,7 @@ trigger_manual_prod_release:
     # The jobs in the downstream pipeline will all be manual, so following
     # the created pipeline would likely cause this job to timeout
     NO_FOLLOW: "--no-follow"
-  rules: !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
+    - !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR introduces a tag-based workflow for the OT beta image gitlab builds. It allows us to share the release branches (and workflow for the most part) with the regular release process and trigger our own pipelines on bespoke tags to produce the OT beta images, with relevant tag naming/versioning. 

The idea is the new conditions and jobs introduced here can allow the regular build pipelines and workflows to remain unchanged, while enabling an almost identical workflow (albeit on slight differently named tags `7.X.Y-vA.B.C`) which will produce and publish the images for OT beta in a similar fashion and following the patterns we are familar with.  

### Motivation

Integrate the OT beta builds into the usual release workflow.

### Describe how to test/QA your changes

No code, purely gitlab changes. Validating the images are correctly published and the right conditions respected remain the key points to validate. Proof will, mostly be in the pudding, though this has already been tested with a few RC builds.

### Possible Drawbacks / Trade-offs

Should be mostly transparent, small change to one A7 build condition that I believe will be a NOP for most usecases.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->