### PR TITLE
[e2e] mark windows upgrade as flake

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
@@ -6,13 +6,15 @@
 package installertests
 
 import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	agentVersion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
-	"testing"
 )
 
 type testInstallerUpgradesSuite struct {
@@ -26,6 +28,7 @@ func TestInstallerUpgrades(t *testing.T) {
 
 // TestUpgrades tests upgrading the stable version of the Datadog installer to the latest from the pipeline.
 func (s *testInstallerUpgradesSuite) TestUpgrades() {
+	flake.Mark(s.T())
 	// Arrange
 	s.Require().NoError(s.Installer().Install(
 		installerwindows.WithInstallerURLFromInstallersJSON(pipeline.StableURL, s.StableInstallerVersion().PackageVersion())),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Mark windows e2e upgrade test as flake

### Motivation

This test is failing on `main` since https://github.com/DataDog/datadog-agent/pull/30680, not sure there is a correlation. 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->