### PR TITLE
[CWS] add a container context on custom events

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -68,16 +69,24 @@ const (
 	InternalCoreDumpRuleDesc = "Internal Core Dump"
 )
 
+// AgentContainerContext is like model.ContainerContext, but without event based resolvers
+type AgentContainerContext struct {
+	ContainerID containerutils.ContainerID `json:"id,omitempty"`
+	CreatedAt   uint64                     `json:"created_at"`
+}
+
 // CustomEventCommonFields represents the fields common to all custom events
 type CustomEventCommonFields struct {
-	Timestamp time.Time `json:"date"`
-	Service   string    `json:"service"`
+	Timestamp             time.Time              `json:"date"`
+	Service               string                 `json:"service"`
+	AgentContainerContext *AgentContainerContext `json:"container"`
 }
 
 // FillCustomEventCommonFields fills the common fields with default values
-func (commonFields *CustomEventCommonFields) FillCustomEventCommonFields() {
+func (commonFields *CustomEventCommonFields) FillCustomEventCommonFields(acc *AgentContainerContext) {
 	commonFields.Service = ServiceName
 	commonFields.Timestamp = time.Now()
+	commonFields.AgentContainerContext = acc
 }
 
 // NewCustomRule returns a new custom rule

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -256,7 +256,7 @@ func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID,
 	}
 
 	// send the custom event with the list of succeed and failed self tests
-	rule, event := selftests.NewSelfTestEvent(success, fails, testEvents)
+	rule, event := selftests.NewSelfTestEvent(c.probe.GetAgentContainerContext(), success, fails, testEvents)
 	c.SendEvent(rule, event, nil, "")
 }
 

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -35,12 +35,12 @@ func (e EventLostRead) ToJSON() ([]byte, error) {
 }
 
 // NewEventLostReadEvent returns the rule and a populated custom event for a lost_events_read event
-func NewEventLostReadEvent(mapName string, lost float64) (*rules.Rule, *events.CustomEvent) {
+func NewEventLostReadEvent(acc *events.AgentContainerContext, mapName string, lost float64) (*rules.Rule, *events.CustomEvent) {
 	evt := EventLostRead{
 		Name: mapName,
 		Lost: lost,
 	}
-	evt.FillCustomEventCommonFields()
+	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomLostReadEventType, evt)
 }
@@ -59,12 +59,12 @@ func (e EventLostWrite) ToJSON() ([]byte, error) {
 }
 
 // NewEventLostWriteEvent returns the rule and a populated custom event for a lost_events_write event
-func NewEventLostWriteEvent(mapName string, perEventPerCPU map[string]uint64) (*rules.Rule, *events.CustomEvent) {
+func NewEventLostWriteEvent(acc *events.AgentContainerContext, mapName string, perEventPerCPU map[string]uint64) (*rules.Rule, *events.CustomEvent) {
 	evt := EventLostWrite{
 		Name: mapName,
 		Lost: perEventPerCPU,
 	}
-	evt.FillCustomEventCommonFields()
+	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomLostWriteEventType, evt)
 }
@@ -92,13 +92,13 @@ func (a AbnormalEvent) ToJSON() ([]byte, error) {
 }
 
 // NewAbnormalEvent returns the rule and a populated custom event for a abnormal event
-func NewAbnormalEvent(id string, description string, event *model.Event, err error) (*rules.Rule, *events.CustomEvent) {
+func NewAbnormalEvent(acc *events.AgentContainerContext, id string, description string, event *model.Event, err error) (*rules.Rule, *events.CustomEvent) {
 	marshalerCtor := func() events.EventMarshaler {
 		evt := AbnormalEvent{
 			Event: serializers.NewEventSerializer(event, nil),
 			Error: err.Error(),
 		}
-		evt.FillCustomEventCommonFields()
+		evt.FillCustomEventCommonFields(acc)
 		// Overwrite common timestamp with event timestamp
 		evt.Timestamp = event.ResolveEventTime()
 
@@ -119,7 +119,7 @@ type EBPFLessHelloMsgEvent struct {
 		Name           string `json:"name,omitempty"`
 		ImageShortName string `json:"short_name,omitempty"`
 		ImageTag       string `json:"image_tag,omitempty"`
-	} `json:"container,omitempty"`
+	} `json:"workload_container,omitempty"`
 	EntrypointArgs []string `json:"args,omitempty"`
 }
 
@@ -129,7 +129,7 @@ func (e EBPFLessHelloMsgEvent) ToJSON() ([]byte, error) {
 }
 
 // NewEBPFLessHelloMsgEvent returns a eBPFLess hello custom event
-func NewEBPFLessHelloMsgEvent(msg *ebpfless.HelloMsg, scrubber *procutil.DataScrubber) (*rules.Rule, *events.CustomEvent) {
+func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.HelloMsg, scrubber *procutil.DataScrubber) (*rules.Rule, *events.CustomEvent) {
 	args := msg.EntrypointArgs
 	if scrubber != nil {
 		args, _ = scrubber.ScrubCommand(msg.EntrypointArgs)
@@ -144,7 +144,7 @@ func NewEBPFLessHelloMsgEvent(msg *ebpfless.HelloMsg, scrubber *procutil.DataScr
 	evt.Container.ImageTag = msg.ContainerContext.ImageTag
 	evt.EntrypointArgs = args
 
-	evt.FillCustomEventCommonFields()
+	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.EBPFLessHelloMessageRuleID, events.EBPFLessHelloMessageRuleDesc), events.NewCustomEvent(model.UnknownEventType, evt)
 }

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -7,6 +7,8 @@ package probe
 
 import (
 	json "encoding/json"
+	events "github.com/DataDog/datadog-agent/pkg/security/events"
+	containerutils "github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	serializers "github.com/DataDog/datadog-agent/pkg/security/serializers"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -64,6 +66,16 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -114,6 +126,15 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 		out.RawString(prefix)
 		out.String(string(in.Service))
 	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
+	}
 	out.RawByte('}')
 }
 
@@ -125,6 +146,61 @@ func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jlexer.Lexer, out *events.AgentContainerContext) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ContainerID = containerutils.ContainerID(in.String())
+		case "created_at":
+			out.CreatedAt = uint64(in.Uint64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jwriter.Writer, in events.AgentContainerContext) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ContainerID != "" {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.ContainerID))
+	}
+	{
+		const prefix string = ",\"created_at\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Uint64(uint64(in.CreatedAt))
+	}
+	out.RawByte('}')
 }
 func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *EventLostRead) {
 	isTopLevel := in.IsStart()
@@ -155,6 +231,16 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -189,6 +275,15 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		out.RawString(prefix)
 		out.String(string(in.Service))
 	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
+	}
 	out.RawByte('}')
 }
 
@@ -222,7 +317,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 		switch key {
 		case "nsid":
 			out.NSID = uint64(in.Uint64())
-		case "container":
+		case "workload_container":
 			easyjsonF8f9ddd1Decode(in, &out.Container)
 		case "args":
 			if in.IsNull() {
@@ -253,6 +348,16 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -274,7 +379,7 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		out.Uint64(uint64(in.NSID))
 	}
 	if true {
-		const prefix string = ",\"container\":"
+		const prefix string = ",\"workload_container\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -316,6 +421,15 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		const prefix string = ",\"service\":"
 		out.RawString(prefix)
 		out.String(string(in.Service))
+	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
 	}
 	out.RawByte('}')
 }
@@ -455,6 +569,16 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -492,6 +616,15 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 		const prefix string = ",\"service\":"
 		out.RawString(prefix)
 		out.String(string(in.Service))
+	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -94,7 +94,8 @@ type actionStatsTags struct {
 // Probe represents the runtime security eBPF probe in charge of
 // setting up the required kProbes and decoding events sent from the kernel
 type Probe struct {
-	PlatformProbe PlatformProbe
+	PlatformProbe         PlatformProbe
+	agentContainerContext *events.AgentContainerContext
 
 	// Constants and configuration
 	Opts         Opts
@@ -440,4 +441,9 @@ func (p *Probe) IsSecurityProfileEnabled() bool {
 // EnableEnforcement sets the enforcement mode
 func (p *Probe) EnableEnforcement(state bool) {
 	p.PlatformProbe.EnableEnforcement(state)
+}
+
+// GetAgentContainerContext returns the agent container context
+func (p *Probe) GetAgentContainerContext() *events.AgentContainerContext {
+	return p.agentContainerContext
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -583,7 +583,7 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 func (p *EBPFProbe) onEventLost(perfMapName string, perEvent map[string]uint64) {
 	if p.config.RuntimeSecurity.InternalMonitoringEnabled {
 		p.probe.DispatchCustomEvent(
-			NewEventLostWriteEvent(perfMapName, perEvent),
+			NewEventLostWriteEvent(p.GetAgentContainerContext(), perfMapName, perEvent),
 		)
 	}
 
@@ -2377,6 +2377,11 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 			}
 		}
 	}
+}
+
+// GetAgentContainerContext returns the agent container context
+func (p *EBPFProbe) GetAgentContainerContext() *events.AgentContainerContext {
+	return p.probe.GetAgentContainerContext()
 }
 
 // newPlaceholderProcessCacheEntryPTraceMe returns a new empty process cache entry for PTRACE_TRACEME calls,

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
@@ -96,7 +97,7 @@ func (p *EBPFLessProbe) handleClientMsg(cl *client, msg *ebpfless.Message) {
 	case ebpfless.MessageTypeHello:
 		if cl.nsID == 0 {
 			p.probe.DispatchCustomEvent(
-				NewEBPFLessHelloMsgEvent(msg.Hello, p.probe.scrubber),
+				NewEBPFLessHelloMsgEvent(p.GetAgentContainerContext(), msg.Hello, p.probe.scrubber),
 			)
 
 			cl.nsID = msg.Hello.NSID
@@ -651,6 +652,11 @@ func (p *EBPFLessProbe) zeroEvent() *model.Event {
 // EnableEnforcement sets the enforcement mode
 func (p *EBPFLessProbe) EnableEnforcement(state bool) {
 	p.processKiller.SetState(state)
+}
+
+// GetAgentContainerContext returns the agent container context
+func (p *EBPFLessProbe) GetAgentContainerContext() *events.AgentContainerContext {
+	return p.probe.GetAgentContainerContext()
 }
 
 // NewEBPFLessProbe returns a new eBPF less probe

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -77,8 +77,8 @@ func NewAgentContainerContext() (*events.AgentContainerContext, error) {
 	}
 
 	cid, err := utils.GetProcContainerID(uint32(pid), uint32(pid))
-	if err != nil { // could fail if not in container
-		return acc, nil
+	if err != nil {
+		return nil, err
 	}
 	acc.ContainerID = cid
 	return acc, nil

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -61,6 +61,7 @@ func (p *Probe) Origin() string {
 	return EBPFOrigin
 }
 
+// NewAgentContainerContext returns the agent container context
 func NewAgentContainerContext() (*events.AgentContainerContext, error) {
 	pid := os.Getpid()
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -165,20 +165,20 @@ func (m *EBPFMonitors) ProcessEvent(event *model.Event) {
 	var pathErr *path.ErrPathResolution
 	if errors.As(event.Error, &pathErr) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(events.AbnormalPathRuleID, events.AbnormalPathRuleDesc, event, pathErr.Err),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.AbnormalPathRuleID, events.AbnormalPathRuleDesc, event, pathErr.Err),
 		)
 	}
 
 	if errors.Is(event.Error, model.ErrNoProcessContext) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, event.Error),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, event.Error),
 		)
 	}
 
 	var brokenLineageErr *model.ErrProcessBrokenLineage
 	if errors.As(event.Error, &brokenLineageErr) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(events.BrokenProcessLineageErrorRuleID, events.BrokenProcessLineageErrorRuleDesc, event, event.Error),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.BrokenProcessLineageErrorRuleID, events.BrokenProcessLineageErrorRuleDesc, event, event.Error),
 		)
 	}
 }

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -105,3 +106,8 @@ func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {}
 
 // EnableEnforcement sets the enforcement mode
 func (p *Probe) EnableEnforcement(_ bool) {}
+
+// GetAgentContainerContext returns nil
+func (p *Probe) GetAgentContainerContext() *events.AgentContainerContext {
+	return nil
+}

--- a/pkg/security/probe/selftests/self_tests.go
+++ b/pkg/security/probe/selftests/self_tests.go
@@ -52,13 +52,13 @@ func (t SelfTestEvent) ToJSON() ([]byte, error) {
 }
 
 // NewSelfTestEvent returns the rule and the result of the self test
-func NewSelfTestEvent(success []eval.RuleID, fails []eval.RuleID, testEvents map[eval.RuleID]*serializers.EventSerializer) (*rules.Rule, *events.CustomEvent) {
+func NewSelfTestEvent(acc *events.AgentContainerContext, success []eval.RuleID, fails []eval.RuleID, testEvents map[eval.RuleID]*serializers.EventSerializer) (*rules.Rule, *events.CustomEvent) {
 	evt := SelfTestEvent{
 		Success:    success,
 		Fails:      fails,
 		TestEvents: testEvents,
 	}
-	evt.FillCustomEventCommonFields()
+	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.SelfTestRuleID, events.SelfTestRuleDesc),
 		events.NewCustomEvent(model.CustomSelfTestEventType, evt)

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -252,9 +252,9 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 				heartBeatCounter = 5
 				heartbeatTicker.Reset(1 * time.Minute)
 				// we report a heartbeat anyway
-				e.policyMonitor.ReportHeartbeatEvent(e.eventSender)
+				e.policyMonitor.ReportHeartbeatEvent(e.probe.GetAgentContainerContext(), e.eventSender)
 			case <-heartbeatTicker.C:
-				e.policyMonitor.ReportHeartbeatEvent(e.eventSender)
+				e.policyMonitor.ReportHeartbeatEvent(e.probe.GetAgentContainerContext(), e.eventSender)
 				if heartBeatCounter > 0 {
 					heartBeatCounter--
 					if heartBeatCounter == 0 {
@@ -348,7 +348,7 @@ func (e *RuleEngine) LoadPolicies(providers []rules.PolicyProvider, sendLoadedRe
 	e.notifyAPIServer(ruleIDs, policies)
 
 	if sendLoadedReport {
-		monitor.ReportRuleSetLoaded(e.eventSender, e.statsdClient, policies)
+		monitor.ReportRuleSetLoaded(e.probe.GetAgentContainerContext(), e.eventSender, e.statsdClient, policies)
 		e.policyMonitor.SetPolicies(policies)
 	}
 

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -4,6 +4,8 @@ package monitor
 
 import (
 	json "encoding/json"
+	events "github.com/DataDog/datadog-agent/pkg/security/events"
+	containerutils "github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -73,6 +75,16 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor(i
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -117,6 +129,15 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor(o
 		out.RawString(prefix)
 		out.String(string(in.Service))
 	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
+	}
 	out.RawByte('}')
 }
 
@@ -128,6 +149,61 @@ func (v RulesetLoadedEvent) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *RulesetLoadedEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor(l, v)
+}
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jlexer.Lexer, out *events.AgentContainerContext) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ContainerID = containerutils.ContainerID(in.String())
+		case "created_at":
+			out.CreatedAt = uint64(in.Uint64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jwriter.Writer, in events.AgentContainerContext) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ContainerID != "" {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.ContainerID))
+	}
+	{
+		const prefix string = ",\"created_at\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Uint64(uint64(in.CreatedAt))
+	}
+	out.RawByte('}')
 }
 func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(in *jlexer.Lexer, out *RuleState) {
 	isTopLevel := in.IsStart()
@@ -805,6 +881,16 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 			}
 		case "service":
 			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -837,6 +923,15 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 		const prefix string = ",\"service\":"
 		out.RawString(prefix)
 		out.String(string(in.Service))
+	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
### What does this PR do?

It adds a "container" section to custom events, containing the containerid (if any) and the createat (equals to the exec time of sysprobe).

### Motivation

Having the containerID filled on custom events on side pannels (and being able to filter on them easily etc)

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->