### PR TITLE
[smp]: prevent some empty regression detector comments

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -35,7 +35,6 @@ single-machine-performance-regression_detector:
   script:
     # Ensure output files exist for artifact downloads step
     - mkdir outputs # Also needed for smp job sync step
-    - touch outputs/report.md # Will be emitted by smp job sync
     # Compute merge base of current commit and `main`
     - git fetch origin
     - SMP_BASE_BRANCH=$(inv release.get-release-json-value base_branch)
@@ -158,6 +157,14 @@ single-machine-performance-regression_detector-pr-comment:
     FF_KUBERNETES_HONOR_ENTRYPOINT: false
   allow_failure: true  # allow_failure here should have same setting as in job above
   script: # ignore error message about no PR, because it happens for dev branches without PRs
+    # Prevent posting empty Regression Detector report if Markdown report is not found or
+    # has zero size.
+    - |
+      if [[ ! -s "outputs/report.md" ]]
+      then
+          echo "ERROR: Regression Detector report not found -- no PR comment posted"
+          exit 1
+      fi
     # We need to transform the Markdown report into a valid JSON string (without
     # quotes) in order to pass a well-formed payload to the PR commenting
     # service. Note that on macOS, the "-z" flag is invalid for `sed` (but


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If the Regression Detector fails to submit a job to SMP, an empty Regression Detector PR comment is posted to PRs. This empty comment is noise and undesirable, so this pull request tests whether the Regression Detector generated a Markdown report before attempting to post. If the Markdown report does not exist, the Regression Detector PR comment will echo an error message and emit a non-zero exit code so that the PR comment job fails before posting.

### Motivation

Reduce PR comment noise.

### Describe how to test/QA your changes

Running this PR in CI should test its changes.

### Possible Drawbacks / Trade-offs

Minor increase in CI config complexity to reduce incidence of empty Regression Detector posts that do nothing but add to alert noise.

### Additional Notes

n/a

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->