### PR TITLE
Change AllSettings to use a WRLock instead of RLock

### DIFF
--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -698,8 +698,8 @@ func (c *safeConfig) MergeConfigMap(cfg map[string]any) error {
 
 // AllSettings wraps Viper for concurrent access
 func (c *safeConfig) AllSettings() map[string]interface{} {
-	c.RLock()
-	defer c.RUnlock()
+	c.Lock()
+	defer c.Unlock()
 
 	// AllSettings returns a fresh map, so the caller may do with it
 	// as they please without holding the lock.
@@ -708,8 +708,8 @@ func (c *safeConfig) AllSettings() map[string]interface{} {
 
 // AllSettingsWithoutDefault returns a copy of the all the settings in the configuration without defaults
 func (c *safeConfig) AllSettingsWithoutDefault() map[string]interface{} {
-	c.RLock()
-	defer c.RUnlock()
+	c.Lock()
+	defer c.Unlock()
 
 	// AllSettingsWithoutDefault returns a fresh map, so the caller may do with it
 	// as they please without holding the lock.
@@ -718,8 +718,8 @@ func (c *safeConfig) AllSettingsWithoutDefault() map[string]interface{} {
 
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (c *safeConfig) AllSettingsBySource() map[Source]interface{} {
-	c.RLock()
-	defer c.RUnlock()
+	c.Lock()
+	defer c.Unlock()
 
 	sources := []Source{
 		SourceDefault,


### PR DESCRIPTION
### What does this PR do?

Change our config wrapper such that the method AllSettings (and more) uses a WRLock instead of a RLock

### Motivation

We observed flaky test failures caused by AllSettings having a data race. Investigating it lead to the discover that AllSettings seems to be modifying leaf nodes with map values by building the map of all settings. This means the associated methods should be fully locking instead of only locking for reading.

### Describe how to test/QA your changes

Flaky tests should be fixed, no additional QA needed.

### Possible Drawbacks / Trade-offs

This may degrade performance slightly because locking is now more aggressive, leading to more lock contention.

### Additional Notes
