### PR TITLE
[smp]: make quality gates mandatory in CI via hack

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -165,6 +165,7 @@ pull_test_dockers*                @DataDog/universal-service-monitoring
 
 # Single machine performance
 single_machine_performance*       @DataDog/single-machine-performance
+single-machine-performance*       @DataDog/single-machine-performance
 
 # Dependency Security
 software_composition_analysis*    @DataDog/software-integrity-and-trust

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -336,7 +336,7 @@ single-machine-performance-quality-gates-only:
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result
-      --submission-metadata submission_metadata
+      --submission-metadata submission_metadata --signal bounds-check
 
 # Shamelessly adapted from golang_deps_commenter job config in
 # golang_deps_diff.yml at commit 01da274032e510d617161cf4e264a53292f44e55.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -208,3 +208,207 @@ single-machine-performance-regression_detector-pr-comment:
         exit 0
       fi
       exit $exitcode
+
+single-machine-performance-quality-gates-only:
+  stage: functional_test
+  timeout: 1h10m
+  rules:
+    - !reference [.except_main_or_release_branch]
+    - when: on_success
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs:
+    - job: single_machine_performance-amd64-a7
+      artifacts: false
+  artifacts:
+    expire_in: 1 weeks
+    paths:
+      - submission_metadata # for provenance, debugging
+      - ${CI_COMMIT_SHA}-baseline_sha # for provenance, debugging
+      - outputs/report.md # for debugging, also on S3
+      - outputs/regression_signal.json # for debugging, also on S3
+      - outputs/bounds_check_signal.json # for debugging, also on S3
+      - outputs/junit.xml # for debugging, also on S3
+    when: always
+  variables:
+    SMP_VERSION: 0.18.1
+  # Single Machine Performance Quality Gates are mandatory.
+  allow_failure: false
+  script:
+    # Ensure output files exist for artifact downloads step
+    - mkdir outputs # Also needed for smp job sync step
+    # Compute merge base of current commit and `main`
+    - git fetch origin
+    - SMP_BASE_BRANCH=$(inv release.get-release-json-value base_branch)
+    - echo "Looking for merge base for branch ${SMP_BASE_BRANCH}"
+    - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/${SMP_BASE_BRANCH})
+    - echo "Merge base is ${SMP_MERGE_BASE}"
+    # Setup AWS credentials for single-machine-performance AWS account
+    - AWS_NAMED_PROFILE="single-machine-performance"
+    - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT account_id) || exit $?
+    - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+    - SMP_AGENT_TEAM_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT agent_team_id) || exit $?
+    - SMP_API=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT api_url) || exit $?
+    - SMP_BOT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT bot_login) || exit $?
+    - SMP_BOT_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT bot_token) || exit $?
+    - aws configure set aws_access_key_id "$SMP_BOT_ID" --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key "$SMP_BOT_KEY" --profile ${AWS_NAMED_PROFILE}
+    - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
+    # Download smp binary and prepare it for use
+    - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
+    - chmod +x smp
+    - BASELINE_SHA="${SMP_MERGE_BASE}"
+    - echo "Computing baseline..."
+    - echo "Checking if commit ${BASELINE_SHA} is recent enough..."
+    # Compute four days before now as UNIX timestamp in order to test against SMP ECR expiration policy;
+    # add an hour as a small correction factor to overestimate time needed for SMP to query and pull the
+    # image so we don't end up with a hard-to-diagnose bug in which the image expires after checking its
+    # age in CI, but before SMP pulls the image.
+    - FOUR_DAYS_BEFORE_NOW=$(date --date="-4 days +1 hour" "+%s")
+    # Compute UNIX timestamp of potential baseline SHA
+    - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
+    # If baseline SHA is older than expiration policy, exit with an error
+    - | # Only 1st line of multiline command echoes, which reduces debuggability, so multiline commands are a maintenance tradeoff
+      if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
+      then
+          echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+          exit 1
+      fi
+    - echo "Commit ${BASELINE_SHA} is recent enough"
+    - echo "Checking if image exists for commit ${BASELINE_SHA}..."
+    - |
+      while [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]
+      do
+          echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"
+          BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^)
+          echo "Checking if commit ${BASELINE_SHA} is recent enough..."
+          BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
+          if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
+          then
+              echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+              exit 1
+          fi
+          echo "Commit ${BASELINE_SHA} is recent enough"
+          echo "Checking if image exists for commit ${BASELINE_SHA}..."
+      done
+    - echo "Image exists for commit ${BASELINE_SHA}"
+    - echo "Baseline SHA is ${BASELINE_SHA}"
+    - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"
+    # Copy the baseline SHA to SMP for debugging purposes later
+    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
+    - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
+    - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
+    - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
+    - echo "${CI_COMMIT_SHA} | ${COMPARISON_IMAGE}"
+    # Incredibly ugly hack to exclude all experiments except Quality Gates experiments
+    - find test/regression/cases ! -iregex '.*quality_gate_.*' -mindepth 1 -maxdepth 1 -type d -print0 | xargs -r0 rm -rf
+    - RUST_LOG="info,aws_config::profile::credentials=error"
+    - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+      job submit
+      --baseline-image ${BASELINE_IMAGE}
+      --comparison-image ${COMPARISON_IMAGE}
+      --baseline-sha ${BASELINE_SHA}
+      --comparison-sha ${CI_COMMIT_SHA}
+      --target-config-dir test/regression/
+      --submission-metadata submission_metadata
+    # Wait for job to complete.
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
+    # Now that the job is completed pull the analysis report, output it to stdout.
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+      job sync
+      --submission-metadata submission_metadata
+      --output-path outputs
+    # Replace empty lines in the output with lines containing various unicode
+    # space characters. This avoids
+    # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
+    - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Upload JUnit XML outside of Agent CI's tooling because the `junit_upload`
+    # invoke task has additional logic that does not seem to apply well to SMP's
+    # JUnit XML. Agent CI seems to use `datadog-agent` as the service name when
+    # uploading JUnit XML, so the upload command below respects that convention.
+    - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY
+    - datadog-ci junit upload --service datadog-agent outputs/junit.xml
+    # Finally, exit 1 if the job signals a regression else 0.
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+      job result
+      --submission-metadata submission_metadata
+
+# Shamelessly adapted from golang_deps_commenter job config in
+# golang_deps_diff.yml at commit 01da274032e510d617161cf4e264a53292f44e55.
+single-machine-performance-quality-gates-pr-comment:
+  stage: functional_test
+  rules:
+    - !reference [.except_main_or_release_branch]
+    - when: on_success
+  image:
+    name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"
+    entrypoint: [""]  # disable entrypoint script for the pr-commenter image
+  tags: ["arch:amd64"]
+  needs:
+    - job: single-machine-performance-quality-gates-only
+  artifacts:
+    expire_in: 1 weeks
+    paths:
+      - report_as_json_string.txt # for debugging transform to valid JSON string
+      - pr_comment_payload.json  # for debugging PR commenter JSON payload bugs
+  variables:
+    # Not using the entrypoint script for the pr-commenter image
+    FF_KUBERNETES_HONOR_ENTRYPOINT: false
+  allow_failure: false
+  script: # ignore error message about no PR, because it happens for dev branches without PRs
+    # Prevent posting empty Regression Detector report if Markdown report is not found or
+    # has zero size.
+    - |
+      if [[ ! -s "outputs/report.md" ]]
+      then
+          echo "ERROR: Quality Gates report not found -- no PR comment posted"
+          exit 1
+      fi
+    # We need to transform the Markdown report into a valid JSON string (without
+    # quotes) in order to pass a well-formed payload to the PR commenting
+    # service. Note that on macOS, the "-z" flag is invalid for `sed` (but
+    # should be fine for GNU `sed`). We need to use `sed` to escape newlines
+    # because JSON does not permit (raw) newlines in strings. We use the "-z"
+    # option with `sed` because that option treats its input as
+    # NUL-character-separated (i.e., '\0'-separated, the zero-byte character),
+    # so `sed` does not interpret its input as newline-delimited. We also need
+    # to escape double quotes to distinguish literal quotes in the report from
+    # the double quotes that delimit the value of the "message" field in the
+    # payload.
+    - cat outputs/report.md | sed -z 's/\n/\\n/g' | sed -z 's/"/\\"/g' > report_as_json_string.txt
+    - cat report_as_json_string.txt
+    # Transforming the Markdown report to a valid JSON string is easy to foul
+    # up, so to make debugging easier, we store the payload in a variable to
+    # help debugging.
+    - PR_COMMENT_JSON_PAYLOAD='{"org":"DataDog", "repo":"datadog-agent", "commit":"'"${CI_COMMIT_SHA}"'", "header":"Quality Gates Report", "message":"'"$(cat report_as_json_string.txt)"'"}'
+    - printf "%s\n" "PR comment JSON payload:${PR_COMMENT_JSON_PAYLOAD}"
+    - printf "%s\n" "${PR_COMMENT_JSON_PAYLOAD}" > pr_comment_payload.json
+    # Craft an HTTPS request to pr-commenter service to post Markdown report to
+    # GitHub, per
+    # https://github.com/DataDog/dd-source/tree/7c941f527fb9c44a73433c7dd0a090d92be7deb4/domains/devex/codex/apps/apis/pr-commenter
+    # and gracefully handle the case when the commit being tested is not a PR
+    - |
+      set +e
+      out=$(curl https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+          -H "$(authanywhere)" \
+          -H "X-DdOrigin: curl" \
+          -X PATCH \
+          -d "${PR_COMMENT_JSON_PAYLOAD}")
+      exitcode=$?
+      set -e
+      if [ -n "${out}" ]; then
+        if [ $exitcode -eq 0 ]; then
+          echo $out
+        else
+          echo $out >&2
+        fi
+      fi
+      if [ "${out}" != "${out/invalid request: no pr found for this commit}" ]; then
+        exit 0
+      fi
+      exit $exitcode

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -209,6 +209,7 @@ single-machine-performance-regression_detector-pr-comment:
       fi
       exit $exitcode
 
+# Single Machine Performance Quality Gates are mandatory.
 single-machine-performance-quality-gates-only:
   stage: functional_test
   timeout: 1h10m
@@ -232,8 +233,6 @@ single-machine-performance-quality-gates-only:
     when: always
   variables:
     SMP_VERSION: 0.18.1
-  # Single Machine Performance Quality Gates are mandatory.
-  allow_failure: false
   script:
     # Ensure output files exist for artifact downloads step
     - mkdir outputs # Also needed for smp job sync step


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We'd like to make Single Machine Performance Quality Gates mandatory in Agent CI without making all Regression Detector experiments mandatory in CI. This commit achieves that goal through an incredibly ugly hack:

    * copy-paste the existing Regression Detector CI jobs

    * find-replace Regression Detector with Quality Gates

    * delete all non-Quality Gates experiments after repo checkout

Ideally, we would achieve the same outcome through more elegant means, but this approach is quicker. We intend to replace this hacky approach with something more elegant in a subsequent PR (see #31016).

### Motivation

Limit Agent RSS.

### Describe how to test/QA your changes

Run these changes in CI.

### Possible Drawbacks / Trade-offs

In general, we'd rather jobs not delete our experiments, but this PR is a simple expedient for mandatory Quality Gates. Making Quality Gates mandatory will hold up some PRs that increase Agent RSS, which is the cost of adding a mechanism to halt Agent RSS growth version-over-version.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->