### PR TITLE
[OTEL-2147] add methods for converter ocb compatibility

### DIFF
--- a/comp/otelcol/converter/fx/fx.go
+++ b/comp/otelcol/converter/fx/fx.go
@@ -15,7 +15,7 @@ import (
 // Module defines the fx options for this component.
 func Module() fxutil.Module {
 	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(converterimpl.NewConverter),
+		fxutil.ProvideComponentConstructor(converterimpl.NewConverterForAgent),
 		fxutil.ProvideOptional[converter.Component](),
 	)
 }

--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -10,8 +10,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 var ddAutoconfiguredSuffix = "dd-autoconfigured"
@@ -115,6 +116,9 @@ func addComponentToPipeline(conf *confmap.Conf, comp component, pipelineName str
 	*conf = *confmap.NewFromStringMap(stringMapConf)
 }
 
+// addCoreAgentConfig enhances the configuration with information about the core agent.
+// For example, if api key is not found in otel config, it can be retrieved from core
+// agent config instead.
 func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 	stringMapConf := conf.ToStringMap()
 	exporters, ok := stringMapConf["exporters"]
@@ -152,7 +156,8 @@ func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 			}
 		}
 	}
-
+	// this is the only reference to Requires.Conf
+	// TODO: add logic to either fail or log message if api key not found
 	if coreCfg != nil {
 		apiMap["key"] = coreCfg.Get("api_key")
 

--- a/comp/otelcol/converter/impl/converter.go
+++ b/comp/otelcol/converter/impl/converter.go
@@ -9,6 +9,8 @@ package converterimpl
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -17,6 +19,7 @@ import (
 
 type ddConverter struct {
 	coreConfig config.Component
+	logger     *zap.Logger
 }
 
 var (
@@ -33,8 +36,19 @@ type Requires struct {
 	Conf config.Component
 }
 
-// NewConverter currently only supports a single URI in the uris slice, and this URI needs to be a file path.
-func NewConverter(reqs Requires) (converter.Component, error) {
+// NewFactory returns a new converter factory.
+func NewFactory() confmap.ConverterFactory {
+	return confmap.NewConverterFactory(newConverter)
+}
+
+func newConverter(set confmap.ConverterSettings) confmap.Converter {
+	return &ddConverter{
+		logger: set.Logger,
+	}
+}
+
+// NewConverterForAgent currently only supports a single URI in the uris slice, and this URI needs to be a file path.
+func NewConverterForAgent(reqs Requires) (converter.Component, error) {
 	return &ddConverter{
 		coreConfig: reqs.Conf,
 	}, nil

--- a/comp/otelcol/converter/impl/converter.go
+++ b/comp/otelcol/converter/impl/converter.go
@@ -31,7 +31,10 @@ var (
 // An agent core configuration component dep is expected. A nil
 // core config component will prevent enhancing the configuration
 // with core agent config elements if any are missing from the provided
-// OTel configutation.
+// OTel configuration. For example, when building in an environment that
+// requires an argument-less constructor, such as with ocb. In this case,
+// the core config component is not available and the converter will not
+// attempt to enhance the configuration using agent data.
 type Requires struct {
 	Conf config.Component
 }

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -37,8 +37,8 @@ func newResolver(uris []string) (*confmap.Resolver, error) {
 	})
 }
 
-func TestNewConverter(t *testing.T) {
-	_, err := NewConverter(Requires{})
+func TestNewConverterForAgent(t *testing.T) {
+	_, err := NewConverterForAgent(Requires{})
 	assert.NoError(t, err)
 }
 
@@ -147,7 +147,7 @@ func TestConvert(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			converter, err := NewConverter(Requires{})
+			converter, err := NewConverterForAgent(Requires{})
 			assert.NoError(t, err)
 
 			resolver, err := newResolver(uriFromFile(tc.provided))

--- a/comp/otelcol/converter/impl/go.mod
+++ b/comp/otelcol/converter/impl/go.mod
@@ -48,6 +48,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.111.0
 	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.111.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.111.0
+	go.uber.org/zap v1.27.0
 
 )
 
@@ -60,9 +61,9 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/env v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.58.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.0.0-00010101000000-000000000000 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.0.0-00010101000000-000000000000 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.2 // indirect
@@ -117,7 +118,6 @@ require (
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/fx v1.22.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/comp/otelcol/ddflareextension/impl/configstore_test.go
+++ b/comp/otelcol/ddflareextension/impl/configstore_test.go
@@ -198,7 +198,7 @@ func newResolverSettings(uris []string, enhanced bool) confmap.ResolverSettings 
 func newConverterFactory(enhanced bool) []confmap.ConverterFactory {
 	converterFactories := []confmap.ConverterFactory{}
 
-	converter, err := converterimpl.NewConverter(converterimpl.Requires{})
+	converter, err := converterimpl.NewConverterForAgent(converterimpl.Requires{})
 	if err != nil {
 		return []confmap.ConverterFactory{}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
adds required methods so that otelcol/converter can be included and built with ocb

### Motivation
https://datadoghq.atlassian.net/browse/OTEL-2236

### Describe how to test/QA your changes
**Note: testing this is currently blocked by https://github.com/open-telemetry/opentelemetry-collector/issues/11649; you can apply the changes in the linked PR/issue to ocb yourself or just wait until that PR is accepted

download latest ocb and build from source
```
$ git clone https://github.com/open-telemetry/opentelemetry-collector.git
$ cd opentelemetry-collector/cmd/builder
$ CGO_ENABLED=0 go build -o ocb -trimpath -ldflags='-s -w'
```
download an ocb manifest
`$ wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/heads/main/distributions/otelcol-contrib/manifest.yaml`

add the following lines to add the converter to manifest.yaml:
```
converters:
  - gomod: github.com/DataDog/datadog-agent/comp/otelcol/converter/impl
    path: ./comp/otelcol/converter/impl
```

download a config file to test your collector
`wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/heads/main/distributions/otelcol-contrib/config.yaml`

delete any sections from config.yaml referencing extensions "zpages", "pprof", or "healthcheck" (we need to make sure converter adds them back into the configuration)

build and run your custom collector
```
./ocb --config manifest.yaml
./_build/otelcol-contrib --config config.yaml
```

send test command in a new terminal window to verify configuration was modified
`$ curl -k https://localhost:7777`
- check for "zpages/dd-autoconfigured" as well as pprof and healthcheck in the "enhanced_configuration" value

### Possible Drawbacks / Trade-offs
cannot push automated test until upstream change is merged, JIRA card for this: https://datadoghq.atlassian.net/browse/OTEL-2238

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->