### PR TITLE
Fix panic in VPA collection in KSM check due to wrong API version

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
@@ -338,11 +338,11 @@ func (f *vpaFactory) ListWatch(customResourceClient interface{}, ns string, fiel
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return vpaClient.AutoscalingV1beta2().VerticalPodAutoscalers(ns).List(ctx, opts)
+			return vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns).List(ctx, opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return vpaClient.AutoscalingV1beta2().VerticalPodAutoscalers(ns).Watch(ctx, opts)
+			return vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns).Watch(ctx, opts)
 		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fix the API version used to fetch VPA in KSM check.

### Motivation

Fix the following panic:
```
panic: interface conversion: interface {} is *v1beta2.VerticalPodAutoscaler, not *v1.VerticalPodAutoscaler [recovered]
        panic: interface conversion: interface {} is *v1beta2.VerticalPodAutoscaler, not *v1.VerticalPodAutoscaler

goroutine 887 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x6db1c48, 0xb0a6ae0}, {0x4cb33a0, 0x4000c2aea0}, {0xb0a6ae0, 0x0, 0x40018076d8?})
        /pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:89 +0xf4
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x400215f180?})
        /pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:59 +0x114
panic({0x4cb33a0?, 0x4000c2aea0?})
        /usr/local/go/src/runtime/panic.go:770 +0x124
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources.(*vpaFactory).MetricFamilyGenerators.wrapVPAFunc.func10({0x54cfde0?, 0x4001df4dc0?})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go:314 +0x214
k8s.io/kube-state-metrics/v2/pkg/metric_generator.(*FamilyGenerator).Generate(0x40000919b0, {0x54cfde0?, 0x4001df4dc0?})
        /pkg/mod/github.com/!l3n41c/kube-state-metrics/v2@v2.13.1-0.20241108192007-8859a4289d92/pkg/metric_generator/generator.go:73 +0x38
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder.GenerateStores[...].ComposeMetricGenFuncs.func1()
        /pkg/mod/github.com/!l3n41c/kube-state-metrics/v2@v2.13.1-0.20241108192007-8859a4289d92/pkg/metric_generator/generator.go:117 +0xd4
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store.(*MetricsStore).Add(0x4001953f40, {0x54cfde0, 0x4001df4dc0})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store/store.go:86 +0x58
github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store.(*MetricsStore).Replace(0x4001953f40, {0x4002006008, 0x94, 0xc1c4e48f2503b851?}, {0x5771d2f0c?, 0xaaed4c0?})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store/store.go:164 +0xa4
k8s.io/client-go/tools/cache.(*Reflector).syncWith(0x4000d5c960, {0x4001317508, 0x94, 0x0?}, {0x4001d938b0, 0xa})
        /pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:718 +0x11c
k8s.io/client-go/tools/cache.(*Reflector).list(0x4000d5c960, 0x40016bf4a0)
        /pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:591 +0x614
k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x4000d5c960, 0x40016bf4a0)
        /pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:362 +0x234
k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
        /pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:307 +0x28
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x10?)
        /pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:226 +0x40
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x4000091f90, {0x6d65360, 0x4000a9f090}, 0x1, 0x40016bf4a0)
        /pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:227 +0x90
k8s.io/client-go/tools/cache.(*Reflector).Run(0x4000d5c960, 0x40016bf4a0)
        /pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:306 +0x184
created by github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder.(*Builder).startReflector in goroutine 330
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder/builder.go:279 +0x1a4
```

### Describe how to test/QA your changes

Validate that the cluster check runners are stable and are not panicking on our internal clusters where VPA collection is already enabled.
The above panic was visible on the nightly deployments.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->