### PR TITLE
[ASCII-2428] Simplify tagger interface

### DIFF
--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/tagger"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	taggerUtils "github.com/DataDog/datadog-agent/comp/core/tagger/utils"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -112,9 +113,15 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 		return ports[i].Port < ports[j].Port
 	})
 
+	var tagsHash string
+	tags, err := l.tagger.Tag(types.NewEntityID(types.ContainerID, container.ID), l.tagger.ChecksCardinality())
+	if err == nil {
+		tagsHash = taggerUtils.ComputeTagsHash(tags)
+	}
+
 	svc := &service{
 		entity:   container,
-		tagsHash: l.tagger.GetEntityHash(types.NewEntityID(types.ContainerID, container.ID), l.tagger.ChecksCardinality()),
+		tagsHash: tagsHash,
 		adIdentifiers: computeContainerServiceIDs(
 			containers.BuildEntityName(string(container.Runtime), container.ID),
 			containerImg.RawName,

--- a/comp/core/tagger/component.go
+++ b/comp/core/tagger/component.go
@@ -49,7 +49,6 @@ type Component interface {
 	GetEntity(entityID types.EntityID) (*types.Entity, error)
 	// subscriptionID is used for logging and debugging purposes
 	Subscribe(subscriptionID string, filter *types.Filter) (types.Subscription, error)
-	GetEntityHash(entityID types.EntityID, cardinality types.TagCardinality) string
 	AgentTags(cardinality types.TagCardinality) ([]string, error)
 	GlobalTags(cardinality types.TagCardinality) ([]string, error)
 	SetNewCaptureTagger(newCaptureTagger Component)

--- a/comp/core/tagger/component.go
+++ b/comp/core/tagger/component.go
@@ -45,7 +45,6 @@ type Component interface {
 	LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error)
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error
-	Standard(entityID types.EntityID) ([]string, error)
 	List() types.TaggerListResponse
 	GetEntity(entityID types.EntityID) (*types.Entity, error)
 	// subscriptionID is used for logging and debugging purposes

--- a/comp/core/tagger/noopimpl/tagger.go
+++ b/comp/core/tagger/noopimpl/tagger.go
@@ -83,10 +83,6 @@ func (n *noopTagger) Subscribe(string, *types.Filter) (types.Subscription, error
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (n *noopTagger) GetEntityHash(types.EntityID, types.TagCardinality) string {
-	return ""
-}
-
 func (n *noopTagger) AgentTags(types.TagCardinality) ([]string, error) {
 	return nil, nil
 }

--- a/comp/core/tagger/taggerimpl/empty/empty.go
+++ b/comp/core/tagger/taggerimpl/empty/empty.go
@@ -16,12 +16,6 @@ import (
 // Tagger struct to embed in other taggers that do not implement some of the tagger component functions
 type Tagger struct{}
 
-// GetEntityHash returns the hash for the tags associated with the given entity
-// Returns an empty string if the tags lookup fails
-func (t *Tagger) GetEntityHash(types.EntityID, types.TagCardinality) string {
-	return ""
-}
-
 // AgentTags returns the agent tags
 // It relies on the container provider utils to get the Agent container ID
 func (t *Tagger) AgentTags(types.TagCardinality) ([]string, error) {

--- a/comp/core/tagger/taggerimpl/local/fake_tagger.go
+++ b/comp/core/tagger/taggerimpl/local/fake_tagger.go
@@ -138,11 +138,6 @@ func (f *FakeTagger) AccumulateTagsFor(entityID types.EntityID, cardinality type
 	return nil
 }
 
-// Standard fake implementation
-func (f *FakeTagger) Standard(entityID types.EntityID) ([]string, error) {
-	return f.store.LookupStandard(entityID)
-}
-
 // GetEntity returns faked entity corresponding to the specified id and an error
 func (f *FakeTagger) GetEntity(entityID types.EntityID) (*types.Entity, error) {
 	return f.store.GetEntity(entityID)

--- a/comp/core/tagger/taggerimpl/local/tagger.go
+++ b/comp/core/tagger/taggerimpl/local/tagger.go
@@ -120,16 +120,6 @@ func (t *Tagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]s
 	return t.Tag(entityID, cardinality)
 }
 
-// Standard returns standard tags for a given entity
-// It triggers a tagger fetch if the no tags are found
-func (t *Tagger) Standard(entityID types.EntityID) ([]string, error) {
-	if entityID.Empty() {
-		return nil, fmt.Errorf("empty entity ID")
-	}
-
-	return t.tagStore.LookupStandard(entityID)
-}
-
 // GetEntity returns the entity corresponding to the specified id and an error
 func (t *Tagger) GetEntity(entityID types.EntityID) (*types.Entity, error) {
 	return t.tagStore.GetEntity(entityID)

--- a/comp/core/tagger/taggerimpl/replay/tagger.go
+++ b/comp/core/tagger/taggerimpl/replay/tagger.go
@@ -99,16 +99,6 @@ func (t *Tagger) AccumulateTagsFor(entityID types.EntityID, cardinality types.Ta
 	return nil
 }
 
-// Standard returns the standard tags for a given entity.
-func (t *Tagger) Standard(entityID types.EntityID) ([]string, error) {
-	tags, err := t.store.LookupStandard(entityID)
-	if err != nil {
-		return []string{}, err
-	}
-
-	return tags, nil
-}
-
 // List returns all the entities currently stored by the tagger.
 func (t *Tagger) List() types.TaggerListResponse {
 	return t.store.List()

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -314,22 +314,6 @@ func (t *TaggerClient) GetEntityHash(entityID types.EntityID, cardinality types.
 	return utils.ComputeTagsHash(tags)
 }
 
-// Standard queries the defaultTagger to get entity
-// standard tags (env, version, service) from cache or sources.
-func (t *TaggerClient) Standard(entityID types.EntityID) ([]string, error) {
-	t.mux.RLock()
-	// TODO(components) (tagger): captureTagger is a legacy global variable to be eliminated
-	if t.captureTagger != nil {
-		tags, err := t.captureTagger.Standard(entityID)
-		if err == nil && len(tags) > 0 {
-			t.mux.RUnlock()
-			return tags, nil
-		}
-	}
-	t.mux.RUnlock()
-	return t.defaultTagger.Standard(entityID)
-}
-
 // AgentTags returns the agent tags
 // It relies on the container provider utils to get the Agent container ID
 func (t *TaggerClient) AgentTags(cardinality types.TagCardinality) ([]string, error) {

--- a/comp/core/tagger/taggerimpl/tagger.go
+++ b/comp/core/tagger/taggerimpl/tagger.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taggerimpl/replay"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/utils"
 	coretelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -302,16 +301,6 @@ func (t *TaggerClient) AccumulateTagsFor(entityID types.EntityID, cardinality ty
 	}
 	t.mux.RUnlock()
 	return t.defaultTagger.AccumulateTagsFor(entityID, cardinality, tb)
-}
-
-// GetEntityHash returns the hash for the tags associated with the given entity
-// Returns an empty string if the tags lookup fails
-func (t *TaggerClient) GetEntityHash(entityID types.EntityID, cardinality types.TagCardinality) string {
-	tags, err := t.Tag(entityID, cardinality)
-	if err != nil {
-		return ""
-	}
-	return utils.ComputeTagsHash(tags)
 }
 
 // AgentTags returns the agent tags

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore.go
@@ -275,16 +275,6 @@ func (s *TagStore) Lookup(entityID types.EntityID, cardinality types.TagCardinal
 	return s.LookupHashed(entityID, cardinality).Get()
 }
 
-// LookupStandard returns the standard tags recorded for a given entity
-func (s *TagStore) LookupStandard(entityID types.EntityID) ([]string, error) {
-	storedTags, err := s.getEntityTags(entityID)
-	if err != nil {
-		return nil, err
-	}
-
-	return storedTags.getStandard(), nil
-}
-
 // List returns full list of entities and their tags per source in an API format.
 func (s *TagStore) List() types.TaggerListResponse {
 	r := types.TaggerListResponse{

--- a/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
+++ b/comp/core/tagger/taggerimpl/tagstore/tagstore_test.go
@@ -126,34 +126,6 @@ func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
 	assert.ElementsMatch(s.T(), tagsHigh.Get(), []string{"low1", "low2", "orchestrator1", "high1"})
 }
 
-func (s *StoreTestSuite) TestLookupStandard() {
-	entityID := types.NewEntityID(types.ContainerID, "test")
-
-	s.tagstore.ProcessTagInfo([]*types.TagInfo{
-		{
-			Source:       "source1",
-			EntityID:     entityID,
-			LowCardTags:  []string{"tag", "env:dev"},
-			StandardTags: []string{"env:dev"},
-		},
-		{
-			Source:       "source2",
-			EntityID:     entityID,
-			LowCardTags:  []string{"tag", "service:foo"},
-			StandardTags: []string{"service:foo"},
-		},
-	})
-
-	standard, err := s.tagstore.LookupStandard(entityID)
-	assert.Nil(s.T(), err)
-	assert.Len(s.T(), standard, 2)
-	assert.Contains(s.T(), standard, "env:dev")
-	assert.Contains(s.T(), standard, "service:foo")
-
-	_, err = s.tagstore.LookupStandard(types.NewEntityID("not", "found"))
-	assert.NotNil(s.T(), err)
-}
-
 func (s *StoreTestSuite) TestLookupNotPresent() {
 	entityID := types.NewEntityID(types.ContainerID, "test")
 	tags := s.tagstore.Lookup(entityID, types.LowCardinality)

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -234,9 +234,8 @@ func (r *runningAggregator) generateRunningAggregatorMetrics(sender sender.Sende
 }
 
 // generateTagHash creates a sorted string representation of the tags supplied. The resulting string that it returns is
-// the concatenated key-value pairs of tags, sorted, which should reduce the likelihood of a hash collision that is
-// possible using tagger.GetEntityHash.
-//
+// the concatenated key-value pairs of tags, sorted, which should reduce the likelihood of a hash collision.
+
 // This is mainly used for aggregation purposes, and is here because go does not support using a slice as a map key.
 // It is intended to keep the existing functionality in place after migrating this check from python.
 func generateTagHash(tags []string) string {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes two functions from the tagger component. The tagger internals is quiet convoluted as, we have multiple types that have to implement the tagger interface. 

- `Standard` is not used by any user of the tagger component 
- `GetEntityHash` is only used by the autodiscovery component. Is only used on two listerners.

By reducing the tagger interface we reduce the amount of boilerplate for each tagger implementation

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->