### PR TITLE
[CWS] fix snapshot test

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -80,7 +80,9 @@ const (
 	// MaxOnDemandEventsPerSecond represents the maximum number of on demand events per second
 	// allowed before we switch off the subsystem
 	MaxOnDemandEventsPerSecond = 1_000
+)
 
+const (
 	playSnapShotState int32 = iota + 1
 	replaySnapShotState
 )

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1698,7 +1698,7 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRepor
 	}
 
 	// replay the snapshot
-	p.playSnapShotState.Store(replaySnapShotState)
+	p.playSnapShotState.CompareAndSwap(0, replaySnapShotState)
 
 	return ars, nil
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -810,7 +810,9 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 		testMod.RegisterRuleEventHandler(func(e *model.Event, r *rules.Rule) {
 			opts.staticOpts.snapshotRuleMatchHandler(testMod, e, r)
 		})
-		defer testMod.RegisterRuleEventHandler(nil)
+		t.Cleanup(func() {
+			testMod.RegisterRuleEventHandler(nil)
+		})
 	}
 
 	if err := testMod.eventMonitor.Start(); err != nil {
@@ -818,7 +820,7 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 	}
 
 	if ruleSetloadedErr.ErrorOrNil() != nil {
-		defer testMod.Close()
+		testMod.Close()
 		return nil, ruleSetloadedErr.ErrorOrNil()
 	}
 

--- a/pkg/security/tests/snapshot_replay_test.go
+++ b/pkg/security/tests/snapshot_replay_test.go
@@ -8,7 +8,9 @@
 package tests
 
 import (
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -39,5 +41,9 @@ func TestSnapshotReplay(t *testing.T) {
 	}
 	defer test.Close()
 
-	assert.True(t, gotEvent, "didn't get the event from snapshot")
+	if _, err := exec.Command("echo", "hello", "world").CombinedOutput(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Eventually(t, func() bool { return gotEvent }, 10*time.Second, 100*time.Millisecond, "didn't get the event from snapshot")
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `TestSnapshotReplay` by:
- ensuring the snapshot handler is still in place after the end of `newTestModule`
- make sure that the `ApplyRuleSet` doesn't overwrite the playSnapshot state with replay state (thus never pushing the events to consumers)
- small cleanups here and there (the state values are now 1 and 2, and not 2 and 3 which was strange)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->