### PR TITLE
[KSM] Fix check failing on startup due to VPA collector

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
@@ -16,7 +16,6 @@ package customresources
 import (
 	"context"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +30,8 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
 var (
@@ -44,12 +45,12 @@ var (
 // NewVerticalPodAutoscalerFactory returns a new VerticalPodAutoscalers metric family generator factory.
 func NewVerticalPodAutoscalerFactory(client *apiserver.APIClient) customresource.RegistryFactory {
 	return &vpaFactory{
-		client: &client.VPAInformerClient,
+		client: client.VPAInformerClient,
 	}
 }
 
 type vpaFactory struct {
-	client *versioned.Interface
+	client versioned.Interface
 }
 
 func (f *vpaFactory) Name() string {
@@ -332,7 +333,7 @@ func wrapVPAFunc(f func(*v1.VerticalPodAutoscaler) *metric.Family) func(interfac
 }
 
 func (f *vpaFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
-	vpaClient := customResourceClient.(versioned.Clientset)
+	vpaClient := customResourceClient.(versioned.Interface)
 	ctx := context.Background()
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes an error following the k8s 1.31 version upgrade, where the KSM check would fail to schedule due to the `verticalpodautoscalers` collector changing names inside of the KSM builder. Original error:
```
Could not configure check kubernetes_state_core: resource verticalpodautoscalers does not exist. 
Available resources: 
rolebindings,
statefulsets,
apiregistration.k8s.io/v1, Resource=apiservices,
core/v1, Resource=nodes_extended,
namespaces,
nodes,
poddisruptionbudgets,
replicationcontrollers,
storageclasses,
ingressclasses,
limitranges,
mutatingwebhookconfigurations,
services,
certificatesigningrequests,
persistentvolumeclaims,
pods,
ingresses,
leases,
replicasets,
resourcequotas,
autoscaling.k8s.io/v1, Resource=verticalpodautoscalers,
clusterroles,
cronjobs,
daemonsets,
validatingwebhookconfigurations,
apiextensions.k8s.io/v1, Resource=customresourcedefinitions,
core/v1, Resource=pods_extended,
clusterrolebindings,
endpoints,
persistentvolumes,
horizontalpodautoscalers,
jobs,
serviceaccounts,
roles,
volumeattachments,
deployments,
endpointslices,
networkpolicies,
configmaps,
secrets,
batch/v1, Resource=jobs_extended
```

While fixing that, a different error popped up resulting in the KSM check panicking, because the incorrect type was being used inside of the `ListWatch` function:
```
panic: interface conversion: interface {} is *versioned.Interface, not versioned.Clientset [recovered]
	panic: interface conversion: interface {} is *versioned.Interface, not versioned.Clientset

goroutine 313 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x8268d68, 0xc3c4ba0}, {0x6d07dc0, 0x40017561b0}, {0xc3c4ba0, 0x0, 0x0})
	/home/datadog/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:89 +0x150
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
	/home/datadog/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:59 +0x1a8
panic({0x6d07dc0?, 0x40017561b0?})
	/home/datadog/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-arm64/src/runtime/panic.go:770 +0xf0
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources.(*vpaFactory).ListWatch(0x4001808790, {0x68a8d20, 0x40001c4b00}, {0x0, 0x0}, {0x0, 0x0})
	/home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go:335 +0x3fc
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder.GenerateStores[...](0x40011fc870, {0x40006dd888, 0x9, 0x9}, {0x754f600, 0x4000ae3340}, {0x68a8d20, 0x40001c4b00}, 0x4000b03068, 0x0)
...
```

And then, after updating only `ListWatch`:
```
panic: interface conversion: *versioned.Interface is not versioned.Interface: missing method AutoscalingV1 [recovered]
	panic: interface conversion: *versioned.Interface is not versioned.Interface: missing method AutoscalingV1

goroutine 294 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x8269d08, 0xc3c5bc0}, {0x6d08d80, 0x4001da5d70}, {0xc3c5bc0, 0x0, 0x0})
	/home/datadog/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:89 +0x150
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
	/home/datadog/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:59 +0x1a8
panic({0x6d08d80?, 0x4001da5d70?})
	/home/datadog/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-arm64/src/runtime/panic.go:770 +0xf0
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources.(*vpaFactory).ListWatch(0x40003876e8, {0x68a9ce0, 0x4000b5e980}, {0x0, 0x0}, {0x0, 0x0})
	/home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go:336 +0x60
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder.GenerateStores[...](0x4000fe8360, {0x40002edc08, 0x9, 0x9}, {0x75505c0, 0x40008b0420}, {0x68a9ce0, 0x4000b5e980}, 0x40010a8ba0, 0x0)
	/home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder/builder.go:209 +0x360
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder.(*Builder).GenerateCustomResourceStoresFunc(0x4000fe8360, {0x767aee2, 0x16}, {0x40002edc08, 0x9, 0x9}, {0x75505c0, 0x40008b0420}, 0x40010a8ba0, 0x0)
	/home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder/builder.go:259 +0x9c
...
```

### Motivation

### Describe how to test/QA your changes

Already done via minikube, with KSM check enabled to use the cluster check runners, and the VPA collector added to the list of collectors. Relevant helm config:
```
datadog:
  kubeStateMetricsCore:
    enabled: true
    collectVpaMetrics: true
    useClusterCheckRunners: true
```

### Possible Drawbacks / Trade-offs

### Additional Notes

Follow-up to https://github.com/DataDog/datadog-agent/pull/30061