### PR TITLE
[APM] Fix race condition on test buffer

### DIFF
--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -434,6 +434,7 @@ func TestActualServer(t *testing.T) {
 	assert.Equal(200, resp.StatusCode)
 
 	close(done)
+	log.SetLogger(log.NoopLogger) // prevent race conditions on test buffer
 	r.telemetryForwarder.Stop()
 	assert.Equal(uint64(1), endpointCalled.Load())
 	assert.NotContains(logs.String(), "ERROR")


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes https://datadoghq.atlassian.net/browse/APMSP-1529

This buffer can be accessed simultaneously by the main loop and the test read statement. Once the test logic is executed, we reset the logger used to prevent the data rance when calling `logs.String()`


### Motivation

https://datadoghq.atlassian.net/browse/APMSP-1529

### Describe how to test/QA your changes

Unit tests cover this change.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->