### PR TITLE
BARX-680 - Add condition to check-for-changes call

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -88,7 +88,11 @@ jobs:
                 MATRIX: ${{ matrix.value }}
                 WARNING: ${{ needs.find_release_branches.outputs.warning }}
               run: |
-                echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
+                if [ -n "${{ needs.find_release_branches.outputs.warning }}" ]; then
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
+                else
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX")" >> $GITHUB_OUTPUT
+                fi
 
             - name: Create RC PR
               if: ${{ steps.check_for_changes.outputs.CHANGES == 'true'}}


### PR DESCRIPTION
### What does this PR do?

This PR adds condition in the github action execution. If the previous step exports `warning` variable then we use it to call the `release.check-for-changes` task. If not - we skip it.

### Motivation

Create RC PR action has two "modes" run on different schedule. In one of them we check integrations-core changes and send a slack message if there is something for the next RC. In the second one - we check datadog-agent repo for changes and create new RC PR if needed.
At the moment the second mode does not work due to this issue.

In case the warning variable is not set in GH action, then the default value '' is used. Calling invoke task with '' does not work properly.

### Describe how to test/QA your changes

Tested from the branch.To be properly verified with the next run of Create RC PR schedule. 

### Comment

I considered splitting the GH action or adding different step, but by the end of the day it will all fall into the similar solution and this way I think the amount of repeated code is minimal and it's easy to understand.