### PR TITLE
make sure nikos users are gated with `linux_bpf`

### DIFF
--- a/pkg/util/kernel/download_headers.go
+++ b/pkg/util/kernel/download_headers.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 package kernel
 

--- a/pkg/util/kernel/download_headers_test.go
+++ b/pkg/util/kernel/download_headers_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 package kernel
 

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 package kernel
 

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 package kernel
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR gates some files that are depending on nikos with the build tag `linux_bpf`. All users of exported functions are already gated with the same build tag so it's not causing any issue.

The main goal is to make sure nikos doesn't end up in the core agent (a win of ~2MiB).

### Motivation

### Describe how to test/QA your changes

The e2e for the core agent will cover those changes.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->