### PR TITLE
ebpf: CPU and memory optimization in `findKernelFuncs`

### DIFF
--- a/pkg/ebpf/ksyms_test.go
+++ b/pkg/ebpf/ksyms_test.go
@@ -42,3 +42,10 @@ func TestVerifyKernelFuncs(t *testing.T) {
 	_, err = fc.verifyKernelFuncs(requiredKernelFuncs)
 	assert.NotEmpty(t, err)
 }
+
+func BenchmarkVerifyKernelFuncs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		fc := newExistCache("./testdata/kallsyms.supported")
+		fc.verifyKernelFuncs(requiredKernelFuncs)
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR optimizes the `findKernelFuncs` by skipping all allocation until we are sure the parsed line is an interesting one, especially the `bytes.Fields` related allocations.

benchmark:
```
go test -benchmem -count=10 -run=^$ -bench ^BenchmarkVerifyKernelFuncs$ github.com/DataDog/datadog-agent/pkg/ebpf

goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/ebpf
cpu: Apple M1 Max
                     │   old.txt   │               new.txt               │
                     │   sec/op    │   sec/op     vs base                │
VerifyKernelFuncs-10   5.975m ± 2%   1.524m ± 6%  -74.50% (p=0.000 n=10)

                     │     old.txt     │               new.txt                │
                     │      B/op       │     B/op      vs base                │
VerifyKernelFuncs-10   4029.156Ki ± 0%   5.461Ki ± 0%  -99.86% (p=0.000 n=10)

                     │    old.txt    │              new.txt               │
                     │   allocs/op   │ allocs/op   vs base                │
VerifyKernelFuncs-10   51531.00 ± 0%   28.00 ± 0%  -99.95% (p=0.000 n=10)
```

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->