### PR TITLE
Set batch size when updating eBPF map in lock contention collector

### DIFF
--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -454,11 +454,17 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 	}
 
 	var iter uint32
+
+	// this loop inserts the lock_ranges we have previously collected
+	// into the per-cpu map `ranges`. We perform the update in batches
+	// of size `batchSize`.
 	for iter = 0; iter < (ranges/batchSize)+1; iter++ {
 		keys := make([]uint32, batchSize)
 		values := make([]LockRange, cpus*batchSize)
 
 		var i, j uint32
+
+		// this loop builds the `values` and `keys` slices for this batch
 		for i = 0; i < batchSize; i++ {
 			key := (iter * batchSize) + i
 			if key >= ranges {
@@ -466,6 +472,9 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 			}
 
 			keys[i] = key
+
+			// Since `ranges` is a per-cpu map we need to duplicate each entry
+			// for the number of CPUs on this system
 			for j = 0; j < cpus; j++ {
 				values[(j*batchSize)+i] = lockRanges[key]
 			}

--- a/pkg/ebpf/lockcontention.go
+++ b/pkg/ebpf/lockcontention.go
@@ -341,8 +341,6 @@ func (l *LockContentionCollector) Initialize(trackAllResources bool) error {
 		l.cpus = cpus
 
 		ranges = constrainMaxRanges(estimateNumOfLockRanges(maps, cpus))
-		log.Debugf("[lock-contention] tracking %d ranges", ranges)
-
 		l.ranges = ranges
 		collectionSpec.Maps["map_addr_fd"].MaxEntries = ranges
 		collectionSpec.Maps["lock_stat"].MaxEntries = ranges

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -38,7 +38,6 @@ import (
 	"golang.org/x/net/http2/hpack"
 	"golang.org/x/sys/unix"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -692,13 +692,7 @@ func TestFullMonitorWithTracer(t *testing.T) {
 	cfg.EnableIstioMonitoring = true
 	cfg.EnableGoTLSSupport = true
 
-	l := ebpf.NewLockContentionCollector()
-	require.NotNil(t, l)
-
 	tr, err := tracer.NewTracer(cfg, nil)
-	require.NoError(t, err)
-
-	err = ebpf.ContentionCollector.Initialize(ebpf.TrackAllEBPFResources)
 	require.NoError(t, err)
 
 	t.Cleanup(tr.Stop)

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -693,7 +693,6 @@ func TestFullMonitorWithTracer(t *testing.T) {
 
 	tr, err := tracer.NewTracer(cfg, nil)
 	require.NoError(t, err)
-
 	t.Cleanup(tr.Stop)
 
 	require.NoError(t, tr.RegisterClient(clientID))

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/http2/hpack"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
@@ -691,8 +692,15 @@ func TestFullMonitorWithTracer(t *testing.T) {
 	cfg.EnableIstioMonitoring = true
 	cfg.EnableGoTLSSupport = true
 
+	l := ebpf.NewLockContentionCollector()
+	require.NotNil(t, l)
+
 	tr, err := tracer.NewTracer(cfg, nil)
 	require.NoError(t, err)
+
+	err = ebpf.ContentionCollector.Initialize(ebpf.TrackAllEBPFResources)
+	require.NoError(t, err)
+
 	t.Cleanup(tr.Stop)
 
 	require.NoError(t, tr.RegisterClient(clientID))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Updating the per-cpu eBPF map for storing the lock ranges we are monitoring uses a lot of memory on startup, since we use a batch operation. This PR alleviates the memory pressure by setting a batch size to bound the memory allocated in this stage.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->