### PR TITLE
close handles during purge

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -389,6 +389,18 @@ func (i *installerImpl) Purge(ctx context.Context) {
 			log.Warnf("could not remove package %s: %v", pkg.Name, err)
 		}
 	}
+	// NOTE: On Windows, purge must be called from a copy of the installer that
+	//       exists outside of the install directory. If purge is called from
+	//       within the installer package, then one of two things may happen:
+	//       - this process will be ctrl-c killed and purge will not complete
+	//       - this process will ignore ctrl-c and msiexec will kill msiserver,
+	//         failing the uninstall.
+	//       We can't workaround this by moving removePackage to the end of purge,
+	//       as the daemon may be running and holding locks on files that need to be removed.
+	err = i.removePackage(ctx, packageDatadogInstaller)
+	if err != nil {
+		log.Warnf("could not remove installer: %v", err)
+	}
 
 	// Must close dependencies before removing the rest of the files,
 	// as some may be open/locked by the dependencies
@@ -416,17 +428,6 @@ func (i *installerImpl) Purge(ctx context.Context) {
 	defer span.Finish(tracer.WithError(err))
 	if err != nil {
 		log.Warnf("could not delete packages dir: %v", err)
-	}
-
-	// Remove the installer package last as this process may be running
-	// from within the installer package. If this is the case:
-	// - Windows: The MSI will force kill this process
-	// - Linux: This process can keep running
-	// TODO: This is a workaround, and the trace made by the caller won't
-	//       be closed. Maybe purge should always run from a separate/temporary path.
-	err = i.removePackage(ctx, packageDatadogInstaller)
-	if err != nil {
-		log.Warnf("could not remove installer: %v", err)
 	}
 }
 

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -89,8 +89,7 @@ func NewInstaller(env *env.Env) (Installer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not ensure packages and config directory exists: %w", err)
 	}
-	packagesDir := paths.PackagesPath
-	db, err := db.New(filepath.Join(packagesDir, "packages.db"), db.WithTimeout(10*time.Second))
+	db, err := db.New(filepath.Join(paths.PackagesPath, "packages.db"), db.WithTimeout(10*time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("could not create packages db: %w", err)
 	}
@@ -103,11 +102,11 @@ func NewInstaller(env *env.Env) (Installer, error) {
 		cdn:        cdn,
 		db:         db,
 		downloader: oci.NewDownloader(env, http.DefaultClient),
-		packages:   repository.NewRepositories(packagesDir, paths.LocksPath),
+		packages:   repository.NewRepositories(paths.PackagesPath, paths.LocksPath),
 		configs:    repository.NewRepositories(paths.ConfigsPath, paths.LocksPath),
 
 		userConfigsDir: paths.DefaultUserConfigsDir,
-		packagesDir:    packagesDir,
+		packagesDir:    paths.PackagesPath,
 	}, nil
 }
 

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -204,3 +204,22 @@ func latestModTimeFS(fsys fs.FS, dirPath string) (time.Time, error) {
 
 	return latestTime, nil
 }
+
+func TestPurge(t *testing.T) {
+	s := fixtures.NewServer(t)
+	rootPath := t.TempDir()
+	installer := newTestPackageManager(t, s, rootPath, t.TempDir())
+	defer installer.db.Close()
+
+	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+	assert.NoError(t, err)
+	r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+
+	state, err := r.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, fixtures.FixtureSimpleV1.Version, state.Stable)
+
+	installer.Purge(testCtx)
+	assert.NoFileExists(t, filepath.Join(rootPath, "packages.db"), "purge should remove the packages database")
+	assert.NoDirExists(t, rootPath, "purge should remove the packages directory")
+}

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -209,7 +209,6 @@ func TestPurge(t *testing.T) {
 	s := fixtures.NewServer(t)
 	rootPath := t.TempDir()
 	installer := newTestPackageManager(t, s, rootPath, t.TempDir())
-	defer installer.db.Close()
 
 	err := installer.Install(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 	assert.NoError(t, err)
@@ -222,4 +221,6 @@ func TestPurge(t *testing.T) {
 	installer.Purge(testCtx)
 	assert.NoFileExists(t, filepath.Join(rootPath, "packages.db"), "purge should remove the packages database")
 	assert.NoDirExists(t, rootPath, "purge should remove the packages directory")
+	assert.Nil(t, installer.db, "purge should close the packages database")
+	assert.Nil(t, installer.cdn, "purge should close the CDN client")
 }

--- a/test/new-e2e/tests/installer/windows/datadog_installer.go
+++ b/test/new-e2e/tests/installer/windows/datadog_installer.go
@@ -87,16 +87,16 @@ func (d *DatadogInstaller) executeFromCopy(cmd string, options ...client.Execute
 	}
 	defer d.env.RemoteHost.Remove(tempFile) //nolint:errcheck
 	// ensure it has a .exe extension
-	tempFile = tempFile + ".exe"
-	defer d.env.RemoteHost.Remove(tempFile) //nolint:errcheck
+	exeTempFile := tempFile + ".exe"
+	defer d.env.RemoteHost.Remove(exeTempFile) //nolint:errcheck
 	// must pass -Force b/c the temporary file is already created
-	copyCmd := fmt.Sprintf(`Copy-Item -Force -Path "%s" -Destination "%s"`, d.binaryPath, tempFile)
+	copyCmd := fmt.Sprintf(`Copy-Item -Force -Path "%s" -Destination "%s"`, d.binaryPath, exeTempFile)
 	_, err = d.env.RemoteHost.Execute(copyCmd)
 	if err != nil {
 		return "", err
 	}
 	// Execute the command with the copied binary
-	output, err := d.env.RemoteHost.Execute(fmt.Sprintf("& \"%s\" %s", tempFile, cmd), options...)
+	output, err := d.env.RemoteHost.Execute(fmt.Sprintf("& \"%s\" %s", exeTempFile, cmd), options...)
 	if err != nil {
 		return output, err
 	}

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -131,6 +131,7 @@ func (s *testInstallerSuite) purge() {
 
 	// Assert
 	s.Assert().NoError(err)
+	s.requireUninstalled()
 	s.Require().Host(s.Env().RemoteHost).
 		NoFileExists(`C:\ProgramData\Datadog Installer\packages\packages.db`)
 }

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -31,11 +31,11 @@ func (s *testInstallerSuite) TestInstalls() {
 		s.Run("Uninstall", func() {
 			s.uninstall()
 			s.Run("Install with existing configuration file", func() {
-				s.installWithExistingConfigFile()
+				s.installWithExistingConfigFile("with-config-install.log")
 				s.Run("Repair", s.repair)
 				s.Run("Purge", s.purge)
 				s.Run("Install after purge", func() {
-					s.installWithExistingConfigFile()
+					s.installWithExistingConfigFile("after-purge-install.log")
 				})
 			})
 		})
@@ -91,12 +91,12 @@ func (s *testInstallerSuite) uninstall() {
 		FileExists(installerwindows.ConfigPath)
 }
 
-func (s *testInstallerSuite) installWithExistingConfigFile() {
+func (s *testInstallerSuite) installWithExistingConfigFile(logFilename string) {
 	// Arrange
 
 	// Act
 	s.Require().NoError(s.Installer().Install(
-		installerwindows.WithMSILogFile("with-config-install.log"),
+		installerwindows.WithMSILogFile(logFilename),
 	))
 
 	// Assert

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -33,6 +33,10 @@ func (s *testInstallerSuite) TestInstalls() {
 			s.Run("Install with existing configuration file", func() {
 				s.installWithExistingConfigFile()
 				s.Run("Repair", s.repair)
+				s.Run("Purge", s.purge)
+				s.Run("Install after purge", func() {
+					s.installWithExistingConfigFile()
+				})
 			})
 		})
 	})
@@ -117,4 +121,16 @@ func (s *testInstallerSuite) repair() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasAService(installerwindows.ServiceName).
 		WithStatus("Running")
+}
+
+func (s *testInstallerSuite) purge() {
+	// Arrange
+
+	// Act
+	_, err := s.Installer().Purge()
+
+	// Assert
+	s.Assert().NoError(err)
+	s.Require().Host(s.Env().RemoteHost).
+		NoFileExists(`C:\ProgramData\Datadog Installer\packages\packages.db`)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
fix fleet installer purge command on Windows, by closing the db handles before trying to remove the files.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1133

### Describe how to test/QA your changes
added e2e test and unit test for purge

#### manual steps
install/bootstrap like normal
then run purge command (from a copy!)
```PowerShell
cp 'C:\Program Files\Datadog\Datadog Installer\datadog-installer.exe' C:\datadog-installer.exe
C:\datadog-installer.exe purge
```
Ensure Agent and Installer are no longer installed, and `C:\ProgramData\Datadog Installer\packages` does not exist.

### Possible Drawbacks / Trade-offs
(on windows) purge will still fail if run from the the install directory, so it must be run from a copy for now. There's more discussion in the jira card, the summary is, as mentioned in the code comment, If purge is called from within the installer package, then one of two things may happen:
- this process will be ctrl-c killed and purge will not complete
  -  we can't easily move `removePackage(installer)` to the end of purge. The daemon may be running and also holding locks on files (remote config db for example). This would also make waiting for purge/uninstall completion tricky, as the process would die and you wouldn't know when `msiexec` was done or if it succeeded/failed.
- this process will ignore ctrl-c and msiexec will kill msiserver, failing the uninstall.
  - this may be an MSI/RestartManager bug. The `msiserver` service attaches to the console to send the ctrl-c signal, to all processes attached to the console, but then never detaches. Then when `msiexec /x` does the same thing, it sends ctrl-c to `msiserver` which kills it. See jira card for further technical details.
  - example to trigger: `ssh Administrator@$host "& 'C:\Program Files\Datadog\Datadog Installer\datadog-installer.exe' purge"`


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->