### PR TITLE
Fix race condition setting global tags in Azure Container Apps.

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -174,7 +174,7 @@ func setupTraceAgent(tags map[string]string, tagger tagger.Component) trace.Serv
 	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
 		Enabled:               pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
 		LoadConfig:            &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
-		ColdStartSpanId:       random.Random.Uint64(),
+		ColdStartSpanID:       random.Random.Uint64(),
 		AzureContainerAppTags: azureTags.String(),
 	})
 	go func() {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -10,8 +10,10 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,13 +152,31 @@ func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *se
 	go flushMetricsAgent(metricAgent)
 	return cloudService, agentLogConfig, traceAgent, metricAgent, logsAgent
 }
+
+var azureContainerAppTags = []string{
+	"subscription_id",
+	"resource_group",
+	"resource_id",
+	"replicate_name",
+	"aca.subscription.id",
+	"aca.resource.group",
+	"aca.resource.id",
+	"aca.replica.name",
+}
+
 func setupTraceAgent(tags map[string]string, tagger tagger.Component) trace.ServerlessTraceAgent {
+	var azureTags strings.Builder
+	for _, azureContainerAppTag := range azureContainerAppTags {
+		if value, ok := tags[azureContainerAppTag]; ok {
+			azureTags.WriteString(fmt.Sprintf(",%s:%s", azureContainerAppTag, value))
+		}
+	}
 	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
-		Enabled:         pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
-		LoadConfig:      &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
-		ColdStartSpanId: random.Random.Uint64(),
+		Enabled:               pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
+		LoadConfig:            &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
+		ColdStartSpanId:       random.Random.Uint64(),
+		AzureContainerAppTags: azureTags.String(),
 	})
-	traceAgent.SetTags(tags)
 	go func() {
 		for range time.Tick(3 * time.Second) {
 			traceAgent.Flush()

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -151,7 +151,11 @@ func setup(_ mode.Conf, tagger tagger.Component) (cloudservice.CloudService, *se
 	return cloudService, agentLogConfig, traceAgent, metricAgent, logsAgent
 }
 func setupTraceAgent(tags map[string]string, tagger tagger.Component) trace.ServerlessTraceAgent {
-	traceAgent := trace.StartServerlessTraceAgent(pkgconfigsetup.Datadog().GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger}, nil, random.Random.Uint64())
+	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
+		Enabled:         pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
+		LoadConfig:      &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	traceAgent.SetTags(tags)
 	go func() {
 		for range time.Tick(3 * time.Second) {

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -341,7 +341,7 @@ func startTraceAgent(wg *sync.WaitGroup, lambdaSpanChan chan *pb.Span, coldStart
 		Enabled:         pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
 		LoadConfig:      &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: coldStartSpanId,
+		ColdStartSpanID: coldStartSpanId,
 	})
 	serverlessDaemon.SetTraceAgent(traceAgent)
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -337,7 +337,12 @@ func startOtlpAgent(wg *sync.WaitGroup, metricAgent *metrics.ServerlessMetricAge
 
 func startTraceAgent(wg *sync.WaitGroup, lambdaSpanChan chan *pb.Span, coldStartSpanId uint64, serverlessDaemon *daemon.Daemon, tagger tagger.Component) {
 	defer wg.Done()
-	traceAgent := trace.StartServerlessTraceAgent(pkgconfigsetup.Datadog().GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger}, lambdaSpanChan, coldStartSpanId)
+	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
+		Enabled:         pkgconfigsetup.Datadog().GetBool("apm_config.enabled"),
+		LoadConfig:      &trace.LoadConfig{Path: datadogConfigPath, Tagger: tagger},
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: coldStartSpanId,
+	})
 	serverlessDaemon.SetTraceAgent(traceAgent)
 }
 

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -175,7 +175,7 @@ func TestSetTraceTagOk(t *testing.T) {
 		Enabled:         true,
 		LoadConfig:      &trace.LoadConfig{Path: "/does-not-exist.yml"},
 		LambdaSpanChan:  make(chan *pb.Span),
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	d := Daemon{

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -171,7 +171,12 @@ func TestSetTraceTagOk(t *testing.T) {
 	}
 	t.Setenv("DD_API_KEY", "x")
 	t.Setenv("DD_RECEIVER_PORT", strconv.Itoa(testutil.FreeTCPPort(t)))
-	agent := trace.StartServerlessTraceAgent(true, &trace.LoadConfig{Path: "/does-not-exist.yml"}, make(chan *pb.Span), random.Random.Uint64())
+	agent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &trace.LoadConfig{Path: "/does-not-exist.yml"},
+		LambdaSpanChan:  make(chan *pb.Span),
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	d := Daemon{
 		TraceAgent: agent,

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -441,7 +441,11 @@ func BenchmarkStartEndInvocation(b *testing.B) {
 func startAgents() *Daemon {
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", testutil.FreeTCPPort(nil)))
 
-	ta := trace.StartServerlessTraceAgent(true, &trace.LoadConfig{Path: "/some/path/datadog.yml"}, nil, 123)
+	ta := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &trace.LoadConfig{Path: "/some/path/datadog.yml"},
+		ColdStartSpanId: 123,
+	})
 	d.SetTraceAgent(ta)
 
 	ma := &metrics.ServerlessMetricAgent{

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -444,7 +444,7 @@ func startAgents() *Daemon {
 	ta := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
 		Enabled:         true,
 		LoadConfig:      &trace.LoadConfig{Path: "/some/path/datadog.yml"},
-		ColdStartSpanId: 123,
+		ColdStartSpanID: 123,
 	})
 	d.SetTraceAgent(ta)
 

--- a/pkg/serverless/otlp/otlp_test.go
+++ b/pkg/serverless/otlp/otlp_test.go
@@ -65,7 +65,10 @@ func TestServerlessOTLPAgentReceivesTraces(t *testing.T) {
 	t.Setenv("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT", grpcEndpoint)
 
 	// setup trace agent
-	traceAgent := trace.StartServerlessTraceAgent(true, &trace.LoadConfig{Path: "./testdata/valid.yml"}, nil, 0)
+	traceAgent := trace.StartServerlessTraceAgent(trace.StartServerlessTraceAgentArgs{
+		Enabled:    true,
+		LoadConfig: &trace.LoadConfig{Path: "./testdata/valid.yml"},
+	})
 	defer traceAgent.Stop()
 	assert.NotNil(traceAgent)
 	traceChan := make(chan struct{})

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -91,11 +91,13 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 	return comptracecfg.LoadConfigFile(l.Path, c, l.Tagger)
 }
 
+// StartServerlessTraceAgentArgs are the arguments for the StartServerlessTraceAgent method
 type StartServerlessTraceAgentArgs struct {
-	Enabled         bool
-	LoadConfig      Load
-	LambdaSpanChan  chan<- *pb.Span
-	ColdStartSpanId uint64
+	Enabled               bool
+	LoadConfig            Load
+	LambdaSpanChan        chan<- *pb.Span
+	ColdStartSpanId       uint64
+	AzureContainerAppTags string
 }
 
 // Start starts the agent
@@ -115,6 +117,7 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 			context, cancel := context.WithCancel(context.Background())
 			tc.Hostname = ""
 			tc.SynchronousFlushing = true
+			tc.AzureContainerAppTags = args.AzureContainerAppTags
 			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 			ta.SpanModifier = &spanModifier{
 				coldStartSpanId: args.ColdStartSpanId,

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -91,17 +91,24 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 	return comptracecfg.LoadConfigFile(l.Path, c, l.Tagger)
 }
 
+type StartServerlessTraceAgentArgs struct {
+	Enabled         bool
+	LoadConfig      Load
+	LambdaSpanChan  chan<- *pb.Span
+	ColdStartSpanId uint64
+}
+
 // Start starts the agent
 //
 //nolint:revive // TODO(SERV) Fix revive linter
-func StartServerlessTraceAgent(enabled bool, loadConfig Load, lambdaSpanChan chan<- *pb.Span, coldStartSpanId uint64) ServerlessTraceAgent {
-	if enabled {
+func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTraceAgent {
+	if args.Enabled {
 		// Set the serverless config option which will be used to determine if
 		// hostname should be resolved. Skipping hostname resolution saves >1s
 		// in load time between gRPC calls and agent commands.
 		pkgconfigsetup.Datadog().Set("serverless.enabled", true, model.SourceAgentRuntime)
 
-		tc, confErr := loadConfig.Load()
+		tc, confErr := args.LoadConfig.Load()
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)
 		} else {
@@ -110,8 +117,8 @@ func StartServerlessTraceAgent(enabled bool, loadConfig Load, lambdaSpanChan cha
 			tc.SynchronousFlushing = true
 			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 			ta.SpanModifier = &spanModifier{
-				coldStartSpanId: coldStartSpanId,
-				lambdaSpanChan:  lambdaSpanChan,
+				coldStartSpanId: args.ColdStartSpanId,
+				lambdaSpanChan:  args.LambdaSpanChan,
 				ddOrigin:        getDDOrigin(),
 			}
 

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -96,7 +96,7 @@ type StartServerlessTraceAgentArgs struct {
 	Enabled               bool
 	LoadConfig            Load
 	LambdaSpanChan        chan<- *pb.Span
-	ColdStartSpanId       uint64
+	ColdStartSpanID       uint64
 	AzureContainerAppTags string
 }
 
@@ -120,7 +120,7 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 			tc.AzureContainerAppTags = args.AzureContainerAppTags
 			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 			ta.SpanModifier = &spanModifier{
-				coldStartSpanId: args.ColdStartSpanId,
+				coldStartSpanId: args.ColdStartSpanID,
 				lambdaSpanChan:  args.LambdaSpanChan,
 				ddOrigin:        getDDOrigin(),
 			}

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -37,7 +37,7 @@ func TestStartEnabledFalse(t *testing.T) {
 	lambdaSpanChan := make(chan *pb.Span)
 	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
@@ -60,7 +60,7 @@ func TestStartEnabledTrueInvalidConfig(t *testing.T) {
 		Enabled:         true,
 		LoadConfig:      &LoadConfigMocked{},
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
@@ -77,7 +77,7 @@ func TestStartEnabledTrueValidConfigInvalidPath(t *testing.T) {
 		Enabled:         true,
 		LoadConfig:      &LoadConfig{Path: "invalid.yml"},
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
@@ -93,7 +93,7 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 		Enabled:         true,
 		LoadConfig:      &LoadConfig{Path: "./testdata/valid.yml"},
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
@@ -111,7 +111,7 @@ func TestLoadConfigShouldBeFast(t *testing.T) {
 		Enabled:         true,
 		LoadConfig:      &LoadConfig{Path: "./testdata/valid.yml"},
 		LambdaSpanChan:  lambdaSpanChan,
-		ColdStartSpanId: random.Random.Uint64(),
+		ColdStartSpanID: random.Random.Uint64(),
 	})
 	defer agent.Stop()
 	assert.True(t, time.Since(startTime) < time.Second)

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -35,7 +35,10 @@ func TestStartEnabledFalse(t *testing.T) {
 	setupTraceAgentTest(t)
 
 	lambdaSpanChan := make(chan *pb.Span)
-	agent := StartServerlessTraceAgent(false, nil, lambdaSpanChan, random.Random.Uint64())
+	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
 	assert.IsType(t, noopTraceAgent{}, agent)
@@ -53,7 +56,12 @@ func TestStartEnabledTrueInvalidConfig(t *testing.T) {
 	setupTraceAgentTest(t)
 
 	lambdaSpanChan := make(chan *pb.Span)
-	agent := StartServerlessTraceAgent(true, &LoadConfigMocked{}, lambdaSpanChan, random.Random.Uint64())
+	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &LoadConfigMocked{},
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
 	assert.IsType(t, noopTraceAgent{}, agent)
@@ -65,7 +73,12 @@ func TestStartEnabledTrueValidConfigInvalidPath(t *testing.T) {
 	lambdaSpanChan := make(chan *pb.Span)
 
 	t.Setenv("DD_API_KEY", "x")
-	agent := StartServerlessTraceAgent(true, &LoadConfig{Path: "invalid.yml"}, lambdaSpanChan, random.Random.Uint64())
+	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &LoadConfig{Path: "invalid.yml"},
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
 	assert.IsType(t, &serverlessTraceAgent{}, agent)
@@ -76,7 +89,12 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 
 	lambdaSpanChan := make(chan *pb.Span)
 
-	agent := StartServerlessTraceAgent(true, &LoadConfig{Path: "./testdata/valid.yml"}, lambdaSpanChan, random.Random.Uint64())
+	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &LoadConfig{Path: "./testdata/valid.yml"},
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	assert.NotNil(t, agent)
 	assert.IsType(t, &serverlessTraceAgent{}, agent)
@@ -89,7 +107,12 @@ func TestLoadConfigShouldBeFast(t *testing.T) {
 	startTime := time.Now()
 	lambdaSpanChan := make(chan *pb.Span)
 
-	agent := StartServerlessTraceAgent(true, &LoadConfig{Path: "./testdata/valid.yml"}, lambdaSpanChan, random.Random.Uint64())
+	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
+		Enabled:         true,
+		LoadConfig:      &LoadConfig{Path: "./testdata/valid.yml"},
+		LambdaSpanChan:  lambdaSpanChan,
+		ColdStartSpanId: random.Random.Uint64(),
+	})
 	defer agent.Stop()
 	assert.True(t, time.Since(startTime) < time.Second)
 }

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -30,17 +30,6 @@ const (
 	profilingV1EndpointSuffix = "v1/input"
 )
 
-var azureContainerAppTags = []string{
-	"subscription_id",
-	"resource_group",
-	"resource_id",
-	"replicate_name",
-	"aca.subscription.id",
-	"aca.resource.group",
-	"aca.resource.id",
-	"aca.replica.name",
-}
-
 // profilingEndpoints returns the profiling intake urls and their corresponding
 // api keys based on agent configuration. The main endpoint is always returned as
 // the first element in the slice.
@@ -97,11 +86,8 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 		tags.WriteString(fmt.Sprintf("functionname:%s", strings.ToLower(r.conf.LambdaFunctionName)))
 		tags.WriteString("_dd.origin:lambda")
 	}
-
-	for _, azureContainerAppTag := range azureContainerAppTags {
-		if value, ok := r.conf.GlobalTags[azureContainerAppTag]; ok {
-			tags.WriteString(fmt.Sprintf(",%s:%s", azureContainerAppTag, value))
-		}
+	if r.conf.AzureContainerAppTags != "" {
+		tags.WriteString(r.conf.AzureContainerAppTags)
 	}
 
 	return newProfileProxy(r.conf, targets, keys, tags.String(), r.statsd)

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -323,15 +323,7 @@ func TestProfileProxyHandler(t *testing.T) {
 		}))
 		conf := newTestReceiverConfig()
 		conf.ProfilingProxy = config.ProfilingProxyConfig{DDURL: srv.URL}
-		conf.GlobalTags = map[string]string{
-			"subscription_id":     "123",
-			"resource_group":      "test-rg",
-			"resource_id":         "456",
-			"aca.subscription.id": "123",
-			"aca.resource.group":  "test-rg",
-			"aca.resource.id":     "456",
-			"aca.replica.name":    "test-replica",
-		}
+		conf.AzureContainerAppTags = ",subscription_id:123,resource_group:test-rg,resource_id:456,aca.subscription.id:123,aca.resource.group:test-rg,aca.resource.id:456,aca.replica.name:test-replica"
 		req, err := http.NewRequest("POST", "/some/path", nil)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -450,6 +450,10 @@ type AgentConfig struct {
 
 	// Lambda function name
 	LambdaFunctionName string
+
+	// Azure container apps tags, in the form of a comma-separated list of
+	// key-value pairs, starting with a comma
+	AzureContainerAppTags string
 }
 
 // RemoteClient client is used to APM Sampling Updates from a remote source.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Addresses a race condition when setting tags for azure container apps profiles.

### Motivation

```
=== RUN   TestSetTraceTagOk
1730756207138578000 [Info] Starting to load the configuration
1730756207139042000 [Warn] config key fleet_policies_dir is unknown
1730756207139820000 [Error] Error when subscribing to remote config management remote configuration is not supported in serverless
1730756207140153000 [Info] Loaded configuration: /does-not-exist.yml
--- PASS: TestSetTraceTagOk (0.02s)
=== RUN   TestOutOfOrderInvocations
1730756207163683000 [Debug] Starting daemon to receive messages from runtime...
==================
WARNING: DATA RACE
Read at 0x00c000167198 by goroutine 140:
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).profileProxyHandler()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/profiles.go:102 +0x430
  github.com/DataDog/datadog-agent/pkg/trace/api.init.func15()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/endpoints.go:99 +0x28
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).buildMux()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api.go:203 +0x1f4
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api.go:255 +0x294
  github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).Run()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:191 +0x388
  github.com/DataDog/datadog-agent/pkg/serverless/trace.StartServerlessTraceAgent.gowrap1()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/trace/trace.go:119 +0x34

Previous write at 0x00c000167198 by goroutine 104:
  github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).SetGlobalTagsUnsafe()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:735 +0x60
  github.com/DataDog/datadog-agent/pkg/serverless/trace.(*serverlessTraceAgent).SetTags()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/trace/trace.go:152 +0x28
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.(*Daemon).setTraceTags()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon.go:442 +0x218
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestSetTraceTagOk()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:179 +0x278
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x40

Goroutine 140 (running) created at:
  github.com/DataDog/datadog-agent/pkg/serverless/trace.StartServerlessTraceAgent()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/trace/trace.go:119 +0x398
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestSetTraceTagOk()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:174 +0x1e8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x40

Goroutine 104 (finished) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x5e0
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2168 +0x80
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.runTests()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2166 +0x6e0
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2034 +0xb74
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestMain()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:31 +0x94
  main.main()
      _testmain.go:95 +0x114
==================
==================
WARNING: DATA RACE
Read at 0x00c00040ed20 by goroutine 140:
  runtime.mapassign_fast64ptr()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/runtime/map_fast64.go:214 +0x36c
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).profileProxyHandler()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/profiles.go:102 +0x44c
  github.com/DataDog/datadog-agent/pkg/trace/api.init.func15()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/endpoints.go:99 +0x28
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).buildMux()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api.go:203 +0x1f4
  github.com/DataDog/datadog-agent/pkg/trace/api.(*HTTPReceiver).Start()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api.go:255 +0x294
  github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).Run()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:191 +0x388
  github.com/DataDog/datadog-agent/pkg/serverless/trace.StartServerlessTraceAgent.gowrap1()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/trace/trace.go:119 +0x34

Previous write at 0x00c00040ed20 by goroutine 104:
  runtime.mapaccess2_faststr()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/runtime/map_faststr.go:117 +0x42c
  github.com/DataDog/datadog-agent/pkg/serverless/tags.buildTags()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/tags/tags.go:173 +0x148
  github.com/DataDog/datadog-agent/pkg/serverless/tags.BuildTracerTags()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/tags/tags.go:167 +0x4c
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.(*Daemon).setTraceTags()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon.go:442 +0x1f8
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestSetTraceTagOk()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:179 +0x278
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x40

Goroutine 140 (running) created at:
  github.com/DataDog/datadog-agent/pkg/serverless/trace.StartServerlessTraceAgent()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/trace/trace.go:119 +0x398
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestSetTraceTagOk()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:174 +0x1e8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x40

Goroutine 104 (finished) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1743 +0x5e0
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2168 +0x80
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1690 +0x184
  testing.runTests()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2166 +0x6e0
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:2034 +0xb74
  github.com/DataDog/datadog-agent/pkg/serverless/daemon.TestMain()
      /Users/rey.abolofia/go/src/github.com/DataDog/datadog-agent/pkg/serverless/daemon/daemon_test.go:31 +0x94
  main.main()
      _testmain.go:95 +0x114
==================
1730756207164898000 [Debug] Waiting to shut down HTTP server
1730756207165086000 [Debug] Shutting down HTTP server
1730756207165571000 [Debug] Beginning metrics flush at time 1730756207
1730756207165946000 [Debug] Finished metrics flush that was started at time 1730756207
1730756207166192000 [Debug] Beginning logs flush at time 1730756207
1730756207166555000 [Debug] Finished logs flush that was started at time 1730756207
1730756207166881000 [Debug] Beginning traces flush at time 1730756207
1730756207167263000 [Debug] Finished traces flush that was started at time 1730756207
1730756207167403000 [Debug] Finished flushing
1730756207167530000 [Debug] Shutting down agents
1730756207167731000 [Debug] Serverless agent shutdown complete
    testing.go:1399: race detected during execution of test
--- FAIL: TestOutOfOrderInvocations (0.01s)
FAIL
FAIL	github.com/DataDog/datadog-agent/pkg/serverless/daemon	0.377s
FAIL
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->