### PR TITLE
chore(ci): [BARX-571] use docker_x64 for image publishing

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -6,7 +6,7 @@
   SRC_CWS_INSTRUMENTATION: registry.ddbuild.io/ci/datadog-agent/cws-instrumentation
 
 .docker_publish_job_definition:
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
     <<: *docker_variables


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replaces the image used in CI to publish docker images from [deb_x64](https://github.com/DataDog/datadog-agent-buildimages/blob/main/deb-x64/Dockerfile) to [docker_x64](https://github.com/DataDog/datadog-agent-buildimages/blob/main/docker-x64/Dockerfile).

### Motivation

We were informed that some of our image publishing jobs were using anonymous auth and need to properly authenticate. The image used also included a number of dependencies that weren't required for these jobs.

The chosen image is already maintained in `buildimages` and is based off an internal `docker` image which has the proper tools and configuration to authenticate.

### Describe how to test/QA your changes

Verify all jobs inheriting from `.docker_publish_job_definition` still pass.

### Possible Drawbacks / Trade-offs

The chosen image likely still has dependencies that are unused in this job, however it didn't feel like a good trade to create yet another image to use in Agent CI that needs to be maintained.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->