### PR TITLE
feat(ssm): Remove unused variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,10 +236,7 @@ variables:
 
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
-  AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile  # agent-devx-infra
   API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2  # agent-devx-infra
-  API_KEY_DDDEV: ci.datadog-agent.datadog_api_key  # agent-devx-infra
-  APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2  # agent-devx-infra
   CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha  # agent-devx-infra
   CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key  # windows-agent
   CODECOV_TOKEN: ci.datadog-agent.codecov_token  # agent-devx-infra
@@ -247,47 +244,8 @@ variables:
   DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}  # agent-delivery
   DOCKER_REGISTRY_LOGIN: ci.datadog-agent.docker_hub_login  # container-integrations
   DOCKER_REGISTRY_PWD: ci.datadog-agent.docker_hub_pwd  # container-integrations
-  E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key  # agent-devx-loops
-  E2E_TESTS_APP_KEY: ci.datadog-agent.e2e_tests_app_key  # agent-devx-loops
-  E2E_TESTS_RC_KEY: ci.datadog-agent.e2e_tests_rc_key  # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_ID: ci.datadog-agent.e2e_tests_azure_client_id  # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_SECRET: ci.datadog-agent.e2e_tests_azure_client_secret  # agent-devx-loops
-  E2E_TESTS_AZURE_TENANT_ID: ci.datadog-agent.e2e_tests_azure_tenant_id  # agent-devx-loops
-  E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id  # agent-devx-loops
-  E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials  # agent-devx-loops
-  KITCHEN_EC2_SSH_KEY: ci.datadog-agent.aws_ec2_kitchen_ssh_key  # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_ID: ci.datadog-agent.azure_kitchen_client_id  # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_SECRET: ci.datadog-agent.azure_kitchen_client_secret  # agent-devx-loops
-  KITCHEN_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.azure_kitchen_subscription_id  # agent-devx-loops
-  KITCHEN_AZURE_TENANT_ID: ci.datadog-agent.azure_kitchen_tenant_id  # agent-devx-loops
-  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key  # agent-devx-infra
-  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id  # agent-devx-infra
-  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id  # agent-devx-infra
-  GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token  # ci-cd
-  GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token  # ci-cd
-  GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token  # ci-cd
-  INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2  # agent-delivery
-  JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token  # agent-devx-infra
-  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id  # agent-devx-infra
-  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id  # agent-devx-infra
-  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key  # agent-devx-infra
-  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id  # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id  # agent-devx-infra
-  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64  # agent-devx-infra
-  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2  # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2  # agent-devx-infra
-  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2  # agent-devx-infra
   RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID}  # agent-delivery
   RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID}  # agent-delivery
-  SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token  # agent-devx-infra
-  SMP_ACCOUNT_ID: ci.datadog-agent.single-machine-performance-account-id  # single-machine-performance
-  SMP_AGENT_TEAM_ID: ci.datadog-agent.single-machine-performance-agent-team-id  # single-machine-performance
-  SMP_API: ci.datadog-agent.single-machine-performance-api  # single-machine-performance
-  SMP_BOT_ACCESS_KEY: ci.datadog-agent.single-machine-performance-bot-access-key  # single-machine-performance
-  SMP_BOT_ACCESS_KEY_ID: ci.datadog-agent.single-machine-performance-bot-access-key-id  # single-machine-performance
-  SSH_KEY: ci.datadog-agent.ssh_key  # system-probe
-  SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa  # agent-devx-loops
-  SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa  # agent-devx-loops
   VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url  # windows-agent
   WINGET_PAT: ci.datadog-agent.winget_pat  # windows-agent
   # End aws ssm variables


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove the SSM params that are not used due to `vault` migration

### Motivation
Simplification of the gitlab configuration
https://datadoghq.atlassian.net/browse/ACIX-498

### Describe how to test/QA your changes
The CI passes, no error nor timeouts in jobs using secrets

### Possible Drawbacks / Trade-offs
Must not be backported to Agent6 branch
We still need to keep some secrets:
- windows cannot use vault
- deb/rpm GPG secrets cannot be migrated easily to vault (need someone to access the real token)

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->