### PR TITLE
[smp]: idle_all_features gate: 785 MiB -> 770 MiB

### DIFF
--- a/test/regression/cases/idle_all_features/experiment.yaml
+++ b/test/regression/cases/idle_all_features/experiment.yaml
@@ -48,7 +48,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "785.0 MiB"
+      upper_bound: "770.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -47,7 +47,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "785.0 MiB"
+      upper_bound: "770.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit tightens the upper bound on Agent's `idle_all_features` memory consumption, stating that the overhead of Agent with all features enabled is no more than 770 MiB by default, instead of the previous 785 MiB.

### Motivation

Reduce Agent resource usage.

### Describe how to test/QA your changes

Quality gates runs will test the changes.

### Possible Drawbacks / Trade-offs

Less headroom for features, lower operating costs for customers (we hope).

### Additional Notes

n/a

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->