### PR TITLE
[ebpfless] Make UDP tests pass in ebpfless test suite

### DIFF
--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -251,9 +251,6 @@ func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionSt
 		return
 	}
 
-	// @stu
-	//if conn.Source.IsLoopback() || conn.Source.IsUnspecified()
-
 	switch pktType {
 	case unix.PACKET_HOST:
 		conn.Direction = network.INCOMING

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -195,11 +195,20 @@ func (t *ebpfLessTracer) processConnection(
 		conn.Duration = time.Duration(time.Now().UnixNano())
 	}
 
+	if ip4 == nil && ip6 == nil {
+		return nil
+	}
 	var err error
 	switch conn.Type {
 	case network.UDP:
+		if (ip4 != nil && !t.config.CollectUDPv4Conns) || (ip6 != nil && !t.config.CollectUDPv6Conns) {
+			return nil
+		}
 		err = t.udp.process(conn, pktType, udp)
 	case network.TCP:
+		if (ip4 != nil && !t.config.CollectTCPv4Conns) || (ip6 != nil && !t.config.CollectTCPv6Conns) {
+			return nil
+		}
 		err = t.tcp.process(conn, pktType, ip4, ip6, tcp)
 	default:
 		err = fmt.Errorf("unsupported connection type %d", conn.Type)
@@ -242,13 +251,14 @@ func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionSt
 		return
 	}
 
-	if conn.Type == network.TCP {
-		switch pktType {
-		case unix.PACKET_HOST:
-			conn.Direction = network.INCOMING
-		case unix.PACKET_OUTGOING:
-			conn.Direction = network.OUTGOING
-		}
+	// @stu
+	//if conn.Source.IsLoopback() || conn.Source.IsUnspecified()
+
+	switch pktType {
+	case unix.PACKET_HOST:
+		conn.Direction = network.INCOMING
+	case unix.PACKET_OUTGOING:
+		conn.Direction = network.OUTGOING
 	}
 }
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -586,11 +586,6 @@ func (s *TracerSuite) TestUnconnectedUDPSendIPv6() {
 	bytesSent, err := conn.WriteTo(message, remoteAddr)
 	require.NoError(t, err)
 
-	bytes := make([]byte, 100)
-	n, _, err := conn.ReadFromUDP(bytes)
-	require.NoError(t, err)
-	require.Equal(t, string(message), string(bytes[:n]))
-
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		connections := getConnections(t, tr)
 		outgoing := network.FilterConnections(connections, func(cs network.ConnectionStats) bool {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1178,12 +1178,12 @@ func (s *TracerSuite) TestConnectedUDPSendIPv6() {
 		outgoing = network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
 			return cs.DPort == uint16(remotePort)
 		})
-		if !assert.Len(t, outgoing, 1) {
+		if !assert.Len(ct, outgoing, 1) {
 			return
 		}
 
-		assert.Equal(t, remoteAddr.IP.String(), outgoing[0].Dest.String())
-		assert.Equal(t, bytesSent, int(outgoing[0].Monotonic.SentBytes))
+		assert.Equal(ct, remoteAddr.IP.String(), outgoing[0].Dest.String())
+		assert.Equal(ct, bytesSent, int(outgoing[0].Monotonic.SentBytes))
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection")
 
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -452,26 +452,29 @@ func testUDPSendAndReceive(t *testing.T, tr *Tracer, addr string) {
 	require.NoError(t, err)
 
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
-	connections := getConnections(t, tr)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// use t instead of ct because getConnections uses require (not assert), and we get a better error message
+		connections := getConnections(t, tr)
+		incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if assert.True(ct, ok, "unable to find incoming connection") {
+			assert.Equal(ct, network.INCOMING, incoming.Direction)
 
-	incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-	if assert.True(t, ok, "unable to find incoming connection") {
-		assert.Equal(t, network.INCOMING, incoming.Direction)
+			// make sure the inverse values are seen for the other message
+			assert.Equal(ct, serverMessageSize, int(incoming.Monotonic.SentBytes), "incoming sent")
+			assert.Equal(ct, clientMessageSize, int(incoming.Monotonic.RecvBytes), "incoming recv")
+			assert.True(ct, incoming.IntraHost, "incoming intrahost")
+		}
 
-		// make sure the inverse values are seen for the other message
-		assert.Equal(t, serverMessageSize, int(incoming.Monotonic.SentBytes), "incoming sent")
-		assert.Equal(t, clientMessageSize, int(incoming.Monotonic.RecvBytes), "incoming recv")
-		assert.True(t, incoming.IntraHost, "incoming intrahost")
-	}
+		outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if assert.True(t, ok, "unable to find outgoing connection") {
+			assert.Equal(t, network.OUTGOING, outgoing.Direction)
 
-	outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	if assert.True(t, ok, "unable to find outgoing connection") {
-		assert.Equal(t, network.OUTGOING, outgoing.Direction)
+			assert.Equal(t, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")
+			assert.Equal(t, serverMessageSize, int(outgoing.Monotonic.RecvBytes), "outgoing recv")
+			assert.True(t, outgoing.IntraHost, "outgoing intrahost")
+		}
 
-		assert.Equal(t, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")
-		assert.Equal(t, serverMessageSize, int(outgoing.Monotonic.RecvBytes), "outgoing recv")
-		assert.True(t, outgoing.IntraHost, "outgoing intrahost")
-	}
+	}, 3*time.Second, 100*time.Millisecond)
 }
 
 func (s *TracerSuite) TestUDPDisabled() {
@@ -1141,13 +1144,15 @@ func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {
 	bytesSent, err := conn.WriteTo(message, remoteAddr)
 	require.NoError(t, err)
 
-	connections := getConnections(t, tr)
-	outgoing := network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
-		return cs.DPort == uint16(remotePort)
-	})
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		connections := getConnections(t, tr)
+		outgoing := network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
+			return cs.DPort == uint16(remotePort)
+		})
 
-	require.Len(t, outgoing, 1)
-	assert.Equal(t, bytesSent, int(outgoing[0].Monotonic.SentBytes))
+		assert.Len(ct, outgoing, 1)
+		assert.Equal(ct, bytesSent, int(outgoing[0].Monotonic.SentBytes))
+	}, 3*time.Second, 100*time.Millisecond)
 }
 
 func (s *TracerSuite) TestConnectedUDPSendIPv6() {
@@ -1168,18 +1173,19 @@ func (s *TracerSuite) TestConnectedUDPSendIPv6() {
 	require.NoError(t, err)
 
 	var outgoing []network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		connections := getConnections(t, tr)
 		outgoing = network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
 			return cs.DPort == uint16(remotePort)
 		})
+		if !assert.Len(t, outgoing, 1) {
+			return
+		}
 
-		return len(outgoing) == 1
+		assert.Equal(t, remoteAddr.IP.String(), outgoing[0].Dest.String())
+		assert.Equal(t, bytesSent, int(outgoing[0].Monotonic.SentBytes))
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection")
 
-	require.Len(t, outgoing, 1)
-	assert.Equal(t, remoteAddr.IP.String(), outgoing[0].Dest.String())
-	assert.Equal(t, bytesSent, int(outgoing[0].Monotonic.SentBytes))
 }
 
 func (s *TracerSuite) TestTCPDirection() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This makes some minor adjustments to make the UDP test suite pass

### Motivation

Reducing noise in the ebpfless test suite

### Describe how to test/QA your changes

`time DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless`

### Possible Drawbacks / Trade-offs

Changed IP for TestUnconnectedUDPSendIPv6 - gopacket doesn't capture multicast without extra sock_raw configuration

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->