### PR TITLE
upgrade(fleet): Add fallbacks to default registries

### DIFF
--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"go.uber.org/multierr"
 	"golang.org/x/net/http2"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
@@ -62,6 +63,17 @@ const (
 const (
 	layerMaxSize        = 3 << 30 // 3GiB
 	extractLayerRetries = 3
+)
+
+var (
+	defaultRegistriesStaging = []string{
+		"docker.io/datadog",
+	}
+	defaultRegistriesProd = []string{
+		"gcr.io/datadoghq",
+		"public.ecr.aws/datadog",
+		"docker.io/datadog",
+	}
 )
 
 // DownloadedPackage is the downloaded package.
@@ -158,6 +170,32 @@ type urlWithKeychain struct {
 	keychain authn.Keychain
 }
 
+// getRefAndKeychains returns the references and their keychains to try in order to download an OCI at the given URL
+func getRefAndKeychains(mainEnv *env.Env, url string) []urlWithKeychain {
+	refAndKeychains := []urlWithKeychain{getRefAndKeychain(mainEnv, url)}
+	defaultRegistries := defaultRegistriesProd
+	if mainEnv.Site == "datad0g.com" {
+		defaultRegistries = defaultRegistriesStaging
+	}
+
+	for _, additionalDefaultRegistry := range defaultRegistries {
+		refAndKeychain := getRefAndKeychain(&env.Env{RegistryOverride: additionalDefaultRegistry}, url)
+		// Deduplicate
+		found := false
+		for _, rk := range refAndKeychains {
+			if rk.ref == refAndKeychain.ref && rk.keychain == refAndKeychain.keychain {
+				found = true
+				break
+			}
+		}
+		if !found {
+			refAndKeychains = append(refAndKeychains, refAndKeychain)
+		}
+	}
+
+	return refAndKeychains
+}
+
 // getRefAndKeychain returns the reference and keychain for the given URL.
 // This function applies potential registry and authentication overrides set either globally or per image.
 func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
@@ -189,17 +227,33 @@ func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
 	}
 }
 
+// downloadRegistry downloads the image from a remote registry.
+// If they are specified, the registry and authentication overrides are applied first.
+// Then we try each registry in the list of default registries in order and return the first successful download.
 func (d *Downloader) downloadRegistry(ctx context.Context, url string) (oci.Image, error) {
-	refAndKeychain := getRefAndKeychain(d.env, url)
-	ref, err := name.ParseReference(refAndKeychain.ref)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse reference: %w", err)
+	var multiErr error
+	for _, refAndKeychain := range getRefAndKeychains(d.env, url) {
+		log.Debugf("Downloading index from %s", refAndKeychain.ref)
+		ref, err := name.ParseReference(refAndKeychain.ref)
+		if err != nil {
+			multiErr = multierr.Append(multiErr, fmt.Errorf("could not parse reference: %w", err))
+			log.Warnf("could not parse reference: %s", err.Error())
+			continue
+		}
+		index, err := remote.Index(
+			ref,
+			remote.WithContext(ctx),
+			remote.WithAuthFromKeychain(refAndKeychain.keychain),
+			remote.WithTransport(httptrace.WrapRoundTripper(d.client.Transport)),
+		)
+		if err != nil {
+			multiErr = multierr.Append(multiErr, fmt.Errorf("could not download image using %s: %w", url, err))
+			log.Warnf("could not download image using %s: %s", url, err.Error())
+			continue
+		}
+		return d.downloadIndex(index)
 	}
-	index, err := remote.Index(ref, remote.WithContext(ctx), remote.WithAuthFromKeychain(refAndKeychain.keychain), remote.WithTransport(httptrace.WrapRoundTripper(d.client.Transport)))
-	if err != nil {
-		return nil, fmt.Errorf("could not download image: %w", err)
-	}
-	return d.downloadIndex(index)
+	return nil, fmt.Errorf("could not download image from any registry: %w", multiErr)
 }
 
 func (d *Downloader) downloadFile(path string) (oci.Image, error) {


### PR DESCRIPTION
### What does this PR do?
Adds registries fallbacks: custom (if any), gcr, ecr, docker -- in that order.

The registry is chosen when downloading the index. If we can't download the index on a registry (at most two HTTP calls), then we try the next one. Once the index is downloaded, the registry used is validated and will be the one used for the rest of the download.

### Motivation
Reduce the number of network errors

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->