### PR TITLE
[EBPF] kmt: fix detection of flaky parents

### DIFF
--- a/test/new-e2e/system-probe/test-json-review/main_test.go
+++ b/test/new-e2e/system-probe/test-json-review/main_test.go
@@ -55,7 +55,7 @@ func TestFlakeInOutput(t *testing.T) {
 	out, err := reviewTestsReaders(bytes.NewBuffer([]byte(flakeTestData)), nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out.Failed)
-	assert.Equal(t, fmt.Sprintf(flakyFormat, "a/b/c", "testname"), out.Flaky)
+	assert.Equal(t, fmt.Sprintf(flakyFormat, "a/b/c", "testname")+"\n", out.Flaky)
 	assert.Empty(t, out.ReRuns)
 }
 
@@ -72,13 +72,13 @@ func TestRerunInOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out.Failed)
 	assert.Empty(t, out.Flaky)
-	assert.Equal(t, fmt.Sprintf(rerunFormat, "a/b/c", "testname", "pass"), out.ReRuns)
+	assert.Equal(t, fmt.Sprintf(rerunFormat, "a/b/c", "testname", "pass")+"\n", out.ReRuns)
 }
 
 func TestOnlyParentOfFlakeFailed(t *testing.T) {
 	out, err := reviewTestsReaders(bytes.NewBuffer([]byte(onlyParentOfFlakeFailed)), nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf(failFormat, "a/b/c", "testparent"), out.Failed)
+	assert.Equal(t, fmt.Sprintf(failFormat, "a/b/c", "testparent")+"\n", out.Failed)
 	assert.Empty(t, out.Flaky)
 	assert.Empty(t, out.ReRuns)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the detection of parents as flakes when there is a failing and a flaky child.

### Motivation

### Describe how to test/QA your changes

Automated tests included.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->