### PR TITLE
[CONTP-387] Validation Webhook base e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -197,31 +197,15 @@ func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
 	expectedWebhookName := "datadog-webhook"
 
 	suite.Run("agent registered mutating webhook configuration", func() {
-		mutatingConfigs, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+		mutatingConfig, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
 		suite.Require().NoError(err)
-		suite.NotEmpty(mutatingConfigs.Items, "No mutating webhook configuration found")
-		found := false
-		for _, mutatingConfig := range mutatingConfigs.Items {
-			if mutatingConfig.Name == expectedWebhookName {
-				found = true
-				break
-			}
-		}
-		suite.Require().True(found, fmt.Sprintf("None of the mutating webhook configurations have the name '%s'", expectedWebhookName))
+		suite.NotNilf(mutatingConfig, "None of the mutating webhook configurations have the name '%s'", expectedWebhookName)
 	})
 
 	suite.Run("agent registered validating webhook configuration", func() {
-		validatingConfigs, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+		validatingConfig, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
 		suite.Require().NoError(err)
-		suite.NotEmpty(validatingConfigs.Items, "No validating webhook configuration found")
-		found := false
-		for _, validatingConfig := range validatingConfigs.Items {
-			if validatingConfig.Name == expectedWebhookName {
-				found = true
-				break
-			}
-		}
-		suite.Require().True(found, fmt.Sprintf("None of the validating webhook configurations have the name '%s'", expectedWebhookName))
+		suite.NotNilf(validatingConfig, "None of the validating webhook configurations have the name '%s'", expectedWebhookName)
 	})
 }
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -209,6 +209,20 @@ func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
 		}
 		suite.Require().True(found, fmt.Sprintf("None of the mutating webhook configurations have the name '%s'", expectedWebhookName))
 	})
+
+	suite.Run("agent registered validating webhook configuration", func() {
+		validatingConfigs, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+		suite.Require().NoError(err)
+		suite.NotEmpty(validatingConfigs.Items, "No validating webhook configuration found")
+		found := false
+		for _, validatingConfig := range validatingConfigs.Items {
+			if validatingConfig.Name == expectedWebhookName {
+				found = true
+				break
+			}
+		}
+		suite.Require().True(found, fmt.Sprintf("None of the validating webhook configurations have the name '%s'", expectedWebhookName))
+	})
 }
 
 func (suite *k8sSuite) TestVersion() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Tests that the validation admission webhook created by the Datadog Cluster Agent exists in the Kubernetes configuration

### Motivation

E2E test coverage for the validation admission webhook similar to the mutating admission webhook in this previous [PR](https://github.com/DataDog/datadog-agent/pull/30290)

### Describe how to test/QA your changes

Run the `inv new-e2e-tests.run --targets ./tests/containers/ --run TestEKSSuite` command

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->