### PR TITLE
[EBPF] kmt: fix python dependencies in CI

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -335,7 +335,7 @@ notify_ebpf_complexity_changes:
     # Python 3.12 changes default behavior how packages are installed.
     # In particular, --break-system-packages command line option is
     # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install -r tasks/kernel_matrix_testing/requirements.txt --break-system-packages # Required for printing the tables
+    - python3 -m pip install -r tasks/kernel_matrix_testing/requirements-ci.txt --break-system-packages # Required for printing the tables
     - python3 -m pip install -r tasks/libs/requirements-github.txt --break-system-packages
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -185,9 +185,9 @@ class CompilerImage:
         self.exec("echo conda activate ddpy3 >> /home/compiler/.bashrc", user="compiler")
         self.exec(f"install -d -m 0777 -o {uid} -g {uid} /go", user="root")
 
-        # Install all requirements except for libvirt ones (they won't build in the compiler and are not needed)
+        # Install requirements only for building in CI (not libvirt)
         self.exec(
-            f"cat {CONTAINER_AGENT_PATH}/tasks/kernel_matrix_testing/requirements.txt | grep -v libvirt | xargs pip install ",
+            f"pip install -r {CONTAINER_AGENT_PATH}/tasks/kernel_matrix_testing/requirements-ci.txt",
             user="compiler",
         )
 

--- a/tasks/kernel_matrix_testing/requirements-ci.txt
+++ b/tasks/kernel_matrix_testing/requirements-ci.txt
@@ -1,4 +1,3 @@
-libvirt-python==10.9.0
 termcolor==2.5.0
 thefuzz==0.22.1
 python-Levenshtein==0.26.1

--- a/tasks/kernel_matrix_testing/requirements-ci.txt
+++ b/tasks/kernel_matrix_testing/requirements-ci.txt
@@ -1,0 +1,6 @@
+libvirt-python==10.9.0
+termcolor==2.5.0
+thefuzz==0.22.1
+python-Levenshtein==0.26.1
+tabulate[widechars]==0.9.0
+jinja2==3.0.3

--- a/tasks/kernel_matrix_testing/requirements.txt
+++ b/tasks/kernel_matrix_testing/requirements.txt
@@ -1,6 +1,2 @@
+-r requirements-ci.txt
 libvirt-python==10.9.0
-termcolor==2.5.0
-thefuzz==0.22.1
-python-Levenshtein==0.26.1
-tabulate[widechars]==0.9.0
-jinja2==3.0.3

--- a/tasks/kernel_matrix_testing/requirements.txt
+++ b/tasks/kernel_matrix_testing/requirements.txt
@@ -1,6 +1,6 @@
-libvirt-python==9.2.0
-termcolor==2.3.0
-thefuzz==0.19.0
-python-Levenshtein==0.21.1
+libvirt-python==10.9.0
+termcolor==2.5.0
+thefuzz==0.22.1
+python-Levenshtein==0.26.1
 tabulate[widechars]==0.9.0
 jinja2==3.0.3


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Bumps the KMT python dependencies and separates them between CI only and "everything"

### Motivation

After the update to Python 3.12, the older versions we had did not have prebuilt wheels for that version and that caused build failures. Additionally, some wheels (such as libvirt-python) never have prebuilt wheels and thus cannot be built in CI.

### Describe how to test/QA your changes

KMT pipeline passing on this branch.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->