### PR TITLE
ci(macos): Source `pyenv` on the `after_script`

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -69,6 +69,7 @@ tests_macos_gitlab_amd64:
   tags: ["macos:monterey-amd64", "specific:true"]
   after_script:
     - !reference [.vault_login]
+    - !reference [.select_python_env_commands]
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
 
@@ -79,5 +80,6 @@ tests_macos_gitlab_arm64:
   tags: ["macos:monterey-arm64", "specific:true"]
   after_script:
     - !reference [.vault_login]
+    - !reference [.select_python_env_commands]
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Run the `pyenv` setup snippet on the `after_script` of macos gitlab jobs

### Motivation
Follow-up of https://github.com/DataDog/datadog-agent/pull/30999 where I noticed the [issue](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/706690128#L2222): we are using `invoke` on `after_script`. As it's a different shell from `before_script` and `script` we need to run the setup once again.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->