### PR TITLE
discovery: Increase saved command line size to 5000

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/cmdline.go
+++ b/pkg/collector/corechecks/servicediscovery/module/cmdline.go
@@ -10,7 +10,7 @@ package module
 import "github.com/DataDog/datadog-agent/pkg/process/procutil"
 
 const (
-	maxCommandLine = 200
+	maxCommandLine = 5000
 )
 
 // countAndAddElements is a helper for truncateCmdline used to be able to


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increase the saved command line size to 5000 characters to make it more useful.

### Motivation

Feedback from beta testing, especially java applications have long command lines where the jar could be cut off.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

Increased memory usage. But the vast amount of processes have less than 200 characters of cmdline.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->