### PR TITLE
Set 7.59.0 as last_stable

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,7 +3,7 @@
     "current_milestone": "7.61.0",
     "last_stable": {
         "6": "6.53.0",
-        "7": "7.58.1"
+        "7": "7.59.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",


### PR DESCRIPTION
After Agent 7.59.0 release - update `latest_stable` to 7.59.0