### PR TITLE
[EBPF] gpu: refactor probe_test to use a suite

### DIFF
--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -12,49 +12,66 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 )
 
-func TestProbeCanLoad(t *testing.T) {
+type probeTestSuite struct {
+	suite.Suite
+}
+
+func TestProbe(t *testing.T) {
 	if err := config.CheckGPUSupported(); err != nil {
 		t.Skipf("minimum kernel version not met, %v", err)
 	}
 
+	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.CORE}, "", func(t *testing.T) {
+		suite.Run(t, new(probeTestSuite))
+	})
+}
+
+func (s *probeTestSuite) getProbe() *Probe {
+	t := s.T()
+
 	cfg := config.New()
+
+	// Avoid waiting for the initial sync to finish in tests, we don't need it
 	cfg.InitialProcessSync = false
-	nvmlMock := testutil.GetBasicNvmlMock()
-	probe, err := NewProbe(cfg, ProbeDependencies{NvmlLib: nvmlMock})
+
+	deps := ProbeDependencies{
+		NvmlLib: testutil.GetBasicNvmlMock(),
+	}
+	probe, err := NewProbe(cfg, deps)
 	require.NoError(t, err)
+	require.NotNil(t, probe)
 	t.Cleanup(probe.Close)
 
+	return probe
+}
+
+func (s *probeTestSuite) TestCanLoad() {
+	t := s.T()
+
+	probe := s.getProbe()
 	data, err := probe.GetAndFlush()
 	require.NoError(t, err)
 	require.NotNil(t, data)
 }
 
-func TestProbeCanReceiveEvents(t *testing.T) {
-	if err := config.CheckGPUSupported(); err != nil {
-		t.Skipf("minimum kernel version not met, %v", err)
-	}
+func (s *probeTestSuite) TestCanReceiveEvents() {
+	t := s.T()
 
 	procMon := monitor.GetProcessMonitor()
 	require.NotNil(t, procMon)
 	require.NoError(t, procMon.Initialize(false))
 	t.Cleanup(procMon.Stop)
 
-	cfg := config.New()
-	cfg.InitialProcessSync = false
-	cfg.BPFDebug = true
-
-	nvmlMock := testutil.GetBasicNvmlMock()
-
-	probe, err := NewProbe(cfg, ProbeDependencies{NvmlLib: nvmlMock})
-	require.NoError(t, err)
-	t.Cleanup(probe.Close)
+	probe := s.getProbe()
 
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)
@@ -89,25 +106,15 @@ func TestProbeCanReceiveEvents(t *testing.T) {
 	require.Greater(t, alloc.endKtime, alloc.startKtime)
 }
 
-func TestProbeCanGenerateStats(t *testing.T) {
-	if err := config.CheckGPUSupported(); err != nil {
-		t.Skipf("minimum kernel version not met, %v", err)
-	}
+func (s *probeTestSuite) TestCanGenerateStats() {
+	t := s.T()
 
 	procMon := monitor.GetProcessMonitor()
 	require.NotNil(t, procMon)
 	require.NoError(t, procMon.Initialize(false))
 	t.Cleanup(procMon.Stop)
 
-	cfg := config.New()
-	cfg.InitialProcessSync = false
-	cfg.BPFDebug = true
-
-	nvmlMock := testutil.GetBasicNvmlMock()
-
-	probe, err := NewProbe(cfg, ProbeDependencies{NvmlLib: nvmlMock})
-	require.NoError(t, err)
-	t.Cleanup(probe.Close)
+	probe := s.getProbe()
 
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Refactors the probe_test file to use a suite for the test.

### Motivation

Move common code to functions, facilitate testing in different build modes for https://github.com/DataDog/datadog-agent/pull/30574

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The process monitor initialization has not been refactored, as it will be changed in https://github.com/DataDog/datadog-agent/pull/30755