### PR TITLE
use pid 1 for TestGetProbeStats

### DIFF
--- a/pkg/ebpf/telemetry/debugfs_test.go
+++ b/pkg/ebpf/telemetry/debugfs_test.go
@@ -41,6 +41,6 @@ func TestGetProbeStats(t *testing.T) {
 	require.Equal(t, uint64(549926224), stats["r_tcp_sendmsg_hits"])
 	require.Equal(t, uint64(549925022), stats["p_tcp_sendmsg_hits"])
 
-	stats = getProbeStats(0, testProfile)
+	stats = getProbeStats(1, testProfile)
 	require.Empty(t, stats)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes `TestGetProbeStats` by using PID `1` instead of `0` (which means current process PID).

### Motivation

If the current process PID happened to be `4256` or `7178` it would fail the test.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-610

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->