### PR TITLE
fix(agent.hacky-dev-image-build): fix after rtloader bump

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -529,11 +529,11 @@ RUN apt-get update && \
     apt-get install -y patchelf
 
 COPY bin/agent/agent                            /opt/datadog-agent/bin/agent/agent
-COPY dev/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+COPY dev/lib/libdatadog-agent-rtloader.so.2 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
 COPY dev/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 
 RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/bin/agent/agent
-RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
 RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 
 FROM golang:latest AS dlv
@@ -560,7 +560,7 @@ COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 COPY --from=bash_completion /etc/bash.bashrc /etc/bash.bashrc
 COPY --from=src /usr/src/datadog-agent {os.getcwd()}
 COPY --from=bin /opt/datadog-agent/bin/agent/agent                                 /opt/datadog-agent/bin/agent/agent
-COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
 COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 {copy_extra_agents}
 RUN agent          completion bash > /usr/share/bash-completion/completions/agent


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the `agent.hacky-dev-image-build` task after the `rtloader` version bump.

### Motivation

Needed to fix the `agent.hacky-dev-image-build` task as the `agent` binary now require the following shared library:
```
root@datadog-agent-6z6dw:/opt/datadog-agent/embedded/lib# ldd /opt/datadog-agent/bin/agent/agent | grep rtloader
	libdatadog-agent-rtloader.so.2 => /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2 (0x0000ffff80880000)
```

### Describe how to test/QA your changes

Run the `agent.hacky-dev-image-build` task and verify that the image is built correctly:
```
datadog@034906835b81:~/go/src/github.com/DataDog/datadog-agent$ DELVE=1 inv -e agent.build && inv agent.hacky-dev-image-build --target-image=wdhifdatadog/agent --push
cd /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build && cmake  -G "Unix Makefiles" -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/home/datadog/go/src/github.com/DataDog/datadog-agent/dev /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader
-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter Development Development.Module Development.Embed
-- Configuring done
-- Generating done
-- Build files have been written to: /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build
make -C /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build
make: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[1]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-rtloader
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 23%] Built target datadog-agent-rtloader
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-three
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 29%] Building CXX object three/CMakeFiles/datadog-agent-three.dir/three.cpp.o
[ 35%] Building CXX object three/CMakeFiles/datadog-agent-three.dir/three_mem.cpp.o
[ 41%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/cgo_free.c.o
[ 47%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/stringutils.c.o
[ 52%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/log.c.o
[ 58%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/aggregator.c.o
[ 64%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/datadog_agent.c.o
[ 70%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/util.c.o
[ 76%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/_util.c.o
[ 82%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/tagger.c.o
[ 88%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/kubeutil.c.o
[ 94%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/containers.c.o
[100%] Linking CXX shared library libdatadog-agent-three.so
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[100%] Built target datadog-agent-three
make[1]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make -C /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build install
make: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[1]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 23%] Built target datadog-agent-rtloader
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-three
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[100%] Built target datadog-agent-three
make[1]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Install the project...
-- Install configuration: ""
-- Installing: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-three.so
-- Set runtime path of "/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-three.so" to ""
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.0.1.0
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.2
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/datadog_agent_rtloader.h
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/rtloader_types.h
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/rtloader_mem.h
make: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
--- Setting rtloader paths to lib:/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib | header:/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include | common headers:
go build -mod=mod   -tags "bundle_security_agent fargateprocess consul gce kubelet containerd docker jetson cri zk otlp podman netcgo bundle_trace_agent bundle_process_agent python datadog.no_waf kubeapiserver oracle process etcd bundle_agent systemd apm orchestrator jmx zlib ec2 zstd trivy" -o ./bin/agent/agent -gcflags="all=-N -l" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.Commit=7cafc5c146 -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=7.61.0-devel+git.152.7cafc5c -X github.com/DataDog/datadog-agent/pkg/serializer.AgentPayloadVersion=v5.0.135 -X github.com/DataDog/datadog-agent/pkg/config/setup.ForceDefaultPython=true -X github.com/DataDog/datadog-agent/pkg/config/setup.DefaultPython=3 -r /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib '-extldflags=-Wl,-z,lazy ' " github.com/DataDog/datadog-agent/cmd/agent
gcc -DDD_AGENT_PATH='"/home/datadog/go/src/github.com/DataDog/datadog-agent/bin/agent/agent"' -DDD_AGENT='"process-agent"' -o ./bin/process-agent/process-agent ./cmd/agent/launcher/launcher.c
gcc -DDD_AGENT_PATH='"/home/datadog/go/src/github.com/DataDog/datadog-agent/bin/agent/agent"' -DDD_AGENT='"trace-agent"' -o ./bin/trace-agent/trace-agent ./cmd/agent/launcher/launcher.c
gcc -DDD_AGENT_PATH='"/home/datadog/go/src/github.com/DataDog/datadog-agent/bin/agent/agent"' -DDD_AGENT='"security-agent"' -o ./bin/security-agent/security-agent ./cmd/agent/launcher/launcher.c
go run ./pkg/config/render_config.go agent-py3 ./pkg/config/config_template.yaml ./cmd/agent/dist/datadog.yaml
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/datadog.yaml
go run ./pkg/config/render_config.go system-probe ./pkg/config/config_template.yaml ./cmd/agent/dist/system-probe.yaml
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/system-probe.yaml
go run ./pkg/config/render_config.go security-agent ./pkg/config/config_template.yaml ./cmd/agent/dist/security-agent.yaml
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/security-agent.yaml
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
-- Found Python3: /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/bin/python3 (found version "3.12.6") found components: Interpreter Development Development.Module Development.Embed
-- Configuring done
-- Generating done
-- Build files have been written to: /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build
make: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[1]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-rtloader
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 23%] Built target datadog-agent-rtloader
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-three
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 29%] Building CXX object three/CMakeFiles/datadog-agent-three.dir/three.cpp.o
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp: In member function ‘void Three::initPythonHome(const char*)’:
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:71:21: warning: ‘void Py_SetPythonHome(const wchar_t*)’ is deprecated [-Wdeprecated-declarations]
   71 |     Py_SetPythonHome(_pythonHome);
      |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
In file included from /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/Python.h:94,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.h:15,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:6:
/tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/pylifecycle.h:40:38: note: declared here
   40 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetPythonHome(const wchar_t *);
      |                                      ^~~~~~~~~~~~~~~~
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp: In member function ‘void Three::initPythonExe(const char*)’:
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:81:22: warning: ‘void Py_SetProgramName(const wchar_t*)’ is deprecated [-Wdeprecated-declarations]
   81 |     Py_SetProgramName(_pythonExe);
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
In file included from /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/Python.h:94,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.h:15,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:6:
/tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/pylifecycle.h:37:38: note: declared here
   37 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
      |                                      ^~~~~~~~~~~~~~~~~
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:88:27: warning: ‘void _Py_SetProgramFullPath(const wchar_t*)’ is deprecated [-Wdeprecated-declarations]
   88 |     _Py_SetProgramFullPath(_pythonExe);
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
In file included from /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/pylifecycle.h:71,
                 from /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/Python.h:94,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.h:15,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:6:
/tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/cpython/pylifecycle.h:49:38: note: declared here
   49 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) _Py_SetProgramFullPath(const wchar_t *);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp: In member function ‘virtual bool Three::init()’:
/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:101:5: warning: ‘Py_UTF8Mode’ is deprecated [-Wdeprecated-declarations]
  101 |     Py_UTF8Mode = 1;
      |     ^~~~~~~~~~~
In file included from /tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/Python.h:72,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.h:15,
                 from /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/three/three.cpp:6:
/tmp/tmplr2wxwb8/opt/datadog-agent/embedded/include/python3.12/fileobject.h:29:37: note: declared here
   29 | Py_DEPRECATED(3.12) PyAPI_DATA(int) Py_UTF8Mode;
      |                                     ^~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-deprecated-register’ may have been intended to silence earlier diagnostics
[ 35%] Building CXX object three/CMakeFiles/datadog-agent-three.dir/three_mem.cpp.o
[ 41%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/cgo_free.c.o
[ 47%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/stringutils.c.o
[ 52%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/log.c.o
[ 58%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/aggregator.c.o
[ 64%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/datadog_agent.c.o
[ 70%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/util.c.o
[ 76%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/_util.c.o
[ 82%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/tagger.c.o
[ 88%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/kubeutil.c.o
[ 94%] Building C object three/CMakeFiles/datadog-agent-three.dir/__/common/builtins/containers.c.o
[100%] Linking CXX shared library libdatadog-agent-three.so
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[100%] Built target datadog-agent-three
make[1]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[1]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[ 23%] Built target datadog-agent-rtloader
make[2]: Entering directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Consolidate compiler generated dependencies of target datadog-agent-three
make[2]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
[100%] Built target datadog-agent-three
make[1]: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
Install the project...
-- Install configuration: ""
-- Installing: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-three.so
-- Set runtime path of "/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-three.so" to ""
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.0.1.0
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.2
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib/libdatadog-agent-rtloader.so
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/datadog_agent_rtloader.h
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/rtloader_types.h
-- Up-to-date: /home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include/rtloader_mem.h
make: Leaving directory '/home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build'
--- Setting rtloader paths to lib:/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/lib | header:/home/datadog/go/src/github.com/DataDog/datadog-agent/dev/include | common headers:
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/datadog.yaml
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/system-probe.yaml
Successfully wrote /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/security-agent.yaml
#0 building with "default" instance using docker driver

#1 [internal] load build definition from tmp5xkhej7e
#1 transferring dockerfile: 2.59kB done
#1 DONE 0.0s

#2 [internal] load metadata for gcr.io/datadoghq/agent:7.59.0
#2 DONE 0.0s

#3 [auth] library/golang:pull token for registry-1.docker.io
#3 DONE 0.0s

#4 [auth] library/ubuntu:pull token for registry-1.docker.io
#4 DONE 0.0s

#5 [internal] load metadata for docker.io/library/golang:latest
#5 DONE 0.7s

#6 [internal] load metadata for docker.io/library/ubuntu:latest
#6 DONE 0.7s

#7 [internal] load .dockerignore
#7 transferring context: 2B done
#7 DONE 0.0s

#8 [dlv 1/2] FROM docker.io/library/golang:latest@sha256:d56c3e08fe5b27729ee3834854ae8f7015af48fd651cd25d1e3bcf3c19830174
#8 DONE 0.0s

#9 [bash_completion 1/3] FROM gcr.io/datadoghq/agent:7.59.0
#9 DONE 0.0s

#10 [bin 1/8] FROM docker.io/library/ubuntu:latest@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5
#10 resolve docker.io/library/ubuntu:latest@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5 done
#10 DONE 0.0s

#11 [internal] load build context
#11 transferring context: 493.37MB 5.0s
#11 transferring context: 1.05GB 10.1s
#11 transferring context: 1.20GB 12.3s done
#11 DONE 12.3s

#12 [bin 2/8] RUN apt-get update &&     apt-get install -y patchelf
#12 CACHED

#10 [bin 1/8] FROM docker.io/library/ubuntu:latest@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5
#10 CACHED

#13 [src 2/4] COPY . /usr/src/datadog-agent
#13 ...

#14 [bin 3/8] COPY bin/agent/agent                            /opt/datadog-agent/bin/agent/agent
#14 DONE 0.6s

#15 [bin 4/8] COPY dev/lib/libdatadog-agent-rtloader.so.2 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
#15 DONE 0.1s

#13 [src 2/4] COPY . /usr/src/datadog-agent
#13 ...

#16 [bin 5/8] COPY dev/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
#16 DONE 0.1s

#17 [bin 6/8] RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/bin/agent/agent
#17 DONE 0.8s

#13 [src 2/4] COPY . /usr/src/datadog-agent
#13 ...

#18 [bin 7/8] RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
#18 DONE 0.4s

#19 [bin 8/8] RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
#19 DONE 0.1s

#13 [src 2/4] COPY . /usr/src/datadog-agent
#13 DONE 3.6s

#20 [src 3/4] RUN find /usr/src/datadog-agent -type f ! -name *.go -print0 | xargs -0 rm
#20 DONE 0.6s

#21 [src 4/4] RUN find /usr/src/datadog-agent -type d -empty -print0 | xargs -0 rmdir
#21 DONE 0.3s

#22 [stage-4  2/13] RUN apt-get update &&     apt-get install -y bash-completion less vim tshark &&     apt-get clean
#22 CACHED

#23 [dlv 2/2] RUN go install github.com/go-delve/delve/cmd/dlv@latest
#23 CACHED

#24 [stage-4  3/13] COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
#24 CACHED

#25 [bash_completion 2/3] RUN apt-get update &&     apt-get install -y gawk
#25 CACHED

#26 [bash_completion 3/3] RUN awk -i inplace '!/^#/ {uncomment=0} uncomment {gsub(/^#/, "")} /# enable bash completion/ {uncomment=1} {print}' /etc/bash.bashrc
#26 CACHED

#27 [stage-4  4/13] COPY --from=bash_completion /etc/bash.bashrc /etc/bash.bashrc
#27 CACHED

#28 [stage-4  5/13] COPY --from=src /usr/src/datadog-agent /home/datadog/go/src/github.com/DataDog/datadog-agent
#28 DONE 0.4s

#29 [stage-4  6/13] COPY --from=bin /opt/datadog-agent/bin/agent/agent                                 /opt/datadog-agent/bin/agent/agent
#29 DONE 0.3s

#30 [stage-4  7/13] COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2
#30 DONE 0.0s

#31 [stage-4  8/13] COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
#31 DONE 0.0s

#32 [stage-4  9/13] RUN agent          completion bash > /usr/share/bash-completion/completions/agent
#32 DONE 0.2s

#33 [stage-4 10/13] RUN process-agent  completion bash > /usr/share/bash-completion/completions/process-agent
#33 DONE 0.2s

#34 [stage-4 11/13] RUN security-agent completion bash > /usr/share/bash-completion/completions/security-agent
#34 DONE 0.2s

#35 [stage-4 12/13] RUN system-probe   completion bash > /usr/share/bash-completion/completions/system-probe
#35 DONE 0.2s

#36 [stage-4 13/13] RUN trace-agent    completion bash > /usr/share/bash-completion/completions/trace-agent
#36 DONE 0.2s

#37 exporting to image
#37 exporting layers
#37 exporting layers 0.3s done
#37 writing image sha256:96cf527614b0bcc010eb3536a8aa19e73925dd4ad563e93066a11dcd9d5d02e4
#37 writing image sha256:96cf527614b0bcc010eb3536a8aa19e73925dd4ad563e93066a11dcd9d5d02e4 done
#37 naming to docker.io/wdhifdatadog/agent done
#37 DONE 0.4s
Using default tag: latest
The push refers to repository [docker.io/wdhifdatadog/agent]
6d1b39b43095: Preparing
a094101946c1: Preparing
b33559030778: Preparing
2d6a7730d5c4: Preparing
826f105976e3: Preparing
1ed7dcfb39a7: Preparing
99b06bd10774: Preparing
dade42bdbfeb: Preparing
e9791184a520: Preparing
098f592c907d: Preparing
84f8bd46e693: Preparing
04b64306f42e: Preparing
27bf1e965246: Preparing
dade42bdbfeb: Waiting
e9791184a520: Waiting
84f8bd46e693: Waiting
098f592c907d: Waiting
04b64306f42e: Waiting
27bf1e965246: Waiting
1ed7dcfb39a7: Waiting
99b06bd10774: Waiting
6d1b39b43095: Pushed
a094101946c1: Pushed
826f105976e3: Pushed
2d6a7730d5c4: Pushed
b33559030778: Pushed
098f592c907d: Layer already exists
84f8bd46e693: Layer already exists
04b64306f42e: Layer already exists
27bf1e965246: Layer already exists
99b06bd10774: Pushed
1ed7dcfb39a7: Pushed
e9791184a520: Pushed
dade42bdbfeb: Pushed
latest: digest: sha256:40688f0372c066b075bf384cf557eef8b4ed839c9587f397f87dc81ecd1e6653 size: 3044
```

Validate that the image works:
```
➜ kex daemonsets/datadog-agent -- agent status
Defaulted container "agent" out of: agent, trace-agent, process-agent, security-agent, system-probe, init-volume (init), init-config (init), seccomp-setup (init)
Getting the status from the agent.

=====================================
Agent (v7.61.0-devel+git.152.7cafc5c)
=====================================
  Status date: 2024-11-08 17:14:43.595 UTC (1731086083595)
  Agent start: 2024-11-08 17:13:44.284 UTC (1731086024284)
  Pid: 5624
  Go Version: go1.22.8
  Python Version: 3.12.6
  Build arch: arm64
  Agent flavor: agent
  Log Level: error
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Relates to https://github.com/DataDog/datadog-agent/pull/30161