### PR TITLE
Prevents panics during ELF parsing from crashing process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -444,6 +444,7 @@
 /pkg/util/ecs/                          @DataDog/container-integrations
 /pkg/util/funcs/                        @DataDog/ebpf-platform
 /pkg/util/kernel/                       @DataDog/ebpf-platform
+/pkg/util/safeelf/                      @DataDog/ebpf-platform
 /pkg/util/ktime                         @DataDog/agent-security
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-platform @DataDog/container-app
 /pkg/util/podman/                       @DataDog/container-integrations

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -605,6 +605,8 @@ linters-settings:
             desc: "Not really forbidden to use, but it is usually imported by mistake instead of github.com/stretchr/testify/assert"
           - pkg: "github.com/tj/assert"
             desc: "Not really forbidden to use, but it is usually imported by mistake instead of github.com/stretchr/testify/assert, and confusing since it actually has the behavior of github.com/stretchr/testify/require"
+          - pkg: "debug/elf"
+            desc: "prefer pkg/util/safeelf to prevent panics during parsing"
 
   errcheck:
     exclude-functions:

--- a/pkg/collector/corechecks/servicediscovery/apm/detect.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect.go
@@ -10,7 +10,6 @@ package apm
 
 import (
 	"bufio"
-	"debug/elf"
 	"io"
 	"io/fs"
 	"os"
@@ -24,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // Instrumentation represents the state of APM instrumentation for a service.
@@ -100,7 +100,7 @@ const (
 func goDetector(ctx usm.DetectionContext) Instrumentation {
 	exePath := kernel.HostProc(strconv.Itoa(ctx.Pid), "exe")
 
-	elfFile, err := elf.Open(exePath)
+	elfFile, err := safeelf.Open(exePath)
 	if err != nil {
 		log.Debugf("Unable to open exe %s: %v", exePath, err)
 		return None

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -8,14 +8,13 @@
 package diconfig
 
 import (
-	"debug/elf"
 	"fmt"
 	"reflect"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // inspectGoBinaries goes through each service and populates information about the binary
@@ -54,7 +53,7 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 
 	procInfo.TypeMap = typeMap
 
-	elfFile, err := elf.Open(procInfo.BinaryPath)
+	elfFile, err := safeelf.Open(procInfo.BinaryPath)
 	if err != nil {
 		return fmt.Errorf("could not open elf file %w", err)
 	}

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
@@ -8,7 +8,6 @@
 package diconfig
 
 import (
-	"debug/elf"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +17,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+
 	"github.com/kr/pretty"
 )
 
@@ -40,7 +41,7 @@ func TestBinaryInspection(t *testing.T) {
 		t.Error(err)
 	}
 
-	f, err := elf.Open(binPath)
+	f, err := safeelf.Open(binPath)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -13,7 +13,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/google/uuid"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/codegen"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diagnostics"
@@ -22,8 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/eventparser"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/proctracker"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ratelimiter"
-	"github.com/cilium/ebpf/ringbuf"
-	"github.com/google/uuid"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type rcConfig struct {

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -10,16 +10,16 @@ package diconfig
 import (
 	"cmp"
 	"debug/dwarf"
-	"debug/elf"
 	"fmt"
 	"io"
 	"reflect"
 	"slices"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
-	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 func getTypeMap(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditypes.TypeMap, error) {
@@ -184,7 +184,7 @@ func loadDWARF(binaryPath string) (*dwarf.Data, error) {
 	if dwarfData, ok := dwarfMap[binaryPath]; ok {
 		return dwarfData, nil
 	}
-	elfFile, err := elf.Open(binaryPath)
+	elfFile, err := safeelf.Open(binaryPath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open elf binary: %w", err)
 	}

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -10,7 +10,6 @@
 package proctracker
 
 import (
-	"debug/elf"
 	"errors"
 	"os"
 	"path/filepath"
@@ -19,19 +18,19 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"golang.org/x/sys/unix"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 type processTrackerCallback func(ditypes.DIProcs)
@@ -134,7 +133,7 @@ func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
 	}
 	defer f.Close()
 
-	elfFile, err := elf.NewFile(f)
+	elfFile, err := safeelf.NewFile(f)
 	if err != nil {
 		log.Infof("file %s could not be parsed as an ELF file: %s", binPath, err)
 		return

--- a/pkg/ebpf/uprobes/inspector.go
+++ b/pkg/ebpf/uprobes/inspector.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"runtime"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
@@ -114,7 +116,7 @@ func (p *NativeBinaryInspector) Inspect(fpath utils.FilePath, requests []SymbolR
 }
 
 func (*NativeBinaryInspector) symbolToFuncMetadata(elfFile *safeelf.File, sym safeelf.Symbol) (*bininspect.FunctionMetadata, error) {
-	SanitizeAddresses(elfFile, []safeelf.Symbol{sym})
+	manager.SanitizeUprobeAddresses(elfFile.File, []safeelf.Symbol{sym})
 	offset, err := bininspect.SymbolToOffset(elfFile, sym)
 	if err != nil {
 		return nil, err
@@ -126,22 +128,4 @@ func (*NativeBinaryInspector) symbolToFuncMetadata(elfFile *safeelf.File, sym sa
 // Cleanup is a no-op for the native inspector
 func (*NativeBinaryInspector) Cleanup(_ utils.FilePath) {
 	// Nothing to do here for the native inspector
-}
-
-// SanitizeAddresses - sanitizes the addresses of the provided symbols
-func SanitizeAddresses(f *safeelf.File, syms []safeelf.Symbol) {
-	// If the binary is a non-PIE executable, addr must be a virtual address, otherwise it must be an offset relative to
-	// the file load address. For executable (ET_EXEC) binaries and shared objects (ET_DYN), translate the virtual
-	// address to physical address in the binary file.
-	if f.Type == safeelf.ET_EXEC || f.Type == safeelf.ET_DYN {
-		for i, sym := range syms {
-			for _, prog := range f.Progs {
-				if prog.Type == safeelf.PT_LOAD {
-					if sym.Value >= prog.Vaddr && sym.Value < (prog.Vaddr+prog.Memsz) {
-						syms[i].Value = sym.Value - prog.Vaddr + prog.Off
-					}
-				}
-			}
-		}
-	}
 }

--- a/pkg/gpu/cuda/fatbin.go
+++ b/pkg/gpu/cuda/fatbin.go
@@ -17,13 +17,14 @@
 package cuda
 
 import (
-	"debug/elf"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"unsafe"
 
 	"github.com/pierrec/lz4/v4"
+
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 type fatbinDataKind uint16
@@ -104,7 +105,7 @@ func (fbd *fatbinData) validate() error {
 
 // ParseFatbinFromELFFilePath opens the given path and parses the resulting ELF for CUDA kernels
 func ParseFatbinFromELFFilePath(path string) (*Fatbin, error) {
-	elfFile, err := elf.Open(path)
+	elfFile, err := safeelf.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open ELF file %s: %w", path, err)
 	}
@@ -119,7 +120,7 @@ func getBufferOffset(buf io.Seeker) int64 {
 }
 
 // ParseFatbinFromELFFile parses the fatbin sections of the given ELF file and returns the information found in it
-func ParseFatbinFromELFFile(elfFile *elf.File) (*Fatbin, error) {
+func ParseFatbinFromELFFile(elfFile *safeelf.File) (*Fatbin, error) {
 	fatbin := &Fatbin{
 		Kernels: make(map[CubinKernelKey]*CubinKernel),
 	}

--- a/pkg/gpu/cuda/symbols.go
+++ b/pkg/gpu/cuda/symbols.go
@@ -6,8 +6,9 @@
 package cuda
 
 import (
-	"debug/elf"
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // Symbols holds all necessary data from a CUDA executable for
@@ -21,7 +22,7 @@ type Symbols struct {
 
 // GetSymbols reads an ELF file from the given path and return the parsed CUDA data
 func GetSymbols(path string) (*Symbols, error) {
-	elfFile, err := elf.Open(path)
+	elfFile, err := safeelf.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening ELF file %s: %w", path, err)
 	}

--- a/pkg/languagedetection/internal/detectors/go_detector.go
+++ b/pkg/languagedetection/internal/detectors/go_detector.go
@@ -8,7 +8,6 @@
 package detectors
 
 import (
-	"debug/elf"
 	"fmt"
 	"path"
 	"strconv"
@@ -17,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 //nolint:revive // TODO(PROC) Fix revive linter
@@ -32,12 +32,12 @@ func NewGoDetector() GoDetector {
 // DetectLanguage allows for detecting if a process is a go process, and its version.
 // Note that currently the goDetector only returns non-retriable errors since in all cases we will not be able to detect the language.
 // Scenarios in which we can return an error:
-//   - Program exits early, and we fail to call `elf.Open`. Note that in the future it may be possible to lock the directory using a system call.
+//   - Program exits early, and we fail to call `safeelf.Open`. Note that in the future it may be possible to lock the directory using a system call.
 //   - Program is not a go binary, or has build tags stripped out. In this case we return a `dderrors.NotFound`.
 func (d GoDetector) DetectLanguage(process languagemodels.Process) (languagemodels.Language, error) {
 	exePath := d.getHostProc(process.GetPid())
 
-	bin, err := elf.Open(exePath)
+	bin, err := safeelf.Open(exePath)
 	if err != nil {
 		return languagemodels.Language{}, fmt.Errorf("open: %v", err)
 	}

--- a/pkg/network/go/asmscan/scan.go
+++ b/pkg/network/go/asmscan/scan.go
@@ -7,6 +7,7 @@
 package asmscan
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/arch/arm64/arm64asm"
@@ -39,6 +40,10 @@ import (
 //     (which describes how this approach works as a workaround)
 //   - https://github.com/golang/go/issues/22008
 func ScanFunction(textSection *safeelf.Section, sym safeelf.Symbol, functionOffset uint64, scanInstructions func(data []byte) ([]uint64, error)) ([]uint64, error) {
+	if textSection.ReaderAt == nil {
+		return nil, errors.New("text section is not available in random-access form")
+	}
+
 	// Determine the offset in the section that the function starts at
 	lowPC := sym.Value
 	highPC := lowPC + sym.Size

--- a/pkg/network/go/asmscan/scan.go
+++ b/pkg/network/go/asmscan/scan.go
@@ -7,11 +7,12 @@
 package asmscan
 
 import (
-	"debug/elf"
 	"fmt"
 
 	"golang.org/x/arch/arm64/arm64asm"
 	"golang.org/x/arch/x86/x86asm"
+
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // ScanFunction finds the program counter (PC) positions of machine code instructions
@@ -37,7 +38,7 @@ import (
 //   - https://github.com/iovisor/bcc/issues/1320#issuecomment-407927542
 //     (which describes how this approach works as a workaround)
 //   - https://github.com/golang/go/issues/22008
-func ScanFunction(textSection *elf.Section, sym elf.Symbol, functionOffset uint64, scanInstructions func(data []byte) ([]uint64, error)) ([]uint64, error) {
+func ScanFunction(textSection *safeelf.Section, sym safeelf.Symbol, functionOffset uint64, scanInstructions func(data []byte) ([]uint64, error)) ([]uint64, error) {
 	// Determine the offset in the section that the function starts at
 	lowPC := sym.Value
 	highPC := lowPC + sym.Size

--- a/pkg/network/go/bininspect/newproc.go
+++ b/pkg/network/go/bininspect/newproc.go
@@ -8,23 +8,23 @@
 package bininspect
 
 import (
-	"debug/elf"
 	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/goid"
 	"github.com/DataDog/datadog-agent/pkg/network/go/goversion"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 type newProcessBinaryInspector struct {
 	elf       elfMetadata
-	symbols   map[string]elf.Symbol
+	symbols   map[string]safeelf.Symbol
 	goVersion goversion.GoVersion
 }
 
 // InspectNewProcessBinary process the given elf File, and returns the offsets of the given functions and structs.
-func InspectNewProcessBinary(elfFile *elf.File, functions map[string]FunctionConfiguration, structs map[FieldIdentifier]StructLookupFunction) (*Result, error) {
+func InspectNewProcessBinary(elfFile *safeelf.File, functions map[string]FunctionConfiguration, structs map[FieldIdentifier]StructLookupFunction) (*Result, error) {
 	if elfFile == nil {
 		return nil, errors.New("got nil elf file")
 	}
@@ -152,9 +152,9 @@ func (i *newProcessBinaryInspector) getRuntimeGAddrTLSOffset() (uint64, error) {
 	// - On ARM64 (but really, any architecture other than i386 and 86x64) the
 	//   offset is calculated using runtime.tls_g and the formula is different.
 
-	var tls *elf.Prog
+	var tls *safeelf.Prog
 	for _, prog := range i.elf.file.Progs {
-		if prog.Type == elf.PT_TLS {
+		if prog.Type == safeelf.PT_TLS {
 			tls = prog
 			break
 		}

--- a/pkg/network/go/bininspect/pclntab.go
+++ b/pkg/network/go/bininspect/pclntab.go
@@ -58,6 +58,9 @@ type sectionAccess struct {
 
 // ReadAt reads len(p) bytes from the section starting at the given offset.
 func (s *sectionAccess) ReadAt(outBuffer []byte, offset int64) (int, error) {
+	if s.section.ReaderAt == nil {
+		return 0, errors.New("section not available in random-access form")
+	}
 	return s.section.ReadAt(outBuffer, s.baseOffset+offset)
 }
 
@@ -119,6 +122,9 @@ func GetPCLNTABSymbolParser(f *safeelf.File, symbolFilter symbolFilter) (map[str
 // parsePclntab parses the pclntab, setting the version and verifying the header.
 // Based on parsePclnTab in https://github.com/golang/go/blob/6a861010be9eed02d5285509cbaf3fb26d2c5041/src/debug/gosym/pclntab.go#L194
 func (p *pclntanSymbolParser) parsePclntab() error {
+	if p.section.ReaderAt == nil {
+		return errors.New("section not available in random-access form")
+	}
 	p.cachedVersion = ver11
 
 	pclntabHeader := make([]byte, 8)

--- a/pkg/network/go/bininspect/pclntab_test.go
+++ b/pkg/network/go/bininspect/pclntab_test.go
@@ -8,33 +8,35 @@
 package bininspect
 
 import (
-	"debug/elf"
-	"github.com/DataDog/datadog-agent/pkg/util/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 const (
 	// Info is composed of the type and binding of the symbol. Type is the lower 4 bits and binding is the upper 4 bits.
 	// We are only interested in functions, which binding STB_GLOBAL (1) and type STT_FUNC (2).
 	// Hence, we are interested in symbols with Info 18.
-	infoFunction = byte(elf.STB_GLOBAL)<<4 | byte(elf.STT_FUNC)
+	infoFunction = byte(safeelf.STB_GLOBAL)<<4 | byte(safeelf.STT_FUNC)
 )
 
 // TestGetPCLNTABSymbolParser tests the GetPCLNTABSymbolParser function with strings set symbol filter.
 // We are looking to find all symbols of the current process executable and check if they are found in the PCLNTAB.
 func TestGetPCLNTABSymbolParser(t *testing.T) {
 	currentPid := os.Getpid()
-	f, err := elf.Open("/proc/" + strconv.Itoa(currentPid) + "/exe")
+	f, err := safeelf.Open("/proc/" + strconv.Itoa(currentPid) + "/exe")
 	require.NoError(t, err)
 	symbolSet := make(common.StringSet)
 	staticSymbols, _ := f.Symbols()
 	dynamicSymbols, _ := f.DynamicSymbols()
-	for _, symbols := range [][]elf.Symbol{staticSymbols, dynamicSymbols} {
+	for _, symbols := range [][]safeelf.Symbol{staticSymbols, dynamicSymbols} {
 		for _, sym := range symbols {
 			if sym.Info != infoFunction {
 				continue

--- a/pkg/network/go/bininspect/symbol_filter.go
+++ b/pkg/network/go/bininspect/symbol_filter.go
@@ -8,10 +8,10 @@
 package bininspect
 
 import (
-	"debug/elf"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // symbolFilter is an interface for filtering symbols read from ELF files.
@@ -24,7 +24,7 @@ type symbolFilter interface {
 	want(symbol string) bool
 	// findMissing returns the list of symbol names which the filter wanted but were not found in the
 	// symbol map. This is only used for error messages.
-	findMissing(map[string]elf.Symbol) []string
+	findMissing(map[string]safeelf.Symbol) []string
 }
 
 // stringSetSymbolFilter is a symbol filter which finds all the symbols in a
@@ -58,7 +58,7 @@ func (f stringSetSymbolFilter) want(symbol string) bool {
 }
 
 // findMissing gets the list of symbols which were missing. Only used for error prints.
-func (f stringSetSymbolFilter) findMissing(symbolByName map[string]elf.Symbol) []string {
+func (f stringSetSymbolFilter) findMissing(symbolByName map[string]safeelf.Symbol) []string {
 	missingSymbols := make([]string, 0, max(0, len(f.symbolSet)-len(symbolByName)))
 	for symbolName := range f.symbolSet {
 		if _, ok := symbolByName[symbolName]; !ok {
@@ -97,6 +97,6 @@ func (f prefixSymbolFilter) want(symbol string) bool {
 
 // findMissing gets the list of symbols which were missing. Only used for error
 // prints. Since we only know we were looking for a prefix, return that.
-func (f prefixSymbolFilter) findMissing(_ map[string]elf.Symbol) []string {
+func (f prefixSymbolFilter) findMissing(_ map[string]safeelf.Symbol) []string {
 	return []string{f.prefix}
 }

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -8,7 +8,6 @@
 package bininspect
 
 import (
-	"debug/elf"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 const (
@@ -89,35 +89,35 @@ func getSymbolLengthBoundaries(set common.StringSet) (int, int) {
 
 // fillSymbol reads the symbol entry from the symbol section with the first 4 bytes of the name entry (which
 // we read using readSymbolEntryInStringTable).
-func fillSymbol(symbol *elf.Symbol, byteOrder binary.ByteOrder, symbolName string, allocatedBufferForRead []byte, is64Bit bool) {
+func fillSymbol(symbol *safeelf.Symbol, byteOrder binary.ByteOrder, symbolName string, allocatedBufferForRead []byte, is64Bit bool) {
 	symbol.Name = symbolName
 	if is64Bit {
 		infoAndOther := byteOrder.Uint16(allocatedBufferForRead[0:2])
 		symbol.Info = uint8(infoAndOther >> 8)
 		symbol.Other = uint8(infoAndOther)
-		symbol.Section = elf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[2:4]))
+		symbol.Section = safeelf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[2:4]))
 		symbol.Value = byteOrder.Uint64(allocatedBufferForRead[4:12])
 		symbol.Size = byteOrder.Uint64(allocatedBufferForRead[12:20])
 	} else {
 		infoAndOther := byteOrder.Uint16(allocatedBufferForRead[8:10])
 		symbol.Info = uint8(infoAndOther >> 8)
 		symbol.Other = uint8(infoAndOther)
-		symbol.Section = elf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[10:12]))
+		symbol.Section = safeelf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[10:12]))
 		symbol.Value = uint64(byteOrder.Uint32(allocatedBufferForRead[0:4]))
 		symbol.Size = uint64(byteOrder.Uint32(allocatedBufferForRead[4:8]))
 	}
 }
 
 // getSymbolsUnified extracts the given symbol list from the binary.
-func getSymbolsUnified(f *elf.File, typ elf.SectionType, filter symbolFilter, is64Bit bool) ([]elf.Symbol, error) {
-	symbolSize := elf.Sym32Size
+func getSymbolsUnified(f *safeelf.File, typ safeelf.SectionType, filter symbolFilter, is64Bit bool) ([]safeelf.Symbol, error) {
+	symbolSize := safeelf.Sym32Size
 	if is64Bit {
-		symbolSize = elf.Sym64Size
+		symbolSize = safeelf.Sym64Size
 	}
 	// Getting the relevant symbol section.
 	symbolSection := f.SectionByType(typ)
 	if symbolSection == nil {
-		return nil, elf.ErrNoSymbols
+		return nil, safeelf.ErrNoSymbols
 	}
 
 	// Checking the symbol section size is aligned to a multiplication of symbolSize.
@@ -133,7 +133,7 @@ func getSymbolsUnified(f *elf.File, typ elf.SectionType, filter symbolFilter, is
 	numWanted := filter.getNumWanted()
 
 	// Allocating entries for all wanted symbols.
-	symbols := make([]elf.Symbol, 0, numWanted)
+	symbols := make([]safeelf.Symbol, 0, numWanted)
 	// Extracting the min and max symbol length.
 	minSymbolNameSize, maxSymbolNameSize := filter.getMinMaxLength()
 	// Pre-allocating a buffer to read the symbol string into.
@@ -183,7 +183,7 @@ func getSymbolsUnified(f *elf.File, typ elf.SectionType, filter symbolFilter, is
 			continue
 		}
 
-		var symbol elf.Symbol
+		var symbol safeelf.Symbol
 		// Complete the symbol reading.
 		// The symbol is composed of 4 bytes representing the symbol name in the string table, and rest is the fields
 		// of the symbols. So here we skip the first 4 bytes of the symbol, as we already processed it.
@@ -199,12 +199,12 @@ func getSymbolsUnified(f *elf.File, typ elf.SectionType, filter symbolFilter, is
 	return symbols, nil
 }
 
-func getSymbols(f *elf.File, typ elf.SectionType, filter symbolFilter) ([]elf.Symbol, error) {
+func getSymbols(f *safeelf.File, typ safeelf.SectionType, filter symbolFilter) ([]safeelf.Symbol, error) {
 	switch f.Class {
-	case elf.ELFCLASS64:
+	case safeelf.ELFCLASS64:
 		return getSymbolsUnified(f, typ, filter, true)
 
-	case elf.ELFCLASS32:
+	case safeelf.ELFCLASS32:
 		return getSymbolsUnified(f, typ, filter, false)
 	}
 
@@ -214,31 +214,31 @@ func getSymbols(f *elf.File, typ elf.SectionType, filter symbolFilter) ([]elf.Sy
 // GetAllSymbolsByName returns all filtered symbols in the given elf file,
 // mapped by the symbol names.  In case of a missing symbol, an error is
 // returned.
-func GetAllSymbolsByName(elfFile *elf.File, filter symbolFilter) (map[string]elf.Symbol, error) {
-	regularSymbols, regularSymbolsErr := getSymbols(elfFile, elf.SHT_SYMTAB, filter)
+func GetAllSymbolsByName(elfFile *safeelf.File, filter symbolFilter) (map[string]safeelf.Symbol, error) {
+	regularSymbols, regularSymbolsErr := getSymbols(elfFile, safeelf.SHT_SYMTAB, filter)
 	if regularSymbolsErr != nil && log.ShouldLog(seelog.TraceLvl) {
 		log.Tracef("Failed getting regular symbols of elf file: %s", regularSymbolsErr)
 	}
 
-	var dynamicSymbols []elf.Symbol
+	var dynamicSymbols []safeelf.Symbol
 	var dynamicSymbolsErr error
 	numWanted := filter.getNumWanted()
 	if len(regularSymbols) != numWanted {
-		dynamicSymbols, dynamicSymbolsErr = getSymbols(elfFile, elf.SHT_DYNSYM, filter)
+		dynamicSymbols, dynamicSymbolsErr = getSymbols(elfFile, safeelf.SHT_DYNSYM, filter)
 		if dynamicSymbolsErr != nil && log.ShouldLog(seelog.TraceLvl) {
 			log.Tracef("Failed getting dynamic symbols of elf file: %s", dynamicSymbolsErr)
 		}
 	}
 
 	// Only if we failed getting both regular and dynamic symbols - then we abort.
-	if regularSymbolsErr == elf.ErrNoSymbols && dynamicSymbolsErr == elf.ErrNoSymbols {
-		return nil, elf.ErrNoSymbols
+	if regularSymbolsErr == safeelf.ErrNoSymbols && dynamicSymbolsErr == safeelf.ErrNoSymbols {
+		return nil, safeelf.ErrNoSymbols
 	}
 	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
 		return nil, fmt.Errorf("could not open symbol sections to resolve symbol offset: %v, %v", regularSymbolsErr, dynamicSymbolsErr)
 	}
 
-	symbolByName := make(map[string]elf.Symbol, len(regularSymbols)+len(dynamicSymbols))
+	symbolByName := make(map[string]safeelf.Symbol, len(regularSymbols)+len(dynamicSymbols))
 
 	for _, regularSymbol := range regularSymbols {
 		symbolByName[regularSymbol.Name] = regularSymbol
@@ -259,14 +259,14 @@ func GetAllSymbolsByName(elfFile *elf.File, filter symbolFilter) (map[string]elf
 // GetAllSymbolsInSetByName returns all symbols (from the symbolSet) in the
 // given elf file, mapped by the symbol names.  In case of a missing symbol, an
 // error is returned.
-func GetAllSymbolsInSetByName(elfFile *elf.File, symbolSet common.StringSet) (map[string]elf.Symbol, error) {
+func GetAllSymbolsInSetByName(elfFile *safeelf.File, symbolSet common.StringSet) (map[string]safeelf.Symbol, error) {
 	filter := newStringSetSymbolFilter(symbolSet)
 	return GetAllSymbolsByName(elfFile, filter)
 }
 
 // GetAnySymbolWithPrefix returns any one symbol with the given prefix and the
 // specified maximum length from the ELF file.
-func GetAnySymbolWithPrefix(elfFile *elf.File, prefix string, maxLength int) (*elf.Symbol, error) {
+func GetAnySymbolWithPrefix(elfFile *safeelf.File, prefix string, maxLength int) (*safeelf.Symbol, error) {
 	filter := newPrefixSymbolFilter(prefix, maxLength)
 	symbols, err := GetAllSymbolsByName(elfFile, filter)
 	if err != nil {
@@ -284,7 +284,7 @@ func GetAnySymbolWithPrefix(elfFile *elf.File, prefix string, maxLength int) (*e
 
 // GetAnySymbolWithPrefixPCLNTAB returns any one symbol with the given prefix and the
 // specified maximum length from the pclntab section in ELF file.
-func GetAnySymbolWithPrefixPCLNTAB(elfFile *elf.File, prefix string, maxLength int) (*elf.Symbol, error) {
+func GetAnySymbolWithPrefixPCLNTAB(elfFile *safeelf.File, prefix string, maxLength int) (*safeelf.Symbol, error) {
 	symbols, err := GetPCLNTABSymbolParser(elfFile, newPrefixSymbolFilter(prefix, maxLength))
 	if err != nil {
 		return nil, err

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -133,7 +133,7 @@ func getSymbolsUnified(f *safeelf.File, typ safeelf.SectionType, filter symbolFi
 		return nil, errors.New("section has invalid string table link")
 	}
 	if symbolSection.ReaderAt == nil {
-		return nil, fmt.Errorf("symbol section not available in random-access form")
+		return nil, errors.New("symbol section not available in random-access form")
 	}
 
 	numWanted := filter.getNumWanted()

--- a/pkg/network/go/bininspect/symbols_test.go
+++ b/pkg/network/go/bininspect/symbols_test.go
@@ -8,7 +8,6 @@
 package bininspect
 
 import (
-	"debug/elf"
 	"path/filepath"
 	"testing"
 
@@ -17,9 +16,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
-func openTestElf(t *testing.T) *elf.File {
+func openTestElf(t *testing.T) *safeelf.File {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 
@@ -27,7 +27,7 @@ func openTestElf(t *testing.T) *elf.File {
 	// always.
 	lib := filepath.Join(curDir, "..", "..", "usm", "testdata",
 		"site-packages", "ddtrace", "libssl.so.arm64")
-	elfFile, err := elf.Open(lib)
+	elfFile, err := safeelf.Open(lib)
 	require.NoError(t, err)
 
 	return elfFile

--- a/pkg/network/go/bininspect/types.go
+++ b/pkg/network/go/bininspect/types.go
@@ -9,12 +9,13 @@
 package bininspect
 
 import (
-	"debug/elf"
 	"errors"
 	"reflect"
 
-	"github.com/DataDog/datadog-agent/pkg/network/go/goversion"
 	delve "github.com/go-delve/delve/pkg/goversion"
+
+	"github.com/DataDog/datadog-agent/pkg/network/go/goversion"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 const (
@@ -63,7 +64,7 @@ var StructOffsetLimitListenerConnNetConn = FieldIdentifier{
 }
 
 type elfMetadata struct {
-	file *elf.File
+	file *safeelf.File
 	arch GoArch
 }
 

--- a/pkg/network/go/binversion/buildinfo.go
+++ b/pkg/network/go/binversion/buildinfo.go
@@ -29,11 +29,11 @@ package binversion
 
 import (
 	"bytes"
-	"debug/elf"
 	"encoding/binary"
 	"errors"
 	"io"
 
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
@@ -77,7 +77,7 @@ type exe interface {
 // ReadElfBuildInfo extracts the Go toolchain version and module information
 // strings from a Go binary. On success, vers should be non-empty. mod
 // is empty if the binary was not built with modules enabled.
-func ReadElfBuildInfo(elfFile *elf.File) (vers string, err error) {
+func ReadElfBuildInfo(elfFile *safeelf.File) (vers string, err error) {
 	x := &elfExe{f: elfFile}
 
 	// Read the first 64kB of dataAddr to find the build info blob.
@@ -176,7 +176,7 @@ func readString(x exe, ptrSize int, readPtr func([]byte) uint64, addr uint64) st
 
 // elfExe is the ELF implementation of the exe interface.
 type elfExe struct {
-	f *elf.File
+	f *safeelf.File
 }
 
 func (x *elfExe) ReadData(addr, size uint64) ([]byte, error) {
@@ -225,7 +225,7 @@ func (x *elfExe) DataStart() uint64 {
 		}
 	}
 	for _, p := range x.f.Progs {
-		if p.Type == elf.PT_LOAD && p.Flags&(elf.PF_X|elf.PF_W) == elf.PF_W {
+		if p.Type == safeelf.PT_LOAD && p.Flags&(safeelf.PF_X|safeelf.PF_W) == safeelf.PF_W {
 			return p.Vaddr
 		}
 	}

--- a/pkg/network/go/goid/internal/generate_goid_lut.go
+++ b/pkg/network/go/goid/internal/generate_goid_lut.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"context"
-	"debug/elf"
 	"flag"
 	"fmt"
 	"log"
@@ -21,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
 	"github.com/DataDog/datadog-agent/pkg/network/go/goversion"
 	"github.com/DataDog/datadog-agent/pkg/network/go/lutgen"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var (
@@ -134,7 +134,7 @@ func inspectBinary(binary lutgen.Binary) (interface{}, error) {
 		return 0, err
 	}
 	defer file.Close()
-	elfFile, err := elf.NewFile(file)
+	elfFile, err := safeelf.NewFile(file)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"context"
-	"debug/elf"
 	_ "embed"
 	"flag"
 	"fmt"
@@ -23,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/goversion"
 	"github.com/DataDog/datadog-agent/pkg/network/go/lutgen"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var (
@@ -255,7 +255,7 @@ func inspectBinary(binary lutgen.Binary) (interface{}, error) {
 	}
 	defer file.Close()
 
-	elfFile, err := elf.NewFile(file)
+	elfFile, err := safeelf.NewFile(file)
 	if err != nil {
 		return bininspect.Result{}, err
 	}

--- a/pkg/network/protocols/tls/nodejs/nodejs.go
+++ b/pkg/network/protocols/tls/nodejs/nodejs.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 // Package nodejs provides helpers to run nodejs HTTPs server.
 package nodejs
 

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -8,7 +8,6 @@
 package usm
 
 import (
-	"debug/elf"
 	"errors"
 	"fmt"
 	"os"
@@ -26,6 +25,7 @@ import (
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var paramLookupFunctions = map[string]bininspect.ParameterLookupFunction{
@@ -74,7 +74,7 @@ func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.
 	}
 	defer f.Close()
 
-	elfFile, err := elf.NewFile(f)
+	elfFile, err := safeelf.NewFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("file %s could not be parsed as an ELF file: %w", path, err)
 	}
@@ -94,7 +94,7 @@ func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.
 
 	inspectionResult, err := bininspect.InspectNewProcessBinary(elfFile, functionsConfig, p.structFieldsLookupFunctions)
 	if err != nil {
-		if errors.Is(err, elf.ErrNoSymbols) {
+		if errors.Is(err, safeelf.ErrNoSymbols) {
 			p.binNoSymbolsMetric.Add(1)
 		}
 		return nil, fmt.Errorf("error extracting inspection data from %s: %w", path, err)

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -25,7 +25,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -698,7 +697,7 @@ func addHooks(m *manager.Manager, procRoot string, probes []manager.ProbesSelect
 						continue
 					}
 				}
-				uprobes.SanitizeAddresses(elfFile, []safeelf.Symbol{sym})
+				manager.SanitizeUprobeAddresses(elfFile.File, []safeelf.Symbol{sym})
 				offset, err := bininspect.SymbolToOffset(elfFile, sym)
 				if err != nil {
 					return err

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -9,7 +9,6 @@ package usm
 
 import (
 	"bytes"
-	"debug/elf"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
@@ -617,7 +618,7 @@ func addHooks(m *manager.Manager, procRoot string, probes []manager.ProbesSelect
 
 		uid := getUID(fpath.ID)
 
-		elfFile, err := elf.Open(fpath.HostPath)
+		elfFile, err := safeelf.Open(fpath.HostPath)
 		if err != nil {
 			return err
 		}
@@ -697,7 +698,7 @@ func addHooks(m *manager.Manager, procRoot string, probes []manager.ProbesSelect
 						continue
 					}
 				}
-				manager.SanitizeUprobeAddresses(elfFile, []elf.Symbol{sym})
+				uprobes.SanitizeAddresses(elfFile, []safeelf.Symbol{sym})
 				offset, err := bininspect.SymbolToOffset(elfFile, sym)
 				if err != nil {
 					return err

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -10,7 +10,6 @@ package constantfetch
 
 import (
 	"bytes"
-	"debug/elf"
 	"fmt"
 	"sort"
 	"text/template"
@@ -20,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 type rcSymbolPair struct {
@@ -121,7 +121,7 @@ func (cf *RuntimeCompilationConstantFetcher) FinishAndGetResults() (map[string]u
 		return nil, err
 	}
 
-	f, err := elf.NewFile(elfFile)
+	f, err := safeelf.NewFile(elfFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -10,6 +10,7 @@ package constantfetch
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sort"
 	"text/template"
@@ -136,6 +137,9 @@ func (cf *RuntimeCompilationConstantFetcher) FinishAndGetResults() (map[string]u
 		}
 
 		section := f.Sections[sym.Section]
+		if section.ReaderAt == nil {
+			return nil, errors.New("section not available in random-access form")
+		}
 		buf := make([]byte, sym.Size)
 		if _, err := section.ReadAt(buf, int64(sym.Value)); err != nil {
 			return nil, fmt.Errorf("unable to read section at %d: %s", int64(sym.Value), err)

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -11,7 +11,6 @@ package ptracer
 import (
 	"bufio"
 	"bytes"
-	"debug/elf"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // Funcs mainly copied from github.com/DataDog/datadog-agent/pkg/security/utils/cgroup.go
@@ -459,7 +459,7 @@ func microsecsToNanosecs(secs uint64) uint64 {
 }
 
 func getModuleName(reader io.ReaderAt) (string, error) {
-	elf, err := elf.NewFile(reader)
+	elf, err := safeelf.NewFile(reader)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/safeelf/elf.go
+++ b/pkg/util/safeelf/elf.go
@@ -29,7 +29,7 @@ package safeelf
 
 import (
 	"debug/dwarf"
-	"debug/elf"
+	"debug/elf" //nolint:depguard
 	"fmt"
 	"io"
 )

--- a/pkg/util/safeelf/elf.go
+++ b/pkg/util/safeelf/elf.go
@@ -1,0 +1,136 @@
+// This file is licensed under the MIT License.
+//
+// Copyright (c) 2017 Nathan Sweet
+// Copyright (c) 2018, 2019 Cloudflare
+// Copyright (c) 2019 Authors of Cilium
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package safeelf provides safe (from panics) wrappers around ELF parsing
+package safeelf
+
+import (
+	"debug/dwarf"
+	"debug/elf"
+	"fmt"
+	"io"
+)
+
+// File is a safe wrapper around *elf.File that handles any panics in parsing
+type File struct {
+	*elf.File
+}
+
+// NewFile reads an ELF safely.
+//
+// Any panic during parsing is turned into an error. This is necessary since
+// there are a bunch of unfixed bugs in debug/elf.
+//
+// https://github.com/golang/go/issues?q=is%3Aissue+is%3Aopen+debug%2Felf+in%3Atitle
+func NewFile(r io.ReaderAt) (safe *File, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		safe = nil
+		err = fmt.Errorf("reading ELF file panicked: %s", r)
+	}()
+
+	file, err := elf.NewFile(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{file}, nil
+}
+
+// Open reads an ELF from a file.
+//
+// It works like NewFile, with the exception that safe.Close will
+// close the underlying file.
+func Open(path string) (safe *File, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		safe = nil
+		err = fmt.Errorf("reading ELF file panicked: %s", r)
+	}()
+
+	file, err := elf.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{file}, nil
+}
+
+// Symbols is the safe version of elf.File.Symbols.
+func (se *File) Symbols() (syms []Symbol, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		syms = nil
+		err = fmt.Errorf("reading ELF symbols panicked: %s", r)
+	}()
+
+	syms, err = se.File.Symbols()
+	return
+}
+
+// DynamicSymbols is the safe version of elf.File.DynamicSymbols.
+func (se *File) DynamicSymbols() (syms []Symbol, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		syms = nil
+		err = fmt.Errorf("reading ELF dynamic symbols panicked: %s", r)
+	}()
+
+	syms, err = se.File.DynamicSymbols()
+	return
+}
+
+// DWARF is the safe version of elf.File.DWARF.
+func (se *File) DWARF() (d *dwarf.Data, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		d = nil
+		err = fmt.Errorf("reading ELF DWARF panicked: %s", r)
+	}()
+
+	d, err = se.File.DWARF()
+	return
+}

--- a/pkg/util/safeelf/types.go
+++ b/pkg/util/safeelf/types.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package safeelf
+
+import "debug/elf"
+
+type Prog = elf.Prog
+type Symbol = elf.Symbol
+type Section = elf.Section
+type SectionType = elf.SectionType
+type SectionIndex = elf.SectionIndex
+
+var ErrNoSymbols = elf.ErrNoSymbols
+
+const SHF_ALLOC = elf.SHF_ALLOC
+const SHF_EXECINSTR = elf.SHF_EXECINSTR
+
+const SHT_SYMTAB = elf.SHT_SYMTAB
+const SHT_DYNSYM = elf.SHT_DYNSYM
+
+const ET_EXEC = elf.ET_EXEC
+const ET_DYN = elf.ET_DYN
+
+const PT_LOAD = elf.PT_LOAD
+const PT_TLS = elf.PT_TLS
+
+const EM_X86_64 = elf.EM_X86_64
+const EM_AARCH64 = elf.EM_AARCH64
+
+const Sym32Size = elf.Sym32Size
+const Sym64Size = elf.Sym64Size
+
+const ELFCLASS32 = elf.ELFCLASS32
+const ELFCLASS64 = elf.ELFCLASS64
+
+const PF_X = elf.PF_X
+const PF_W = elf.PF_W
+
+const STB_GLOBAL = elf.STB_GLOBAL
+const STT_FUNC = elf.STT_FUNC

--- a/pkg/util/safeelf/types.go
+++ b/pkg/util/safeelf/types.go
@@ -3,9 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//nolint:revive
 package safeelf
 
-import "debug/elf"
+import "debug/elf" //nolint:depguard
 
 type Prog = elf.Prog
 type Symbol = elf.Symbol

--- a/test/new-e2e/system-probe/test-json-review/testowners.go
+++ b/test/new-e2e/system-probe/test-json-review/testowners.go
@@ -8,7 +8,7 @@
 package main
 
 import (
-	"debug/elf"
+	"debug/elf" //nolint:depguard
 	"debug/gosym"
 	"fmt"
 	"io"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

1. Uses the `safeelf` package everywhere, which handles panics during ELF parsing.
2. Prevents the usage of `debug/elf` with `depguard`.
3. Handles if `elf.Section.ReaderAt` is `nil`, which is possible.

### Motivation

The `debug/elf` package is known to have several bugs/limitations which result in panics. Since system-probe parses many arbitrary binaries, this change will prevent those binaries from crashing system-probe if they are malformed in some way.

### Describe how to test/QA your changes

Existing automated tests pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->