### PR TITLE
[CI][macOS runners] Temporary never fail on `virtualenv already exists` error + debug messages

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -28,8 +28,15 @@
       echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
       echo "Installing Python $PYTHON_REPO_VERSION..."
     fi
+    ## START TEMPORARY DEBUG see ACIX-500
+    echo $PYTHON_VERSION
+    echo $VENV_NAME
+    pyenv virtualenvs --bare
+    ## END TEMPORARY DEBUG see ACIX-500
     if ! pyenv virtualenvs --bare | grep -q "^${VENV_NAME}$"; then
-      pyenv virtualenv $PYTHON_VERSION $VENV_NAME
+      # The || true is a quickfix avoiding the command to fail if the virtualenv already exists
+      # This should be removed once ACIX-500 is done
+      pyenv virtualenv $PYTHON_VERSION $VENV_NAME || true
     fi
     pyenv activate $VENV_NAME
 

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -32,6 +32,7 @@
     echo $PYTHON_VERSION
     echo $VENV_NAME
     pyenv virtualenvs --bare
+    ls $(pyenv root)/versions/
     ## END TEMPORARY DEBUG see ACIX-500
     if ! pyenv virtualenvs --bare | grep -q "^${VENV_NAME}$"; then
       # The || true is a quickfix avoiding the command to fail if the virtualenv already exists


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR temporary fixes the following error on the macOS runners:
```
pyenv-virtualenv: `/Users/ec2-user/.pyenv/versions/datadog-agent-python-3.11' already exists.
```
It also adds a debug to allow us understanding the failure on poisoned long runners.

### Motivation

Fix the CI.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/ACIX-500