### PR TITLE
chore(installer): use install.datadoghq.com by default

### DIFF
--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -30,12 +30,12 @@ func TestDefaultPackagesAPMInjectEnabled(t *testing.T) {
 	packages := DefaultPackages(env)
 
 	assert.Equal(t, []string{
-		"oci://gcr.io/datadoghq/apm-inject-package:latest",
-		"oci://gcr.io/datadoghq/apm-library-java-package:1",
-		"oci://gcr.io/datadoghq/apm-library-ruby-package:2",
-		"oci://gcr.io/datadoghq/apm-library-js-package:5",
-		"oci://gcr.io/datadoghq/apm-library-dotnet-package:3",
-		"oci://gcr.io/datadoghq/apm-library-python-package:2",
+		"oci://install.datadoghq.com/apm-inject-package:latest",
+		"oci://install.datadoghq.com/apm-library-java-package:1",
+		"oci://install.datadoghq.com/apm-library-ruby-package:2",
+		"oci://install.datadoghq.com/apm-library-js-package:5",
+		"oci://install.datadoghq.com/apm-library-dotnet-package:3",
+		"oci://install.datadoghq.com/apm-library-python-package:2",
 	}, packages)
 }
 
@@ -49,7 +49,7 @@ func TestDefaultPackagesAgentVersion(t *testing.T) {
 	}
 	packages := DefaultPackages(env)
 
-	assert.Equal(t, []string{"oci://gcr.io/datadoghq/agent-package:7.42.0-1"}, packages)
+	assert.Equal(t, []string{"oci://install.datadoghq.com/agent-package:7.42.0-1"}, packages)
 }
 
 func TestDefaultPackagesAgentMinorVersion(t *testing.T) {
@@ -61,7 +61,7 @@ func TestDefaultPackagesAgentMinorVersion(t *testing.T) {
 	}
 	packages := DefaultPackages(env)
 
-	assert.Equal(t, []string{"oci://gcr.io/datadoghq/agent-package:7.42.0-1"}, packages)
+	assert.Equal(t, []string{"oci://install.datadoghq.com/agent-package:7.42.0-1"}, packages)
 }
 
 func TestDefaultPackages(t *testing.T) {

--- a/pkg/fleet/internal/oci/download.go
+++ b/pkg/fleet/internal/oci/download.go
@@ -67,9 +67,11 @@ const (
 
 var (
 	defaultRegistriesStaging = []string{
+		"install.datad0g.com",
 		"docker.io/datadog",
 	}
 	defaultRegistriesProd = []string{
+		"install.datadoghq.com",
 		"gcr.io/datadoghq",
 		"public.ecr.aws/datadog",
 		"docker.io/datadog",
@@ -349,9 +351,9 @@ func (d *DownloadedPackage) WriteOCILayout(dir string) error {
 func PackageURL(env *env.Env, pkg string, version string) string {
 	switch env.Site {
 	case "datad0g.com":
-		return fmt.Sprintf("oci://docker.io/datadog/%s-package-dev:%s", strings.TrimPrefix(pkg, "datadog-"), version)
+		return fmt.Sprintf("oci://install.datad0g.com/%s-package-dev:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	default:
-		return fmt.Sprintf("oci://gcr.io/datadoghq/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
+		return fmt.Sprintf("oci://install.datadoghq.com/%s-package:%s", strings.TrimPrefix(pkg, "datadog-"), version)
 	}
 }
 

--- a/pkg/fleet/internal/oci/download_test.go
+++ b/pkg/fleet/internal/oci/download_test.go
@@ -200,8 +200,8 @@ func TestPackageURL(t *testing.T) {
 	}
 
 	tests := []test{
-		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://docker.io/datadog/agent-package-dev:latest"},
-		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://gcr.io/datadoghq/agent-package:1.2.3"},
+		{site: "datad0g.com", pkg: "datadog-agent", version: "latest", expected: "oci://install.datad0g.com/agent-package-dev:latest"},
+		{site: "datadoghq.com", pkg: "datadog-agent", version: "1.2.3", expected: "oci://install.datadoghq.com/agent-package:1.2.3"},
 	}
 
 	for _, tt := range tests {
@@ -266,16 +266,18 @@ func TestGetRefAndKeychains(t *testing.T) {
 	tests := []test{
 		{
 			name: "no override - staging",
-			url:  "docker.io/datadog/agent-package-dev:latest",
+			url:  "install.datad0g.com/agent-package-dev:latest",
 			expectedRefAndKeychains: []urlWithKeychain{
+				{ref: "install.datad0g.com/agent-package-dev:latest", keychain: authn.DefaultKeychain},
 				{ref: "docker.io/datadog/agent-package-dev:latest", keychain: authn.DefaultKeychain},
 			},
 		},
 		{
 			name:   "no override - prod",
-			url:    "gcr.io/datadoghq/agent-package@sha256:1234",
+			url:    "install.datadoghq.com/agent-package@sha256:1234",
 			isProd: true,
 			expectedRefAndKeychains: []urlWithKeychain{
+				{ref: "install.datadoghq.com/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "gcr.io/datadoghq/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "public.ecr.aws/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "docker.io/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
@@ -287,6 +289,7 @@ func TestGetRefAndKeychains(t *testing.T) {
 			isProd: true,
 			expectedRefAndKeychains: []urlWithKeychain{
 				{ref: "mysuperregistry.tv/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
+				{ref: "install.datadoghq.com/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "gcr.io/datadoghq/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "public.ecr.aws/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "docker.io/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
@@ -300,6 +303,7 @@ func TestGetRefAndKeychains(t *testing.T) {
 			isProd:               true,
 			expectedRefAndKeychains: []urlWithKeychain{
 				{ref: "mysuperregistry.tv/agent-package@sha256:1234", keychain: google.Keychain},
+				{ref: "install.datadoghq.com/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "gcr.io/datadoghq/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "public.ecr.aws/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},
 				{ref: "docker.io/datadog/agent-package@sha256:1234", keychain: authn.DefaultKeychain},

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -59,22 +59,22 @@ var testCatalog = catalog{
 		{
 			Package: string(datadogAgent),
 			Version: latestAgentImageVersion,
-			URL:     fmt.Sprintf("oci://gcr.io/datadoghq/agent-package:%s", latestAgentImageVersion),
+			URL:     fmt.Sprintf("oci://install.datadoghq.com/agent-package:%s", latestAgentImageVersion),
 		},
 		{
 			Package: string(datadogAgent),
 			Version: previousAgentImageVersion,
-			URL:     fmt.Sprintf("oci://gcr.io/datadoghq/agent-package:%s", previousAgentImageVersion),
+			URL:     fmt.Sprintf("oci://install.datadoghq.com/agent-package:%s", previousAgentImageVersion),
 		},
 		{
 			Package: string(datadogInstaller),
 			Version: latestInstallerImageVersion,
-			URL:     fmt.Sprintf("oci://gcr.io/datadoghq/installer-package:%s", latestInstallerImageVersion),
+			URL:     fmt.Sprintf("oci://install.datadoghq.com/installer-package:%s", latestInstallerImageVersion),
 		},
 		{
 			Package: string(datadogInstaller),
 			Version: previousInstallerImageVersion,
-			URL:     fmt.Sprintf("oci://gcr.io/datadoghq/installer-package:%s", previousInstallerImageVersion),
+			URL:     fmt.Sprintf("oci://install.datadoghq.com/installer-package:%s", previousInstallerImageVersion),
 		},
 	},
 }
@@ -209,7 +209,7 @@ func (s *upgradeScenarioSuite) TestExperimentCurrentVersion() {
 			{
 				Package: "datadog-agent",
 				Version: currentVersion,
-				URL:     fmt.Sprintf("oci://gcr.io/datadoghq/agent-package:%s", currentVersion),
+				URL:     fmt.Sprintf("oci://install.datadoghq.com/agent-package:%s", currentVersion),
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Uses `install.datad{0g, oghq}.com` as default when downloading OCIs 

### Motivation
Avoid proxy issues

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->