### PR TITLE
Fix flaky docker integration test

### DIFF
--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -82,6 +82,7 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 	}
 
 	var err error
+	env.SetFeatures(suite.T(), env.Docker)
 	deps := fxutil.Test[deps](suite.T(), fx.Options(
 		core.MockBundle(),
 		fx.Replace(compcfg.MockParams{
@@ -91,7 +92,6 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 		workloadmetafx.Module(workloadmeta.NewParams()),
 		taggerfx.Module(tagger.Params{}),
 	))
-	env.SetFeatures(suite.T(), env.Docker)
 	suite.wmeta = deps.WMeta
 	suite.telemetryStore = acTelemetry.NewStore(deps.Telemetry)
 	suite.dockerutil, err = docker.GetDockerUtil()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix a race condition in the `TestDockerListenerSuite/TestListenBeforeStart` and `TestDockerListenerSuite/TestListenAfterStart` integration tests

### Motivation

The tests started failing around 8/28 with the following errors:
```
    --- FAIL: TestDockerListenerSuite/TestListenAfterStart (11.95s)
        docker_listener_test.go:235: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:235
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:186
                Error:          Expected nil, but got: &errors.errorString{s:"timeout listening for services, only got 0, expecting 2"}
                Test:           TestDockerListenerSuite/TestListenAfterStart
        docker_listener_test.go:236: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:236
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:186
                Error:          "map[]" should have 2 item(s), but has 0
                Test:           TestDockerListenerSuite/TestListenAfterStart
        docker_listener_test.go:279: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:279
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:186
                Error:          "map[]" should have 2 item(s), but has 0
                Test:           TestDockerListenerSuite/TestListenAfterStart
    mock.go:33: 2024-08-28 19:45:52 UTC | INFO | (comp/core/autodiscovery/listeners/workloadmeta.go:142 in Listen) | ad-containerlistener initialized successfully
    --- FAIL: TestDockerListenerSuite/TestListenBeforeStart (11.94s)
        docker_listener_test.go:235: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:235
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:202
                Error:          Expected nil, but got: &errors.errorString{s:"timeout listening for services, only got 0, expecting 2"}
                Test:           TestDockerListenerSuite/TestListenBeforeStart
        docker_listener_test.go:236: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:236
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:202
                Error:          "map[]" should have 2 item(s), but has 0
                Test:           TestDockerListenerSuite/TestListenBeforeStart
        docker_listener_test.go:279: 
                Error Trace:    /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:279
                                                        /go/src/github.com/DataDog/datadog-agent/test/integration/listeners/docker/docker_listener_test.go:202
                Error:          "map[]" should have 2 item(s), but has 0
                Test:           TestDockerListenerSuite/TestListenBeforeStart
FAIL


FAIL    github.com/DataDog/datadog-agent/test/integration/listeners/docker      27.564s
FAIL
```

Looking at the debug logs, I see:
```
    mock.go:33: 2024-08-28 19:45:40 UTC | INFO | (comp/core/workloadmeta/impl/store.go:557 in startCandidates) | workloadmeta collector "docker" could not start. error: component workloadmeta-docker is disabled: Agent is not running on Docker
```

Which leads us to think this is a race condition because the WLM component start is possibly not a blocking operation

[Job failures on main](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.provider.name%3Acircleci%20%40ci.pipeline.name%3Atest_and_build%20%40ci.job.name%3Aintegration_tests%20%40git.branch%3Amain%20%40ci.status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&colorBy=meta%5B%27ci.job.name%27%5D&colorByAttr=meta%5B%27ci.job.name%27%5D&currentTab=trace&fromUser=true&graphType=flamegraph&index=cipipeline&spanID=2492660005813385740&spanViewType=overview&start=1723663620000&end=1726618620000&paused=true)

### Describe how to test/QA your changes

Integration test suite should remain green

### Possible Drawbacks / Trade-offs

### Additional Notes
Possibly related to https://github.com/DataDog/datadog-agent/pull/28703