### PR TITLE
Reduce `idle` quality gate limit to 425MB from 430MB

### DIFF
--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -34,7 +34,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "430.0 MiB"
+      upper_bound: "425.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
This commit tightens the bound on Agent's `idle` memory consumption, stating essentially that the overhead of Agent is no more than 425MB by default.
