### PR TITLE
Pass CI pipeline and job ids through SMP as tags

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -99,6 +99,8 @@ single-machine-performance-regression_detector:
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
     - echo "${CI_COMMIT_SHA} | ${COMPARISON_IMAGE}"
+    - SMP_TAGS="ci_pipeline_id=${CI_PIPELINE_ID},ci_job_id=${CI_JOB_ID}"
+    - echo "Tags passed through SMP are ${SMP_TAGS}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
@@ -109,6 +111,7 @@ single-machine-performance-regression_detector:
       --comparison-sha ${CI_COMMIT_SHA}
       --target-config-dir test/regression/
       --submission-metadata submission_metadata
+      --tags ${SMP_TAGS}
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job status


### PR DESCRIPTION
### What does this PR do?

Passes the 'CI_PIPELINE_ID' and 'CI_JOB_ID' through SMP as tags

### Motivation

Part of an effort to better link SMP job data with CI Vis data in the platform.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
[SMPTNG-516](https://datadoghq.atlassian.net/browse/SMPTNG-516)

[SMPTNG-516]: https://datadoghq.atlassian.net/browse/SMPTNG-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ