### PR TITLE
[fleet] Stop install on err

### DIFF
--- a/pkg/fleet/installer/setup.go
+++ b/pkg/fleet/installer/setup.go
@@ -26,7 +26,7 @@ func Setup(ctx context.Context, env *env.Env) error {
 	for _, url := range defaultPackages {
 		err = cmd.Install(ctx, url, nil)
 		if err != nil {
-			return fmt.Errorf("failed to install package %s: %v\n", url, err)
+			return fmt.Errorf("failed to install package %s: %w", url, err)
 		}
 	}
 	return nil

--- a/pkg/fleet/installer/setup.go
+++ b/pkg/fleet/installer/setup.go
@@ -26,7 +26,7 @@ func Setup(ctx context.Context, env *env.Env) error {
 	for _, url := range defaultPackages {
 		err = cmd.Install(ctx, url, nil)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to install package %s: %v\n", url, err)
+			return fmt.Errorf("failed to install package %s: %v\n", url, err)
 		}
 	}
 	return nil

--- a/pkg/fleet/installer/setup.go
+++ b/pkg/fleet/installer/setup.go
@@ -9,7 +9,6 @@ package installer
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/exec"


### PR DESCRIPTION
Stop installation on failing to install a package.
Since the[ beginning the behaviour was to continue on next installation and not intended/missed](https://github.com/DataDog/datadog-agent/blob/0ac97712b88955c217c594b5c48a30657fc7323b/pkg/fleet/bootstraper/bootstraper.go#L41-L47)


test by running locally
```
$ sudo go run ./cmd/installer/main.go setup
```