### PR TITLE
ensure that Tagger field for ServerlessMetricAgent is set properly

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -142,7 +142,7 @@ func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *se
 
 	traceAgent := setupTraceAgent(tags)
 
-	metricAgent := setupMetricAgent(tags)
+	metricAgent := setupMetricAgent(tags, tagger)
 	metric.AddColdStartMetric(prefix, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 
 	setupOtlpAgent(metricAgent)
@@ -161,12 +161,13 @@ func setupTraceAgent(tags map[string]string) trace.ServerlessTraceAgent {
 	return traceAgent
 }
 
-func setupMetricAgent(tags map[string]string) *metrics.ServerlessMetricAgent {
+func setupMetricAgent(tags map[string]string, tagger tagger.Component) *metrics.ServerlessMetricAgent {
 	pkgconfigsetup.Datadog().Set("use_v2_api.series", false, model.SourceAgentRuntime)
 	pkgconfigsetup.Datadog().Set("dogstatsd_socket", "", model.SourceAgentRuntime)
 
 	metricAgent := &metrics.ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 0,
+		Tagger:               tagger,
 	}
 	// we don't want to add the container_id tag to metrics for cardinality reasons
 	tags = serverlessInitTag.WithoutContainerID(tags)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -140,7 +140,7 @@ func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *se
 	}
 	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags, tagger)
 
-	traceAgent := setupTraceAgent(tags)
+	traceAgent := setupTraceAgent(tags, tagger)
 
 	metricAgent := setupMetricAgent(tags, tagger)
 	metric.AddColdStartMetric(prefix, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
@@ -150,8 +150,8 @@ func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *se
 	go flushMetricsAgent(metricAgent)
 	return cloudService, agentLogConfig, traceAgent, metricAgent, logsAgent
 }
-func setupTraceAgent(tags map[string]string) trace.ServerlessTraceAgent {
-	traceAgent := trace.StartServerlessTraceAgent(pkgconfigsetup.Datadog().GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath}, nil, random.Random.Uint64())
+func setupTraceAgent(tags map[string]string, tagger tagger.Component) trace.ServerlessTraceAgent {
+	traceAgent := trace.StartServerlessTraceAgent(pkgconfigsetup.Datadog().GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger}, nil, random.Random.Uint64())
 	traceAgent.SetTags(tags)
 	go func() {
 		for range time.Tick(3 * time.Second) {

--- a/comp/core/autodiscovery/listeners/container_nop.go
+++ b/comp/core/autodiscovery/listeners/container_nop.go
@@ -7,6 +7,4 @@
 
 package listeners
 
-type noopServiceListenerFactory func(ServiceListernerDeps) (ServiceListener, error)
-
-var NewContainerListener noopServiceListenerFactory
+var NewContainerListener func(ServiceListernerDeps) (ServiceListener, error)

--- a/comp/core/autodiscovery/listeners/kubelet_nop.go
+++ b/comp/core/autodiscovery/listeners/kubelet_nop.go
@@ -7,4 +7,4 @@
 
 package listeners
 
-var NewKubeletListener noopServiceListenerFactory
+var NewKubeletListener func(ServiceListernerDeps) (ServiceListener, error)

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 
+	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/noopimpl"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -445,6 +446,7 @@ func startAgents() *Daemon {
 
 	ma := &metrics.ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
+		Tagger:               nooptagger.NewTaggerClient(),
 	}
 	ma.Start(FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
 	d.SetStatsdServer(ma)

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -8,7 +8,6 @@ package metrics
 import (
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"math/rand"
 	"net"
 	"net/http"
@@ -38,13 +37,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestStartDoesNotBlock(t *testing.T) {
-	flake.Mark(t)
 	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 		t.Skip("TestStartDoesNotBlock is known to fail on the macOS Gitlab runners because of the already running Agent")
 	}
 	pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil)
 	metricAgent := &ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
+		Tagger:               nooptagger.NewTaggerClient(),
 	}
 	defer metricAgent.Stop()
 	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
@@ -67,6 +66,7 @@ func (m *InvalidMetricConfigMocked) GetMultipleEndpoints() (map[string][]string,
 func TestStartInvalidConfig(t *testing.T) {
 	metricAgent := &ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
+		Tagger:               nooptagger.NewTaggerClient(),
 	}
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &InvalidMetricConfigMocked{}, &MetricDogStatsD{})
@@ -84,6 +84,7 @@ func (m *MetricDogStatsDMocked) NewServer(_ aggregator.Demultiplexer) (dogstatsd
 func TestStartInvalidDogStatsD(t *testing.T) {
 	metricAgent := &ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
+		Tagger:               nooptagger.NewTaggerClient(),
 	}
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &MetricConfig{}, &MetricDogStatsDMocked{})
@@ -100,6 +101,7 @@ func TestStartWithProxy(t *testing.T) {
 
 	metricAgent := &ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
+		Tagger:               nooptagger.NewTaggerClient(),
 	}
 	defer metricAgent.Stop()
 	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

One the previous [PR](https://github.com/DataDog/datadog-agent/pull/30214) that removed the global tagger from the codebase, we forgot to set the `Tagger` on all instances of `ServerlessMetricAgent`


### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->