### PR TITLE
ci(vault): Use the correct vault for macos runners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,7 +99,7 @@
 /.gitlab/package_deps_build/package_deps_build.yml   @DataDog/agent-devx-infra @DataDog/ebpf-platform
 /.gitlab/powershell_script_signing/powershell_script_signing.yml    @DataDog/agent-delivery @DataDog/windows-agent
 /.gitlab/source_test/golang_deps_diff.yml            @DataDog/agent-devx-infra @DataDog/agent-devx-loops
-/.gitlab/source_test/include.yml                     @DataDog/agent-devx-infra
+/.gitlab/source_test/*                               @DataDog/agent-devx-infra
 /.gitlab/source_test/linux.yml                       @DataDog/agent-devx-infra @DataDog/agent-devx-loops
 /.gitlab/source_test/macos.yml                       @DataDog/agent-devx-infra @DataDog/agent-devx-loops
 /.gitlab/source_test/notify.yml                      @DataDog/agent-devx-infra @DataDog/agent-devx-loops

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -33,6 +33,11 @@
     fi
   - pyenv activate $VENV_NAME
 
+.vault_login:
+  # Point the CLI to our internal vault
+  - export VAULT_ADDR=https://vault.us1.ddbuild.io
+  - vault login -method=aws -no-print
+
 .macos_gitlab:
   before_script:
     # Selecting the current Go version

--- a/.gitlab/source_test/common.yml
+++ b/.gitlab/source_test/common.yml
@@ -1,0 +1,8 @@
+---
+.upload_junit_source:
+  - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
+
+.upload_coverage:
+  # Upload coverage files to Codecov. Never fail on coverage upload.
+  - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
+  - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true

--- a/.gitlab/source_test/include.yml
+++ b/.gitlab/source_test/include.yml
@@ -4,6 +4,7 @@
 # security scans & go.mod checks.
 
 include:
+  - .gitlab/source_test/common.yml # Included first for shared definitions
   - .gitlab/source_test/ebpf.yml
   - .gitlab/source_test/linux.yml
   - .gitlab/source_test/macos.yml

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -45,14 +45,6 @@
       annotations:
         - $EXTERNAL_LINKS_PATH
 
-.upload_junit_source:
-  - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
-
-.upload_coverage:
-  # Upload coverage files to Codecov. Never fail on coverage upload.
-  - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
-  - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
-
 .linux_x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -76,6 +76,7 @@ tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
   tags: ["macos:monterey-amd64", "specific:true"]
   after_script:
+    - !reference [.vault_login]
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
 
@@ -85,5 +86,6 @@ tests_macos_gitlab_arm64:
     !reference [.manual]
   tags: ["macos:monterey-arm64", "specific:true"]
   after_script:
+    - !reference [.vault_login]
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -64,14 +64,6 @@ tests_macos:
       annotations:
         - $EXTERNAL_LINKS_PATH
 
-.upload_junit_source:
-  - $CI_PROJECT_DIR/tools/ci/junit_upload.sh
-
-.upload_coverage:
-  # Upload coverage files to Codecov. Never fail on coverage upload.
-  - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV_TOKEN) || exit $?; export CODECOV_TOKEN
-  - inv -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
-
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
   tags: ["macos:monterey-amd64", "specific:true"]

--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -9,7 +9,11 @@ set +x
 
 while [[ $retry_count -lt $max_retries ]]; do
     if [ -n "$parameter_field" ]; then
-        result=$(vault kv get -field="${parameter_field}" kv/k8s/gitlab-runner/datadog-agent/"${parameter_name}" 2> errorFile)
+        vault_name="kv/k8s/gitlab-runner/datadog-agent"
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            vault_name="kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent"
+        fi
+        result=$(vault kv get -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)
     else
         result=$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)
     fi


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the `fetch_secret` script to fetch secrets from the correct vault when running on macos runners.

### Motivation
macos runners are not k8s runners, they can't reach the `kv/k8s/gitlab-runner/datadog-agent` vault leading to [timeouts](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/703521410) in `after_script`. Their access to vault is through a [dedicated path](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3557065191/Getting+Started+with+macOS+Runners#Accessing-Vault), so:
- We [changed the vault policy](https://github.com/DataDog/vault-config/pull/6810) for `agent-devxinfra` team to be an admin of this vault. 
- We put the codecov token and created a dedicated api_key on org2 for macos runners.
https://datadoghq.atlassian.net/browse/ACIX-497

### Describe how to test/QA your changes
- No more timeout error in the `after_script` for macos_runner jobs
  - WIP for macos_tests [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/703640047)
- No error/timeout on other jobs
  - ok for codecov token [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/703640036#L479)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->