### PR TITLE
Don't fail to build the agent locally when system probe is disabled

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https:#www.datadoghq.com/).
 # Copyright 2016-present Datadog, Inc.
 require "./lib/ostools.rb"
+require "./lib/project_helpers.rb"
 flavor = ENV['AGENT_FLAVOR']
 output_config_dir = ENV["OUTPUT_CONFIG_DIR"]
 
@@ -224,7 +225,7 @@ if do_build
   dependency 'datadog-agent'
 
   # System-probe
-  if linux_target? && !heroku_target?
+  if sysprobe_enabled?
     dependency 'system-probe'
   end
 

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -91,7 +91,7 @@ build do
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
             unless heroku_target?
-              if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
+              if sysprobe_enabled?
                 move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "#{output_config_dir}/etc/datadog-agent"
                 # SElinux policies aren't generated when system-probe isn't built
                 # Move SELinux policy

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -93,15 +93,15 @@ build do
             unless heroku_target?
               if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
                 move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "#{output_config_dir}/etc/datadog-agent"
+                # SElinux policies aren't generated when system-probe isn't built
+                # Move SELinux policy
+                if debian_target? || redhat_target?
+                  move "#{install_dir}/etc/datadog-agent/selinux", "#{output_config_dir}/etc/datadog-agent/selinux"
+                end
               end
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", "#{output_config_dir}/etc/datadog-agent", :force=>true
               move "#{install_dir}/etc/datadog-agent/runtime-security.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
               move "#{install_dir}/etc/datadog-agent/compliance.d", "#{output_config_dir}/etc/datadog-agent"
-
-              # Move SELinux policy
-              if debian_target? || redhat_target?
-                move "#{install_dir}/etc/datadog-agent/selinux", "#{output_config_dir}/etc/datadog-agent/selinux"
-              end
             end
 
             if ot_target?

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -91,7 +91,9 @@ build do
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "#{output_config_dir}/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
             unless heroku_target?
-              move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "#{output_config_dir}/etc/datadog-agent"
+              if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
+                move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "#{output_config_dir}/etc/datadog-agent"
+              end
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", "#{output_config_dir}/etc/datadog-agent", :force=>true
               move "#{install_dir}/etc/datadog-agent/runtime-security.d", "#{output_config_dir}/etc/datadog-agent", :force=>true
               move "#{install_dir}/etc/datadog-agent/compliance.d", "#{output_config_dir}/etc/datadog-agent"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -4,6 +4,7 @@
 # Copyright 2016-present Datadog, Inc.
 
 require './lib/ostools.rb'
+require './lib/project_helpers.rb'
 require 'pathname'
 
 name 'datadog-agent'
@@ -134,9 +135,7 @@ build do
   end
 
   # System-probe
-  sysprobe_support = (not heroku_target?) && (linux_target? || (windows_target? && do_windows_sysprobe != "")) &&
-                       ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
-  if sysprobe_support
+  if sysprobe_enabled? || (windows_target? && do_windows_sysprobe != "")
     if windows_target?
       command "invoke -e system-probe.build", env: env
     elsif linux_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -135,6 +135,7 @@ build do
 
   # System-probe
   sysprobe_support = (not heroku_target?) && (linux_target? || (windows_target? && do_windows_sysprobe != ""))
+                      && ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
   if sysprobe_support
     if windows_target?
       command "invoke -e system-probe.build", env: env

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -134,8 +134,8 @@ build do
   end
 
   # System-probe
-  sysprobe_support = (not heroku_target?) && (linux_target? || (windows_target? && do_windows_sysprobe != ""))
-                      && ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
+  sysprobe_support = (not heroku_target?) && (linux_target? || (windows_target? && do_windows_sysprobe != "")) &&
+                       ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
   if sysprobe_support
     if windows_target?
       command "invoke -e system-probe.build", env: env

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -5,6 +5,8 @@
 
 name 'system-probe'
 
+require './lib/project_helpers.rb'
+
 source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 
@@ -21,7 +23,7 @@ build do
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf"
   mkdir "#{install_dir}/embedded/share/system-probe/java"
 
-  if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
+  if sysprobe_enabled?
     arch = `uname -m`.strip
     if arch == "aarch64"
       arch = "arm64"

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -5,8 +5,6 @@
 
 name 'system-probe'
 
-require './lib/project_helpers.rb'
-
 source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 
@@ -23,19 +21,17 @@ build do
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf"
   mkdir "#{install_dir}/embedded/share/system-probe/java"
 
-  if sysprobe_enabled?
-    arch = `uname -m`.strip
-    if arch == "aarch64"
-      arch = "arm64"
-    end
-    copy "pkg/ebpf/bytecode/build/#{arch}/*.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
-    delete "#{install_dir}/embedded/share/system-probe/ebpf/usm_events_test*.o"
-    copy "pkg/ebpf/bytecode/build/#{arch}/co-re/*.o", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/"
-    copy "pkg/ebpf/bytecode/build/runtime/*.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
-    copy "#{ENV['SYSTEM_PROBE_BIN']}/clang-bpf", "#{install_dir}/embedded/bin/clang-bpf"
-    copy "#{ENV['SYSTEM_PROBE_BIN']}/llc-bpf", "#{install_dir}/embedded/bin/llc-bpf"
-    copy "#{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.xz", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/minimized-btfs.tar.xz"
+  arch = `uname -m`.strip
+  if arch == "aarch64"
+    arch = "arm64"
   end
+  copy "pkg/ebpf/bytecode/build/#{arch}/*.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+  delete "#{install_dir}/embedded/share/system-probe/ebpf/usm_events_test*.o"
+  copy "pkg/ebpf/bytecode/build/#{arch}/co-re/*.o", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/"
+  copy "pkg/ebpf/bytecode/build/runtime/*.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
+  copy "#{ENV['SYSTEM_PROBE_BIN']}/clang-bpf", "#{install_dir}/embedded/bin/clang-bpf"
+  copy "#{ENV['SYSTEM_PROBE_BIN']}/llc-bpf", "#{install_dir}/embedded/bin/llc-bpf"
+  copy "#{ENV['SYSTEM_PROBE_BIN']}/minimized-btfs.tar.xz", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/btf/minimized-btfs.tar.xz"
 
   copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"
 end

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -1,0 +1,12 @@
+#
+# Profect related helpers
+#
+
+require './lib/ostools.rb'
+
+def sysprobe_enabled?()
+  # This doesn't account for Windows special case which build system probe as part of the
+  # agent build process
+  !heroku_target? && linux_target? && ENV.fetch('SYSTEM_PROBE_BIN', '').empty?
+end
+

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -1,5 +1,5 @@
 #
-# Profect related helpers
+# Project related helpers
 #
 
 require './lib/ostools.rb'

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -7,6 +7,6 @@ require './lib/ostools.rb'
 def sysprobe_enabled?()
   # This doesn't account for Windows special case which build system probe as part of the
   # agent build process
-  !heroku_target? && linux_target? && ENV.fetch('SYSTEM_PROBE_BIN', '').empty?
+  !heroku_target? && linux_target? && !ENV.fetch('SYSTEM_PROBE_BIN', '').empty?
 end
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Disable system probe build throughout various locations to allow building the agent when `--system-probe-bin` isn't provided

### Motivation

Simplify building the agent locally
https://datadoghq.atlassian.net/browse/BARX-622

### Describe how to test/QA your changes

I'm not sure this is worth doing QA, but it can be verified manually by attempting to build the agent on `main` of before that commit is merged and confirm that if fails, and then with this commit and confirm that it doesn't

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->