### PR TITLE
When a module (go.mod) isn't a package, fail gracefully

### DIFF
--- a/pkg/security/seclwin/doc.go
+++ b/pkg/security/seclwin/doc.go
@@ -1,3 +1,8 @@
-// Package seclwin contains security functionality
-package seclwin
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
 
+// Package secl provides utilities related to Datadog Cloud Workload Security Policy Language.
+// This module has no API stability guarantees.
+package secl

--- a/pkg/security/seclwin/doc.go
+++ b/pkg/security/seclwin/doc.go
@@ -1,0 +1,3 @@
+// Package seclwin contains security functionality
+package seclwin
+

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -442,6 +442,8 @@ def tidy_all(ctx):
 
 @task
 def tidy(ctx):
+    check_valid_mods(ctx)
+
     if os.name != 'nt':  # not windows
         import resource
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -869,6 +869,7 @@ def sync_secl_win_pkg(ctx):
 
     ctx.run("rm -r pkg/security/seclwin/model")
     ctx.run("mkdir -p pkg/security/seclwin/model")
+    ctx.run("cp pkg/security/secl/doc.go pkg/security/seclwin/doc.go")
 
     for ffrom, fto in files_to_copy:
         if not fto:


### PR DESCRIPTION
### What does this PR do?

When a module (folder containing a `go.mod`) isn't a package (folder containing one or more Go source files), the `inv tidy` and `inv check-mod-tidy` commands should fail gracefully.

### Motivation

Without this fix, running `inv check-mod-tidy` with such an invalid module leads to this sort of error:

```
go: creating new go.mod: module example.com/testmodule
go: to add module requirements and sums:
	go mod tidy
go: finding module for package github.com/DataDog/datadog-agent/comp/core/config
go: github.com/DataDog/datadog-agent/cmd/agent/command imports
	github.com/DataDog/datadog-agent/comp/core/config: module github.com/DataDog/datadog-agent/comp/core/config@latest found (v0.59.0, replaced by ./comp/core/config/), but does not contain package github.com/DataDog/datadog-agent/comp/core/config
```

With the fix, the error is this:

```
Errors found:
  - module github.com/DataDog/datadog-agent/comp/core/config does not contain *.go source files, so it is not a package
```

### Describe how to test/QA your changes

```
% rm comp/core/config/*.go
% inv check-mod-tidy
```

### Possible Drawbacks / Trade-offs

### Additional Notes

Seems to only happen when the invalid module contains subfolders.