### PR TITLE
Added legacy_go_mod_version to gomodule

### DIFF
--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -151,6 +151,7 @@ class GoModule:
     lint_targets: list[str] | None = None
     # Whether the module is an otel dependency or not
     used_by_otel: bool = False
+    legacy_go_mod_version: bool | None = None
 
     @staticmethod
     def from_dict(path: str, data: dict[str, object]) -> GoModule:
@@ -165,6 +166,7 @@ class GoModule:
             importable=data.get("importable", default["importable"]),
             independent=data.get("independent", default["independent"]),
             used_by_otel=data.get("used_by_otel", default["used_by_otel"]),
+            legacy_go_mod_version=data.get("legacy_go_mod_version", default["legacy_go_mod_version"]),
         )
 
     @staticmethod
@@ -197,6 +199,7 @@ class GoModule:
             "importable": self.importable,
             "independent": self.independent,
             "used_by_otel": self.used_by_otel,
+            "legacy_go_mod_version": self.legacy_go_mod_version,
         }
 
         if remove_path:

--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -151,6 +151,7 @@ class GoModule:
     lint_targets: list[str] | None = None
     # Whether the module is an otel dependency or not
     used_by_otel: bool = False
+    # Used to load agent 6 modules from agent 7
     legacy_go_mod_version: bool | None = None
 
     @staticmethod

--- a/tasks/unit_tests/modules_tests.py
+++ b/tasks/unit_tests/modules_tests.py
@@ -188,6 +188,7 @@ class TestGoModuleSerialization(unittest.TestCase):
             'importable': True,
             'independent': True,
             'used_by_otel': True,
+            'legacy_go_mod_version': None,
         }
         module = GoModule.from_dict(d['path'], d)
         d2 = module.to_dict(remove_defaults=False)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Following https://github.com/DataDog/datadog-agent/pull/30753 and https://github.com/DataDog/datadog-agent/pull/31073, added legacy attributes for agent 6 module files ([context](https://github.com/DataDog/datadog-agent/blob/7fe2d8e9503521b1d459be598d80f4e57fee59f6/modules.yml#L88)).
This will be used to load agent 6 modules from agent 7 files.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->