### PR TITLE
pkg/fleet/telemetry: explicitly disable appsec from tracer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,16 +146,16 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.9.1
 	github.com/DataDog/appsec-internal-go v1.9.0
 	github.com/DataDog/datadog-agent/pkg/gohai v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.58.0
 	github.com/DataDog/datadog-agent/pkg/security/secl v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/trace v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/trace v0.58.0
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/util/log v0.57.1
+	github.com/DataDog/datadog-agent/pkg/util/log v0.58.0
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.57.1
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.57.1
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.58.0
 	github.com/DataDog/datadog-go/v5 v5.5.0
-	github.com/DataDog/datadog-operator v1.8.0-rc.1
+	github.com/DataDog/datadog-operator v1.0.3
 	github.com/DataDog/ebpf-manager v0.7.1
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.7
@@ -316,7 +316,7 @@ require (
 	google.golang.org/grpc v1.67.1
 	google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a
 	google.golang.org/protobuf v1.35.1
-	gopkg.in/DataDog/dd-trace-go.v1 v1.69.1
+	gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20241106231100-d2882eb00f61
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
@@ -655,7 +655,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/env v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.57.1
-	github.com/DataDog/datadog-agent/pkg/config/remote v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.57.1
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.57.1
 	github.com/DataDog/datadog-agent/pkg/errors v0.56.0-rc.3
@@ -675,7 +674,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/networkdevice/profile v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/pkg/proto v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/proto v0.58.0
 	github.com/DataDog/datadog-agent/pkg/security/seclwin v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/serializer v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/status/health v0.56.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -693,6 +693,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.26.0/go.mod h1:QKOu6vscsh87fMY1lH
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI6LDrKU=
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
+github.com/DataDog/datadog-operator v1.0.3 h1:zBGNnmFsU99wttrt0PWXXRgJvTRGeWt3YD7wUh7VBd4=
+github.com/DataDog/datadog-operator v1.0.3/go.mod h1:CXTLg7VFcpaMvjbwkKTxKUIzxRumfSe01/CWOINo4c0=
 github.com/DataDog/datadog-operator v1.8.0-rc.1 h1:w6/z5jcTzWGv90/H9AhcgZd3gAdP3eaWEGpnE7nVdRM=
 github.com/DataDog/datadog-operator v1.8.0-rc.1/go.mod h1:qxwdMzmiZ165BAMbTYkr4yJKvhOnDUMAcGNQiPJVmAA=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 h1:RoH7VLzTnxHEugRPIgnGlxwDFszFGI7b3WZZUtWuPRM=
@@ -3596,6 +3598,8 @@ google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20241106231100-d2882eb00f61 h1:KB8C1gY+AwP8jU/HtHX9kQ6NzV5uXIux1X5aWTAudjo=
+gopkg.in/DataDog/dd-trace-go.v1 v1.39.0-alpha.1.0.20241106231100-d2882eb00f61/go.mod h1:2re6Ub8ErfDhx+vP2SkYnwkW8DFX2enftcG2N+IE7RY=
 gopkg.in/DataDog/dd-trace-go.v1 v1.69.1 h1:grTElrPaCfxUsrJjyPLHlVPbmlKVzWMxVdcBrGZSzEk=
 gopkg.in/DataDog/dd-trace-go.v1 v1.69.1/go.mod h1:U9AOeBHNAL95JXcd/SPf4a7O5GNeF/yD13sJtli/yaU=
 gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=

--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -98,10 +98,13 @@ func (t *Telemetry) Start(_ context.Context) error {
 	// The environment variable is usually not present, but can in certain cases
 	// be inherited from the login shell when the agent is started by the
 	// install script.
-	if appsecEnv, envSet := os.LookupEnv("DD_APPSEC_ENABLED"); envSet {
+	const appsecEnvVar = "DD_APPSEC_ENABLED"
+	if appsecEnv, envSet := os.LookupEnv(appsecEnvVar); envSet {
 		truthy, err := strconv.ParseBool(appsecEnv)
 		if truthy || err != nil {
-			os.Setenv("DD_APPSEC_ENABLED", "false")
+			os.Setenv(appsecEnvVar, "false")
+			// Restore the original value after the tracer is started...
+			defer os.Setenv(appsecEnvVar, appsecEnv)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This change explicitly disables appsec before starting the tracer in order to avoid this behavior. It also redirects all tracer logging output to the agent's own logger, so that all the agent's logging is centrally controlled.

### Motivation

At least one customer was startled by the presence of the appsec startup error produced by the tracer when appsec features are explicitly enabled but the environment or build does not permit the use of it:

```
2024/10/31 18:33:04 Datadog Tracer v1.69.0 ERROR: appsec: threats detection cannot be enabled for the following reasons: go-libddwaf is disabled when cgo is disabled unless you compile with the go build tag `appsec`. It will require libdl.so.2. libpthread.so.0 and libc.so.6 shared libraries at run time on linuxappsec: no security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.
```

Ref: SCRS-1135

### Possible Drawbacks / Trade-offs

All log messages produced by the tracer are downgraded to the DEBUG log level on the agent's own logger. This should not be a concern in general.