### PR TITLE
Revert "[e2e] mark windows upgrade as flake"

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
@@ -6,15 +6,13 @@
 package installertests
 
 import (
-	"testing"
-
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	agentVersion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
+	"testing"
 )
 
 type testInstallerUpgradesSuite struct {
@@ -28,7 +26,6 @@ func TestInstallerUpgrades(t *testing.T) {
 
 // TestUpgrades tests upgrading the stable version of the Datadog installer to the latest from the pipeline.
 func (s *testInstallerUpgradesSuite) TestUpgrades() {
-	flake.Mark(s.T())
 	// Arrange
 	s.Require().NoError(s.Installer().Install(
 		installerwindows.WithInstallerURLFromInstallersJSON(pipeline.StableURL, s.StableInstallerVersion().PackageVersion())),


### PR DESCRIPTION
Reverts DataDog/datadog-agent#30838