### PR TITLE
[WF-9570] add AP_RUNNER_KEYS to RC products

### DIFF
--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -9,6 +9,7 @@ var validProducts = map[string]struct{}{
 	ProductUpdaterCatalogDD:             {},
 	ProductUpdaterAgent:                 {},
 	ProductUpdaterTask:                  {},
+	ProductActionPlatformRunnerKeys:     {},
 	ProductAgentConfig:                  {},
 	ProductAgentFailover:                {},
 	ProductAgentTask:                    {},
@@ -40,6 +41,8 @@ const (
 	ProductUpdaterAgent = "UPDATER_AGENT"
 	// ProductUpdaterTask is the product used to receive tasks to execute
 	ProductUpdaterTask = "UPDATER_TASK"
+	// ProductActionPlatformRunnerKeys is to receive signing keys for the action platform "private action runner"
+	ProductActionPlatformRunnerKeys = "AP_RUNNER_KEYS"
 	// ProductAgentConfig is to receive agent configurations, like the log level
 	ProductAgentConfig = "AGENT_CONFIG"
 	// ProductAgentFailover is to receive the multi-region failover configuration


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds the Action Platform "Private Action Runner" to the list of Remote Config products

### Motivation

Integration between RC and Action Platform

### Describe how to test/QA your changes

Confirmed working by a local build of the PAR containing this changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->