### PR TITLE
Add debug logs to RC db operations

### DIFF
--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -11,12 +11,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/DataDog/go-tuf/client"
 	"github.com/DataDog/go-tuf/data"

--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -175,7 +175,7 @@ func (ts *transactionalStore) commit() error {
 		return nil
 	})
 	if err != nil {
-		log.Debugf("Failed Commit", err)
+		log.Debugf("Failed Commit: %s", err.Error())
 	} else {
 		log.Debugf("Commit successful. %d keys", len(ts.cachedData))
 	}

--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -175,7 +175,7 @@ func (ts *transactionalStore) commit() error {
 		return nil
 	})
 	if err != nil {
-		log.Debugf("Failed Commit: %s", err.Error())
+		log.Debugf("Failed Commit: %v", err)
 	} else {
 		log.Debugf("Commit successful. %d keys", len(ts.cachedData))
 	}

--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -8,6 +8,7 @@ package uptane
 import (
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
@@ -173,34 +174,40 @@ func (ts *transactionalStore) commit() error {
 		}
 		return nil
 	})
-	ts.clearCache()
-	return err
-}
-
-func (ts *transactionalStore) clearCache() {
-	for k := range ts.cachedData {
-		delete(ts.cachedData, k)
+	if err != nil {
+		log.Debugf("Failed Commit", err)
+	} else {
+		log.Debugf("Commit successful. %d keys", len(ts.cachedData))
 	}
+	ts.cachedData = make(map[string]dbBucket)
+
+	return err
 }
 
 // removes all cached changes
 func (ts *transactionalStore) rollback() {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
-	ts.clearCache()
+	if len(ts.cachedData) > 0 {
+		log.Debugf("Rollback of %d keys", len(ts.cachedData))
+		ts.cachedData = make(map[string]dbBucket)
+	}
 }
 
 func (t *transaction) put(bucketName string, path string, data []byte) {
+	log.Debugf("Putting %s in bucket %s", path, bucketName)
 	bucket := t.store.getMemBucket(bucketName)
 	bucket[path] = data
 }
 
 func (t *transaction) delete(bucketName string, path string) {
+	log.Debugf("Deleting %s from bucket %s", path, bucketName)
 	bucket := t.store.getMemBucket(bucketName)
 	bucket[path] = nil
 }
 
 func (t *transaction) get(bucketName string, path string) ([]byte, error) {
+	log.Debugf("Get %s from bucket %s", path, bucketName)
 	bucket := t.store.getMemBucket(bucketName)
 
 	// check if it's present in the in-memory cache


### PR DESCRIPTION
We have currently no way to look into the operation being executed on
the store in case of incidents, we need to add debug logs.

QA
- Validate that RC functions as normal but generates debug logs of database operations
