### PR TITLE
Revert "networks: reduce the size of the `ConnectionStats` structure (#30532)"

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -84,16 +84,15 @@ func getExpectedConnections(encodedWithQueryType bool, httpOutBlob []byte) *mode
 	out := &model.Connections{
 		Conns: []*model.Connection{
 			{
-				Laddr:                &model.Addr{Ip: "10.1.1.1", Port: int32(1000)},
-				Raddr:                &model.Addr{Ip: "10.2.2.2", Port: int32(9000)},
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralFalse,
-				LastBytesSent:        2,
-				LastBytesReceived:    101,
-				LastRetransmits:      201,
-				LastTcpEstablished:   1,
-				LastTcpClosed:        1,
-				Pid:                  int32(6000),
-				NetNS:                7,
+				Laddr:              &model.Addr{Ip: "10.1.1.1", Port: int32(1000)},
+				Raddr:              &model.Addr{Ip: "10.2.2.2", Port: int32(9000)},
+				LastBytesSent:      2,
+				LastBytesReceived:  101,
+				LastRetransmits:    201,
+				LastTcpEstablished: 1,
+				LastTcpClosed:      1,
+				Pid:                int32(6000),
+				NetNS:              7,
 				IpTranslation: &model.IPTranslation{
 					ReplSrcIP:   "20.1.1.1",
 					ReplDstIP:   "20.1.1.1",
@@ -112,9 +111,8 @@ func getExpectedConnections(encodedWithQueryType bool, httpOutBlob []byte) *mode
 				},
 			},
 			{
-				Laddr:                &model.Addr{Ip: "10.1.1.1", Port: int32(1000)},
-				Raddr:                &model.Addr{Ip: "8.8.8.8", Port: int32(53)},
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralFalse,
+				Laddr: &model.Addr{Ip: "10.1.1.1", Port: int32(1000)},
+				Raddr: &model.Addr{Ip: "8.8.8.8", Port: int32(53)},
 
 				Type:      model.ConnectionType_udp,
 				Family:    model.ConnectionFamily_v6,
@@ -559,20 +557,18 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 	out := &model.Connections{
 		Conns: []*model.Connection{
 			{
-				Laddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
-				Raddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralTrue,
-				HttpAggregations:     httpOutBlob,
-				RouteIdx:             -1,
-				Protocol:             marshal.FormatProtocolStack(protocols.Stack{}, 0),
+				Laddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
+				Raddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
+				HttpAggregations: httpOutBlob,
+				RouteIdx:         -1,
+				Protocol:         marshal.FormatProtocolStack(protocols.Stack{}, 0),
 			},
 			{
-				Laddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
-				Raddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralFalse,
-				HttpAggregations:     httpOutBlob,
-				RouteIdx:             -1,
-				Protocol:             marshal.FormatProtocolStack(protocols.Stack{}, 0),
+				Laddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
+				Raddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
+				HttpAggregations: httpOutBlob,
+				RouteIdx:         -1,
+				Protocol:         marshal.FormatProtocolStack(protocols.Stack{}, 0),
 			},
 		},
 		AgentConfiguration: &model.AgentConfiguration{
@@ -721,20 +717,18 @@ func TestHTTP2SerializationWithLocalhostTraffic(t *testing.T) {
 	out := &model.Connections{
 		Conns: []*model.Connection{
 			{
-				Laddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
-				Raddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
-				Http2Aggregations:    http2OutBlob,
-				RouteIdx:             -1,
-				Protocol:             marshal.FormatProtocolStack(protocols.Stack{}, 0),
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralTrue,
+				Laddr:             &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
+				Raddr:             &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
+				Http2Aggregations: http2OutBlob,
+				RouteIdx:          -1,
+				Protocol:          marshal.FormatProtocolStack(protocols.Stack{}, 0),
 			},
 			{
-				Laddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
-				Raddr:                &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
-				Http2Aggregations:    http2OutBlob,
-				RouteIdx:             -1,
-				Protocol:             marshal.FormatProtocolStack(protocols.Stack{}, 0),
-				IsLocalPortEphemeral: model.EphemeralPortState_ephemeralFalse,
+				Laddr:             &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
+				Raddr:             &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
+				Http2Aggregations: http2OutBlob,
+				RouteIdx:          -1,
+				Protocol:          marshal.FormatProtocolStack(protocols.Stack{}, 0),
 			},
 		},
 		AgentConfiguration: &model.AgentConfiguration{
@@ -984,7 +978,6 @@ func TestKafkaSerializationWithLocalhostTraffic(t *testing.T) {
 			{
 				Laddr:                   &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
 				Raddr:                   &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
-				IsLocalPortEphemeral:    model.EphemeralPortState_ephemeralTrue,
 				DataStreamsAggregations: kafkaOutBlob,
 				RouteIdx:                -1,
 				Protocol:                marshal.FormatProtocolStack(protocols.Stack{}, 0),
@@ -993,7 +986,6 @@ func TestKafkaSerializationWithLocalhostTraffic(t *testing.T) {
 			{
 				Laddr:                   &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
 				Raddr:                   &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
-				IsLocalPortEphemeral:    model.EphemeralPortState_ephemeralFalse,
 				DataStreamsAggregations: kafkaOutBlob,
 				RouteIdx:                -1,
 				Protocol:                marshal.FormatProtocolStack(protocols.Stack{}, 0),

--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -77,7 +77,7 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 	})
 	builder.SetFamily(uint64(formatFamily(conn.Family)))
 	builder.SetType(uint64(formatType(conn.Type)))
-	builder.SetIsLocalPortEphemeral(uint64(formatEphemeralType(conn.SPortIsEphemeral())))
+	builder.SetIsLocalPortEphemeral(uint64(formatEphemeralType(conn.SPortIsEphemeral)))
 	builder.SetLastBytesSent(conn.Last.SentBytes)
 	builder.SetLastBytesReceived(conn.Last.RecvBytes)
 	builder.SetLastPacketsSent(conn.Last.SentPackets)
@@ -97,8 +97,8 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 	builder.SetRtt(conn.RTT)
 	builder.SetRttVar(conn.RTTVar)
 	builder.SetIntraHost(conn.IntraHost)
-	builder.SetLastTcpEstablished(uint32(conn.Last.TCPEstablished))
-	builder.SetLastTcpClosed(uint32(conn.Last.TCPClosed))
+	builder.SetLastTcpEstablished(conn.Last.TCPEstablished)
+	builder.SetLastTcpClosed(conn.Last.TCPClosed)
 	builder.SetProtocol(func(w *model.ProtocolStackBuilder) {
 		ps := FormatProtocolStack(conn.ProtocolStack, conn.StaticTags)
 		for _, p := range ps.Stack {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -218,8 +218,8 @@ type StatCounters struct {
 	// * Value 1 represents a connection that was established after system-probe started;
 	// * Values greater than 1 should be rare, but can occur when multiple connections
 	//   are established with the same tuple between two agent checks;
-	TCPEstablished uint16
-	TCPClosed      uint16
+	TCPEstablished uint32
+	TCPClosed      uint32
 }
 
 // IsZero returns whether all the stat counter values are zeroes
@@ -285,15 +285,11 @@ type ConnectionStats struct {
 	ProtocolStack   protocols.Stack
 
 	// keep these fields last because they are 1 byte each and otherwise inflate the struct size due to alignment
-	Direction ConnectionDirection
-	IntraHost bool
-	IsAssured bool
-	IsClosed  bool
-}
-
-// SPortIsEphemeral returns whether the source port is in the ephemeral range
-func (c *ConnectionStats) SPortIsEphemeral() EphemeralPortType {
-	return IsPortInEphemeralRange(c.Family, c.Type, c.SPort)
+	Direction        ConnectionDirection
+	SPortIsEphemeral EphemeralPortType
+	IntraHost        bool
+	IsAssured        bool
+	IsClosed         bool
 }
 
 // Via has info about the routing decision for a flow

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -114,6 +114,7 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 	cs.Type = connectionType
 	cs.Family = family
 	cs.Direction = connDirection(flow.Flags)
+	cs.SPortIsEphemeral = IsPortInEphemeralRange(cs.Family, cs.Type, cs.SPort)
 	cs.Cookie = flow.FlowCookie
 	if connectionType == TCP {
 

--- a/pkg/network/protocols/types.go
+++ b/pkg/network/protocols/types.go
@@ -6,7 +6,7 @@
 package protocols
 
 // ProtocolType is an enum of supported protocols
-type ProtocolType uint8
+type ProtocolType uint16
 
 const (
 	// Unknown is the default value, protocol was not detected

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -2413,7 +2413,8 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcIP:   util.AddressFromString("172.29.177.127"),
 				ReplSrcPort: 53,
 			},
-			ContainerID: struct{ Source, Dest *intern.Value }{intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f"), nil},
+			SPortIsEphemeral: EphemeralTrue,
+			ContainerID:      struct{ Source, Dest *intern.Value }{intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f"), nil},
 			Monotonic: StatCounters{
 				RecvBytes:      342,
 				SentBytes:      156,
@@ -2446,7 +2447,8 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcIP:   util.AddressFromString("172.29.177.127"),
 				ReplSrcPort: 53,
 			},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
+			SPortIsEphemeral: EphemeralTrue,
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      314,
 				SentBytes:      128,
@@ -2479,7 +2481,8 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcIP:   util.AddressFromString("172.29.151.242"),
 				ReplSrcPort: 53,
 			},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
+			SPortIsEphemeral: EphemeralTrue,
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      306,
 				SentBytes:      120,
@@ -2512,7 +2515,8 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcIP:   util.AddressFromString("172.29.151.242"),
 				ReplSrcPort: 53,
 			},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
+			SPortIsEphemeral: EphemeralTrue,
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      288,
 				SentBytes:      118,
@@ -2545,7 +2549,8 @@ func TestConnectionRollup(t *testing.T) {
 				ReplSrcIP:   util.AddressFromString("172.29.151.242"),
 				ReplSrcPort: 53,
 			},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
+			SPortIsEphemeral: EphemeralTrue,
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("4c66f035f6855163dcb6a9e8755b5f81c5f90088cb3938aad617d9992024394f")},
 			Monotonic: StatCounters{
 				RecvBytes:      594,
 				SentBytes:      92,
@@ -2569,7 +2574,8 @@ func TestConnectionRollup(t *testing.T) {
 			Type:   TCP,
 			NetNS:  4026531992,
 		},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      0,
 				RecvBytes:      306,
@@ -2596,7 +2602,8 @@ func TestConnectionRollup(t *testing.T) {
 			Type:   TCP,
 			NetNS:  4026531992,
 		},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      0,
 				RecvBytes:      306,
@@ -2623,7 +2630,8 @@ func TestConnectionRollup(t *testing.T) {
 			Type:   TCP,
 			NetNS:  4026531992,
 		},
-			ContainerID: struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			ContainerID:      struct{ Source, Dest *intern.Value }{Source: intern.GetByString("403ca32ba9b1c3955ba79a84039c9de34d81c83aa3a27ece70b19b3df84c9460")},
+			SPortIsEphemeral: EphemeralFalse,
 			Monotonic: StatCounters{
 				SentBytes:      2392,
 				RecvBytes:      670,

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -775,6 +775,8 @@ func populateConnStats(stats *network.ConnectionStats, t *netebpf.ConnTuple, s *
 		stats.Family = network.AFINET6
 	}
 
+	stats.SPortIsEphemeral = network.IsPortInEphemeralRange(stats.Family, stats.Type, t.Sport)
+
 	switch s.ConnectionDirection() {
 	case netebpf.Incoming:
 		stats.Direction = network.INCOMING
@@ -796,8 +798,8 @@ func updateTCPStats(conn *network.ConnectionStats, tcpStats *netebpf.TCPStats, r
 
 	conn.Monotonic.Retransmits = retransmits
 	if tcpStats != nil {
-		conn.Monotonic.TCPEstablished = tcpStats.State_transitions >> netebpf.Established & 1
-		conn.Monotonic.TCPClosed = tcpStats.State_transitions >> netebpf.Close & 1
+		conn.Monotonic.TCPEstablished = uint32(tcpStats.State_transitions >> netebpf.Established & 1)
+		conn.Monotonic.TCPClosed = uint32(tcpStats.State_transitions >> netebpf.Close & 1)
 		conn.RTT = tcpStats.Rtt
 		conn.RTTVar = tcpStats.Rtt_var
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2047,7 +2047,7 @@ func testPreexistingEmptyIncomingConnectionDirection(t *testing.T, config *confi
 	assert.Zero(t, m.SentPackets, "sent packets should be 0")
 	assert.Zero(t, m.RecvPackets, "recv packets should be 0")
 	assert.Zero(t, m.TCPEstablished, "tcp established should be 0")
-	assert.Equal(t, uint16(1), m.TCPClosed, "tcp closed should be 1")
+	assert.Equal(t, uint32(1), m.TCPClosed, "tcp closed should be 1")
 	assert.Equal(t, network.INCOMING, conn.Direction, "connection direction should be incoming")
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -262,8 +262,8 @@ func (s *TracerSuite) TestTCPShortLived() {
 	assert.True(t, conn.IntraHost)
 
 	// Verify the short lived connection is accounting for both TCP_ESTABLISHED and TCP_CLOSED events
-	assert.Equal(t, uint16(1), m.TCPEstablished)
-	assert.Equal(t, uint16(1), m.TCPClosed)
+	assert.Equal(t, uint32(1), m.TCPEstablished)
+	assert.Equal(t, uint32(1), m.TCPClosed)
 
 	_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), getConnections(t, tr))
 	assert.False(t, ok)
@@ -1075,8 +1075,8 @@ func (s *TracerSuite) TestTCPEstablished() {
 	conn, ok := findConnection(laddr, raddr, connections)
 
 	require.True(t, ok)
-	assert.Equal(t, uint16(1), conn.Last.TCPEstablished)
-	assert.Equal(t, uint16(0), conn.Last.TCPClosed)
+	assert.Equal(t, uint32(1), conn.Last.TCPEstablished)
+	assert.Equal(t, uint32(0), conn.Last.TCPClosed)
 
 	c.Close()
 
@@ -1088,8 +1088,8 @@ func (s *TracerSuite) TestTCPEstablished() {
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	require.True(t, ok)
-	assert.Equal(t, uint16(0), conn.Last.TCPEstablished)
-	assert.Equal(t, uint16(1), conn.Last.TCPClosed)
+	assert.Equal(t, uint32(0), conn.Last.TCPEstablished)
+	assert.Equal(t, uint32(1), conn.Last.TCPClosed)
 }
 
 func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
@@ -1122,8 +1122,8 @@ func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	m := conn.Monotonic
-	assert.Equal(t, uint16(0), m.TCPEstablished)
-	assert.Equal(t, uint16(1), m.TCPClosed)
+	assert.Equal(t, uint32(0), m.TCPEstablished)
+	assert.Equal(t, uint32(1), m.TCPClosed)
 }
 
 func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {


### PR DESCRIPTION
This reverts commit 85172c9634f4cb7276c231a9786a5f04b6bde055.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

#incident-32000

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->