### PR TITLE
Introduce telemetry macro for ring buffer helper

### DIFF
--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -50,16 +50,17 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
 
 #define MK_FN_INDX(fn) FN_INDX_##fn
 
-#define FN_INDX_bpf_probe_read read_indx
+#define FN_INDX_bpf_probe_read bpf_probe_read_indx
 
-#define FN_INDX_bpf_probe_read_kernel read_kernel_indx
-#define FN_INDX_bpf_probe_read_kernel_str read_kernel_indx
+#define FN_INDX_bpf_probe_read_kernel bpf_probe_read_kernel_indx
+#define FN_INDX_bpf_probe_read_kernel_str bpf_probe_read_kernel_indx
 
-#define FN_INDX_bpf_probe_read_user read_user_indx
-#define FN_INDX_bpf_probe_read_user_str read_user_indx
+#define FN_INDX_bpf_probe_read_user bpf_probe_read_user_indx
+#define FN_INDX_bpf_probe_read_user_str bpf_probe_read_user_indx
 
-#define FN_INDX_bpf_skb_load_bytes skb_load_bytes
-#define FN_INDX_bpf_perf_event_output perf_event_output
+#define FN_INDX_bpf_skb_load_bytes bpf_skb_load_bytes_indx
+#define FN_INDX_bpf_perf_event_output bpf_perf_event_output_indx
+#define FN_INDX_bpf_ringbuf_output bpf_ringbuf_output_indx
 
 #define helper_with_telemetry(fn, ...)                                                          \
     ({                                                                                          \
@@ -150,5 +151,8 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
 
 #define bpf_perf_event_output_with_telemetry(...) \
     helper_with_telemetry(bpf_perf_event_output, __VA_ARGS__)
+
+#define bpf_ringbuf_output_with_telemetry(...) \
+    helper_with_telemetry(bpf_ringbuf_output, __VA_ARGS__)
 
 #endif // BPF_TELEMETRY_H

--- a/pkg/ebpf/c/telemetry_types.h
+++ b/pkg/ebpf/c/telemetry_types.h
@@ -11,12 +11,13 @@ typedef struct {
     unsigned long err_count[T_MAX_ERRNO];
 } map_err_telemetry_t;
 
-#define read_indx 0
-#define read_user_indx 1
-#define read_kernel_indx 2
-#define skb_load_bytes 3
-#define perf_event_output 4
-#define MAX_TELEMETRY_INDX 5
+#define bpf_probe_read_indx         0
+#define bpf_probe_read_user_indx    1
+#define bpf_probe_read_kernel_indx  2
+#define bpf_skb_load_bytes_indx     3
+#define bpf_perf_event_output_indx  4
+#define bpf_ringbuf_output_indx     5
+#define MAX_TELEMETRY_INDX          6
 typedef struct {
     unsigned long err_count[MAX_TELEMETRY_INDX * T_MAX_ERRNO];
 } helper_err_telemetry_t;

--- a/pkg/ebpf/telemetry/errors_collector_linux_test.go
+++ b/pkg/ebpf/telemetry/errors_collector_linux_test.go
@@ -145,14 +145,14 @@ func TestEBPFErrorsCollector_SingleCollect(t *testing.T) {
 				resourceName: &MockProgramName{n: mockProbeName},
 				moduleName:   names.NewModuleName("m3"),
 			},
-		}: {Count: [320]uint64{helperErrorsMockValue}},
+		}: {Count: [384]uint64{helperErrorsMockValue}},
 		{
 			eBPFKey: 3,
 			tKey: telemetryKey{
 				resourceName: &MockProgramName{n: mockProbeName},
 				moduleName:   names.NewModuleName("m4"),
 			},
-		}: {Count: [320]uint64{helperErrorsMockValue}},
+		}: {Count: [384]uint64{helperErrorsMockValue}},
 	}
 
 	//check expected metrics and labels
@@ -251,14 +251,14 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 				resourceName: &MockProgramName{n: mockProbeName},
 				moduleName:   names.NewModuleName("m3"),
 			},
-		}: {Count: [320]uint64{helperErrorsMockValue1}},
+		}: {Count: [384]uint64{helperErrorsMockValue1}},
 		{
 			eBPFKey: 3,
 			tKey: telemetryKey{
 				resourceName: &MockProgramName{n: mockProbeName},
 				moduleName:   names.NewModuleName("m4"),
 			},
-		}: {Count: [320]uint64{helperErrorsMockValue1}},
+		}: {Count: [384]uint64{helperErrorsMockValue1}},
 	}
 
 	//in this test we expect the values to match the delta between second and first collects
@@ -318,14 +318,14 @@ func TestEBPFErrorsCollector_DoubleCollect(t *testing.T) {
 					resourceName: &MockProgramName{n: mockProbeName},
 					moduleName:   names.NewModuleName("m3"),
 				},
-			}: {Count: [320]uint64{helperErrorsMockValue2}},
+			}: {Count: [384]uint64{helperErrorsMockValue2}},
 			{
 				eBPFKey: 3,
 				tKey: telemetryKey{
 					resourceName: &MockProgramName{n: mockProbeName},
 					moduleName:   names.NewModuleName("m4"),
 				},
-			}: {Count: [320]uint64{helperErrorsMockValue2}},
+			}: {Count: [384]uint64{helperErrorsMockValue2}},
 		},
 	}
 

--- a/pkg/ebpf/telemetry/errors_telemetry.go
+++ b/pkg/ebpf/telemetry/errors_telemetry.go
@@ -30,6 +30,7 @@ const (
 	readKernelIndx
 	skbLoadBytes
 	perfEventOutput
+	ringbufOutput
 	mapErr = math.MaxInt
 )
 
@@ -39,6 +40,7 @@ var helperNames = map[int]string{
 	readKernelIndx:  "bpf_probe_read_kernel",
 	skbLoadBytes:    "bpf_skb_load_bytes",
 	perfEventOutput: "bpf_perf_event_output",
+	ringbufOutput:   "bpf_ringbuf_output",
 }
 
 type telemetryKey struct {

--- a/pkg/ebpf/telemetry/types_linux.go
+++ b/pkg/ebpf/telemetry/types_linux.go
@@ -7,5 +7,5 @@ type mapErrTelemetry struct {
 	Count [64]uint64
 }
 type helperErrTelemetry struct {
-	Count [320]uint64
+	Count [384]uint64
 }

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -63,7 +63,7 @@ int BPF_UPROBE(uprobe__cudaLaunchKernel, const void *func, __u64 grid_xy, __u64 
     log_debug("cudaLaunchKernel: EMIT[1/2] pid_tgid=%llu, ts=%llu", launch_data.header.pid_tgid, launch_data.header.ktime_ns);
     log_debug("cudaLaunchKernel: EMIT[2/2] kernel_addr=0x%llx, shared_mem=%llu, stream_id=%llu", launch_data.kernel_addr, launch_data.shared_mem_size, launch_data.header.stream_id);
 
-    bpf_ringbuf_output(&cuda_events, &launch_data, sizeof(launch_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &launch_data, sizeof(launch_data), 0);
 
     return 0;
 }
@@ -107,7 +107,7 @@ int BPF_URETPROBE(uretprobe__cudaMalloc) {
 
     log_debug("cudaMalloc[ret]: EMIT size=%llu, addr=0x%llx, ts=%llu", mem_data.size, (__u64)mem_data.addr, mem_data.header.ktime_ns);
 
-    bpf_ringbuf_output(&cuda_events, &mem_data, sizeof(mem_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), 0);
 
 out:
     bpf_map_delete_elem(&cuda_alloc_cache, &pid_tgid);
@@ -126,7 +126,7 @@ int BPF_UPROBE(uprobe__cudaFree, void *mem) {
     mem_data.addr = (uint64_t)mem;
     mem_data.type = cudaFree;
 
-    bpf_ringbuf_output(&cuda_events, &mem_data, sizeof(mem_data), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &mem_data, sizeof(mem_data), 0);
 
     return 0;
 }
@@ -162,7 +162,7 @@ int BPF_URETPROBE(uretprobe__cudaStreamSynchronize) {
 
     log_debug("cudaStreamSynchronize[ret]: EMIT cudaSync pid_tgid=%llu, stream_id=%llu", event.header.pid_tgid, event.header.stream_id);
 
-    bpf_ringbuf_output(&cuda_events, &event, sizeof(event), 0);
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
     bpf_map_delete_elem(&cuda_sync_cache, &pid_tgid);
 
     return 0;


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR introduces `bpf_ringbuf_output_with_telemetry` macro.

### Motivation

### Describe how to test/QA your changes
Covered by functional tests in KMT

### Possible Drawbacks / Trade-offs
64 byte increase in each helper telemetry map entry

### Additional Notes
More detail about how to view this telemetry provided in confluence
https://datadoghq.atlassian.net/wiki/spaces/EBPF/pages/3097986439/bpf_telemetry+pkg

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->