### PR TITLE
[ha-agent] Add haagent component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -316,7 +316,7 @@
 /comp/trace/etwtracer @DataDog/windows-agent
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/etw @DataDog/windows-agent
-/comp/haagent @DataDog/network-device-monitoring
+/comp/haagent @DataDog/ndm-core
 /comp/languagedetection/client @DataDog/container-platform
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/compression @DataDog/agent-metrics-logs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -316,7 +316,7 @@
 /comp/trace/etwtracer @DataDog/windows-agent
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/etw @DataDog/windows-agent
-/comp/haagent @DataDog/network-device-monitoring @DataDog/remote-config @DataDog/fleet
+/comp/haagent @DataDog/network-device-monitoring
 /comp/languagedetection/client @DataDog/container-platform
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/compression @DataDog/agent-metrics-logs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -320,6 +320,7 @@
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/compression @DataDog/agent-metrics-logs
 /comp/snmpscan @DataDog/ndm-core
+/comp/haagent @DataDog/network-device-monitoring @DataDog/remote-config @DataDog/fleet
 # END COMPONENTS
 
 # Additional notification to  @iglendd about Agent Telemetry changes for optional approval and governance acknowledgement

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -316,11 +316,11 @@
 /comp/trace/etwtracer @DataDog/windows-agent
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/etw @DataDog/windows-agent
+/comp/haagent @DataDog/network-device-monitoring @DataDog/remote-config @DataDog/fleet
 /comp/languagedetection/client @DataDog/container-platform
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/compression @DataDog/agent-metrics-logs
 /comp/snmpscan @DataDog/ndm-core
-/comp/haagent @DataDog/network-device-monitoring @DataDog/remote-config @DataDog/fleet
 # END COMPONENTS
 
 # Additional notification to  @iglendd about Agent Telemetry changes for optional approval and governance acknowledgement

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -30,6 +30,7 @@ import (
 	internalsettings "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/settings"
 	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
 	agenttelemetryfx "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx"
+	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 
 	// checks implemented as components
 
@@ -472,6 +473,7 @@ func getSharedFxOption() fx.Option {
 		agenttelemetryfx.Module(),
 		networkpath.Bundle(),
 		remoteagentregistryfx.Module(),
+		haagentfx.Module(),
 	)
 }
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -599,7 +599,7 @@ Package etw provides an ETW tracing interface
 
 ### [comp/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/haagent)
 
-*Datadog Team*: network-device-monitoring
+*Datadog Team*: ndm-core
 
 Package haagent handles states for HA Agent feature.
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -599,7 +599,7 @@ Package etw provides an ETW tracing interface
 
 ### [comp/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/haagent)
 
-*Datadog Team*: network-device-monitoring remote-config fleet
+*Datadog Team*: network-device-monitoring
 
 Package haagent handles states for HA Agent feature.
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -597,6 +597,12 @@ Package datadogclient provides a client to query the datadog API
 
 Package etw provides an ETW tracing interface
 
+### [comp/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/haagent)
+
+*Datadog Team*: network-device-monitoring remote-config fleet
+
+Package haagent handles states for HA Agent feature.
+
 ### [comp/languagedetection/client](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/languagedetection/client)
 
 *Datadog Team*: container-platform

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -6,7 +6,7 @@
 // Package haagent handles states for HA Agent feature.
 package haagent
 
-// team: network-device-monitoring
+// team: network-device-monitoring remote-config fleet
 
 // Component is the component type.
 type Component interface {

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -6,7 +6,7 @@
 // Package haagent handles states for HA Agent feature.
 package haagent
 
-// team: network-device-monitoring
+// team: ndm-core
 
 // Component is the component type.
 type Component interface {

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -6,7 +6,7 @@
 // Package haagent handles states for HA Agent feature.
 package haagent
 
-// team: network-device-monitoring remote-config fleet
+// team: network-device-monitoring
 
 // Component is the component type.
 type Component interface {

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package haagent handles states for HA Agent feature.
+package haagent
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	// Enabled returns true if ha_agent.enabled is set to true
+	Enabled() bool
+
+	// GetGroup returns the value of ha_agent.group
+	GetGroup() string
+
+	// IsLeader returns true if the current Agent is leader
+	IsLeader() bool
+
+	// SetLeader takes the leader agent hostname as input, if it matches the current agent hostname,
+	// the isLeader state is set to true, otherwise false.
+	SetLeader(leaderAgentHostname string)
+}

--- a/comp/haagent/fx/fx.go
+++ b/comp/haagent/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the haagent component
+package fx
+
+import (
+	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+	haagentimpl "github.com/DataDog/datadog-agent/comp/haagent/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			haagentimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[haagent.Component](),
+	)
+}

--- a/comp/haagent/impl/config.go
+++ b/comp/haagent/impl/config.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package haagentimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+type haAgentConfigs struct {
+	enabled bool
+	group   string
+}
+
+func newHaAgentConfigs(agentConfig config.Component) *haAgentConfigs {
+	return &haAgentConfigs{
+		enabled: agentConfig.GetBool("ha_agent.enabled"),
+		group:   agentConfig.GetString("ha_agent.group"),
+	}
+}

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -1,0 +1,44 @@
+package haagentimpl
+
+import (
+	"context"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"go.uber.org/atomic"
+)
+
+type haAgentImpl struct {
+	log            log.Component
+	haAgentConfigs *haAgentConfigs
+	isLeader       *atomic.Bool
+}
+
+func newHaAgentImpl(log log.Component, haAgentConfigs *haAgentConfigs) *haAgentImpl {
+	return &haAgentImpl{
+		log:            log,
+		haAgentConfigs: haAgentConfigs,
+		isLeader:       atomic.NewBool(false),
+	}
+}
+
+func (h *haAgentImpl) Enabled() bool {
+	return h.haAgentConfigs.enabled
+}
+
+func (h *haAgentImpl) GetGroup() string {
+	return h.haAgentConfigs.group
+}
+
+func (h *haAgentImpl) IsLeader() bool {
+	return h.isLeader.Load()
+}
+
+func (h *haAgentImpl) SetLeader(leaderAgentHostname string) {
+	agentHostname, err := hostname.Get(context.TODO())
+	if err != nil {
+		h.log.Warnf("Error getting the hostname: %v", err)
+		return
+	}
+	h.isLeader.Store(agentHostname == leaderAgentHostname)
+}

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package haagentimpl
 
 import (

--- a/comp/haagent/impl/haagent_comp.go
+++ b/comp/haagent/impl/haagent_comp.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package haagentimpl implements the haagent component interface
+package haagentimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+)
+
+// Requires defines the dependencies for the haagent component
+type Requires struct {
+	Logger      log.Component
+	AgentConfig config.Component
+}
+
+// Provides defines the output of the haagent component
+type Provides struct {
+	Comp haagent.Component
+}
+
+// NewComponent creates a new haagent component
+func NewComponent(reqs Requires) (Provides, error) {
+	haAgentConfigs := newHaAgentConfigs(reqs.AgentConfig)
+	provides := Provides{
+		Comp: newHaAgentImpl(reqs.Logger, haAgentConfigs),
+	}
+	return provides, nil
+}

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package haagentimpl
 
 import (

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -1,0 +1,57 @@
+package haagentimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Enabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		configs         map[string]interface{}
+		expectedEnabled bool
+	}{
+		{
+			name: "enabled",
+			configs: map[string]interface{}{
+				"ha_agent.enabled": true,
+			},
+			expectedEnabled: true,
+		},
+		{
+			name: "disabled",
+			configs: map[string]interface{}{
+				"ha_agent.enabled": false,
+			},
+			expectedEnabled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haAgent := newTestHaAgentComponent(t, tt.configs)
+			assert.Equal(t, tt.expectedEnabled, haAgent.Enabled())
+		})
+	}
+}
+
+func Test_GetGroup(t *testing.T) {
+	agentConfigs := map[string]interface{}{
+		"ha_agent.group": "my-group-01",
+	}
+	haAgent := newTestHaAgentComponent(t, agentConfigs)
+	assert.Equal(t, "my-group-01", haAgent.GetGroup())
+}
+
+func Test_IsLeader_SetLeader(t *testing.T) {
+	agentConfigs := map[string]interface{}{
+		"hostname": "my-agent-hostname",
+	}
+	haAgent := newTestHaAgentComponent(t, agentConfigs)
+
+	haAgent.SetLeader("another-agent")
+	assert.False(t, haAgent.IsLeader())
+
+	haAgent.SetLeader("my-agent-hostname")
+	assert.True(t, haAgent.IsLeader())
+}

--- a/comp/haagent/impl/haagent_testutils_test.go
+++ b/comp/haagent/impl/haagent_testutils_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 package haagentimpl
 
 import (

--- a/comp/haagent/impl/haagent_testutils_test.go
+++ b/comp/haagent/impl/haagent_testutils_test.go
@@ -1,0 +1,32 @@
+package haagentimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func newTestHaAgentComponent(t *testing.T, agentConfigs map[string]interface{}) haagent.Component {
+	logComponent := logmock.New(t)
+	agentConfigComponent := fxutil.Test[config.Component](t, fx.Options(
+		config.MockModule(),
+		fx.Replace(config.MockParams{Overrides: agentConfigs}),
+	))
+
+	requires := Requires{
+		Logger:      logComponent,
+		AgentConfig: agentConfigComponent,
+	}
+
+	provides, err := NewComponent(requires)
+	require.NoError(t, err)
+
+	comp := provides.Comp
+	require.NotNil(t, comp)
+	return comp
+}

--- a/comp/haagent/mock/mock.go
+++ b/comp/haagent/mock/mock.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the haagent component
+package mock
+
+import (
+	"testing"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+)
+
+type mock struct {
+	Logger log.Component
+}
+
+func (m *mock) GetGroup() string {
+	return "mockGroup01"
+}
+
+func (m *mock) Enabled() bool {
+	return true
+}
+
+func (m *mock) SetLeader(_ string) {
+}
+
+func (m *mock) IsLeader() bool { return false }
+
+// Provides that defines the output of mocked snmpscan component
+type Provides struct {
+	comp haagent.Component
+}
+
+// Mock returns a mock for haagent component.
+func Mock(_ *testing.T) Provides {
+	return Provides{
+		comp: &mock{},
+	}
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -474,6 +474,10 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.reverse_dns_enrichment.timeout", 5000)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
+	// HA Agent
+	config.BindEnvAndSetDefault("ha_agent.enabled", false)
+	config.BindEnv("ha_agent.group")
+
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")
 	config.BindEnvAndSetDefault("kubernetes_apiserver_ca_path", "")

--- a/releasenotes/notes/add_haagent_comp-060918c70bcadb08.yaml
+++ b/releasenotes/notes/add_haagent_comp-060918c70bcadb08.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    [ha-agent] Add haagent component used for HA Agent feature.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[ha-agent] Add haagent component that will be used for HA Agent feature.

### Motivation

haagent component is needed for High Availability Agent project.

### Describe how to test/QA your changes

This component doesn't do anything as it, it will be used by follow-up PRs:
https://github.com/DataDog/datadog-agent/pull/31156
https://github.com/DataDog/datadog-agent/pull/31172
https://github.com/DataDog/datadog-agent/pull/31186

Right now, assessing that agent still start normally is enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->