### PR TITLE
[github] set dd api key for report merged pr action

### DIFF
--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DD_API_KEY: ${{ secrets.REPORT_MERGED_PR_DD_API_KEY }}
 
 jobs:
   if_merged:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set DD api key to post events from github action

### Motivation

Action is currently failing as the API key is not set

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I created a key `
REPORT_MERGED_PR_DD_API_KEY` on org2 