### PR TITLE
[CWS] fix `TestConnect` ipv6 tests

### DIFF
--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/net/nettest"
 	"golang.org/x/sys/unix"
 
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,10 @@ func TestConnectEvent(t *testing.T) {
 	})
 
 	t.Run("connect-af-inet6-any-tcp-success", func(t *testing.T) {
+		if !nettest.SupportsIPv6() {
+			t.Skip("IPv6 is not supported")
+		}
+
 		var wg sync.WaitGroup
 		wg.Add(1)
 		defer wg.Wait()
@@ -130,6 +135,10 @@ func TestConnectEvent(t *testing.T) {
 	})
 
 	t.Run("connect-af-inet6-any-udp-success", func(t *testing.T) {
+		if !nettest.SupportsIPv6() {
+			t.Skip("IPv6 is not supported")
+		}
+
 		var wg sync.WaitGroup
 		wg.Add(1)
 		defer wg.Wait()

--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -48,9 +49,14 @@ func TestConnectEvent(t *testing.T) {
 	}
 
 	t.Run("connect-af-inet-any-tcp-success", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		defer wg.Wait()
+
 		done := make(chan struct{})
 		defer close(done)
 		go func() {
+			defer wg.Done()
 			err := bindAndAcceptConnection("tcp", ":4242", done)
 			if err != nil {
 				t.Fatal(err)
@@ -70,9 +76,14 @@ func TestConnectEvent(t *testing.T) {
 	})
 
 	t.Run("connect-af-inet-any-udp-success", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		defer wg.Wait()
+
 		done := make(chan struct{})
 		defer close(done)
 		go func() {
+			defer wg.Done()
 			err := bindAndAcceptConnection("udp", ":4242", done)
 			if err != nil {
 				t.Fatal(err)
@@ -92,9 +103,14 @@ func TestConnectEvent(t *testing.T) {
 	})
 
 	t.Run("connect-af-inet6-any-tcp-success", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		defer wg.Wait()
+
 		done := make(chan struct{})
 		defer close(done)
 		go func() {
+			defer wg.Done()
 			err := bindAndAcceptConnection("tcp", ":4242", done)
 			if err != nil {
 				t.Fatal(err)
@@ -114,9 +130,14 @@ func TestConnectEvent(t *testing.T) {
 	})
 
 	t.Run("connect-af-inet6-any-udp-success", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		defer wg.Wait()
+
 		done := make(chan struct{})
 		defer close(done)
 		go func() {
+			defer wg.Done()
 			err := bindAndAcceptConnection("udp", ":4242", done)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -62,11 +62,7 @@ func runSyscallTesterFunc(ctx context.Context, t *testing.T, path string, args .
 	output, err := sideTester.CombinedOutput()
 
 	if err != nil {
-		t.Error(err)
-		output := string(output)
-		if output != "" {
-			t.Error(output)
-		}
+		t.Fatalf("failed to run syscall tester: %v, output: %s", err, string(output))
 	}
 	return err
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -536,6 +536,7 @@ int test_connect_af_inet(int argc, char** argv) {
     addr.sin_port = htons(4242);
 
     if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(s);
         perror("Failed to connect to port");
         return EXIT_FAILURE;
     }
@@ -582,6 +583,7 @@ int test_connect_af_inet6(int argc, char** argv) {
 
     addr.sin6_port = htons(4242);
     if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(s);
         perror("Failed to connect to port");
         return EXIT_FAILURE;
     }
@@ -601,7 +603,7 @@ int test_connect(int argc, char** argv) {
         return test_connect_af_inet(argc - 1, argv + 1);
     } else if  (!strcmp(addr_family, "AF_INET6")) {
         return test_connect_af_inet6(argc - 1, argv + 1);
-    } 
+    }
     fprintf(stderr, "Specified %s addr_type is not a valid one, try: AF_INET or AF_INET6 \n", addr_family);
     return EXIT_FAILURE;
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the TestConnect tests by:
- checking if ipv6 is supported before running the ipv6 tests
- ensuring the server is closed before running the following test

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->