### PR TITLE
[CI] Set the `docker_integration_tests` job to allowed to fail

### DIFF
--- a/.gitlab/integration_test/linux.yml
+++ b/.gitlab/integration_test/linux.yml
@@ -23,6 +23,8 @@ agent_integration_tests:
 
 docker_integration_tests:
   extends: .integration_tests_deb
+  # This job is not stable yet because of rate limit issues and micro vms beta status.
+  allow_failure: true
   script:
     - inv -e docker.test
     - inv -e docker.integration-tests


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It sets `allow_failure: true` for the `docker_integration_tests` job.

### Motivation

This job is not stable yet because of rate limit issues and micro vms beta status.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->