### PR TITLE
[CWS] Add a faster CIDR set to match against IPv4/6 addresses

### DIFF
--- a/pkg/security/utils/cidr.go
+++ b/pkg/security/utils/cidr.go
@@ -60,7 +60,6 @@ func appendByteFilter(filter *[]*byteMaskFilter, iter int, ipnet *net.IPNet) {
 		return
 	}
 	appendByteFilter(&newBMF.next, iter+1, ipnet)
-	return
 }
 
 // AppendCIDR appends a CIDR to the set

--- a/pkg/security/utils/cidr.go
+++ b/pkg/security/utils/cidr.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils holds utils related files
+package utils
+
+import (
+	"fmt"
+	"net"
+	"slices"
+)
+
+type byteMaskFilter struct {
+	mask byte
+	ip   byte
+	next []*byteMaskFilter
+}
+
+// CIDRSet defines a set of CIDRs
+type CIDRSet struct {
+	cidrList  []string
+	cidrGraph []*byteMaskFilter
+}
+
+func appendByteFilter(filter *[]*byteMaskFilter, iter int, ipnet *net.IPNet) {
+	if iter > len(ipnet.IP) {
+		// we already append all needed filters
+		return
+	}
+
+	if ipnet.Mask[iter] == 0 {
+		// filter already pushed
+		return
+	}
+
+	last := false
+	if ipnet.Mask[iter] != 0xFF ||
+		(ipnet.Mask[iter] == 0xFF && iter+1 < len(ipnet.IP) && ipnet.Mask[iter+1] == 0) {
+		// last filter
+		last = true
+	}
+
+	// check filter is not already present:
+	for _, f := range *filter {
+		if f.mask == ipnet.Mask[iter] && f.ip == ipnet.IP[iter] {
+			// found
+			appendByteFilter(&f.next, iter+1, ipnet)
+			return
+		}
+	}
+	newBMF := &byteMaskFilter{
+		mask: ipnet.Mask[iter],
+		ip:   ipnet.IP[iter],
+		next: []*byteMaskFilter{},
+	}
+	*filter = append(*filter, newBMF)
+	if last {
+		return
+	}
+	appendByteFilter(&newBMF.next, iter+1, ipnet)
+	return
+}
+
+// AppendCIDR appends a CIDR to the set
+func (cs *CIDRSet) AppendCIDR(cidr string) error {
+	if slices.Contains(cs.cidrList, cidr) {
+		return nil // already present
+	}
+
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	appendByteFilter(&cs.cidrGraph, 0, ipnet)
+	cs.cidrList = append(cs.cidrList, cidr)
+	return nil
+}
+
+func debugFilter(filter *byteMaskFilter, prefix string) {
+	fmt.Printf("%s . ip/mask: %d/%d\n", prefix, filter.ip, filter.mask)
+	for _, f := range filter.next {
+		debugFilter(f, prefix+"  ")
+	}
+}
+
+// Debug prints on stdout the content of the CIDR set
+func (cs *CIDRSet) Debug() {
+	fmt.Printf("List of %d CIDR:\n", len(cs.cidrList))
+	for _, cidr := range cs.cidrList {
+		fmt.Printf("  - %s\n", cidr)
+	}
+	fmt.Println("Filter graph:")
+	for _, f := range cs.cidrGraph {
+		debugFilter(f, "  ")
+	}
+}
+
+func matchByteMask(maskFilter *[]*byteMaskFilter, iter int, ip []byte) bool {
+	if len(*maskFilter) == 0 {
+		// no more filters
+		return true
+	}
+
+	for _, f := range *maskFilter {
+		if f.ip == (ip[iter] & f.mask) {
+			// match
+			return matchByteMask(&f.next, iter+1, ip)
+		}
+	}
+	// no match
+	return false
+}
+
+// MatchIP returns true if the given IP match the CIDR set
+func (cs *CIDRSet) MatchIP(ipstring string) bool {
+	ipnet := net.ParseIP(ipstring)
+	if ipnet == nil {
+		return false
+	}
+	if ipv4 := ipnet.To4(); ipv4 != nil {
+		return matchByteMask(&cs.cidrGraph, 0, ipv4)
+	} else if ipv6 := ipnet.To16(); ipv6 != nil {
+		return matchByteMask(&cs.cidrGraph, 0, ipv6)
+	}
+	return false
+}

--- a/pkg/security/utils/cidr_test.go
+++ b/pkg/security/utils/cidr_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+// Package utils holds utils related files
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIPMatch(t *testing.T) {
+	// DefaultPrivateIPCIDRs is a list of private IP CIDRs that are used to determine if an IP is private or not.
+	var DefaultPrivateIPCIDRs = []string{
+		// IETF RPC 1918
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		// IETF RFC 5735
+		"0.0.0.0/8",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"192.88.99.0/24",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		// IETF RFC 6598
+		"100.64.0.0/10",
+		// // IETF RFC 4193
+		"fc00::/7",
+	}
+
+	cset := CIDRSet{}
+	for _, cidr := range DefaultPrivateIPCIDRs {
+		if err := cset.AppendCIDR(cidr); err != nil {
+			t.Fatalf("failed to append CIDR %s: %v", cidr, err)
+		}
+	}
+
+	// cset.Debug()
+
+	testCases := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{
+			name:     "dont match 1",
+			ip:       "11.1.1.1",
+			expected: false,
+		},
+
+		{
+			name:     "dont match 2",
+			ip:       "172.48.1.1",
+			expected: false,
+		},
+
+		{
+			name:     "dont match 3",
+			ip:       "192.167.1.1",
+			expected: false,
+		},
+
+		{
+			name:     "match in 24-bit block",
+			ip:       "10.11.11.11",
+			expected: true,
+		},
+		{
+			name:     "match in 20-bit block",
+			ip:       "172.24.11.11",
+			expected: true,
+		},
+		{
+			name:     "match in 16-bit block",
+			ip:       "192.168.11.11",
+			expected: true,
+		},
+		{
+			name:     "IPv6 ULA",
+			ip:       "fdf8:b35f:91b1::11",
+			expected: true,
+		},
+		{
+			name:     "IPv6 Global",
+			ip:       "2001:0:0eab:dead::a0:abcd:4e",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, cset.MatchIP(testCase.ip))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

It adds a new util tool, a CIDR set of IPv4/6 addresses on which let you append you CIDR on the set, and match an ip against it.

Today it's not used, but could replace our first implementation in `secl/compiler/eval/cidr.go`.

### Motivation

Mostly have fun :), and be a little faster to match an IP against a set of CIDR addresses than we do with our current implem

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->