### PR TITLE
Creating a temp directory for JMXFetch to use when it runs

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -242,7 +242,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		}
 		if !strings.Contains(javaOptions, "java.io.tmpdir") {
 			javaTmpDir := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "jmxfetch")
-			if err := os.Mkdirs(javaTmpDir, 0755); err != nil {
+			if err := os.MkdirAll(javaTmpDir, 0755); err != nil {
 				log.Warnf("Failed to create jmxfetch temporary directory %s: %v", javaTmpDir, err)
 			} else {
 				javaTmpDirOpt := fmt.Sprintf(" -Djava.io.tmpdir=%s", javaTmpDir)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -240,6 +240,15 @@ func (j *JMXFetch) Start(manage bool) error {
 			log.Warnf("Java option -XX:MaxRAMPercentage will not take effect since either -Xmx or XX:MaxHeapSize is already present. These options override MaxRAMPercentage.")
 			passOption = false
 		}
+		if !strings.Contains(javaOptions, "java.io.tmpdir") {
+			javaTmpDir := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "jmxfetch")
+			if err := os.Mkdir(javaTmpDir, os.ModeDir|0755); err != nil {
+				log.Warnf("Failed to create jmxfetch temporary directory %s: %v", javaTmpDir, err)
+			} else {
+				javaTmpDirOpt := fmt.Sprintf(" -Djava.io.tmpdir=%s", javaTmpDir)
+				javaOptions += javaTmpDirOpt
+			}
+		}
 		if maxHeapSizeAsPercentRAM < 0.00 || maxHeapSizeAsPercentRAM > 100.0 {
 			log.Warnf("The value for MaxRAMPercentage must be between 0.0 and 100.0 for the option to take effect")
 			passOption = false

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -242,7 +242,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		}
 		if !strings.Contains(javaOptions, "java.io.tmpdir") {
 			javaTmpDir := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "jmxfetch")
-			if err := os.Mkdir(javaTmpDir, os.ModeDir|0755); err != nil {
+			if err := os.Mkdirs(javaTmpDir, 0755); err != nil {
 				log.Warnf("Failed to create jmxfetch temporary directory %s: %v", javaTmpDir, err)
 			} else {
 				javaTmpDirOpt := fmt.Sprintf(" -Djava.io.tmpdir=%s", javaTmpDir)

--- a/releasenotes/notes/jmxfetch-tmpdir-fix-59c8d9cb58f8920a.yaml
+++ b/releasenotes/notes/jmxfetch-tmpdir-fix-59c8d9cb58f8920a.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Setting up a temporary directory for `JMXFetch  <https://github.com/DataDog/jmxfetch>`_ to use
+    when it runs. Using the same one the Agent uses when running as this guarantees a directory where
+    JMXFetch can write to. This helps when JMXFetch sends metrics over
+    `Unix Domain Socket <https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=host>` as it needs
+    access to a temp directory which it can write to.


### PR DESCRIPTION
### What does this PR do?

Sets a temp directory for JMXFetch to use when it runs.

### Motivation

When JMXFetch is asked to use UDS it needs access to a temp directory. Creating one for JMXFetch guarantees it has access to one that it can write to.

### Describe how to test/QA your changes

Update the misbehaving-jmx-server docker-compose (l[ink](https://github.com/DataDog/jmxfetch/tree/master/tools/misbehaving-jmx-server)) to use the new RC or dev image and ensure that metrics are collected properly.

### Possible Drawbacks / Trade-offs

If JMXFetch crashes it may leave some temp files in the Agent run directory.