### PR TITLE
allow absolute paths to verifier calculator

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -86,6 +86,7 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 			flags = append(flags, fmt.Sprintf("-include%s", helperPath))
 		}
 
+		log.Debugf("compiling runtime version of %s to %s", filename, outputFile)
 		if err := compiler.CompileToObjectFile(inFile, outputFile, flags, kernelHeaders); err != nil {
 			return nil, compilationErr, fmt.Errorf("failed to compile runtime version of %s: %s", filename, err)
 		}
@@ -93,6 +94,7 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 		log.Infof("successfully compiled runtime version of %s", filename)
 		result = compilationSuccess
 	} else {
+		log.Debugf("previously compiled runtime version of %s exists at %s", filename, outputFile)
 		log.Infof("found previously compiled runtime version of %s", filename)
 		result = compiledOutputFound
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allows the verifier complexity calculator to operate on absolute paths

### Motivation

Runtime generated programs do not sit in the normal bpf directory, so the `-filter-file` argument needs to allow absolute paths.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->