### PR TITLE
[SMP] Update Quality Gate experiment

### DIFF
--- a/test/regression/cases/idle/experiment.yaml
+++ b/test/regression/cases/idle/experiment.yaml
@@ -30,6 +30,7 @@ target:
     DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:idle
 
 checks:
+  # Note: quality gates will stop using this experiment in the future in favor of quality_gate_idle.
   - name: memory_usage
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:

--- a/test/regression/cases/idle_all_features/experiment.yaml
+++ b/test/regression/cases/idle_all_features/experiment.yaml
@@ -43,6 +43,7 @@ target:
     DD_PROFILING_WAIT_PROFILE: true
 
 checks:
+  # Note: quality gates will stop using this experiment in the future in favor of quality_gate_idle_all_features.
   - name: memory_usage
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -34,7 +34,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "430.0 MiB"
+      upper_bound: "425.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
### What does this PR do?

Follow-up from https://github.com/DataDog/datadog-agent/pull/30687. Update the idle quality gate and add notes to the idle experiments. We plan to switch quality gate reports to the `quality_gate` prefixed experiments in the next week or two.