### PR TITLE
ci(macos): Migrate to macos13 ventura

### DIFF
--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,7 +13,7 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:monterey-amd64", "specific:true"]
+  tags: ["macos:ventura-amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -24,4 +24,4 @@ lint_macos_gitlab_arm64:
   rules:
     - !reference [.on_main]
     - !reference [.manual]
-  tags: ["macos:monterey-arm64", "specific:true"]
+  tags: ["macos:ventura-arm64", "specific:true"]

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,7 +13,7 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-amd64-test", "specific:true"]
+  tags: ["macos:ventura-amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -24,4 +24,4 @@ lint_macos_gitlab_arm64:
   rules:
     - !reference [.on_main]
     - !reference [.manual]
-  tags: ["macos:ventura-arm64-test", "specific:true"]
+  tags: ["macos:ventura-arm64", "specific:true"]

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,7 +13,7 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:ventura-amd64-test", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -24,4 +24,4 @@ lint_macos_gitlab_arm64:
   rules:
     - !reference [.on_main]
     - !reference [.manual]
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:ventura-arm64-test", "specific:true"]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -29,7 +29,7 @@ include:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:monterey-amd64", "specific:true"]
+  tags: ["macos:ventura-amd64", "specific:true"]
   after_script:
     - !reference [.vault_login]
     - !reference [.select_python_env_commands]
@@ -40,7 +40,7 @@ tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   rules:
     !reference [.manual]
-  tags: ["macos:monterey-arm64", "specific:true"]
+  tags: ["macos:ventura-arm64", "specific:true"]
   allow_failure: true
   after_script:
     - !reference [.vault_login]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -29,7 +29,7 @@ include:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-amd64-test", "specific:true"]
+  tags: ["macos:ventura-amd64", "specific:true"]
   after_script:
     - !reference [.vault_login]
     - !reference [.select_python_env_commands]
@@ -40,7 +40,7 @@ tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   rules:
     !reference [.manual]
-  tags: ["macos:ventura-arm64-test", "specific:true"]
+  tags: ["macos:ventura-arm64", "specific:true"]
   allow_failure: true
   after_script:
     - !reference [.vault_login]

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -29,7 +29,7 @@ include:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:ventura-amd64-test", "specific:true"]
   after_script:
     - !reference [.vault_login]
     - !reference [.select_python_env_commands]
@@ -40,7 +40,7 @@ tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   rules:
     !reference [.manual]
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:ventura-arm64-test", "specific:true"]
   allow_failure: true
   after_script:
     - !reference [.vault_login]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the gitlab runners to macos13 (ventura)

### Motivation
- Align macos version with [what is running](https://github.com/DataDog/datadog-agent-macos-build/blob/master/.github/workflows/macos.yaml#L63) on the `datadog-agent-macos-build` repo
[ACIX-492](https://datadoghq.atlassian.net/browse/ACIX-492)
- It will also prevent the duplication of the `datadog-agent` test service on Test Visibility (ACIX-519) as the `DD_ENV` is set on these new amis.
[ACIX-519](https://datadoghq.atlassian.net/browse/ACIX-519)

### Describe how to test/QA your changes
Macos jobs running on gitlab are passing (see the previous pipelines).


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[ACIX-492]: https://datadoghq.atlassian.net/browse/ACIX-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACIX-519]: https://datadoghq.atlassian.net/browse/ACIX-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ