### PR TITLE
installer - fix e2e test

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -31,7 +31,6 @@ type packageTestsWithSkipedFlavors struct {
 	t                          packageTests
 	skippedFlavors             []e2eos.Descriptor
 	skippedInstallationMethods []InstallMethodOption
-	flaky                      bool
 }
 
 var (
@@ -52,7 +51,7 @@ var (
 	packagesTestsWithSkippedFlavors = []packageTestsWithSkipedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.Suse15}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}, flaky: true},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.Suse15}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
 		{t: testUpgradeScenario},
 	}
 )
@@ -110,10 +109,6 @@ func TestPackages(t *testing.T) {
 				t.Parallel()
 				// FIXME: Fedora currently has DNS issues
 				if flavor.Flavor == e2eos.Fedora {
-					flake.Mark(t)
-				}
-
-				if test.flaky {
 					flake.Mark(t)
 				}
 

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -43,7 +43,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	defer s.host.StopExamplePythonAppInDocker()
 
 	s.host.AssertPackageInstalledByInstaller("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
-	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-", "datadog-apm-library-python")
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
 	state := s.host.State()
 	state.AssertFileExists("/opt/datadog-packages/run/environment", 0644, "root", "root")
 	state.AssertSymlinkExists("/run/datadog-installer", "/opt/datadog-packages/run", "root", "root") // /run as /var/run points to /run, it's a limitation of the state packages

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -364,7 +364,7 @@ func (s *packageApmInjectSuite) TestInstrumentScripts() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
-	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python || sudo yum install -y datadog-apm-inject datadog-apm-library-python")
 	defer s.Purge()
 	defer s.purgeInjectorDebInstall()
 

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -43,7 +43,7 @@ func (s *packageApmInjectSuite) TestInstall() {
 	defer s.host.StopExamplePythonAppInDocker()
 
 	s.host.AssertPackageInstalledByInstaller("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
-	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-apm-inject", "datadog-apm-library-python")
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent", "datadog-", "datadog-apm-library-python")
 	state := s.host.State()
 	state.AssertFileExists("/opt/datadog-packages/run/environment", 0644, "root", "root")
 	state.AssertSymlinkExists("/run/datadog-installer", "/opt/datadog-packages/run", "root", "root") // /run as /var/run points to /run, it's a limitation of the state packages
@@ -167,7 +167,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
-	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python || sudo yum install -y datadog-apm-inject datadog-apm-library-python")
 	s.host.Run("sudo dd-container-install --no-agent-restart")
 	s.host.Run("sudo dd-host-install --no-agent-restart")
 	defer s.Purge()
@@ -220,7 +220,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
-	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python || sudo yum install -y datadog-apm-inject datadog-apm-library-python")
 	defer s.purgeInjectorDebInstall()
 
 	// OCI mustn't be overridden

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -167,6 +167,9 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
+	s.host.Run("sudo dd-container-install --no-agent-restart")
+	s.host.Run("sudo dd-host-install --no-agent-restart")
 	defer s.Purge()
 	defer s.purgeInjectorDebInstall()
 
@@ -217,6 +220,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
 	defer s.purgeInjectorDebInstall()
 
 	// OCI mustn't be overridden
@@ -360,6 +364,7 @@ func (s *packageApmInjectSuite) TestInstrumentScripts() {
 		"TESTING_YUM_VERSION_PATH=",
 		"DD_REPO_URL=datadoghq.com",
 	)
+	s.host.Run("sudo apt-get install -y datadog-apm-inject datadog-apm-library-python")
 	defer s.Purge()
 	defer s.purgeInjectorDebInstall()
 
@@ -531,10 +536,6 @@ func (s *packageApmInjectSuite) purgeInjectorDebInstall() {
 	packageList := []string{
 		"datadog-agent",
 		"datadog-apm-inject",
-		"datadog-apm-library-java",
-		"datadog-apm-library-ruby",
-		"datadog-apm-library-js",
-		"datadog-apm-library-dotnet",
 		"datadog-apm-library-python",
 	}
 	s.Env().RemoteHost.Execute(fmt.Sprintf("sudo apt-get remove -y --purge %[1]s || sudo yum remove -y %[1]s", strings.Join(packageList, " ")))


### PR DESCRIPTION
Revert of https://github.com/DataDog/datadog-agent/pull/31048/files
I missed that deb/rpm migration tests would fail with the agent install script release containing [removal of apm deb/rpm packages](https://github.com/DataDog/agent-linux-install-script/pull/298/files)
Fixing them for the moment.

Will fully remove them in couple weeks if we see no customer issue related to deb/rpm being removed