### PR TITLE
[CWS-3560] [CSM] Fix Raw packet TC classifier handle

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -367,6 +367,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.lazy_interface_prefixes"), []string{})
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_priority"), 10)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_handle"), 0)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_classifier_handle"), 0)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_ring_buffer"), true)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry_amd64"), false)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -76,7 +76,7 @@ func AllProbes(fentry bool) []*manager.Probe {
 	allProbes = append(allProbes, getSpliceProbes(fentry)...)
 	allProbes = append(allProbes, getFlowProbes()...)
 	allProbes = append(allProbes, getNetDeviceProbes()...)
-	allProbes = append(allProbes, GetTCProbes(true)...)
+	allProbes = append(allProbes, GetTCProbes(true, true)...)
 	allProbes = append(allProbes, getBindProbes(fentry)...)
 	allProbes = append(allProbes, getConnectProbes(fentry)...)
 	allProbes = append(allProbes, getSyscallMonitorProbes()...)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -121,6 +121,9 @@ type Config struct {
 	// NetworkClassifierHandle defines the handle at which CWS should insert its TC classifiers.
 	NetworkClassifierHandle uint16
 
+	// RawNetworkClassifierHandle defines the handle at which CWS should insert its Raw TC classifiers.
+	RawNetworkClassifierHandle uint16
+
 	// ProcessConsumerEnabled defines if the process-agent wants to receive kernel events
 	ProcessConsumerEnabled bool
 
@@ -173,6 +176,7 @@ func NewConfig() (*Config, error) {
 		NetworkLazyInterfacePrefixes: getStringSlice("network.lazy_interface_prefixes"),
 		NetworkClassifierPriority:    uint16(getInt("network.classifier_priority")),
 		NetworkClassifierHandle:      uint16(getInt("network.classifier_handle")),
+		RawNetworkClassifierHandle:   uint16(getInt("network.raw_classifier_handle")),
 		EventStreamUseRingBuffer:     getBool("event_stream.use_ring_buffer"),
 		EventStreamBufferSize:        getInt("event_stream.buffer_size"),
 		EventStreamUseFentry:         getEventStreamFentryValue(),
@@ -206,6 +210,18 @@ func NewConfig() (*Config, error) {
 func (c *Config) sanitize() error {
 	if !c.ERPCDentryResolutionEnabled && !c.MapDentryResolutionEnabled {
 		c.MapDentryResolutionEnabled = true
+	}
+
+	if c.NetworkRawPacketEnabled {
+		if c.RawNetworkClassifierHandle != c.NetworkClassifierHandle {
+			if c.NetworkClassifierHandle*c.RawNetworkClassifierHandle == 0 {
+				return fmt.Errorf("none or both of network.classifier_handle and network.raw_classifier_handle must be provided: got classifier_handle:%d raw_classifier_handle:%d", c.NetworkClassifierHandle, c.RawNetworkClassifierHandle)
+			}
+		} else {
+			if c.NetworkClassifierHandle*c.RawNetworkClassifierHandle != 0 {
+				return fmt.Errorf("network.classifier_handle and network.raw_classifier_handle can't be equal and not null: got classifier_handle:%d raw_classifier_handle:%d", c.NetworkClassifierHandle, c.RawNetworkClassifierHandle)
+			}
+		}
 	}
 
 	// not enable at the system-probe level, disable for cws as well

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -163,7 +163,9 @@ func (nn *NetworkNamespace) dequeueNetworkDevices(tcResolver *tc.Resolver, manag
 	}()
 
 	for _, queuedDevice := range nn.networkDevicesQueue {
-		_ = tcResolver.SetupNewTCClassifierWithNetNSHandle(queuedDevice, handle, manager)
+		if err = tcResolver.SetupNewTCClassifierWithNetNSHandle(queuedDevice, handle, manager); err != nil {
+			seclog.Errorf("error setting up new tc classifier on queued device: %v", err)
+		}
 	}
 	nn.flushNetworkDevicesQueue()
 }
@@ -346,6 +348,8 @@ func (nr *Resolver) snapshotNetworkDevices(netns *NetworkNamespace) int {
 			if !nr.IsLazyDeletionInterface(device.Name) && attrs.HardwareAddr.String() != "" {
 				attachedDeviceCountNoLazyDeletion++
 			}
+		} else {
+			seclog.Errorf("error setting up new tc classifier on snapshot: %v", err)
 		}
 	}
 

--- a/pkg/security/resolvers/tc/resolver.go
+++ b/pkg/security/resolvers/tc/resolver.go
@@ -94,11 +94,7 @@ func (tcr *Resolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice,
 	defer tcr.Unlock()
 
 	var combinedErr multierror.Error
-	for _, tcProbe := range probes.GetTCProbes(tcr.config.NetworkIngressEnabled) {
-		if !tcr.config.NetworkRawPacketEnabled && slices.Contains(probes.RawPacketTCProgram, tcProbe.EBPFFuncName) {
-			continue
-		}
-
+	for _, tcProbe := range probes.GetTCProbes(tcr.config.NetworkIngressEnabled, tcr.config.NetworkRawPacketEnabled) {
 		// make sure we're not overriding an existing network probe
 		progKey := ProgramKey{
 			UID:              tcProbe.UID,
@@ -120,7 +116,12 @@ func (tcr *Resolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice,
 		newProbe.IfIndexNetnsID = device.NetNS
 		newProbe.KeepProgramSpec = false
 		newProbe.TCFilterPrio = tcr.config.NetworkClassifierPriority
-		newProbe.TCFilterHandle = netlink.MakeHandle(0, tcr.config.NetworkClassifierHandle)
+
+		if slices.Contains(probes.RawPacketTCProgram, tcProbe.EBPFFuncName) {
+			newProbe.TCFilterHandle = netlink.MakeHandle(0, tcr.config.RawNetworkClassifierHandle)
+		} else {
+			newProbe.TCFilterHandle = netlink.MakeHandle(0, tcr.config.NetworkClassifierHandle)
+		}
 
 		netnsEditor := []manager.ConstantEditor{
 			{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR ensures that the same TC classifier handle cannot be reused by our TC classifiers. Handles can now be configured independently, which also introduces the ability to configure which program should be triggered first.

New config added:
```
event_monitoring_config:
  network:
    raw_classifier_handle: 42
```

### Motivation

When the same TC classifier handle is reused, the kernel rejects the request with the following error:
```
2024-11-12 13:20:11 CET | SYS-PROBE | ERROR | (pkg/security/resolvers/netns/resolver.go:352 in snapshotNetworkDevices) | error setting up new tc classifier on snapshot: 2 errors occurred:
	* couldn't clone {UID:security EBPFFuncName:classifier_raw_packet_egress}: failed to attach new probe {UID:security_classifier_raw_packet_egress_6_4026531840 EBPFFuncName:classifier_raw_packet_egress}: couldn't start probe {UID:security_classifier_raw_packet_egress_6_4026531840 EBPFFuncName:classifier_raw_packet_egress}: couldn't add a egress filter to interface docker0[6]: file exists
	* couldn't clone {UID:security EBPFFuncName:classifier_raw_packet_ingress}: failed to attach new probe {UID:security_classifier_raw_packet_ingress_6_4026531840 EBPFFuncName:classifier_raw_packet_ingress}: couldn't start probe {UID:security_classifier_raw_packet_ingress_6_4026531840 EBPFFuncName:classifier_raw_packet_ingress}: couldn't add a ingress filter to interface docker0[6]: file exists
```

### Describe how to test/QA your changes

Turn on the the raw packet capture feature and make sure the agent starts and fails as expected with different values for `raw_classifier_handle` and `classifier_handle`.

For example:
```
event_monitoring_config:
  network:
    raw_classifier_handle: 43
    classifier_handle: 42
    raw_packet:
      enabled: true
```