### PR TITLE
Don't set rpath relative to $ORIGIN on Linux builds

### DIFF
--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -80,36 +80,6 @@
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
-# Temporary custom agent build test to prevent regression
-# This test will be removed when custom path are used to build macos agent
-# with in-house macos runner builds.
-datadog-agent-7-x64-custom-path-test:
-  extends: [.agent_build_x86, .agent_7_build]
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  stage: package_build
-  script:
-    - mkdir /custom
-    - export CONFIG_DIR="/custom"
-    - export INSTALL_DIR="/custom/datadog-agent"
-    - !reference [.agent_build_script]
-    - ls -la $OMNIBUS_PACKAGE_DIR
-    - ls -la $INSTALL_DIR
-    - ls -la /custom/etc
-    - (ls -la /opt/datadog-agent 2>/dev/null && exit 1) || echo "/opt/datadog-agent has correctly not been generated"
-    - (ls -la /etc/datadog-agent 2>/dev/null && exit 1) || echo "/etc/datadog-agent has correctly not been generated"
-  variables:
-    KUBERNETES_CPU_REQUEST: 16
-    KUBERNETES_MEMORY_REQUEST: "32Gi"
-    KUBERNETES_MEMORY_LIMIT: "32Gi"
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
-
 # build Agent 7 binaries for x86_64
 datadog-agent-7-x64:
   extends: [.agent_build_common, .agent_build_x86, .agent_7_build]

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -168,9 +168,6 @@ build do
             # Most postgres binaries are removed in postgres' own software
             # recipe, but we need pg_config to build psycopq.
             delete "#{install_dir}/embedded/bin/pg_config"
-
-            # Edit rpath from a true path to relative path for each binary
-            command "inv omnibus.rpath-edit #{install_dir} #{install_dir}", cwd: Dir.pwd
         end
 
         if osx_target?

--- a/releasenotes/notes/remove-rpath-patching-linux-b7afc259e338e1b5.yaml
+++ b/releasenotes/notes/remove-rpath-patching-linux-b7afc259e338e1b5.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+    Fix a regression that caused the Agent to not be able to run if its
+    capabilities had been modified with the `setcap` command.


### PR DESCRIPTION
### What does this PR do?

It stops patching the rpath in the packaged binaries to use paths relative to $ORIGIN.

### Motivation

A number of setups require (or are made easier) by using `setcap` to for example let the Agent listen on reserved ports (< 1024) without requiring it to run as root. For security, $ORIGIN is not followed by binaries that have been modified permissions wise in this fashion (same with comands such as `setuid`). This causes a `setcap`-ed Agent to not find libraries when $ORIGIN is used in the rpath.

### Describe how to test/QA your changes

Tested on a Ubuntu VM:

```
$ datadog-agent version
Agent 7.61.0-devel - Meta: git.238.43b5fca - Commit: 43b5fca25b - Serialization version: v5.0.135 - Go version: go1.22.8
$ datadog-agent
# [ outputs help ]
$ sudo setcap CAP_NET_BIND_SERVICE=+ep /opt/datadog-agent/bin/agent/agent
$ datadog-agent
# [ outputs help normally, before this fix it would complain about not finding rtloader ]
```

### Possible Drawbacks / Trade-offs

This throws a spanner in the works in our plan to make a location-independent Agent, but it's not urgent enough to warrant inconveniencing users and thus can be postponed.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->