### PR TITLE
[USM] Clear error for docker test utils

### DIFF
--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -34,7 +34,11 @@ func GetDockerPID(dockerName string) (int64, error) {
 	if err := c.Run(); err != nil {
 		return 0, fmt.Errorf("failed to get %s pid: %s", dockerName, stderr.String())
 	}
-	return strconv.ParseInt(strings.TrimSpace(stdout.String()), 10, 64)
+	pid, err := strconv.ParseInt(strings.TrimSpace(stdout.String()), 10, 64)
+	if pid == 0 {
+		return 0, fmt.Errorf("failed to retrieve %s pid, container is not running", dockerName)
+	}
+	return pid, err
 }
 
 // RunDockerServer is a template for running a protocols server in a docker.


### PR DESCRIPTION
### What does this PR do?

If the container exists but is not running (e.g: stopped), `docker inspect -f {{State.Pid}} containerName` will return `pid: 0` without any error

### Motivation

clear error for UTs that use the docker utils for containerized envs scenarios

### Describe how to test/QA your changes

existing UTs should pass.
Flaky UTs that use this utility should have a better error

### Possible Drawbacks / Trade-offs

### Additional Notes
[example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/702212936#L1906) for current flaky test before the change

