### PR TITLE
Add back secret scripts

### DIFF
--- a/docs/public/secrets/Set-SecretPermissions.ps1
+++ b/docs/public/secrets/Set-SecretPermissions.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+
+Sets the correct permissions on a file to be used with the Datadog Secret feature.
+
+.DESCRIPTION
+
+The script will use the `ddagentuser` stored in the registry, create a new `FileSecurity` object and:
+- Set the Builtin\Administrators as the owner
+- Set the Builtin\Administrators as the group
+- Grant full access to LOCAL_SYSTEM
+- Grant full access to the Builtin\Administrators
+- Grant read access to the `ddagentuser`
+
+It's a good idea to make a backup of the secrets executable before running this command.
+
+.PARAMETER SecretBinaryPath
+
+File path of the binary to update.
+
+.INPUTS
+
+None
+
+.OUTPUTS
+
+The `ddagentuser` SID, the new ACLs on the secret binary and whether or not the `secret` command considers the file permissions as valid.
+
+.EXAMPLE
+
+PS> .\Set-SecretPermissions -SecretBinaryPath C:\Example\Datadog\secrets\decrypt_secrets.exe
+#>
+
+
+[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(DefaultParameterSetName='SecretBinaryPath')]
+param(
+    [Parameter(Mandatory=$true, ParameterSetName='SecretBinaryPath')]
+    [string]$SecretBinaryPath = $null
+)
+
+$ddagentUserDomain = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Datadog\Datadog Agent' -Name 'installedDomain'
+$ddagentUser = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Datadog\Datadog Agent' -Name 'installedUser'
+$fullDdagentUserName = ("{0}\{1}" -f $ddagentUserDomain, $ddagentUser)
+$ddagentUserSid = New-Object System.Security.Principal.SecurityIdentifier((New-Object System.Security.Principal.NTAccount($fullDdagentUserName)).Translate([System.Security.Principal.SecurityIdentifier]).Value)
+Write-Host ("ddagentuser SID: {0}" -f $ddagentUserSid)
+$builtInAdminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
+$localSystemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
+$fileSecurity = New-Object System.Security.AccessControl.FileSecurity
+$fileSecurity.SetAccessRuleProtection($true, $false)
+$fileSecurity.SetOwner($builtInAdminSid)
+$fileSecurity.SetGroup($builtInAdminSid)
+$fileSecurity.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentList ($ddagentUserSid, ([System.Security.AccessControl.FileSystemRights]::Read -bor [System.Security.AccessControl.FileSystemRights]::ExecuteFile), [System.Security.AccessControl.AccessControlType]::Allow)))
+$fileSecurity.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentList ($builtInAdminSid, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)))
+$fileSecurity.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule -ArgumentList ($localSystemSid, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)))
+if ($pscmdlet.ShouldProcess($SecretBinaryPath, "SetAccessControl")) {
+    [System.IO.File]::SetAccessControl($SecretBinaryPath, $fileSecurity)
+}
+try {
+    $agentBinary = (Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Datadog\Datadog Agent' -Name 'InstallPath') + "\bin\agent.exe"
+    & $agentBinary secret
+}
+catch {
+    icacls.exe $SecretBinaryPath
+}

--- a/docs/public/secrets/secrets_tester.ps1
+++ b/docs/public/secrets/secrets_tester.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory=$True)]
+    [string]$user,
+
+    [Parameter(Mandatory=$True)]
+    [string]$executable,
+
+    [Parameter(Mandatory=$True)]
+    [string]$password,
+
+    [Parameter(Mandatory=$False)]
+    [string]$arguments,
+
+    [Parameter(Mandatory=$True)]
+    [string]$payload
+)
+
+$ErrorActionPreference = "Stop"
+
+$cmd  = New-Object System.Diagnostics.ProcessStartInfo;
+
+$cmd.FileName = $executable
+$cmd.Arguments = $arguments
+$cmd.RedirectStandardOutput = $true
+$cmd.RedirectStandardError = $true
+$cmd.RedirectStandardInput = $true
+$cmd.UseShellExecute = $false
+$cmd.UserName = $user
+$cmd.Password = ConvertTo-SecureString $password -AsPlainText -Force
+
+"Creating new Process with $($executable) $($arguments)"
+$process = [System.Diagnostics.Process]::Start($cmd);
+
+"Waiting a second for the process to be up and running"
+Start-Sleep -s 1
+
+"Writing the payload to Stdin"
+$process.StandardInput.WriteLine($payload)
+$process.StandardInput.Close()
+
+"Waiting a second so the process can fetch the secrets"
+Start-Sleep -s 1
+
+"stdout:"
+$process.StandardOutput.ReadToEnd()
+if ($process.StandardOutErr) {
+    "stderr:"
+    $process.StandardOutErr.ReadToEnd()
+} else {
+    "stderr: None"
+}
+"exit code:"
+$process.ExitCode


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add back the secret script which was removed by https://github.com/DataDog/datadog-agent/pull/26037.
Also add a script helper to set the correct permission on a secret executable.

### Motivation
The file is referenced by https://github.com/DataDog/documentation/blob/master/content/en/agent/configuration/secrets-management.md (currently dead, will update once this is merged).

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
See related PR in the documentation repository: https://github.com/DataDog/documentation/pull/26165
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->