### PR TITLE
Skip Kafka TLS tests on ubuntu 24.10

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -109,8 +109,9 @@ func isUnsupportedUbuntu(t *testing.T) bool {
 	require.NoError(t, err)
 	platformVersion, err := kernel.PlatformVersion()
 	require.NoError(t, err)
+	arch := kernel.Arch()
 
-	return platform == ubuntuPlatform && platformVersion == "24.10"
+	return platform == ubuntuPlatform && platformVersion == "24.10" && arch == "x86"
 }
 
 func skipTestIfKernelNotSupported(t *testing.T) {

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -52,6 +52,7 @@ const (
 	kafkaPort             = "9092"
 	kafkaTLSPort          = "9093"
 	kafkaSuccessErrorCode = 0
+	ubuntuPlatform        = "ubuntu"
 )
 
 // testContext shares the context of a given test.
@@ -98,6 +99,18 @@ type kafkaParsingValidationWithErrorCodes struct {
 type groupInfo struct {
 	numSets int
 	msgs    []Message
+}
+
+// isUnsupportedUbuntu checks if the test is running on an unsupported Ubuntu version.
+// As of now, we don’t support Kafka TLS with Ubuntu 24.10, so this function identifies
+// if the current platform and version match this unsupported configuration.
+func isUnsupportedUbuntu(t *testing.T) bool {
+	platform, err := kernel.Platform()
+	require.NoError(t, err)
+	platformVersion, err := kernel.PlatformVersion()
+	require.NoError(t, err)
+
+	return platform == ubuntuPlatform && platformVersion == "24.10"
 }
 
 func skipTestIfKernelNotSupported(t *testing.T) {
@@ -155,6 +168,9 @@ func (s *KafkaProtocolParsingSuite) TestKafkaProtocolParsing() {
 		t.Run(name, func(t *testing.T) {
 			if mode && !gotlsutils.GoTLSSupported(t, config.New()) {
 				t.Skip("GoTLS not supported for this setup")
+			}
+			if mode && isUnsupportedUbuntu(t) {
+				t.Skip("Kafka TLS not supported on Ubuntu 24.10")
 			}
 			for _, version := range versions {
 				t.Run(versionName(version), func(t *testing.T) {
@@ -1250,6 +1266,9 @@ func (s *KafkaProtocolParsingSuite) TestKafkaFetchRaw() {
 		if !gotlsutils.GoTLSSupported(t, config.New()) {
 			t.Skip("GoTLS not supported for this setup")
 		}
+		if isUnsupportedUbuntu(t) {
+			t.Skip("Kafka TLS not supported on Ubuntu 24.10")
+		}
 
 		for _, version := range versions {
 			t.Run(fmt.Sprintf("api%d", version), func(t *testing.T) {
@@ -1475,6 +1494,9 @@ func (s *KafkaProtocolParsingSuite) TestKafkaProduceRaw() {
 	t.Run("with TLS", func(t *testing.T) {
 		if !gotlsutils.GoTLSSupported(t, config.New()) {
 			t.Skip("GoTLS not supported for this setup")
+		}
+		if isUnsupportedUbuntu(t) {
+			t.Skip("Kafka TLS not supported on Ubuntu 24.10")
 		}
 
 		for _, version := range versions {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Skips Kafka TLS tests on Ubuntu 24.10

### Motivation
During work on [this PR](https://github.com/DataDog/datadog-agent/pull/30807), we discovered that Kafka TLS tests are failing on Ubuntu 24.10 (x86 only). To avoid blocking this PR while we investigate the issue, we’re temporarily disabling these tests.

### Describe how to test/QA your changes
Run `inv -e kmt.test --vms=ubuntu24.10-x86-distro --packages=./pkg/network/usm --run=TestKafkaProtocolParsing --retry=0`. Without this change, the test fails, but with this change, all tests pass successfully.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->