### PR TITLE
[CONTP-500] Including the internal prefix in tagger for filtering

### DIFF
--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -39,7 +39,7 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 	}
 }
 
-var globalEntityID = types.NewEntityID("internal", "global-entity-id")
+var globalEntityID = types.NewEntityID(types.InternalID, "global-entity-id")
 
 // GetGlobalEntityID returns the entity ID that holds global tags
 func GetGlobalEntityID() types.EntityID {

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -62,6 +62,8 @@ const (
 	KubernetesPodUID EntityIDPrefix = "kubernetes_pod_uid"
 	// Process is the prefix `process`
 	Process EntityIDPrefix = "process"
+	// InternalID is the prefix `internal`
+	InternalID EntityIDPrefix = "internal"
 )
 
 // AllPrefixesSet returns a set of all possible entity id prefixes that can be used in the tagger
@@ -75,5 +77,6 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		KubernetesMetadata:     {},
 		KubernetesPodUID:       {},
 		Process:                {},
+		InternalID:             {},
 	}
 }

--- a/comp/core/tagger/types/filter_builder_test.go
+++ b/comp/core/tagger/types/filter_builder_test.go
@@ -58,6 +58,7 @@ func TestFilterBuilderOps(t *testing.T) {
 					KubernetesMetadata:     {},
 					KubernetesPodUID:       {},
 					Process:                {},
+					InternalID:             {},
 				},
 				cardinality: HighCardinality,
 			},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Addresses a bug in the new 7.60 agent tagger implementation. Ensures that the internal prefix for the global entity (global tags) is properly fetched when filters are in use.

### Motivation

Missing prefix in the EntityIDPrefix list. Noticed missed entity when executing tagger-list.

### Describe how to test/QA your changes

Spin up the cluster agent locally and execute `tagger-list`
```
k exec -it datadog-agent-linux-cluster-agent-5d889975fc-wwcmk -- agent tagger-list
=== Entity internal://global-entity-id ===
== Source workloadmeta-static =
=Tags: [kube_cluster_name:gabedos-v13102-cluster]
===
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We should be defining the **Internal prefix** in `entity_id.go` as an `EntityIDPrefix` to maintain consistency as to how `EntityIDPrefix` is used from `entity_id.go` to `entity_id_builder.go`. 