### PR TITLE
Add new logs Agent Regression Detector experiment

### DIFF
--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/smp-shared/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/experiment.yaml
@@ -1,0 +1,33 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: total_rss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1.2GiB

--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/lading/lading.yaml
@@ -1,0 +1,34 @@
+generator:
+  - file_gen:
+      logrotate_fs:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          linear:
+            # Over a ten minute experiment this will mean load proceeds from
+            # 10MB to 310MB per second. As a file rotates every 500MB we will
+            # see files rotating, by the end, every two seconds.
+            #
+            # Agent is not expected to keep up.
+            initial_bytes_per_second: 10MB
+            rate: 0.5MB
+        concurrent_logs: 8
+        maximum_bytes_per_log: 500MB
+        total_rotations: 5
+        max_depth: 0
+        variant: "ascii"
+        maximum_prebuild_cache_size_bytes: 300MB
+        mount_point: /smp-shared
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 1000
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
This commit introduces a Regression Detector experiment for logs Agent that has very high intake latency -- 1sec -- and which linearly ramps load as time goes on. We do not expect Agent to keep up and want to stress its ability to handle large numbers of file rotations.

