### PR TITLE
[CWS] fix fallback exec lineage

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -911,7 +911,6 @@ func (p *EBPFResolver) resolveFromProcfs(pid uint32, maxDepth int) *model.Proces
 		return nil
 	}
 
-	var ppid uint32
 	proc, err := process.NewProcess(int32(pid))
 	if err != nil {
 		seclog.Tracef("unable to find pid: %d", pid)
@@ -929,24 +928,12 @@ func (p *EBPFResolver) resolveFromProcfs(pid uint32, maxDepth int) *model.Proces
 		return nil
 	}
 
-	entry, inserted := p.syncCache(proc, filledProc, model.ProcessCacheEntryFromProcFS)
-	if entry != nil {
-		// consider kworker processes with 0 as ppid
-		entry.IsKworker = filledProc.Ppid == 0 && filledProc.Pid != 1
-
-		ppid = uint32(filledProc.Ppid)
-
-		parent := p.resolveFromProcfs(ppid, maxDepth-1)
-		if inserted && parent != nil {
-			if parent.Equals(entry) {
-				entry.SetForkParent(parent)
-			} else {
-				entry.SetExecParent(parent)
-			}
-		}
+	ppid := uint32(filledProc.Ppid)
+	if ppid != 0 && p.entryCache[ppid] == nil {
+		p.resolveFromProcfs(ppid, maxDepth-1)
 	}
 
-	return entry
+	return p.newEntryFromProcfsAndSyncKernelMaps(proc, filledProc, model.ProcessCacheEntryFromProcFS)
 }
 
 // SetProcessArgs set arguments to cache entry
@@ -1223,8 +1210,8 @@ func (p *EBPFResolver) cacheFlush(ctx context.Context) {
 	}
 }
 
-// SyncCache snapshots /proc for the provided pid. This method returns true if it updated the process cache.
-func (p *EBPFResolver) SyncCache(proc *process.Process) bool {
+// SyncCache snapshots /proc for the provided pid.
+func (p *EBPFResolver) SyncCache(proc *process.Process) {
 	// Only a R lock is necessary to check if the entry exists, but if it exists, we'll update it, so a RW lock is
 	// required.
 	p.Lock()
@@ -1233,11 +1220,10 @@ func (p *EBPFResolver) SyncCache(proc *process.Process) bool {
 	filledProc, err := utils.GetFilledProcess(proc)
 	if err != nil {
 		seclog.Tracef("unable to get a filled process for %d: %v", proc.Pid, err)
-		return false
+		return
 	}
 
-	_, ret := p.syncCache(proc, filledProc, model.ProcessCacheEntryFromSnapshot)
-	return ret
+	p.newEntryFromProcfsAndSyncKernelMaps(proc, filledProc, model.ProcessCacheEntryFromSnapshot)
 }
 
 func (p *EBPFResolver) setAncestor(pce *model.ProcessCacheEntry) {
@@ -1247,33 +1233,29 @@ func (p *EBPFResolver) setAncestor(pce *model.ProcessCacheEntry) {
 	}
 }
 
-// syncCache snapshots /proc for the provided pid. This method returns true if it updated the process cache.
-func (p *EBPFResolver) syncCache(proc *process.Process, filledProc *utils.FilledProcess, source uint64) (*model.ProcessCacheEntry, bool) {
+// newEntryFromProcfsAndSyncKernelMaps snapshots /proc for the provided pid and sync the kernel maps
+func (p *EBPFResolver) newEntryFromProcfsAndSyncKernelMaps(proc *process.Process, filledProc *utils.FilledProcess, source uint64) *model.ProcessCacheEntry {
 	pid := uint32(proc.Pid)
 
-	// Check if an entry is already in cache for the given pid.
-	entry := p.entryCache[pid]
-	if entry != nil {
-		p.setAncestor(entry)
-
-		return entry, false
-	}
-
-	entry = p.NewProcessCacheEntry(model.PIDContext{Pid: pid, Tid: pid})
+	entry := p.NewProcessCacheEntry(model.PIDContext{Pid: pid, Tid: pid})
 
 	// update the cache entry
 	if err := p.enrichEventFromProc(entry, proc, filledProc); err != nil {
 		entry.Release()
 
 		seclog.Trace(err)
-		return nil, false
+		return nil
 	}
+
+	entry.IsKworker = filledProc.Ppid == 0 && filledProc.Pid != 1
 
 	parent := p.entryCache[entry.PPid]
 	if parent != nil {
 		if parent.Equals(entry) {
 			entry.SetForkParent(parent)
-		} else {
+		} else if prev := p.entryCache[pid]; prev != nil { // exec-exec
+			entry.SetExecParent(prev)
+		} else { // exec
 			entry.SetExecParent(parent)
 		}
 	}
@@ -1304,7 +1286,7 @@ func (p *EBPFResolver) syncCache(proc *process.Process, filledProc *utils.Filled
 
 	seclog.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.FileEvent.PathnameStr, pid, entry.FileEvent.Inode)
 
-	return entry, true
+	return entry
 }
 
 // ToJSON return a json version of the cache

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2223,7 +2223,7 @@ func TestProcessResolution(t *testing.T) {
 
 		args := []string{"open", "/tmp/test-process-resolution", ";",
 			"getchar", ";",
-			"open", "/tmp/test-process-resolution"}
+			"open", "/tmp/test-process-resolution-done"}
 
 		cmd = exec.Command(syscallTester, args...)
 		stdin, err = cmd.StdinPipe()
@@ -2254,7 +2254,7 @@ func TestProcessResolution(t *testing.T) {
 		resolver := p.Resolvers.ProcessResolver
 
 		// compare only few fields as the hierarchy fields(pointers, etc) are modified by the resolution function calls
-		equals := func(t *testing.T, entry1, entry2 *model.ProcessCacheEntry) {
+		equals := func(t *testing.T, entry1, entry2 *model.ProcessCacheEntry, checkCookie bool) {
 			t.Helper()
 
 			assert.NotNil(t, entry1)
@@ -2263,11 +2263,13 @@ func TestProcessResolution(t *testing.T) {
 			assert.Equal(t, entry1.Pid, entry2.Pid)
 			assert.Equal(t, entry1.PPid, entry2.PPid)
 			assert.Equal(t, entry1.ContainerID, entry2.ContainerID)
-			assert.Equal(t, entry1.Cookie, entry2.Cookie)
+			if checkCookie {
+				assert.Equal(t, entry1.Cookie, entry2.Cookie)
+			}
 
 			// may not be exactly equal because of clock drift between two boot time resolution, see time resolver
-			assert.Greater(t, time.Second, entry1.ExecTime.Sub(entry2.ExecTime).Abs())
-			assert.Greater(t, time.Second, entry1.ForkTime.Sub(entry2.ForkTime).Abs())
+			assert.Greater(t, 2*time.Second, entry1.ExecTime.Sub(entry2.ExecTime).Abs())
+			assert.Greater(t, 2*time.Second, entry1.ForkTime.Sub(entry2.ForkTime).Abs())
 		}
 
 		cacheEntry := resolver.ResolveFromCache(pid, pid, inode)
@@ -2280,7 +2282,7 @@ func TestProcessResolution(t *testing.T) {
 			t.Errorf("not able to resolve the entry")
 		}
 
-		equals(t, cacheEntry, mapsEntry)
+		equals(t, cacheEntry, mapsEntry, true)
 
 		// This makes use of the cache and do not parse /proc
 		// it still checks the ResolveFromProcfs returns the correct entry
@@ -2289,7 +2291,7 @@ func TestProcessResolution(t *testing.T) {
 			t.Fatalf("not able to resolve the entry")
 		}
 
-		equals(t, mapsEntry, procEntry)
+		equals(t, mapsEntry, procEntry, false)
 
 		io.WriteString(stdin, "\n")
 	})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Before this PR an fallback of an exec-exec was re-inserted in the cache causing continuously to generate fallbacks for related events. 

### Motivation

### Describe how to test/QA your changes

This PR has been deployed on staging. We need to validate the level of process resolution fallbacks. Kernel map fallbacks should be lower than without this fix.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->