### PR TITLE
[CWS] fix undetected ebpfless failure in KMT tests

### DIFF
--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -146,12 +146,12 @@ func preTestsHook() {
 			Debug:           true,
 		}
 
-		_, err := ptracer.Wrap(args, envs, constants.DefaultEBPFLessProbeAddr, opts)
+		retCode, err := ptracer.Wrap(args, envs, constants.DefaultEBPFLessProbeAddr, opts)
 		if err != nil {
 			fmt.Printf("unable to trace [%v]: %s", args, err)
 			os.Exit(-1)
 		}
-		os.Exit(0)
+		os.Exit(retCode)
 	}
 }
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -144,7 +144,7 @@ func buildCommandArgs(pkg string, xmlpath string, jsonpath string, testArgs []st
 	args = append(args, testArgs...)
 	args = append(
 		args,
-		"-test.v",
+		"-test.v=test2json",
 		fmt.Sprintf("-test.count=%d", testConfig.runCount),
 		"-test.timeout="+getTimeout(pkg).String(),
 	)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes an issue where the ebpfless testsuite could fail, but the failure was not detected by the test running infrastructure. This PR:
- makes sure the exit code of the testsuite is != 0 when there is a fail. This is important because `test2json` uses that to guess some pass/fail state for the testsuite
- makes sure the testsuite writes to stdout in a format that is suited to test2json, as instructed in the go 1.20 release notes https://tip.golang.org/doc/go1.20

Example job of the issue https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/697843443

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->