### PR TITLE
Add default values for boolean OTLP config options

### DIFF
--- a/comp/otelcol/otlp/config.go
+++ b/comp/otelcol/otlp/config.go
@@ -48,12 +48,12 @@ func readConfigSection(cfg config.Reader, section string) *confmap.Conf {
 	//
 	// `GetStringMap` it will fail to cast `interface{}` nil to
 	// `map[string]interface{}` nil; we use `Get` and cast manually.
-	rawVal := cfg.Get(section)
 	stringMap := map[string]interface{}{}
-	if val, ok := rawVal.(map[string]interface{}); ok {
-		// deep copy since `cfg.Get` returns a reference
-		stringMap = deepcopy.Copy(val).(map[string]interface{})
-	}
+	// NOTE: causes non-deterministic behavior in confmap.NewFromStringMap, don't do this!
+	//if val, ok := rawVal.(map[string]interface{}); ok {
+	//	// deep copy since `cfg.Get` returns a reference
+	//	stringMap = deepcopy.Copy(val).(map[string]interface{})
+	//}
 
 	// Step two works around https://github.com/spf13/viper/issues/1012
 	// we check every key manually, and if it belongs to the OTLP receiver section,

--- a/comp/otelcol/otlp/config.go
+++ b/comp/otelcol/otlp/config.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
@@ -110,7 +111,27 @@ func FromAgentConfig(cfg config.Reader) (PipelineConfig, error) {
 
 // IsEnabled checks if OTLP pipeline is enabled in a given config.
 func IsEnabled(cfg config.Reader) bool {
-	return hasSection(cfg, coreconfig.OTLPReceiverSubSectionKey)
+	receiverOptions := []string{
+		coreconfig.OTLPReceiverSection,
+		coreconfig.OTLPReceiverGRPCEndpoint,
+		coreconfig.OTLPReceiverGRPCTransport,
+		coreconfig.OTLPReceiverGRPCMaxRecvMsgSize,
+		coreconfig.OTLPReceiverGRPCMaxConcurrentStreams,
+		coreconfig.OTLPReceiverGRPCReadBufferSize,
+		coreconfig.OTLPReceiverGRPCWriteBufferSize,
+		coreconfig.OTLPReceiverGRPCIncludeMetadata,
+		coreconfig.OTLPReceiverHTTPEndpoint,
+		coreconfig.OTLPReceiverHTTPMaxRequestBodySize,
+		coreconfig.OTLPReceiverHTTPIncludeMetadata,
+	}
+	for _, opt := range receiverOptions {
+		fmt.Println(opt)
+		fmt.Println(cfg.GetSource(opt))
+		if src := cfg.GetSource(opt).String(); src != model.SourceDefault.String() && src != model.SourceUnknown.String() {
+			return true
+		}
+	}
+	return false
 }
 
 // HasLogsSectionEnabled checks if OTLP logs are explicitly enabled in a given config.

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -426,6 +426,27 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				Debug: map[string]interface{}{},
 			},
 		},
+		{
+			name: "metrics resource_attributes_as_tags",
+			env: map[string]string{
+				"DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS": "true",
+			},
+			cfg: PipelineConfig{
+				OTLPReceiverConfig: map[string]interface{}{},
+
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				LogsEnabled:    false,
+				TracePort:      5003,
+				Metrics: map[string]interface{}{
+					"enabled":                     true,
+					"tag_cardinality":             "low",
+					"apm_stats_receiver_addr":     "http://localhost:8126/v0.6/stats",
+					"resource_attributes_as_tags": true,
+				},
+				Debug: map[string]interface{}{},
+			},
+		},
 	}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -256,7 +256,8 @@ func TestFromEnvironmentVariables(t *testing.T) {
 							"include_metadata": false,
 						},
 						"http": map[string]interface{}{
-							"endpoint": "0.0.0.0:9998",
+							"endpoint":         "0.0.0.0:9998",
+							"include_metadata": false,
 						},
 					},
 				},

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -214,7 +214,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint": "0.0.0.0:9999",
+							"endpoint":         "0.0.0.0:9999",
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
 						},
 					},
 				},
@@ -224,9 +228,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -241,7 +252,8 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint": "0.0.0.0:9997",
+							"endpoint":         "0.0.0.0:9997",
+							"include_metadata": false,
 						},
 						"http": map[string]interface{}{
 							"endpoint": "0.0.0.0:9998",
@@ -254,9 +266,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -274,10 +293,12 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint": "0.0.0.0:9995",
+							"endpoint":         "0.0.0.0:9995",
+							"include_metadata": false,
 						},
 						"http": map[string]interface{}{
-							"endpoint": "0.0.0.0:9996",
+							"endpoint":         "0.0.0.0:9996",
+							"include_metadata": false,
 						},
 					},
 				},
@@ -288,14 +309,18 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
 					"enabled":                                true,
-					"instrumentation_scope_metadata_as_tags": "true",
+					"instrumentation_scope_metadata_as_tags": true,
 					"tag_cardinality":                        "low",
 					"apm_stats_receiver_addr":                "http://localhost:8126/v0.6/stats",
 
 					"delta_ttl": "2400",
 					"histograms": map[string]interface{}{
-						"mode": "counters",
+						"mode":                     "counters",
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
 					},
+					"instrumentation_library_metadata_as_tags": false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -310,7 +335,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint": "0.0.0.0:9999",
+							"endpoint":         "0.0.0.0:9999",
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
 						},
 					},
 				},
@@ -320,9 +349,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{
 					"verbosity": "none",
@@ -339,7 +375,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint": "0.0.0.0:9999",
+							"endpoint":         "0.0.0.0:9999",
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
 						},
 					},
 				},
@@ -349,9 +389,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{
 					"verbosity": "normal",
@@ -369,7 +416,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
 							"endpoint":              "0.0.0.0:9999",
+							"include_metadata":      false,
 							"max_recv_msg_size_mib": "10",
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
 						},
 					},
 				},
@@ -379,9 +430,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -392,16 +450,31 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				"DD_OTLP_CONFIG_LOGS_ENABLED": "true",
 			},
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
-
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 				MetricsEnabled: true,
 				TracesEnabled:  true,
 				LogsEnabled:    true,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -412,16 +485,31 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				"DD_OTLP_CONFIG_LOGS_ENABLED": "false",
 			},
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
-
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 				MetricsEnabled: true,
 				TracesEnabled:  true,
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                 true,
-					"tag_cardinality":         "low",
-					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -432,17 +520,31 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				"DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS": "true",
 			},
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
-
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 				MetricsEnabled: true,
 				TracesEnabled:  true,
 				LogsEnabled:    false,
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
-					"enabled":                     true,
-					"tag_cardinality":             "low",
-					"apm_stats_receiver_addr":     "http://localhost:8126/v0.6/stats",
-					"resource_attributes_as_tags": true,
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"resource_attributes_as_tags":              true,
 				},
 				Debug: map[string]interface{}{},
 			},

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -53,7 +53,16 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 		{
 			path: "receiver/noprotocols.yaml",
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,
@@ -63,6 +72,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -72,8 +88,12 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 			cfg: PipelineConfig{
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
-						"grpc": nil,
-						"http": nil,
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
 					},
 				},
 
@@ -85,6 +105,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -94,8 +121,12 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 			cfg: PipelineConfig{
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
-						"grpc": nil,
-						"http": nil,
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
 					},
 				},
 
@@ -107,6 +138,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -118,6 +156,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
 							"endpoint":               "0.0.0.0:5678",
+							"include_metadata":       false,
 							"max_concurrent_streams": 16,
 							"transport":              "tcp",
 							"keepalive": map[string]interface{}{
@@ -128,7 +167,8 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 							"max_recv_msg_size_mib": 10,
 						},
 						"http": map[string]interface{}{
-							"endpoint": "localhost:1234",
+							"endpoint":         "localhost:1234",
+							"include_metadata": false,
 							"cors": map[string]interface{}{
 								"allowed_origins": []interface{}{"http://test.com"},
 								"allowed_headers": []interface{}{"ExampleHeader"},
@@ -144,6 +184,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -151,7 +198,16 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 		{
 			path: "logs_enabled.yaml",
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,
@@ -161,6 +217,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -168,7 +231,16 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 		{
 			path: "logs_disabled.yaml",
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,
@@ -178,6 +250,13 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -630,12 +709,21 @@ func TestFromAgentConfigDebug(t *testing.T) {
 			path:      "debug/empty_but_set_debug.yaml",
 			shouldSet: true,
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
-				TracePort:          5003,
-				MetricsEnabled:     true,
-				TracesEnabled:      true,
-				LogsEnabled:        false,
-				Debug:              map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				LogsEnabled:    false,
+				Debug:          map[string]interface{}{},
 				Metrics: map[string]interface{}{
 					"enabled":                 true,
 					"tag_cardinality":         "low",
@@ -647,7 +735,16 @@ func TestFromAgentConfigDebug(t *testing.T) {
 			path:      "debug/verbosity_detailed.yaml",
 			shouldSet: true,
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,
@@ -665,7 +762,16 @@ func TestFromAgentConfigDebug(t *testing.T) {
 			path:      "debug/verbosity_none.yaml",
 			shouldSet: false,
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,
@@ -683,7 +789,16 @@ func TestFromAgentConfigDebug(t *testing.T) {
 			path:      "debug/verbosity_normal.yaml",
 			shouldSet: true,
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: map[string]interface{}{},
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"include_metadata": false,
+						},
+					},
+				},
 
 				TracePort:      5003,
 				MetricsEnabled: true,

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -656,8 +656,18 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 		{
 			path: "metrics/allconfig.yaml",
 			cfg: PipelineConfig{
-				OTLPReceiverConfig: testutil.OTLPConfigFromPorts("localhost", 5678, 1234),
-
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"endpoint":         "localhost:5678",
+							"include_metadata": false,
+						},
+						"http": map[string]interface{}{
+							"endpoint":         "localhost:1234",
+							"include_metadata": false,
+						},
+					},
+				},
 				TracePort:      5003,
 				MetricsEnabled: true,
 				TracesEnabled:  true,
@@ -728,6 +738,13 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 			},
 		},
@@ -755,6 +772,13 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 			},
 		},
@@ -782,6 +806,13 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 			},
 		},
@@ -809,6 +840,13 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"resource_attributes_as_tags":              false,
 				},
 			},
 		},

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -56,10 +56,15 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -72,6 +77,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -89,10 +95,15 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -105,6 +116,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -122,10 +134,15 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -138,6 +155,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -157,6 +175,8 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 						"grpc": map[string]interface{}{
 							"endpoint":               "0.0.0.0:5678",
 							"include_metadata":       false,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 							"max_concurrent_streams": 16,
 							"transport":              "tcp",
 							"keepalive": map[string]interface{}{
@@ -167,8 +187,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 							"max_recv_msg_size_mib": 10,
 						},
 						"http": map[string]interface{}{
-							"endpoint":         "localhost:1234",
-							"include_metadata": false,
+							"endpoint":              "localhost:1234",
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 							"cors": map[string]interface{}{
 								"allowed_origins": []interface{}{"http://test.com"},
 								"allowed_headers": []interface{}{"ExampleHeader"},
@@ -184,6 +205,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -201,10 +223,15 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -217,6 +244,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -234,10 +262,15 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -250,6 +283,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -293,11 +327,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9999",
-							"include_metadata": false,
+							"endpoint":               "0.0.0.0:9999",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -316,6 +355,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"instrumentation_scope_metadata_as_tags":   false,
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
+					"delta_ttl":                                3600,
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
@@ -331,12 +371,17 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9997",
-							"include_metadata": false,
+							"endpoint":               "0.0.0.0:9997",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9998",
-							"include_metadata": false,
+							"endpoint":              "0.0.0.0:9998",
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -355,6 +400,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"instrumentation_scope_metadata_as_tags":   false,
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
+					"delta_ttl":                                3600,
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 				},
 				Debug: map[string]interface{}{},
@@ -373,12 +419,17 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9995",
-							"include_metadata": false,
+							"endpoint":               "0.0.0.0:9995",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9996",
-							"include_metadata": false,
+							"endpoint":              "0.0.0.0:9996",
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -393,7 +444,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"tag_cardinality":                        "low",
 					"apm_stats_receiver_addr":                "http://localhost:8126/v0.6/stats",
 
-					"delta_ttl": "2400",
+					"delta_ttl": 2400,
 					"histograms": map[string]interface{}{
 						"mode":                     "counters",
 						"send_aggregation_metrics": false,
@@ -415,11 +466,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9999",
-							"include_metadata": false,
+							"endpoint":               "0.0.0.0:9999",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -439,6 +495,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"delta_ttl":                                3600,
 				},
 				Debug: map[string]interface{}{
 					"verbosity": "none",
@@ -455,11 +512,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "0.0.0.0:9999",
-							"include_metadata": false,
+							"endpoint":               "0.0.0.0:9999",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -479,6 +541,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"delta_ttl":                                3600,
 				},
 				Debug: map[string]interface{}{
 					"verbosity": "normal",
@@ -495,12 +558,16 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":              "0.0.0.0:9999",
-							"include_metadata":      false,
-							"max_recv_msg_size_mib": "10",
+							"endpoint":               "0.0.0.0:9999",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
+							"max_recv_msg_size_mib":  10,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -520,6 +587,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"delta_ttl":                                3600,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -533,10 +601,15 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -555,6 +628,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"delta_ttl":                                3600,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -568,10 +642,15 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -590,6 +669,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"resource_attributes_as_tags":              false,
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"delta_ttl":                                3600,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -603,10 +683,15 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -625,6 +710,48 @@ func TestFromEnvironmentVariables(t *testing.T) {
 					"tag_cardinality":                          "low",
 					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
 					"resource_attributes_as_tags":              true,
+					"delta_ttl":                                3600,
+				},
+				Debug: map[string]interface{}{},
+			},
+		},
+		{
+			name: "metrics delta_ttl",
+			env: map[string]string{
+				"DD_OTLP_CONFIG_METRICS_DELTA_TTL": "1000",
+			},
+			cfg: PipelineConfig{
+				OTLPReceiverConfig: map[string]interface{}{
+					"protocols": map[string]interface{}{
+						"grpc": map[string]interface{}{
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
+						},
+						"http": map[string]interface{}{
+							"include_metadata":      false,
+							"max_request_body_size": 0,
+						},
+					},
+				},
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				LogsEnabled:    false,
+				TracePort:      5003,
+				Metrics: map[string]interface{}{
+					"enabled": true,
+					"histograms": map[string]interface{}{
+						"send_aggregation_metrics": false,
+						"send_count_sum_metrics":   false,
+					},
+					"instrumentation_library_metadata_as_tags": false,
+					"instrumentation_scope_metadata_as_tags":   false,
+					"tag_cardinality":                          "low",
+					"apm_stats_receiver_addr":                  "http://localhost:8126/v0.6/stats",
+					"resource_attributes_as_tags":              false,
+					"delta_ttl":                                1000,
 				},
 				Debug: map[string]interface{}{},
 			},
@@ -659,12 +786,17 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"endpoint":         "localhost:5678",
-							"include_metadata": false,
+							"endpoint":               "localhost:5678",
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"endpoint":         "localhost:1234",
-							"include_metadata": false,
+							"endpoint":              "localhost:1234",
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -722,10 +854,15 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -738,6 +875,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -755,10 +893,15 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -772,6 +915,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -789,10 +933,15 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -806,6 +955,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,
@@ -823,10 +973,15 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				OTLPReceiverConfig: map[string]interface{}{
 					"protocols": map[string]interface{}{
 						"grpc": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":       false,
+							"max_concurrent_streams": 0,
+							"max_recv_msg_size_mib":  4,
+							"read_buffer_size":       0,
+							"write_buffer_size":      0,
 						},
 						"http": map[string]interface{}{
-							"include_metadata": false,
+							"include_metadata":      false,
+							"max_request_body_size": 0,
 						},
 					},
 				},
@@ -840,6 +995,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 					"enabled":                 true,
 					"tag_cardinality":         "low",
 					"apm_stats_receiver_addr": "http://localhost:8126/v0.6/stats",
+					"delta_ttl":               3600,
 					"histograms": map[string]interface{}{
 						"send_aggregation_metrics": false,
 						"send_count_sum_metrics":   false,

--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -75,10 +75,10 @@ func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 	// gRPC settings
 	config.BindEnv(OTLPReceiverGRPCEndpoint)
 	config.BindEnv(OTLPReceiverGRPCTransport)
-	config.BindEnv(OTLPReceiverGRPCMaxRecvMsgSize)
-	config.BindEnv(OTLPReceiverGRPCMaxConcurrentStreams)
-	config.BindEnv(OTLPReceiverGRPCReadBufferSize)
-	config.BindEnv(OTLPReceiverGRPCWriteBufferSize)
+	config.BindEnvAndSetDefault(OTLPReceiverGRPCMaxRecvMsgSize, 4)
+	config.BindEnvAndSetDefault(OTLPReceiverGRPCMaxConcurrentStreams, 0)
+	config.BindEnvAndSetDefault(OTLPReceiverGRPCReadBufferSize, 0)
+	config.BindEnvAndSetDefault(OTLPReceiverGRPCWriteBufferSize, 0)
 	config.BindEnvAndSetDefault(OTLPReceiverGRPCIncludeMetadata, false)
 
 	// Traces settings
@@ -89,11 +89,11 @@ func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 
 	// HTTP settings
 	config.BindEnv(OTLPReceiverHTTPEndpoint)
-	config.BindEnv(OTLPReceiverHTTPMaxRequestBodySize)
+	config.BindEnvAndSetDefault(OTLPReceiverHTTPMaxRequestBodySize, 0)
 	config.BindEnvAndSetDefault(OTLPReceiverHTTPIncludeMetadata, false)
 
 	// Metrics settings
-	config.BindEnv(OTLPSection + ".metrics.delta_ttl")
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.delta_ttl", 3600)
 	config.BindEnvAndSetDefault(OTLPSection+".metrics.resource_attributes_as_tags", false)
 	config.BindEnvAndSetDefault(OTLPSection+".metrics.instrumentation_library_metadata_as_tags", false)
 	config.BindEnvAndSetDefault(OTLPSection+".metrics.instrumentation_scope_metadata_as_tags", false)

--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -11,20 +11,32 @@ import (
 
 // OTLP configuration paths.
 const (
-	OTLPSection               = "otlp_config"
-	OTLPTracesSubSectionKey   = "traces"
-	OTLPTracePort             = OTLPSection + "." + OTLPTracesSubSectionKey + ".internal_port"
-	OTLPTracesEnabled         = OTLPSection + "." + OTLPTracesSubSectionKey + ".enabled"
-	OTLPLogsSubSectionKey     = "logs"
-	OTLPLogsEnabled           = OTLPSection + "." + OTLPLogsSubSectionKey + ".enabled"
-	OTLPReceiverSubSectionKey = "receiver"
-	OTLPReceiverSection       = OTLPSection + "." + OTLPReceiverSubSectionKey
-	OTLPMetricsSubSectionKey  = "metrics"
-	OTLPMetrics               = OTLPSection + "." + OTLPMetricsSubSectionKey
-	OTLPMetricsEnabled        = OTLPSection + "." + OTLPMetricsSubSectionKey + ".enabled"
-	OTLPTagCardinalityKey     = OTLPMetrics + ".tag_cardinality"
-	OTLPDebugKey              = "debug"
-	OTLPDebug                 = OTLPSection + "." + OTLPDebugKey
+	OTLPSection                          = "otlp_config"
+	OTLPTracesSubSectionKey              = "traces"
+	OTLPTracePort                        = OTLPSection + "." + OTLPTracesSubSectionKey + ".internal_port"
+	OTLPTracesEnabled                    = OTLPSection + "." + OTLPTracesSubSectionKey + ".enabled"
+	OTLPLogsSubSectionKey                = "logs"
+	OTLPLogsEnabled                      = OTLPSection + "." + OTLPLogsSubSectionKey + ".enabled"
+	OTLPReceiverSubSectionKey            = "receiver"
+	OTLPReceiverSection                  = OTLPSection + "." + OTLPReceiverSubSectionKey
+	OTLPReceiverGRPCSection              = OTLPReceiverSection + ".protocols.grpc"
+	OTLPReceiverGRPCEndpoint             = OTLPReceiverGRPCSection + ".endpoint"
+	OTLPReceiverGRPCTransport            = OTLPReceiverGRPCSection + ".transport"
+	OTLPReceiverGRPCMaxRecvMsgSize       = OTLPReceiverGRPCSection + ".max_recv_msg_size_mib"
+	OTLPReceiverGRPCMaxConcurrentStreams = OTLPReceiverGRPCSection + ".max_concurrent_streams"
+	OTLPReceiverGRPCReadBufferSize       = OTLPReceiverGRPCSection + ".read_buffer_size"
+	OTLPReceiverGRPCWriteBufferSize      = OTLPReceiverGRPCSection + ".write_buffer_size"
+	OTLPReceiverGRPCIncludeMetadata      = OTLPReceiverGRPCSection + ".include_metadata"
+	OTLPReceiverHTTPSection              = OTLPReceiverSection + ".protocols.http"
+	OTLPReceiverHTTPEndpoint             = OTLPReceiverHTTPSection + ".endpoint"
+	OTLPReceiverHTTPMaxRequestBodySize   = OTLPReceiverHTTPSection + ".max_request_body_size"
+	OTLPReceiverHTTPIncludeMetadata      = OTLPReceiverHTTPSection + ".include_metadata"
+	OTLPMetricsSubSectionKey             = "metrics"
+	OTLPMetrics                          = OTLPSection + "." + OTLPMetricsSubSectionKey
+	OTLPMetricsEnabled                   = OTLPSection + "." + OTLPMetricsSubSectionKey + ".enabled"
+	OTLPTagCardinalityKey                = OTLPMetrics + ".tag_cardinality"
+	OTLPDebugKey                         = "debug"
+	OTLPDebug                            = OTLPSection + "." + OTLPDebugKey
 )
 
 // OTLP related configuration.
@@ -61,13 +73,13 @@ func OTLP(config pkgconfigmodel.Setup) {
 // We are missing TLS settings: since some of them need more work to work right they are not included here.
 func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 	// gRPC settings
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.endpoint")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.transport")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.max_recv_msg_size_mib")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.max_concurrent_streams")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.read_buffer_size")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.write_buffer_size")
-	config.BindEnvAndSetDefault(OTLPSection+".receiver.protocols.grpc.include_metadata", false)
+	config.BindEnv(OTLPReceiverGRPCEndpoint)
+	config.BindEnv(OTLPReceiverGRPCTransport)
+	config.BindEnv(OTLPReceiverGRPCMaxRecvMsgSize)
+	config.BindEnv(OTLPReceiverGRPCMaxConcurrentStreams)
+	config.BindEnv(OTLPReceiverGRPCReadBufferSize)
+	config.BindEnv(OTLPReceiverGRPCWriteBufferSize)
+	config.BindEnvAndSetDefault(OTLPReceiverGRPCIncludeMetadata, false)
 
 	// Traces settings
 	config.BindEnvAndSetDefault("otlp_config.traces.span_name_remappings", map[string]string{})
@@ -76,9 +88,9 @@ func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 		"DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")
 
 	// HTTP settings
-	config.BindEnv(OTLPSection + ".receiver.protocols.http.endpoint")
-	config.BindEnv(OTLPSection + ".receiver.protocols.http.max_request_body_size")
-	config.BindEnvAndSetDefault(OTLPSection+".receiver.protocols.http.include_metadata", false)
+	config.BindEnv(OTLPReceiverHTTPEndpoint)
+	config.BindEnv(OTLPReceiverHTTPMaxRequestBodySize)
+	config.BindEnvAndSetDefault(OTLPReceiverHTTPIncludeMetadata, false)
 
 	// Metrics settings
 	config.BindEnv(OTLPSection + ".metrics.delta_ttl")

--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -67,28 +67,28 @@ func setupOTLPEnvironmentVariables(config pkgconfigmodel.Setup) {
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.max_concurrent_streams")
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.read_buffer_size")
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.write_buffer_size")
-	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.include_metadata")
+	config.BindEnvAndSetDefault(OTLPSection+".receiver.protocols.grpc.include_metadata", false)
 
 	// Traces settings
 	config.BindEnvAndSetDefault("otlp_config.traces.span_name_remappings", map[string]string{})
-	config.BindEnv("otlp_config.traces.span_name_as_resource_name")
+	config.BindEnvAndSetDefault("otlp_config.traces.span_name_as_resource_name", false)
 	config.BindEnvAndSetDefault("otlp_config.traces.probabilistic_sampler.sampling_percentage", 100.,
 		"DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")
 
 	// HTTP settings
 	config.BindEnv(OTLPSection + ".receiver.protocols.http.endpoint")
 	config.BindEnv(OTLPSection + ".receiver.protocols.http.max_request_body_size")
-	config.BindEnv(OTLPSection + ".receiver.protocols.http.include_metadata")
+	config.BindEnvAndSetDefault(OTLPSection+".receiver.protocols.http.include_metadata", false)
 
 	// Metrics settings
 	config.BindEnv(OTLPSection + ".metrics.delta_ttl")
-	config.BindEnv(OTLPSection + ".metrics.resource_attributes_as_tags")
-	config.BindEnv(OTLPSection + ".metrics.instrumentation_library_metadata_as_tags")
-	config.BindEnv(OTLPSection + ".metrics.instrumentation_scope_metadata_as_tags")
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.resource_attributes_as_tags", false)
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.instrumentation_library_metadata_as_tags", false)
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.instrumentation_scope_metadata_as_tags", false)
 	config.BindEnv(OTLPSection + ".metrics.tag_cardinality")
 	config.BindEnv(OTLPSection + ".metrics.histograms.mode")
-	config.BindEnv(OTLPSection + ".metrics.histograms.send_count_sum_metrics")
-	config.BindEnv(OTLPSection + ".metrics.histograms.send_aggregation_metrics")
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.histograms.send_count_sum_metrics", false)
+	config.BindEnvAndSetDefault(OTLPSection+".metrics.histograms.send_aggregation_metrics", false)
 	config.BindEnv(OTLPSection + ".metrics.sums.cumulative_monotonic_mode")
 	config.BindEnv(OTLPSection + ".metrics.sums.initial_cumulative_monotonic_value")
 	config.BindEnv(OTLPSection + ".metrics.summaries.mode")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds default values (false) for boolean OTLP config options.

### Motivation
Fixes the following bug which was found in https://github.com/DataDog/datadog-agent/pull/30061 when upgrading dependencies:
```
2024-10-29 17:59:31 UTC | CORE | ERROR | (comp/otelcol/collector/impl-pipeline/pipeline.go:111 in func1) | Error running the OTLP ingest pipeline: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

error decoding 'exporters': error reading configuration for "serializer": decoding failed due to the following error(s):

error decoding '': decoding failed due to the following error(s):

'metrics.resource_attributes_as_tags' expected type 'bool', got unconvertible type 'string', value: 'true'
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->