### PR TITLE
Disable fail-fast in create_rc_pr action

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -57,6 +57,7 @@ jobs:
       strategy:
         matrix:
           value: ${{fromJSON(needs.find_release_branches.outputs.branches)}}
+        fail-fast: false
       steps:
             - name: Checkout release branch
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/BARX-676

This PR disables fail-fast strategy in the [Create RC PR](https://github.com/DataDog/datadog-agent/actions/workflows/create_rc_pr.yml) action. This should allow matrix jobs to run independently. 

### Motivation

Fix case when there are multiple release branches and action does not work on one of them.

### Describe how to test/QA your changes

To be tested with the next situation when we have multiple release branches open at the same time.