### PR TITLE
Avoid some reallocations in tailer mechanism

### DIFF
--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -116,9 +116,6 @@ type Tailer struct {
 	// blocked sending to the tailer's outputChan.
 	stopForward context.CancelFunc
 
-	// inBuf holds a buffer for reading from the file.
-	inBuf []byte
-
 	info      *status.InfoRegistry
 	bytesRead *status.CountInfo
 	movingSum *util.MovingSum

--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -38,8 +38,6 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	t.lastReadOffset.Store(ret)
 	t.decodedOffset.Store(ret)
 
-	t.inBuf = make([]byte, 4096)
-
 	return nil
 }
 
@@ -47,7 +45,8 @@ func (t *Tailer) setup(offset int64, whence int) error {
 // until it is closed or the tailer is stopped.
 func (t *Tailer) read() (int, error) {
 	// keep reading data from file
-	n, err := t.osFile.Read(t.inBuf)
+	inBuf := make([]byte, 1024)
+	n, err := t.osFile.Read(inBuf)
 	if err != nil && err != io.EOF {
 		// an unexpected error occurred, stop the tailor
 		t.file.Source.Status().Error(err)
@@ -57,6 +56,6 @@ func (t *Tailer) read() (int, error) {
 		return 0, nil
 	}
 	t.lastReadOffset.Add(int64(n))
-	t.decoder.InputChan <- decoder.NewInput(t.inBuf[:n])
+	t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 	return n, nil
 }


### PR DESCRIPTION
### What does this PR do?

This commit avoids a reallocation of inBuf for every call to the `read` function and sizes a tags array up to the size of its appended members. Small stuff mostly that showed up under the profiler while looking at #30979.

### Motivation

Avoid the CPU time being spent if we can avoid it.

### Describe how to test/QA your changes

Existing tests should cover this.

### Possible Drawbacks / Trade-offs

Slightly larger Tailer struct, although overall GC pressure reduced. Non-nix tailers are not updated in this change. 

