### PR TITLE
[CI] Fix the macOS runners pyenv issue

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -23,16 +23,8 @@
     PYTHON_VERSION=$(python3 --version | awk '{print $2}')
     VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
     echo "Using Python $PYTHON_VERSION..."
-    ## START TEMPORARY DEBUG see ACIX-500
-    echo $PYTHON_VERSION
-    echo $VENV_NAME
-    pyenv virtualenvs --bare
-    ls $(pyenv root)/versions/
-    ## END TEMPORARY DEBUG see ACIX-500
     if ! pyenv virtualenvs --bare | grep -q "${VENV_NAME}$"; then
-      # The || true is a quickfix avoiding the command to fail if the virtualenv already exists
-      # This should be removed once ACIX-500 is done
-      pyenv virtualenv $PYTHON_VERSION $VENV_NAME || true
+      pyenv virtualenv $PYTHON_VERSION $VENV_NAME
     fi
     pyenv activate $VENV_NAME
 

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -34,7 +34,7 @@
     pyenv virtualenvs --bare
     ls $(pyenv root)/versions/
     ## END TEMPORARY DEBUG see ACIX-500
-    if ! pyenv virtualenvs --bare | grep -q "^${VENV_NAME}$"; then
+    if ! pyenv virtualenvs --bare | grep -q "${VENV_NAME}$"; then
       # The || true is a quickfix avoiding the command to fail if the virtualenv already exists
       # This should be removed once ACIX-500 is done
       pyenv virtualenv $PYTHON_VERSION $VENV_NAME || true

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -18,16 +18,11 @@
     echo "pyenv uninstall -f <version>"
 
 .select_python_env_commands:
-  # Print a warning if the current Python version is different from the one in .python-version
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
   - |
-    PYTHON_REPO_VERSION=$(cat .python-version)
     PYTHON_VERSION=$(python3 --version | awk '{print $2}')
     VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
-    if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
-      echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."
-      echo "Installing Python $PYTHON_REPO_VERSION..."
-    fi
+    echo "Using Python $PYTHON_VERSION..."
     ## START TEMPORARY DEBUG see ACIX-500
     echo $PYTHON_VERSION
     echo $VENV_NAME

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -22,7 +22,7 @@
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
   - |
     PYTHON_REPO_VERSION=$(cat .python-version)
-    PYTHON_VERSION=$(python3 --version | awk '{print $2}' | sed 's/\.[0-9]*$//')
+    PYTHON_VERSION=$(python3 --version | awk '{print $2}')
     VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
     if [ "$PYTHON_REPO_VERSION" != "$PYTHON_VERSION" ]; then
       echo "Warning: The current Python version $PYTHON_VERSION is different from $PYTHON_REPO_VERSION in .python-version."


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the `pyenv` logic in the macOS Gitlab runners breaking the `lint_macos_gitlab_amd64` and `tests_macos_gitlab_amd64` jobs.

In details:
- It fixes the error by checking only that the end of the lines of `pyenv virtualenvs --bare` output matches the `VENV_NAME` variable.
- It uses the full python version (we were not using the patch version before) to name the virtual environment.
- It removes the version discrepancy warning between the used python and the repo `.python-version` because it's not used in practice so it uselessly complexify the code.
- It removes the debug logs.

### Motivation

Fix the CI.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/ACIX-500