### PR TITLE
[CI] Escape the backport-pr GHA body template to avoid template injection

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -35,8 +35,8 @@ jobs:
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
           github_token: ${{ steps.app-token.outputs.token }}
           body_template: |
-            Backport <%= mergeCommitSha %> from #<%= number %>.
+            Backport <%- mergeCommitSha %> from #<%- number %>.
 
             ___
 
-            <%= body %>
+            <%- body %>


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a security vulnerability in the "Backport PR" GitHub Actions workflow by properly escaping the pull request body in the EJS template used by the `tibdex/backport` action (using `<%-` instead of `<%=`). This prevents the execution of malicious code that could be injected through untrusted PR bodies.

### Motivation

The use of unsanitized, user-controlled inputs in EJS templates within the `tibdex/backport` action allows for arbitrary code execution, leading to potential leakage of secrets and other malicious activities.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->