### PR TITLE
[oracle] Add `query_timeout` parameter by using context.WithTimeout

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -315,3 +315,8 @@ instances:
       ## Limit the number of traced check executions to avoid filling the file system.
       #
       # traced_runs: 10
+
+    ## @param query_timeout - int - optional - default: 20000
+    ## Aborts any queries that takes more than the specified number of milliseconds,
+    #
+    # query_timeout: 20000

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
@@ -20,7 +21,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultLoader = "core"
+const (
+	defaultLoader       = "core"
+	defaultQueryTimeout = 200000
+)
 
 // InitConfig is used to deserialize integration init config.
 type InitConfig struct {
@@ -137,6 +141,14 @@ type ConnectionConfig struct {
 	Wallet             string `yaml:"wallet"`
 	OracleClient       bool   `yaml:"oracle_client"`
 	OracleClientLibDir string `yaml:"oracle_client_lib_dir"`
+	QueryTimeout       int    `yaml:"query_timeout"`
+}
+
+func (c ConnectionConfig) QueryTimeoutString() string {
+	if c.QueryTimeout <= 0 {
+		return strconv.Itoa(defaultQueryTimeout)
+	}
+	return strconv.Itoa(c.QueryTimeout)
 }
 
 // InstanceConfig is used to deserialize integration instance config.
@@ -169,6 +181,21 @@ type InstanceConfig struct {
 	OnlyCustomQueries                  bool                   `yaml:"only_custom_queries"`
 	Service                            string                 `yaml:"service"`
 	Loader                             string                 `yaml:"loader"`
+}
+
+// QueryTimeoutDuration returns query_timeout as time.Duration.
+// If it is less than or equal to 0, it returns the default query timeout.
+func (c *InstanceConfig) QueryTimeoutDuration() time.Duration {
+	if c.QueryTimeout <= 0 {
+		return defaultQueryTimeout * time.Millisecond
+	}
+	return time.Duration(c.QueryTimeout) * time.Millisecond
+}
+
+// QueryTimeoutDuration returns query_timeout as string.
+// If it is less than or equal to 0, it returns the default query timeout.
+func (c *InstanceConfig) QueryTimeoutString() string {
+	return c.ConnectionConfig.QueryTimeoutString()
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -217,6 +244,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QueryMetrics.CollectionInterval = defaultMetricCollectionInterval
 	instance.QueryMetrics.DBRowsLimit = 10000
 	instance.QueryMetrics.MaxRunTime = 20
+	instance.QueryTimeout = defaultQueryTimeout
 
 	instance.ExecutionPlans.Enabled = true
 	instance.ExecutionPlans.PlanCacheRetention = 15

--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -93,7 +93,7 @@ func (c *Check) CustomQueries() error {
 			if pdb == "" {
 				pdb = "cdb$root"
 			}
-			_, err := c.dbCustomQueries.Exec(fmt.Sprintf("alter session set container = %s", pdb))
+			_, err := execWrapper(c.dbCustomQueries, fmt.Sprintf("alter session set container = %s", pdb), c.config.QueryTimeoutDuration())
 			if err != nil {
 				allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container %s %s", pdb, err))
 				reconnectOnConnectionError(c, &c.dbCustomQueries, err)

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -43,9 +43,6 @@ var MAX_OPEN_CONNECTIONS = 10
 //nolint:revive // TODO(DBM) Fix revive linter
 var DEFAULT_SQL_TRACED_RUNS = 10
 
-//nolint:revive // TODO(DBM) Fix revive linter
-var DB_TIMEOUT = "20000"
-
 const (
 	// MaxSQLFullTextVSQL is SQL_FULLTEXT size in V$SQL
 	MaxSQLFullTextVSQL = 4000
@@ -327,7 +324,7 @@ func (c *Check) Run() error {
 		c.sqlTraceRunsCount++
 		if c.sqlTraceRunsCount >= c.config.AgentSQLTrace.TracedRuns {
 			c.config.AgentSQLTrace.Enabled = false
-			_, err := c.db.Exec("BEGIN dbms_monitor.session_trace_disable; END;")
+			_, err := execWrapper(c.db, "BEGIN dbms_monitor.session_trace_disable; END;", c.config.QueryTimeoutDuration())
 			if err != nil {
 				log.Errorf("%s failed to stop SQL trace: %v", c.logPrompt, err)
 			}

--- a/pkg/collector/corechecks/oracle/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle/oracle_dictionary.go
@@ -26,7 +26,7 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 	switch c.driver {
 	case common.Godror:
 		sql = fmt.Sprintf("SELECT /* DD */ sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1", key)
-		err = c.db.Get(SQLStatement, sql, value)
+		err = getWrapper(c, SQLStatement, sql, value)
 		reconnectOnConnectionError(c, &c.db, err)
 		if err != nil && strings.Contains(err.Error(), "no rows") {
 			log.Infof("%s The SQL text for the statement %s = %s couldn't be fetched because the SQL was evicted from shared pool", c.logPrompt, key, value)

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -341,7 +341,7 @@ func buildConnectionString(connectionConfig config.ConnectionConfig) string {
 			connectionConfig.Username, connectionConfig.Password, protocolString, connectionConfig.Server,
 			connectionConfig.Port, connectionConfig.ServiceName, walletString)
 	} else {
-		connectionOptions := map[string]string{"TIMEOUT": DB_TIMEOUT}
+		connectionOptions := map[string]string{"TIMEOUT": connectionConfig.QueryTimeoutString()}
 		if connectionConfig.Protocol == "TCPS" {
 			connectionOptions["SSL"] = "TRUE"
 			if connectionConfig.Wallet != "" {

--- a/pkg/collector/corechecks/oracle/os_stats.go
+++ b/pkg/collector/corechecks/oracle/os_stats.go
@@ -58,7 +58,7 @@ func (c *Check) OS_Stats() error {
 
 	var cpuCount float64
 	if !numCPUsFound {
-		if err := c.db.Get(&cpuCount, "SELECT value FROM v$parameter WHERE name = 'cpu_count'"); err == nil {
+		if err := getWrapper(c, &cpuCount, "SELECT value FROM v$parameter WHERE name = 'cpu_count'"); err == nil {
 			sendMetricWithDefaultTags(c, gauge, fmt.Sprintf("%s.num_cpus", common.IntegrationName), cpuCount)
 		} else {
 			log.Errorf("%s failed to get cpu_count: %s", c.logPrompt, err)

--- a/pkg/collector/corechecks/oracle/shared_memory.go
+++ b/pkg/collector/corechecks/oracle/shared_memory.go
@@ -44,7 +44,7 @@ func (c *Check) SharedMemory() error {
 	} else {
 		shmQuery = shmQuery11
 	}
-	err := c.db.Select(&rows, shmQuery)
+	err := selectWrapper(c, &rows, shmQuery)
 	if err != nil {
 		return fmt.Errorf("failed to collect shared memory info: %w", err)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use [context.WithTimeout](https://pkg.go.dev/context#WithTimeout) to fix the issue timeout setting in the go-ora doesn't work. 
With new `query_timeout`, user can adjust timeout setting like [query_timeout](https://github.com/DataDog/integrations-core/blob/b1017c0723df39a5cfe42a90e72fea56dc34cb10/postgres/datadog_checks/postgres/data/conf.yaml.example#L133-L139) of postgres/mysql check.

### Motivation

The client side timeout in the go-ora URL doesn't work, so oracle check sometime hangs up and no data is sent then. Every time we face this issue, we need to restart Datadog Agent.

A customer reported that "Last Execution Date" of oracle check in `status.log` was not updated for over hours.
They got this status output on 2024-11-07 06:09:28.217 UTC but "Last Execution Date" of `oracle:f66b37dc51801185 [OK]` was 2024-11-06 13:35:15.

After restarting Agent, it is updated with OK status. I believe Agent hanged up in this case like https://github.com/jmoiron/sqlx/issues/866

<details><summary>status output</summary>

```
Agent (v7.56.2)
===============
  Status date: 2024-11-07 15:09:28.217 JST / 2024-11-07 06:09:28.217 UTC (1730959768217)
  Agent start: 2024-11-04 09:22:09.766 JST / 2024-11-04 00:22:09.766 UTC (1730679729766)
...
    oracle
    ------
      Instance ID: oracle:1d584175608f380 [OK]
      Configuration Source: file:C:\ProgramData\Datadog\conf.d\oracle.d\conf.yaml
      Total Runs: 3,640
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 3,640
      Average Execution Time : 1m28.3s
      Last Execution Date : 2024-11-07 15:08:55 JST / 2024-11-07 06:08:55 UTC (1730959735000)
      Last Successful Execution Date : 2024-11-07 15:08:55 JST / 2024-11-07 06:08:55 UTC (1730959735000)

      Instance ID: oracle:5052c24b388cf4d5 [OK]
      Configuration Source: file:C:\ProgramData\Datadog\conf.d\oracle.d\conf.yaml
      Total Runs: 27,202
      Metric Samples: Last Run: 1, Total: 1
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 27,202
      Average Execution Time : 4.021s
      Last Execution Date : 2024-11-07 15:09:25 JST / 2024-11-07 06:09:25 UTC (1730959765000)
      Last Successful Execution Date : 2024-11-07 15:09:25 JST / 2024-11-07 06:09:25 UTC (1730959765000)

      Instance ID: oracle:f66b37dc51801185 [OK]
      Configuration Source: file:C:\ProgramData\Datadog\conf.d\oracle.d\conf.yaml
      Total Runs: 10,761
      Metric Samples: Last Run: 1, Total: 2
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 10,761
      Average Execution Time : 8.608s
      // ↓↓↓↓ NOT UPDATED ↓↓↓↓
      Last Execution Date : 2024-11-06 22:35:15 JST / 2024-11-06 13:35:15 UTC (1730900115000)
      Last Successful Execution Date : 2024-11-06 22:35:15 JST / 2024-11-06 13:35:15 UTC (1730900115000)
      // ↑↑↑↑ NOT UPDATED ↑↑↑↑
```

</details>

To prevent this issue, client side timeout should work as suggested in https://github.com/jmoiron/sqlx/issues/866#issuecomment-1603995267.

https://github.com/DataDog/datadog-agent/blob/cf1046fa3981209a213a2e663c2aa080bc81be29/pkg/collector/corechecks/oracle/connection_handling.go#L19-L28

Actually we have client side timeout like above, but it doesn't seem to work based on the [Go execution trace](https://go.dev/blog/execution-traces-2024).

[profile.zip](https://github.com/user-attachments/files/17657907/profile.zip): 
- `go-routine-dump.log` of core-agent.
- Go execution trace of core-agent.

```bash
go tool trace -http ':6060' ~/Downloads/profile/core.trace

# Go to localhost:6060/io to see "Network blocking profile "
```

We can see there was a case that Agent waited at least 313 seconds (this is longer than 20,000ms) in "Network blocking profile ". This should be proof that timeout config in the go-ora URL doesn't work as expected.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->