### PR TITLE
[OTEL-2153] return a config even when there is no DD exporter cfg in otel agent

### DIFF
--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -100,7 +100,10 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 	if err == agentConfig.ErrNoDDExporter {
 		return fxutil.Run(
 			fx.Supply(uris),
-			fx.Supply(optional.NewNoneOption[coreconfig.Component]()),
+			fx.Provide(func() (coreconfig.Component, error) {
+				pkgconfigenv.DetectFeatures(acfg)
+				return acfg, nil
+			}),
 			converterfx.Module(),
 			fx.Provide(func(cp converter.Component) confmap.Converter {
 				return cp

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -100,9 +100,8 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 	if err == agentConfig.ErrNoDDExporter {
 		return fxutil.Run(
 			fx.Supply(uris),
-			fx.Provide(func() (coreconfig.Component, error) {
-				pkgconfigenv.DetectFeatures(acfg)
-				return acfg, nil
+			fx.Provide(func() coreconfig.Component {
+				return acfg
 			}),
 			converterfx.Module(),
 			fx.Provide(func(cp converter.Component) confmap.Converter {

--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -83,6 +83,7 @@ type RequiresNoAgent struct {
 
 	CollectorContrib collectorcontrib.Component
 	URIs             []string
+	Config           config.Component
 	Converter        confmap.Converter
 }
 
@@ -198,12 +199,13 @@ func NewComponentNoAgent(reqs RequiresNoAgent) (Provides, error) {
 	factories.Connectors[component.MustNewType("datadog")] = datadogconnector.NewFactory()
 	factories.Extensions[ddextension.Type] = ddextension.NewFactory(&factories, newConfigProviderSettings(reqs.URIs, reqs.Converter, false))
 
+	converterEnabled := reqs.Config.GetBool("otelcollector.converter.enabled")
 	set := otelcol.CollectorSettings{
 		BuildInfo: buildInfo,
 		Factories: func() (otelcol.Factories, error) {
 			return factories, nil
 		},
-		ConfigProviderSettings: newConfigProviderSettings(reqs.URIs, reqs.Converter, true),
+		ConfigProviderSettings: newConfigProviderSettings(reqs.URIs, reqs.Converter, converterEnabled),
 	}
 	col, err := otelcol.NewCollector(set)
 	if err != nil {

--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -153,11 +153,13 @@ func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 		}
 	}
 
-	apiMap["key"] = coreCfg.Get("api_key")
+	if coreCfg != nil {
+		apiMap["key"] = coreCfg.Get("api_key")
 
-	apiSite, ok := apiMap["site"]
-	if ok && apiSite == "" {
-		apiMap["site"] = coreCfg.Get("site")
+		apiSite, ok := apiMap["site"]
+		if ok && apiSite == "" {
+			apiMap["site"] = coreCfg.Get("site")
+		}
 	}
 
 	*conf = *confmap.NewFromStringMap(stringMapConf)

--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -116,7 +115,7 @@ func addComponentToPipeline(conf *confmap.Conf, comp component, pipelineName str
 	*conf = *confmap.NewFromStringMap(stringMapConf)
 }
 
-func addCoreAgentConfig(conf *confmap.Conf, coreCfg optional.Option[config.Component]) {
+func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 	stringMapConf := conf.ToStringMap()
 	exporters, ok := stringMapConf["exporters"]
 	if !ok {
@@ -154,14 +153,11 @@ func addCoreAgentConfig(conf *confmap.Conf, coreCfg optional.Option[config.Compo
 		}
 	}
 
-	ccfg, ok := coreCfg.Get()
-	if ok {
-		apiMap["key"] = ccfg.Get("api_key")
+	apiMap["key"] = coreCfg.Get("api_key")
 
-		apiSite, ok := apiMap["site"]
-		if ok && apiSite == "" {
-			apiMap["site"] = ccfg.Get("site")
-		}
+	apiSite, ok := apiMap["site"]
+	if ok && apiSite == "" {
+		apiMap["site"] = coreCfg.Get("site")
 	}
 
 	*conf = *confmap.NewFromStringMap(stringMapConf)

--- a/comp/otelcol/converter/impl/converter.go
+++ b/comp/otelcol/converter/impl/converter.go
@@ -13,11 +13,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	converter "github.com/DataDog/datadog-agent/comp/otelcol/converter/def"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 type ddConverter struct {
-	coreConfig optional.Option[config.Component]
+	coreConfig config.Component
 }
 
 var (
@@ -31,7 +30,7 @@ var (
 // with core agent config elements if any are missing from the provided
 // OTel configutation.
 type Requires struct {
-	Conf optional.Option[config.Component]
+	Conf config.Component
 }
 
 // NewConverter currently only supports a single URI in the uris slice, and this URI needs to be a file path.

--- a/comp/otelcol/converter/impl/go.mod
+++ b/comp/otelcol/converter/impl/go.mod
@@ -42,7 +42,6 @@ replace (
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.56.2
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/optional v0.56.2
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/confmap v0.104.0
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.104.0
@@ -71,6 +70,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.57.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/optional v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.56.2 // indirect


### PR DESCRIPTION
### What does this PR do?
Create an agent core config comp even when there is no DD exporter config in otel agent. This core config comp does not have API keys but has everything else.

### Motivation
This solves a few issues when there is no DD exporter config in otel agent:
- allow otelcollector converter to be disabled
- dd flare extension now has access to auth tokens

### Describe how to test/QA your changes
Test with a config that does not have DD exporter, e.g.
```
receivers:
  hostmetrics:
    scrapers:
      load:
      memory:

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    metrics/sys:
      receivers: [hostmetrics]
      exporters: [debug]
```

1. Deploy otel agent with core agent, verify `agent flare` contains otel flares
2. Disable converter with env var `DD_OTELCOLLECTOR_CONVERTER_ENABLED` or agent config `otelcollector.converter.enabled`, verify otel agent config is not enhanced, e.g. no zpages / healthcheck etc. extensions are added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->