### PR TITLE
[NDMII-3168] Migrate OOTB profiles to the latest format

### DIFF
--- a/pkg/networkdevice/profile/go.mod
+++ b/pkg/networkdevice/profile/go.mod
@@ -13,10 +13,13 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/networkdevice/profile/go.sum
+++ b/pkg/networkdevice/profile/go.sum
@@ -2,9 +2,12 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.10.0 h1:c1ktzNLBun3LyQQhyty5WE3lulbOdIIyOVlkmDLehcE=
 github.com/invopop/jsonschema v0.10.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -23,8 +26,13 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -59,9 +59,8 @@ type SymbolConfig struct {
 	ExtractValue         string         `yaml:"extract_value,omitempty" json:"extract_value,omitempty"`
 	ExtractValueCompiled *regexp.Regexp `yaml:"-" json:"-"`
 
-	// MatchPattern/MatchValue are not exposed as json (UI) since ExtractValue can be used instead
-	MatchPattern         string         `yaml:"match_pattern,omitempty" json:"-"`
-	MatchValue           string         `yaml:"match_value,omitempty" json:"-"`
+	MatchPattern         string         `yaml:"match_pattern,omitempty" json:"match_pattern,omitempty"`
+	MatchValue           string         `yaml:"match_value,omitempty" json:"match_value,omitempty"`
 	MatchPatternCompiled *regexp.Regexp `yaml:"-" json:"-"`
 
 	ScaleFactor      float64 `yaml:"scale_factor,omitempty" json:"scale_factor,omitempty"`
@@ -82,7 +81,7 @@ type MetricTagConfig struct {
 	// Table config
 	Index uint `yaml:"index,omitempty" json:"index,omitempty"`
 
-	// DEPRECATED: Column field is deprecated in favour Symbol field
+	// DEPRECATED: Column field is deprecated in favour of Symbol field
 	Column SymbolConfig `yaml:"column,omitempty" json:"-"`
 
 	// Symbol config
@@ -141,7 +140,7 @@ type MetricsConfig struct {
 	MetricTags MetricTagConfigList `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
 
 	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"` // deprecated in favour of metric_type
-	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
+	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty" jsonschema:"-"` // deprecated in favour of symbol.metric_type
 
 	// `options` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
 	Options MetricsConfigOption `yaml:"options,omitempty" json:"-"`

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -14,6 +14,8 @@ import (
 type ProfileMetricType string
 
 const (
+	ProfileMetricTypeUnset ProfileMetricType = ""
+
 	// ProfileMetricTypeGauge is used to create a gauge metric
 	ProfileMetricTypeGauge ProfileMetricType = "gauge"
 
@@ -55,6 +57,8 @@ type SymbolConfigCompat SymbolConfig
 type SymbolConfig struct {
 	OID  string `yaml:"OID,omitempty" json:"OID,omitempty"`
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	// Documentation-only: This field exists solely so hand-written profiles can document where they found a symbol.
+	MIB string `yaml:"MIB,omitempty" json:"-"`
 
 	ExtractValue         string         `yaml:"extract_value,omitempty" json:"extract_value,omitempty"`
 	ExtractValueCompiled *regexp.Regexp `yaml:"-" json:"-"`
@@ -81,12 +85,15 @@ type MetricTagConfig struct {
 	// Table config
 	Index uint `yaml:"index,omitempty" json:"index,omitempty"`
 
-	// DEPRECATED: Column field is deprecated in favour of Symbol field
-	Column SymbolConfig `yaml:"column,omitempty" json:"-"`
+	// Documentation-only: These fields exist solely so hand-written yaml profiles can document where they found a symbol.
+	MIB   string `yaml:"MIB,omitempty" json:"-"`
+	Table string `yaml:"table,omitempty" json:"-"`
 
-	// Symbol config
-	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"` // DEPRECATED replaced by Symbol field
-	// Using Symbol field below as string is deprecated
+	// DEPRECATED: Column and OID are replaced by the Symbol field
+	Column SymbolConfig `yaml:"column,omitempty" json:"-"`
+	OID    string       `yaml:"OID,omitempty" json:"-"` // DEPRECATED replaced by Symbol field
+
+	// SymbolConfigCompat will also parse a plain string, but this behavior is deprecated.
 	Symbol SymbolConfigCompat `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
 	IndexTransform []MetricIndexTransform `yaml:"index_transform,omitempty" json:"index_transform,omitempty"`
@@ -128,9 +135,11 @@ type MetricsConfig struct {
 	// Symbol configs
 	Symbol SymbolConfig `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
-	// Legacy Symbol configs syntax
-	OID  string `yaml:"OID,omitempty" json:"OID,omitempty" jsonschema:"-"`
-	Name string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"-"`
+	// DEPRECATED: These have been moved into Symbol and/or Symbols
+	OID        string            `yaml:"OID,omitempty" json:"-" jsonschema:"-"`
+	Name       string            `yaml:"name,omitempty" json:"-" jsonschema:"-"`
+	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"-"` // renamed to MetricType
+	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"-"` // moved into Symbol/Symbols
 
 	// Table configs
 	Symbols []SymbolConfig `yaml:"symbols,omitempty" json:"symbols,omitempty"`
@@ -138,9 +147,6 @@ type MetricsConfig struct {
 	// `static_tags` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
 	StaticTags []string            `yaml:"static_tags,omitempty" json:"-"`
 	MetricTags MetricTagConfigList `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
-
-	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"` // deprecated in favour of metric_type
-	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty" jsonschema:"-"` // deprecated in favour of symbol.metric_type
 
 	// `options` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
 	Options MetricsConfigOption `yaml:"options,omitempty" json:"-"`

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "normalize_cmd",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	Run: func(cmd *cobra.Command, args []string) {
+		outdir, err := cmd.Flags().GetString("outdir")
+		if err != nil {
+			fmt.Printf("parse failure %v, unable to generate output\n", err)
+		}
+		useJSON, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			fmt.Printf("parse failure %v, unable to generate output\n", err)
+		}
+		for _, filePath := range args {
+			filename := filepath.Base(filePath)
+			name := filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
+			def, errors := GetProfile(filePath)
+			if len(errors) > 0 {
+				fmt.Printf("*** %d error(s) in profile %q ***\n", len(errors), filePath)
+				for _, e := range errors {
+					fmt.Println("  ", e)
+				}
+				fmt.Println()
+				continue
+			}
+			if err := WriteProfile(def, name, outdir, useJSON); err != nil {
+				fmt.Println(err)
+			}
+		}
+	},
+}
+
+func GetProfile(filePath string) (*profiledefinition.ProfileDefinition, []string) {
+	buf, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+	}
+	def := profiledefinition.NewProfileDefinition()
+	err = yaml.Unmarshal(buf, def)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("unable to parse profile: %v", err)}
+	}
+	errors := profiledefinition.ValidateEnrichProfile(def)
+	if len(errors) > 0 {
+		return nil, errors
+	}
+	return def, nil
+}
+
+func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir string, useJSON bool) error {
+	if outdir == "" {
+		return nil
+	}
+	var filename string
+	var data []byte
+	if useJSON {
+		var err error
+		filename = name + ".json"
+		data, err = json.Marshal(def)
+		if err != nil {
+			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
+		}
+	} else {
+		var err error
+		data, err = yaml.Marshal(def)
+		filename = name + ".yaml"
+		if err != nil {
+			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
+		}
+	}
+	outfile := filepath.Join(outdir, filename)
+	f, err := os.Create(outfile)
+	if err != nil {
+		return fmt.Errorf("unable to create file %s: %w", outfile, err)
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	if err != nil {
+		return fmt.Errorf("unable to write to file %s: %w", outfile, err)
+	}
+	return nil
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	rootCmd.Flags().StringP("outdir", "o", "", "Output path for normalized files. If blank, inputs will be validated but not output.")
+	rootCmd.Flags().BoolP("json", "j", false, "Output as JSON")
+}

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -61,7 +61,8 @@ func GetProfile(filePath string) (*profiledefinition.ProfileDefinition, []string
 		return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
 	}
 	def := profiledefinition.NewProfileDefinition()
-	err = yaml.Unmarshal(buf, def)
+
+	err = yaml.UnmarshalStrict(buf, def)
 	if err != nil {
 		return nil, []string{fmt.Sprintf("unable to parse profile: %v", err)}
 	}

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/main.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/main.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package main
+
+import "github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -18,7 +18,7 @@ type DeviceMeta struct {
 // 2/ Datadog backend: the profiles are in json format, they are used to store profiles created via UI.
 // The serialisation of json profiles are defined by the json annotation.
 type ProfileDefinition struct {
-	Name         string            `yaml:"name" json:"name"`
+	Name         string            `yaml:"name,omitempty" json:"name,omitempty"`
 	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
 	SysObjectIDs StringArray       `yaml:"sysobjectid,omitempty" json:"sysobjectid,omitempty"`
 	Extends      []string          `yaml:"extends,omitempty" json:"extends,omitempty"`
@@ -33,7 +33,7 @@ type ProfileDefinition struct {
 
 	// Version is the profile version.
 	// It is currently used only with downloaded/RC profiles.
-	Version uint64 `yaml:"version,omitempty" json:"version"`
+	Version uint64 `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 // DeviceProfileRcConfig represent the profile stored in remote config.

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -111,9 +111,6 @@
         },
         "metric_tags": {
           "$ref": "#/$defs/MetricTagConfigList"
-        },
-        "metric_type": {
-          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -162,11 +159,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name",
-        "version"
-      ]
+      "type": "object"
     },
     "StringArray": {
       "items": {
@@ -183,6 +176,12 @@
           "type": "string"
         },
         "extract_value": {
+          "type": "string"
+        },
+        "match_pattern": {
+          "type": "string"
+        },
+        "match_value": {
           "type": "string"
         },
         "scale_factor": {
@@ -210,6 +209,12 @@
           "type": "string"
         },
         "extract_value": {
+          "type": "string"
+        },
+        "match_pattern": {
+          "type": "string"
+        },
+        "match_value": {
           "type": "string"
         },
         "scale_factor": {

--- a/pkg/networkdevice/profile/profiledefinition/validation.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation.go
@@ -1,0 +1,260 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var validMetadataResources = map[string]map[string]bool{
+	"device": {
+		"name":          true,
+		"description":   true,
+		"sys_object_id": true,
+		"location":      true,
+		"serial_number": true,
+		"vendor":        true,
+		"version":       true,
+		"product_name":  true,
+		"model":         true,
+		"os_name":       true,
+		"os_version":    true,
+		"os_hostname":   true,
+		"type":          true,
+	},
+	"interface": {
+		"name":         true,
+		"alias":        true,
+		"description":  true,
+		"mac_address":  true,
+		"admin_status": true,
+		"oper_status":  true,
+	},
+}
+
+// SymbolContext represent the context in which the symbol is used
+type SymbolContext int64
+
+// ScalarSymbol enums
+const (
+	ScalarSymbol SymbolContext = iota
+	ColumnSymbol
+	MetricTagSymbol
+	MetadataSymbol
+)
+
+// ValidateEnrichProfile validates a profile and normalizes it.
+func ValidateEnrichProfile(profile *ProfileDefinition) []string {
+	NormalizeMetrics(profile.Metrics)
+	if profile.Device.Vendor != "" {
+		dev, ok := profile.Metadata["device"]
+		if !ok {
+			profile.Metadata["device"] = MetadataResourceConfig{
+				Fields: make(map[string]MetadataField),
+			}
+			dev = profile.Metadata["device"]
+		}
+		_, ok = dev.Fields["vendor"]
+		if !ok {
+			dev.Fields["vendor"] = MetadataField{
+				Value: profile.Device.Vendor,
+			}
+		}
+	}
+	profile.Device.Vendor = ""
+	errors := ValidateEnrichMetadata(profile.Metadata)
+	errors = append(errors, ValidateEnrichMetrics(profile.Metrics)...)
+	errors = append(errors, ValidateEnrichMetricTags(profile.MetricTags)...)
+	return errors
+}
+
+// ValidateEnrichMetricTags validates and normalizes metric tags
+func ValidateEnrichMetricTags(metricTags []MetricTagConfig) []string {
+	var errors []string
+	for i := range metricTags {
+		errors = append(errors, validateEnrichMetricTag(&metricTags[i])...)
+	}
+	return errors
+}
+
+// ValidateEnrichMetrics will validate MetricsConfig and enrich it.
+// Example of enrichment:
+// - storage of compiled regex pattern
+func ValidateEnrichMetrics(metrics []MetricsConfig) []string {
+	var errors []string
+	for i := range metrics {
+		metricConfig := &metrics[i]
+		if !metricConfig.IsScalar() && !metricConfig.IsColumn() {
+			errors = append(errors, fmt.Sprintf("either a table symbol or a scalar symbol must be provided: %#v", metricConfig))
+		}
+		if metricConfig.IsScalar() && metricConfig.IsColumn() {
+			errors = append(errors, fmt.Sprintf("table symbol and scalar symbol cannot be both provided: %#v", metricConfig))
+		}
+		if metricConfig.IsScalar() {
+			errors = append(errors, validateEnrichSymbol(&metricConfig.Symbol, ScalarSymbol)...)
+		}
+		if metricConfig.IsColumn() {
+			for j := range metricConfig.Symbols {
+				errors = append(errors, validateEnrichSymbol(&metricConfig.Symbols[j], ColumnSymbol)...)
+			}
+			if len(metricConfig.MetricTags) == 0 {
+				errors = append(errors, fmt.Sprintf("column symbols doesn't have a 'metric_tags' section (%+v), all its metrics will use the same tags; "+
+					"if the table has multiple rows, only one row will be submitted; "+
+					"please add at least one discriminating metric tag (such as a row index) "+
+					"to ensure metrics of all rows are submitted", metricConfig.Symbols))
+			}
+			for i := range metricConfig.MetricTags {
+				metricTag := &metricConfig.MetricTags[i]
+				errors = append(errors, validateEnrichMetricTag(metricTag)...)
+			}
+		}
+		// Setting forced_type value to metric_type value for backward compatibility
+		if metricConfig.MetricType == "" && metricConfig.ForcedType != "" {
+			metricConfig.MetricType = metricConfig.ForcedType
+		}
+		metricConfig.ForcedType = ""
+		// Migrate metric_type into the symbol for scalars.
+		if metricConfig.MetricType != "" {
+			if metricConfig.IsColumn() {
+				errors = append(errors, fmt.Sprintf("tables cannot have metric_type set: %#v", metricConfig))
+			} else {
+				if metricConfig.Symbol.MetricType == "" {
+					metricConfig.Symbol.MetricType = metricConfig.MetricType
+				}
+				metricConfig.MetricType = ""
+			}
+		}
+	}
+	return errors
+}
+
+// ValidateEnrichMetadata will validate MetadataConfig and enrich it.
+func ValidateEnrichMetadata(metadata MetadataConfig) []string {
+	var errors []string
+	for resName := range metadata {
+		_, isValidRes := validMetadataResources[resName]
+		if !isValidRes {
+			errors = append(errors, fmt.Sprintf("invalid resource: %s", resName))
+		} else {
+			res := metadata[resName]
+			for fieldName := range res.Fields {
+				_, isValidField := validMetadataResources[resName][fieldName]
+				if !isValidField {
+					errors = append(errors, fmt.Sprintf("invalid resource (%s) field: %s", resName, fieldName))
+					continue
+				}
+				field := res.Fields[fieldName]
+				for i := range field.Symbols {
+					errors = append(errors, validateEnrichSymbol(&field.Symbols[i], MetadataSymbol)...)
+				}
+				if field.Symbol.OID != "" {
+					errors = append(errors, validateEnrichSymbol(&field.Symbol, MetadataSymbol)...)
+				}
+				res.Fields[fieldName] = field
+			}
+			metadata[resName] = res
+		}
+		if resName == "device" && len(metadata[resName].IDTags) > 0 {
+			errors = append(errors, "device resource does not support custom id_tags")
+		}
+		for i := range metadata[resName].IDTags {
+			metricTag := &metadata[resName].IDTags[i]
+			errors = append(errors, validateEnrichMetricTag(metricTag)...)
+		}
+	}
+	return errors
+}
+
+func validateEnrichSymbol(symbol *SymbolConfig, symbolContext SymbolContext) []string {
+	var errors []string
+	if symbol.Name == "" {
+		errors = append(errors, fmt.Sprintf("symbol name missing: name=`%s` oid=`%s`", symbol.Name, symbol.OID))
+	}
+	if symbol.OID == "" {
+		if symbolContext == ColumnSymbol && !symbol.ConstantValueOne {
+			errors = append(errors, fmt.Sprintf("symbol oid or send_as_one missing: name=`%s` oid=`%s`", symbol.Name, symbol.OID))
+		} else if symbolContext != ColumnSymbol {
+			errors = append(errors, fmt.Sprintf("symbol oid missing: name=`%s` oid=`%s`", symbol.Name, symbol.OID))
+		}
+	}
+	if symbol.ExtractValue != "" {
+		pattern, err := regexp.Compile(symbol.ExtractValue)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("cannot compile `extract_value` (%s): %s", symbol.ExtractValue, err.Error()))
+		} else {
+			symbol.ExtractValueCompiled = pattern
+		}
+	}
+	if symbol.MatchPattern != "" {
+		pattern, err := regexp.Compile(symbol.MatchPattern)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("cannot compile `extract_value` (%s): %s", symbol.ExtractValue, err.Error()))
+		} else {
+			symbol.MatchPatternCompiled = pattern
+		}
+	}
+	if symbolContext != ColumnSymbol && symbol.ConstantValueOne {
+		errors = append(errors, "`constant_value_one` cannot be used outside of tables")
+	}
+	if (symbolContext != ColumnSymbol && symbolContext != ScalarSymbol) && symbol.MetricType != "" {
+		errors = append(errors, "`metric_type` cannot be used outside scalar/table metric symbols and metrics root")
+	}
+	return errors
+}
+func validateEnrichMetricTag(metricTag *MetricTagConfig) []string {
+	var errors []string
+	if (metricTag.Column.OID != "" || metricTag.Column.Name != "") && (metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "") {
+		errors = append(errors, fmt.Sprintf("metric tag symbol and column cannot be both declared: symbol=%v, column=%v", metricTag.Symbol, metricTag.Column))
+	}
+
+	// Move deprecated metricTag.Column to metricTag.Symbol
+	if metricTag.Column.OID != "" || metricTag.Column.Name != "" {
+		metricTag.Symbol = SymbolConfigCompat(metricTag.Column)
+		metricTag.Column = SymbolConfig{}
+	}
+
+	// OID/Name to Symbol harmonization:
+	// When users declare metric tag like:
+	//   metric_tags:
+	//     - OID: 1.2.3
+	//       symbol: aSymbol
+	// this will lead to OID stored as MetricTagConfig.OID  and name stored as MetricTagConfig.Symbol.Name
+	// When this happens, we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.
+	if metricTag.OID != "" && metricTag.Symbol.OID != "" {
+		errors = append(errors, fmt.Sprintf("metric tag OID and symbol.OID cannot be both declared: OID=%s, symbol.OID=%s", metricTag.OID, metricTag.Symbol.OID))
+	}
+	if metricTag.OID != "" && metricTag.Symbol.OID == "" {
+		metricTag.Symbol.OID = metricTag.OID
+		metricTag.OID = ""
+	}
+	if metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "" {
+		symbol := SymbolConfig(metricTag.Symbol)
+		errors = append(errors, validateEnrichSymbol(&symbol, MetricTagSymbol)...)
+		metricTag.Symbol = SymbolConfigCompat(symbol)
+	}
+	if metricTag.Match != "" {
+		errors = append(errors, fmt.Sprintf("MetricTag.Match is deprecated."))
+		pattern, err := regexp.Compile(metricTag.Match)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("cannot compile `match` (`%s`): %s", metricTag.Match, err.Error()))
+		} else {
+			metricTag.Pattern = pattern
+		}
+		if len(metricTag.Tags) == 0 {
+			errors = append(errors, fmt.Sprintf("`tags` mapping must be provided if `match` (`%s`) is defined", metricTag.Match))
+		}
+	}
+	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" {
+		errors = append(errors, fmt.Sprintf("``tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
+	}
+	for _, transform := range metricTag.IndexTransform {
+		if transform.Start > transform.End {
+			errors = append(errors, fmt.Sprintf("transform rule end should be greater than start. Invalid rule: %#v", transform))
+		}
+	}
+	return errors
+}

--- a/pkg/networkdevice/profile/profiledefinition/validation_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation_test.go
@@ -856,7 +856,7 @@ func Test_validateEnrichMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errors := NormalizeMetadata(tt.metadata)
+			errors := ValidateEnrichMetadata(tt.metadata)
 			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
 			for i := range errors {
 				assert.Contains(t, errors[i], tt.expectedErrors[i])

--- a/pkg/networkdevice/profile/profiledefinition/validation_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation_test.go
@@ -1,0 +1,871 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateEnrichMetrics(t *testing.T) {
+	tests := []struct {
+		name            string
+		metrics         []MetricsConfig
+		expectedErrors  []string
+		expectedMetrics []MetricsConfig
+	}{
+		{
+			name: "either table symbol or scalar symbol must be provided",
+			metrics: []MetricsConfig{
+				{},
+			},
+			expectedErrors: []string{
+				"either a table symbol or a scalar symbol must be provided",
+			},
+			expectedMetrics: []MetricsConfig{
+				{},
+			},
+		},
+		{
+			name: "table column symbols and scalar symbol cannot be both provided",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2",
+						Name: "abc",
+					},
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"table symbol and scalar symbol cannot be both provided",
+			},
+		},
+		{
+			name: "multiple errors",
+			metrics: []MetricsConfig{
+				{},
+				{
+					Symbol: SymbolConfig{
+						OID:  "1.2",
+						Name: "abc",
+					},
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"either a table symbol or a scalar symbol must be provided",
+				"table symbol and scalar symbol cannot be both provided",
+			},
+		},
+		{
+			name: "missing symbol name",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID: "1.2.3",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"either a table symbol or a scalar symbol must be provided",
+			},
+		},
+		{
+			name: "table column symbol name missing",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID: "1.2",
+						},
+						{
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol name missing: name=`` oid=`1.2`",
+				"symbol oid or send_as_one missing: name=`abc` oid=``",
+			},
+		},
+		{
+			name: "table external metric column tag symbol error",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID: "1.2.3",
+							},
+						},
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol name missing: name=`` oid=`1.2.3`",
+				"symbol oid missing: name=`abc` oid=``",
+			},
+		},
+		{
+			name: "missing MetricTags",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{},
+				},
+			},
+			expectedErrors: []string{
+				"column symbols doesn't have a 'metric_tags' section",
+			},
+		},
+		{
+			name: "table external metric column tag MIB error",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID: "1.2.3",
+							},
+						},
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol name missing: name=`` oid=`1.2.3`",
+				"symbol oid missing: name=`abc` oid=``",
+			},
+		},
+		{
+			name: "missing match tags",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.3",
+								Name: "abc",
+							},
+							Match: "([a-z])",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"`tags` mapping must be provided if `match` (`([a-z])`) is defined",
+			},
+		},
+		{
+			name: "match cannot compile regex",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.3",
+								Name: "abc",
+							},
+							Match: "([a-z)",
+							Tags: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"cannot compile `match` (`([a-z)`)",
+			},
+		},
+		{
+			name: "match cannot compile regex",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.3",
+								Name: "abc",
+							},
+							Tag: "hello",
+							IndexTransform: []MetricIndexTransform{
+								{
+									Start: 2,
+									End:   1,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"transform rule end should be greater than start. Invalid rule",
+			},
+		},
+		{
+			name: "compiling extract_value",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:          "1.2.3",
+						Name:         "myMetric",
+						ExtractValue: `(\d+)C`,
+					},
+				},
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:          "1.2",
+							Name:         "hey",
+							ExtractValue: `(\d+)C`,
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:          "1.2.3",
+								Name:         "abc",
+								ExtractValue: `(\d+)C`,
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedMetrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:                  "1.2.3",
+						Name:                 "myMetric",
+						ExtractValue:         `(\d+)C`,
+						ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
+					},
+				},
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:                  "1.2",
+							Name:                 "hey",
+							ExtractValue:         `(\d+)C`,
+							ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:                  "1.2.3",
+								Name:                 "abc",
+								ExtractValue:         `(\d+)C`,
+								ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "error compiling extract_value",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:          "1.2.3",
+						Name:         "myMetric",
+						ExtractValue: "[{",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"cannot compile `extract_value`",
+			},
+		},
+		{
+			name: "constant_value_one usage in column symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							Name:             "abc",
+							ConstantValueOne: true,
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "constant_value_one usage in scalar symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						Name:             "myMetric",
+						ConstantValueOne: true,
+					},
+				},
+			},
+			expectedErrors: []string{
+				"either a table symbol or a scalar symbol must be provided",
+			},
+		},
+		{
+			name: "constant_value_one usage in scalar symbol with OID",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						OID:              "1.2.3",
+						Name:             "myMetric",
+						ConstantValueOne: true,
+					},
+				},
+			},
+			expectedErrors: []string{
+				"`constant_value_one` cannot be used outside of tables",
+			},
+		},
+		{
+			name: "constant_value_one usage in metric tags",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name:             "abc",
+								ConstantValueOne: true,
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol oid missing",
+				"`constant_value_one` cannot be used outside of tables",
+			},
+		},
+		{
+			name: "metric_type usage in column symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							Name:       "abc",
+							OID:        "1.2.3",
+							MetricType: ProfileMetricTypeCounter,
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "metric_type usage in scalar symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						Name:       "abc",
+						OID:        "1.2.3",
+						MetricType: ProfileMetricTypeCounter,
+					},
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "ERROR metric_type usage in metric_tags",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name:       "abc",
+								OID:        "1.2.3",
+								MetricType: ProfileMetricTypeCounter,
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"`metric_type` cannot be used outside scalar/table metric symbols and metrics root",
+			},
+		},
+		{
+			name: "metric root forced_type converted to metric_type",
+			metrics: []MetricsConfig{
+				{
+					ForcedType: ProfileMetricTypeCounter,
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedMetrics: []MetricsConfig{
+				{
+					MetricType: ProfileMetricTypeCounter,
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mapping used without tag should raise an error",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2",
+								Name: "abc",
+							},
+							Mapping: map[string]string{
+								"1": "abc",
+								"2": "def",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{"`tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateEnrichMetrics(tt.metrics)
+			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
+			for i := range errors {
+				assert.Contains(t, errors[i], tt.expectedErrors[i])
+			}
+			if tt.expectedMetrics != nil {
+				assert.Equal(t, tt.expectedMetrics, tt.metrics)
+			}
+		})
+	}
+}
+
+func Test_ValidateEnrichMetricTags(t *testing.T) {
+	tests := []struct {
+		name            string
+		metrics         []MetricTagConfig
+		expectedErrors  []string
+		expectedMetrics []MetricTagConfig
+	}{
+		{
+			name: "Move OID to Symbol",
+			metrics: []MetricTagConfig{
+				{
+					OID: "1.2.3.4",
+					Symbol: SymbolConfigCompat{
+						Name: "mySymbol",
+					},
+				},
+			},
+			expectedMetrics: []MetricTagConfig{
+				{
+					Symbol: SymbolConfigCompat{
+						OID:  "1.2.3.4",
+						Name: "mySymbol",
+					},
+				},
+			},
+		},
+		{
+			name: "Metric tag OID and symbol.OID cannot be both declared",
+			metrics: []MetricTagConfig{
+				{
+					OID: "1.2.3.4",
+					Symbol: SymbolConfigCompat{
+						OID:  "1.2.3.5",
+						Name: "mySymbol",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"metric tag OID and symbol.OID cannot be both declared",
+			},
+		},
+		{
+			name: "metric tag symbol and column cannot be both declared",
+			metrics: []MetricTagConfig{
+				{
+					Symbol: SymbolConfigCompat{
+						OID:  "1.2.3.5",
+						Name: "mySymbol",
+					},
+					Column: SymbolConfig{
+						OID:  "1.2.3.5",
+						Name: "mySymbol",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"metric tag symbol and column cannot be both declared",
+			},
+		},
+		{
+			name: "Missing OID",
+			metrics: []MetricTagConfig{
+				{
+					Symbol: SymbolConfigCompat{
+						Name: "mySymbol",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol oid missing",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateEnrichMetricTags(tt.metrics)
+			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
+			for i := range errors {
+				assert.Contains(t, errors[i], tt.expectedErrors[i])
+			}
+			if tt.expectedMetrics != nil {
+				assert.Equal(t, tt.expectedMetrics, tt.metrics)
+			}
+		})
+	}
+}
+
+func Test_validateEnrichMetadata(t *testing.T) {
+	tests := []struct {
+		name             string
+		metadata         MetadataConfig
+		expectedErrors   []string
+		expectedMetadata MetadataConfig
+	}{
+		{
+			name: "both field symbol and value can be provided",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Value: "hey",
+							Symbol: SymbolConfig{
+								OID:  "1.2.3",
+								Name: "someSymbol",
+							},
+						},
+					},
+				},
+			},
+			expectedMetadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Value: "hey",
+							Symbol: SymbolConfig{
+								OID:  "1.2.3",
+								Name: "someSymbol",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid regex pattern for symbol",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Symbol: SymbolConfig{
+								OID:          "1.2.3",
+								Name:         "someSymbol",
+								ExtractValue: "(\\w[)",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"cannot compile `extract_value`",
+			},
+		},
+		{
+			name: "invalid regex pattern for multiple symbols",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Symbols: []SymbolConfig{
+								{
+									OID:          "1.2.3",
+									Name:         "someSymbol",
+									ExtractValue: "(\\w[)",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"cannot compile `extract_value`",
+			},
+		},
+		{
+			name: "field regex pattern is compiled",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Symbol: SymbolConfig{
+								OID:          "1.2.3",
+								Name:         "someSymbol",
+								ExtractValue: "(\\w)",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+			expectedMetadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Symbol: SymbolConfig{
+								OID:                  "1.2.3",
+								Name:                 "someSymbol",
+								ExtractValue:         "(\\w)",
+								ExtractValueCompiled: regexp.MustCompile(`(\w)`),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid resource",
+			metadata: MetadataConfig{
+				"invalid-res": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Value: "hey",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"invalid resource: invalid-res",
+			},
+		},
+		{
+			name: "invalid field",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"invalid-field": {
+							Value: "hey",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"invalid resource (device) field: invalid-field",
+			},
+		},
+		{
+			name: "invalid idtags",
+			metadata: MetadataConfig{
+				"interface": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"invalid-field": {
+							Value: "hey",
+						},
+					},
+					IDTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.3",
+								Name: "abc",
+							},
+							Match: "([a-z)",
+							Tags: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"invalid resource (interface) field: invalid-field",
+				"cannot compile `match` (`([a-z)`)",
+			},
+		},
+		{
+			name: "device resource does not support id_tags",
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
+						"name": {
+							Value: "hey",
+						},
+					},
+					IDTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
+								OID:  "1.2.3",
+								Name: "abc",
+							},
+							Tag: "abc",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"device resource does not support custom id_tags",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := NormalizeMetadata(tt.metadata)
+			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
+			for i := range errors {
+				assert.Contains(t, errors[i], tt.expectedErrors[i])
+			}
+			if tt.expectedMetadata != nil {
+				assert.Equal(t, tt.expectedMetadata, tt.metadata)
+			}
+		})
+	}
+}
+
+// TODO: Add test for ValidateEnrichMetricTags

--- a/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
+++ b/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
@@ -5,6 +5,8 @@
 
 package profiledefinition
 
+import "fmt"
+
 // StringArray is list of string with a yaml un-marshaller that support both array and string.
 // See test file for example usage.
 // Credit: https://github.com/go-yaml/yaml/issues/100#issuecomment-324964723
@@ -15,10 +17,12 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var multi []string
 	err := unmarshal(&multi)
 	if err != nil {
+		// we have to cache the error because calling unmarshal again *modifies err in place* for some reason.
+		cachedErr := fmt.Errorf("%w", err)
 		var single string
-		err := unmarshal(&single)
-		if err != nil {
-			return err
+		err2 := unmarshal(&single)
+		if err2 != nil {
+			return cachedErr
 		}
 		*a = []string{single}
 	} else {
@@ -32,10 +36,12 @@ func (a *SymbolConfigCompat) UnmarshalYAML(unmarshal func(interface{}) error) er
 	var symbol SymbolConfig
 	err := unmarshal(&symbol)
 	if err != nil {
+		// we have to cache the error because calling unmarshal again *modifies err in place* for some reason.
+		cachedErr := fmt.Errorf("%w", err)
 		var str string
-		err := unmarshal(&str)
-		if err != nil {
-			return err
+		err2 := unmarshal(&str)
+		if err2 != nil {
+			return cachedErr
 		}
 		*a = SymbolConfigCompat(SymbolConfig{Name: str})
 	} else {
@@ -44,15 +50,19 @@ func (a *SymbolConfigCompat) UnmarshalYAML(unmarshal func(interface{}) error) er
 	return nil
 }
 
-// UnmarshalYAML unmarshalls MetricTagConfigList
+// UnmarshalYAML unmarshals a MetricTagConfigList.
+// If the value is a valid []MetricTagConfig, it will be unmarshalled normally.
+// If it's not, we try to unmarshal it as a list of strings, and save those as symbol tags.
 func (mtcl *MetricTagConfigList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var multi []MetricTagConfig
 	err := unmarshal(&multi)
 	if err != nil {
+		// we have to cache the error because calling unmarshal again *modifies err in place* for some reason.
+		cachedErr := fmt.Errorf("%w", err)
 		var tags []string
-		err := unmarshal(&tags)
-		if err != nil {
-			return err
+		err2 := unmarshal(&tags)
+		if err2 != nil {
+			return cachedErr
 		}
 		multi = []MetricTagConfig{}
 		for _, tag := range tags {


### PR DESCRIPTION
### What does this PR do?

This PR copies the validation code from the snmp internals to the `profiledefinition` package, adds some additional validation/normalization, and adds a simple CLI tool for validating profiles and converting them to the latest version.

### Motivation

Some of our OOTB profiles have outdated features and so can't be displayed properly in the new profile editor; we need to mass-update them. In addition, this tool could be helpful for validating customer-written profiles in support cases.

### Describe how to test/QA your changes

This doesn't change anything the agent currently executes so no qa is needed.

### Possible Drawbacks / Trade-offs

Validation code is now duplicated between `profiledefinition` and the internal `config_validate_enrich` package, with slightly different logic in each. We should unify these eventually, but doing so comes at the expense of potentially breaking existing customer profiles if they have errors that we're currently ignoring.

### Additional Notes

Assuming you have this repo and `integrations-core` under `~/dd/`, you can generate cleaned-up JSON versions of all the OOTB profiles except `apc_ups` (which uses `flag_stream`, not yet supported in the frontend) by running:
```sh
cd ~/dd/datadog-agent/pkg/networkdevice/profile/profiledefinition/normalize_cmd
mkdir ~/profiles-fixed
go run main.go ~/dd/integrations-core/snmp/datadog_checks/snmp/data/default_profiles/*.yaml -o ~/profiles-fixed -j
```