### PR TITLE
[usm] service discovery, add ignored services 'security-agent' and 'system-probe' to system-probe config

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/config_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config_test.go
@@ -137,7 +137,7 @@ func TestConfigIgnoredServices(t *testing.T) {
 		discovery := newDiscovery()
 		require.NotEmpty(t, discovery)
 
-		assert.Equal(t, len(discovery.config.ignoreServices), 4)
+		assert.Equal(t, len(discovery.config.ignoreServices), 6)
 	})
 
 	t.Run("check services in env variable", func(t *testing.T) {

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -408,7 +408,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_services"), []string{"datadog-agent", "trace-agent", "process-agent", "datadog-cluster-agent"})
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_services"), []string{"datadog-agent", "trace-agent", "process-agent", "system-probe", "security-agent", "datadog-cluster-agent"})
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir")


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds two Datadog services **"system-probe", "security-agent"** to list of ignored services in system-probe config file.

### Motivation
Datadog services should not be reported as discovered services on the system.

### Describe how to test/QA your changes
Passed service discovery unit tests on local VM
PASS
ok  	github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/module	39.196s


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->