### PR TITLE
[CSM] Prevent CSM program ID leak in ebpfcheck

### DIFF
--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -38,6 +38,17 @@ func AddProgramNameMapping(progid uint32, name string, module string) {
 	progModuleMapping[progid] = module
 }
 
+// RemoveProgramID manually removes a program name mapping
+func RemoveProgramID(progID uint32, expectedModule string) {
+	mappingLock.Lock()
+	defer mappingLock.Unlock()
+
+	if progModuleMapping[progID] == expectedModule {
+		delete(progNameMapping, progID)
+		delete(progModuleMapping, progID)
+	}
+}
+
 // AddNameMappings adds the full name mappings for ebpf maps in the manager
 func AddNameMappings(mgr *manager.Manager, module string) {
 	maps, err := mgr.GetMaps()

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -479,7 +479,6 @@ func (p *EBPFProbe) Setup() error {
 	if err := p.Manager.Start(); err != nil {
 		return err
 	}
-	ddebpf.AddNameMappings(p.Manager, "cws")
 
 	p.applyDefaultFilterPolicies()
 
@@ -1522,7 +1521,52 @@ func (p *EBPFProbe) updateProbes(ruleEventTypes []eval.EventType, needRawSyscall
 		return fmt.Errorf("failed to set enabled events: %w", err)
 	}
 
-	return p.Manager.UpdateActivatedProbes(activatedProbes)
+	previousProbes := p.computeProbesIDs()
+	if err = p.Manager.UpdateActivatedProbes(activatedProbes); err != nil {
+		return err
+	}
+	newProbes := p.computeProbesIDs()
+
+	p.computeProbesDiffAndRemoveMapping(previousProbes, newProbes)
+	return nil
+}
+
+func (p *EBPFProbe) computeProbesIDs() map[string]lib.ProgramID {
+	out := make(map[string]lib.ProgramID)
+	progList, err := p.Manager.GetPrograms()
+	if err != nil {
+		return out
+	}
+	for funcName, prog := range progList {
+		programInfo, err := prog.Info()
+		if err != nil {
+			continue
+		}
+
+		programID, isAvailable := programInfo.ID()
+		if isAvailable {
+			out[funcName] = programID
+		}
+	}
+
+	return out
+}
+
+func (p *EBPFProbe) computeProbesDiffAndRemoveMapping(previousProbes map[string]lib.ProgramID, newProbes map[string]lib.ProgramID) {
+	// Compute the list of programs that need to be deleted from the ddebpf mapping
+	var toDelete []lib.ProgramID
+	for previousProbeFuncName, programID := range previousProbes {
+		if _, ok := newProbes[previousProbeFuncName]; !ok {
+			toDelete = append(toDelete, programID)
+		}
+	}
+
+	for _, id := range toDelete {
+		ddebpf.RemoveProgramID(uint32(id), "cws")
+	}
+
+	// new programs could have been introduced during the update, add them now
+	ddebpf.AddNameMappings(p.Manager, "cws")
 }
 
 // GetDiscarders retrieve the discarders

--- a/pkg/security/resolvers/tc/resolver.go
+++ b/pkg/security/resolvers/tc/resolver.go
@@ -149,6 +149,7 @@ func (tcr *Resolver) FlushNetworkNamespaceID(namespaceID uint32, m *manager.Mana
 
 	for tcKey, tcProbe := range tcr.programs {
 		if tcKey.NetDevice.NetNS == namespaceID {
+			ddebpf.RemoveProgramID(tcProbe.ID(), "cws")
 			_ = m.DetachHook(tcProbe.ProbeIdentificationPair)
 			delete(tcr.programs, tcKey)
 		}
@@ -166,6 +167,7 @@ func (tcr *Resolver) FlushInactiveProbes(m *manager.Manager, isLazy func(string)
 	var linkName string
 	for tcKey, tcProbe := range tcr.programs {
 		if !tcProbe.IsTCFilterActive() {
+			ddebpf.RemoveProgramID(tcProbe.ID(), "cws")
 			_ = m.DetachHook(tcProbe.ProbeIdentificationPair)
 			delete(tcr.programs, tcKey)
 		} else {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR ensures updates to `mapModuleMapping` and `progNameMapping` are done where programs are truly added and removed from our manager. CSM loads and unloads programs dynamically based on ruleset updates or container scheduling. Without this change, the two maps may end up out of sync, and leak map entries.

### Motivation

Prevent a leak of entries in `mapModuleMapping` and `progNameMapping`.
