### PR TITLE
[OTEL-2190] Try making otel flare e2e test stable again

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -81,7 +81,7 @@ func (s *minimalTestSuite) TestOTelAgentInstalled() {
 	utils.TestOTelAgentInstalled(s)
 }
 
-func (s *minimalTestSuite) TestOTelFlareExtensionRespsonse() {
+func (s *minimalTestSuite) TestOTelFlareExtensionResponse() {
 	utils.TestOTelFlareExtensionRespsonse(s, minimalProvidedConfig, minimalFullConfig, minimalSources)
 }
 

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -81,6 +81,10 @@ func (s *minimalTestSuite) TestOTelAgentInstalled() {
 	utils.TestOTelAgentInstalled(s)
 }
 
-func (s *minimalTestSuite) TestOTelFlare() {
-	utils.TestOTelFlare(s, minimalProvidedConfig, minimalFullConfig, minimalSources)
+func (s *minimalTestSuite) TestOTelFlareExtensionRespsonse() {
+	utils.TestOTelFlareExtensionRespsonse(s, minimalProvidedConfig, minimalFullConfig, minimalSources)
+}
+
+func (s *minimalTestSuite) TestOTelFlareFiles() {
+	utils.TestOTelFlareFiles(s)
 }

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -82,7 +82,7 @@ func (s *minimalTestSuite) TestOTelAgentInstalled() {
 }
 
 func (s *minimalTestSuite) TestOTelFlareExtensionResponse() {
-	utils.TestOTelFlareExtensionRespsonse(s, minimalProvidedConfig, minimalFullConfig, minimalSources)
+	utils.TestOTelFlareExtensionResponse(s, minimalProvidedConfig, minimalFullConfig, minimalSources)
 }
 
 func (s *minimalTestSuite) TestOTelFlareFiles() {

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -54,8 +54,8 @@ var otelFlareFilesZpages = []string{
 	"otel/otel-flare/zpages/dd-autoconfigured_debug_servicez.dat",
 }
 
-// TestOTelFlareExtensionRespsonse tests that the OTel Agent DD flare extension returns expected responses
-func TestOTelFlareExtensionRespsonse(s OTelTestSuite, providedCfg string, fullCfg string, sources string) {
+// TestOTelFlareExtensionResponse tests that the OTel Agent DD flare extension returns expected responses
+func TestOTelFlareExtensionResponse(s OTelTestSuite, providedCfg string, fullCfg string, sources string) {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	require.NoError(s.T(), err)
 	agent := getAgentPod(s)


### PR DESCRIPTION
### What does this PR do?

Another attempt to make otel flare e2e test stable: cache the flare response and only update the cache if new flares are being returned.