### PR TITLE
[cluster-agent][auto injection] Fix minimum resource requirements bug

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -644,13 +644,11 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 				switch k {
 				case corev1.ResourceMemory:
 					if minimumMemoryLimit.Cmp(maxPodLim) == 1 {
-						log.Debugf("The memory limit is too low to acceptable for the datadog library container: %v required: %v", maxPodLim.String(), minimumMemoryLimit.String())
 						decision.skipInjection = true
 						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumMemoryLimit.String())
 					}
 				case corev1.ResourceCPU:
 					if minimumCPULimit.Cmp(maxPodLim) == 1 {
-						log.Debugf("The cpu limit is too low to acceptable for the datadog library init-container: %v required: %v", maxPodLim.String(), minimumCPULimit.String())
 						decision.skipInjection = true
 						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumCPULimit.String())
 					}
@@ -665,6 +663,7 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 		}
 	}
 	if decision.skipInjection {
+		log.Debug(insufficientResourcesMessage)
 		decision.message = insufficientResourcesMessage
 	}
 	return requirements, decision

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -603,6 +603,11 @@ func podSumRessourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
 	return ressourceRequirement
 }
 
+type injectionResourceRequirementsDecision struct {
+	skipInjection bool
+	message       string
+}
+
 // initContainerResourceRequirements computes init container cpu/memory requests and limits.
 // There are two cases:
 //
@@ -618,23 +623,19 @@ func podSumRessourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
 //     so our init container will also have request == limit.
 //
 //     In the 2nd case, of we wouldn't have enough memory, we bail on injection
-func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequirementConfiguration) (requirements corev1.ResourceRequirements, skipInjection bool) {
+func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequirementConfiguration) (requirements corev1.ResourceRequirements, decision injectionResourceRequirementsDecision) {
 	requirements = corev1.ResourceRequirements{
 		Limits:   corev1.ResourceList{},
 		Requests: corev1.ResourceList{},
 	}
 	podRequirements := podSumRessourceRequirements(pod)
-	var shouldSkipInjection bool
+	insufficientResourcesMessage := "The overall pod's containers limit is too low"
 	for _, k := range [2]corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		if q, ok := conf[k]; ok {
 			requirements.Limits[k] = q
 			requirements.Requests[k] = q
 		} else {
 			if maxPodLim, ok := podRequirements.Limits[k]; ok {
-				val, ok := maxPodLim.AsInt64()
-				if !ok {
-					log.Debugf("Unable do convert resource value to int64, raw value: %v", maxPodLim)
-				}
 				// If the pod before adding instrumentation init containers would have had a limits smaller than
 				// a certain amount, we just don't do anything, for two reasons:
 				// 1. The init containers need quite a lot of memory/CPU in order to not OOM or initialize in reasonnable time
@@ -642,14 +643,16 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 				//   non trivial amount, and we don't want to cause issues for constrained apps
 				switch k {
 				case corev1.ResourceMemory:
-					if val < minimumMemoryLimit {
-						log.Debugf("The memory limit is too low to acceptable for the datadog library init-container: %v", val)
-						shouldSkipInjection = true
+					if minimumMemoryLimit.Cmp(maxPodLim) == 1 {
+						log.Debugf("The memory limit is too low to acceptable for the datadog library container: %v required: %v", maxPodLim.String(), minimumMemoryLimit.String())
+						decision.skipInjection = true
+						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumMemoryLimit.String())
 					}
 				case corev1.ResourceCPU:
-					if val < minimumCPULimit {
-						log.Debugf("The cpu limit is too low to acceptable for the datadog library init-container: %v", val)
-						shouldSkipInjection = true
+					if minimumCPULimit.Cmp(maxPodLim) == 1 {
+						log.Debugf("The cpu limit is too low to acceptable for the datadog library init-container: %v required: %v", maxPodLim.String(), minimumCPULimit.String())
+						decision.skipInjection = true
+						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumCPULimit.String())
 					}
 				default:
 					// We don't support other resources
@@ -661,22 +664,22 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 			}
 		}
 	}
-	if shouldSkipInjection {
-		return corev1.ResourceRequirements{}, shouldSkipInjection
+	if decision.skipInjection {
+		decision.message = insufficientResourcesMessage
 	}
-	return requirements, false
+	return requirements, decision
 }
 
 func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLibInfo) error {
 	if len(config.libs) == 0 {
 		return nil
 	}
-	requirements, skipInjection := initContainerResourceRequirements(pod, w.config.defaultResourceRequirements)
-	if skipInjection {
+	requirements, injectionDecision := initContainerResourceRequirements(pod, w.config.defaultResourceRequirements)
+	if injectionDecision.skipInjection {
 		if pod.Annotations == nil {
 			pod.Annotations = make(map[string]string)
 		}
-		pod.Annotations[apmInjectionErrorAnnotationKey] = "The overall pod's containers memory limit is too low to acceptable for the datadog library init-container"
+		pod.Annotations[apmInjectionErrorAnnotationKey] = injectionDecision.message
 		return nil
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1110,17 +1110,18 @@ func TestInjectLibConfig(t *testing.T) {
 
 func TestInjectLibInitContainer(t *testing.T) {
 	tests := []struct {
-		name              string
-		cpu               string
-		mem               string
-		pod               *corev1.Pod
-		image             string
-		lang              language
-		wantSkipInjection bool
-		wantErr           bool
-		wantCPU           string
-		wantMem           string
-		secCtx            *corev1.SecurityContext
+		name                      string
+		cpu                       string
+		mem                       string
+		pod                       *corev1.Pod
+		image                     string
+		lang                      language
+		wantSkipInjection         bool
+		resourceRequireAnnotation string
+		wantErr                   bool
+		wantCPU                   string
+		wantMem                   string
+		secCtx                    *corev1.SecurityContext
 	}{
 		{
 			name:    "no_resources,no_security_context",
@@ -1239,18 +1240,18 @@ func TestInjectLibInitContainer(t *testing.T) {
 			name: "with_container_resources",
 			pod: common.FakePodWithResources("java-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("101Mi"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("101Mi"),
 				},
 			}),
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "499",
+			wantCPU: "499m",
 			wantMem: "101Mi",
 		},
 		{
@@ -1262,20 +1263,20 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{{Name: "with_init_container_resources_init-1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 					}}, {Name: "with_init_container_resources_init-2", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 					}}},
@@ -1285,7 +1286,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "501",
+			wantCPU: "501m",
 			wantMem: "101Mi",
 		},
 		{
@@ -1294,11 +1295,11 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Name: "c1",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("499"),
+						corev1.ResourceCPU:    resource.MustParse("499m"),
 						corev1.ResourceMemory: resource.MustParse("101Mi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("499"),
+						corev1.ResourceCPU:    resource.MustParse("499m"),
 						corev1.ResourceMemory: resource.MustParse("101Mi"),
 					},
 				},
@@ -1306,11 +1307,11 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Name: "c2",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("499"),
+						corev1.ResourceCPU:    resource.MustParse("499m"),
 						corev1.ResourceMemory: resource.MustParse("101Mi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("499"),
+						corev1.ResourceCPU:    resource.MustParse("499m"),
 						corev1.ResourceMemory: resource.MustParse("101Mi"),
 					},
 				},
@@ -1318,7 +1319,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "998",
+			wantCPU: "998m",
 			wantMem: "202Mi",
 		},
 		{
@@ -1330,21 +1331,21 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{{Name: "i1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 					}}},
 					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 					}}},
@@ -1353,7 +1354,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "501",
+			wantCPU: "501m",
 			wantMem: "101Mi",
 		},
 		{
@@ -1365,21 +1366,21 @@ func TestInjectLibInitContainer(t *testing.T) {
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{{Name: "i1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("501"),
+							corev1.ResourceCPU:    resource.MustParse("501m"),
 							corev1.ResourceMemory: resource.MustParse("99Mi"),
 						},
 					}}},
 					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("499"),
+							corev1.ResourceCPU:    resource.MustParse("499m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 					}}},
@@ -1388,70 +1389,90 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "501",
+			wantCPU: "501m",
 			wantMem: "101Mi",
 		},
 		{
 			name: "config_and_resources",
 			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("101Mi"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("101Mi"),
 				},
 			}}),
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
-			cpu:     "100",
+			cpu:     "100m",
 			mem:     "256Mi",
 			wantErr: false,
-			wantCPU: "100",
+			wantCPU: "100m",
 			wantMem: "256Mi",
 		},
 		{
 			name: "low_memory_skip",
 			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			}}),
-			image:             "gcr.io/datadoghq/dd-lib-java-init:v1",
-			lang:              java,
-			wantErr:           false,
-			wantSkipInjection: true,
+			image:                     "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:                      java,
+			wantErr:                   false,
+			wantSkipInjection:         true,
+			resourceRequireAnnotation: "The overall pod's containers limit is too low, memory pod_limit=50Mi needed=100Mi",
 		},
 		{
 			name: "low_cpu_skip",
 			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("25"),
+					corev1.ResourceCPU: resource.MustParse("0.025"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("25"),
+					corev1.ResourceCPU: resource.MustParse("0.025"),
 				},
 			}}),
-			image:             "gcr.io/datadoghq/dd-lib-java-init:v1",
-			lang:              java,
-			wantErr:           false,
-			wantSkipInjection: true,
+			image:                     "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:                      java,
+			wantErr:                   false,
+			wantSkipInjection:         true,
+			resourceRequireAnnotation: "The overall pod's containers limit is too low, cpu pod_limit=25m needed=50m",
+		},
+		{
+			name: "both_cpu_memory_skip",
+			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0.025"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0.025"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			}}),
+			image:                     "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:                      java,
+			wantErr:                   false,
+			wantSkipInjection:         true,
+			resourceRequireAnnotation: "The overall pod's containers limit is too low, cpu pod_limit=25m needed=50m, memory pod_limit=50Mi needed=100Mi",
 		},
 		{
 			name: "config_override_low_limit_skip",
 			pod: common.FakePodWithContainer("java-pod", corev1.Container{Name: "c1", Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("499"),
+					corev1.ResourceCPU:    resource.MustParse("499m"),
 					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			}}),
@@ -1476,11 +1497,11 @@ func TestInjectLibInitContainer(t *testing.T) {
 							Name: "init-container-1",
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("501"),
+									corev1.ResourceCPU:    resource.MustParse("501m"),
 									corev1.ResourceMemory: resource.MustParse("101Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("501"),
+									corev1.ResourceCPU:    resource.MustParse("501m"),
 									corev1.ResourceMemory: resource.MustParse("101Mi"),
 								},
 							},
@@ -1489,11 +1510,11 @@ func TestInjectLibInitContainer(t *testing.T) {
 							RestartPolicy: pointer.Ptr(corev1.ContainerRestartPolicyAlways),
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
@@ -1501,11 +1522,11 @@ func TestInjectLibInitContainer(t *testing.T) {
 					},
 					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200"),
+							corev1.ResourceCPU:    resource.MustParse("200m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200"),
+							corev1.ResourceCPU:    resource.MustParse("200m"),
 							corev1.ResourceMemory: resource.MustParse("101Mi"),
 						},
 					}}},
@@ -1514,8 +1535,67 @@ func TestInjectLibInitContainer(t *testing.T) {
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,
 			wantErr: false,
-			wantCPU: "700",
+			wantCPU: "700m",
 			wantMem: "151Mi",
+		},
+		{
+			name: "todo",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "java-pod",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "1", Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+						}},
+					},
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1m"),
+								corev1.ResourceMemory: resource.MustParse("8Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1m"),
+								corev1.ResourceMemory: resource.MustParse("8Mi"),
+							},
+						}},
+						{Name: "c1", Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("8692Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("8692Mi"),
+							},
+						}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						}},
+					},
+				},
+			},
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:    java,
+			wantErr: false,
+			wantCPU: "2011m",
+			wantMem: "8764Mi",
 		},
 	}
 
@@ -1546,8 +1626,9 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wh.config.initSecurityContext = tt.secCtx
 
 			c := tt.lang.libInfo("", tt.image).initContainers(wh.config.version)[0]
-			requirements, skipInjection := initContainerResourceRequirements(tt.pod, wh.config.defaultResourceRequirements)
-			require.Equal(t, tt.wantSkipInjection, skipInjection)
+			requirements, injectionDecision := initContainerResourceRequirements(tt.pod, wh.config.defaultResourceRequirements)
+			require.Equal(t, tt.wantSkipInjection, injectionDecision.skipInjection)
+			require.Equal(t, tt.resourceRequireAnnotation, injectionDecision.message)
 			if tt.wantSkipInjection {
 				return
 			}
@@ -1566,13 +1647,14 @@ func TestInjectLibInitContainer(t *testing.T) {
 			req := tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Requests[corev1.ResourceCPU]
 			lim := tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Limits[corev1.ResourceCPU]
 			wantCPUQuantity := resource.MustParse(tt.wantCPU)
-			t.Log(wantCPUQuantity, req)
+			t.Log("CPU wants:", wantCPUQuantity.String(), "actual lim: ", lim.String())
 			require.Zero(t, wantCPUQuantity.Cmp(req)) // Cmp returns 0 if equal
 			require.Zero(t, wantCPUQuantity.Cmp(lim))
 
 			req = tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Requests[corev1.ResourceMemory]
 			lim = tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Limits[corev1.ResourceMemory]
 			wantMemQuantity := resource.MustParse(tt.wantMem)
+			t.Log("memeory wants:", wantMemQuantity.String(), "actual lim: ", lim.String())
 			require.Zero(t, wantMemQuantity.Cmp(req))
 			require.Zero(t, wantMemQuantity.Cmp(lim))
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -19,9 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	minimumCPULimit    int64 = 50                // 0.05 core, otherwise copying + library initialization is going to take forever
-	minimumMemoryLimit int64 = 100 * 1024 * 1024 // 100 MB (recommended minimum by Alpine)
+var (
+	minimumCPULimit    resource.Quantity = resource.MustParse("0.05")  // 0.05 core, otherwise copying + library initialization is going to take forever
+	minimumMemoryLimit resource.Quantity = resource.MustParse("100Mi") // 100 MB (recommended minimum by Alpine)
 )
 
 // webhookConfig use to store options from the config.Component for the autoinstrumentation webhook


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Fix CPU requirements from 50 CPU cores to 0.05 CPU cores
* Fix imprecise not enough resources annotations

### Motivation

In PR #30266 we introduced minimum requirements on pods to trigger injection.
There are two bugs:
* A major one. The minimum CPU required was set to 50 core instead of 0.05 cores, disabling inejction in almost all cases
* A minor one. A pod annotation was added if resources where lower than needed, but this annotation always says that the memory limit is the issue, even when the CPU limit is the resource that prevents injection.

This PR fixes both bugs and adds a few test cases to ensure it doesn't happen again. 

### Describe how to test/QA your changes

Enable SSI on the cluster agent
Case 1:
Deploy a new pod with combinations of init-containers/sidecar containers/containers.
Verify that the resource limits and requests on injected init containers are set to the effective request/limit for the pod

Case 2:
Set auto_instrumentation.init_resources.(cpu|memory)
Verify that the value is applied to injected init container resources, regardless of the pod limits and requests

Case 3:
Deploy a pod with a container with a very small memory footprint (<100Mi) or a very small CPU footprint (<0.05CPU)
Verify that we are not injecting anything into it

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->