### PR TITLE
upgrade(installer): Forward tags to binary

### DIFF
--- a/pkg/fleet/env/env_test.go
+++ b/pkg/fleet/env/env_test.go
@@ -37,6 +37,7 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationNotSet,
 				},
+				Tags: []string{},
 			},
 		},
 		{
@@ -65,6 +66,8 @@ func TestFromEnv(t *testing.T) {
 				envApmLibraries:                               "java,dotnet:latest,ruby:1.2",
 				envApmInstrumentationEnabled:                  "all",
 				envAgentUserName:                              "customuser",
+				envTags:                                       "k1:v1,k2:v2",
+				envExtraTags:                                  "k3:v3,k4:v4",
 			},
 			expected: &Env{
 				APIKey:               "123456",
@@ -108,6 +111,7 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationEnabledAll,
 				},
+				Tags: []string{"k1:v1", "k2:v2", "k3:v3", "k4:v4"},
 			},
 		},
 		{
@@ -135,6 +139,7 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationNotSet,
 				},
+				Tags: []string{},
 			},
 		},
 		{
@@ -161,6 +166,7 @@ func TestFromEnv(t *testing.T) {
 				RegistryPasswordByImage:        map[string]string{},
 				DefaultPackagesInstallOverride: map[string]bool{},
 				DefaultPackagesVersionOverride: map[string]string{},
+				Tags:                           []string{},
 			},
 		},
 	}
@@ -228,6 +234,7 @@ func TestToEnv(t *testing.T) {
 					"dotnet": "latest",
 					"ruby":   "1.2",
 				},
+				Tags: []string{"k1:v1", "k2:v2"},
 			},
 			expected: []string{
 				"DD_API_KEY=123456",
@@ -251,6 +258,7 @@ func TestToEnv(t *testing.T) {
 				"DD_INSTALLER_DEFAULT_PKG_INSTALL_ANOTHER_PACKAGE=false",
 				"DD_INSTALLER_DEFAULT_PKG_VERSION_PACKAGE=1.2.3",
 				"DD_INSTALLER_DEFAULT_PKG_VERSION_ANOTHER_PACKAGE=4.5.6",
+				"DD_TAGS=k1:v1,k2:v2",
 			},
 		},
 	}

--- a/pkg/fleet/internal/cdn/cdn_http.go
+++ b/pkg/fleet/internal/cdn/cdn_http.go
@@ -39,7 +39,7 @@ func newCDNHTTP(env *env.Env, configDBPath string) (CDN, error) {
 	return &cdnHTTP{
 		client:              client,
 		currentRootsVersion: 1,
-		hostTagsGetter:      newHostTagsGetter(),
+		hostTagsGetter:      newHostTagsGetter(env),
 	}, nil
 }
 

--- a/pkg/fleet/internal/cdn/cdn_rc.go
+++ b/pkg/fleet/internal/cdn/cdn_rc.go
@@ -41,7 +41,7 @@ func newCDNRC(env *env.Env, configDBPath string) (CDN, error) {
 	ctx, cc := context.WithTimeout(ctx, 10*time.Second)
 	defer cc()
 
-	ht := newHostTagsGetter()
+	ht := newHostTagsGetter(env)
 	hostname, err := pkghostname.Get(ctx)
 	if err != nil {
 		hostname = "unknown"


### PR DESCRIPTION
### What does this PR do?
Forward config host tags from installer daemon to installer binary

### Motivation

### Describe how to test/QA your changes
Tested manually on a VM, tags are indeed used in the CDN

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->