### PR TITLE
[NDMII-3159] Refactor GoSNMP logic into snmpparse

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -9,11 +9,6 @@ package snmp
 import (
 	"errors"
 	"fmt"
-	"net"
-	"os"
-	"strconv"
-	"time"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/aggregator"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
@@ -30,65 +25,24 @@ import (
 	"github.com/DataDog/datadog-agent/comp/serializer/compression/compressionimpl"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	snmpscanfx "github.com/DataDog/datadog-agent/comp/snmpscan/fx"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/snmplog"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"net"
+	"os"
+	"strconv"
 
-	"github.com/gosnmp/gosnmp"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
 
 const (
-	defaultPort                    = 161
-	defaultCommunityString         = "public"
 	defaultTimeout                 = 10 // Timeout better suited to walking
 	defaultRetries                 = 3
 	defaultUseUnconnectedUDPSocket = false
 )
 
-var authOpts = NewOptions(OptPairs[gosnmp.SnmpV3AuthProtocol]{
-	{"", gosnmp.NoAuth},
-	{"MD5", gosnmp.MD5},
-	{"SHA", gosnmp.SHA},
-	{"SHA-224", gosnmp.SHA224},
-	{"SHA-256", gosnmp.SHA256},
-	{"SHA-384", gosnmp.SHA384},
-	{"SHA-512", gosnmp.SHA512},
-})
-
-var privOpts = NewOptions(OptPairs[gosnmp.SnmpV3PrivProtocol]{
-	{"", gosnmp.NoPriv},
-	{"DES", gosnmp.DES},
-	{"AES", gosnmp.AES},
-	{"AES192", gosnmp.AES192},
-	{"AES192C", gosnmp.AES192C},
-	{"AES256", gosnmp.AES256},
-	{"AES256C", gosnmp.AES256C},
-})
-
-var versionOpts = NewOptions(OptPairs[gosnmp.SnmpVersion]{
-	{"1", gosnmp.Version1},
-	{"2c", gosnmp.Version2c},
-	{"3", gosnmp.Version3},
-})
-
-var levelOpts = NewOptions(OptPairs[gosnmp.SnmpV3MsgFlags]{
-	{"noAuthNoPriv", gosnmp.NoAuthNoPriv},
-	{"authNoPriv", gosnmp.AuthNoPriv},
-	{"authPriv", gosnmp.AuthPriv},
-})
-
 // argsType is an alias so we can inject the args via fx.
 type argsType []string
-
-type snmpConnectionParams struct {
-	// embed a SNMPConfig because it's all the same fields anyway
-	snmpparse.SNMPConfig
-	// fields that aren't part of snmpparse.SNMPConfig
-	SecurityLevel           string
-	UseUnconnectedUDPSocket bool
-}
 
 // configErr wraps any error caused by invalid configuration.
 // If the main script returns a configErr it will print the usage string along
@@ -115,7 +69,7 @@ func confErrf(msg string, args ...any) configErr {
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	connParams := &snmpConnectionParams{}
+	connParams := &snmpparse.SNMPConfig{}
 	snmpCmd := &cobra.Command{
 		Use:   "snmp",
 		Short: "Snmp tools",
@@ -156,18 +110,22 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return nil
 		},
 	}
-	snmpWalkCmd.Flags().VarP(versionOpts.Flag(&connParams.Version), "snmp-version", "v", fmt.Sprintf("Specify SNMP version to use (%s)", versionOpts.OptsStr()))
+	snmpWalkCmd.Flags().VarP(Flag(&snmpparse.VersionOpts, &connParams.Version), "snmp-version", "v",
+		fmt.Sprintf("Specify SNMP version to use (%s)", snmpparse.VersionOpts.OptsStr()))
 
 	// snmp v1 or v2c specific
 	snmpWalkCmd.Flags().StringVarP(&connParams.CommunityString, "community-string", "C", "", "Set the community string")
 
 	// snmp v3 specific
-	snmpWalkCmd.Flags().VarP(authOpts.Flag(&connParams.AuthProtocol), "auth-protocol", "a", fmt.Sprintf("Set authentication protocol (%s)", authOpts.OptsStr()))
+	snmpWalkCmd.Flags().VarP(Flag(&snmpparse.AuthOpts, &connParams.AuthProtocol), "auth-protocol", "a",
+		fmt.Sprintf("Set authentication protocol (%s)", snmpparse.AuthOpts.OptsStr()))
 	snmpWalkCmd.Flags().StringVarP(&connParams.AuthKey, "auth-key", "A", "", "Set authentication protocol pass phrase")
-	snmpWalkCmd.Flags().VarP(levelOpts.Flag(&connParams.SecurityLevel), "security-level", "l", fmt.Sprintf("Set security level (%s)", levelOpts.OptsStr()))
+	snmpWalkCmd.Flags().VarP(Flag(&snmpparse.LevelOpts, &connParams.SecurityLevel), "security-level", "l",
+		fmt.Sprintf("Set security level (%s)", snmpparse.LevelOpts.OptsStr()))
 	snmpWalkCmd.Flags().StringVarP(&connParams.Context, "context", "N", "", "Set context name")
 	snmpWalkCmd.Flags().StringVarP(&connParams.Username, "user-name", "u", "", "Set security name")
-	snmpWalkCmd.Flags().VarP(privOpts.Flag(&connParams.PrivProtocol), "priv-protocol", "x", fmt.Sprintf("Set privacy protocol (%s)", privOpts.OptsStr()))
+	snmpWalkCmd.Flags().VarP(Flag(&snmpparse.PrivOpts, &connParams.PrivProtocol), "priv-protocol", "x",
+		fmt.Sprintf("Set privacy protocol (%s)", snmpparse.PrivOpts.OptsStr()))
 	snmpWalkCmd.Flags().StringVarP(&connParams.PrivKey, "priv-key", "X", "", "Set privacy protocol pass phrase")
 
 	// general communication options
@@ -214,18 +172,22 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		},
 	}
 	// TODO is there a way to merge these flags with snmpWalkCmd flags, without cobra changing the docs to mark them as "global flags"?
-	snmpScanCmd.Flags().VarP(versionOpts.Flag(&connParams.Version), "snmp-version", "v", fmt.Sprintf("Specify SNMP version to use (%s)", versionOpts.OptsStr()))
+	snmpScanCmd.Flags().VarP(Flag(&snmpparse.VersionOpts, &connParams.Version), "snmp-version", "v",
+		fmt.Sprintf("Specify SNMP version to use (%s)", snmpparse.VersionOpts.OptsStr()))
 
 	// snmp v1 or v2c specific
 	snmpScanCmd.Flags().StringVarP(&connParams.CommunityString, "community-string", "C", "", "Set the community string")
 
 	// snmp v3 specific
-	snmpScanCmd.Flags().VarP(authOpts.Flag(&connParams.AuthProtocol), "auth-protocol", "a", fmt.Sprintf("Set authentication protocol (%s)", authOpts.OptsStr()))
+	snmpScanCmd.Flags().VarP(Flag(&snmpparse.AuthOpts, &connParams.AuthProtocol), "auth-protocol", "a",
+		fmt.Sprintf("Set authentication protocol (%s)", snmpparse.AuthOpts.OptsStr()))
 	snmpScanCmd.Flags().StringVarP(&connParams.AuthKey, "auth-key", "A", "", "Set authentication protocol pass phrase")
-	snmpScanCmd.Flags().VarP(levelOpts.Flag(&connParams.SecurityLevel), "security-level", "l", fmt.Sprintf("Set security level (%s)", levelOpts.OptsStr()))
+	snmpScanCmd.Flags().VarP(Flag(&snmpparse.LevelOpts, &connParams.SecurityLevel), "security-level", "l",
+		fmt.Sprintf("Set security level (%s)", snmpparse.LevelOpts.OptsStr()))
 	snmpScanCmd.Flags().StringVarP(&connParams.Context, "context", "N", "", "Set context name")
 	snmpScanCmd.Flags().StringVarP(&connParams.Username, "user-name", "u", "", "Set security name")
-	snmpScanCmd.Flags().VarP(privOpts.Flag(&connParams.PrivProtocol), "priv-protocol", "x", fmt.Sprintf("Set privacy protocol (%s)", privOpts.OptsStr()))
+	snmpScanCmd.Flags().VarP(Flag(&snmpparse.PrivOpts, &connParams.PrivProtocol), "priv-protocol", "x",
+		fmt.Sprintf("Set privacy protocol (%s)", snmpparse.PrivOpts.OptsStr()))
 	snmpScanCmd.Flags().StringVarP(&connParams.PrivKey, "priv-key", "X", "", "Set privacy protocol pass phrase")
 
 	// general communication options
@@ -268,7 +230,7 @@ func getParamsFromAgent(deviceIP string, conf config.Component) (*snmpparse.SNMP
 	return nil, fmt.Errorf("agent has no SNMP config for IP %s", deviceIP)
 }
 
-func setDefaultsFromAgent(connParams *snmpConnectionParams, conf config.Component) error {
+func setDefaultsFromAgent(connParams *snmpparse.SNMPConfig, conf config.Component) error {
 	agentParams, agentError := getParamsFromAgent(connParams.IPAddress, conf)
 	if agentError != nil {
 		return agentError
@@ -309,89 +271,7 @@ func setDefaultsFromAgent(connParams *snmpConnectionParams, conf config.Componen
 	return nil
 }
 
-// newSNMP validates connection parameters and builds a GoSNMP from them.
-func newSNMP(connParams *snmpConnectionParams, logger log.Component) (*gosnmp.GoSNMP, error) {
-	// Communication options check
-	if connParams.Timeout == 0 {
-		return nil, fmt.Errorf("timeout cannot be 0")
-	}
-	var version gosnmp.SnmpVersion
-	var ok bool
-	if connParams.Version == "" {
-		// Assume v3 if a username was set, otherwise assume v2c.
-		if connParams.Username != "" {
-			version = gosnmp.Version3
-		} else {
-			version = gosnmp.Version2c
-		}
-	} else if version, ok = versionOpts.getVal(connParams.Version); !ok {
-		return nil, fmt.Errorf("SNMP version %q not supported; must be %s", connParams.Version, versionOpts.OptsStr())
-	}
-
-	// Set default community string if version 1 or 2c and no given community string
-	if version != gosnmp.Version3 && connParams.CommunityString == "" {
-		connParams.CommunityString = defaultCommunityString
-	}
-
-	// Authentication check
-	if version == gosnmp.Version3 && connParams.Username == "" {
-		return nil, fmt.Errorf("username is required for snmp v3")
-	}
-
-	port := connParams.Port
-	if port == 0 {
-		port = defaultPort
-	}
-
-	securityParams := &gosnmp.UsmSecurityParameters{}
-	var msgFlags gosnmp.SnmpV3MsgFlags
-	// Set v3 security parameters
-	if version == gosnmp.Version3 {
-		securityParams.UserName = connParams.Username
-		securityParams.AuthenticationPassphrase = connParams.AuthKey
-		securityParams.PrivacyPassphrase = connParams.PrivKey
-
-		if securityParams.AuthenticationProtocol, ok = authOpts.getVal(connParams.AuthProtocol); !ok {
-			return nil, fmt.Errorf("authentication protocol %q not supported; must be %s", connParams.AuthProtocol, authOpts.OptsStr())
-		}
-
-		if securityParams.PrivacyProtocol, ok = privOpts.getVal(connParams.PrivProtocol); !ok {
-			return nil, fmt.Errorf("privacy protocol %q not supported; must be %s", connParams.PrivProtocol, privOpts.OptsStr())
-		}
-
-		if connParams.SecurityLevel == "" {
-			msgFlags = gosnmp.NoAuthNoPriv
-			if connParams.PrivKey != "" {
-				msgFlags = gosnmp.AuthPriv
-			} else if connParams.AuthKey != "" {
-				msgFlags = gosnmp.AuthNoPriv
-			}
-		} else {
-			var ok bool // can't use := below because it'll make a new msgFlags instead of setting the one in the parent scope.
-			if msgFlags, ok = levelOpts.getVal(connParams.SecurityLevel); !ok {
-				return nil, fmt.Errorf("security level %q not supported; must be %s", connParams.SecurityLevel, levelOpts.OptsStr())
-			}
-		}
-	}
-	// Set SNMP parameters
-	return &gosnmp.GoSNMP{
-		Target:                  connParams.IPAddress,
-		Port:                    port,
-		Community:               connParams.CommunityString,
-		Transport:               "udp",
-		Version:                 version,
-		Timeout:                 time.Duration(connParams.Timeout * int(time.Second)),
-		Retries:                 connParams.Retries,
-		SecurityModel:           gosnmp.UserSecurityModel,
-		ContextName:             connParams.Context,
-		MsgFlags:                msgFlags,
-		SecurityParameters:      securityParams,
-		UseUnconnectedUDPSocket: connParams.UseUnconnectedUDPSocket,
-		Logger:                  gosnmp.NewLogger(snmplog.New(logger)),
-	}, nil
-}
-
-func scanDevice(connParams *snmpConnectionParams, args argsType, snmpScanner snmpscan.Component, conf config.Component, logger log.Component) error {
+func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, logger log.Component) error {
 	// Parse args
 	if len(args) == 0 {
 		return confErrf("missing argument: IP address")
@@ -406,10 +286,10 @@ func scanDevice(connParams *snmpConnectionParams, args argsType, snmpScanner snm
 	if agentErr != nil {
 		// Warn that we couldn't contact the agent, but keep going in case the
 		// user provided enough arguments to do this anyway.
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", agentErr)
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: %v\n", agentErr)
 	}
 	// Establish connection
-	snmp, err := newSNMP(connParams, logger)
+	snmp, err := snmpparse.NewSNMP(connParams, logger)
 	if err != nil {
 		// newSNMP only returns config errors, so any problem is a usage error
 		return configErr{err}
@@ -428,7 +308,7 @@ func scanDevice(connParams *snmpConnectionParams, args argsType, snmpScanner snm
 }
 
 // snmpWalk prints every SNMP value, in the style of the unix snmpwalk command.
-func snmpWalk(connParams *snmpConnectionParams, args argsType, snmpScanner snmpscan.Component, conf config.Component, logger log.Component) error {
+func snmpWalk(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, logger log.Component) error {
 	// Parse args
 	if len(args) == 0 {
 		return confErrf("missing argument: IP address")
@@ -447,10 +327,10 @@ func snmpWalk(connParams *snmpConnectionParams, args argsType, snmpScanner snmps
 	if agentErr != nil {
 		// Warn that we couldn't contact the agent, but keep going in case the
 		// user provided enough arguments to do this anyway.
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", agentErr)
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: %v\n", agentErr)
 	}
 	// Establish connection
-	snmp, err := newSNMP(connParams, logger)
+	snmp, err := snmpparse.NewSNMP(connParams, logger)
 	if err != nil {
 		// newSNMP only returns config errors, so any problem is a usage error
 		return configErr{err}
@@ -458,7 +338,7 @@ func snmpWalk(connParams *snmpConnectionParams, args argsType, snmpScanner snmps
 	if err := snmp.Connect(); err != nil {
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
-	defer snmp.Conn.Close()
+	defer func() { _ = snmp.Conn.Close() }()
 
 	err = snmpScanner.RunSnmpWalk(snmp, oid)
 

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -6,6 +6,7 @@
 package snmp
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestWalkCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "-v", "3", "-r", "10"},
 		snmpWalk,
-		func(cliParams *snmpConnectionParams, args argsType) {
+		func(cliParams *snmpparse.SNMPConfig, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
@@ -32,7 +33,7 @@ func TestWalkCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "--use-unconnected-udp-socket"},
 		snmpWalk,
-		func(cliParams *snmpConnectionParams, args argsType) {
+		func(cliParams *snmpparse.SNMPConfig, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})
@@ -44,7 +45,7 @@ func TestScanCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "scan", "1.2.3.4", "-v", "3", "-r", "10"},
 		scanDevice,
-		func(cliParams *snmpConnectionParams, args argsType) {
+		func(cliParams *snmpparse.SNMPConfig, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
@@ -55,7 +56,7 @@ func TestScanCommand(t *testing.T) {
 		Commands(&command.GlobalParams{}),
 		[]string{"snmp", "scan", "1.2.3.4", "--use-unconnected-udp-socket"},
 		scanDevice,
-		func(cliParams *snmpConnectionParams, args argsType) {
+		func(cliParams *snmpparse.SNMPConfig, args argsType) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})

--- a/cmd/agent/subcommands/snmp/optionsflag.go
+++ b/cmd/agent/subcommands/snmp/optionsflag.go
@@ -7,79 +7,22 @@ package snmp
 
 import (
 	"fmt"
-	"strings"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 )
 
-// OptPairs is just a useful type alias to avoid writing this out multiple times.
-type OptPairs[T any] []struct {
-	key string
-	val T
-}
-
-// Options represents an ordered map of choices
-type Options[T any] struct {
-	Options map[string]T
-	Order   []string
-}
-
-// OptsStr provides a '|'-delimited list of all nonempty options.
-func (o Options[T]) OptsStr() string {
-	var keys []string
-	for _, k := range o.Order {
-		if k == "" {
-			continue
-		}
-		keys = append(keys, k)
-	}
-	return strings.Join(keys, "|")
-}
-
-// getOpt returns the key that matches choice, case-insensitively.
-func (o Options[T]) getOpt(choice string) (string, bool) {
-	choice = strings.ToLower(choice)
-	for opt := range o.Options {
-		if choice == strings.ToLower(opt) {
-			return opt, true
-		}
-	}
-	return "", false
-}
-
-// getVal returns the value whose key matches choice, case-insensitively.
-func (o Options[T]) getVal(choice string) (T, bool) {
-	if key, ok := o.getOpt(choice); ok {
-		return o.Options[key], true
-	}
-	// return a zero-value T
-	var t T
-	return t, false
-}
-
 // Flag creates a flag using these options and storing the selected choice in target.
-func (o Options[T]) Flag(target *string) OptionsFlag[T] {
-	return OptionsFlag[T]{o, target, "option"}
+func Flag[T any](options *snmpparse.Options[T], target *string) OptionsFlag[T] {
+	return OptionsFlag[T]{options, target, "option"}
 }
 
 // TypedFlag is the same as Flag but lets you customize how the type of flag is shown in the help.
-func (o Options[T]) TypedFlag(target *string, typeName string) OptionsFlag[T] {
-	return OptionsFlag[T]{o, target, typeName}
-}
-
-// NewOptions creates a new Options object from a set of pairs.
-// We don't just create one directly from a map because map iteration order is random.
-func NewOptions[T any](pairs OptPairs[T]) Options[T] {
-	var order []string
-	opts := make(map[string]T)
-	for _, pair := range pairs {
-		order = append(order, pair.key)
-		opts[pair.key] = pair.val
-	}
-	return Options[T]{opts, order}
+func TypedFlag[T any](options *snmpparse.Options[T], target *string, typeName string) OptionsFlag[T] {
+	return OptionsFlag[T]{options, target, typeName}
 }
 
 // OptionsFlag is an implementation of pflag.Value that complains when set to an invalid option.
 type OptionsFlag[T any] struct {
-	opts     Options[T]
+	opts     *snmpparse.Options[T]
 	value    *string
 	typeName string
 }
@@ -94,7 +37,7 @@ func (a OptionsFlag[T]) String() string {
 
 // Set sets the value, returning an error if the given choice isn't valid.
 func (a OptionsFlag[T]) Set(p string) error {
-	if opt, ok := a.opts.getOpt(p); ok {
+	if opt, ok := a.opts.GetOpt(p); ok {
 		*a.value = opt
 		return nil
 	}

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -10,11 +10,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	yaml "gopkg.in/yaml.v2"
 	"net"
 	"net/url"
 	"reflect"
-
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/viper"
 
@@ -46,6 +45,10 @@ type SNMPConfig struct {
 	Context      string `yaml:"context_name"`
 	// network
 	NetAddress string `yaml:"network_address"`
+	// These are omitted from the yaml because we don't let users configure
+	// them, but there are cases where we use them (e.g. the snmpwalk command)
+	SecurityLevel           string `yaml:"-"`
+	UseUnconnectedUDPSocket bool   `yaml:"-"`
 }
 
 // SetDefault sets the standard default config values

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -29,22 +29,22 @@ import (
 // integration.
 type SNMPConfig struct {
 
-	//General
+	// General
 	IPAddress string `yaml:"ip_address"`
 	Port      uint16 `yaml:"port"`
 	Version   string `yaml:"snmp_version"`
 	Timeout   int    `yaml:"timeout"`
 	Retries   int    `yaml:"retries"`
-	//v1 &2
+	// v1 &2
 	CommunityString string `yaml:"community_string"`
-	//v3
+	// v3
 	Username     string `yaml:"user"`
 	AuthProtocol string `yaml:"authProtocol"`
 	AuthKey      string `yaml:"authKey"`
 	PrivProtocol string `yaml:"privProtocol"`
 	PrivKey      string `yaml:"privKey"`
 	Context      string `yaml:"context_name"`
-	//network
+	// network
 	NetAddress string `yaml:"network_address"`
 }
 
@@ -60,8 +60,8 @@ func SetDefault(sc *SNMPConfig) {
 // ParseConfigSnmp extracts all SNMPConfigs from an autodiscovery config.
 // Any loading errors are logged but not returned.
 func ParseConfigSnmp(c integration.Config) []SNMPConfig {
-	//an array containing all the snmp instances
-	snmpconfigs := []SNMPConfig{}
+	// an array containing all the snmp instances
+	var snmpconfigs []SNMPConfig
 
 	for _, inst := range c.Instances {
 		instance := SNMPConfig{}
@@ -78,8 +78,8 @@ func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 }
 
 func parseConfigSnmpMain(conf config.Component) ([]SNMPConfig, error) {
-	snmpconfigs := []SNMPConfig{}
-	configs := []snmplistener.Config{}
+	var snmpconfigs []SNMPConfig
+	var configs []snmplistener.Config
 	opt := viper.DecodeHook(
 		func(rf reflect.Kind, rt reflect.Kind, data interface{}) (interface{}, error) {
 			// Turn an array into a map for ignored addresses
@@ -96,8 +96,8 @@ func parseConfigSnmpMain(conf config.Component) ([]SNMPConfig, error) {
 			return newData, nil
 		},
 	)
-	//the UnmarshalKey stores the result in mapstructures while the snmpconfig is in yaml
-	//so for each result of the Unmarshal key we store the result in a tmp SNMPConfig{} object
+	// the UnmarshalKey stores the result in mapstructures while the snmpconfig is in yaml
+	// so for each result of the Unmarshal key we store the result in a tmp SNMPConfig{} object
 	if conf.IsSet("network_devices.autodiscovery.configs") {
 		err := conf.UnmarshalKey("network_devices.autodiscovery.configs", &configs, opt)
 		if err != nil {
@@ -162,18 +162,18 @@ func GetConfigCheckSnmp(conf config.Component) ([]SNMPConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	//Store the SNMP config in an array (snmpconfigs)
-	//c is of type config while the cr is the config check response including the instances
-	snmpconfigs := []SNMPConfig{}
+	// Store the SNMP config in an array (snmpConfigs)
+	// c is of type config while the cr is the config check response including the instances
+	var snmpConfigs []SNMPConfig
 	for _, c := range cr.Configs {
 		if c.Name == "snmp" {
-			snmpconfigs = append(snmpconfigs, ParseConfigSnmp(c)...)
+			snmpConfigs = append(snmpConfigs, ParseConfigSnmp(c)...)
 		}
 	}
 	snmpconfigMain, _ := parseConfigSnmpMain(conf)
-	snmpconfigs = append(snmpconfigs, snmpconfigMain...)
+	snmpConfigs = append(snmpConfigs, snmpconfigMain...)
 
-	return snmpconfigs, nil
+	return snmpConfigs, nil
 
 }
 
@@ -183,27 +183,27 @@ func GetConfigCheckSnmp(conf config.Component) ([]SNMPConfig, error) {
 // subnet config will be returned. If there are no matches, this
 // will return an empty SNMPConfig.
 func GetIPConfig(ipAddress string, SnmpConfigList []SNMPConfig) SNMPConfig {
-	ipAddressConfigs := []SNMPConfig{}
-	netAddressConfigs := []SNMPConfig{}
+	var ipAddressConfigs []SNMPConfig
+	var netAddressConfigs []SNMPConfig
 
-	//split the SnmpConfigList to get the IP addresses separated from
-	//the network addresses
-	for _, snmpconfig := range SnmpConfigList {
-		if snmpconfig.IPAddress != "" {
-			ipAddressConfigs = append(ipAddressConfigs, snmpconfig)
+	// split the SnmpConfigList to get the IP addresses separated from
+	// the network addresses
+	for _, snmpConfig := range SnmpConfigList {
+		if snmpConfig.IPAddress != "" {
+			ipAddressConfigs = append(ipAddressConfigs, snmpConfig)
 		}
-		if snmpconfig.NetAddress != "" {
-			netAddressConfigs = append(netAddressConfigs, snmpconfig)
+		if snmpConfig.NetAddress != "" {
+			netAddressConfigs = append(netAddressConfigs, snmpConfig)
 		}
 	}
 
-	//check if the ip address is explicitly mentioned
+	// check if the ip address is explicitly mentioned
 	for _, snmpIPconfig := range ipAddressConfigs {
 		if snmpIPconfig.IPAddress == ipAddress {
 			return snmpIPconfig
 		}
 	}
-	//check if the ip address is a part of a network/subnet
+	// check if the ip address is a part of a network/subnet
 	for _, snmpNetConfig := range netAddressConfigs {
 		_, subnet, err := net.ParseCIDR(snmpNetConfig.NetAddress)
 		if err != nil {

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -20,13 +20,13 @@ import (
 )
 
 func TestOneInstance(t *testing.T) {
-	//define the input
+	// define the input
 	type Data = integration.Data
 	input := integration.Config{
 		Name:      "snmp",
 		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":161,\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":60,\"retries\":3}")},
 	}
-	//define the output
+	// define the output
 	Exoutput := []SNMPConfig{
 		{
 			Version:         "2",
@@ -41,13 +41,13 @@ func TestOneInstance(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	//define the input
+	// define the input
 	type Data = integration.Data
 	input := integration.Config{
 		Name:      "snmp",
 		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\"}")},
 	}
-	//define the output
+	// define the output
 	Exoutput := []SNMPConfig{
 		{
 			Version:   "",
@@ -60,14 +60,14 @@ func TestDefaultSet(t *testing.T) {
 	assertSNMP(t, input, Exoutput)
 }
 func TestSeveralInstances(t *testing.T) {
-	//define the input
+	// define the input
 	type Data = integration.Data
 	input := integration.Config{
 		Name: "snmp",
 		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"port\":161,\"community_string\":\"password\",\"snmp_version\":\"2\",\"timeout\":60,\"retries\":3}"),
 			Data("{\"ip_address\":\"98.6.18.159\",\"port\":162,\"community_string\":\"drowssap\",\"snmp_version\":\"2\",\"timeout\":30,\"retries\":5}")},
 	}
-	//define the output
+	// define the output
 	Exoutput := []SNMPConfig{
 		{
 			Version:         "2",
@@ -176,7 +176,7 @@ func TestGetSNMPConfigNetwork(t *testing.T) {
 }
 
 func TestGetSNMPConfigNet(t *testing.T) {
-	//if the ip address is a part of network but alos is defined indivudualy
+	// if the ip address is a part of network but alos is defined indivudualy
 	// the ip_address field should be the one that works
 	IPList := []SNMPConfig{
 		{
@@ -218,7 +218,7 @@ func TestGetSNMPConfigNet(t *testing.T) {
 }
 
 func TestGetSNMPConfigNoAddress(t *testing.T) {
-	//if the ip address doesn't match anything
+	// if the ip address doesn't match anything
 	IPList := []SNMPConfig{
 		{
 			Version:         "2",
@@ -251,8 +251,8 @@ func TestGetSNMPConfigNoAddress(t *testing.T) {
 
 }
 func TestGetSNMPConfigEmpty(t *testing.T) {
-	//if the snmp configuration is empty
-	IPList := []SNMPConfig{}
+	// if the snmp configuration is empty
+	var IPList []SNMPConfig
 	input := "192.168.6.4"
 	Exoutput := SNMPConfig{}
 	assertIP(t, input, IPList, Exoutput)
@@ -260,7 +260,7 @@ func TestGetSNMPConfigEmpty(t *testing.T) {
 }
 
 func TestGetSNMPConfigDefault(t *testing.T) {
-	//check if the default setter is valid
+	// check if the default setter is valid
 	input := SNMPConfig{}
 	SetDefault(&input)
 	Exoutput := SNMPConfig{

--- a/pkg/snmp/snmpparse/constants.go
+++ b/pkg/snmp/snmpparse/constants.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmpparse
+
+import "github.com/gosnmp/gosnmp"
+
+const (
+	// DefaultPort is the standard SNMP port
+	DefaultPort = 161
+	// DefaultCommunityString is the default on most v2 implementations
+	DefaultCommunityString = "public"
+)
+
+// AuthOpts maps string names to gosnmp auth protocols
+var AuthOpts = NewOptions(OptPairs[gosnmp.SnmpV3AuthProtocol]{
+	{"", gosnmp.NoAuth},
+	{"MD5", gosnmp.MD5},
+	{"SHA", gosnmp.SHA},
+	{"SHA-224", gosnmp.SHA224},
+	{"SHA-256", gosnmp.SHA256},
+	{"SHA-384", gosnmp.SHA384},
+	{"SHA-512", gosnmp.SHA512},
+})
+
+// PrivOpts maps string names to gosnmp privacy protocols
+var PrivOpts = NewOptions(OptPairs[gosnmp.SnmpV3PrivProtocol]{
+	{"", gosnmp.NoPriv},
+	{"DES", gosnmp.DES},
+	{"AES", gosnmp.AES},
+	{"AES192", gosnmp.AES192},
+	{"AES192C", gosnmp.AES192C},
+	{"AES256", gosnmp.AES256},
+	{"AES256C", gosnmp.AES256C},
+})
+
+// VersionOpts maps string names to gosnmp versions
+var VersionOpts = NewOptions(OptPairs[gosnmp.SnmpVersion]{
+	{"1", gosnmp.Version1},
+	{"2c", gosnmp.Version2c},
+	{"3", gosnmp.Version3},
+})
+
+// LevelOpts maps string names to gosnmp auth levels
+var LevelOpts = NewOptions(OptPairs[gosnmp.SnmpV3MsgFlags]{
+	{"noAuthNoPriv", gosnmp.NoAuthNoPriv},
+	{"authNoPriv", gosnmp.AuthNoPriv},
+	{"authPriv", gosnmp.AuthPriv},
+})

--- a/pkg/snmp/snmpparse/gosnmp.go
+++ b/pkg/snmp/snmpparse/gosnmp.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmpparse
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/snmptraps/snmplog"
+	"github.com/gosnmp/gosnmp"
+	"time"
+)
+
+// NewSNMP validates an SNMPConfig and builds a GoSNMP from it.
+func NewSNMP(conf *SNMPConfig, logger log.Component) (*gosnmp.GoSNMP, error) {
+	// Communication options check
+	if conf.Timeout == 0 {
+		return nil, fmt.Errorf("timeout cannot be 0")
+	}
+	var version gosnmp.SnmpVersion
+	var ok bool
+	if conf.Version == "" {
+		// Assume v3 if a username was set, otherwise assume v2c.
+		if conf.Username != "" {
+			version = gosnmp.Version3
+		} else {
+			version = gosnmp.Version2c
+		}
+	} else if version, ok = VersionOpts.GetVal(conf.Version); !ok {
+		return nil, fmt.Errorf("SNMP version %q not supported; must be %s", conf.Version, VersionOpts.OptsStr())
+	}
+
+	// Set default community string if version 1 or 2c and no given community string
+	if version != gosnmp.Version3 && conf.CommunityString == "" {
+		conf.CommunityString = DefaultCommunityString
+	}
+
+	// Authentication check
+	if version == gosnmp.Version3 && conf.Username == "" {
+		return nil, fmt.Errorf("username is required for snmp v3")
+	}
+
+	port := conf.Port
+	if port == 0 {
+		port = DefaultPort
+	}
+
+	securityParams := &gosnmp.UsmSecurityParameters{}
+	var msgFlags gosnmp.SnmpV3MsgFlags
+	// Set v3 security parameters
+	if version == gosnmp.Version3 {
+		securityParams.UserName = conf.Username
+		securityParams.AuthenticationPassphrase = conf.AuthKey
+		securityParams.PrivacyPassphrase = conf.PrivKey
+
+		if securityParams.AuthenticationProtocol, ok = AuthOpts.GetVal(conf.AuthProtocol); !ok {
+			return nil, fmt.Errorf("authentication protocol %q not supported; must be %s", conf.AuthProtocol, AuthOpts.OptsStr())
+		}
+
+		if securityParams.PrivacyProtocol, ok = PrivOpts.GetVal(conf.PrivProtocol); !ok {
+			return nil, fmt.Errorf("privacy protocol %q not supported; must be %s", conf.PrivProtocol, PrivOpts.OptsStr())
+		}
+
+		if conf.SecurityLevel == "" {
+			msgFlags = gosnmp.NoAuthNoPriv
+			if conf.PrivKey != "" {
+				msgFlags = gosnmp.AuthPriv
+			} else if conf.AuthKey != "" {
+				msgFlags = gosnmp.AuthNoPriv
+			}
+		} else {
+			var ok bool // can't use := below because it'll make a new msgFlags instead of setting the one in the parent scope.
+			if msgFlags, ok = LevelOpts.GetVal(conf.SecurityLevel); !ok {
+				return nil, fmt.Errorf("security level %q not supported; must be %s", conf.SecurityLevel, LevelOpts.OptsStr())
+			}
+		}
+	}
+	// Set SNMP parameters
+	return &gosnmp.GoSNMP{
+		Target:                  conf.IPAddress,
+		Port:                    port,
+		Community:               conf.CommunityString,
+		Transport:               "udp",
+		Version:                 version,
+		Timeout:                 time.Duration(conf.Timeout * int(time.Second)),
+		Retries:                 conf.Retries,
+		SecurityModel:           gosnmp.UserSecurityModel,
+		ContextName:             conf.Context,
+		MsgFlags:                msgFlags,
+		SecurityParameters:      securityParams,
+		UseUnconnectedUDPSocket: conf.UseUnconnectedUDPSocket,
+		Logger:                  gosnmp.NewLogger(snmplog.New(logger)),
+	}, nil
+}

--- a/pkg/snmp/snmpparse/options.go
+++ b/pkg/snmp/snmpparse/options.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package snmpparse
+
+import "strings"
+
+// OptPairs is just a useful type alias to avoid writing this out multiple times.
+type OptPairs[T any] []struct {
+	Key string
+	Val T
+}
+
+// Options represents an ordered map of case-insensitive choices.
+// This is particularly useful for generating sensible error messages
+// and command-line documentation.
+type Options[T any] struct {
+	Options map[string]T
+	Order   []string
+}
+
+// OptsStr provides a '|'-delimited list of all nonempty options.
+func (o Options[T]) OptsStr() string {
+	var keys []string
+	for _, k := range o.Order {
+		if k == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, "|")
+}
+
+// GetOpt returns the key that matches choice, case-insensitively.
+// The key is found case-insensitively; the returned value will be
+// the key as defined in the original list.
+func (o Options[T]) GetOpt(choice string) (string, bool) {
+	choice = strings.ToLower(choice)
+	for opt := range o.Options {
+		if choice == strings.ToLower(opt) {
+			return opt, true
+		}
+	}
+	return "", false
+}
+
+// GetVal returns the value whose key matches choice, case-insensitively.
+func (o Options[T]) GetVal(choice string) (T, bool) {
+	if key, ok := o.GetOpt(choice); ok {
+		return o.Options[key], true
+	}
+	// return a zero-value T
+	var t T
+	return t, false
+}
+
+// NewOptions creates a new Options object from a slice of pairs.
+// We don't just create one directly from a map because map iteration order is random.
+func NewOptions[T any](pairs OptPairs[T]) Options[T] {
+	var order []string
+	opts := make(map[string]T)
+	for _, pair := range pairs {
+		order = append(order, pair.Key)
+		opts[pair.Key] = pair.Val
+	}
+	return Options[T]{opts, order}
+}

--- a/pkg/snmp/snmpparse/options_test.go
+++ b/pkg/snmp/snmpparse/options_test.go
@@ -3,21 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package snmp
+package snmpparse
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-var opts = snmpparse.NewOptions(snmpparse.OptPairs[int]{
+var vals = OptPairs[int]{
 	{"", 1},
 	{"TWO", 2},
 	{"three", 3},
 	{"fOUr", 4},
-})
+}
 
 var testCases = []struct {
 	choice      string
@@ -34,23 +32,20 @@ var testCases = []struct {
 	{"five", "", 0, false},
 }
 
-func TestOptsFlag(t *testing.T) {
-	var s string
-	flag := Flag(&opts, &s)
+func TestOptions(t *testing.T) {
+	m := NewOptions(vals)
 
-	assert.Equal(t, flag.String(), "")
-	assert.Equal(t, flag.Type(), "option")
-
+	assert.Equal(t, "TWO|three|fOUr", m.OptsStr())
 	for _, tc := range testCases {
-		if !tc.ok {
-			old := s
-			err := flag.Set(tc.choice)
-			assert.ErrorContains(t, err, "TWO|three|fOUr")
-			assert.Equal(t, s, old)
-		} else {
-			assert.NoError(t, flag.Set(tc.choice))
-			assert.Equal(t, tc.expectedKey, s)
-			assert.Equal(t, tc.expectedKey, flag.String())
+		gotKey, ok := m.GetOpt(tc.choice)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.expectedKey, gotKey)
+		}
+		gotVal, ok := m.GetVal(tc.choice)
+		assert.Equal(t, tc.ok, ok)
+		if ok {
+			assert.Equal(t, tc.expectedVal, gotVal)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR relocates the logic that takes an SNMP configuration and generates a GoSNMP instance. It was part of the command-line `snmp scan` command; this moves it to the `snmpparse` library, so that it can be used by other code.

This also required moving the `Options` type, which represents an ordered mapping from strings to other objects, and several option maps to `snmpparse` (for example, the mapping that converts string values like `"SHA-224"` to `gosnmp` constants like `gosnmp.SHA224`).

I also added `SecurityLevel` and `UseUnconnectedUDPSocket` as attributes to `SNMPConfig` that currently aren't exposed to yaml - this preserves the existing behavior that users cannot configure these in yaml while allowing the `SNMPConfig` type to completely replace the `snmpConnectionParams` type, so that we no longer need two separate structs for basically exactly the same data.

### Motivation

I'm adding another case where we connect to a device gosnmp, and I didn't want to duplicate this code yet again (there are already multiple places where we implement this logic).

### Describe how to test/QA your changes

There should be no behavioral changes. I QA'd locally that the SNMP integration still works, as do the `snmp scan` and `snmp walk` commands.
