### PR TITLE
[windows][usm] Fix json parsing for usm

### DIFF
--- a/pkg/util/winutil/iisconfig/apmtags.go
+++ b/pkg/util/winutil/iisconfig/apmtags.go
@@ -22,14 +22,18 @@ import (
 
 // APMTags holds the APM tags
 type APMTags struct {
-	DDService string
-	DDEnv     string
-	DDVersion string
+	DDService string `json:"DD_SERVICE"`
+	DDEnv     string `json:"DD_ENV"`
+	DDVersion string `json:"DD_VERSION"`
 }
-
+// keep a count of errors to avoid flooding the log
+var (
+	jsonLogCount = 0
+	dotnetConfigLogCount = 0
+	logErrorCountInterval = 500
+)
 // ReadDatadogJSON reads a datadog.json file and returns the APM tags
 func ReadDatadogJSON(datadogJSONPath string) (APMTags, error) {
-	var datadogJSON map[string]string
 	var apmtags APMTags
 
 	file, err := os.Open(datadogJSONPath)
@@ -39,13 +43,14 @@ func ReadDatadogJSON(datadogJSONPath string) (APMTags, error) {
 	defer file.Close()
 
 	decoder := json.NewDecoder(file)
-	err = decoder.Decode(&datadogJSON)
+	err = decoder.Decode(&apmtags)
 	if err != nil {
+		if jsonLogCount%logErrorCountInterval == 0 {
+			log.Warnf("Error reading datadog.json file %s: %v", datadogJSONPath, err)
+			jsonLogCount++
+		}
 		return apmtags, err
 	}
-	apmtags.DDService = datadogJSON["DD_SERVICE"]
-	apmtags.DDEnv = datadogJSON["DD_ENV"]
-	apmtags.DDVersion = datadogJSON["DD_VERSION"]
 	return apmtags, nil
 }
 
@@ -78,6 +83,10 @@ func ReadDotNetConfig(cfgpath string) (APMTags, error) { //(APMTags, error) {
 	}
 	err = xml.Unmarshal(f, &newcfg)
 	if err != nil {
+		if dotnetConfigLogCount%logErrorCountInterval == 0 {
+			log.Warnf("Error reading datadog.json file %s: %v", cfgpath, err)
+			jsonLogCount++
+		}
 		return apmtags, err
 	}
 	for _, setting := range newcfg.AppSettings.Adds {
@@ -105,8 +114,8 @@ func ReadDotNetConfig(cfgpath string) (APMTags, error) { //(APMTags, error) {
 				apmtags.DDVersion = ddjson.DDVersion
 			}
 		} else {
-			// only log every 1000 occurrences because if this is misconfigured, it could flood the log
-			if errorlogcount%1000 == 0 {
+			// only log every logErrorCountInterval occurrences because if this is misconfigured, it could flood the log
+			if errorlogcount%logErrorCountInterval == 0 {
 				log.Warnf("Error reading configured datadog.json file %s: %v", chasedatadogJSON, err)
 			}
 			errorlogcount++

--- a/pkg/util/winutil/iisconfig/apmtags.go
+++ b/pkg/util/winutil/iisconfig/apmtags.go
@@ -26,12 +26,14 @@ type APMTags struct {
 	DDEnv     string `json:"DD_ENV"`
 	DDVersion string `json:"DD_VERSION"`
 }
+
 // keep a count of errors to avoid flooding the log
 var (
-	jsonLogCount = 0
-	dotnetConfigLogCount = 0
+	jsonLogCount          = 0
+	dotnetConfigLogCount  = 0
 	logErrorCountInterval = 500
 )
+
 // ReadDatadogJSON reads a datadog.json file and returns the APM tags
 func ReadDatadogJSON(datadogJSONPath string) (APMTags, error) {
 	var apmtags APMTags

--- a/pkg/util/winutil/iisconfig/testdata/app1/datadog.json
+++ b/pkg/util/winutil/iisconfig/testdata/app1/datadog.json
@@ -1,5 +1,6 @@
 {
     "DD_SERVICE": "app1",
     "DD_ENV": "staging",
-    "DD_VERSION": "1.0-prerelease"
+    "DD_VERSION": "1.0-prerelease",
+    "DD_RUNTIME_METRICS_ENABLED":  true
   }

--- a/pkg/util/winutil/iisconfig/testdata/app2/datadog.json
+++ b/pkg/util/winutil/iisconfig/testdata/app2/datadog.json
@@ -1,5 +1,6 @@
 {
     "DD_SERVICE": "app2",
     "DD_ENV": "staging",
-    "DD_VERSION": "1.0-prerelease"
+    "DD_VERSION": "1.0-prerelease",
+    "DD_RUNTIME_METRICS_ENABLED":  true
   }

--- a/pkg/util/winutil/iisconfig/testdata/app3/datadog.json
+++ b/pkg/util/winutil/iisconfig/testdata/app3/datadog.json
@@ -1,5 +1,6 @@
 {
     "DD_SERVICE": "app3",
     "DD_ENV": "staging",
-    "DD_VERSION": "1.0-prerelease"
+    "DD_VERSION": "1.0-prerelease",
+    "DD_RUNTIME_METRICS_ENABLED":  true
   }

--- a/pkg/util/winutil/iisconfig/testdata/app4/datadog.json
+++ b/pkg/util/winutil/iisconfig/testdata/app4/datadog.json
@@ -1,5 +1,6 @@
 {
     "DD_SERVICE": "app4",
     "DD_ENV": "staging",
-    "DD_VERSION": "1.0-prerelease"
+    "DD_VERSION": "1.0-prerelease",
+    "DD_RUNTIME_METRICS_ENABLED":  true
   }


### PR DESCRIPTION
The parsing of `datadog.json` for USM service tagging was far too restrictive. It assumed all values were always string values, and failed if any entry had a non-string (e.g. bool) value; even though those values are allowed for other keys.

Fixes parser to allow this case, and also updates test to have the additional entries in them.
### Motivation

Customer reported issue with USM service tagging not working

### Describe how to test/QA your changes

Automated tests in place.

Create a `datadog.json` in the director 

Install IIS.
Create one or more IIS sites in the IIS configuration.

Place a datadog.json or web.config file in the root of the site directory, with any combination of env/version/service tags.
The file formats are documented
https://datadoghq.atlassian.net/wiki/spaces/WKIT/pages/4012835378/USM+APM+Compatibility#.NET-Tracer-configuration-file-formats

In addition, the customer had a valid entry that we were parsing as invalid, such as:
    "DD_RUNTIME_METRICS_ENABLED":  true

Add this entry to the top level block.

Make a connection to the site.

YOu can check that the appropriate tag(s) have been added by hitting the HTTP information endpoint:

(from the source tree, download `NamedPipeCmd.ex`)
.\NamedPipeCmd.exe -method GET -path /network_tracer/debug/http_monitoring -quiet |convertfrom-json

YOu should see output such as:


Client      : @{IP=::1; Port=80}
Server      : @{IP=::1; Port=62700}
DNS         :
Path        : /
Method      : GET
ByStatus    : @{200=}
StaticTags  : 0
DynamicTags : {http.iis.app_pool:DefaultAppPool, http.iis.site:1, http.iis.sitename:Default Web Site}
with the addition of service, env, and or version tags that match what was configured in the file that you applied.

### Possible Drawbacks / Trade-offs

