### PR TITLE
Add jira_component

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -227,6 +227,7 @@ github_labels = ["team/agent-release-management"]
 
 [teams."Dynamic Instrumentation"]
 jira_project = "DEBUG"
+jira_component = "datadog-agent"
 jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "debugger-go"


### PR DESCRIPTION
Dynamic Instrumentation team uses DEBUG JIRA project, where Component field is mandatory for new card creation. Because of that Agent release QA cards generation was failing.

This PR adds the missing field.