### PR TITLE
fix(oracle): Turn back to `runner-docker` as the job is pretty instable since #30609

### DIFF
--- a/.gitlab/functional_test/oracle.yml
+++ b/.gitlab/functional_test/oracle.yml
@@ -1,6 +1,6 @@
 oracle:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["runner:docker"]
   stage: functional_test
   needs: ["go_deps"]
   rules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fall back the `oracle` job on `runner:docker`

### Motivation
Since the merge of #30609, the job is pretty instable

#incident-32003

### Describe how to test/QA your changes
I [restarted](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/691152081) a bunch of times the job on the current branch to check if it it stable

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->