### PR TITLE
fix(installer): Properly support DD_AGENT_MINOR_VERSION when it's not in the minor.patch format

### DIFF
--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -132,11 +132,15 @@ func packageToLanguage(packageName string) env.ApmLibLanguage {
 }
 
 func agentVersion(_ Package, e *env.Env) string {
-	if e.AgentMajorVersion != "" && e.AgentMinorVersion != "" {
-		return e.AgentMajorVersion + "." + e.AgentMinorVersion + "-1"
+	minorVersion := e.AgentMinorVersion
+	if strings.Contains(minorVersion, ".") && !strings.HasSuffix(minorVersion, "-1") {
+		minorVersion = minorVersion + "-1"
 	}
-	if e.AgentMinorVersion != "" {
-		return "7." + e.AgentMinorVersion + "-1"
+	if e.AgentMajorVersion != "" && minorVersion != "" {
+		return e.AgentMajorVersion + "." + minorVersion
+	}
+	if minorVersion != "" {
+		return "7." + minorVersion
 	}
 	return "latest"
 }

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -279,3 +279,64 @@ func TestDefaultPackages(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentVersion(t *testing.T) {
+	type testCase struct {
+		name           string
+		majorVersion   string
+		minorVersions  string
+		expectedResult string
+	}
+
+	tests := []testCase{
+		{
+			name:           "No version",
+			majorVersion:   "",
+			minorVersions:  "",
+			expectedResult: "latest",
+		},
+		{
+			name:           "Major version only",
+			majorVersion:   "7",
+			minorVersions:  "",
+			expectedResult: "latest",
+		},
+		{
+			name:           "Major, minor+patch version",
+			majorVersion:   "7",
+			minorVersions:  "42.0",
+			expectedResult: "7.42.0-1",
+		},
+		{
+			name:           "Major, minor version",
+			majorVersion:   "7",
+			minorVersions:  "42",
+			expectedResult: "7.42",
+		},
+		{
+			name:           "minor+patch",
+			minorVersions:  "42.0",
+			expectedResult: "7.42.0-1",
+		},
+		{
+			name:           "minor+patch-1",
+			minorVersions:  "42.0-1",
+			expectedResult: "7.42.0-1",
+		},
+		{
+			name:           "minor only",
+			minorVersions:  "42",
+			expectedResult: "7.42",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &env.Env{
+				AgentMajorVersion: tt.majorVersion,
+				AgentMinorVersion: tt.minorVersions,
+			}
+			res := agentVersion(Package{}, e)
+			assert.Equal(t, tt.expectedResult, res)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Supports setting `DD_AGENT_MINOR_VERSION=58`

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->