### PR TITLE
SMP: 'idle-all-features' removes duplicated config and sets explicit endpoints for logs/processes

### DIFF
--- a/test/regression/cases/idle_all_features/datadog-agent/datadog.yaml
+++ b/test/regression/cases/idle_all_features/datadog-agent/datadog.yaml
@@ -1,9 +1,6 @@
 auth_token_file_path: /tmp/agent-auth-token
-hostname: smp-regression
 
 dd_url: http://127.0.0.1:9092
-
-confd_path: /etc/datadog-agent/conf.d
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target
@@ -12,12 +9,20 @@ cloud_provider_metadata: []
 
 dogstatsd_socket: '/tmp/dsd.socket'
 
+telemetry.enabled: true
+telemetry.checks: '*'
+
 logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9091
+  logs_no_ssl: true
+  force_use_tcp: true
 
 apm_config:
   enabled: true
 
 process_config:
+  process_dd_url: http://localhost:9093
   process_collection:
     enabled: true
   container_collection:

--- a/test/regression/cases/idle_all_features/experiment.yaml
+++ b/test/regression/cases/idle_all_features/experiment.yaml
@@ -11,10 +11,8 @@ target:
   command: /bin/entrypoint.sh
 
   environment:
-    DD_TELEMETRY_ENABLED: true
     DD_API_KEY: 00000001
     DD_HOSTNAME: smp-regression
-    DD_DD_URL: http://127.0.0.1:9092
 
   profiling_environment:
     # internal profiling

--- a/test/regression/cases/idle_all_features/lading/lading.yaml
+++ b/test/regression/cases/idle_all_features/lading/lading.yaml
@@ -5,13 +5,15 @@ blackhole:
       binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"
+  - http:
+      binding_addr: "127.0.0.1:9093"
 
 target_metrics:
   - prometheus: #core agent telemetry
       uri: "http://127.0.0.1:5000/telemetry"
       tags:
         sub_agent: "core"
-  - prometheus: #process agent telemetry 
+  - prometheus: #process agent telemetry
       uri: "http://127.0.0.1:6062/telemetry"
       tags:
         sub_agent: "process"

--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
@@ -1,9 +1,6 @@
 auth_token_file_path: /tmp/agent-auth-token
-hostname: smp-regression
 
 dd_url: http://127.0.0.1:9092
-
-confd_path: /etc/datadog-agent/conf.d
 
 # Disable cloud detection. This stops the Agent from poking around the
 # execution environment & network. This is particularly important if the target
@@ -12,12 +9,20 @@ cloud_provider_metadata: []
 
 dogstatsd_socket: '/tmp/dsd.socket'
 
+telemetry.enabled: true
+telemetry.checks: '*'
+
 logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9091
+  logs_no_ssl: true
+  force_use_tcp: true
 
 apm_config:
   enabled: true
 
 process_config:
+  process_dd_url: http://localhost:9093
   process_collection:
     enabled: true
   container_collection:

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -11,10 +11,8 @@ target:
   command: /bin/entrypoint.sh
 
   environment:
-    DD_TELEMETRY_ENABLED: true
     DD_API_KEY: 00000001
     DD_HOSTNAME: smp-regression
-    DD_DD_URL: http://127.0.0.1:9092
 
   profiling_environment:
     # internal profiling

--- a/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
@@ -5,13 +5,15 @@ blackhole:
       binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"
+  - http:
+      binding_addr: "127.0.0.1:9093"
 
 target_metrics:
   - prometheus: #core agent telemetry
       uri: "http://127.0.0.1:5000/telemetry"
       tags:
         sub_agent: "core"
-  - prometheus: #process agent telemetry 
+  - prometheus: #process agent telemetry
       uri: "http://127.0.0.1:6062/telemetry"
       tags:
         sub_agent: "process"


### PR DESCRIPTION
### What does this PR do?
Removes duplicated config between env vars and `datadog.yaml`, preferring `datadog.yaml` when there is no requirement to use env vars.

Also sets explicit blackhole endpoints for logs and processes to prevent those components trying to send to unreachable endpoints.

### Motivation

Remove errors from 'idle-all-features' experiments.

### Describe how to test/QA your changes
QA from SMP tests on this PR

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->