### PR TITLE
[CWS] send event based on fallback process cache entries

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -125,7 +125,7 @@ func (bfh *BaseFieldHandlers) ResolveService(ev *model.Event, e *model.BaseEvent
 		return e.Service
 	}
 
-	entry, _ := ev.ResolveProcessCacheEntry()
+	entry, _ := ev.ResolveProcessCacheEntry(nil)
 	if entry == nil {
 		return ""
 	}

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -41,7 +41,7 @@ func NewEBPFLessFieldHandlers(config *config.Config, resolvers *resolvers.EBPFLe
 }
 
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
-func (fh *EBPFLessFieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
+func (fh *EBPFLessFieldHandlers) ResolveProcessCacheEntry(ev *model.Event, _ func(*model.ProcessCacheEntry, error)) (*model.ProcessCacheEntry, bool) {
 	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
 		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(sprocess.CacheResolverKey{
 			Pid:  ev.PIDContext.Pid,
@@ -178,7 +178,7 @@ func (fh *EBPFLessFieldHandlers) ResolveContainerRuntime(_ *model.Event, _ *mode
 // ResolveContainerID resolves the container ID of the event
 func (fh *EBPFLessFieldHandlers) ResolveContainerID(ev *model.Event, e *model.ContainerContext) string {
 	if len(e.ContainerID) == 0 {
-		if entry, _ := fh.ResolveProcessCacheEntry(ev); entry != nil {
+		if entry, _ := fh.ResolveProcessCacheEntry(ev, nil); entry != nil {
 			e.ContainerID = containerutils.ContainerID(entry.ContainerID)
 		}
 	}

--- a/pkg/security/probe/field_handlers_windows.go
+++ b/pkg/security/probe/field_handlers_windows.go
@@ -77,7 +77,7 @@ func (fh *FieldHandlers) ResolveProcessEnvs(_ *model.Event, process *model.Proce
 }
 
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
-func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
+func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event, _ func(*model.ProcessCacheEntry, error)) (*model.ProcessCacheEntry, bool) {
 	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
 		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid)
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -425,7 +425,7 @@ func (p *EBPFProbe) Start() error {
 // PlaySnapshot plays a snapshot
 func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 	seclog.Debugf("playing the snapshot")
-	// Get the snapshotted data
+
 	var events []*model.Event
 
 	entryToEvent := func(entry *model.ProcessCacheEntry) {
@@ -433,14 +433,8 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 			return
 		}
 		entry.Retain()
-		event := NewEBPFEvent(p.fieldHandlers)
-		event.Type = uint32(model.ExecEventType)
-		event.TimestampRaw = uint64(time.Now().UnixNano())
-		event.ProcessCacheEntry = entry
-		event.ProcessContext = &entry.ProcessContext
-		event.Exec.Process = &entry.Process
-		event.ProcessContext.Process.ContainerID = entry.ContainerID
-		event.ProcessContext.Process.CGroup = entry.CGroup
+
+		event := newEBPFEventFromPCE(entry, p.fieldHandlers)
 
 		if _, err := entry.HasValidLineage(); err != nil {
 			event.Error = &model.ErrProcessBrokenLineage{Err: err}
@@ -600,8 +594,8 @@ func (p *EBPFProbe) onEventLost(perfMapName string, perEvent map[string]uint64) 
 }
 
 // setProcessContext set the process context, should return false if the event shouldn't be dispatched
-func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event) bool {
-	entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event)
+func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+	entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event, newEntryCb)
 	event.ProcessCacheEntry = entry
 	if event.ProcessCacheEntry == nil {
 		panic("should always return a process cache entry")
@@ -646,10 +640,31 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		p.playSnapshot(false)
 	}
 
-	offset := 0
-	event := p.zeroEvent()
+	var (
+		offset        = 0
+		event         = p.zeroEvent()
+		dataLen       = uint64(len(data))
+		relatedEvents []*model.Event
+		newEntryCb    = func(entry *model.ProcessCacheEntry, err error) {
+			// all Execs will be forwarded since used by AD. Forks will be forwarded all if there are consumers
+			if !entry.IsExec && p.probe.eventConsumers[model.ForkEventType] == nil {
+				return
+			}
 
-	dataLen := uint64(len(data))
+			relatedEvent := newEBPFEventFromPCE(entry, p.fieldHandlers)
+
+			if err != nil {
+				var errResolution *path.ErrPathResolution
+				if errors.As(err, &errResolution) {
+					relatedEvent.SetPathResolutionError(&relatedEvent.ProcessCacheEntry.FileEvent, err)
+				} else {
+					return
+				}
+			}
+
+			relatedEvents = append(relatedEvents, relatedEvent)
+		}
+	)
 
 	read, err := event.UnmarshalBinary(data)
 	if err != nil {
@@ -710,7 +725,8 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode cgroup write released event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-		pce := p.Resolvers.ProcessResolver.Resolve(event.CgroupWrite.Pid, event.CgroupWrite.Pid, 0, false)
+
+		pce := p.Resolvers.ProcessResolver.Resolve(event.CgroupWrite.Pid, event.CgroupWrite.Pid, 0, false, newEntryCb)
 		if pce != nil {
 			path, err := p.Resolvers.DentryResolver.Resolve(event.CgroupWrite.File.PathKey, true)
 			if err == nil && path != "" {
@@ -770,7 +786,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		p.Resolvers.ProcessResolver.ApplyBootTime(event.ProcessCacheEntry)
 		event.ProcessCacheEntry.SetSpan(event.SpanContext.SpanID, event.SpanContext.TraceID)
 
-		p.Resolvers.ProcessResolver.AddForkEntry(event.ProcessCacheEntry, event.PIDContext.ExecInode)
+		p.Resolvers.ProcessResolver.AddForkEntry(event.ProcessCacheEntry, event.PIDContext.ExecInode, newEntryCb)
 	case model.ExecEventType:
 		// unmarshal and fill event.processCacheEntry
 		if _, err = p.unmarshalProcessCacheEntry(event, data[offset:]); err != nil {
@@ -792,7 +808,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		event.Exec.Process = &event.ProcessCacheEntry.Process
 	}
 
-	if !p.setProcessContext(eventType, event) {
+	if !p.setProcessContext(eventType, event, newEntryCb) {
 		return
 	}
 
@@ -902,7 +918,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		}
 
 		var exists bool
-		event.ProcessCacheEntry, exists = p.fieldHandlers.GetProcessCacheEntry(event)
+		event.ProcessCacheEntry, exists = p.fieldHandlers.GetProcessCacheEntry(event, newEntryCb)
 		if !exists {
 			// no need to dispatch an exit event that don't have the corresponding cache entry
 			return
@@ -983,7 +999,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		if event.PTrace.PID == 0 { // pid can be 0 for a PTRACE_TRACEME request
 			pce = newPlaceholderProcessCacheEntryPTraceMe()
 		} else {
-			pce = p.Resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID, 0, false)
+			pce = p.Resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID, 0, false, newEntryCb)
 			if pce == nil {
 				pce = model.NewPlaceholderProcessCacheEntry(event.PTrace.PID, event.PTrace.PID, false)
 			}
@@ -1028,7 +1044,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		// resolve target process context
 		var pce *model.ProcessCacheEntry
 		if event.Signal.PID > 0 { // Linux accepts a kill syscall with both negative and zero pid
-			pce = p.Resolvers.ProcessResolver.Resolve(event.Signal.PID, event.Signal.PID, 0, false)
+			pce = p.Resolvers.ProcessResolver.Resolve(event.Signal.PID, event.Signal.PID, 0, false, newEntryCb)
 		}
 		if pce == nil {
 			pce = model.NewPlaceholderProcessCacheEntry(event.Signal.PID, event.Signal.PID, false)
@@ -1115,6 +1131,12 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 
 	// resolve the container context
 	event.ContainerContext, _ = p.fieldHandlers.ResolveContainerContext(event)
+
+	// send related events
+	for _, relatedEvent := range relatedEvents {
+		p.DispatchEvent(relatedEvent, true)
+	}
+	relatedEvents = relatedEvents[0:0]
 
 	p.DispatchEvent(event, true)
 
@@ -1721,7 +1743,7 @@ func (p *EBPFProbe) OnNewRuleSetLoaded(rs *rules.RuleSet) {
 
 // NewEvent returns a new event
 func (p *EBPFProbe) NewEvent() *model.Event {
-	return NewEBPFEvent(p.fieldHandlers)
+	return newEBPFEvent(p.fieldHandlers)
 }
 
 // GetFieldHandlers returns the field handlers

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -975,7 +975,7 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 func (p *WindowsProbe) setProcessContext(pid uint32, event *model.Event) error {
 	event.PIDContext.Pid = pid
 	err := backoff.Retry(func() error {
-		entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event)
+		entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event, nil)
 		event.ProcessCacheEntry = entry
 		// use ProcessCacheEntry process context as process context
 		event.ProcessContext = &event.ProcessCacheEntry.ProcessContext

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -169,7 +169,7 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 		return false
 	}
 
-	entry, exists := ev.ResolveProcessCacheEntry()
+	entry, exists := ev.ResolveProcessCacheEntry(nil)
 	if !exists {
 		return false
 	}

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -47,14 +47,14 @@ func TestFork1st(t *testing.T) {
 	child.ForkTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -86,14 +86,14 @@ func TestFork2nd(t *testing.T) {
 	child.ForkTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -132,14 +132,14 @@ func TestForkExec(t *testing.T) {
 	exec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -189,14 +189,14 @@ func TestOrphanExec(t *testing.T) {
 	exec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -250,14 +250,14 @@ func TestForkExecExec(t *testing.T) {
 	exec2.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -322,14 +322,14 @@ func TestForkReuse(t *testing.T) {
 	child2.ForkTime = time.Now()
 
 	// parent1
-	resolver.AddForkEntry(parent1, 0)
+	resolver.AddForkEntry(parent1, 0, nil)
 	assert.Equal(t, parent1, resolver.entryCache[parent1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent1
 	//     \ child1
-	resolver.AddForkEntry(child1, 0)
+	resolver.AddForkEntry(child1, 0, nil)
 	assert.Equal(t, child1, resolver.entryCache[child1.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent1, child1.Ancestor)
@@ -355,7 +355,7 @@ func TestForkReuse(t *testing.T) {
 	//     \ [child1] -> exec1
 	//
 	// parent2:pid1
-	resolver.AddForkEntry(parent2, 0)
+	resolver.AddForkEntry(parent2, 0, nil)
 	assert.Equal(t, parent2, resolver.entryCache[parent2.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.EqualValues(t, 4, resolver.cacheSize.Load())
@@ -365,7 +365,7 @@ func TestForkReuse(t *testing.T) {
 	//
 	// parent2:pid1
 	//     \ child2
-	resolver.AddForkEntry(child2, 0)
+	resolver.AddForkEntry(child2, 0, nil)
 	assert.Equal(t, child2, resolver.entryCache[child2.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, parent2, child2.Ancestor)
@@ -415,13 +415,13 @@ func TestForkForkExec(t *testing.T) {
 	childExec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -429,7 +429,7 @@ func TestForkForkExec(t *testing.T) {
 	// parent
 	//     \ child
 	//          \ grandChild
-	resolver.AddForkEntry(grandChild, 0)
+	resolver.AddForkEntry(grandChild, 0, nil)
 	assert.Equal(t, grandChild, resolver.entryCache[grandChild.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, child, grandChild.Ancestor)
@@ -492,14 +492,14 @@ func TestExecBomb(t *testing.T) {
 	exec2.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -549,7 +549,7 @@ func TestExecLostFork(t *testing.T) {
 	parent.ExecInode = 1
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 
 	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 22, Tid: 22})
 	child.PPid = parent.Pid
@@ -557,7 +557,7 @@ func TestExecLostFork(t *testing.T) {
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, parent.ExecInode)
+	resolver.AddForkEntry(child, parent.ExecInode, nil)
 
 	assert.Equal(t, "agent", child.FileEvent.BasenameStr)
 	assert.False(t, child.IsParentMissing)
@@ -572,7 +572,7 @@ func TestExecLostFork(t *testing.T) {
 	// parent
 	//     \ child
 	//		\ child1
-	resolver.AddForkEntry(child1, child1.ExecInode)
+	resolver.AddForkEntry(child1, child1.ExecInode, nil)
 
 	assert.Equal(t, "agent", child1.FileEvent.BasenameStr)
 	assert.True(t, child1.IsParentMissing)
@@ -591,7 +591,7 @@ func TestExecLostExec(t *testing.T) {
 	parent.ExecInode = 1
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 
 	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 22, Tid: 22})
 	child1.PPid = parent.Pid
@@ -600,7 +600,7 @@ func TestExecLostExec(t *testing.T) {
 
 	// parent
 	//     \ child1
-	resolver.AddForkEntry(child1, parent.ExecInode)
+	resolver.AddForkEntry(child1, parent.ExecInode, nil)
 
 	assert.Equal(t, "agent", child1.FileEvent.BasenameStr)
 	assert.False(t, child1.IsParentMissing)
@@ -615,7 +615,7 @@ func TestExecLostExec(t *testing.T) {
 	// parent
 	//     \ child1
 	//		\ child2
-	resolver.AddForkEntry(child2, child2.ExecInode)
+	resolver.AddForkEntry(child2, child2.ExecInode, nil)
 
 	assert.Equal(t, "agent", child2.FileEvent.BasenameStr)
 	assert.True(t, child2.IsParentMissing)
@@ -632,7 +632,7 @@ func TestIsExecExecRuntime(t *testing.T) {
 	parent.FileEvent.Inode = 1
 
 	// parent
-	resolver.AddForkEntry(parent, 0)
+	resolver.AddForkEntry(parent, 0, nil)
 
 	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child.PPid = parent.Pid
@@ -640,7 +640,7 @@ func TestIsExecExecRuntime(t *testing.T) {
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child, 0)
+	resolver.AddForkEntry(child, 0, nil)
 
 	// parent
 	//     \ child

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -282,8 +282,8 @@ func (e *Event) Release() {
 }
 
 // ResolveProcessCacheEntry uses the field handler
-func (e *Event) ResolveProcessCacheEntry() (*ProcessCacheEntry, bool) {
-	return e.FieldHandlers.ResolveProcessCacheEntry(e)
+func (e *Event) ResolveProcessCacheEntry(newEntryCb func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool) {
+	return e.FieldHandlers.ResolveProcessCacheEntry(e, newEntryCb)
 }
 
 // ResolveEventTime uses the field handler
@@ -614,12 +614,12 @@ type AWSSecurityCredentials struct {
 
 // BaseExtraFieldHandlers handlers not hold by any field
 type BaseExtraFieldHandlers interface {
-	ResolveProcessCacheEntry(ev *Event) (*ProcessCacheEntry, bool)
+	ResolveProcessCacheEntry(ev *Event, newEntryCb func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool)
 	ResolveContainerContext(ev *Event) (*ContainerContext, bool)
 }
 
 // ResolveProcessCacheEntry stub implementation
-func (dfh *FakeFieldHandlers) ResolveProcessCacheEntry(_ *Event) (*ProcessCacheEntry, bool) {
+func (dfh *FakeFieldHandlers) ResolveProcessCacheEntry(_ *Event, _ func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool) {
 	return nil, false
 }
 

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -282,8 +282,8 @@ func (e *Event) Release() {
 }
 
 // ResolveProcessCacheEntry uses the field handler
-func (e *Event) ResolveProcessCacheEntry() (*ProcessCacheEntry, bool) {
-	return e.FieldHandlers.ResolveProcessCacheEntry(e)
+func (e *Event) ResolveProcessCacheEntry(newEntryCb func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool) {
+	return e.FieldHandlers.ResolveProcessCacheEntry(e, newEntryCb)
 }
 
 // ResolveEventTime uses the field handler
@@ -614,12 +614,12 @@ type AWSSecurityCredentials struct {
 
 // BaseExtraFieldHandlers handlers not hold by any field
 type BaseExtraFieldHandlers interface {
-	ResolveProcessCacheEntry(ev *Event) (*ProcessCacheEntry, bool)
+	ResolveProcessCacheEntry(ev *Event, newEntryCb func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool)
 	ResolveContainerContext(ev *Event) (*ContainerContext, bool)
 }
 
 // ResolveProcessCacheEntry stub implementation
-func (dfh *FakeFieldHandlers) ResolveProcessCacheEntry(_ *Event) (*ProcessCacheEntry, bool) {
+func (dfh *FakeFieldHandlers) ResolveProcessCacheEntry(_ *Event, _ func(*ProcessCacheEntry, error)) (*ProcessCacheEntry, bool) {
 	return nil, false
 }
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2277,7 +2277,7 @@ func TestProcessResolution(t *testing.T) {
 			t.Errorf("not able to resolve the entry")
 		}
 
-		mapsEntry := resolver.ResolveFromKernelMaps(pid, pid, inode)
+		mapsEntry := resolver.ResolveFromKernelMaps(pid, pid, inode, nil)
 		if mapsEntry == nil {
 			t.Errorf("not able to resolve the entry")
 		}
@@ -2286,7 +2286,7 @@ func TestProcessResolution(t *testing.T) {
 
 		// This makes use of the cache and do not parse /proc
 		// it still checks the ResolveFromProcfs returns the correct entry
-		procEntry := resolver.ResolveFromProcfs(pid)
+		procEntry := resolver.ResolveFromProcfs(pid, nil)
 		if procEntry == nil {
 			t.Fatalf("not able to resolve the entry")
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Process cache entries can be inserted from a fallback without generating exec/fork events. This PR adds a mechanism to generate events in this case and notify the different handlers/consumers.

### Motivation

### Describe how to test/QA your changes

This PR has been deployed on staging and the metrics / logs of the process cache entries + the event generated confirmed that the PR works as expected.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->