### PR TITLE
[KSM] Revert back to VPA v1beta2

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -338,11 +338,11 @@ func (f *vpaFactory) ListWatch(customResourceClient interface{}, ns string, fiel
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns).List(ctx, opts)
+			return vpaClient.AutoscalingV1beta2().VerticalPodAutoscalers(ns).List(ctx, opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns).Watch(ctx, opts)
+			return vpaClient.AutoscalingV1beta2().VerticalPodAutoscalers(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/vpa.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	vpav1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -69,7 +69,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := kubeMapToPrometheusLabels("annotation", a.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -88,7 +88,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := kubeMapToPrometheusLabels("label", a.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -107,7 +107,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if a.Spec.UpdatePolicy == nil || a.Spec.UpdatePolicy.UpdateMode == nil {
@@ -116,11 +116,11 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 					}
 				}
 
-				for _, mode := range []v1.UpdateMode{
-					v1.UpdateModeOff,
-					v1.UpdateModeInitial,
-					v1.UpdateModeRecreate,
-					v1.UpdateModeAuto,
+				for _, mode := range []vpav1beta2.UpdateMode{
+					vpav1beta2.UpdateModeOff,
+					vpav1beta2.UpdateModeInitial,
+					vpav1beta2.UpdateModeRecreate,
+					vpav1beta2.UpdateModeAuto,
 				} {
 					var v float64
 					if *a.Spec.UpdatePolicy.UpdateMode == mode {
@@ -146,7 +146,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
 					return &metric.Family{
@@ -169,7 +169,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
 					return &metric.Family{
@@ -191,7 +191,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -213,7 +213,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -235,7 +235,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -256,7 +256,7 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 			metric.Gauge,
 			basemetrics.ALPHA,
 			"",
-			wrapVPAFunc(func(a *v1.VerticalPodAutoscaler) *metric.Family {
+			wrapVPAFunc(func(a *vpav1beta2.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -275,10 +275,10 @@ func (f *vpaFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 }
 
 func (f *vpaFactory) ExpectedType() interface{} {
-	return &v1.VerticalPodAutoscaler{
+	return &vpav1beta2.VerticalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VerticalPodAutoscaler",
-			APIVersion: v1.SchemeGroupVersion.String(),
+			APIVersion: vpav1beta2.SchemeGroupVersion.String(),
 		},
 	}
 }
@@ -309,9 +309,9 @@ func vpaResourcesToMetrics(containerName string, resources corev1.ResourceList) 
 	return ms
 }
 
-func wrapVPAFunc(f func(*v1.VerticalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
+func wrapVPAFunc(f func(*vpav1beta2.VerticalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		vpa := obj.(*v1.VerticalPodAutoscaler)
+		vpa := obj.(*vpav1beta2.VerticalPodAutoscaler)
 
 		metricFamily := f(vpa)
 		targetRef := vpa.Spec.TargetRef

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -72,7 +72,7 @@ var extendedCollectors = map[string]string{
 var collectorNameReplacement = map[string]string{
 	// verticalpodautoscalers were removed from the built-in KSM metrics in KSM 2.9, and the changes made to
 	// the KSM builder in KSM 2.9 result in the detected custom resource store name being different.
-	"verticalpodautoscalers": "autoscaling.k8s.io/v1, Resource=verticalpodautoscalers",
+	"verticalpodautoscalers": "autoscaling.k8s.io/v1beta2, Resource=verticalpodautoscalers",
 }
 
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Revert change that dropped support for VPA v1beta2

### Motivation

Change was introduced here: https://github.com/DataDog/datadog-agent/pull/30986

The panic was pointing to the type conversion happening in `MetricFamilyGenerators()`, not the `ListWatch` function. Changing the v1 import to point to v1beta2 should fix the problem 

### Describe how to test/QA your changes

Validate that the cluster check runners are stable and are not panicking on our internal clusters where VPA collection is already enabled.
The above panic was visible on the nightly deployments.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->