### PR TITLE
trace-agent: add config for delta profiles in internal profiling

### DIFF
--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -127,6 +127,7 @@ func profilingConfig(tracecfg *tracecfg.AgentConfig) *profiling.Settings {
 		WithGoroutineProfile: pkgconfigsetup.Datadog().GetBool("internal_profiling.enable_goroutine_stacktraces"),
 		WithBlockProfile:     pkgconfigsetup.Datadog().GetBool("internal_profiling.enable_block_profiling"),
 		WithMutexProfile:     pkgconfigsetup.Datadog().GetBool("internal_profiling.enable_mutex_profiling"),
+		WithDeltaProfiles:    pkgconfigsetup.Datadog().GetBool("internal_profiling.delta_profiles"),
 		Tags:                 tags,
 	}
 }


### PR DESCRIPTION
### What does this PR do?

All other agents have a config to enable/disable delta profiles (and it's actually turned on by default for other agents and when deployed internally).

This PR plugs the already available config (shared with the core agent) to the profiling config used by the trace agent.

The main goal with this PR is to bring consistency around profiling of Datadog agents.

You can read more about delta profiles [here](https://docs.datadoghq.com/profiler/profile_types/?code-lang=go#delta-profiles).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->