### PR TITLE
[CWS] windows: do not send events for rename pre args

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -768,7 +768,9 @@ func (p *WindowsProbe) Start() error {
 					continue
 				}
 			case notif := <-p.onETWNotification:
-				p.handleETWNotification(ev, notif)
+				if ok := p.handleETWNotification(ev, notif); !ok {
+					continue
+				}
 			}
 
 			p.DispatchEvent(ev)
@@ -849,7 +851,7 @@ func (p *WindowsProbe) handleProcessStop(ev *model.Event, stop *procmon.ProcessS
 	return true
 }
 
-func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) {
+func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotification) bool {
 	// handle incoming events here
 	// each event will come in as a different type
 	// parse it with
@@ -870,17 +872,19 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 			userFileName: arg.userFileName,
 		}
 		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
+		return false
 	case *rename29Args:
 		fc := fileCache{
 			fileName:     arg.fileName,
 			userFileName: arg.userFileName,
 		}
 		p.renamePreArgs.Add(uint64(arg.fileObject), fc)
+		return false
 	case *renamePath:
 		fileCache, found := p.renamePreArgs.Get(uint64(arg.fileObject))
 		if !found {
 			log.Debugf("unable to find renamePreArgs for %d", uint64(arg.fileObject))
-			return
+			return false
 		}
 		ev.Type = uint32(model.FileRenameEventType)
 		ev.RenameFile = model.RenameFileEvent{
@@ -964,12 +968,16 @@ func (p *WindowsProbe) handleETWNotification(ev *model.Event, notif etwNotificat
 		}
 	}
 
-	if ev.Type != uint32(model.UnknownEventType) {
-		errRes := p.setProcessContext(notif.pid, ev)
-		if errRes != nil {
-			log.Debugf("%v", errRes)
-		}
+	if ev.Type == uint32(model.UnknownEventType) {
+		log.Errorf("unknown event type: %T", notif.arg)
+		return false
 	}
+
+	errRes := p.setProcessContext(notif.pid, ev)
+	if errRes != nil {
+		log.Debugf("%v", errRes)
+	}
+	return true
 }
 
 func (p *WindowsProbe) setProcessContext(pid uint32, event *model.Event) error {


### PR DESCRIPTION
### What does this PR do?

Some of the rename ETW events are not generating probe events but just filling an LRU waiting for further events to actually create the final probe events. As such we definitely should not be creating a probe event with an unknown event type. This is seemingly not causing issues further down the road but could in the future and it's clearly wasting some CPU cycles.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->