### PR TITLE
[serverless] Support trace context propagation for ALB target groups with MultiValueHeaders

### DIFF
--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -253,6 +253,16 @@ func headersCarrier(hdrs map[string]string) (tracer.TextMapReader, error) {
 	return tracer.TextMapCarrier(hdrs), nil
 }
 
+// headersOrMultiheadersCarrier returns the tracer.TextMapReader used to extract
+// trace context from a Headers field of form map[string]string or MultiValueHeaders
+// field of form map[string][]string.
+func headersOrMultiheadersCarrier(hdrs map[string]string, multiHdrs map[string][]string) (tracer.TextMapReader, error) {
+	if len(hdrs) > 0 {
+		return headersCarrier(hdrs)
+	}
+	return tracer.HTTPHeadersCarrier(multiHdrs), nil
+}
+
 // extractTraceContextFromStepFunctionContext extracts the execution ARN, state name, and state entered time and uses them to generate Trace ID and Parent ID
 // The logic is based on the trace context conversion in Logs To Traces, dd-trace-py, dd-trace-js, etc.
 func extractTraceContextFromStepFunctionContext(event events.StepFunctionPayload) (*TraceContext, error) {

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -253,16 +253,6 @@ func headersCarrier(hdrs map[string]string) (tracer.TextMapReader, error) {
 	return tracer.TextMapCarrier(hdrs), nil
 }
 
-// multiValueHeadersCarrier returns the tracer.TextMapReader used to extract trace
-// context from a MultiValueHeaders field of form map[string][]string.
-func multiValueHeadersCarrier(hdrs map[string][]string) (tracer.TextMapReader, error) {
-	headers := make(map[string]string)
-	for k, v := range hdrs {
-		headers[k] = v[0]
-	}
-	return headersCarrier(headers)
-}
-
 // extractTraceContextFromStepFunctionContext extracts the execution ARN, state name, and state entered time and uses them to generate Trace ID and Parent ID
 // The logic is based on the trace context conversion in Logs To Traces, dd-trace-py, dd-trace-js, etc.
 func extractTraceContextFromStepFunctionContext(event events.StepFunctionPayload) (*TraceContext, error) {

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -253,6 +253,16 @@ func headersCarrier(hdrs map[string]string) (tracer.TextMapReader, error) {
 	return tracer.TextMapCarrier(hdrs), nil
 }
 
+// multiValueHeadersCarrier returns the tracer.TextMapReader used to extract trace
+// context from a MultiValueHeaders field of form map[string][]string.
+func multiValueHeadersCarrier(hdrs map[string][]string) (tracer.TextMapReader, error) {
+	headers := make(map[string]string)
+	for k, v := range hdrs {
+		headers[k] = v[0]
+	}
+	return headersCarrier(headers)
+}
+
 // extractTraceContextFromStepFunctionContext extracts the execution ARN, state name, and state entered time and uses them to generate Trace ID and Parent ID
 // The logic is based on the trace context conversion in Logs To Traces, dd-trace-py, dd-trace-js, etc.
 func extractTraceContextFromStepFunctionContext(event events.StepFunctionPayload) (*TraceContext, error) {

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -826,51 +826,6 @@ func TestHeadersCarrier(t *testing.T) {
 	}
 }
 
-func TestMultiValueHeadersCarrier(t *testing.T) {
-	testcases := []struct {
-		name   string
-		event  map[string]string
-		expMap map[string]string
-		expErr error
-	}{
-		{
-			name:   "nil-map",
-			event:  headersMapNone,
-			expMap: headersMapEmpty,
-			expErr: nil,
-		},
-		{
-			name:   "empty-map",
-			event:  headersMapEmpty,
-			expMap: headersMapEmpty,
-			expErr: nil,
-		},
-		{
-			name:   "headers-all",
-			event:  headersMapAll,
-			expMap: headersMapAll,
-			expErr: nil,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			event := map[string][]string{}
-			for k, v := range tc.event {
-				event[k] = []string{v, "dummy"}
-			}
-
-			tm, err := multiValueHeadersCarrier(event)
-			t.Logf("rawPayloadCarrier returned TextMapReader=%#v error=%#v", tm, err)
-			assert.Equal(t, tc.expErr != nil, err != nil)
-			if tc.expErr != nil && err != nil {
-				assert.Equal(t, tc.expErr.Error(), err.Error())
-			}
-			assert.Equal(t, tc.expMap, getMapFromCarrier(tm))
-		})
-	}
-}
-
 func Test_stringToDdSpanId(t *testing.T) {
 	type args struct {
 		execArn          string

--- a/pkg/serverless/trace/propagation/carriers_test.go
+++ b/pkg/serverless/trace/propagation/carriers_test.go
@@ -826,6 +826,51 @@ func TestHeadersCarrier(t *testing.T) {
 	}
 }
 
+func TestMultiValueHeadersCarrier(t *testing.T) {
+	testcases := []struct {
+		name   string
+		event  map[string]string
+		expMap map[string]string
+		expErr error
+	}{
+		{
+			name:   "nil-map",
+			event:  headersMapNone,
+			expMap: headersMapEmpty,
+			expErr: nil,
+		},
+		{
+			name:   "empty-map",
+			event:  headersMapEmpty,
+			expMap: headersMapEmpty,
+			expErr: nil,
+		},
+		{
+			name:   "headers-all",
+			event:  headersMapAll,
+			expMap: headersMapAll,
+			expErr: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := map[string][]string{}
+			for k, v := range tc.event {
+				event[k] = []string{v, "dummy"}
+			}
+
+			tm, err := multiValueHeadersCarrier(event)
+			t.Logf("rawPayloadCarrier returned TextMapReader=%#v error=%#v", tm, err)
+			assert.Equal(t, tc.expErr != nil, err != nil)
+			if tc.expErr != nil && err != nil {
+				assert.Equal(t, tc.expErr.Error(), err.Error())
+			}
+			assert.Equal(t, tc.expMap, getMapFromCarrier(tm))
+		})
+	}
+}
+
 func Test_stringToDdSpanId(t *testing.T) {
 	type args struct {
 		execArn          string

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -115,7 +115,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 		if len(ev.Headers) > 0 {
 			carrier, err = headersCarrier(ev.Headers)
 		} else {
-			carrier, err = multiValueHeadersCarrier(ev.MultiValueHeaders)
+			carrier = tracer.HTTPHeadersCarrier(ev.MultiValueHeaders)
 		}
 	case events.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -112,11 +112,7 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 	case events.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.ALBTargetGroupRequest:
-		if len(ev.Headers) > 0 {
-			carrier, err = headersCarrier(ev.Headers)
-		} else {
-			carrier = tracer.HTTPHeadersCarrier(ev.MultiValueHeaders)
-		}
+		carrier, err = headersOrMultiheadersCarrier(ev.Headers, ev.MultiValueHeaders)
 	case events.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.StepFunctionPayload:

--- a/pkg/serverless/trace/propagation/extractor.go
+++ b/pkg/serverless/trace/propagation/extractor.go
@@ -112,7 +112,11 @@ func (e Extractor) extract(event interface{}) (*TraceContext, error) {
 	case events.APIGatewayCustomAuthorizerRequestTypeRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.ALBTargetGroupRequest:
-		carrier, err = headersCarrier(ev.Headers)
+		if len(ev.Headers) > 0 {
+			carrier, err = headersCarrier(ev.Headers)
+		} else {
+			carrier, err = multiValueHeadersCarrier(ev.MultiValueHeaders)
+		}
 	case events.LambdaFunctionURLRequest:
 		carrier, err = headersCarrier(ev.Headers)
 	case events.StepFunctionPayload:

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -176,6 +176,14 @@ var (
 	}
 )
 
+func toMultiValueHeaders(headers map[string]string) map[string][]string {
+	mvh := make(map[string][]string)
+	for k, v := range headers {
+		mvh[k] = []string{v, "dummy"}
+	}
+	return mvh
+}
+
 func TestNilPropagator(t *testing.T) {
 	var extractor Extractor
 	tc, err := extractor.Extract([]byte(`{"headers":` + headersAll + `}`))
@@ -528,6 +536,16 @@ func TestExtractorExtract(t *testing.T) {
 			events: []interface{}{
 				events.ALBTargetGroupRequest{
 					Headers: headersMapAll,
+				},
+			},
+			expCtx:   ddTraceContext,
+			expNoErr: true,
+		},
+		{
+			name: "ALBTargetGroupRequestMultiValueHeaders",
+			events: []interface{}{
+				events.ALBTargetGroupRequest{
+					MultiValueHeaders: toMultiValueHeaders(headersMapAll),
 				},
 			},
 			expCtx:   ddTraceContext,

--- a/pkg/serverless/trace/propagation/extractor_test.go
+++ b/pkg/serverless/trace/propagation/extractor_test.go
@@ -179,7 +179,7 @@ var (
 func toMultiValueHeaders(headers map[string]string) map[string][]string {
 	mvh := make(map[string][]string)
 	for k, v := range headers {
-		mvh[k] = []string{v, "dummy"}
+		mvh[k] = []string{v}
 	}
 	return mvh
 }

--- a/pkg/serverless/trigger/events/events.go
+++ b/pkg/serverless/trigger/events/events.go
@@ -122,10 +122,11 @@ type APIGatewayCustomAuthorizerRequestTypeRequestContext struct {
 // ALBTargetGroupRequest mirrors events.ALBTargetGroupRequest type, removing
 // unused fields.
 type ALBTargetGroupRequest struct {
-	HTTPMethod     string
-	Path           string
-	Headers        map[string]string
-	RequestContext ALBTargetGroupRequestContext
+	HTTPMethod        string
+	Path              string
+	Headers           map[string]string
+	MultiValueHeaders map[string][]string
+	RequestContext    ALBTargetGroupRequestContext
 }
 
 // ALBTargetGroupRequestContext mirrors events.ALBTargetGroupRequestContext

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -189,22 +189,22 @@ func GetTagsFromALBTargetGroupRequest(event events.ALBTargetGroupRequest) map[st
 	httpTags["http.url_details.path"] = event.Path
 	httpTags["http.method"] = event.HTTPMethod
 
-	headers := event.Headers
-	if headers == nil && event.MultiValueHeaders != nil {
-		headers = make(map[string]string)
-		for k, v := range event.MultiValueHeaders {
-			headers[k] = v[0]
+	if event.Headers != nil {
+		if r := event.Headers["Referer"]; r != "" {
+			httpTags["http.referer"] = r
+		}
+		if ua := event.Headers["User-Agent"]; ua != "" {
+			httpTags["http.useragent"] = ua
+		}
+	} else if event.MultiValueHeaders != nil {
+		if r := event.MultiValueHeaders["Referer"]; len(r) > 0 && r[0] != "" {
+			httpTags["http.referer"] = r[0]
+		}
+		if ua := event.MultiValueHeaders["User-Agent"]; len(ua) > 0 && ua[0] != "" {
+			httpTags["http.useragent"] = ua[0]
 		}
 	}
 
-	if headers != nil {
-		if headers["Referer"] != "" {
-			httpTags["http.referer"] = headers["Referer"]
-		}
-		if ua := headers["User-Agent"]; ua != "" {
-			httpTags["http.useragent"] = ua
-		}
-	}
 	return httpTags
 }
 

--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -188,11 +188,20 @@ func GetTagsFromALBTargetGroupRequest(event events.ALBTargetGroupRequest) map[st
 	httpTags := make(map[string]string)
 	httpTags["http.url_details.path"] = event.Path
 	httpTags["http.method"] = event.HTTPMethod
-	if event.Headers != nil {
-		if event.Headers["Referer"] != "" {
-			httpTags["http.referer"] = event.Headers["Referer"]
+
+	headers := event.Headers
+	if headers == nil && event.MultiValueHeaders != nil {
+		headers = make(map[string]string)
+		for k, v := range event.MultiValueHeaders {
+			headers[k] = v[0]
 		}
-		if ua := event.Headers["User-Agent"]; ua != "" {
+	}
+
+	if headers != nil {
+		if headers["Referer"] != "" {
+			httpTags["http.referer"] = headers["Referer"]
+		}
+		if ua := headers["User-Agent"]; ua != "" {
 			httpTags["http.useragent"] = ua
 		}
 	}

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -353,6 +353,25 @@ func TestGetTagsFromALBTargetGroupRequest(t *testing.T) {
 	}, httpTags)
 }
 
+func TestGetTagsFromALBTargetGroupRequestMultiValueHeaders(t *testing.T) {
+	event := events.ALBTargetGroupRequest{
+		MultiValueHeaders: map[string][]string{
+			"key":     {"val"},
+			"Referer": {"referer"},
+		},
+		Path:       "path",
+		HTTPMethod: "http-method",
+	}
+
+	httpTags := GetTagsFromALBTargetGroupRequest(event)
+
+	assert.Equal(t, map[string]string{
+		"http.url_details.path": "path",
+		"http.method":           "http-method",
+		"http.referer":          "referer",
+	}, httpTags)
+}
+
 func TestGetTagsFromFunctionURLRequest(t *testing.T) {
 	event := events.LambdaFunctionURLRequest{
 		Headers: map[string]string{


### PR DESCRIPTION
### What does this PR do?

Adds support for extracting trace context from MultiValueHeaders in ALBTargetGroupRequest

### Motivation

Currently, Datadog APM context propagation doesn't work when MultiValueHeaders is enabled in ALB target groups. This PR resolves this issue by allowing trace context propagation even when using MultiValueHeaders configuration.

### Describe how to test/QA your changes

- Enable MultiValueHeaders in ALB target group
- Create a Lambda endpoint
- Send a request with trace context headers to the ALB endpoint
- Verify in Datadog's trace view that the trace context is properly propagated from ALB to Lambda

### Possible Drawbacks / Trade-offs

- Only the first value from MultiValueHeaders is used, subsequent values are ignored

### Additional Notes

- This PR includes test coverage:
  - Unit tests for MultiValueHeadersCarrier
  - Tests for MultiValueHeaders extraction in ALB target groups
  - Tests for MultiValueHeaders support in tag extraction functionality
- Maintains backward compatibility by prioritizing the existing Headers field

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers-request