### PR TITLE
[backport 7.59.x][gitlab]  release OTel to public facing repos on relevant tags

### DIFF
--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -1,5 +1,19 @@
 
 # Rule to make job manual when running deploy pipelines, or automatic and on success on RC pipelines
+#
+## Note on CI_COMMIT_TAGS
+#
+# The standard(vanilla) agent builds expect COMMIT TAGS that match the following
+# patterns:
+#    - RC: ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ (eg. 7.60.0-rc.2)
+#    - FINAL: ^[0-9]+\.[0-9]+\.[0-9]$ (eg. 7.60.0)
+#
+#
+# The OTel beta agent builds expect COMMIT TAGS that match the following
+# patterns. These tags will eventually be unrequired once GA is offered:
+#    - RC: ^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ (eg. 7.60.0-v1.1.0-rc.2)
+#    - FINAL: ^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$ (eg.
+#    7.60.0-v1.1.0)
 .manual_on_deploy_auto_on_rc:
   - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
     when: manual
@@ -28,6 +42,30 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
+.manual_on_deploy_auto_on_rc-ot:
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL != "true"
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL == "true"
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 # Rule for job that are triggered on_success on RC pipelines
 .on_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
@@ -42,6 +80,20 @@
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
+# Rule for job that are triggered on_success on RC pipelines for OTel Beta
+.on_rc-ot:
+  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
 # Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
@@ -62,19 +114,51 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
+# Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
+# For OTel Beta builds
+.on_final-ot:
+  - if: $BUCKET_BRANCH == "beta"
+    when: never
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 # Rule to deploy to our internal repository, on stable branch deploy
 .on_internal_final:
   - if: $BUCKET_BRANCH == "beta"
     when: never
   - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
     when: never
-  - when: manual
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
     allow_failure: true
     variables:
       AGENT_REPOSITORY: ci/datadog-agent/agent-release
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+
+# Rule to deploy to our internal repository, on stable branch deploy
+.on_internal_final-ot:
+  - if: $BUCKET_BRANCH == "beta"
+    when: never
+  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
+    when: never
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
 # Rule to deploy to our internal repository on RC
@@ -95,4 +179,18 @@
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+
+# Rule to deploy to our internal repository on RC for OTel Agent Beta
+.on_internal_rc-ot:
+  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -48,12 +48,6 @@ include:
 .deploy_containers-a7-base-ot:
   extends: .docker_publish_job_definition
   stage: deploy_containers
-  rules:
-    - when: manual
-      allow_failure: true
-  variables:
-    AGENT_REPOSITORY: agent
-    IMG_REGISTRIES: public
   dependencies: []
 
 deploy_containers-a7:
@@ -61,12 +55,24 @@ deploy_containers-a7:
   rules:
     !reference [.manual_on_deploy_auto_on_rc]
 
+deploy_containers-a7-ot:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.manual_on_deploy_auto_on_rc-ot]
+
 deploy_containers-a7-rc:
   extends: .deploy_containers-a7_external
   rules:
     !reference [.on_rc]
   variables:
     VERSION: 7-rc
+
+deploy_containers-a7-ot-rc:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_rc-ot]
+  variables:
+    VERSION: 7-ot-beta-rc
 
 deploy_containers-dogstatsd:
   extends: .docker_publish_job_definition
@@ -95,10 +101,26 @@ deploy_containers-a7_internal-rc:
     VERSION: 7-rc
 
 
-deploy_containers-ot:
+deploy_containers-a7-ot_internal:
   extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_internal_final-ot]
   before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
+
+deploy_containers-a7-ot_internal-rc:
+  extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_internal_rc-ot]
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
   parallel:
@@ -155,8 +177,10 @@ deploy_containers_latest-dogstatsd:
     IMG_SOURCES: ${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
 
-deploy_containers_latest-ot:
+deploy_containers_latest-a7-ot:
   extends: .deploy_containers-a7-base-ot
+  rules:
+    !reference [.on_final-ot]
   variables:
     VERSION: 7
   parallel:

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -49,6 +49,10 @@ include:
   extends: .docker_publish_job_definition
   stage: deploy_containers
   dependencies: []
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)-ot-beta" || exit $?; fi
+    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
 
 deploy_containers-a7:
   extends: .deploy_containers-a7_external
@@ -59,6 +63,11 @@ deploy_containers-a7-ot:
   extends: .deploy_containers-a7-base-ot
   rules:
     !reference [.manual_on_deploy_auto_on_rc-ot]
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
 
 deploy_containers-a7-rc:
   extends: .deploy_containers-a7_external
@@ -73,6 +82,11 @@ deploy_containers-a7-ot-rc:
     !reference [.on_rc-ot]
   variables:
     VERSION: 7-ot-beta-rc
+  parallel:
+    matrix:
+      - JMX:
+          - ""
+          - "-jmx"
 
 deploy_containers-dogstatsd:
   extends: .docker_publish_job_definition
@@ -105,24 +119,15 @@ deploy_containers-a7-ot_internal:
   extends: .deploy_containers-a7-base-ot
   rules:
     !reference [.on_internal_final-ot]
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
-    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
-  parallel:
-    matrix:
-      - JMX:
-          - ""
-          - "-jmx"
+  variables:
+    JMX: "-jmx"
 
 deploy_containers-a7-ot_internal-rc:
   extends: .deploy_containers-a7-base-ot
   rules:
     !reference [.on_internal_rc-ot]
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
-    - export IMG_SOURCES="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta${JMX}-arm64"
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}-ot-beta${JMX}"
+  variables:
+    VERSION: 7-ot-beta-rc
   parallel:
     matrix:
       - JMX:

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -39,6 +39,8 @@ trigger_auto_staging_release:
   rules:
     - if: $DDR == "true"
       when: never
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
     - !reference [.on_deploy]
 
 trigger_manual_prod_release:
@@ -49,4 +51,7 @@ trigger_manual_prod_release:
     # The jobs in the downstream pipeline will all be manual, so following
     # the created pipeline would likely cause this job to timeout
     NO_FOLLOW: "--no-follow"
-  rules: !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
+    - !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This backport PR backports PRs ##30641 and #30790  

### Motivation
Enables releasing OTel beta images (final and RC) to the correct public facing repos using an identical workflow to that employed for the standard Datadog Agent image builds/deployments but on OTel-specific git tags so as to not interefere with the standard workflow in any way.  

### Describe how to test/QA your changes
Previously tested on 7.60.x and test branches.

### Possible Drawbacks / Trade-offs
Should be a NOP for all non-OTel effects.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->