### PR TITLE
[oracle] Add `query_timeout` parameter

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -315,3 +315,8 @@ instances:
       ## Limit the number of traced check executions to avoid filling the file system.
       #
       # traced_runs: 10
+
+    ## @param query_timeout - int - optional - default: 20000
+    ## Aborts any queries that takes more than the specified number of seconds,
+    #
+    # query_timeout: 20000

--- a/pkg/collector/corechecks/oracle/connection_handling.go
+++ b/pkg/collector/corechecks/oracle/connection_handling.go
@@ -17,7 +17,7 @@ import (
 )
 
 func buildGoOraURL(c *Check) string {
-	connectionOptions := map[string]string{"TIMEOUT": DB_TIMEOUT}
+	connectionOptions := map[string]string{"TIMEOUT": c.config.QueryTimeoutString()}
 	if c.config.Protocol == "TCPS" {
 		connectionOptions["SSL"] = "TRUE"
 		if c.config.Wallet != "" {

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -43,9 +43,6 @@ var MAX_OPEN_CONNECTIONS = 10
 //nolint:revive // TODO(DBM) Fix revive linter
 var DEFAULT_SQL_TRACED_RUNS = 10
 
-//nolint:revive // TODO(DBM) Fix revive linter
-var DB_TIMEOUT = "20000"
-
 const (
 	// MaxSQLFullTextVSQL is SQL_FULLTEXT size in V$SQL
 	MaxSQLFullTextVSQL = 4000

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -46,6 +46,76 @@ func TestConnection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestTimeout(t *testing.T) {
+	const sleepFmt = `DECLARE
+  result NUMBER;
+BEGIN
+  DBMS_SESSION.SLEEP(%d);
+  result := 1;
+  DBMS_OUTPUT.PUT_LINE(result);
+END;`
+	tests := []struct {
+		name         string
+		queryTimeout int
+		sessionSleep int
+	}{
+		{
+			name:         "query_timeout will be overridden to default",
+			queryTimeout: 0,
+			sessionSleep: 0,
+		},
+		{
+			name:         "query_timeout should be respected",
+			queryTimeout: 1,
+			sessionSleep: 30,
+		},
+		{
+			name:         "query should be done before query_timeout",
+			queryTimeout: 5,
+			sessionSleep: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := newDefaultCheck(t, "", "")
+			c.config.ConnectionConfig.QueryTimeout = tt.queryTimeout
+			defer c.Teardown()
+			if tt.queryTimeout <= 0 {
+				require.Equal(t, 20000*time.Second, c.config.QueryTimeoutDuration())
+				return
+			}
+			require.Equal(t, time.Duration(tt.queryTimeout)*time.Second, c.config.QueryTimeoutDuration())
+			var err error
+			c.db, err = c.Connect()
+			require.NoError(t, err)
+
+			testDone := make(chan struct{})
+			go func() {
+				toBeIgnored := make([]struct{}, 0, 1)
+				err := c.db.Select(&toBeIgnored, fmt.Sprintf(sleepFmt, tt.sessionSleep))
+				if tt.queryTimeout < tt.sessionSleep {
+					require.Contains(t, err.Error(), "timeout")
+				} else {
+					require.NoError(t, err)
+					result, err := getSession(&c)
+					require.NoError(t, err)
+					require.NotEmpty(t, result)
+				}
+				close(testDone)
+			}()
+
+			select {
+			case <-time.After(10 * time.Second):
+				// To detect if timeout is not working.
+				t.Errorf("test didn't finish in 10 seconds")
+				t.FailNow()
+			case <-testDone:
+				return
+			}
+		})
+	}
+}
+
 func connectToDB(driver string) (*sqlx.DB, error) {
 	var connStr string
 	connectionConfig := getConnectData(nil, useDefaultUser)

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -341,7 +341,7 @@ func buildConnectionString(connectionConfig config.ConnectionConfig) string {
 			connectionConfig.Username, connectionConfig.Password, protocolString, connectionConfig.Server,
 			connectionConfig.Port, connectionConfig.ServiceName, walletString)
 	} else {
-		connectionOptions := map[string]string{"TIMEOUT": DB_TIMEOUT}
+		connectionOptions := map[string]string{"TIMEOUT": connectionConfig.QueryTimeoutString()}
 		if connectionConfig.Protocol == "TCPS" {
 			connectionOptions["SSL"] = "TRUE"
 			if connectionConfig.Wallet != "" {

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -34,7 +34,7 @@ const (
 )
 
 const (
-	expectedSessionsDefault           = 2
+	expectedSessionsDefault           = 3
 	expectedSessionsWithCustomQueries = 3
 )
 

--- a/releasenotes/notes/add-query-timeout-to-oracle-config-9eb01fbed78dc209.yaml
+++ b/releasenotes/notes/add-query-timeout-to-oracle-config-9eb01fbed78dc209.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``query_timeout`` to customize the timeout for queries in the Oracle check.
+    Previously, this was fixed at 20,000 seconds.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make timeout configurable via `query_timeout`.

### Motivation

https://github.com/DataDog/datadog-agent/pull/30643#issuecomment-2463991628

### Describe how to test/QA your changes

```bash
cd ./pkg/collector/corechecks/oracle/compose
docker compose up -d
go test -v -timeout 30s -tags oracle,oracle_test,test ./pkg/collector/corechecks/oracle/...
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->