### PR TITLE
auto create pull request for cleanup job

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -565,6 +565,7 @@
 /tasks/libs/ciproviders/                @DataDog/agent-devx-infra
 /tasks/libs/common/omnibus.py           @DataDog/agent-delivery
 /tasks/omnibus.py                       @DataDog/agent-delivery
+/tasks/release.py                       @DataDog/agent-delivery
 /tasks/unit_tests/components_tests.py   @DataDog/agent-shared-components
 /tasks/unit_tests/omnibus_tests.py      @DataDog/agent-delivery
 /tasks/unit_tests/testdata/components_src/ @DataDog/agent-shared-components

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -451,13 +451,15 @@ def get_user_query(login):
     return query + string_var
 
 
-def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False):
+def create_release_pr(
+    title, base_branch, target_branch, version, changelog_pr=False, laststable_pr=False, milestone=None
+):
     print(color_message("Creating PR", "bold"))
 
     github = GithubAPI(repository=GITHUB_REPO_NAME)
 
     # Find milestone based on what the next final version is. If the milestone does not exist, fail.
-    milestone_name = str(version)
+    milestone_name = milestone if milestone else str(version)
 
     milestone = github.get_milestone_by_name(milestone_name)
 
@@ -491,8 +493,10 @@ Make sure that milestone is open before trying again.""",
         "qa/no-code-change",
         "team/agent-delivery",
         "team/agent-release-management",
-        "category/release_operations",
     ]
+
+    if not laststable_pr:
+        labels.append("category/release_operations")
 
     if changelog_pr:
         labels.append("backport/main")

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -451,15 +451,13 @@ def get_user_query(login):
     return query + string_var
 
 
-def create_release_pr(
-    title, base_branch, target_branch, version, changelog_pr=False, laststable_pr=False, milestone=None
-):
+def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None):
     print(color_message("Creating PR", "bold"))
 
     github = GithubAPI(repository=GITHUB_REPO_NAME)
 
     # Find milestone based on what the next final version is. If the milestone does not exist, fail.
-    milestone_name = milestone if milestone else str(version)
+    milestone_name = milestone or str(version)
 
     milestone = github.get_milestone_by_name(milestone_name)
 
@@ -494,9 +492,6 @@ Make sure that milestone is open before trying again.""",
         "team/agent-delivery",
         "team/agent-release-management",
     ]
-
-    if not laststable_pr:
-        labels.append("category/release_operations")
 
     if changelog_pr:
         labels.append("backport/main")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -760,7 +760,7 @@ def cleanup(ctx):
     ctx.run("git add release.json")
 
     commit_message = f"Update last_stable to {version}"
-    ok = try_git_command(ctx, f'git commit -m "{commit_message}"')
+    ok = try_git_command(ctx, f"git commit -m '{commit_message}'")
     if not ok:
         raise Exit(
             color_message(
@@ -770,8 +770,7 @@ def cleanup(ctx):
             code=1,
         )
 
-    res = ctx.run(f"git push --set-upstream origin {cleanup_branch}", warn=True)
-    if res.exited is None or res.exited > 0:
+    if not ctx.run(f"git push --set-upstream origin {cleanup_branch}", warn=True):
         raise Exit(
             color_message(
                 f"Could not push branch {cleanup_branch} to the upstream 'origin'. Please push it manually and then open a PR against {main_branch}.",
@@ -780,9 +779,7 @@ def cleanup(ctx):
             code=1,
         )
 
-    create_release_pr(
-        commit_message, main_branch, cleanup_branch, version, laststable_pr=True, milestone=current_milestone
-    )
+    create_release_pr(commit_message, main_branch, cleanup_branch, version, milestone=current_milestone)
 
     edit_schedule(ctx, 2555, ref=version.branch())
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -724,7 +724,7 @@ def create_release_branches(ctx, base_directory="~/dd", major_versions="6,7", up
 
 def _update_last_stable(_, version, major_versions="7"):
     """
-    Updates the last_release field(s) of release.json
+    Updates the last_release field(s) of release.json and returns the current milestone
     """
     release_json = load_release_json()
     list_major_versions = parse_major_versions(major_versions)
@@ -733,6 +733,8 @@ def _update_last_stable(_, version, major_versions="7"):
         version.major = major
         release_json['last_stable'][str(major)] = str(version)
     _save_release_json(release_json)
+
+    return release_json["current_milestone"]
 
 
 @task
@@ -749,7 +751,39 @@ def cleanup(ctx):
     if not match:
         raise Exit(f'Unexpected version fetched from github {latest_release}', code=1)
     version = _create_version_from_match(match)
-    _update_last_stable(ctx, version)
+    current_milestone = _update_last_stable(ctx, version)
+
+    # create pull request to update last stable version
+    main_branch = "main"
+    cleanup_branch = f"release/{version}-cleanup"
+    ctx.run(f"git checkout -b {cleanup_branch}")
+    ctx.run("git add release.json")
+
+    commit_message = f"Update last_stable to {version}"
+    ok = try_git_command(ctx, f'git commit -m "{commit_message}"')
+    if not ok:
+        raise Exit(
+            color_message(
+                f"Could not create commit. Please commit manually with:\ngit commit -m {commit_message}\n, push the {cleanup_branch} branch and then open a PR against {main_branch}.",
+                "red",
+            ),
+            code=1,
+        )
+
+    res = ctx.run(f"git push --set-upstream origin {cleanup_branch}", warn=True)
+    if res.exited is None or res.exited > 0:
+        raise Exit(
+            color_message(
+                f"Could not push branch {cleanup_branch} to the upstream 'origin'. Please push it manually and then open a PR against {main_branch}.",
+                "red",
+            ),
+            code=1,
+        )
+
+    create_release_pr(
+        commit_message, main_branch, cleanup_branch, version, laststable_pr=True, milestone=current_milestone
+    )
+
     edit_schedule(ctx, 2555, ref=version.branch())
 
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds logic in the `release.cleanup` job to auto create the last stable update pull request ([BARX-674](https://datadoghq.atlassian.net/browse/BARX-674))

### Motivation
Reduces the manual work involved in updating the stable version after each release.

### Describe how to test/QA your changes
Ran `inv release.cleanup` job locally with version `7.60.0` (version that isn't stable yet) and checked if a PR is created properly.

Here is [the test PR](https://github.com/DataDog/datadog-agent/pull/31059):

<img width="1185" alt="image" src="https://github.com/user-attachments/assets/3e1b8d96-eee7-490c-add2-85334d54c355">

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[BARX-674]: https://datadoghq.atlassian.net/browse/BARX-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ