### PR TITLE
[CWS] Allow enabling a disabled rule

### DIFF
--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -90,7 +90,7 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) error {
 	case OverridePolicy:
 		applyOverride(r, r2)
 	default:
-		if !r2.Def.Disabled {
+		if r.Def.Disabled == r2.Def.Disabled {
 			return &ErrRuleLoad{Rule: r2, Err: ErrDefinitionIDConflict}
 		}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes an issue in the rule merging logic that prevented disabled rules from being turned to an enabled state.

### Motivation

This fix allows customers to enable rules that were created as disabled.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->