### PR TITLE
[NPM-3531] Add TCP state tracking to ebpf-less

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -78,6 +78,8 @@ func (t *TCPProcessor) updateSynFlag(conn *network.ConnectionStats, st *connecti
 	}
 }
 
+// updateTcpStats is designed to mirror the stat tracking in the windows driver's handleFlowProtocolTcp
+// https://github.com/DataDog/datadog-windows-filter/blob/d7560d83eb627117521d631a4c05cd654a01987e/ddfilter/flow/flow_tcp.c#L91
 func (t *TCPProcessor) updateTcpStats(conn *network.ConnectionStats, st *connectionState, pktType uint8, tcp *layers.TCP, payloadLen uint16) {
 	payloadSeq := tcp.Seq + uint32(payloadLen)
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -218,7 +218,7 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 	if tcp.RST {
 		switch st.tcpState {
 		case TcpStateClosed:
-			// retransmitted, ignore
+			// TODO retransmit
 		case TcpStateTimeWait:
 			// already closed, ignore
 		case TcpStateSynSent:

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -96,6 +96,7 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 				st.lastAck = tcp.Ack
 			} else if isSeqBefore(st.lastAck, tcp.Ack) {
 				ackDiff := tcp.Ack - st.lastAck
+				// if this is ack'ing a fin packet, there is an extra sequence number to cancel out
 				if isFinAck {
 					ackDiff--
 				}
@@ -207,6 +208,8 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 		switch st.tcpState {
 		case TcpStateClosed:
 			// retransmitted, ignore
+		case TcpStateTimeWait:
+			// already closed, ignore
 		case TcpStateSynSent:
 			fallthrough
 		case TcpStateSynRecv:

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -9,10 +9,14 @@ package ebpfless
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/google/gopacket/layers"
-	"golang.org/x/sys/unix"
 	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/google/gopacket/layers"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type connectionState struct {
@@ -169,6 +173,10 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 	if err != nil {
 		return err
 	}
+
+	log.TraceFunc(func() string {
+		return "tcp processor: " + debugPacketInfo(pktType, tcp, payloadLen)
+	})
 
 	st := t.conns[conn.ConnectionTuple]
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -1,0 +1,343 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpfless
+
+import (
+	"errors"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/sys/unix"
+	"syscall"
+)
+
+type connectionState struct {
+	tcpState tcpState
+
+	// @stu doc
+	hasSentPacket bool
+	// localStartSeq is only used for debugging
+	localStartSeq  uint32
+	maxSeqSent     uint32
+	hasAckedPacket bool
+	lastAck        uint32
+
+	// hasReceivedPacket is only used for debugging
+	hasReceivedPacket bool
+	// remoteStartSeq is only used for debugging
+	remoteStartSeq uint32
+
+	hasSynAcked bool
+
+	hasLocalFin  bool
+	hasRemoteFin bool
+	localFinSeq  uint32
+	remoteFinSeq uint32
+}
+
+type TCPProcessor struct {
+	conns map[network.ConnectionTuple]connectionState
+}
+
+func NewTCPProcessor() *TCPProcessor {
+	return &TCPProcessor{
+		conns: map[network.ConnectionTuple]connectionState{},
+	}
+}
+
+func logFailedConn(fmt string, params ...interface{}) {
+	// @stu
+	log.Debugf(fmt, params...)
+}
+
+// https://users.cs.northwestern.edu/~agupta/cs340/project2/TCPIP_State_Transition_Diagram.pdf
+func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4 *layers.IPv4, ip6 *layers.IPv6, tcp *layers.TCP) error {
+	payloadLen, err := TCPPayloadLen(conn.Family, ip4, ip6, tcp)
+	if err != nil {
+		return err
+	}
+
+	st := t.conns[conn.ConnectionTuple]
+	log.TraceFunc(func() string {
+		return fmt.Sprintf("pre ack_seq=%+v", st)
+	})
+
+	payloadSeq := tcp.Seq + uint32(payloadLen)
+
+	switch pktType {
+	case unix.PACKET_OUTGOING:
+		conn.Monotonic.SentPackets++
+		if !st.hasSentPacket {
+			st.localStartSeq = tcp.Seq
+		}
+		if !st.hasSentPacket || isSeqBefore(st.maxSeqSent, payloadSeq) {
+			st.hasSentPacket = true
+			conn.Monotonic.SentBytes += uint64(payloadLen)
+			st.maxSeqSent = payloadSeq
+		} else {
+			// TODO retransmit
+		}
+		if tcp.ACK {
+			isFinAck := st.hasRemoteFin && tcp.Ack == st.remoteFinSeq+1
+			if !st.hasAckedPacket {
+				st.hasAckedPacket = true
+				st.lastAck = tcp.Ack
+			} else if isSeqBefore(st.lastAck, tcp.Ack) {
+				ackDiff := tcp.Ack - st.lastAck
+				if isFinAck {
+					ackDiff--
+				}
+				conn.Monotonic.RecvBytes += uint64(ackDiff)
+				st.lastAck = tcp.Ack
+			}
+		}
+	case unix.PACKET_HOST:
+		conn.Monotonic.RecvPackets++
+		if !st.hasReceivedPacket {
+			st.hasReceivedPacket = true
+			st.remoteStartSeq = tcp.Seq
+		}
+	default:
+		return fmt.Errorf("TCPProcessor saw invalid pktType: %d", pktType)
+	}
+
+	log.TraceFunc(func() string {
+		packetInfo := debugPacketInfo(pktType, tcp, payloadLen, st)
+		return "tcp processor: " + packetInfo
+	})
+
+	// skip invalid packets we don't recognize.
+	synFinCombo := tcp.SYN && tcp.FIN
+	noFlagsCombo := !tcp.SYN && !tcp.FIN && !tcp.ACK && !tcp.RST
+	if synFinCombo || noFlagsCombo {
+		// TODO remove this warning since probably these occur in the wild
+		log.Warnf("invalid flags combo: SYN=%t FIN=%t ACK=%t RST=%t", tcp.SYN, tcp.FIN, tcp.ACK, tcp.RST)
+		return nil
+	}
+
+	// regular ACK (no SYN)
+	if !tcp.SYN && tcp.ACK {
+		switch st.tcpState {
+		case TcpStateClosed:
+		// TODO missed the handshake?
+		case TcpStateSynSent:
+			if pktType == unix.PACKET_OUTGOING {
+				if st.hasSynAcked {
+					// we are acking the remote's synack, mark as established
+					st.tcpState = TcpStateEstablished
+					conn.Monotonic.TCPEstablished++
+				} else {
+					log.Warnf("missed the SYNACK for tcpState=%d", st.tcpState)
+				}
+			}
+		case TcpStateSynRecv:
+			if pktType == unix.PACKET_HOST {
+				if st.hasSynAcked {
+					// remote has acked our synack, mark as established
+					st.tcpState = TcpStateEstablished
+					conn.Monotonic.TCPEstablished++
+				} else {
+					log.Warnf("missed the SYNACK for tcpState=%d", st.tcpState)
+				}
+			}
+		case TcpStateEstablished:
+			// if the remote closed, and we have acknowledged, enter CloseWait (passive close)
+			if st.hasRemoteFin && isSeqBefore(st.remoteFinSeq, tcp.Ack) {
+				st.tcpState = TcpStateCloseWait
+			}
+		case TcpStateFinWait1:
+			// active close: wait until we've received an ack of the fin we sent
+			if pktType == unix.PACKET_HOST {
+				if !st.hasLocalFin {
+					return errors.New("entered FinWait1 without a localFin (shouldn't get here)")
+				}
+				if isSeqBefore(st.localFinSeq, tcp.Ack) {
+					st.tcpState = TcpStateFinWait2
+				}
+			}
+		case TcpStateFinWait2:
+			// active close: wait until we send an ack of the fin received from the remote
+			if pktType == unix.PACKET_OUTGOING {
+				if st.hasRemoteFin && isSeqBefore(st.remoteFinSeq, tcp.Ack) {
+					st.tcpState = TcpStateTimeWait
+					conn.Monotonic.TCPClosed++
+				}
+			}
+		case TcpStateCloseWait:
+			// nothing but counting up data bytes
+		case TcpStateClosing:
+			// same as LastAck - we wait until we receive an ACK of the fin
+			fallthrough
+		case TcpStateLastAck:
+			// passive close: waiting until the remote acks the client's FIN
+			if pktType == unix.PACKET_HOST {
+				if !st.hasLocalFin {
+					return fmt.Errorf("entered state=%d without a localFin (shouldn't get here)", st.tcpState)
+				}
+				if isSeqBefore(st.localFinSeq, tcp.Ack) {
+					st.tcpState = TcpStateClosed
+					conn.Monotonic.TCPClosed++
+				}
+			}
+		case TcpStateTimeWait:
+		}
+		// this branch is the only one that doesn't GOTO done - it needs to fall through
+		// because there can be RSTACK and FINACK packets
+	} // end regular ACK
+
+	// RST flag
+	if tcp.RST {
+		switch st.tcpState {
+		case TcpStateClosed:
+			// retransmitted, ignore
+		case TcpStateSynSent:
+			fallthrough
+		case TcpStateSynRecv:
+			logFailedConn("RST on an attempted connection; Failure")
+			conn.TCPFailures[uint32(syscall.ECONNREFUSED)]++
+		case TcpStateEstablished:
+			logFailedConn("RST on an established connection; Failure")
+			conn.TCPFailures[uint32(syscall.ECONNRESET)]++
+			// TODO what to do when RST happens in one of the closing states?
+		default:
+			logFailedConn("RST on a connection with tcpState=%d; Failure", st.tcpState)
+			conn.TCPFailures[uint32(syscall.ECONNRESET)]++
+		}
+
+		if !isClosedState(st.tcpState) {
+			conn.Monotonic.TCPClosed++
+			st.tcpState = TcpStateClosed
+		}
+		goto done
+	} // end RST
+
+	// initial SYN (no ACK)
+	if tcp.SYN && !tcp.ACK {
+		switch st.tcpState {
+		case TcpStateClosed:
+			fallthrough
+		case TcpStateTimeWait:
+			if pktType == unix.PACKET_OUTGOING {
+				st.tcpState = TcpStateSynSent
+			} else {
+				st.tcpState = TcpStateSynRecv
+			}
+		case TcpStateSynSent:
+			if pktType == unix.PACKET_OUTGOING {
+				// TODO retransmit
+			} else {
+				// simultaneous open
+				st.tcpState = TcpStateSynRecv
+			}
+		case TcpStateSynRecv:
+			// TODO retransmit
+		default:
+			log.Warnf("SYN on a connection with tcpState=%d", st.tcpState)
+		}
+		goto done
+	} // end SYN (no ACK)
+
+	// SYNACK
+	if tcp.SYN && tcp.ACK {
+		switch st.tcpState {
+		case TcpStateClosed:
+			// TODO we missed the initial SYN packet, what to do here?
+			// for now assume things proceeded normally prior
+			st.tcpState = TcpStateSynRecv
+			fallthrough
+		case TcpStateSynSent:
+			fallthrough
+		case TcpStateSynRecv:
+			st.hasSynAcked = true
+		case TcpStateEstablished:
+			// TODO retransmit
+		default:
+			log.Warnf("SYNACK on a connection with tcpState=%d", st.tcpState)
+		}
+		goto done
+	} // end SYNACK
+
+	if tcp.FIN {
+		if pktType == unix.PACKET_OUTGOING {
+			if !st.hasLocalFin {
+				st.hasLocalFin = true
+				st.localFinSeq = payloadSeq
+			} else {
+				// TODO retransmit
+			}
+		} else {
+			if !st.hasRemoteFin {
+				st.hasRemoteFin = true
+				st.remoteFinSeq = payloadSeq
+			} else {
+				// TODO remote retransmit? do we care?
+			}
+		}
+		switch st.tcpState {
+		case TcpStateSynRecv:
+			// apparently this is possible if the OS handles the connection via listen() but the server process isn't
+			// calling accept(), or is out of FDs so accept() fails
+			// https://stackoverflow.com/a/5245704
+			fallthrough
+		case TcpStateEstablished:
+			if pktType == unix.PACKET_OUTGOING {
+				// active close
+				st.tcpState = TcpStateFinWait1
+			} else {
+				// passive close, no change here besides the above recording remoteFinSeq.
+				// once remoteFinSeq is acked, it switches to TcpStateCloseWait
+			}
+		case TcpStateFinWait1:
+			if pktType == unix.PACKET_HOST {
+				// simultaneous close
+				// XXXXXXXXXXXXXXX
+			}
+			// nothing but counting FIN retransmits
+		case TcpStateFinWait2:
+		case TcpStateCloseWait:
+			if pktType == unix.PACKET_OUTGOING {
+				st.tcpState = TcpStateLastAck
+			}
+		case TcpStateClosing:
+			// nothing but counting FIN retransmits
+		case TcpStateLastAck:
+			// nothing but counting FIN retransmits
+		case TcpStateTimeWait:
+			// nothing but counting FIN retransmits
+		default:
+			// if we get here, we missed traffic and can't know if this is an active or passive close.
+			// TODO what to do?
+			log.Warnf("saw initial FIN in tcpState=%d", st.tcpState)
+		}
+		goto done
+	} // end FIN
+
+	//if tcp.FIN || tcp.RST {
+	//	if !st.closed {
+	//		st.closed = true
+	//		conn.Monotonic.TCPClosed++
+	//		conn.Duration = time.Duration(time.Now().UnixNano() - int64(conn.Duration))
+	//	}
+	//	delete(t.conns, key)
+	//	return nil
+	//}
+	//
+	//if !tcp.SYN && !st.established {
+	//	st.established = true
+	//	conn.Monotonic.TCPEstablished++
+	//}
+
+done:
+
+	log.TraceFunc(func() string {
+		return fmt.Sprintf("ack_seq=%+v", st)
+	})
+	t.conns[conn.ConnectionTuple] = st
+	return nil
+}

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -60,6 +60,8 @@ func NewTCPProcessor() *TCPProcessor {
 	}
 }
 
+// Process handles a TCP packet, calculating stats and keeping track of its state according to the
+// TCP state machine.
 // https://users.cs.northwestern.edu/~agupta/cs340/project2/TCPIP_State_Transition_Diagram.pdf
 func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4 *layers.IPv4, ip6 *layers.IPv6, tcp *layers.TCP) error {
 	payloadLen, err := TCPPayloadLen(conn.Family, ip4, ip6, tcp)
@@ -322,21 +324,6 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 		}
 		goto done
 	} // end FIN
-
-	//if tcp.FIN || tcp.RST {
-	//	if !st.closed {
-	//		st.closed = true
-	//		conn.Monotonic.TCPClosed++
-	//		conn.Duration = time.Duration(time.Now().UnixNano() - int64(conn.Duration))
-	//	}
-	//	delete(t.conns, key)
-	//	return nil
-	//}
-	//
-	//if !tcp.SYN && !st.established {
-	//	st.established = true
-	//	conn.Monotonic.TCPEstablished++
-	//}
 
 done:
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -704,6 +704,13 @@ func TestConnectTwice(t *testing.T) {
 	}
 
 	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	state := f.tcp.conns[f.conn.ConnectionTuple]
+	// make sure the TCP state was erased after the connection was closed
+	require.Equal(t, connectionState{
+		tcpState: TcpStateTimeWait,
+	}, state)
+
 	// second connection here
 	f.runAgainstState(basicHandshake, expectedClientStates)
 
@@ -722,7 +729,6 @@ func TestConnectTwice(t *testing.T) {
 }
 
 func TestSimultaneousOpen(t *testing.T) {
-	t.Skip("simultaneous open is slightly wrong")
 	f := newTcpTestFixture(t, lowerSeq, higherSeq)
 
 	basicHandshake := []testCapture{

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -1,0 +1,722 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpfless
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+var localhost net.IP = net.ParseIP("127.0.0.1")
+var remoteIP net.IP = net.ParseIP("12.34.56.78")
+
+const (
+	MIN_IHL             = 5
+	DEFAULT_LOCAL_PORT  = 12345
+	DEFAULT_REMOTE_PORT = 8080
+	DEFAULT_NS_ID       = 123
+)
+
+const (
+	FIN = 0x01
+	SYN = 0x02
+	RST = 0x04
+	ACK = 0x10
+)
+
+func ipv4Packet(src, dst net.IP, length uint16) layers.IPv4 {
+	return layers.IPv4{
+		Version:    4,
+		IHL:        MIN_IHL,
+		TOS:        0,
+		Length:     length,
+		Id:         12345,
+		Flags:      0x02,
+		FragOffset: 0,
+		TTL:        64,
+		Protocol:   6,
+		Checksum:   0xbeef,
+		SrcIP:      src,
+		DstIP:      dst,
+	}
+}
+
+func tcpPacket(srcPort, dstPort uint16, seq, ack uint32, flags uint8) layers.TCP {
+	return layers.TCP{
+		DataOffset: 5,
+		Window:     65535,
+		SrcPort:    layers.TCPPort(srcPort),
+		DstPort:    layers.TCPPort(dstPort),
+		Seq:        seq,
+		Ack:        ack,
+		FIN:        flags&FIN != 0,
+		SYN:        flags&SYN != 0,
+		RST:        flags&RST != 0,
+		ACK:        flags&ACK != 0,
+	}
+}
+
+type testCapture struct {
+	pktType uint8
+	ipv4    *layers.IPv4
+	ipv6    *layers.IPv6
+	tcp     *layers.TCP
+}
+
+func (tc testCapture) reverse() testCapture {
+	ret := tc
+	if tc.pktType == unix.PACKET_HOST {
+		ret.pktType = unix.PACKET_OUTGOING
+	} else {
+		ret.pktType = unix.PACKET_HOST
+	}
+	if tc.ipv4 != nil {
+		ipv4 := *tc.ipv4
+		ipv4.SrcIP, ipv4.DstIP = ipv4.DstIP, ipv4.SrcIP
+		ret.ipv4 = &ipv4
+	}
+	if tc.ipv6 != nil {
+		ipv6 := *tc.ipv6
+		ipv6.SrcIP, ipv6.DstIP = ipv6.DstIP, ipv6.SrcIP
+		ret.ipv6 = &ipv6
+	}
+	tcp := *tc.tcp
+	tcp.SrcPort, tcp.DstPort = tcp.DstPort, tcp.SrcPort
+	ret.tcp = &tcp
+	return ret
+}
+func reversePkts(tc []testCapture) []testCapture {
+	var ret []testCapture
+	for _, t := range tc {
+		ret = append(ret, t.reverse())
+	}
+	return ret
+}
+
+// TODO can this be merged with the logic creating scratchConns in ebpfless tracer?
+func makeTcpStates(synPkt testCapture) *network.ConnectionStats {
+	var family network.ConnectionFamily
+	var srcIP, dstIP net.IP
+	if synPkt.ipv4 != nil && synPkt.ipv6 != nil {
+		panic("testCapture shouldn't have both IP families")
+	}
+	if synPkt.ipv4 != nil {
+		family = network.AFINET
+		srcIP = synPkt.ipv4.SrcIP
+		dstIP = synPkt.ipv4.DstIP
+	} else if synPkt.ipv6 != nil {
+		family = network.AFINET6
+		srcIP = synPkt.ipv6.SrcIP
+		dstIP = synPkt.ipv6.DstIP
+	} else {
+		panic("testCapture had no IP family")
+	}
+	var direction network.ConnectionDirection
+	switch synPkt.pktType {
+	case unix.PACKET_HOST:
+		direction = network.INCOMING
+	case unix.PACKET_OUTGOING:
+		direction = network.OUTGOING
+	default:
+		panic("testCapture had unknown packet type")
+	}
+	return &network.ConnectionStats{
+		ConnectionTuple: network.ConnectionTuple{
+			Source: util.AddressFromNetIP(srcIP),
+			Dest:   util.AddressFromNetIP(dstIP),
+			Pid:    0, // @stu we can't know this right
+			NetNS:  DEFAULT_NS_ID,
+			SPort:  uint16(synPkt.tcp.SrcPort),
+			DPort:  uint16(synPkt.tcp.DstPort),
+			Type:   network.TCP,
+			Family: family,
+		},
+		Direction:   direction,
+		TCPFailures: make(map[uint32]uint32),
+	}
+}
+
+type tcpTestFixture struct {
+	t                           *testing.T
+	tcp                         *TCPProcessor
+	conn                        *network.ConnectionStats
+	localSeqBase, remoteSeqBase uint32
+}
+
+const TCP_HEADER_SIZE = 20
+
+func (fixture *tcpTestFixture) incoming(payloadLen uint16, relSeq, relAck uint32, flags uint8) testCapture {
+	ipv4 := ipv4Packet(remoteIP, localhost, MIN_IHL*4+TCP_HEADER_SIZE+payloadLen)
+	seq := relSeq + fixture.localSeqBase
+	ack := relAck + fixture.remoteSeqBase
+	tcp := tcpPacket(DEFAULT_REMOTE_PORT, DEFAULT_LOCAL_PORT, seq, ack, flags)
+	return testCapture{
+		pktType: unix.PACKET_HOST,
+		ipv4:    &ipv4,
+		ipv6:    nil,
+		tcp:     &tcp,
+	}
+}
+
+func (fixture *tcpTestFixture) outgoing(payloadLen uint16, relSeq, relAck uint32, flags uint8) testCapture {
+	ipv4 := ipv4Packet(localhost, remoteIP, MIN_IHL*4+TCP_HEADER_SIZE+payloadLen)
+	seq := relSeq + fixture.remoteSeqBase
+	ack := relAck + fixture.localSeqBase
+	tcp := tcpPacket(DEFAULT_LOCAL_PORT, DEFAULT_REMOTE_PORT, seq, ack, flags)
+	return testCapture{
+		pktType: unix.PACKET_OUTGOING,
+		ipv4:    &ipv4,
+		ipv6:    nil,
+		tcp:     &tcp,
+	}
+}
+
+func newTcpTestFixture(t *testing.T, localSeqBase, remoteSeqBase uint32) *tcpTestFixture {
+	return &tcpTestFixture{
+		t:             t,
+		tcp:           NewTCPProcessor(),
+		conn:          nil,
+		localSeqBase:  localSeqBase,
+		remoteSeqBase: remoteSeqBase,
+	}
+}
+
+func (fixture *tcpTestFixture) runPkt(pkt testCapture) {
+	if fixture.conn == nil {
+		fixture.conn = makeTcpStates(pkt)
+	}
+	err := fixture.tcp.Process(fixture.conn, pkt.pktType, pkt.ipv4, pkt.ipv6, pkt.tcp)
+	require.NoError(fixture.t, err)
+}
+
+func (fixture *tcpTestFixture) runPkts(packets []testCapture) {
+	for _, pkt := range packets {
+		fixture.runPkt(pkt)
+	}
+}
+
+//func (fixture *tcpTestFixture) expectState(expected tcpState, msg string = "tcp state mismatch") {
+//	require.NotNil(fixture.t, fixture.conn, "can't expectState() before runPkt() has been called")
+//}
+
+func (fixture *tcpTestFixture) runAgainstState(packets []testCapture, expected []tcpState) {
+	require.Equal(fixture.t, len(packets), len(expected), "packet length didn't match expected states length")
+	var expectedStrs []string
+	var actualStrs []string
+
+	for i, pkt := range packets {
+		expectedStrs = append(expectedStrs, LabelForState(expected[i]))
+
+		fixture.runPkt(pkt)
+		connTuple := fixture.conn.ConnectionTuple
+		actual := fixture.tcp.conns[connTuple].tcpState
+		actualStrs = append(actualStrs, LabelForState(actual))
+	}
+	require.Equal(fixture.t, expectedStrs, actualStrs)
+}
+
+func testBasicHandshake(t *testing.T, f *tcpTestFixture) {
+
+	basicHandshake := []testCapture{
+		f.outgoing(0, 0, 0, SYN),
+		f.incoming(0, 0, 1, SYN|ACK),
+		// separate ack and first send of data
+		f.outgoing(0, 1, 1, ACK),
+		f.outgoing(123, 1, 1, ACK),
+		// acknowledge data separately
+		f.incoming(0, 1, 124, ACK),
+		f.incoming(345, 1, 124, ACK),
+		// remote FINs separately
+		f.incoming(0, 346, 124, FIN|ACK),
+		// local acknowledges data, (not the FIN)
+		f.outgoing(0, 124, 346, ACK),
+		// local acknowledges FIN and sends their own
+		f.outgoing(0, 124, 347, FIN|ACK),
+		// remote sends final ACK
+		f.incoming(0, 347, 125, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynSent,
+		TcpStateSynSent,
+		// three-way handshake finishes here
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		// passive close begins here, but CloseWait doesn't begin until the fin was acked
+		TcpStateEstablished,
+		TcpStateEstablished,
+		// ...which happens in the same packet as FIN gets sent out, so it skips CloseWait
+		TcpStateLastAck,
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      123,
+		RecvBytes:      345,
+		SentPackets:    5,
+		RecvPackets:    5,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+var lowerSeq uint32 = 2134452051
+var higherSeq uint32 = 2973263073
+
+func TestBasicHandshake(t *testing.T) {
+	t.Run("localSeq lt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, lowerSeq, higherSeq)
+		testBasicHandshake(t, f)
+	})
+
+	t.Run("localSeq gt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, higherSeq, lowerSeq)
+		testBasicHandshake(t, f)
+	})
+}
+
+func testBasicHandshakeReversed(t *testing.T, f *tcpTestFixture) {
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		// separate ack and first send of data
+		f.incoming(0, 1, 1, ACK),
+		f.incoming(123, 1, 1, ACK),
+		// acknowledge data separately
+		f.outgoing(0, 1, 124, ACK),
+		f.outgoing(345, 1, 124, ACK),
+		// local FINs separately
+		f.outgoing(0, 346, 124, FIN|ACK),
+		// remote acknowledges data, (not the FIN)
+		f.incoming(0, 124, 346, ACK),
+		// remote acknowledges FIN and sends their own
+		f.incoming(0, 124, 347, FIN|ACK),
+		// local sends final ACK
+		f.outgoing(0, 347, 125, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		// three-way handshake finishes here
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		// active close begins here
+		TcpStateFinWait1,
+		TcpStateFinWait1,
+		// acking the initial happens in the same packet as the final FIN gets sent out, so it skips CloseWait
+		TcpStateFinWait2,
+		TcpStateTimeWait,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      345,
+		RecvBytes:      123,
+		SentPackets:    5,
+		RecvPackets:    5,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestBasicHandshakeReversed(t *testing.T) {
+	t.Run("localSeq lt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, lowerSeq, higherSeq)
+		testBasicHandshakeReversed(t, f)
+	})
+
+	t.Run("localSeq gt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, higherSeq, lowerSeq)
+		testBasicHandshakeReversed(t, f)
+	})
+}
+
+func testCloseWaitState(t *testing.T, f *tcpTestFixture) {
+	// test the CloseWait state, which is when the local client still has data left
+	// to send during a passive close
+
+	basicHandshake := []testCapture{
+		f.outgoing(0, 0, 0, SYN),
+		f.incoming(0, 0, 1, SYN|ACK),
+		// local sends data right out the gate with ACK
+		f.outgoing(123, 1, 1, ACK),
+		// remote acknowledges and sends data back
+		f.incoming(345, 1, 124, ACK),
+		// remote FINs separately
+		f.incoming(0, 346, 124, FIN|ACK),
+		// local acknowledges FIN, but keeps sending data for a bit
+		f.outgoing(100, 124, 347, ACK),
+		// client finally FINACKs
+		f.outgoing(42, 224, 347, FIN|ACK),
+		// remote acknowledges data but not including the FIN
+		f.incoming(0, 347, 224, ACK),
+		// server sends final ACK
+		f.incoming(0, 347, 224+42+1, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynSent,
+		TcpStateSynSent,
+		// three-way handshake finishes here
+		TcpStateEstablished,
+		TcpStateEstablished,
+		// passive close begins here, but CloseWait doesn't begin until the fin was acked
+		TcpStateEstablished,
+		// ...which is here
+		TcpStateCloseWait,
+		TcpStateLastAck,
+		TcpStateLastAck,
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      123 + 100 + 42,
+		RecvBytes:      345,
+		SentPackets:    4,
+		RecvPackets:    5,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestCloseWaitState(t *testing.T) {
+	t.Run("localSeq lt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, lowerSeq, higherSeq)
+		testCloseWaitState(t, f)
+	})
+
+	t.Run("localSeq gt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, higherSeq, lowerSeq)
+		testCloseWaitState(t, f)
+	})
+}
+
+func testFinWait2State(t *testing.T, f *tcpTestFixture) {
+	// test the FinWait2 state, which is when the remote still has data left
+	// to send during an active close
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		// separate ack and first send of data
+		f.incoming(0, 1, 1, ACK),
+		f.incoming(123, 1, 1, ACK),
+		// acknowledge data separately
+		f.outgoing(0, 1, 124, ACK),
+		f.outgoing(345, 1, 124, ACK),
+		// local FINs separately
+		f.outgoing(0, 346, 124, FIN|ACK),
+		// remote acknowledges the FIN but keeps sending data
+		f.incoming(100, 124, 347, ACK),
+		// local acknowledges this data
+		f.outgoing(0, 347, 224, ACK),
+		// remote sends their own FIN
+		f.incoming(0, 224, 347, FIN|ACK),
+		// local sends final ACK
+		f.outgoing(0, 347, 225, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		// three-way handshake finishes here
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		TcpStateEstablished,
+		// active close begins here
+		TcpStateFinWait1,
+		TcpStateFinWait2,
+		TcpStateFinWait2,
+		TcpStateFinWait2,
+		TcpStateTimeWait,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      345,
+		RecvBytes:      223,
+		SentPackets:    6,
+		RecvPackets:    5,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestFinWait2State(t *testing.T) {
+	t.Run("localSeq lt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, lowerSeq, higherSeq)
+		testFinWait2State(t, f)
+	})
+
+	t.Run("localSeq gt remoteSeq", func(t *testing.T) {
+		f := newTcpTestFixture(t, higherSeq, lowerSeq)
+		testFinWait2State(t, f)
+	})
+}
+
+func TestImmediateFin(t *testing.T) {
+	// originally captured from TestTCPConnsReported which closes connections right as it gets them
+
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		f.incoming(0, 1, 1, ACK),
+		// active close after sending no data
+		f.outgoing(0, 1, 1, FIN|ACK),
+		f.incoming(0, 1, 2, FIN|ACK),
+		f.outgoing(0, 2, 2, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateEstablished,
+		// active close begins here
+		TcpStateFinWait1,
+		TcpStateFinWait2,
+		TcpStateTimeWait,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    3,
+		RecvPackets:    3,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestConnRefusedSyn(t *testing.T) {
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 0, RST|ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Equal(t, f.conn.TCPFailures, map[uint32]uint32{
+		uint32(syscall.ECONNREFUSED): 1,
+	})
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    1,
+		RecvPackets:    1,
+		Retransmits:    0,
+		TCPEstablished: 0,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestConnRefusedSynAck(t *testing.T) {
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		f.outgoing(0, 0, 0, RST|ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Equal(t, f.conn.TCPFailures, map[uint32]uint32{
+		uint32(syscall.ECONNREFUSED): 1,
+	})
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    2,
+		RecvPackets:    1,
+		Retransmits:    0,
+		TCPEstablished: 0,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestConnReset(t *testing.T) {
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		f.incoming(0, 1, 1, ACK),
+		// handshake done, now blow up
+		f.outgoing(0, 1, 1, RST|ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateEstablished,
+		// reset
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Equal(t, f.conn.TCPFailures, map[uint32]uint32{
+		uint32(syscall.ECONNRESET): 1,
+	})
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    2,
+		RecvPackets:    2,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestRstRetransmit(t *testing.T) {
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		f.incoming(0, 1, 1, ACK),
+		// handshake done, now blow up
+		f.outgoing(0, 1, 1, RST|ACK),
+		f.outgoing(0, 1, 1, RST|ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateEstablished,
+		// reset
+		TcpStateClosed,
+		TcpStateClosed,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	// should count as a single failure
+	require.Equal(t, f.conn.TCPFailures, map[uint32]uint32{
+		uint32(syscall.ECONNRESET): 1,
+	})
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    3,
+		RecvPackets:    2,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		// should count as a single closed connection
+		TCPClosed: 1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
+func TestConnectTwice(t *testing.T) {
+	// same as TestImmediateFin but everything happens twice
+
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		f.outgoing(0, 0, 1, SYN|ACK),
+		f.incoming(0, 1, 1, ACK),
+		// active close after sending no data
+		f.outgoing(0, 1, 1, FIN|ACK),
+		f.incoming(0, 1, 2, FIN|ACK),
+		f.outgoing(0, 2, 2, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateEstablished,
+		// active close begins here
+		TcpStateFinWait1,
+		TcpStateFinWait2,
+		TcpStateTimeWait,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+	// second connection here
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    3 * 2,
+		RecvPackets:    3 * 2,
+		Retransmits:    0,
+		TCPEstablished: 1 * 2,
+		TCPClosed:      1 * 2,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -12,11 +12,13 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"golang.org/x/sys/unix"
+
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 var localhost net.IP = net.ParseIP("127.0.0.1")

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -774,6 +774,53 @@ func TestSimultaneousOpen(t *testing.T) {
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }
 
+func TestReorderedSimultaneousOpen(t *testing.T) {
+	f := newTcpTestFixture(t, lowerSeq, higherSeq)
+
+	basicHandshake := []testCapture{
+		f.incoming(0, 0, 0, SYN),
+		// this is swapped, happens early now
+		f.outgoing(0, 1, 1, SYN|ACK),
+		f.outgoing(0, 0, 0, SYN),
+		f.incoming(0, 1, 1, SYN|ACK),
+		f.incoming(0, 2, 2, ACK),
+		f.outgoing(0, 2, 2, ACK),
+		// active close after sending no data
+		f.outgoing(0, 2, 2, FIN|ACK),
+		f.incoming(0, 2, 3, FIN|ACK),
+		f.outgoing(0, 3, 3, ACK),
+	}
+
+	expectedClientStates := []tcpState{
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		TcpStateSynRecv,
+		// even though a synack has been ack'd, both synacks have not been ack'd so it is not established
+		TcpStateSynRecv,
+		TcpStateEstablished,
+		// active close begins here
+		TcpStateFinWait1,
+		TcpStateFinWait2,
+		TcpStateTimeWait,
+	}
+
+	f.runAgainstState(basicHandshake, expectedClientStates)
+
+	require.Empty(t, f.conn.TCPFailures)
+
+	expectedStats := network.StatCounters{
+		SentBytes:      0,
+		RecvBytes:      0,
+		SentPackets:    5,
+		RecvPackets:    4,
+		Retransmits:    0,
+		TCPEstablished: 1,
+		TCPClosed:      1,
+	}
+	require.Equal(t, expectedStats, f.conn.Monotonic)
+}
+
 func TestSimultaneousClose(t *testing.T) {
 	f := newTcpTestFixture(t, lowerSeq, higherSeq)
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -23,10 +23,10 @@ var localhost net.IP = net.ParseIP("127.0.0.1")
 var remoteIP net.IP = net.ParseIP("12.34.56.78")
 
 const (
-	MIN_IHL             = 5
-	DEFAULT_LOCAL_PORT  = 12345
-	DEFAULT_REMOTE_PORT = 8080
-	DEFAULT_NS_ID       = 123
+	minIhl            = 5
+	defaultLocalPort  = 12345
+	defaultRemotePort = 8080
+	defaultNsId       = 123
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 func ipv4Packet(src, dst net.IP, length uint16) layers.IPv4 {
 	return layers.IPv4{
 		Version:    4,
-		IHL:        MIN_IHL,
+		IHL:        minIhl,
 		TOS:        0,
 		Length:     length,
 		Id:         12345,
@@ -137,7 +137,7 @@ func makeTcpStates(synPkt testCapture) *network.ConnectionStats {
 			Source: util.AddressFromNetIP(srcIP),
 			Dest:   util.AddressFromNetIP(dstIP),
 			Pid:    0, // @stu we can't know this right
-			NetNS:  DEFAULT_NS_ID,
+			NetNS:  defaultNsId,
 			SPort:  uint16(synPkt.tcp.SrcPort),
 			DPort:  uint16(synPkt.tcp.DstPort),
 			Type:   network.TCP,
@@ -158,10 +158,10 @@ type tcpTestFixture struct {
 const TCP_HEADER_SIZE = 20
 
 func (fixture *tcpTestFixture) incoming(payloadLen uint16, relSeq, relAck uint32, flags uint8) testCapture {
-	ipv4 := ipv4Packet(remoteIP, localhost, MIN_IHL*4+TCP_HEADER_SIZE+payloadLen)
+	ipv4 := ipv4Packet(remoteIP, localhost, minIhl*4+TCP_HEADER_SIZE+payloadLen)
 	seq := relSeq + fixture.localSeqBase
 	ack := relAck + fixture.remoteSeqBase
-	tcp := tcpPacket(DEFAULT_REMOTE_PORT, DEFAULT_LOCAL_PORT, seq, ack, flags)
+	tcp := tcpPacket(defaultRemotePort, defaultLocalPort, seq, ack, flags)
 	return testCapture{
 		pktType: unix.PACKET_HOST,
 		ipv4:    &ipv4,
@@ -171,10 +171,10 @@ func (fixture *tcpTestFixture) incoming(payloadLen uint16, relSeq, relAck uint32
 }
 
 func (fixture *tcpTestFixture) outgoing(payloadLen uint16, relSeq, relAck uint32, flags uint8) testCapture {
-	ipv4 := ipv4Packet(localhost, remoteIP, MIN_IHL*4+TCP_HEADER_SIZE+payloadLen)
+	ipv4 := ipv4Packet(localhost, remoteIP, minIhl*4+TCP_HEADER_SIZE+payloadLen)
 	seq := relSeq + fixture.remoteSeqBase
 	ack := relAck + fixture.localSeqBase
-	tcp := tcpPacket(DEFAULT_LOCAL_PORT, DEFAULT_REMOTE_PORT, seq, ack, flags)
+	tcp := tcpPacket(defaultLocalPort, defaultRemotePort, seq, ack, flags)
 	return testCapture{
 		pktType: unix.PACKET_OUTGOING,
 		ipv4:    &ipv4,

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -92,7 +92,8 @@ func debugTcpFlags(tcp *layers.TCP) string {
 	return strings.Join(flags, "|")
 }
 
-func seqDiff(seq uint32, hasBase bool, base uint32) uint32 {
+// getRelativeSeq is used for debugging to visualize
+func getRelativeSeq(seq uint32, hasBase bool, base uint32) uint32 {
 	if !hasBase {
 		return seq
 	}
@@ -107,7 +108,7 @@ func debugPacketInfo(pktType uint8, tcp *layers.TCP, payloadLen uint16, st conne
 		hasStartSeq, hasAckSeq = hasAckSeq, hasStartSeq
 		startSeq, ackSeq = ackSeq, startSeq
 	}
-	relativeSeq := seqDiff(tcp.Seq, hasStartSeq, startSeq)
-	relativeAck := seqDiff(tcp.Ack, hasAckSeq, ackSeq)
+	relativeSeq := getRelativeSeq(tcp.Seq, hasStartSeq, startSeq)
+	relativeAck := getRelativeSeq(tcp.Ack, hasAckSeq, ackSeq)
 	return fmt.Sprintf("pktType=%+v ports=(%+v, %+v) size=%d relSeq=%+v relAck=%+v flags=%s", debugPacketDir(pktType), uint16(tcp.SrcPort), uint16(tcp.DstPort), payloadLen, relativeSeq, relativeAck, debugTcpFlags(tcp))
 }

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpfless
+
+import (
+	"fmt"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/sys/unix"
+	"strconv"
+	"strings"
+)
+
+const tcpSeqMidpoint = 0x80000000
+
+type tcpState uint8
+
+const (
+	TcpStateClosed tcpState = iota
+	TcpStateSynSent
+	TcpStateSynRecv
+	TcpStateEstablished
+	TcpStateFinWait1
+	TcpStateFinWait2
+	TcpStateCloseWait
+	TcpStateClosing
+	TcpStateLastAck
+	TcpStateTimeWait
+)
+
+var TcpStateLabels = []string{
+	"Closed",
+	"SynSent",
+	"SynRecv",
+	"Established",
+	"FinWait1",
+	"FinWait2",
+	"CloseWait",
+	"Closing",
+	"LastAck",
+	"TimeWait",
+}
+
+func LabelForState(tcpState tcpState) string {
+	idx := int(tcpState)
+	if idx < len(TcpStateLabels) {
+		return TcpStateLabels[idx]
+	}
+	return "BadState-" + strconv.Itoa(idx)
+}
+
+func isSeqBefore(prev, cur uint32) bool {
+	// check for wraparound with unsigned subtraction
+	diff := cur - prev
+	// constrain the maximum difference to half the number space
+	return diff > 0 && diff < tcpSeqMidpoint
+}
+
+func isClosedState(state tcpState) bool {
+	return state == TcpStateClosed || state == TcpStateTimeWait
+}
+
+func debugPacketDir(pktType uint8) string {
+	switch pktType {
+	case unix.PACKET_HOST:
+		return "Incoming"
+	case unix.PACKET_OUTGOING:
+		return "Outgoing"
+	default:
+		return "InvalidDir-" + strconv.Itoa(int(pktType))
+	}
+}
+
+func debugTcpFlags(tcp *layers.TCP) string {
+	var flags []string
+	if tcp.RST {
+		flags = append(flags, "RST")
+	}
+	if tcp.FIN {
+		flags = append(flags, "FIN")
+	}
+	if tcp.SYN {
+		flags = append(flags, "SYN")
+	}
+	if tcp.ACK {
+		flags = append(flags, "ACK")
+	}
+	return strings.Join(flags, "|")
+}
+
+func seqDiff(seq uint32, hasBase bool, base uint32) uint32 {
+	if !hasBase {
+		return seq
+	}
+	return seq - base
+}
+
+func debugPacketInfo(pktType uint8, tcp *layers.TCP, payloadLen uint16, st connectionState) string {
+	hasStartSeq, startSeq := st.hasSentPacket, st.localStartSeq
+	hasAckSeq, ackSeq := st.hasReceivedPacket, st.remoteStartSeq
+
+	if pktType == unix.PACKET_HOST {
+		hasStartSeq, hasAckSeq = hasAckSeq, hasStartSeq
+		startSeq, ackSeq = ackSeq, startSeq
+	}
+	relativeSeq := seqDiff(tcp.Seq, hasStartSeq, startSeq)
+	relativeAck := seqDiff(tcp.Ack, hasAckSeq, ackSeq)
+	return fmt.Sprintf("pktType=%+v ports=(%+v, %+v) size=%d relSeq=%+v relAck=%+v flags=%s", debugPacketDir(pktType), uint16(tcp.SrcPort), uint16(tcp.DstPort), payloadLen, relativeSeq, relativeAck, debugTcpFlags(tcp))
+}

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -150,7 +150,7 @@ func (t *ebpfLessTracer) processConnection(
 ) error {
 	t.scratchConn.Source, t.scratchConn.Dest = util.Address{}, util.Address{}
 	t.scratchConn.SPort, t.scratchConn.DPort = 0, 0
-	t.scratchConn.TCPFailures = make(map[uint32]uint32)
+	t.scratchConn.TCPFailures = make(map[uint16]uint32)
 	var udpPresent, tcpPresent bool
 	for _, layerType := range decoded {
 		switch layerType {

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -56,7 +56,7 @@ type ebpfLessTracer struct {
 	scratchConn *network.ConnectionStats
 
 	udp *udpProcessor
-	tcp *tcpProcessor
+	tcp *ebpfless.TCPProcessor
 
 	// connection maps
 	conns        map[network.ConnectionTuple]*network.ConnectionStats
@@ -81,7 +81,7 @@ func newEbpfLessTracer(cfg *config.Config) (*ebpfLessTracer, error) {
 		exit:         make(chan struct{}),
 		scratchConn:  &network.ConnectionStats{},
 		udp:          &udpProcessor{},
-		tcp:          newTCPProcessor(),
+		tcp:          ebpfless.NewTCPProcessor(),
 		conns:        make(map[network.ConnectionTuple]*network.ConnectionStats, cfg.MaxTrackedConnections),
 		boundPorts:   ebpfless.NewBoundPorts(cfg),
 		cookieHasher: newCookieHasher(),
@@ -150,6 +150,7 @@ func (t *ebpfLessTracer) processConnection(
 ) error {
 	t.scratchConn.Source, t.scratchConn.Dest = util.Address{}, util.Address{}
 	t.scratchConn.SPort, t.scratchConn.DPort = 0, 0
+	t.scratchConn.TCPFailures = make(map[uint32]uint32)
 	var udpPresent, tcpPresent bool
 	for _, layerType := range decoded {
 		switch layerType {
@@ -209,7 +210,7 @@ func (t *ebpfLessTracer) processConnection(
 		if (ip4 != nil && !t.config.CollectTCPv4Conns) || (ip6 != nil && !t.config.CollectTCPv6Conns) {
 			return nil
 		}
-		err = t.tcp.process(conn, pktType, ip4, ip6, tcp)
+		err = t.tcp.Process(conn, pktType, ip4, ip6, tcp)
 	default:
 		err = fmt.Errorf("unsupported connection type %d", conn.Type)
 	}
@@ -355,65 +356,5 @@ func (u *udpProcessor) process(conn *network.ConnectionStats, pktType uint8, udp
 		conn.Monotonic.RecvBytes += uint64(payloadLen)
 	}
 
-	return nil
-}
-
-type tcpProcessor struct {
-	conns map[network.ConnectionTuple]struct {
-		established bool
-		closed      bool
-	}
-}
-
-func newTCPProcessor() *tcpProcessor {
-	return &tcpProcessor{
-		conns: map[network.ConnectionTuple]struct {
-			established bool
-			closed      bool
-		}{},
-	}
-}
-
-func (t *tcpProcessor) process(conn *network.ConnectionStats, pktType uint8, ip4 *layers.IPv4, ip6 *layers.IPv6, tcp *layers.TCP) error {
-	payloadLen, err := ebpfless.TCPPayloadLen(conn.Family, ip4, ip6, tcp)
-	if err != nil {
-		return err
-	}
-
-	log.TraceFunc(func() string {
-		return fmt.Sprintf("tcp processor: pktType=%+v seq=%+v ack=%+v fin=%+v rst=%+v syn=%+v ack=%+v", pktType, tcp.Seq, tcp.Ack, tcp.FIN, tcp.RST, tcp.SYN, tcp.ACK)
-	})
-	c := t.conns[conn.ConnectionTuple]
-	log.TraceFunc(func() string {
-		return fmt.Sprintf("pre ack_seq=%+v", c)
-	})
-	switch pktType {
-	case unix.PACKET_OUTGOING:
-		conn.Monotonic.SentPackets++
-		conn.Monotonic.SentBytes += uint64(payloadLen)
-	case unix.PACKET_HOST:
-		conn.Monotonic.RecvPackets++
-		conn.Monotonic.RecvBytes += uint64(payloadLen)
-	}
-
-	if tcp.FIN || tcp.RST {
-		if !c.closed {
-			c.closed = true
-			conn.Monotonic.TCPClosed++
-			conn.Duration = time.Duration(time.Now().UnixNano() - int64(conn.Duration))
-		}
-		delete(t.conns, conn.ConnectionTuple)
-		return nil
-	}
-
-	if !tcp.SYN && !c.established {
-		c.established = true
-		conn.Monotonic.TCPEstablished++
-	}
-
-	log.TraceFunc(func() string {
-		return fmt.Sprintf("ack_seq=%+v", c)
-	})
-	t.conns[conn.ConnectionTuple] = c
 	return nil
 }

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -126,8 +126,10 @@ func (s *TracerSuite) TestTCPRemoveEntries() {
 
 func (s *TracerSuite) TestTCPRetransmit() {
 	t := s.T()
+	cfg := testConfig()
+	skipEbpflessTodo(t, cfg)
 	// Enable BPF-based system probe
-	tr := setupTracer(t, testConfig())
+	tr := setupTracer(t, cfg)
 
 	// Create TCP Server which sends back serverMessageSize bytes
 	server := tracertestutil.NewTCPServer(func(c net.Conn) {
@@ -175,6 +177,8 @@ func (s *TracerSuite) TestTCPRetransmit() {
 
 func (s *TracerSuite) TestTCPRetransmitSharedSocket() {
 	t := s.T()
+	cfg := testConfig()
+	skipEbpflessTodo(t, cfg)
 	// Create TCP Server that simply "drains" connection until receiving an EOF
 	server := tracertestutil.NewTCPServer(func(c net.Conn) {
 		io.Copy(io.Discard, c)
@@ -203,7 +207,7 @@ func (s *TracerSuite) TestTCPRetransmitSharedSocket() {
 	// this connection (if there are pid collisions,
 	// we assign the tcp stats to one connection randomly,
 	// which is the point of this test)
-	tr := setupTracer(t, testConfig())
+	tr := setupTracer(t, cfg)
 
 	const numProcesses = 10
 	iptablesWrapper(t, func() {
@@ -252,8 +256,10 @@ func (s *TracerSuite) TestTCPRTT() {
 	if ebpftest.GetBuildMode() == ebpftest.Prebuilt {
 		flake.Mark(t)
 	}
+	cfg := testConfig()
+	skipEbpflessTodo(t, cfg)
 	// Enable BPF-based system probe
-	tr := setupTracer(t, testConfig())
+	tr := setupTracer(t, cfg)
 	// Create TCP Server that simply "drains" connection until receiving an EOF
 	server := tracertestutil.NewTCPServer(func(c net.Conn) {
 		io.Copy(io.Discard, c)
@@ -1101,6 +1107,10 @@ func (s *TracerSuite) TestSelfConnect() {
 	// Enable BPF-based system probe
 	cfg := testConfig()
 	cfg.TCPConnTimeout = 3 * time.Second
+	// TODO filter out connections in ebpfless where the incoming IP:port == outgoing IP:port because
+	// packet capture can't trace it properly
+	skipEbpflessTodo(t, cfg)
+
 	tr := setupTracer(t, cfg)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -2328,6 +2338,7 @@ func BenchmarkAddProcessInfo(b *testing.B) {
 func (s *TracerSuite) TestConnectionDuration() {
 	t := s.T()
 	cfg := testConfig()
+	skipEbpflessTodo(t, cfg)
 	tr := setupTracer(t, cfg)
 
 	srv := tracertestutil.NewTCPServer(func(c net.Conn) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -394,7 +394,7 @@ func (s *TracerSuite) TestTCPConnsReported() {
 		time.Sleep(time.Millisecond * 500)
 	}
 
-	// in ebpfless, it takes time for the packet capture to arrive, so poll
+	// for ebpfless, it takes time for the packet capture to arrive, so poll
 	require.Eventually(t, func() bool {
 		// Test
 		connections := getConnections(t, tr)
@@ -1084,7 +1084,7 @@ func (s *TracerSuite) TestTCPEstablished() {
 	var conn *network.ConnectionStats
 	var ok bool
 
-	// in ebpfless, wait for the packet capture to appear
+	// for ebpfless, wait for the packet capture to appear
 	require.Eventually(t, func() bool {
 		conn, ok = findConnection(laddr, raddr, getConnections(t, tr))
 		return ok

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -390,10 +390,6 @@ func (s *TracerSuite) TestTCPConnsReported() {
 	defer c.Close()
 	<-processedChan
 
-	if tr.config.EnableEbpfless {
-		time.Sleep(time.Millisecond * 500)
-	}
-
 	// for ebpfless, it takes time for the packet capture to arrive, so poll
 	require.Eventually(t, func() bool {
 		// Test

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -256,7 +256,9 @@ func (s *TracerSuite) TestTCPShortLived() {
 	assert.Equal(t, clientMessageSize, int(m.SentBytes))
 	assert.Equal(t, serverMessageSize, int(m.RecvBytes))
 	assert.Equal(t, 0, int(m.Retransmits))
-	assert.Equal(t, os.Getpid(), int(conn.Pid))
+	if !tr.config.EnableEbpfless {
+		assert.Equal(t, os.Getpid(), int(conn.Pid))
+	}
 	assert.Equal(t, addrPort(server.Address()), int(conn.DPort))
 	assert.Equal(t, network.OUTGOING, conn.Direction)
 	assert.True(t, conn.IntraHost)
@@ -318,7 +320,9 @@ func (s *TracerSuite) TestTCPOverIPv6() {
 	assert.Equal(t, clientMessageSize, int(m.SentBytes))
 	assert.Equal(t, serverMessageSize, int(m.RecvBytes))
 	assert.Equal(t, 0, int(m.Retransmits))
-	assert.Equal(t, os.Getpid(), int(conn.Pid))
+	if !tr.config.EnableEbpfless {
+		assert.Equal(t, os.Getpid(), int(conn.Pid))
+	}
 	assert.Equal(t, ln.Addr().(*net.TCPAddr).Port, int(conn.DPort))
 	assert.Equal(t, network.OUTGOING, conn.Direction)
 	assert.True(t, conn.IntraHost)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR separates the TCPProcessor into its own file and adds logic tracking state according to the TCP RFC's state machine.

### Motivation
We need this to keep track of tcp connections opening/closing, retransmits, etc

### Describe how to test/QA your changes

To just test the TCP state machine without running the tracer:
```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```

To run the ebpfless tracer end to end on the test suite:
```
 DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```
### Possible Drawbacks / Trade-offs

Currently TCP simultaneous open is not quite tracked correctly (~~`RecvBytes` is one off,~~ and it decides the connection is established 1 packet too early) but it is good enough for now.

Might not be possible to pass TestSelfConnect because each packet is captured twice on the send/receiving end respectively. We could filter out this case based on `srcIP==dstIP && srcPort == dstPort`

Right now, doesn't implement pre-existing connections (I think it needs to populate the connections from netlink)

Connection durations are not tracked yet (this is probably simple, just not sure how yet).

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Future things to implement:
* RTT
* TCP retransmit detection (I put TODOs in the places where retransmits occur)
