### PR TITLE
comp/trace/config: use dedicated testing.T in subtests

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -369,7 +369,7 @@ func TestConfigHostname(t *testing.T) {
 
 		// makeProgram creates a new binary file which returns the given response and exits to the OS
 		// given the specified code, returning the path of the program.
-		makeProgram := func(response string, code int) string {
+		makeProgram := func(t *testing.T, response string, code int) string {
 			f, err := os.CreateTemp("", "trace-test-hostname.*.go")
 			if err != nil {
 				t.Fatal(err)
@@ -401,7 +401,7 @@ func TestConfigHostname(t *testing.T) {
 		fallbackHostnameFunc = func() (string, error) { return "fallback.host", nil }
 
 		t.Run("good", func(t *testing.T) {
-			bin := makeProgram("host.name", 0)
+			bin := makeProgram(t, "host.name", 0)
 			defer os.Remove(bin)
 
 			config := buildConfigComponent(t)
@@ -415,7 +415,7 @@ func TestConfigHostname(t *testing.T) {
 		})
 
 		t.Run("empty", func(t *testing.T) {
-			bin := makeProgram("", 0)
+			bin := makeProgram(t, "", 0)
 			defer os.Remove(bin)
 
 			config := buildConfigComponent(t)
@@ -428,7 +428,7 @@ func TestConfigHostname(t *testing.T) {
 		})
 
 		t.Run("empty+disallowed", func(t *testing.T) {
-			bin := makeProgram("", 0)
+			bin := makeProgram(t, "", 0)
 			defer os.Remove(bin)
 
 			config := buildConfigComponent(t)
@@ -443,7 +443,7 @@ func TestConfigHostname(t *testing.T) {
 		})
 
 		t.Run("fallback1", func(t *testing.T) {
-			bin := makeProgram("", 1)
+			bin := makeProgram(t, "", 1)
 			defer os.Remove(bin)
 
 			config := buildConfigComponent(t)
@@ -456,7 +456,7 @@ func TestConfigHostname(t *testing.T) {
 		})
 
 		t.Run("fallback2", func(t *testing.T) {
-			bin := makeProgram("some text", 1)
+			bin := makeProgram(t, "some text", 1)
 			defer os.Remove(bin)
 
 			config := buildConfigComponent(t)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix a minor bug where if the `makeProgram` function failed it would improperly use the testing.T of the parent test, this causes an invalid test error and makes debugging the real failure much harder.

### Motivation

### Describe how to test/QA your changes
n/a
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->