### PR TITLE
[gitlab] deploy_containers: allow final otel beta jobs on beta branch builds

### DIFF
--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -150,8 +150,10 @@
 
 # Rule to deploy to our internal repository, on stable branch deploy
 .on_internal_final-ot:
-  - if: $BUCKET_BRANCH == "beta"
-    when: never
+  ## Jobs will be triggered on beta repo-branch so it's fine
+  ## if the "final" artifacts job is available on non-stable BUCKET_BRANCH
+  # - if: $BUCKET_BRANCH == "beta"
+  #   when: never
   - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
     when: never
   - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -184,14 +184,15 @@ deploy_containers_latest-dogstatsd:
 
 deploy_containers_latest-a7-ot:
   extends: .deploy_containers-a7-base-ot
+  stage: deploy_containers
   rules:
     !reference [.on_final-ot]
+  dependencies: []
   variables:
-    VERSION: 7
+    VERSION: 7-ot-beta
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta
-      - IMG_SOURCES: ${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-amd64,${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-arm64
-        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:${VERSION}-ot-beta-jmx
+      - JMX:
+          - ""
+          - "-jmx"
 


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?
This PR enables the manual final build jobs when the CI_COMMIT_TAG matches the expected `7.x.y-vA.B.C` final tag format for OTel beta builds but while targeting the beta `REPO_BRANCH` (which is safer).

Also some small cleanup.

### Motivation
For a bit of added safety and coherence with the internal documentation available.

### Describe how to test/QA your changes
Final beta release pipeline will help validate.

### Possible Drawbacks / Trade-offs
None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->