### PR TITLE
[CWS] set pid1 as an exec

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -429,7 +429,7 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 	var events []*model.Event
 
 	entryToEvent := func(entry *model.ProcessCacheEntry) {
-		if entry.Source != model.ProcessCacheEntryFromSnapshot && !entry.IsExec {
+		if entry.Source != model.ProcessCacheEntryFromSnapshot {
 			return
 		}
 		entry.Retain()

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1268,6 +1268,10 @@ func (p *EBPFResolver) newEntryFromProcfsAndSyncKernelMaps(proc *process.Process
 		} else { // exec
 			entry.SetExecParent(parent)
 		}
+	} else if pid == 1 {
+		entry.SetAsExec()
+	} else {
+		seclog.Debugf("unable to set the type of process, not pid 1, no parent in cache: %+v", entry)
 	}
 
 	p.insertEntry(entry, p.entryCache[pid], source)

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -100,6 +100,11 @@ func (pc *ProcessCacheEntry) SetExecParent(parent *ProcessCacheEntry) {
 	pc.IsExecExec = pc.Parent != nil && pc.Parent.IsExec
 }
 
+// SetAsExec set the entry as an Exec
+func (pc *ProcessCacheEntry) SetAsExec() {
+	pc.IsExec = true
+}
+
 // Exec replace a process
 func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 	entry.SetExecParent(pc)

--- a/pkg/security/secl/model/process_cache_entry_unix_test.go
+++ b/pkg/security/secl/model/process_cache_entry_unix_test.go
@@ -83,3 +83,28 @@ func TestHasValidLineage(t *testing.T) {
 		assert.ErrorAs(t, err, &mn)
 	})
 }
+
+func TestEntryEquals(t *testing.T) {
+	e1 := NewProcessCacheEntry(nil)
+	e1.Pid = 2
+	e2 := NewProcessCacheEntry(nil)
+	e2.Pid = 3
+	assert.True(t, e1.Equals(e2))
+
+	// different file
+	e1.FileEvent.Inode = 33
+	e2.FileEvent.Inode = 44
+	assert.False(t, e1.Equals(e2))
+
+	// same file
+	e2.FileEvent.Inode = 33
+	assert.True(t, e1.Equals(e2))
+
+	// different args
+	e2.ArgsEntry = &ArgsEntry{Values: []string{"aaa"}}
+	assert.False(t, e1.Equals(e2))
+
+	// same args
+	e1.ArgsEntry = &ArgsEntry{Values: []string{"aaa"}}
+	assert.True(t, e1.Equals(e2))
+}

--- a/pkg/security/tests/snapshot_test.go
+++ b/pkg/security/tests/snapshot_test.go
@@ -35,6 +35,17 @@ func TestSnapshot(t *testing.T) {
 			snapshotRuleMatchHandler: func(testMod *testModule, e *model.Event, r *rules.Rule) {
 				assertTriggeredRule(t, r, "test_rule_snapshot_host")
 				testMod.validateExecSchema(t, e)
+				validateProcessContext(t, e)
+
+				// validate that pid 1 is reported as an exec
+				ancestor := e.ProcessContext.Ancestor
+				for ancestor != nil {
+					if ancestor.Pid == 1 && !ancestor.IsExec {
+						t.Errorf("pid1 should be reported as an Exec: %+v", e)
+					}
+					ancestor = ancestor.Ancestor
+				}
+
 				gotEvent.Store(true)
 			},
 		}))
@@ -80,6 +91,7 @@ func TestSnapshot(t *testing.T) {
 			snapshotRuleMatchHandler: func(testMod *testModule, e *model.Event, r *rules.Rule) {
 				assertTriggeredRule(t, r, "test_rule_snapshot_container")
 				testMod.validateExecSchema(t, e)
+				validateProcessContext(t, e)
 				gotEvent.Store(true)
 			},
 		}))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set the pid 1 as an Exec. Before this PR the type on the process pid1 was not set.
It also use the pid in the Equals function of the process cache entry, otherwise during the snapshot the following pstree will not generate exec for the second pid.

```
 244885 ?        S      0:00  |   |   |   \_ /opt/1Password/1password --type=zygote
 244887 ?        S      0:00  |   |   |       \_ /opt/1Password/1password --type=zygote
```

### Motivation

### Describe how to test/QA your changes

A functional test check has been added. Pid1 should be seen by the event consumers.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->