### PR TITLE
[EBPF] gpu: improve sample for KMT tests

### DIFF
--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -30,14 +30,33 @@ cudaError_t cudaStreamSynchronize(cudaStream_t stream) {
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
 
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <wait-to-start-sec> <wait-to-end-sec>\n", argv[0]);
+        return 1;
+    }
+
+    int waitStart = atoi(argv[1]);
+    int waitEnd = atoi(argv[2]);
+
+    fprintf(stderr, "Waiting for %d seconds before starting\n", waitStart);
+
     // Give time for the eBPF program to load
-    sleep(5);
+    sleep(waitStart);
+
+    fprintf(stderr, "Starting calls.\n");
 
     cudaLaunchKernel((void *)0x1234, (dim3){ 1, 2, 3 }, (dim3){ 4, 5, 6 }, NULL, 10, stream);
     void *ptr;
     cudaMalloc(&ptr, 100);
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
+
+    fprintf(stderr, "CUDA calls made. Waiting for %d seconds before exiting\n", waitEnd);
+
+    // Give time for the agent to inspect this process and check environment variables/etc before this exits
+    sleep(waitEnd);
+
+    fprintf(stderr, "Exiting\n");
 
     return 0;
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR improves the sample file used to test the eBPF probes in KMT without requiring a GPU. It adds support for sleeps before/after the calls are made, to avoid flakiness due to probes not being attached in time and to the process ending before the probe can inspect certain aspects of the binary respectively. It also adds redirection of the output of the sample to the log output so failures can be more easily debugged.

### Motivation

Support testing in https://github.com/DataDog/datadog-agent/pull/29651 and https://github.com/DataDog/datadog-agent/pull/30811

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->