### PR TITLE
Fix Config type issues

### DIFF
--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -191,9 +191,11 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 			pcfg, err := FromAgentConfig(cfg)
 			if err != nil || testInstance.err != "" {
 				assert.Equal(t, testInstance.err, err.Error())
-			} else {
-				assert.Equal(t, testInstance.cfg, pcfg)
+				return
 			}
+			testInstance.cfg.Metrics, err = normalizeMetricsConfig(testInstance.cfg.Metrics, true)
+			require.NoError(t, err)
+			assert.Equal(t, testInstance.cfg, pcfg)
 		})
 	}
 }
@@ -288,11 +290,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				TracePort:      5003,
 				Metrics: map[string]interface{}{
 					"enabled":                                true,
-					"instrumentation_scope_metadata_as_tags": "true",
+					"instrumentation_scope_metadata_as_tags": true,
 					"tag_cardinality":                        "low",
 					"apm_stats_receiver_addr":                "http://localhost:8126/v0.6/stats",
 
-					"delta_ttl": "2400",
+					"delta_ttl": 2400,
 					"histograms": map[string]interface{}{
 						"mode": "counters",
 					},
@@ -426,6 +428,27 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				Debug: map[string]interface{}{},
 			},
 		},
+		{
+			name: "metrics resource_attributes_as_tags",
+			env: map[string]string{
+				"DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS": "true",
+			},
+			cfg: PipelineConfig{
+				OTLPReceiverConfig: map[string]interface{}{},
+
+				MetricsEnabled: true,
+				TracesEnabled:  true,
+				LogsEnabled:    false,
+				TracePort:      5003,
+				Metrics: map[string]interface{}{
+					"enabled":                     true,
+					"tag_cardinality":             "low",
+					"apm_stats_receiver_addr":     "http://localhost:8126/v0.6/stats",
+					"resource_attributes_as_tags": true,
+				},
+				Debug: map[string]interface{}{},
+			},
+		},
 	}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
@@ -437,9 +460,11 @@ func TestFromEnvironmentVariables(t *testing.T) {
 			pcfg, err := FromAgentConfig(cfg)
 			if err != nil || testInstance.err != "" {
 				assert.Equal(t, testInstance.err, err.Error())
-			} else {
-				assert.Equal(t, testInstance.cfg, pcfg)
+				return
 			}
+			testInstance.cfg.Metrics, err = normalizeMetricsConfig(testInstance.cfg.Metrics, true)
+			require.NoError(t, err)
+			assert.Equal(t, testInstance.cfg, pcfg)
 		})
 	}
 }
@@ -488,9 +513,11 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 			pcfg, err := FromAgentConfig(cfg)
 			if err != nil || testInstance.err != "" {
 				assert.Equal(t, testInstance.err, err.Error())
-			} else {
-				assert.Equal(t, testInstance.cfg, pcfg)
+				return
 			}
+			testInstance.cfg.Metrics, err = normalizeMetricsConfig(testInstance.cfg.Metrics, true)
+			require.NoError(t, err)
+			assert.Equal(t, testInstance.cfg, pcfg)
 		})
 	}
 }
@@ -582,10 +609,12 @@ func TestFromAgentConfigDebug(t *testing.T) {
 			pcfg, err := FromAgentConfig(cfg)
 			if err != nil || testInstance.err != "" {
 				assert.Equal(t, testInstance.err, err.Error())
-			} else {
-				assert.Equal(t, testInstance.cfg, pcfg)
-				assert.Equal(t, testInstance.shouldSet, pcfg.shouldSetLoggingSection())
+				return
 			}
+			testInstance.cfg.Metrics, err = normalizeMetricsConfig(testInstance.cfg.Metrics, true)
+			require.NoError(t, err)
+			assert.Equal(t, testInstance.cfg, pcfg)
+			assert.Equal(t, testInstance.shouldSet, pcfg.shouldSetLoggingSection())
 		})
 	}
 }

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,9 +11,3 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-
-# TODO: https://datadoghq.atlassian.net/browse/OTEL-2192
-# To be removed once https://github.com/DataDog/datadog-agent/pull/30669 is merged.
-test/new-e2e/tests/otel/otlp-ingest:
-  - TestOTLPIngest
-  - TestOTLPIngestSampling/TestSampling

--- a/go.mod
+++ b/go.mod
@@ -606,6 +606,7 @@ require (
 	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/reference v0.6.0
+	github.com/go-viper/mapstructure/v2 v2.1.0
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/kouhin/envflag v0.0.0-20150818174321-0e9a86061649
 	github.com/lorenzosaino/go-sysctl v0.3.1
@@ -826,7 +827,6 @@ require (
 	github.com/go-openapi/spec v0.20.14 // indirect
 	github.com/go-resty/resty/v2 v2.13.1 // indirect
 	github.com/go-test/deep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.1.0 // indirect
 	github.com/go-zookeeper/zk v1.0.3 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/goccy/go-yaml v1.11.0 // indirect


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
JIRA https://datadoghq.atlassian.net/browse/OTEL-2192

When  Collector enforced strict types see [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/9532) , the OTLP ingest was breaking as we are alway do a get .

To overcome the issue we do following 
- After the string map is constructed, we decode into serializerexporter.MetricsConfig
- We reverse decode  serializerexporter.MetricsConfig into map, that would result in map with strict types. 

### Motivation

### Describe how to test/QA your changes
QA done. We also have a e2e test that uses this configuration. 
      

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->