### PR TITLE
chore(installer): Remove useless injector socket env code

### DIFF
--- a/pkg/fleet/installer/service/apm_sockets.go
+++ b/pkg/fleet/installer/service/apm_sockets.go
@@ -24,7 +24,6 @@ import (
 const (
 	apmInstallerSocket    = "/var/run/datadog/apm.socket"
 	statsdInstallerSocket = "/var/run/datadog/dsd.socket"
-	apmInjectOldPath      = "/opt/datadog/apm/inject"
 	envFilePath           = "/opt/datadog-packages/run/environment"
 )
 
@@ -86,6 +85,36 @@ func (a *apmInjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr 
 	if err := os.Chmod(envFilePath, 0644); err != nil {
 		return fmt.Errorf("error changing permissions of %s: %w", envFilePath, err)
 	}
+
+	// Symlinks for sysvinit
+	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent-trace"); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent-trace: %w", envFilePath, err)
+	}
+	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent: %w", envFilePath, err)
+	}
+	systemdRunning, err := isSystemdRunning()
+	if err != nil {
+		return fmt.Errorf("failed to check if systemd is running: %w", err)
+	}
+	if systemdRunning {
+		if err := addSystemDEnvOverrides(ctx, agentUnit); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, agentExp); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, traceAgentUnit); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, traceAgentExp); err != nil {
+			return err
+		}
+		if err := systemdReload(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -45,10 +45,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	s.host.AssertPackageInstalledByInstaller("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	state := s.host.State()
-	state.AssertFileExists("/opt/datadog-packages/run/environment", 0644, "root", "root")
 	state.AssertSymlinkExists("/run/datadog-installer", "/opt/datadog-packages/run", "root", "root") // /run as /var/run points to /run, it's a limitation of the state packages
-	state.AssertSymlinkExists("/etc/default/datadog-agent", "/opt/datadog-packages/run/environment", "root", "root")
-	state.AssertSymlinkExists("/etc/default/datadog-agent-trace", "/opt/datadog-packages/run/environment", "root", "root")
 	state.AssertDirExists("/var/log/datadog/dotnet", 0777, "root", "root")
 	state.AssertFileExists("/etc/ld.so.preload", 0644, "root", "root")
 	state.AssertFileExists("/usr/bin/dd-host-install", 0755, "root", "root")
@@ -463,7 +460,8 @@ func (s *packageApmInjectSuite) assertTraceReceived(traceID uint64) {
 	if !found {
 		tracePayloads, _ := s.Env().FakeIntake.Client().GetTraces()
 		s.T().Logf("Traces received: %v", tracePayloads)
-		s.T().Logf("Server logs: %v", s.Env().RemoteHost.MustExecute("cat /tmp/server.log"))
+		s.T().Logf("Server logs: %v", s.Env().RemoteHost.MustExecute("cat /tmp/server.log || true"))
+		s.T().Logf("Docker server logs (if any): %v", s.Env().RemoteHost.MustExecute("docker logs python-app || true"))
 		s.T().Logf("Trace Agent logs: %v", s.Env().RemoteHost.MustExecute("cat /var/log/datadog/trace-agent.log"))
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Following injector PR 468 & https://github.com/DataDog/datadog-agent/pull/26969; we can now safely remove the code that would set the socket path if the agent is strictly older than 7.57

### Motivation

### Describe how to test/QA your changes
Only impacts the installer. Tested manually on a VM.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->