### PR TITLE
Remove unused method MergeConfigMap from the configuration

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -147,7 +147,6 @@ type Compound interface {
 	ReadInConfig() error
 	ReadConfig(in io.Reader) error
 	MergeConfig(in io.Reader) error
-	MergeConfigMap(cfg map[string]any) error
 	MergeFleetPolicy(configPath string) error
 }
 

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -688,14 +688,6 @@ func (c *safeConfig) MergeFleetPolicy(configPath string) error {
 	return nil
 }
 
-// MergeConfigMap merges the configuration from the map given with an existing config.
-// Note that the map given may be modified.
-func (c *safeConfig) MergeConfigMap(cfg map[string]any) error {
-	c.Lock()
-	defer c.Unlock()
-	return c.Viper.MergeConfigMap(cfg)
-}
-
 // AllSettings wraps Viper for concurrent access
 func (c *safeConfig) AllSettings() map[string]interface{} {
 	c.Lock()

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -758,15 +758,6 @@ func (c *ntmConfig) MergeFleetPolicy(configPath string) error {
 	return c.logErrorNotImplemented("MergeFleetPolicy")
 }
 
-// MergeConfigMap merges the configuration from the map given with an existing config.
-// Note that the map given may be modified.
-func (c *ntmConfig) MergeConfigMap(_cfg map[string]any) error {
-	c.Lock()
-	defer c.Unlock()
-	c.logErrorNotImplemented("AllSettings")
-	return nil
-}
-
 // AllSettings returns all settings from the config
 func (c *ntmConfig) AllSettings() map[string]interface{} {
 	c.RLock()

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -285,20 +285,6 @@ func (t *teeConfig) MergeFleetPolicy(configPath string) error {
 	return nil
 }
 
-// MergeConfigMap merges the configuration from the map given with an existing config.
-// Note that the map given may be modified.
-func (t *teeConfig) MergeConfigMap(cfg map[string]any) error {
-	err1 := t.baseline.MergeConfigMap(cfg)
-	err2 := t.compare.MergeConfigMap(cfg)
-	if err1 != nil {
-		return err1
-	}
-	if err2 != nil {
-		return err2
-	}
-	return nil
-}
-
 // AllSettings wraps Viper for concurrent access
 func (t *teeConfig) AllSettings() map[string]interface{} {
 	return t.baseline.AllSettings()


### PR DESCRIPTION
### What does this PR do?

Remove unused method MergeConfigMap from the configuration

### Describe how to test/QA your changes

Unit test were added. This code is not used anywhere for now. We're building a replacement for viper and will QA it entirely, outside of unit-tests, once it's ready.