### PR TITLE
kubelet: Add support for resource assignments via PodResources API

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3771,6 +3771,7 @@ core,k8s.io/kube-state-metrics/v2/pkg/watch,Apache-2.0,Copyright 2014 The Kubern
 core,k8s.io/kubectl/pkg/cmd/util,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/kubectl/pkg/cmd/util/podcmd,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/kubectl/pkg/scheme,Apache-2.0,Copyright 2014 The Kubernetes Authors.
+core,k8s.io/kubelet/pkg/apis/podresources/v1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/kubelet/pkg/apis/stats/v1alpha1,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/metrics/pkg/apis/custom_metrics,Apache-2.0,Copyright 2014 The Kubernetes Authors.
 core,k8s.io/metrics/pkg/apis/custom_metrics/install,Apache-2.0,Copyright 2014 The Kubernetes Authors.

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -265,6 +265,14 @@ func (c *collector) parsePodContainers(
 			log.Debugf("cannot find spec for container %q", container.Name)
 		}
 
+		var allocatedResources []workloadmeta.ContainerAllocatedResource
+		for _, resource := range container.Resources {
+			allocatedResources = append(allocatedResources, workloadmeta.ContainerAllocatedResource{
+				Name: resource.Name,
+				ID:   resource.ID,
+			})
+		}
+
 		containerState := workloadmeta.ContainerState{}
 		if st := container.State.Running; st != nil {
 			containerState.Running = true
@@ -301,14 +309,15 @@ func (c *collector) parsePodContainers(
 						kubernetes.CriContainerNamespaceLabel: pod.Metadata.Namespace,
 					},
 				},
-				Image:           image,
-				EnvVars:         env,
-				SecurityContext: containerSecurityContext,
-				Ports:           ports,
-				Runtime:         workloadmeta.ContainerRuntime(runtime),
-				State:           containerState,
-				Owner:           parent,
-				Resources:       resources,
+				Image:              image,
+				EnvVars:            env,
+				SecurityContext:    containerSecurityContext,
+				Ports:              ports,
+				Runtime:            workloadmeta.ContainerRuntime(runtime),
+				State:              containerState,
+				Owner:              parent,
+				Resources:          resources,
+				AllocatedResources: allocatedResources,
 			},
 		})
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -266,7 +266,7 @@ func (c *collector) parsePodContainers(
 		}
 
 		var allocatedResources []workloadmeta.ContainerAllocatedResource
-		for _, resource := range container.Resources {
+		for _, resource := range container.AllocatedResources {
 			allocatedResources = append(allocatedResources, workloadmeta.ContainerAllocatedResource{
 				Name: resource.Name,
 				ID:   resource.ID,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -463,7 +463,7 @@ type ContainerAllocatedResource struct {
 }
 
 func (c ContainerAllocatedResource) String() string {
-	return fmt.Sprintf("Name:%s, ID:%s", c.Name, c.ID)
+	return fmt.Sprintf("Name: %s, ID: %s", c.Name, c.ID)
 }
 
 // OrchestratorContainer is a reference to a Container with
@@ -606,7 +606,7 @@ func (c Container) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "----------- Resources -----------")
 	_, _ = fmt.Fprint(&sb, c.Resources.String(verbose))
 
-	_, _ = fmt.Fprintln(&sb, "----------- Allocated resources -----------")
+	_, _ = fmt.Fprintln(&sb, "----------- Allocated Resources -----------")
 	for _, r := range c.AllocatedResources {
 		_, _ = fmt.Fprintln(&sb, r.String())
 	}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -453,6 +453,19 @@ func (cr ContainerResources) String(bool) string {
 	return sb.String()
 }
 
+// ContainerAllocatedResource is a resource allocated to a container, consisting of a name and an ID.
+type ContainerAllocatedResource struct {
+	// Name is the name of the resource as defined in the pod spec (e.g. "nvidia.com/gpu").
+	Name string
+
+	// ID is the unique ID of the resource, the format depends on the provider
+	ID string
+}
+
+func (c ContainerAllocatedResource) String() string {
+	return fmt.Sprintf("Name:%s, ID:%s", c.Name, c.ID)
+}
+
 // OrchestratorContainer is a reference to a Container with
 // orchestrator-specific data attached to it.
 type OrchestratorContainer struct {
@@ -536,6 +549,10 @@ type Container struct {
 	Owner           *EntityID
 	SecurityContext *ContainerSecurityContext
 	Resources       ContainerResources
+
+	// AllocatedResources is the list of resources allocated to this pod. Requires the
+	// PodResources API to query that data.
+	AllocatedResources []ContainerAllocatedResource
 	// CgroupPath is a path to the cgroup of the container.
 	// It can be relative to the cgroup parent.
 	// Linux only.
@@ -588,6 +605,11 @@ func (c Container) String(verbose bool) string {
 
 	_, _ = fmt.Fprintln(&sb, "----------- Resources -----------")
 	_, _ = fmt.Fprint(&sb, c.Resources.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Allocated resources -----------")
+	for _, r := range c.AllocatedResources {
+		_, _ = fmt.Fprintln(&sb, r.String())
+	}
 
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Hostname:", c.Hostname)

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -30,6 +30,9 @@ func TestDump(t *testing.T) {
 		Resources: wmdef.ContainerResources{
 			GPUVendorList: []string{"nvidia"},
 		},
+		AllocatedResources: []wmdef.ContainerAllocatedResource{
+			{Name: "nvidia.com/gpu", ID: "GPU-1234"},
+		},
 		Runtime:       wmdef.ContainerRuntimeDocker,
 		RuntimeFlavor: wmdef.ContainerRuntimeFlavorKata,
 		EnvVars: map[string]string{
@@ -87,6 +90,8 @@ RuntimeFlavor: kata
 Running: false
 ----------- Resources -----------
 GPUVendor: [nvidia]
+----------- Allocated Resources -----------
+Name: nvidia.com/gpu, ID: GPU-1234
 `,
 				},
 			},
@@ -125,6 +130,8 @@ Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 GPUVendor: [nvidia]
+----------- Allocated Resources -----------
+Name: nvidia.com/gpu, ID: GPU-1234
 Hostname: 
 Network IPs: 
 PID: 0
@@ -154,6 +161,7 @@ Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
+----------- Allocated Resources -----------
 Hostname: 
 Network IPs: 
 PID: 1
@@ -184,6 +192,8 @@ Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 GPUVendor: [nvidia]
+----------- Allocated Resources -----------
+Name: nvidia.com/gpu, ID: GPU-1234
 Hostname: 
 Network IPs: 
 PID: 1

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1677,6 +1677,12 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})
+
+	defaultPodresourcesSocket := "/var/lib/kubelet/pod-resources/kubelet.sock"
+	if runtime.GOOS == "windows" {
+		defaultPodresourcesSocket = `\\.\pipe\kubelet-pod-resources`
+	}
+	config.BindEnvAndSetDefault("kubernetes_kubelet_podresources_socket", defaultPodresourcesSocket)
 }
 
 func podman(config pkgconfigmodel.Setup) {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -84,7 +84,7 @@ func (ku *KubeUtil) init() error {
 		}
 	}
 
-	ku.podResourcesClient, err = NewPodResourcesClient()
+	ku.podResourcesClient, err = NewPodResourcesClient(pkgconfigsetup.Datadog())
 	if err != nil {
 		log.Warnf("Failed to create pod resources client, resource data will not be available: %s", err)
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -281,7 +281,7 @@ func (ku *KubeUtil) addResourcesToContainerList(containerToDevicesMap map[Contai
 		for _, device := range devices {
 			name := device.GetResourceName()
 			for _, id := range device.GetDeviceIds() {
-				container.Resources = append(container.Resources, ContainerResource{
+				container.AllocatedResources = append(container.AllocatedResources, ContainerAllocatedResource{
 					Name: name,
 					ID:   id,
 				})

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -85,7 +85,7 @@ func (ku *KubeUtil) init() error {
 
 	ku.podResources, err = NewPodResourcesClient()
 	if err != nil {
-		log.Debugf("Failed to create pod resources client, resource data will not be available: %s", err)
+		log.Warnf("Failed to create pod resources client, resource data will not be available: %s", err)
 	}
 
 	return nil

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -54,7 +54,7 @@ type KubeUtil struct {
 	filter                 *containers.Filter
 	waitOnMissingContainer time.Duration
 	podUnmarshaller        *podUnmarshaller
-	podResources           *PodResourcesClient
+	podResourcesClient     *PodResourcesClient
 }
 
 func (ku *KubeUtil) init() error {
@@ -84,7 +84,7 @@ func (ku *KubeUtil) init() error {
 		}
 	}
 
-	ku.podResources, err = NewPodResourcesClient()
+	ku.podResourcesClient, err = NewPodResourcesClient()
 	if err != nil {
 		log.Warnf("Failed to create pod resources client, resource data will not be available: %s", err)
 	}
@@ -248,11 +248,11 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 // resources field of each container. If the pod resources API is not available,
 // this is a no-op.
 func (ku *KubeUtil) addContainerResourcesData(ctx context.Context, pods []*Pod) error {
-	if ku.podResources == nil {
+	if ku.podResourcesClient == nil {
 		return nil
 	}
 
-	containerToDevicesMap, err := ku.podResources.GetContainerToDevicesMap(ctx)
+	containerToDevicesMap, err := ku.podResourcesClient.GetContainerToDevicesMap(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting container resources data: %w", err)
 	}

--- a/pkg/util/kubernetes/kubelet/podresources.go
+++ b/pkg/util/kubernetes/kubelet/podresources.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build kubelet
+
+package kubelet
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// PodResourcesClient is a small wrapper for the PodResources kubernetes API
+type PodResourcesClient struct {
+	conn   *grpc.ClientConn
+	client podresourcesv1.PodResourcesListerClient
+}
+
+// ContainerKey is a struct that represents a unique container
+type ContainerKey struct {
+	// Namespace is the namespace of the pod
+	Namespace string
+
+	// PodName is the name of the pod
+	PodName string
+
+	// ContainerName is the name of the container
+	ContainerName string
+}
+
+// NewPodResourcesClient creates a new PodResourcesClient using the socket path
+// from the configuration. Will fail if the socket path is not set.
+func NewPodResourcesClient() (*PodResourcesClient, error) {
+	podResourcesSocket := pkgconfigsetup.Datadog().GetString("kubernetes_kubelet_podresources_socket")
+	if podResourcesSocket == "" {
+		return nil, fmt.Errorf("kubernetes_kubelet_podresources_socket is not set")
+	}
+
+	return NewPodResourcesClientWithSocket("unix://" + podResourcesSocket)
+}
+
+// NewPodResourcesClientWithSocket creates a new PodResourcesClient using the
+// provided socket path (must start with unix://)
+func NewPodResourcesClientWithSocket(socket string) (*PodResourcesClient, error) {
+	conn, err := grpc.NewClient(
+		socket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100*1024*1024)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failure creating gRPC client to '%s': %w", socket, err)
+	}
+
+	client := podresourcesv1.NewPodResourcesListerClient(conn)
+
+	return &PodResourcesClient{
+		conn:   conn,
+		client: client,
+	}, nil
+}
+
+// Close closes the connection to the gRPC server.
+func (c *PodResourcesClient) Close() {
+	c.conn.Close()
+}
+
+// ListPodResources returns a list of PodResources from the gRPC server.
+func (c *PodResourcesClient) ListPodResources(ctx context.Context) ([]*podresourcesv1.PodResources, error) {
+	resp, err := c.client.List(ctx, &podresourcesv1.ListPodResourcesRequest{})
+	return resp.GetPodResources(), err
+}
+
+// GetContainerToDevicesMap returns a map that contains all the containers and
+// the devices assigned to them. Only container with devices are included
+func (c *PodResourcesClient) GetContainerToDevicesMap(ctx context.Context) (map[ContainerKey][]*podresourcesv1.ContainerDevices, error) {
+	pods, err := c.ListPodResources(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	containerResourceMap := make(map[ContainerKey][]*podresourcesv1.ContainerDevices)
+	for _, pod := range pods {
+		for _, container := range pod.GetContainers() {
+			devices := container.GetDevices()
+			if len(devices) == 0 {
+				continue
+			}
+
+			key := ContainerKey{
+				Namespace:     pod.GetNamespace(),
+				PodName:       pod.GetName(),
+				ContainerName: container.GetName(),
+			}
+			containerResourceMap[key] = devices
+		}
+	}
+
+	return containerResourceMap, nil
+}

--- a/pkg/util/kubernetes/kubelet/podresources.go
+++ b/pkg/util/kubernetes/kubelet/podresources.go
@@ -53,7 +53,7 @@ func NewPodResourcesClient() (*PodResourcesClient, error) {
 }
 
 // NewPodResourcesClientWithSocket creates a new PodResourcesClient using the
-// provided socket path (must start with unix://)
+// provided socket path (must start with unix:// on Linux or npipe:// on Windows).
 func NewPodResourcesClientWithSocket(socket string) (*PodResourcesClient, error) {
 	conn, err := grpc.NewClient(
 		socket,

--- a/pkg/util/kubernetes/kubelet/podresources.go
+++ b/pkg/util/kubernetes/kubelet/podresources.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 // PodResourcesClient is a small wrapper for the PodResources kubernetes API
@@ -39,8 +39,8 @@ type ContainerKey struct {
 
 // NewPodResourcesClient creates a new PodResourcesClient using the socket path
 // from the configuration. Will fail if the socket path is not set.
-func NewPodResourcesClient() (*PodResourcesClient, error) {
-	podResourcesSocket := pkgconfigsetup.Datadog().GetString("kubernetes_kubelet_podresources_socket")
+func NewPodResourcesClient(config config.Component) (*PodResourcesClient, error) {
+	podResourcesSocket := config.GetString("kubernetes_kubelet_podresources_socket")
 	if podResourcesSocket == "" {
 		return nil, fmt.Errorf("kubernetes_kubelet_podresources_socket is not set")
 	}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -220,14 +220,21 @@ type Conditions struct {
 
 // ContainerStatus contains fields for unmarshalling a Pod.Status.Containers
 type ContainerStatus struct {
-	Name         string         `json:"name"`
-	Image        string         `json:"image"`
-	ImageID      string         `json:"imageID"`
-	ID           string         `json:"containerID"`
-	Ready        bool           `json:"ready"`
-	RestartCount int            `json:"restartCount"`
-	State        ContainerState `json:"state"`
-	LastState    ContainerState `json:"lastState"`
+	Name         string              `json:"name"`
+	Image        string              `json:"image"`
+	ImageID      string              `json:"imageID"`
+	ID           string              `json:"containerID"`
+	Ready        bool                `json:"ready"`
+	RestartCount int                 `json:"restartCount"`
+	State        ContainerState      `json:"state"`
+	LastState    ContainerState      `json:"lastState"`
+	Resources    []ContainerResource `json:"resources,omitempty"`
+}
+
+// ContainerResource contains the fields for an assigned resource to a container
+type ContainerResource struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
 }
 
 // IsPending returns if the container doesn't have an ID

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -233,8 +233,11 @@ type ContainerStatus struct {
 
 // ContainerResource contains the fields for an assigned resource to a container
 type ContainerResource struct {
+	// Name is the name of the resource as specified in the spec (e.g. nvidia.com/gpu)
 	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
+
+	// ID is the unique ID of that resource. The format will depend on the resource provider
+	ID string `json:"id,omitempty"`
 }
 
 // IsPending returns if the container doesn't have an ID

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -220,19 +220,19 @@ type Conditions struct {
 
 // ContainerStatus contains fields for unmarshalling a Pod.Status.Containers
 type ContainerStatus struct {
-	Name         string              `json:"name"`
-	Image        string              `json:"image"`
-	ImageID      string              `json:"imageID"`
-	ID           string              `json:"containerID"`
-	Ready        bool                `json:"ready"`
-	RestartCount int                 `json:"restartCount"`
-	State        ContainerState      `json:"state"`
-	LastState    ContainerState      `json:"lastState"`
-	Resources    []ContainerResource `json:"resources,omitempty"`
+	Name               string                       `json:"name"`
+	Image              string                       `json:"image"`
+	ImageID            string                       `json:"imageID"`
+	ID                 string                       `json:"containerID"`
+	Ready              bool                         `json:"ready"`
+	RestartCount       int                          `json:"restartCount"`
+	State              ContainerState               `json:"state"`
+	LastState          ContainerState               `json:"lastState"`
+	AllocatedResources []ContainerAllocatedResource `json:"allocatedResources,omitempty"`
 }
 
-// ContainerResource contains the fields for an assigned resource to a container
-type ContainerResource struct {
+// ContainerAllocatedResource contains the fields for an assigned resource to a container
+type ContainerAllocatedResource struct {
 	// Name is the name of the resource as specified in the spec (e.g. nvidia.com/gpu)
 	Name string `json:"name,omitempty"`
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds an initial implementation for the PodResources API client, retrieving pod resources and adding that data to the container structures that get included in Workloadmeta.

### Motivation

For the GPU monitoring module we need to know which GPUs are assigned to which containers.

### Describe how to test/QA your changes

Manually tested by: 

- Configuring the agent with a kubernetes cluster
- Running a pod with GPU assignments in the cluster
- Running `agent workload-list` and ensuring the pod with GPU assignments has allocated resources.

### Possible Drawbacks / Trade-offs

### Additional Notes

This PR adds a new setting, `kubernetes_kubelet_podresources_socket`, to allow users to specify the path of the PodResources API socket.