### PR TITLE
USM: enable Istio TLS monitoring by default

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -490,7 +490,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_usm_postgres_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_redis_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_http2_enabled"].(bool))
-	assert.False(t, ia.data["feature_usm_istio_enabled"].(bool))
+	assert.True(t, ia.data["feature_usm_istio_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_go_tls_enabled"].(bool))
 	assert.False(t, ia.data["feature_discovery_enabled"].(bool))
 	assert.False(t, ia.data["feature_tcp_queue_length_enabled"].(bool))

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -249,7 +249,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_kafka_monitoring"), false)
 	cfg.BindEnv(join(smNS, "enable_postgres_monitoring"))
 	cfg.BindEnv(join(smNS, "enable_redis_monitoring"))
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), false)
+	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), true)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "envoy_path"), defaultEnvoyPath)
 	cfg.BindEnv(join(smNS, "tls", "nodejs", "enabled"))
 	cfg.BindEnvAndSetDefault(join(smjtNS, "enabled"), false)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1269,23 +1269,23 @@ func TestIstioMonitoring(t *testing.T) {
 		mock.NewSystemProbe(t)
 		cfg := New()
 
-		assert.False(t, cfg.EnableIstioMonitoring)
+		assert.True(t, cfg.EnableIstioMonitoring)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.istio.enabled", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.tls.istio.enabled", false)
 		cfg := New()
 
-		assert.True(t, cfg.EnableIstioMonitoring)
+		assert.False(t, cfg.EnableIstioMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED", "false")
 		cfg := New()
 
-		assert.True(t, cfg.EnableIstioMonitoring)
+		assert.False(t, cfg.EnableIstioMonitoring)
 	})
 }
 

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -82,6 +82,8 @@ func TestMonitorProtocolFail(t *testing.T) {
 
 			cfg := config.New()
 			cfg.EnableHTTPMonitoring = true
+			cfg.EnableIstioMonitoring = false
+
 			monitor, err := NewMonitor(cfg, nil)
 			skipIfNotSupported(t, err)
 			require.NoError(t, err)

--- a/releasenotes/notes/enable-istio-tls-by-default-1da65945911f278a.yaml
+++ b/releasenotes/notes/enable-istio-tls-by-default-1da65945911f278a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enable USM Istio TLS monitoring by default, if USM is enabled.

--- a/releasenotes/notes/enable-istio-tls-by-default-1da65945911f278a.yaml
+++ b/releasenotes/notes/enable-istio-tls-by-default-1da65945911f278a.yaml
@@ -1,4 +1,6 @@
 ---
 features:
   - |
-    Enable USM Istio TLS monitoring by default, if USM is enabled.
+    USM will now monitor traffic that is encrypted using Istio mTLS by default.
+    This can be turned off by setting to false the
+    `service_monitoring_config.tls.istio.enabled` configuration option.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables USM's Istio TLS monitoring by default.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->