### PR TITLE
Update `smp` binary in Regression Detector CI job

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -20,7 +20,7 @@ single-machine-performance-regression_detector:
       - outputs/junit.xml # for debugging, also on S3
     when: always
   variables:
-    SMP_VERSION: 0.16.0
+    SMP_VERSION: 0.18.1
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main


### PR DESCRIPTION
This commit updates the `smp` binary to current in Agent CI.
