### PR TITLE
Implements AllSettings getters

### DIFF
--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -235,3 +235,78 @@ func TestSetUnkownKey(t *testing.T) {
 	assert.Nil(t, cfg.Get("unknown_key"))
 	assert.Equal(t, model.SourceUnknown, cfg.GetSource("unknown_key"))
 }
+
+func TestAllSettings(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b.c", 0)
+	cfg.SetDefault("b.d", 0)
+	cfg.BuildSchema()
+
+	cfg.ReadConfig(strings.NewReader("a: 987"))
+	cfg.Set("b.c", 123, model.SourceAgentRuntime)
+
+	expected := map[string]interface{}{
+		"a": 987,
+		"b": map[string]interface{}{
+			"c": 123,
+			"d": 0,
+		},
+	}
+	assert.Equal(t, expected, cfg.AllSettings())
+}
+
+func TestAllSettingsWithoutDefault(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b.c", 0)
+	cfg.SetDefault("b.d", 0)
+	cfg.BuildSchema()
+
+	cfg.ReadConfig(strings.NewReader("a: 987"))
+	cfg.Set("b.c", 123, model.SourceAgentRuntime)
+
+	expected := map[string]interface{}{
+		"a": 987,
+		"b": map[string]interface{}{
+			"c": 123,
+		},
+	}
+	assert.Equal(t, expected, cfg.AllSettingsWithoutDefault())
+}
+
+func TestAllSettingsBySource(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b.c", 0)
+	cfg.SetDefault("b.d", 0)
+	cfg.BuildSchema()
+
+	cfg.ReadConfig(strings.NewReader("a: 987"))
+	cfg.Set("b.c", 123, model.SourceAgentRuntime)
+
+	expected := map[model.Source]interface{}{
+		model.SourceDefault: map[string]interface{}{
+			"a": 0,
+			"b": map[string]interface{}{
+				"c": 0,
+				"d": 0,
+			},
+		},
+		model.SourceUnknown: map[string]interface{}{},
+		model.SourceFile: map[string]interface{}{
+			"a": 987,
+		},
+		model.SourceEnvVar:        map[string]interface{}{},
+		model.SourceFleetPolicies: map[string]interface{}{},
+		model.SourceAgentRuntime: map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": 123,
+			},
+		},
+		model.SourceLocalConfigProcess: map[string]interface{}{},
+		model.SourceRC:                 map[string]interface{}{},
+		model.SourceCLI:                map[string]interface{}{},
+	}
+	assert.Equal(t, expected, cfg.AllSettingsBySource())
+}

--- a/pkg/config/nodetreemodel/inner_node.go
+++ b/pkg/config/nodetreemodel/inner_node.go
@@ -162,3 +162,26 @@ func (n *innerNode) InsertChildNode(name string, node Node) {
 	n.children[name] = node
 	n.makeRemapCase()
 }
+
+// DumpSettings clone the entire tree starting from the node into a map based on the leaf source.
+//
+// The selector will be call with the source of each leaf to determine if it should be included in the dump.
+func (n *innerNode) DumpSettings(selector func(model.Source) bool) map[string]interface{} {
+	res := map[string]interface{}{}
+
+	for _, k := range n.ChildrenKeys() {
+		child, _ := n.GetChild(k)
+		if leaf, ok := child.(LeafNode); ok {
+			if selector(leaf.Source()) {
+				res[k], _ = leaf.GetAny()
+			}
+			continue
+		}
+
+		childDump := child.(InnerNode).DumpSettings(selector)
+		if len(childDump) != 0 {
+			res[k] = childDump
+		}
+	}
+	return res
+}

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -84,6 +84,7 @@ type InnerNode interface {
 	SetAt([]string, interface{}, model.Source) (bool, error)
 	InsertChildNode(string, Node)
 	makeRemapCase()
+	DumpSettings(func(model.Source) bool) map[string]interface{}
 }
 
 // LeafNode represents a leaf node of the config

--- a/pkg/config/nodetreemodel/struct_node.go
+++ b/pkg/config/nodetreemodel/struct_node.go
@@ -22,6 +22,7 @@ type structNodeImpl struct {
 }
 
 var _ Node = (*structNodeImpl)(nil)
+var _ InnerNode = (*structNodeImpl)(nil)
 
 // GetChild returns the child node at the given case-insensitive key, or an error if not found
 func (n *structNodeImpl) GetChild(key string) (Node, error) {
@@ -130,6 +131,11 @@ func (n *structNodeImpl) SetWithSource(interface{}, model.Source) error {
 // Source returns the source for this leaf
 func (n *structNodeImpl) Source() model.Source {
 	return model.SourceUnknown
+}
+
+// DumpSettings returns nil
+func (n *structNodeImpl) DumpSettings(func(model.Source) bool) map[string]interface{} {
+	return nil
 }
 
 type specifierSet map[string]struct{}


### PR DESCRIPTION
### What does this PR do?

Implements `AllSettings*` getters. Those mimic the behavior from viper.

### Describe how to test/QA your changes

Unit test were added. This code is not used anywhere for now. We're building a replacement for viper and will QA it entirely, outside of unit-tests, once it's ready.