### PR TITLE
logs: pack a maximum of 3000 messages (instead of 1000) per logs payload

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -62,7 +62,7 @@ const (
 	DefaultBatchMaxConcurrentSend = 0
 
 	// DefaultBatchMaxSize is the default HTTP batch max size (maximum number of events in a single batch) for logs
-	DefaultBatchMaxSize = 1000
+	DefaultBatchMaxSize = 3000
 
 	// DefaultInputChanSize is the default input chan size for events
 	DefaultInputChanSize = 100


### PR DESCRIPTION
### What does this PR do?

Adapts the default setting to pack a maximum of `3000`  messages (instead of `1000`) per logs payload.

### Motivation

Improve the throughput, `1000` was thought to be a backend limitation but actually it isn't.