### PR TITLE
discovery: match javaagent jars with datadog in the name

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/apm/detect.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect.go
@@ -200,6 +200,8 @@ func nodeDetector(ctx usm.DetectionContext) Instrumentation {
 	return None
 }
 
+var javaAgentRegex = regexp.MustCompile("-javaagent:.*(?:datadog|dd-java-agent)")
+
 func javaDetector(ctx usm.DetectionContext) Instrumentation {
 	ignoreArgs := map[string]bool{
 		"-version":     true,
@@ -213,7 +215,7 @@ func javaDetector(ctx usm.DetectionContext) Instrumentation {
 			return None
 		}
 		// don't instrument if javaagent is already there on the command line
-		if strings.HasPrefix(v, "-javaagent:") && strings.Contains(v, "dd-java-agent.jar") {
+		if javaAgentRegex.MatchString(v) {
 			return Provided
 		}
 	}
@@ -231,7 +233,7 @@ func javaDetector(ctx usm.DetectionContext) Instrumentation {
 	}
 	for _, name := range toolOptionEnvs {
 		if val, ok := ctx.Envs.Get(name); ok {
-			if strings.Contains(val, "-javaagent:") && strings.Contains(val, "dd-java-agent.jar") {
+			if javaAgentRegex.MatchString(val) {
 				return Provided
 			}
 		}

--- a/pkg/collector/corechecks/servicediscovery/apm/detect.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect.go
@@ -200,7 +200,7 @@ func nodeDetector(ctx usm.DetectionContext) Instrumentation {
 	return None
 }
 
-var javaAgentRegex = regexp.MustCompile("-javaagent:.*(?:datadog|dd-java-agent)")
+var javaAgentRegex = regexp.MustCompile(`-javaagent:.*(?:datadog|dd-java-agent|dd-trace-agent)\S*\.jar`)
 
 func javaDetector(ctx usm.DetectionContext) Instrumentation {
 	ignoreArgs := map[string]bool{

--- a/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
@@ -84,9 +84,24 @@ func Test_javaDetector(t *testing.T) {
 			result: Provided,
 		},
 		{
+			name:   "cmdline - dd-trace-agent.jar",
+			args:   []string{"java", "-foo", "-javaagent:/path/to/data dog/dd-trace-agent.jar", "-Ddd.profiling.enabled=true"},
+			result: Provided,
+		},
+		{
 			name:   "cmdline - datadog.jar",
 			args:   []string{"java", "-foo", "-javaagent:/path/to/data dog/datadog.jar", "-Ddd.profiling.enabled=true"},
 			result: Provided,
+		},
+		{
+			name:   "cmdline - datadog only in does not match",
+			args:   []string{"java", "-foo", "path/to/data dog/datadog", "-Ddd.profiling.enabled=true"},
+			result: None,
+		},
+		{
+			name:   "cmdline - jar only in does not match",
+			args:   []string{"java", "-foo", "path/to/data dog/datadog.jar", "-Ddd.profiling.enabled=true"},
+			result: None,
 		},
 		{
 			name: "CATALINA_OPTS",

--- a/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
@@ -79,8 +79,13 @@ func Test_javaDetector(t *testing.T) {
 			result: None,
 		},
 		{
-			name:   "cmdline",
+			name:   "cmdline - dd-java-agent.jar",
 			args:   []string{"java", "-foo", "-javaagent:/path/to/data dog/dd-java-agent.jar", "-Ddd.profiling.enabled=true"},
+			result: Provided,
+		},
+		{
+			name:   "cmdline - datadog.jar",
+			args:   []string{"java", "-foo", "-javaagent:/path/to/data dog/datadog.jar", "-Ddd.profiling.enabled=true"},
 			result: Provided,
 		},
 		{

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -509,8 +509,12 @@ func TestAPMInstrumentationProvided(t *testing.T) {
 				"CORECLR_ENABLE_PROFILING=1",
 			},
 		},
-		"java": {
+		"java - dd-java-agent.jar": {
 			commandline: []string{"java", "-javaagent:/path/to/dd-java-agent.jar", "-jar", "foo.jar"},
+			language:    language.Java,
+		},
+		"java - datadog.jar": {
+			commandline: []string{"java", "-javaagent:/path/to/datadog-java-agent.jar", "-jar", "foo.jar"},
 			language:    language.Java,
 		},
 		"node": {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows the javaagent detector of service discovery to also match files containing `datadog` in the name, alongside the previous `dd-java-agent`.
It also replace the usage of strings function to a regex, which should prevent multiple traversals of the strings.

### Motivation

[USMON-1305](https://datadoghq.atlassian.net/browse/USMON-1305)

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[USMON-1305]: https://datadoghq.atlassian.net/browse/USMON-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ