### PR TITLE
fix(admission controller): fix unit test data race

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -76,8 +76,6 @@ func TestCreateWebhookV1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
-	c.config.validationEnabled = true
-	c.config.mutationEnabled = true
 
 	var validatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
@@ -145,8 +143,6 @@ func TestUpdateOutdatedWebhookV1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
-	c.config.validationEnabled = true
-	c.config.mutationEnabled = true
 
 	var newValidatingWebhookConfiguration *admiv1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -71,8 +71,6 @@ func TestCreateWebhookV1beta1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
-	c.config.validationEnabled = true
-	c.config.mutationEnabled = true
 
 	var validatingWebhookConfiguration *admiv1beta1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {
@@ -140,8 +138,6 @@ func TestUpdateOutdatedWebhookV1beta1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c := f.run(stopCh)
-	c.config.validationEnabled = true
-	c.config.mutationEnabled = true
 
 	var newValidatingWebhookConfiguration *admiv1beta1.ValidatingWebhookConfiguration
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes data races that can happen when trying to set both `c.config.validationEnabled` and `c.config.mutationEnabled` to `true`. Setting them is not needed as both those config variables defaults to `true`.

With the following error:
```
Failed

=== RUN   TestUpdateOutdatedWebhookV1
    mock.go:33: 2024-11-05 16:26:28 UTC | ERROR | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:134 in generateWebhooks) | failed to register CWS Instrumentation webhook: can't initialize CWS Instrumentation in remote_copy mode without providing a service account name in config (cluster_agent.service_account_name)
==================
Read at 0x00c000abe9d0 by goroutine 294:
  github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook.(*ControllerV1).Run()
      /go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook/controller_v1.go:122 +0x8f8
  github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook.(*fixtureV1).run.gowrap1()
      /go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go:1193 +0x44

Previous write at 0x00c000abe9d0 by goroutine 265:
  github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook.TestUpdateOutdatedWebhookV1()
      /go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go:148 +0xad2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

Goroutine 294 (running) created at:
  github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook.(*fixtureV1).run()
      /go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go:1193 +0xf0
  github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook.TestUpdateOutdatedWebhookV1()
      /go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go:147 +0xabc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

Goroutine 265 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:113 +0x2e4
==================
    testing.go:1398: race detected during execution of test
--- FAIL: TestUpdateOutdatedWebhookV1 (0.72s)
```

We can see that the values are read on those lines:
https://github.com/DataDog/datadog-agent/blob/d9289683200bfd023f0342d48b9e0d48acc12835/pkg/clusteragent/admission/controllers/webhook/controller_v1.go#L122-L127

But at the same time in the unit test, right after starting the controller, we have the following lines:
https://github.com/DataDog/datadog-agent/blob/d9289683200bfd023f0342d48b9e0d48acc12835/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go#L148-L149

Meaning that it could happen that the variables are being set at the same time when it is being read from the `Run()` method, causing the Data Race Detector to flag the test as failing.

As those lines are not needed, we might as well remove them.

### Motivation

Fixes data race to avoid unit tests flakiness.

### Describe how to test/QA your changes

N/A

### Possible Drawbacks / Trade-offs

N/A