### PR TITLE
[CI] Fix last Github Actions workflows linter errors

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -9,12 +9,13 @@ on:
         description: "PR number"
         required: true
         type: number
-permissions:
-  contents: write
+
 jobs:
   mod_tidy_and_generate_licenses:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go')) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:

--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -4,7 +4,7 @@ name: Report Merged PR
 
 on:
   pull_request:
-    types: closed
+    types: [closed]
 
 permissions: {}
 
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
 
       - name: Setup Python3
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
@@ -31,5 +33,7 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: Send merge event to Datadog
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          invoke -e github.pr-merge-dd-event-sender -p ${{ github.event.pull_request.number }}
+          invoke -e github.pr-merge-dd-event-sender -p "$PR_NUMBER"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the last GHA workflows linter errors from [zizmor](https://github.com/woodruffw/zizmor).

### Motivation

Right after this PR I will add Zizmor and Actionlint to the CI linters (+ in the precommit hooks).

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->