### PR TITLE
[Serverless] Reset both inferred spans on each invocation.

### DIFF
--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -358,6 +358,7 @@ func (lp *LifecycleProcessor) newRequest(lambdaPayloadString []byte, startTime t
 			SpanID: inferredspan.GenerateSpanId(),
 		},
 	}
+	lp.requestHandler.inferredSpans[1] = nil
 	lp.requestHandler.triggerTags = make(map[string]string)
 	lp.requestHandler.triggerMetrics = make(map[string]float64)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When a new invocation starts, the `resourceHandler` is reset. In addition to resetting the first inferred span, also reset the second by setting it to `nil`.

### Motivation

A single lambda can have multiple event types that invoke it. When some of the invocations would create 2 inferred spans, and some of the invocations would create 1 inferred span, we must ensure that both inferred spans are reset.

This was leading to some really weird behavior when I tried to add sns->sqs trace propagation to the Trace Propagation Functional Tests. I was seeing weird stuff like this, where an `sqs.sendMessage`, calls `aws.sns` inferred span, calls `aws.lambda.url` inferred span, calls `aws.lambda` span.

<img width="965" alt="Screenshot 2024-11-07 at 3 19 16 PM" src="https://github.com/user-attachments/assets/b487e3bd-d313-485a-9b90-e49d304c9f45">

### Describe how to test/QA your changes

I built an extension layer with this change as `arn:aws:lambda:us-east-1:425362996713:layer:Datadog-Extension-REY:8` and ran the Trace Propagation Functional Tests and finally saw them all passing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[datadoghq.atlassian.net/browse/SVLS-5732](https://datadoghq.atlassian.net/browse/SVLS-5732)