### PR TITLE
fix(coverage): Prevent hard failure in case of empty file

### DIFF
--- a/tasks/coverage.py
+++ b/tasks/coverage.py
@@ -205,16 +205,22 @@ def _merge_dev_in_main_coverage(main_cov_file: str, dev_cov_file: str) -> None:
     """
     with open(main_cov_file, encoding='utf-8') as main_cov:
         main_cov_lines = main_cov.readlines()
-        main_mode_line = main_cov_lines.pop(0)
     with open(dev_cov_file, encoding='utf-8') as dev_cov:
         dev_cov_lines = dev_cov.readlines()
-        dev_mode_line = dev_cov_lines.pop(0)
 
+    if len(main_cov_lines) == 0:
+        print(f"[{color_message('WARNING', Color.ORANGE)}] Main coverage file {main_cov_file} is empty.")
+        with open(main_cov_file, 'w', encoding='utf-8') as main_cov:
+            main_cov.writelines(dev_cov_lines)
+            return
+
+    main_mode = main_cov_lines.pop(0)
+    dev_mode = dev_cov_lines.pop(0)
     # Check if the mode is the same in both files.
-    if dev_mode_line != main_mode_line:
+    if dev_mode != main_mode:
         raise Exit(
             color_message(
-                f"Error: the mode in the dev coverage file ({dev_mode_line}) is different from the one in the main coverage file {main_mode_line}.",
+                f"Error: the mode in the dev coverage file ({dev_mode}) is different from the one in the main coverage file {main_mode}.",
                 Color.RED,
             ),
             code=1,
@@ -227,7 +233,7 @@ def _merge_dev_in_main_coverage(main_cov_file: str, dev_cov_file: str) -> None:
         if file_path not in browsed_dev_files:
             final_file_lines.append(line)
 
-    final_file_lines = [main_mode_line] + sorted(final_file_lines + dev_cov_lines)
+    final_file_lines = [main_mode] + sorted(final_file_lines + dev_cov_lines)
     with open(main_cov_file, 'w', encoding='utf-8') as main_cov:
         main_cov.writelines(final_file_lines)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adapt the `merge_dev_in_main` method to prevent hard failure when the main file is empty

### Motivation
We sometimes faces [failures](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/690302667#L2634) in coverage uploadm, because some files stored in the cache are empty (in my case it was `pkg/trace/stats/oteltest/coverage.out`.
If such case can happen we might want to prevent such failure to occur

### Describe how to test/QA your changes
No QA but we can monitor we don't have no more occurrence of some logs [here](https://app.datadoghq.com/logs?query=service%3Agitlab-runner%20%22main_mode_line%20%3D%20main_cov_lines.pop%280%29%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1730713475615&to_ts=1730727875615&live=true)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->