### PR TITLE
[CWS] remove `go:linkname` usage in `pkg/security/secl/utils/pprof.go`

### DIFF
--- a/pkg/security/secl/utils/pprof.go
+++ b/pkg/security/secl/utils/pprof.go
@@ -7,54 +7,30 @@
 package utils
 
 import (
-	"errors"
-	"unsafe"
+	"context"
+	"runtime/pprof"
 )
 
 // LabelSet represents an abstracted set of labels that can be used to call PprofDoWithoutContext
 type LabelSet struct {
-	inner *map[string]string
+	innerCtx context.Context
 }
 
 // NewLabelSet returns a new LabelSet based on the labels provided as a pair number of arguments (key, value, key value ....)
 func NewLabelSet(labels ...string) (LabelSet, error) {
-	if len(labels)%2 != 0 {
-		return LabelSet{}, errors.New("non-pair label set values")
-	}
-
-	set := make(map[string]string)
-	for i := 0; i+1 < len(labels); i += 2 {
-		set[labels[i]] = labels[i+1]
-	}
+	labelSet := pprof.Labels(labels...)
+	innerCtx := pprof.WithLabels(context.Background(), labelSet)
 
 	return LabelSet{
-		inner: &set,
+		innerCtx: innerCtx,
 	}, nil
-}
-
-type labelMap map[string]string
-
-//go:linkname runtimeSetProfLabel runtime/pprof.runtime_setProfLabel
-func runtimeSetProfLabel(labels unsafe.Pointer)
-
-//go:linkname runtimeGetProfLabel runtime/pprof.runtime_getProfLabel
-func runtimeGetProfLabel() unsafe.Pointer
-
-func setGoroutineLabels(labels *labelMap) {
-	runtimeSetProfLabel(unsafe.Pointer(labels))
-}
-
-func getGoroutineLabels() *labelMap {
-	return (*labelMap)(runtimeGetProfLabel())
 }
 
 // PprofDoWithoutContext does the same thing as https://pkg.go.dev/runtime/pprof#Do, but without the allocation resulting
 // from the usage of context values. This function also directly takes a map of labels, instead of incuring allocations
 // when converting from one format (LabelSet) to the other (map).
 func PprofDoWithoutContext(labelSet LabelSet, f func()) {
-	previousLabels := getGoroutineLabels()
-	defer setGoroutineLabels(previousLabels)
-
-	setGoroutineLabels((*labelMap)(labelSet.inner))
+	defer pprof.SetGoroutineLabels(context.Background())
+	pprof.SetGoroutineLabels(labelSet.innerCtx)
 	f()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove the unsafe code used to set the pprof labels around rule evaluation by re-using context with labels attached. This has the benefit of simplifying the code drastically, the performance is similar to the unsafe method (way better than the classical `pprof.Do` anyway)

### Motivation

We are currently getting "shamed" in https://github.com/golang/go/blob/b813e6fd73e0925ca57f5b3ff6b0d991bb2e5aea/src/runtime/proflabel.go#L15 because of this.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->