### PR TITLE
Do not disable GOWORK and log when completing

### DIFF
--- a/tasks/libs/common/go_workspaces.py
+++ b/tasks/libs/common/go_workspaces.py
@@ -22,6 +22,10 @@ def handle_go_work():
         # go work is explicitly set
         return
 
+    if len(sys.argv) >= 1 and sys.argv[1] == "--complete":
+        # GOWORK=off is not needed when completing
+        return
+
     try:
         # find the go.work file
         # according to the blog https://go.dev/blog/get-familiar-with-workspaces :


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Do not set GOWORK=off when running `inv --complete`.

It means in particular:
- do not run commands to determine if there is a `go.work` enabled
- do not log that `go.work` was disabled

### Motivation
Mainly avoid getting the warning log in the middle of the completion, and also minimize time to complete.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->