### PR TITLE
Update lading 0.23.5

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.23.3
+  version: 0.23.5
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
This commit, when paired with an SMP update, will allow us to use logrotate FS in Regression Detector experiments. Likewise fixes a targetting PID bug.

