### PR TITLE
ci(kitchen): Set kitchen_test_security_agent_amazonlinux as `allowed_failure`

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -93,6 +93,7 @@ kitchen_test_security_agent_arm64:
         KITCHEN_CWS_PLATFORM: [host, docker, ad, ebpfless]
 
 kitchen_test_security_agent_amazonlinux_x64:
+  allow_failure: true
   extends:
     - .kitchen_test_security_agent_linux
     - .kitchen_ec2_location_us_east_1
@@ -144,7 +145,6 @@ kitchen_test_security_agent_x64_ec2:
 kitchen_test_security_agent_amazonlinux_x64_fentry:
   extends:
     - kitchen_test_security_agent_amazonlinux_x64
-  allow_failure: true
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set `allow_failure: true` on `kitchen_test_security_agent_amazonlinux`

### Motivation
These tests are consistently failing with the same issue:
```
FAIL: [amazonlinux2023-ec2-x86_64] github com/DataDog/datadog-agent/pkg/security/tests.TestOctogonConstants/rc-vs-fallback
FAIL: [amazonlinux2023-ec2-x86_64] github com/DataDog/datadog-agent/pkg/security/tests.TestOctogonConstants/btf-vs-fallback
FAIL: [amazonlinux2023-ec2-x86_64] github com/DataDog/datadog-agent/pkg/security/tests.TestOctogonConstants
```
Security tests will be covered by other testing means, we can deactivate these

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->