### PR TITLE
[CWS] Prevent a segfault on ebpfless mode startup

### DIFF
--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -700,6 +700,8 @@ func NewEBPFLessProbe(probe *Probe, config *config.Config, opts Opts, telemetry 
 	}
 	p.fieldHandlers = fh
 
+	p.event = p.NewEvent()
+
 	// be sure to zero the probe event before everything else
 	p.zeroEvent()
 


### PR DESCRIPTION
### What does this PR do?

Bug introduced in [The PR "Add is_public field to IP addresses"](https://github.com/DataDog/datadog-agent/pull/30767/files#diff-91ea8b037ebc0897dd13f89610bc251a2f6fe503c9b357095ceb4bd4bb7301b7L699)

In the actual state, systemprobe segfault at startup.

### Motivation



### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->