### PR TITLE
Build the env var layer for the nodetreemodel config

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -597,8 +597,7 @@ func (c *ntmConfig) GetSource(key string) model.Source {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	c.logErrorNotImplemented("GetSource")
-	return model.SourceUnknown
+	return c.leafAtPath(key).Source()
 }
 
 // SetEnvPrefix sets the environment variable prefix to use

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -255,8 +255,7 @@ func (c *ntmConfig) BuildSchema() {
 	defer c.Unlock()
 	c.buildEnvVars()
 	c.ready.Store(true)
-	// TODO: Instead of assigning defaultSource to root, merge the trees
-	c.root = c.defaults
+	c.mergeAllLayers()
 }
 
 func (c *ntmConfig) isReady() bool {

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -255,7 +255,9 @@ func (c *ntmConfig) BuildSchema() {
 	defer c.Unlock()
 	c.buildEnvVars()
 	c.ready.Store(true)
-	c.mergeAllLayers()
+	if err := c.mergeAllLayers(); err != nil {
+		c.warnings = append(c.warnings, err.Error())
+	}
 }
 
 func (c *ntmConfig) isReady() bool {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -32,17 +32,15 @@ func TestBuildDefaultMakesTooManyNodes(t *testing.T) {
 
 // Test that default, file, and env layers can build, get merged, and retrieve settings
 func TestBuildDefaultFileAndEnv(t *testing.T) {
-	t.Skip("fix merge to enable this test")
-
 	configData := `network_path:
   collector:
     workers: 6
 secret_backend_command: ./my_secret_fetcher.sh
 `
-	os.Setenv("DD_SECRET_BACKEND_TIMEOUT", "60")
-	os.Setenv("DD_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	os.Setenv("TEST_SECRET_BACKEND_TIMEOUT", "60")
+	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
 
-	cfg := NewConfig("test", "DD", nil)
+	cfg := NewConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
 	cfg.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 100000)
 	cfg.BindEnvAndSetDefault("network_path.collector.workers", 4)
@@ -64,7 +62,7 @@ secret_backend_command: ./my_secret_fetcher.sh
 		{
 			description:  "nested setting from env var works",
 			setting:      "network_path.collector.input_chan_size",
-			expectValue:  23456,
+			expectValue:  "23456",
 			expectSource: model.SourceEnvVar,
 		},
 		{

--- a/pkg/config/nodetreemodel/helpers.go
+++ b/pkg/config/nodetreemodel/helpers.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package nodetreemodel
+
+import (
+	"strings"
+)
+
+func splitKey(key string) []string {
+	return strings.Split(strings.ToLower(key), ".")
+}

--- a/pkg/config/nodetreemodel/noimpl_methods.go
+++ b/pkg/config/nodetreemodel/noimpl_methods.go
@@ -16,7 +16,6 @@ type notImplementedMethods interface {
 	SetFs(afero.Fs)
 	IsSet(string) bool
 	AllKeys() []string
-	SetEnvKeyTransformer(string, func(data string) interface{})
 	GetStringSliceE(string) ([]string, error)
 	GetStringMapE(string) (map[string]interface{}, error)
 	GetStringMapStringE(string) (map[string]string, error)
@@ -38,10 +37,6 @@ func (n *notImplMethodsImpl) IsSet(string) bool {
 func (n *notImplMethodsImpl) AllKeys() []string {
 	n.logErrorNotImplemented("AllKeys")
 	return nil
-}
-
-func (n *notImplMethodsImpl) SetEnvKeyTransformer(string, func(data string) interface{}) {
-	n.logErrorNotImplemented("SetEnvKeyTransformer")
 }
 
 func (n *notImplMethodsImpl) GetStringSliceE(string) ([]string, error) {

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -22,10 +22,14 @@ func (c *ntmConfig) mergeAllLayers() error {
 	treeList := []InnerNode{
 		c.defaults,
 		c.file,
+		c.envs,
 	}
 
 	// TODO: handle all configuration sources
 	for _, tree := range treeList {
+		if tree == nil {
+			continue
+		}
 		err := root.Merge(tree)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What does this PR do?

Build the env layer from environmental variables. Merge the layers that currently exist (default, file, env). Some functionality is missing so the associated unit test is skipped for now.

### Motivation

Configuration can come from environment variables.

### Describe how to test/QA your changes

Test exists in `pkg/config/nodetreemodel/config_test.go` but is currently disabled because the layers are not being properly merged. That will either be fixed before this PR is merged, or in a follow-up PR.

To manually test, use `DD_CONF_NODETREEMODEL=true`. Not recommended for any purpose other than development of the nodetreemodel config. The agent currently won't run past initialization due to the log level not being configured.

### Possible Drawbacks / Trade-offs

The env vars are all read at once, at startup. This adds a bit of additional start-up time, because viper instead would read the associated env var (potentially) every time a setting was accessed. Because we're reading all env vars at startup, this also means we will no longer support env vars changing during runtime, which seems to be more in line with the behavior that we want.

### Additional Notes
