### PR TITLE
[ASCII-2428] Create a metaCollector singleton

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -54,6 +54,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	procnet "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
@@ -127,6 +128,11 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				fx.Provide(tagger.NewTaggerParams),
 				taggerimpl.Module(),
+				// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+				// TODO: (component) - create a container metrics provider component.
+				fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+					metrics.GetProvider(wmeta)
+				}),
 				autodiscoveryimpl.Module(),
 				fx.Supply(optional.NewNoneOption[collector.Component]()),
 				compressionimpl.Module(),

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -59,6 +59,7 @@ import (
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -161,11 +162,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			autodiscoveryimpl.Module(),
 			agent.Bundle(jmxloggerimpl.NewCliParams(cliParams.logFile)),
 			// InitSharedContainerProvider must be called before the application starts so the workloadmeta collector can be initiailized correctly.
-			// Since the tagger depends on the workloadmeta collector, we can not make the tagger a dependency of workloadmeta as it would create a circular dependency.
-			// TODO: (component) - once we remove the dependency of workloadmeta component from the tagger component
-			// we can include the tagger as part of the workloadmeta component.
+			// TODO: (component) - create a container provider component.
 			fx.Invoke(func(wmeta workloadmeta.Component, tagger tagger.Component) {
 				proccontainers.InitSharedContainerProvider(wmeta, tagger)
+			}),
+			// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+			// TODO: (component) - create a container metrics provider component.
+			fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+				metrics.GetProvider(wmeta)
 			}),
 		)
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
@@ -198,11 +199,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				settingsimpl.Module(),
 				datadogclientmodule.Module(),
 				// InitSharedContainerProvider must be called before the application starts so the workloadmeta collector can be initiailized correctly.
-				// Since the tagger depends on the workloadmeta collector, we can not make the tagger a dependency of workloadmeta as it would create a circular dependency.
-				// TODO: (component) - once we remove the dependency of workloadmeta component from the tagger component
-				// we can include the tagger as part of the workloadmeta component.
+				// TODO: (component) - create a container provider component.
 				fx.Invoke(func(wmeta workloadmeta.Component, tagger tagger.Component) {
 					proccontainers.InitSharedContainerProvider(wmeta, tagger)
+				}),
+				// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+				// TODO: (component) - create a container metrics provider component.
+				fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+					metrics.GetProvider(wmeta)
 				}),
 			)
 		},

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -58,6 +58,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
@@ -152,6 +153,11 @@ func RunDogstatsdFct(cliParams *CLIParams, defaultConfPath string, defaultLogFil
 		eventplatformreceiverimpl.Module(),
 		hostnameimpl.Module(),
 		taggerimpl.Module(),
+		// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+		// TODO: (component) - create a container metrics provider component.
+		fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+			metrics.GetProvider(wmeta)
+		}),
 		fx.Provide(tagger.NewTaggerParams),
 		// injecting the shared Serializer to FX until we migrate it to a prpoper component. This allows other
 		// already migrated components to request it.

--- a/cmd/dogstatsd/subcommands/start/command_test.go
+++ b/cmd/dogstatsd/subcommands/start/command_test.go
@@ -8,18 +8,19 @@ package start
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestStartCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		[]*cobra.Command{MakeCommand("defaultLogFile")},
-		[]string{"start", "--cfgpath", "PATH"},
+		[]string{"start"},
 		start,
 		func(cliParams *CLIParams, _ config.Params) {
-			require.Equal(t, "PATH", cliParams.confPath)
+			require.Equal(t, "", cliParams.confPath)
 		})
 }

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -54,6 +54,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
@@ -189,6 +190,11 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 			return tagger.NewNodeRemoteTaggerParamsWithFallback()
 		}),
 		taggerimpl.Module(),
+		// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+		// TODO: (component) - create a container metrics provider component.
+		fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+			metrics.GetProvider(wmeta)
+		}),
 		telemetryimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -62,6 +62,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -117,6 +118,11 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 						return tagger.NewNodeRemoteTaggerParams()
 					}
 					return tagger.NewTaggerParams()
+				}),
+				// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+				// TODO: (component) - create a container metrics provider component.
+				fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+					metrics.GetProvider(wmeta)
 				}),
 				fx.Provide(func() startstop.Stopper {
 					return startstop.NewSerialStopper()

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -38,6 +38,7 @@ import (
 	zstdfx "github.com/DataDog/datadog-agent/comp/trace/compression/fx-zstd"
 	"github.com/DataDog/datadog-agent/comp/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
@@ -105,6 +106,11 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 			return tagger.NewTaggerParams()
 		}),
 		taggerimpl.Module(),
+		// GetProvider must be called before the application starts so components using either GetProvider or GetMetaCollector can function correctly.
+		// TODO: (component) - create a container metrics provider component.
+		fx.Invoke(func(wmeta optional.Option[workloadmeta.Component]) {
+			metrics.GetProvider(wmeta)
+		}),
 		fx.Invoke(func(_ config.Component) {}),
 		// Required to avoid cyclic imports.
 		fx.Provide(func(cfg config.Component) telemetry.TelemetryCollector { return telemetry.NewCollector(cfg.Object()) }),

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 
 	"go.uber.org/fx"
 )
@@ -333,7 +332,7 @@ func (t *TaggerClient) Standard(entityID types.EntityID) ([]string, error) {
 // AgentTags returns the agent tags
 // It relies on the container provider utils to get the Agent container ID
 func (t *TaggerClient) AgentTags(cardinality types.TagCardinality) ([]string, error) {
-	ctrID, err := metrics.GetProvider(optional.NewOption(t.wmeta)).GetMetaCollector().GetSelfContainerID()
+	ctrID, err := metrics.GetMetaCollector().GetSelfContainerID()
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +527,7 @@ func (t *TaggerClient) EnrichTags(tb tagset.TagsAccumulator, originInfo taggerty
 			}
 
 			// Generate container ID from External Data
-			generatedContainerID, err := t.generateContainerIDFromExternalData(parsedExternalData, metrics.GetProvider(optional.NewOption(t.wmeta)).GetMetaCollector())
+			generatedContainerID, err := t.generateContainerIDFromExternalData(parsedExternalData, metrics.GetMetaCollector())
 			if err != nil {
 				t.log.Tracef("Failed to generate container ID from %s: %s", originInfo.ExternalData, err)
 			}

--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -58,7 +58,7 @@ type StreamHandler interface {
 	// NewClient returns a client to connect to a remote gRPC server.
 	NewClient(cc grpc.ClientConnInterface) GrpcClient
 	// HandleResponse handles a response from the remote gRPC server.
-	HandleResponse(store workloadmeta.Component, response interface{}) ([]workloadmeta.CollectorEvent, error)
+	HandleResponse(response interface{}) ([]workloadmeta.CollectorEvent, error)
 	// HandleResync is called on resynchronization.
 	HandleResync(store workloadmeta.Component, events []workloadmeta.CollectorEvent)
 }
@@ -226,7 +226,7 @@ func (c *GenericCollector) Run() {
 			continue
 		}
 
-		collectorEvents, err := c.StreamHandler.HandleResponse(c.store, response)
+		collectorEvents, err := c.StreamHandler.HandleResponse(response)
 		if err != nil {
 			log.Warnf("error processing event received from remote workloadmeta: %s", err)
 			continue

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -140,7 +140,7 @@ func (s *streamHandler) IsEnabled() bool {
 	return true
 }
 
-func (s *streamHandler) HandleResponse(_ workloadmeta.Component, resp interface{}) ([]workloadmeta.CollectorEvent, error) {
+func (s *streamHandler) HandleResponse(resp interface{}) ([]workloadmeta.CollectorEvent, error) {
 	response, ok := resp.(*pb.WorkloadmetaStreamResponse)
 	if !ok {
 		return nil, fmt.Errorf("incorrect response type")

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -164,12 +164,6 @@ func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 			},
 		},
 	}
-	// workloadmeta client store
-	mockClientStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
-		core.MockBundle(),
-		workloadmetafxmock.MockModule(workloadmeta.Params{AgentType: workloadmeta.Remote}),
-	))
-
 	expectedEvent, err := proto.WorkloadmetaEventFromProtoEvent(protoWorkloadmetaEvent)
 	require.NoError(t, err)
 
@@ -178,7 +172,7 @@ func TestHandleWorkloadmetaStreamResponse(t *testing.T) {
 	}
 
 	streamhandler := &streamHandler{}
-	collectorEvents, err := streamhandler.HandleResponse(mockClientStore, mockResponse)
+	collectorEvents, err := streamhandler.HandleResponse(mockResponse)
 
 	require.NoError(t, err)
 	assert.Len(t, collectorEvents, 1)

--- a/comp/dogstatsd/listeners/uds_datagram.go
+++ b/comp/dogstatsd/listeners/uds_datagram.go
@@ -10,13 +10,11 @@ import (
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // UDSDatagramListener implements the StatsdListener interface for Unix Domain (datagrams)
@@ -27,7 +25,7 @@ type UDSDatagramListener struct {
 }
 
 // NewUDSDatagramListener returns an idle UDS datagram Statsd listener
-func NewUDSDatagramListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], sharedOobPoolManager *packets.PoolManager[[]byte], cfg model.Reader, capture replay.Component, wmeta optional.Option[workloadmeta.Component], pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetryComponent telemetry.Component) (*UDSDatagramListener, error) {
+func NewUDSDatagramListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], sharedOobPoolManager *packets.PoolManager[[]byte], cfg model.Reader, capture replay.Component, pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetryComponent telemetry.Component) (*UDSDatagramListener, error) {
 	socketPath := cfg.GetString("dogstatsd_socket")
 	transport := "unixgram"
 
@@ -46,7 +44,7 @@ func NewUDSDatagramListener(packetOut chan packets.Packets, sharedPacketPoolMana
 		return nil, err
 	}
 
-	l, err := NewUDSListener(packetOut, sharedPacketPoolManager, sharedOobPoolManager, cfg, capture, transport, wmeta, pidMap, telemetryStore, packetsTelemetryStore, telemetryComponent)
+	l, err := NewUDSListener(packetOut, sharedPacketPoolManager, sharedOobPoolManager, cfg, capture, transport, pidMap, telemetryStore, packetsTelemetryStore, telemetryComponent)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/dogstatsd/listeners/uds_datagram_test.go
+++ b/comp/dogstatsd/listeners/uds_datagram_test.go
@@ -19,14 +19,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func udsDatagramListenerFactory(packetOut chan packets.Packets, manager *packets.PoolManager[packets.Packet], cfg config.Component, pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetry telemetry.Component) (StatsdListener, error) {
-	return NewUDSDatagramListener(packetOut, manager, nil, cfg, nil, optional.NewNoneOption[workloadmeta.Component](), pidMap, telemetryStore, packetsTelemetryStore, telemetry)
+	return NewUDSDatagramListener(packetOut, manager, nil, cfg, nil, pidMap, telemetryStore, packetsTelemetryStore, telemetry)
 }
 
 func TestNewUDSDatagramListener(t *testing.T) {

--- a/comp/dogstatsd/listeners/uds_linux.go
+++ b/comp/dogstatsd/listeners/uds_linux.go
@@ -15,13 +15,11 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 const (
@@ -62,7 +60,7 @@ func enableUDSPassCred(conn *net.UnixConn) error {
 // source, and an error if any.
 // PID is added to ancillary data by the Linux kernel if we added the
 // SO_PASSCRED to the socket, see enableUDSPassCred.
-func processUDSOrigin(ancillary []byte, wmeta optional.Option[workloadmeta.Component], state pidmap.Component) (int, string, error) {
+func processUDSOrigin(ancillary []byte, state pidmap.Component) (int, string, error) {
 	messages, err := unix.ParseSocketControlMessage(ancillary)
 	if err != nil {
 		return 0, packets.NoOrigin, err
@@ -87,7 +85,7 @@ func processUDSOrigin(ancillary []byte, wmeta optional.Option[workloadmeta.Compo
 		capture = true
 	}
 
-	entity, err := getEntityForPID(pid, capture, wmeta, state)
+	entity, err := getEntityForPID(pid, capture, state)
 	if err != nil {
 		return int(pid), packets.NoOrigin, err
 	}
@@ -98,13 +96,13 @@ func processUDSOrigin(ancillary []byte, wmeta optional.Option[workloadmeta.Compo
 // getEntityForPID returns the container entity name and caches the value for future lookups
 // As the result is cached and the lookup is really fast (parsing local files), it can be
 // called from the intake goroutine.
-func getEntityForPID(pid int32, capture bool, wmeta optional.Option[workloadmeta.Component], state pidmap.Component) (string, error) {
+func getEntityForPID(pid int32, capture bool, state pidmap.Component) (string, error) {
 	key := cache.BuildAgentKey(pidToEntityCacheKeyPrefix, strconv.Itoa(int(pid)))
 	if x, found := cache.Cache.Get(key); found {
 		return x.(string), nil
 	}
 
-	entity, err := entityForPID(pid, capture, wmeta, state)
+	entity, err := entityForPID(pid, capture, state)
 	switch err {
 	case nil:
 		// No error, yay!
@@ -124,12 +122,12 @@ func getEntityForPID(pid int32, capture bool, wmeta optional.Option[workloadmeta
 
 // entityForPID returns the entity ID for a given PID. It can return
 // errNoContainerMatch if no match is found for the PID.
-func entityForPID(pid int32, capture bool, wmeta optional.Option[workloadmeta.Component], state pidmap.Component) (string, error) {
+func entityForPID(pid int32, capture bool, state pidmap.Component) (string, error) {
 	if capture {
 		return state.ContainerIDForPID(pid)
 	}
 
-	cID, err := provider.GetProvider(wmeta).GetMetaCollector().GetContainerIDForPID(int(pid), pidToEntityCacheDuration)
+	cID, err := provider.GetMetaCollector().GetContainerIDForPID(int(pid), pidToEntityCacheDuration)
 	if err != nil {
 		return "", err
 	}

--- a/comp/dogstatsd/listeners/uds_linux_test.go
+++ b/comp/dogstatsd/listeners/uds_linux_test.go
@@ -21,9 +21,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func TestUDSPassCred(t *testing.T) {
@@ -39,7 +37,7 @@ func TestUDSPassCred(t *testing.T) {
 	listernersTelemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	pool := packets.NewPool(512, packetsTelemetryStore)
 	poolManager := packets.NewPoolManager(pool)
-	s, err := NewUDSDatagramListener(nil, poolManager, nil, deps.Config, nil, optional.NewNoneOption[workloadmeta.Component](), deps.PidMap, listernersTelemetryStore, packetsTelemetryStore, deps.Telemetry)
+	s, err := NewUDSDatagramListener(nil, poolManager, nil, deps.Config, nil, deps.PidMap, listernersTelemetryStore, packetsTelemetryStore, deps.Telemetry)
 	defer s.Stop()
 
 	assert.Nil(t, err)

--- a/comp/dogstatsd/listeners/uds_nolinux.go
+++ b/comp/dogstatsd/listeners/uds_nolinux.go
@@ -11,10 +11,8 @@ import (
 	"errors"
 	"net"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // ErrLinuxOnly is emitted on non-linux platforms
@@ -26,15 +24,11 @@ func getUDSAncillarySize() int {
 }
 
 // enableUDSPassCred returns a "not implemented" error on non-linux hosts
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func enableUDSPassCred(_ *net.UnixConn) error {
 	return ErrLinuxOnly
 }
 
 // processUDSOrigin returns a "not implemented" error on non-linux hosts
-//
-//nolint:revive // TODO(AML) Fix revive linter
-func processUDSOrigin(_ []byte, _ optional.Option[workloadmeta.Component], _ pidmap.Component) (int, string, error) {
+func processUDSOrigin(_ []byte, _ pidmap.Component) (int, string, error) {
 	return 0, packets.NoOrigin, ErrLinuxOnly
 }

--- a/comp/dogstatsd/listeners/uds_stream.go
+++ b/comp/dogstatsd/listeners/uds_stream.go
@@ -12,13 +12,11 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // UDSStreamListener implements the StatsdListener interface for Unix Domain (streams)
@@ -29,7 +27,7 @@ type UDSStreamListener struct {
 }
 
 // NewUDSStreamListener returns an idle UDS datagram Statsd listener
-func NewUDSStreamListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], sharedOobPacketPoolManager *packets.PoolManager[[]byte], cfg model.Reader, capture replay.Component, wmeta optional.Option[workloadmeta.Component], pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetry telemetry.Component) (*UDSStreamListener, error) {
+func NewUDSStreamListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], sharedOobPacketPoolManager *packets.PoolManager[[]byte], cfg model.Reader, capture replay.Component, pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetry telemetry.Component) (*UDSStreamListener, error) {
 	socketPath := cfg.GetString("dogstatsd_stream_socket")
 	transport := "unix"
 
@@ -48,7 +46,7 @@ func NewUDSStreamListener(packetOut chan packets.Packets, sharedPacketPoolManage
 		return nil, err
 	}
 
-	l, err := NewUDSListener(packetOut, sharedPacketPoolManager, sharedOobPacketPoolManager, cfg, capture, transport, wmeta, pidMap, telemetryStore, packetsTelemetryStore, telemetry)
+	l, err := NewUDSListener(packetOut, sharedPacketPoolManager, sharedOobPacketPoolManager, cfg, capture, transport, pidMap, telemetryStore, packetsTelemetryStore, telemetry)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/dogstatsd/listeners/uds_stream_test.go
+++ b/comp/dogstatsd/listeners/uds_stream_test.go
@@ -19,14 +19,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func udsStreamListenerFactory(packetOut chan packets.Packets, manager *packets.PoolManager[packets.Packet], cfg config.Component, pidMap pidmap.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, telemetry telemetry.Component) (StatsdListener, error) {
-	return NewUDSStreamListener(packetOut, manager, nil, cfg, nil, optional.NewNoneOption[workloadmeta.Component](), pidMap, telemetryStore, packetsTelemetryStore, telemetry)
+	return NewUDSStreamListener(packetOut, manager, nil, cfg, nil, pidMap, telemetryStore, packetsTelemetryStore, telemetry)
 }
 
 func TestNewUDSStreamListener(t *testing.T) {

--- a/comp/dogstatsd/server/convert_bench_test.go
+++ b/comp/dogstatsd/server/convert_bench_test.go
@@ -14,11 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func buildRawSample(tagCount int, multipleValues bool) []byte {
@@ -41,7 +38,7 @@ var (
 func runParseMetricBenchmark(b *testing.B, multipleValues bool) {
 	deps := newServerDeps(b)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 
 	conf := enrichConfig{
 		defaultHostname:           "default-hostname",
@@ -78,10 +75,9 @@ func BenchmarkParseMultipleMetric(b *testing.B) {
 type ServerDeps struct {
 	fx.In
 	Config    config.Component
-	WMeta     optional.Option[workloadmeta.Component]
 	Telemetry telemetry.Component
 }
 
 func newServerDeps(t testing.TB, options ...fx.Option) ServerDeps {
-	return fxutil.Test[ServerDeps](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()), fx.Options(options...))
+	return fxutil.Test[ServerDeps](t, core.MockBundle(), fx.Options(options...))
 }

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -33,7 +33,7 @@ var (
 func parseAndEnrichSingleMetricMessage(t *testing.T, message []byte, conf enrichConfig) (metrics.MetricSample, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseMetricSample(message)
 	if err != nil {
 		return metrics.MetricSample{}, err
@@ -50,7 +50,7 @@ func parseAndEnrichSingleMetricMessage(t *testing.T, message []byte, conf enrich
 func parseAndEnrichMultipleMetricMessage(t *testing.T, message []byte, conf enrichConfig) ([]metrics.MetricSample, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseMetricSample(message)
 	if err != nil {
 		return []metrics.MetricSample{}, err
@@ -63,7 +63,7 @@ func parseAndEnrichMultipleMetricMessage(t *testing.T, message []byte, conf enri
 func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrichConfig) (*servicecheck.ServiceCheck, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseServiceCheck(message)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrich
 func parseAndEnrichEventMessage(t *testing.T, message []byte, conf enrichConfig) (*event.Event, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseEvent(message)
 	if err != nil {
 		return nil, err
@@ -1000,7 +1000,7 @@ func TestMetricBlocklistShouldBlock(t *testing.T) {
 
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
@@ -1018,7 +1018,7 @@ func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 	message := []byte("custom.metric.a:21|ms")
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
@@ -1039,7 +1039,7 @@ func TestMetricBlocklistShouldNotBlock(t *testing.T) {
 	}
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}

--- a/comp/dogstatsd/server/parse_events_test.go
+++ b/comp/dogstatsd/server/parse_events_test.go
@@ -15,7 +15,7 @@ import (
 func parseEvent(t *testing.T, rawEvent []byte) (dogstatsdEvent, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	return parser.parseEvent(rawEvent)
 }
 

--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -20,7 +20,7 @@ import (
 func parseMetricSample(t *testing.T, overrides map[string]any, rawSample []byte) (dogstatsdMetricSample, error) {
 	deps := newServerDeps(t, fx.Replace(config.MockParams{Overrides: overrides}))
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	_, found := overrides["parser"]
 	if found {
 		p = overrides["parser"].(*parser)
@@ -578,14 +578,13 @@ func TestParseContainerID(t *testing.T) {
 	// Testing with an Inode
 	deps := newServerDeps(t, fx.Replace(config.MockParams{Overrides: cfg}))
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
-	mockProvider := mock.NewMetricsProvider()
-	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
+
+	p.provider = &mock.MetaCollector{
 		CIDFromInode: map[uint64]string{
 			1234567890: "1234567890abcdef",
 		},
-	})
-	p.provider = mockProvider
+	}
 	cfg["parser"] = p
 
 	sample, err = parseMetricSample(t, cfg, []byte("metric:1234|g|c:in-1234567890"))

--- a/comp/dogstatsd/server/parse_service_checks_test.go
+++ b/comp/dogstatsd/server/parse_service_checks_test.go
@@ -15,7 +15,7 @@ import (
 func parseServiceCheck(t *testing.T, rawServiceCheck []byte) (dogstatsdServiceCheck, error) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	return parser.parseServiceCheck(rawServiceCheck)
 }
 

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -41,7 +41,7 @@ func TestIdentifyRandomString(t *testing.T) {
 func TestParseTags(t *testing.T) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	rawTags := []byte("tag:test,mytag,good:boy")
 	tags := p.parseTags(rawTags)
 	expectedTags := []string{"tag:test", "mytag", "good:boy"}
@@ -51,7 +51,7 @@ func TestParseTags(t *testing.T) {
 func TestParseTagsEmpty(t *testing.T) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	rawTags := []byte("")
 	tags := p.parseTags(rawTags)
 	assert.Nil(t, tags)
@@ -71,7 +71,7 @@ func TestUnsafeParseFloat(t *testing.T) {
 func TestUnsafeParseFloatList(t *testing.T) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	unsafeFloats, err := p.parseFloat64List([]byte("1.1234:21.5:13"))
 	assert.NoError(t, err)
 	assert.Len(t, unsafeFloats, 3)
@@ -123,17 +123,15 @@ func TestResolveContainerIDFromLocalData(t *testing.T) {
 
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 
 	// Mock the provider to resolve the container ID from the inode
-	mockProvider := mock.NewMetricsProvider()
 	containerInodeUint, _ := strconv.ParseUint(containerInode, 10, 64)
-	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
+	p.provider = &mock.MetaCollector{
 		CIDFromInode: map[uint64]string{
 			containerInodeUint: containerID,
 		},
-	})
-	p.provider = mockProvider
+	}
 
 	tests := []struct {
 		name     string

--- a/comp/dogstatsd/server/server_bench_test.go
+++ b/comp/dogstatsd/server/server_bench_test.go
@@ -57,7 +57,7 @@ func benchParsePackets(b *testing.B, rawPacket []byte) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		batcher := newBatcher(demux, histogram)
-		parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
+		parser := newParser(deps.Config, s.sharedFloat64List, 1, s.stringInternerTelemetry)
 		packet := packets.Packet{
 			Contents: rawPacket,
 			Origin:   packets.NoOrigin,
@@ -102,7 +102,7 @@ func BenchmarkPbarseMetricMessage(b *testing.B) {
 	defer close(done)
 
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 	message := []byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2")
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -161,7 +161,7 @@ func benchmarkMapperControl(b *testing.B, yaml string) {
 
 	batcher := newBatcher(demux, histogram)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, stringInternerTelemetry)
 
 	samples := make([]metrics.MetricSample, 0, 512)
 	for n := 0; n < b.N; n++ {

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -6,11 +6,9 @@
 package server
 
 import (
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 var (
@@ -36,7 +34,7 @@ type worker struct {
 	packetsTelemetry *packets.TelemetryStore
 }
 
-func newWorker(s *server, workerNum int, wmeta optional.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
+func newWorker(s *server, workerNum int, packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
 	var batcher *batcher
 	if s.ServerlessMode {
 		batcher = newServerlessBatcher(s.demultiplexer, s.tlmChannel)
@@ -47,7 +45,7 @@ func newWorker(s *server, workerNum int, wmeta optional.Option[workloadmeta.Comp
 	return &worker{
 		server:           s,
 		batcher:          batcher,
-		parser:           newParser(s.config, s.sharedFloat64List, workerNum, wmeta, stringInternerTelemetry),
+		parser:           newParser(s.config, s.sharedFloat64List, workerNum, stringInternerTelemetry),
 		samples:          make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 		packetsTelemetry: packetsTelemetry,
 	}

--- a/comp/dogstatsd/server/serverless.go
+++ b/comp/dogstatsd/server/serverless.go
@@ -11,13 +11,11 @@ import (
 
 	logComponentImpl "github.com/DataDog/datadog-agent/comp/core/log/impl"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/pidmapimpl"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/impl-noop"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // team: agent-metrics-logs
@@ -30,8 +28,7 @@ type ServerlessDogstatsd interface {
 
 //nolint:revive // TODO(AML) Fix revive linter
 func NewServerlessServer(demux aggregator.Demultiplexer) (ServerlessDogstatsd, error) {
-	wmeta := optional.NewNoneOption[workloadmeta.Component]()
-	s := newServerCompat(pkgconfigsetup.Datadog(), logComponentImpl.NewTemporaryLoggerWithoutInit(), replay.NewNoopTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(), true, demux, wmeta, pidmapimpl.NewServerlessPidMap(), telemetry.GetCompatComponent())
+	s := newServerCompat(pkgconfigsetup.Datadog(), logComponentImpl.NewTemporaryLoggerWithoutInit(), replay.NewNoopTrafficCapture(), serverdebugimpl.NewServerlessServerDebug(), true, demux, pidmapimpl.NewServerlessPidMap(), telemetry.GetCompatComponent())
 
 	err := s.start(context.TODO())
 	if err != nil {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -73,7 +73,7 @@ func ExtraFlareProviders(diagnoseDeps diagnose.SuitesDeps) []flaretypes.FlareCal
 		provideInstallInfo,
 		provideAuthTokenPerm,
 		provideDiagnoses(diagnoseDeps),
-		provideContainers(diagnoseDeps),
+		provideContainers(),
 	}
 
 	pprofURL := fmt.Sprintf("http://127.0.0.1:%s/debug/pprof/goroutine?debug=2",
@@ -95,13 +95,13 @@ func ExtraFlareProviders(diagnoseDeps diagnose.SuitesDeps) []flaretypes.FlareCal
 	return providers
 }
 
-func provideContainers(diagnoseDeps diagnose.SuitesDeps) func(fb flaretypes.FlareBuilder) error {
+func provideContainers() func(fb flaretypes.FlareBuilder) error {
 	return func(fb flaretypes.FlareBuilder) error {
-		fb.AddFileFromFunc("docker_ps.log", getDockerPs)                                                                          //nolint:errcheck
-		fb.AddFileFromFunc("k8s/kubelet_config.yaml", getKubeletConfig)                                                           //nolint:errcheck
-		fb.AddFileFromFunc("k8s/kubelet_pods.yaml", getKubeletPods)                                                               //nolint:errcheck
-		fb.AddFileFromFunc("ecs_metadata.json", getECSMeta)                                                                       //nolint:errcheck
-		fb.AddFileFromFunc("docker_inspect.log", func() ([]byte, error) { return getDockerSelfInspect(diagnoseDeps.GetWMeta()) }) //nolint:errcheck
+		fb.AddFileFromFunc("docker_ps.log", getDockerPs)                                                   //nolint:errcheck
+		fb.AddFileFromFunc("k8s/kubelet_config.yaml", getKubeletConfig)                                    //nolint:errcheck
+		fb.AddFileFromFunc("k8s/kubelet_pods.yaml", getKubeletPods)                                        //nolint:errcheck
+		fb.AddFileFromFunc("ecs_metadata.json", getECSMeta)                                                //nolint:errcheck
+		fb.AddFileFromFunc("docker_inspect.log", func() ([]byte, error) { return getDockerSelfInspect() }) //nolint:errcheck
 
 		return nil
 	}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -16,18 +16,17 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"github.com/docker/docker/api/types/container"
 )
 
 const dockerCommandMaxLength = 29
 
-func getDockerSelfInspect(wmeta optional.Option[workloadmeta.Component]) ([]byte, error) {
+func getDockerSelfInspect() ([]byte, error) {
 	if !env.IsContainerized() {
 		return nil, fmt.Errorf("The Agent is not containerized")
 	}
@@ -37,7 +36,7 @@ func getDockerSelfInspect(wmeta optional.Option[workloadmeta.Component]) ([]byte
 		return nil, err
 	}
 
-	selfContainerID, err := metrics.GetProvider(wmeta).GetMetaCollector().GetSelfContainerID()
+	selfContainerID, err := metrics.GetMetaCollector().GetSelfContainerID()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to determine self container id, err: %w", err)
 	}

--- a/pkg/flare/archive_nodocker.go
+++ b/pkg/flare/archive_nodocker.go
@@ -7,12 +7,7 @@
 
 package flare
 
-import (
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
-)
-
-func getDockerSelfInspect(_ optional.Option[workloadmeta.Component]) ([]byte, error) {
+func getDockerSelfInspect() ([]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/util/containers/metrics/facade.go
+++ b/pkg/util/containers/metrics/facade.go
@@ -57,3 +57,6 @@ type ContainerStats = provider.ContainerStats
 
 // GetProvider returns the metrics provider singleton
 var GetProvider = provider.GetProvider
+
+// GetMetaCollector returns the meta collector singleton
+var GetMetaCollector = provider.GetMetaCollector

--- a/test/integration/utils/compose.go
+++ b/test/integration/utils/compose.go
@@ -16,10 +16,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 type ComposeConf struct {
@@ -139,7 +137,7 @@ func getNetworkMode() (string, error) {
 	}
 
 	// Get container id if containerized
-	selfContainerID, err := metrics.GetProvider(optional.NewNoneOption[workloadmeta.Component]()).GetMetaCollector().GetSelfContainerID()
+	selfContainerID, err := metrics.GetMetaCollector().GetSelfContainerID()
 	if err != nil {
 		return "host", nil
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Create a metaCollector singleton

### Motivation

That way we no longer need to provide an optional workloadmeta when calling the tagger functions

This would allow us to fully decouple the different tagger implementation into separate packages, and ensuring the remote tagger implementation do not have a reference to the workloadmeta component

The last three commits also refactor a few places in the codebase that there were passing an optional workloadmeta. component to get the `MetaCollector`

- The workloadmeta component 
- Dogstatsd component
- The `pkg/flare` 

#### The future 
Ideally the `util/containers/metrics` should become **its own component**. That would avoid the usage of globals. Creating the component is a much bigger change. This change unblocks us from splitting the tagger component into multiple implementations, but ideally, we should create a separate component and pass it as a dependency to the places that used it. 

### Describe how to test/QA your changes

Unit tests are updated 

[TBD] How to to test origin detection mode

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->