### PR TITLE
networks: reduce the size of the ConnectionStats structure

### DIFF
--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -97,8 +97,8 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 	builder.SetRtt(conn.RTT)
 	builder.SetRttVar(conn.RTTVar)
 	builder.SetIntraHost(conn.IntraHost)
-	builder.SetLastTcpEstablished(conn.Last.TCPEstablished)
-	builder.SetLastTcpClosed(conn.Last.TCPClosed)
+	builder.SetLastTcpEstablished(uint32(conn.Last.TCPEstablished))
+	builder.SetLastTcpClosed(uint32(conn.Last.TCPClosed))
 	builder.SetProtocol(func(w *model.ProtocolStackBuilder) {
 		ps := FormatProtocolStack(conn.ProtocolStack, conn.StaticTags)
 		for _, p := range ps.Stack {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -218,8 +218,8 @@ type StatCounters struct {
 	// * Value 1 represents a connection that was established after system-probe started;
 	// * Values greater than 1 should be rare, but can occur when multiple connections
 	//   are established with the same tuple between two agent checks;
-	TCPEstablished uint32
-	TCPClosed      uint32
+	TCPEstablished uint16
+	TCPClosed      uint16
 }
 
 // IsZero returns whether all the stat counter values are zeroes

--- a/pkg/network/protocols/types.go
+++ b/pkg/network/protocols/types.go
@@ -6,7 +6,7 @@
 package protocols
 
 // ProtocolType is an enum of supported protocols
-type ProtocolType uint16
+type ProtocolType uint8
 
 const (
 	// Unknown is the default value, protocol was not detected

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -798,8 +798,8 @@ func updateTCPStats(conn *network.ConnectionStats, tcpStats *netebpf.TCPStats, r
 
 	conn.Monotonic.Retransmits = retransmits
 	if tcpStats != nil {
-		conn.Monotonic.TCPEstablished = uint32(tcpStats.State_transitions >> netebpf.Established & 1)
-		conn.Monotonic.TCPClosed = uint32(tcpStats.State_transitions >> netebpf.Close & 1)
+		conn.Monotonic.TCPEstablished = tcpStats.State_transitions >> netebpf.Established & 1
+		conn.Monotonic.TCPClosed = tcpStats.State_transitions >> netebpf.Close & 1
 		conn.RTT = tcpStats.Rtt
 		conn.RTTVar = tcpStats.Rtt_var
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2047,7 +2047,7 @@ func testPreexistingEmptyIncomingConnectionDirection(t *testing.T, config *confi
 	assert.Zero(t, m.SentPackets, "sent packets should be 0")
 	assert.Zero(t, m.RecvPackets, "recv packets should be 0")
 	assert.Zero(t, m.TCPEstablished, "tcp established should be 0")
-	assert.Equal(t, uint32(1), m.TCPClosed, "tcp closed should be 1")
+	assert.Equal(t, uint16(1), m.TCPClosed, "tcp closed should be 1")
 	assert.Equal(t, network.INCOMING, conn.Direction, "connection direction should be incoming")
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -262,8 +262,8 @@ func (s *TracerSuite) TestTCPShortLived() {
 	assert.True(t, conn.IntraHost)
 
 	// Verify the short lived connection is accounting for both TCP_ESTABLISHED and TCP_CLOSED events
-	assert.Equal(t, uint32(1), m.TCPEstablished)
-	assert.Equal(t, uint32(1), m.TCPClosed)
+	assert.Equal(t, uint16(1), m.TCPEstablished)
+	assert.Equal(t, uint16(1), m.TCPClosed)
 
 	_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), getConnections(t, tr))
 	assert.False(t, ok)
@@ -1075,8 +1075,8 @@ func (s *TracerSuite) TestTCPEstablished() {
 	conn, ok := findConnection(laddr, raddr, connections)
 
 	require.True(t, ok)
-	assert.Equal(t, uint32(1), conn.Last.TCPEstablished)
-	assert.Equal(t, uint32(0), conn.Last.TCPClosed)
+	assert.Equal(t, uint16(1), conn.Last.TCPEstablished)
+	assert.Equal(t, uint16(0), conn.Last.TCPClosed)
 
 	c.Close()
 
@@ -1088,8 +1088,8 @@ func (s *TracerSuite) TestTCPEstablished() {
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	require.True(t, ok)
-	assert.Equal(t, uint32(0), conn.Last.TCPEstablished)
-	assert.Equal(t, uint32(1), conn.Last.TCPClosed)
+	assert.Equal(t, uint16(0), conn.Last.TCPEstablished)
+	assert.Equal(t, uint16(1), conn.Last.TCPClosed)
 }
 
 func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
@@ -1122,8 +1122,8 @@ func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	m := conn.Monotonic
-	assert.Equal(t, uint32(0), m.TCPEstablished)
-	assert.Equal(t, uint32(1), m.TCPClosed)
+	assert.Equal(t, uint16(0), m.TCPEstablished)
+	assert.Equal(t, uint16(1), m.TCPClosed)
 }
 
 func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {


### PR DESCRIPTION
### What does this PR do?

Second try on https://github.com/DataDog/datadog-agent/pull/30532, this time without breaking macOS. It drops the ephemeral port range commit.

---

The goal of this PR is to bootstrap the reduction in size of the ConnectionStats structure.
To do that this PR reduces the int-width of some of those fields that don't require such big width
I would suggest to review this PR commit by commit, each one of the commits is doing something fairly simple on its own.

Pahole output on linux arm64:
Before:
```
struct github.com/DataDog/datadog-agent/pkg/network.ConnectionStats {
	github.com/DataDog/datadog-agent/pkg/network.IPTranslation * IPTranslation; /*     0     8 */
	github.com/DataDog/datadog-agent/pkg/network.Via * Via; /*     8     8 */
	struct []*go4.org/intern.Value Tags;             /*    16    24 */
	struct struct { Source *go4.org/intern.Value; Dest *go4.org/intern.Value } ContainerID; /*    40    16 */
	map[*github.com/DataDog/datadog-agent/pkg/util/intern.StringValue]map[github.com/DataDog/datadog-agent/pkg/network/dns.QueryTyp DNSStats; /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	map[uint32]uint32          TCPFailures;          /*    64     8 */
	github.com/DataDog/datadog-agent/pkg/network.ConnectionTuple ConnectionTuple; /*    72    64 */
	/* --- cacheline 2 boundary (128 bytes) was 8 bytes ago --- */
	github.com/DataDog/datadog-agent/pkg/network.StatCounters Monotonic; /*   136    48 */
	github.com/DataDog/datadog-agent/pkg/network.StatCounters Last; /*   184    48 */
	/* --- cacheline 3 boundary (192 bytes) was 40 bytes ago --- */
	uint64                     Cookie;               /*   232     8 */
	uint64                     LastUpdateEpoch;      /*   240     8 */
	time.Duration              Duration;             /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	uint32                     RTT;                  /*   256     4 */
	uint32                     RTTVar;               /*   260     4 */
	uint64                     StaticTags;           /*   264     8 */
	github.com/DataDog/datadog-agent/pkg/network/protocols.Stack ProtocolStack; /*   272     6 */
	github.com/DataDog/datadog-agent/pkg/network.ConnectionDirection Direction; /*   278     1 */
	github.com/DataDog/datadog-agent/pkg/network.EphemeralPortType SPortIsEphemeral; /*   279     1 */
	bool                       IntraHost;            /*   280     1 */
	bool                       IsAssured;            /*   281     1 */
	bool                       IsClosed;             /*   282     1 */

	/* size: 288, cachelines: 5, members: 21 */
	/* padding: 5 */
	/* last cacheline: 32 bytes */
};
```
After:
```
struct github.com/DataDog/datadog-agent/pkg/network.ConnectionStats {
	github.com/DataDog/datadog-agent/pkg/network.IPTranslation * IPTranslation; /*     0     8 */
	github.com/DataDog/datadog-agent/pkg/network.Via * Via; /*     8     8 */
	struct []*go4.org/intern.Value Tags;             /*    16    24 */
	struct struct { Source *go4.org/intern.Value; Dest *go4.org/intern.Value } ContainerID; /*    40    16 */
	map[*github.com/DataDog/datadog-agent/pkg/util/intern.StringValue]map[github.com/DataDog/datadog-agent/pkg/network/dns.QueryTyp DNSStats; /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	map[uint32]uint32          TCPFailures;          /*    64     8 */
	github.com/DataDog/datadog-agent/pkg/network.ConnectionTuple ConnectionTuple; /*    72    64 */
	/* --- cacheline 2 boundary (128 bytes) was 8 bytes ago --- */
	github.com/DataDog/datadog-agent/pkg/network.StatCounters Monotonic; /*   136    40 */
	github.com/DataDog/datadog-agent/pkg/network.StatCounters Last; /*   176    40 */
	/* --- cacheline 3 boundary (192 bytes) was 24 bytes ago --- */
	uint64                     Cookie;               /*   216     8 */
	uint64                     LastUpdateEpoch;      /*   224     8 */
	time.Duration              Duration;             /*   232     8 */
	uint32                     RTT;                  /*   240     4 */
	uint32                     RTTVar;               /*   244     4 */
	uint64                     StaticTags;           /*   248     8 */
	/* --- cacheline 4 boundary (256 bytes) --- */
	github.com/DataDog/datadog-agent/pkg/network/protocols.Stack ProtocolStack; /*   256     3 */
	github.com/DataDog/datadog-agent/pkg/network.ConnectionDirection Direction; /*   259     1 */
	github.com/DataDog/datadog-agent/pkg/network.EphemeralPortType SPortIsEphemeral; /*   260     1 */
	bool                       IntraHost;            /*   261     1 */
	bool                       IsAssured;            /*   262     1 */
	bool                       IsClosed;             /*   263     1 */

	/* size: 264, cachelines: 5, members: 21 */
	/* last cacheline: 8 bytes */
};
```
As you can see the size goes from 288 bytes to 264 (~9% reduction). This can result in a few megabytes of reduction for example when used in the closed connection stats.

This PR also paves the way for future reduction efforts, especially packing all the boolean flags


### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->