### PR TITLE
[network path] Avoid reporting unknown_hop_X for successful hops

### DIFF
--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -330,6 +330,7 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 
 		// then add all the other hops
 		for _, hop := range hops {
+			hop := hop
 			var nodename string
 			if hop.Received != nil {
 				nodename = hop.Received.IP.SrcIP.String()

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -260,16 +260,19 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 	for i, hop := range res.Hops {
 		ttl := i + 1
 		isReachable := false
-		var hopIPAddress string
+		hopname := fmt.Sprintf("unknown_hop_%d", ttl)
+		hostname := hopname
 
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
-			hopIPAddress = hop.IP.String()
+			hopname = hop.IP.String()
+			hostname = "" // reverse dns hostname will be set later
 		}
 
 		npHop := payload.NetworkPathHop{
 			TTL:       ttl,
-			IPAddress: hopIPAddress,
+			IPAddress: hopname,
+			Hostname:  hostname,
 			RTT:       float64(hop.RTT.Microseconds()) / float64(1000),
 			Reachable: isReachable,
 		}
@@ -331,7 +334,7 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 		// then add all the other hops
 		for _, hop := range hops {
 			hop := hop
-			var nodename string
+			nodename := fmt.Sprintf("unknown_hop_%d", hop.Sent.IP.TTL)
 			if hop.Received != nil {
 				nodename = hop.Received.IP.SrcIP.String()
 			}

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -260,16 +260,16 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 	for i, hop := range res.Hops {
 		ttl := i + 1
 		isReachable := false
-		var hopIpAddress string
+		var hopIPAddress string
 
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
-			hopIpAddress = hop.IP.String()
+			hopIPAddress = hop.IP.String()
 		}
 
 		npHop := payload.NetworkPathHop{
 			TTL:       ttl,
-			IPAddress: hopIpAddress,
+			IPAddress: hopIPAddress,
 			RTT:       float64(hop.RTT.Microseconds()) / float64(1000),
 			Reachable: isReachable,
 		}

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -266,7 +266,7 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
 			hopname = hop.IP.String()
-			hostname = hopname // setting hopname for now, reverse DNS lookup will override this field later
+			hostname = hopname // setting to ip address for now, reverse DNS lookup will override hostname field later
 		}
 
 		npHop := payload.NetworkPathHop{

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -260,18 +260,16 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 	for i, hop := range res.Hops {
 		ttl := i + 1
 		isReachable := false
-		hopname := fmt.Sprintf("unknown_hop_%d", ttl)
-		hostname := hopname
+		var hopIpAddress string
 
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
-			hopname = hop.IP.String()
+			hopIpAddress = hop.IP.String()
 		}
 
 		npHop := payload.NetworkPathHop{
 			TTL:       ttl,
-			IPAddress: hopname,
-			Hostname:  hostname,
+			IPAddress: hopIpAddress,
 			RTT:       float64(hop.RTT.Microseconds()) / float64(1000),
 			Reachable: isReachable,
 		}
@@ -332,8 +330,7 @@ func (r *Runner) processUDPResults(res *results.Results, hname string, destinati
 
 		// then add all the other hops
 		for _, hop := range hops {
-			hop := hop
-			nodename := fmt.Sprintf("unknown_hop_%d", hop.Sent.IP.TTL)
+			var nodename string
 			if hop.Received != nil {
 				nodename = hop.Received.IP.SrcIP.String()
 			}

--- a/pkg/networkpath/traceroute/runner.go
+++ b/pkg/networkpath/traceroute/runner.go
@@ -266,7 +266,7 @@ func (r *Runner) processTCPResults(res *tcp.Results, hname string, destinationHo
 		if !hop.IP.Equal(net.IP{}) {
 			isReachable = true
 			hopname = hop.IP.String()
-			hostname = "" // reverse dns hostname will be set later
+			hostname = hopname // setting hopname for now, reverse DNS lookup will override this field later
 		}
 
 		npHop := payload.NetworkPathHop{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[network path] Stop setting unknown hostname

### Motivation

Since we are not doing Reverse DNS anymore for public IPs, I noticed that we are showing hostname like unknown_hop_3 in UI:
![image](https://github.com/user-attachments/assets/039eca90-ebe5-4af8-a5bb-a38e0addf725)


Related to this change [this change](https://github.com/DataDog/datadog-agent/pull/30530/files#diff-0e4673cc94122ef603dff5e9136709a8aacaf00a59c56f58bf0328861239e8f5R268-R269) in 7.60.0 the backend is now showing 

### Describe how to test/QA your changes

Verify that hop.hostname is not `unknown_hop_X`, when the hop is reachable.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->