### PR TITLE
Update lading to 0.24.0

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
@@ -3,12 +3,13 @@ generator:
       logrotate_fs:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 10MB
         concurrent_logs: 8
         maximum_bytes_per_log: 500MB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
         maximum_prebuild_cache_size_bytes: 300MB
         mount_point: /smp-shared
 

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
@@ -3,12 +3,13 @@ generator:
       logrotate_fs:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 10MB
         concurrent_logs: 8
         maximum_bytes_per_log: 500MB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
         maximum_prebuild_cache_size_bytes: 300MB
         mount_point: /smp-shared
 

--- a/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
@@ -3,12 +3,13 @@ generator:
       logrotate_fs:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 10MB
         concurrent_logs: 8
         maximum_bytes_per_log: 500MB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
         maximum_prebuild_cache_size_bytes: 300MB
         mount_point: /smp-shared
 

--- a/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
@@ -3,12 +3,13 @@ generator:
       logrotate_fs:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 10MB
         concurrent_logs: 8
         maximum_bytes_per_log: 500MB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
         maximum_prebuild_cache_size_bytes: 300MB
         mount_point: /smp-shared
 

--- a/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
@@ -3,12 +3,13 @@ generator:
       logrotate_fs:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 10MB
         concurrent_logs: 8
         maximum_bytes_per_log: 500MB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
         maximum_prebuild_cache_size_bytes: 300MB
         mount_point: /smp-shared
 

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.23.5
+  version: 0.24.0
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
This commit updates lading to the latest release version, updating logrotate configuration as the bytes-per-second setting is removed and replaced with a load profile.
