### PR TITLE
Implement IsSet and AllKeys

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/DataDog/viper"
 	"github.com/mohae/deepcopy"
-	"github.com/spf13/afero"
 	"go.uber.org/atomic"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -390,25 +390,20 @@ func (c *ntmConfig) ParseEnvAsSlice(key string, fn func(string) []interface{}) {
 	c.envTransform[strings.ToLower(key)] = func(k string) interface{} { return fn(k) }
 }
 
-// SetFs assigns a filesystem to the config
-func (c *ntmConfig) SetFs(fs afero.Fs) {
-	c.Lock()
-	defer c.Unlock()
-	c.noimpl.SetFs(fs)
-}
-
 // IsSet checks if a key is set in the config
 func (c *ntmConfig) IsSet(key string) bool {
 	c.RLock()
 	defer c.RUnlock()
-	return c.noimpl.IsSet(key)
+
+	return c.IsKnown(key)
 }
 
 // AllKeysLowercased returns all keys lower-cased
 func (c *ntmConfig) AllKeysLowercased() []string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.noimpl.AllKeys()
+
+	return maps.Keys(c.knownKeys)
 }
 
 func (c *ntmConfig) leafAtPath(key string) LeafNode {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -8,6 +8,7 @@ package nodetreemodel
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -309,4 +310,30 @@ func TestAllSettingsBySource(t *testing.T) {
 		model.SourceCLI:                map[string]interface{}{},
 	}
 	assert.Equal(t, expected, cfg.AllSettingsBySource())
+}
+
+func TestIsSet(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.BuildSchema()
+
+	cfg.Set("b", 123, model.SourceAgentRuntime)
+
+	assert.True(t, cfg.IsSet("b"))
+	assert.True(t, cfg.IsSet("a"))
+	assert.False(t, cfg.IsSet("unknown"))
+}
+
+func TestAllKeysLowercased(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.BuildSchema()
+
+	cfg.Set("b", 123, model.SourceAgentRuntime)
+
+	keys := cfg.AllKeysLowercased()
+	sort.Strings(keys)
+	assert.Equal(t, []string{"a", "b"}, keys)
 }

--- a/pkg/config/nodetreemodel/go.mod
+++ b/pkg/config/nodetreemodel/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3
 	github.com/DataDog/viper v1.13.5
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/spf13/afero v1.11.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6
@@ -30,6 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/pkg/config/nodetreemodel/noimpl_methods.go
+++ b/pkg/config/nodetreemodel/noimpl_methods.go
@@ -9,13 +9,9 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/spf13/afero"
 )
 
 type notImplementedMethods interface {
-	SetFs(afero.Fs)
-	IsSet(string) bool
-	AllKeys() []string
 	GetStringSliceE(string) ([]string, error)
 	GetStringMapE(string) (map[string]interface{}, error)
 	GetStringMapStringE(string) (map[string]string, error)
@@ -24,20 +20,6 @@ type notImplementedMethods interface {
 }
 
 type notImplMethodsImpl struct{}
-
-func (n *notImplMethodsImpl) SetFs(afero.Fs) {
-	n.logErrorNotImplemented("SetFs")
-}
-
-func (n *notImplMethodsImpl) IsSet(string) bool {
-	n.logErrorNotImplemented("IsSet")
-	return false
-}
-
-func (n *notImplMethodsImpl) AllKeys() []string {
-	n.logErrorNotImplemented("AllKeys")
-	return nil
-}
 
 func (n *notImplMethodsImpl) GetStringSliceE(string) ([]string, error) {
 	return nil, n.logErrorNotImplemented("GetStringSliceE")


### PR DESCRIPTION
### What does this PR do?

Implement `IsSet` and `AllKeys`.

`IsSet` implementation is different from viper. We check if the keys exists where viper checked if the key existed and was different from `nil`. This was a edge case force by viper's internal use of `map[string]interface{}`.

### Describe how to test/QA your changes

Unit test were added. This code is not used anywhere for now. We're building a replacement for viper and will QA it entirely, outside of unit-tests, once it's ready.