### PR TITLE
[EBPF] kmt: fix parent tests of flaky tests marked as failed

### DIFF
--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -195,11 +195,17 @@ func reviewTestsReaders(jf io.Reader, ff io.Reader, owners *testowners) (*review
 			}
 
 			// check if a subtest also failed and is marked as flaky
+			hasFlakyChild := false
 			for _, failedTest := range tests {
 				if kf.IsFlaky(pkg, failedTest) && strings.HasPrefix(failedTest, test+"/") {
-					flakyTestsOut.WriteString(addOwnerInformation(fmt.Sprintf(flakyFormat, pkg, test), owner))
-					continue
+					hasFlakyChild = true
+					break
 				}
+			}
+
+			if hasFlakyChild {
+				flakyTestsOut.WriteString(addOwnerInformation(fmt.Sprintf(flakyFormat, pkg, test), owner))
+				continue
 			}
 
 			failedTestsOut.WriteString(addOwnerInformation(fmt.Sprintf(failFormat, pkg, test), owner))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes `test-json-review` to stop it from reporting parent tests as failed when a child one is marked as flaky.

### Motivation

### Describe how to test/QA your changes

Unit tests included.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->