### PR TITLE
[CWS] drop writes with no files attached sooner in the pipeline

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -49,6 +49,7 @@ type fileObjectPointer uint64
 
 var (
 	errDiscardedPath = errors.New("discarded path")
+	errReadNoPath    = errors.New("read with no path")
 )
 
 /*
@@ -540,7 +541,10 @@ func (wp *WindowsProbe) parseReadArgs(e *etw.DDEventRecord) (*readArgs, error) {
 	if s, ok := wp.filePathResolver.Get(fileObjectPointer(ra.fileObject)); ok {
 		ra.fileName = s.fileName
 		ra.userFileName = s.userFileName
+	} else {
+		return nil, errReadNoPath
 	}
+
 	return ra, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

We currently receive a lot of writes event that we cannot map to a given filename. As such those events are not usable in the downstream pipeline, so this PR drops them as early as possible freeing some CPU cycles and some space in the ETW notification channel.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->