### PR TITLE
Pass smp job id through ci

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -113,7 +113,7 @@ single-machine-performance-regression_detector:
     - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
     # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
     # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
-    - SMP_JOB_ID=$(jq -r '.jobId' submission-metadata)
+    - SMP_JOB_ID=$(jq -r '.jobId' submission_metadata)
     - echo "SMP Job Id is ${SMP_JOB_ID}"
     - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Wait for job to complete.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -113,7 +113,7 @@ single-machine-performance-regression_detector:
     - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
     # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
     # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
-    - SMP_JOB_ID=${jq -r '.jobId' submission-metadata}
+    - SMP_JOB_ID=$(jq -r '.jobId' submission-metadata)
     - echo "SMP Job Id is ${SMP_JOB_ID}"
     - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Wait for job to complete.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -109,6 +109,13 @@ single-machine-performance-regression_detector:
       --comparison-sha ${CI_COMMIT_SHA}
       --target-config-dir test/regression/
       --submission-metadata submission_metadata
+    # `datadog-ci` relies on `DATADOG_API_KEY` so we get that here.
+    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
+    # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
+    # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
+    - SMP_JOB_ID = jq -r '.jobId' submission-metadata
+    - echo "SMP Job Id is ${SMP_JOB_ID}"
+    - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job status
@@ -128,13 +135,7 @@ single-machine-performance-regression_detector:
     # invoke task has additional logic that does not seem to apply well to SMP's
     # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
     # uploading JUnit XML, so the upload command below respects that convention.
-    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
     - datadog-ci junit upload --service datadog-agent outputs/junit.xml
-    # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
-    # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
-    - SMP_JOB_ID = jq -r '.jobId' submission-metadata
-    - echo "SMP Job Id is ${SMP_JOB_ID}"
-    - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -113,7 +113,7 @@ single-machine-performance-regression_detector:
     - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
     # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
     # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
-    - SMP_JOB_ID = jq -r '.jobId' submission-metadata
+    - SMP_JOB_ID=${jq -r '.jobId' submission-metadata}
     - echo "SMP Job Id is ${SMP_JOB_ID}"
     - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Wait for job to complete.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -130,6 +130,11 @@ single-machine-performance-regression_detector:
     # uploading JUnit XML, so the upload command below respects that convention.
     - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
     - datadog-ci junit upload --service datadog-agent outputs/junit.xml
+    # Get the SMP Job Id from 'submission-metadata' and use 'datadog-ci' 
+    # to tag the gitlab job seen in CI Visibility with the SMP Job Id.
+    - SMP_JOB_ID = jq -r '.jobId' submission-metadata
+    - echo "SMP Job Id is ${SMP_JOB_ID}"
+    - datadog-ci tag --level job --tags job_id:${SMP_JOB_ID}
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result


### PR DESCRIPTION
### What does this PR do?

Tags the gitlab job data seen in CI Vis with the smp job id.

### Motivation

Part of an effort to better link SMP job data with CI Vis data in the platform.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
[SMPTNG-519](https://datadoghq.atlassian.net/browse/SMPTNG-519)

[SMPTNG-519]: https://datadoghq.atlassian.net/browse/SMPTNG-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ