### PR TITLE
use Content Length hint to pre-allocate buffer when reading body from sysprobe

### DIFF
--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -123,7 +123,7 @@ func (r *RemoteSysProbeUtil) GetProcStats(pids []int32) (*model.ProcStatsWithPer
 		return nil, fmt.Errorf("proc_stats request failed: Probe Path %s, url: %s, status code: %d", r.path, procStatsURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections
 		return nil, fmt.Errorf("conn request failed: Probe Path %s, url: %s, status code: %d", r.path, connectionsURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (r *RemoteSysProbeUtil) GetNetworkID() (string, error) {
 		return "", fmt.Errorf("network_id request failed: url: %s, status code: %d", networkIDURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -211,7 +211,7 @@ func (r *RemoteSysProbeUtil) GetPing(clientID string, host string, count int, in
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusBadRequest {
-		body, err := io.ReadAll(resp.Body)
+		body, err := readAllResponseBody(resp)
 		if err != nil {
 			return nil, fmt.Errorf("ping request failed: Probe Path %s, url: %s, status code: %d", r.path, pingURL, resp.StatusCode)
 		}
@@ -220,7 +220,7 @@ func (r *RemoteSysProbeUtil) GetPing(clientID string, host string, count int, in
 		return nil, fmt.Errorf("ping request failed: Probe Path %s, url: %s, status code: %d", r.path, pingURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (r *RemoteSysProbeUtil) GetTraceroute(clientID string, host string, port ui
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusBadRequest {
-		body, err := io.ReadAll(resp.Body)
+		body, err := readAllResponseBody(resp)
 		if err != nil {
 			return nil, fmt.Errorf("traceroute request failed: Probe Path %s, url: %s, status code: %d", r.path, tracerouteURL, resp.StatusCode)
 		}
@@ -257,7 +257,7 @@ func (r *RemoteSysProbeUtil) GetTraceroute(clientID string, host string, port ui
 		return nil, fmt.Errorf("traceroute request failed: Probe Path %s, url: %s, status code: %d", r.path, tracerouteURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("conn request failed: Path %s, url: %s, status code: %d", r.path, statsURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readAllResponseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -486,4 +486,23 @@ func (r *RemoteSysProbeUtil) init() error {
 		return fmt.Errorf("remote tracer status check failed: socket %s, url: %s, status code: %d", r.path, statsURL, resp.StatusCode)
 	}
 	return nil
+}
+
+func readAllResponseBody(resp *http.Response) ([]byte, error) {
+	// if we are not able to determine the content length
+	// we read the whole body without pre-allocation
+	if resp.ContentLength <= 0 {
+		return io.ReadAll(resp.Body)
+	}
+
+	// if we know the content length we pre-allocate the buffer
+	var buf bytes.Buffer
+	buf.Grow(int(resp.ContentLength))
+
+	_, err := buf.ReadFrom(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Now that the core process code is running in the core agent, most of the process agent work is spent fetching connections from the system-probe and this is reflected in the amount of allocations done by the process agent. [Example profile](https://app.datadoghq.com/profiling/explorer?query=service%3Aprocess-agent&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_heap_growth_bytes_per_sec&event=AgAAAZLxTUQ7ugO-1gAAAAAAAAAYAAAAAEFaTHhUVWFGQUFCU1FJRktEMDZLY0FBQQAAACQAAAAAMDE5MmYxNGUtMTk3Ny00MTEwLTlhYWMtZmExMzBmMDhiOGQ3&my_code=disabled&profile_type=alloc-size&profileId=AZLxTUaFAABSQIFKD06KcAAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1730623713396&to_ts=1730627313396&live=false).

This PR improves the situation a bit by taking advantage of the Content Length header of system probe responses to pre-allocate the response buffer. 

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->