### PR TITLE
[EBPF] attacher: Optimize timings in executable resolution

### DIFF
--- a/pkg/ebpf/uprobes/procfs.go
+++ b/pkg/ebpf/uprobes/procfs.go
@@ -17,7 +17,9 @@ import (
 	"time"
 )
 
-const procFSUpdateTimeout = 100 * time.Millisecond
+const numProcFSUpdateRetries = 10
+const procFSUpdateInterval = 1 * time.Millisecond
+const procFSUpdateTimeout = numProcFSUpdateRetries * procFSUpdateInterval
 
 // ProcInfo holds the information extracted from procfs, to avoid repeat calls to the filesystem.
 type ProcInfo struct {
@@ -50,7 +52,7 @@ func waitUntilSucceeds[T any](p *ProcInfo, procFile string, readFunc func(string
 	for err != nil && end.After(time.Now()) {
 		result, err = readFunc(filePath)
 		if err != nil {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(procFSUpdateInterval)
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR restores the timeouts and query intervals for the checks of `/proc` files in the uprobe attacher, after a problem was detected where the increased timeouts would cause full channels in the process monitor.

### Motivation

### Describe how to test/QA your changes

All tests against 7.58.0 base version.

**processes** load-test with node-tls, go-tls enabled: Shows reduction of channel full events, no CPU increase, no increase in profiling CPU times 

<details>
<summary>Graphs</summary>
https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=gj-upp-gotls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http&tpl_var_compare_agent-env%5B0%5D=gj-upp-gotls-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=sp-test-env-1&tpl_var_server-service%5B0%5D=golang-httpbin&from_ts=1730363295384&to_ts=1730377695384&live=true

![Screenshot 2024-10-31 at 13 26 01](https://github.com/user-attachments/assets/00f06984-dcc2-4c47-8b00-bfa967bdaa80)

![Screenshot 2024-10-31 at 13 26 38](https://github.com/user-attachments/assets/5720be83-28be-4833-ae3d-d8562c72b18e)

![Screenshot 2024-10-31 at 13 28 31](https://github.com/user-attachments/assets/14e8d97d-506e-4f2b-ba2e-6ad63f9bec68)


</details>

**soak_test** load-test with node-tls enabled: no channel full events, CPU profiling is similar on the corresponding function calls, accuracy maintained.

<details> 
<summary>Graphs</summary>
https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=gj-procinfo-node-base&tpl_var_client-service%5B0%5D=node-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=gj-procinfo-node-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=sp-test-env-1&tpl_var_server-service%5B0%5D=node-httpbin-tls&tpl_var_tls.library%5B0%5D=nodejs&from_ts=1730364177041&to_ts=1730378577041&live=true

![Screenshot 2024-10-31 at 14 21 17](https://github.com/user-attachments/assets/84845e65-2671-4e0b-93e2-e2ca99c4a6c3)

![Screenshot 2024-10-31 at 14 22 14](https://github.com/user-attachments/assets/2a126fc9-88d0-4a88-9b2c-9ae2e1f71546)

![Screenshot 2024-10-31 at 14 22 00](https://github.com/user-attachments/assets/7aeaa647-37ed-4fe6-b2c8-845b3d57ec81)



</details>

**soak_test** load-test with go-tls enabled: same results as node-tls 

<details> 
<summary>Graphs</summary> 
https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=gj-proc-gotls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http&tpl_var_compare_agent-env%5B0%5D=gj-proc-gotls-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=sp-test-env-1&tpl_var_server-service%5B0%5D=golang-httpbin&from_ts=1730373942975&to_ts=1730388342975&live=true

![Screenshot 2024-10-31 at 16 26 40](https://github.com/user-attachments/assets/fc35ddf6-27d9-47c6-8c66-0fcead228254)

![Screenshot 2024-10-31 at 16 26 02](https://github.com/user-attachments/assets/401e9c0b-8b73-421c-a52f-97a3dc3d36b3)
</details>

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->