### PR TITLE
Run regression-detector on main, but make it a no-op

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,77 +235,77 @@ variables:
 
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
-  AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile # agent-devx-infra
-  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2 # agent-devx-infra
-  API_KEY_DDDEV: ci.datadog-agent.datadog_api_key # agent-devx-infra
-  APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2 # agent-devx-infra
-  CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha # agent-devx-infra
-  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key # windows-agent
-  CODECOV_TOKEN: ci.datadog-agent.codecov_token # agent-devx-infra
-  DEB_GPG_KEY: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID} # agent-delivery
-  DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID} # agent-delivery
-  DOCKER_REGISTRY_LOGIN: ci.datadog-agent.docker_hub_login # container-integrations
-  DOCKER_REGISTRY_PWD: ci.datadog-agent.docker_hub_pwd # container-integrations
-  E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key # agent-devx-loops
-  E2E_TESTS_APP_KEY: ci.datadog-agent.e2e_tests_app_key # agent-devx-loops
-  E2E_TESTS_RC_KEY: ci.datadog-agent.e2e_tests_rc_key # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_ID: ci.datadog-agent.e2e_tests_azure_client_id # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_SECRET: ci.datadog-agent.e2e_tests_azure_client_secret # agent-devx-loops
-  E2E_TESTS_AZURE_TENANT_ID: ci.datadog-agent.e2e_tests_azure_tenant_id # agent-devx-loops
-  E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id # agent-devx-loops
-  E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials # agent-devx-loops
-  E2E_PULUMI_CONFIG_PASSPHRASE: ci.datadog-agent.pulumi_password # agent-devx-loops
-  KITCHEN_EC2_SSH_KEY: ci.datadog-agent.aws_ec2_kitchen_ssh_key # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_ID: ci.datadog-agent.azure_kitchen_client_id # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_SECRET: ci.datadog-agent.azure_kitchen_client_secret # agent-devx-loops
-  KITCHEN_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.azure_kitchen_subscription_id # agent-devx-loops
-  KITCHEN_AZURE_TENANT_ID: ci.datadog-agent.azure_kitchen_tenant_id # agent-devx-loops
-  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key # agent-devx-infra
-  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id # agent-devx-infra
-  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id # agent-devx-infra
-  GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token # ci-cd
-  GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token # ci-cd
-  GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token # ci-cd
-  INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2 # agent-delivery
-  JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token # agent-devx-infra
-  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id # agent-devx-infra
-  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id # agent-devx-infra
-  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key # agent-devx-infra
-  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id # agent-devx-infra
-  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64 # agent-devx-infra
-  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2 # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2 # agent-devx-infra
-  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2 # agent-devx-infra
-  RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID} # agent-delivery
-  RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID} # agent-delivery
-  SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token # agent-devx-infra
-  SMP_ACCOUNT_ID: ci.datadog-agent.single-machine-performance-account-id # single-machine-performance
-  SMP_AGENT_TEAM_ID: ci.datadog-agent.single-machine-performance-agent-team-id # single-machine-performance
-  SMP_API: ci.datadog-agent.single-machine-performance-api # single-machine-performance
-  SMP_BOT_ACCESS_KEY: ci.datadog-agent.single-machine-performance-bot-access-key # single-machine-performance
-  SMP_BOT_ACCESS_KEY_ID: ci.datadog-agent.single-machine-performance-bot-access-key-id # single-machine-performance
-  SSH_KEY: ci.datadog-agent.ssh_key # system-probe
-  SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa # agent-devx-loops
-  SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa # agent-devx-loops
-  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url # windows-agent
-  WINGET_PAT: ci.datadog-agent.winget_pat # windows-agent
+  AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile  # agent-devx-infra
+  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2  # agent-devx-infra
+  API_KEY_DDDEV: ci.datadog-agent.datadog_api_key  # agent-devx-infra
+  APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2  # agent-devx-infra
+  CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha  # agent-devx-infra
+  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key  # windows-agent
+  CODECOV_TOKEN: ci.datadog-agent.codecov_token  # agent-devx-infra
+  DEB_GPG_KEY: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID}  # agent-delivery
+  DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}  # agent-delivery
+  DOCKER_REGISTRY_LOGIN: ci.datadog-agent.docker_hub_login  # container-integrations
+  DOCKER_REGISTRY_PWD: ci.datadog-agent.docker_hub_pwd  # container-integrations
+  E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key  # agent-devx-loops
+  E2E_TESTS_APP_KEY: ci.datadog-agent.e2e_tests_app_key  # agent-devx-loops
+  E2E_TESTS_RC_KEY: ci.datadog-agent.e2e_tests_rc_key  # agent-devx-loops
+  E2E_TESTS_AZURE_CLIENT_ID: ci.datadog-agent.e2e_tests_azure_client_id  # agent-devx-loops
+  E2E_TESTS_AZURE_CLIENT_SECRET: ci.datadog-agent.e2e_tests_azure_client_secret  # agent-devx-loops
+  E2E_TESTS_AZURE_TENANT_ID: ci.datadog-agent.e2e_tests_azure_tenant_id  # agent-devx-loops
+  E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id  # agent-devx-loops
+  E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials  # agent-devx-loops
+  E2E_PULUMI_CONFIG_PASSPHRASE: ci.datadog-agent.pulumi_password  # agent-devx-loops
+  KITCHEN_EC2_SSH_KEY: ci.datadog-agent.aws_ec2_kitchen_ssh_key  # agent-devx-loops
+  KITCHEN_AZURE_CLIENT_ID: ci.datadog-agent.azure_kitchen_client_id  # agent-devx-loops
+  KITCHEN_AZURE_CLIENT_SECRET: ci.datadog-agent.azure_kitchen_client_secret  # agent-devx-loops
+  KITCHEN_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.azure_kitchen_subscription_id  # agent-devx-loops
+  KITCHEN_AZURE_TENANT_ID: ci.datadog-agent.azure_kitchen_tenant_id  # agent-devx-loops
+  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key  # agent-devx-infra
+  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id  # agent-devx-infra
+  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id  # agent-devx-infra
+  GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token  # ci-cd
+  GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token  # ci-cd
+  GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token  # ci-cd
+  INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2  # agent-delivery
+  JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token  # agent-devx-infra
+  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id  # agent-devx-infra
+  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id  # agent-devx-infra
+  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key  # agent-devx-infra
+  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id  # agent-devx-infra
+  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id  # agent-devx-infra
+  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64  # agent-devx-infra
+  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2  # agent-devx-infra
+  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2  # agent-devx-infra
+  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2  # agent-devx-infra
+  RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID}  # agent-delivery
+  RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID}  # agent-delivery
+  SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token  # agent-devx-infra
+  SMP_ACCOUNT_ID: ci.datadog-agent.single-machine-performance-account-id  # single-machine-performance
+  SMP_AGENT_TEAM_ID: ci.datadog-agent.single-machine-performance-agent-team-id  # single-machine-performance
+  SMP_API: ci.datadog-agent.single-machine-performance-api  # single-machine-performance
+  SMP_BOT_ACCESS_KEY: ci.datadog-agent.single-machine-performance-bot-access-key  # single-machine-performance
+  SMP_BOT_ACCESS_KEY_ID: ci.datadog-agent.single-machine-performance-bot-access-key-id  # single-machine-performance
+  SSH_KEY: ci.datadog-agent.ssh_key  # system-probe
+  SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa  # agent-devx-loops
+  SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa  # agent-devx-loops
+  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url  # windows-agent
+  WINGET_PAT: ci.datadog-agent.winget_pat  # windows-agent
   # End aws ssm variables
 
   # Start vault variables
-  AGENT_API_KEY_ORG2: agent-api-key-org-2 # agent-devx-infra
-  AGENT_APP_KEY_ORG2: agent-ci-app-key-org-2 # agent-devx-infra
-  AGENT_GITHUB_APP: agent-github-app # agent-devx-infra
-  AGENT_QA_E2E: agent-qa-e2e # agent-devx-loops
-  ATLASSIAN_WRITE: atlassian-write # agent-devx-infra
-  CODECOV: codecov # agent-devx-infra
-  DOCKER_REGISTRY_RO: dockerhub-readonly # agent-delivery
-  GITLAB_TOKEN: gitlab-token # agent-devx-infra
-  INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2 # agent-devx-infra
-  MACOS_GITHUB_APP_1: macos-github-app-one # agent-devx-infra
-  MACOS_GITHUB_APP_2: macos-github-app-two # agent-devx-infra
-  SLACK_AGENT: slack-agent-ci # agent-devx-infra
-  SMP_ACCOUNT: smp # single-machine-performance
+  AGENT_API_KEY_ORG2: agent-api-key-org-2  # agent-devx-infra
+  AGENT_APP_KEY_ORG2: agent-ci-app-key-org-2  # agent-devx-infra
+  AGENT_GITHUB_APP: agent-github-app  # agent-devx-infra
+  AGENT_QA_E2E: agent-qa-e2e  # agent-devx-loops
+  ATLASSIAN_WRITE: atlassian-write  # agent-devx-infra
+  CODECOV: codecov  # agent-devx-infra
+  DOCKER_REGISTRY_RO: dockerhub-readonly  # agent-delivery
+  GITLAB_TOKEN: gitlab-token  # agent-devx-infra
+  INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2  # agent-devx-infra
+  MACOS_GITHUB_APP_1: macos-github-app-one  # agent-devx-infra
+  MACOS_GITHUB_APP_2: macos-github-app-two  # agent-devx-infra
+  SLACK_AGENT: slack-agent-ci  # agent-devx-infra
+  SMP_ACCOUNT: smp  # single-machine-performance
   # End vault variables
 
   DD_PKG_VERSION: "latest"
@@ -416,8 +416,7 @@ variables:
 # Note: due to workflow rules, rc tag => deploy pipeline, so there's technically no
 # need to check again if the pipeline is a deploy pipeline, but it doesn't hurt
 # to explicitly add it.
-.if_deploy_on_rc_tag_on_beta_repo_branch:
-  &if_deploy_on_rc_tag_on_beta_repo_branch
+.if_deploy_on_rc_tag_on_beta_repo_branch: &if_deploy_on_rc_tag_on_beta_repo_branch
   if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
 .if_scheduled_main: &if_scheduled_main
@@ -775,13 +774,13 @@ workflow:
 
 .if_windows_installer_changes: &if_windows_installer_changes
   changes:
-    paths:
-      - tools/windows/DatadogAgentInstaller/**/*
-      - .gitlab/e2e_install_packages/windows.yml
-      - test/new-e2e/tests/windows/install-test/**/*
-      - test/new-e2e/tests/windows/domain-test/**/*
-      - tasks/msi.py
-    compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      paths:
+        - tools/windows/DatadogAgentInstaller/**/*
+        - .gitlab/e2e_install_packages/windows.yml
+        - test/new-e2e/tests/windows/install-test/**/*
+        - test/new-e2e/tests/windows/domain-test/**/*
+        - tasks/msi.py
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .except_windows_installer_changes:
   - <<: *if_windows_installer_changes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,77 +235,77 @@ variables:
 
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
-  AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile  # agent-devx-infra
-  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2  # agent-devx-infra
-  API_KEY_DDDEV: ci.datadog-agent.datadog_api_key  # agent-devx-infra
-  APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2  # agent-devx-infra
-  CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha  # agent-devx-infra
-  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key  # windows-agent
-  CODECOV_TOKEN: ci.datadog-agent.codecov_token  # agent-devx-infra
-  DEB_GPG_KEY: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID}  # agent-delivery
-  DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}  # agent-delivery
-  DOCKER_REGISTRY_LOGIN: ci.datadog-agent.docker_hub_login  # container-integrations
-  DOCKER_REGISTRY_PWD: ci.datadog-agent.docker_hub_pwd  # container-integrations
-  E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key  # agent-devx-loops
-  E2E_TESTS_APP_KEY: ci.datadog-agent.e2e_tests_app_key  # agent-devx-loops
-  E2E_TESTS_RC_KEY: ci.datadog-agent.e2e_tests_rc_key  # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_ID: ci.datadog-agent.e2e_tests_azure_client_id  # agent-devx-loops
-  E2E_TESTS_AZURE_CLIENT_SECRET: ci.datadog-agent.e2e_tests_azure_client_secret  # agent-devx-loops
-  E2E_TESTS_AZURE_TENANT_ID: ci.datadog-agent.e2e_tests_azure_tenant_id  # agent-devx-loops
-  E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id  # agent-devx-loops
-  E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials  # agent-devx-loops
-  E2E_PULUMI_CONFIG_PASSPHRASE: ci.datadog-agent.pulumi_password  # agent-devx-loops
-  KITCHEN_EC2_SSH_KEY: ci.datadog-agent.aws_ec2_kitchen_ssh_key  # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_ID: ci.datadog-agent.azure_kitchen_client_id  # agent-devx-loops
-  KITCHEN_AZURE_CLIENT_SECRET: ci.datadog-agent.azure_kitchen_client_secret  # agent-devx-loops
-  KITCHEN_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.azure_kitchen_subscription_id  # agent-devx-loops
-  KITCHEN_AZURE_TENANT_ID: ci.datadog-agent.azure_kitchen_tenant_id  # agent-devx-loops
-  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key  # agent-devx-infra
-  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id  # agent-devx-infra
-  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id  # agent-devx-infra
-  GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token  # ci-cd
-  GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token  # ci-cd
-  GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token  # ci-cd
-  INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2  # agent-delivery
-  JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token  # agent-devx-infra
-  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id  # agent-devx-infra
-  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id  # agent-devx-infra
-  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key  # agent-devx-infra
-  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id  # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id  # agent-devx-infra
-  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64  # agent-devx-infra
-  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2  # agent-devx-infra
-  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2  # agent-devx-infra
-  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2  # agent-devx-infra
-  RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID}  # agent-delivery
-  RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID}  # agent-delivery
-  SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token  # agent-devx-infra
-  SMP_ACCOUNT_ID: ci.datadog-agent.single-machine-performance-account-id  # single-machine-performance
-  SMP_AGENT_TEAM_ID: ci.datadog-agent.single-machine-performance-agent-team-id  # single-machine-performance
-  SMP_API: ci.datadog-agent.single-machine-performance-api  # single-machine-performance
-  SMP_BOT_ACCESS_KEY: ci.datadog-agent.single-machine-performance-bot-access-key  # single-machine-performance
-  SMP_BOT_ACCESS_KEY_ID: ci.datadog-agent.single-machine-performance-bot-access-key-id  # single-machine-performance
-  SSH_KEY: ci.datadog-agent.ssh_key  # system-probe
-  SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa  # agent-devx-loops
-  SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa  # agent-devx-loops
-  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url  # windows-agent
-  WINGET_PAT: ci.datadog-agent.winget_pat  # windows-agent
+  AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile # agent-devx-infra
+  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2 # agent-devx-infra
+  API_KEY_DDDEV: ci.datadog-agent.datadog_api_key # agent-devx-infra
+  APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2 # agent-devx-infra
+  CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha # agent-devx-infra
+  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key # windows-agent
+  CODECOV_TOKEN: ci.datadog-agent.codecov_token # agent-devx-infra
+  DEB_GPG_KEY: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID} # agent-delivery
+  DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID} # agent-delivery
+  DOCKER_REGISTRY_LOGIN: ci.datadog-agent.docker_hub_login # container-integrations
+  DOCKER_REGISTRY_PWD: ci.datadog-agent.docker_hub_pwd # container-integrations
+  E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key # agent-devx-loops
+  E2E_TESTS_APP_KEY: ci.datadog-agent.e2e_tests_app_key # agent-devx-loops
+  E2E_TESTS_RC_KEY: ci.datadog-agent.e2e_tests_rc_key # agent-devx-loops
+  E2E_TESTS_AZURE_CLIENT_ID: ci.datadog-agent.e2e_tests_azure_client_id # agent-devx-loops
+  E2E_TESTS_AZURE_CLIENT_SECRET: ci.datadog-agent.e2e_tests_azure_client_secret # agent-devx-loops
+  E2E_TESTS_AZURE_TENANT_ID: ci.datadog-agent.e2e_tests_azure_tenant_id # agent-devx-loops
+  E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id # agent-devx-loops
+  E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials # agent-devx-loops
+  E2E_PULUMI_CONFIG_PASSPHRASE: ci.datadog-agent.pulumi_password # agent-devx-loops
+  KITCHEN_EC2_SSH_KEY: ci.datadog-agent.aws_ec2_kitchen_ssh_key # agent-devx-loops
+  KITCHEN_AZURE_CLIENT_ID: ci.datadog-agent.azure_kitchen_client_id # agent-devx-loops
+  KITCHEN_AZURE_CLIENT_SECRET: ci.datadog-agent.azure_kitchen_client_secret # agent-devx-loops
+  KITCHEN_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.azure_kitchen_subscription_id # agent-devx-loops
+  KITCHEN_AZURE_TENANT_ID: ci.datadog-agent.azure_kitchen_tenant_id # agent-devx-loops
+  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key # agent-devx-infra
+  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id # agent-devx-infra
+  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id # agent-devx-infra
+  GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token # ci-cd
+  GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token # ci-cd
+  GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token # ci-cd
+  INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2 # agent-delivery
+  JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token # agent-devx-infra
+  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id # agent-devx-infra
+  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id # agent-devx-infra
+  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key # agent-devx-infra
+  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id # agent-devx-infra
+  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id # agent-devx-infra
+  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64 # agent-devx-infra
+  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2 # agent-devx-infra
+  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2 # agent-devx-infra
+  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2 # agent-devx-infra
+  RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID} # agent-delivery
+  RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID} # agent-delivery
+  SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token # agent-devx-infra
+  SMP_ACCOUNT_ID: ci.datadog-agent.single-machine-performance-account-id # single-machine-performance
+  SMP_AGENT_TEAM_ID: ci.datadog-agent.single-machine-performance-agent-team-id # single-machine-performance
+  SMP_API: ci.datadog-agent.single-machine-performance-api # single-machine-performance
+  SMP_BOT_ACCESS_KEY: ci.datadog-agent.single-machine-performance-bot-access-key # single-machine-performance
+  SMP_BOT_ACCESS_KEY_ID: ci.datadog-agent.single-machine-performance-bot-access-key-id # single-machine-performance
+  SSH_KEY: ci.datadog-agent.ssh_key # system-probe
+  SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa # agent-devx-loops
+  SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa # agent-devx-loops
+  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url # windows-agent
+  WINGET_PAT: ci.datadog-agent.winget_pat # windows-agent
   # End aws ssm variables
 
   # Start vault variables
-  AGENT_API_KEY_ORG2: agent-api-key-org-2  # agent-devx-infra
-  AGENT_APP_KEY_ORG2: agent-ci-app-key-org-2  # agent-devx-infra
-  AGENT_GITHUB_APP: agent-github-app  # agent-devx-infra
-  AGENT_QA_E2E: agent-qa-e2e  # agent-devx-loops
-  ATLASSIAN_WRITE: atlassian-write  # agent-devx-infra
-  CODECOV: codecov  # agent-devx-infra
-  DOCKER_REGISTRY_RO: dockerhub-readonly  # agent-delivery
-  GITLAB_TOKEN: gitlab-token  # agent-devx-infra
-  INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2  # agent-devx-infra
-  MACOS_GITHUB_APP_1: macos-github-app-one  # agent-devx-infra
-  MACOS_GITHUB_APP_2: macos-github-app-two  # agent-devx-infra
-  SLACK_AGENT: slack-agent-ci  # agent-devx-infra
-  SMP_ACCOUNT: smp  # single-machine-performance
+  AGENT_API_KEY_ORG2: agent-api-key-org-2 # agent-devx-infra
+  AGENT_APP_KEY_ORG2: agent-ci-app-key-org-2 # agent-devx-infra
+  AGENT_GITHUB_APP: agent-github-app # agent-devx-infra
+  AGENT_QA_E2E: agent-qa-e2e # agent-devx-loops
+  ATLASSIAN_WRITE: atlassian-write # agent-devx-infra
+  CODECOV: codecov # agent-devx-infra
+  DOCKER_REGISTRY_RO: dockerhub-readonly # agent-delivery
+  GITLAB_TOKEN: gitlab-token # agent-devx-infra
+  INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2 # agent-devx-infra
+  MACOS_GITHUB_APP_1: macos-github-app-one # agent-devx-infra
+  MACOS_GITHUB_APP_2: macos-github-app-two # agent-devx-infra
+  SLACK_AGENT: slack-agent-ci # agent-devx-infra
+  SMP_ACCOUNT: smp # single-machine-performance
   # End vault variables
 
   DD_PKG_VERSION: "latest"
@@ -416,7 +416,8 @@ variables:
 # Note: due to workflow rules, rc tag => deploy pipeline, so there's technically no
 # need to check again if the pipeline is a deploy pipeline, but it doesn't hurt
 # to explicitly add it.
-.if_deploy_on_rc_tag_on_beta_repo_branch: &if_deploy_on_rc_tag_on_beta_repo_branch
+.if_deploy_on_rc_tag_on_beta_repo_branch:
+  &if_deploy_on_rc_tag_on_beta_repo_branch
   if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
 .if_scheduled_main: &if_scheduled_main
@@ -678,6 +679,11 @@ workflow:
     when: never
   - !reference [.except_mergequeue]
 
+.except_release_branch:
+  - <<: *if_release_branch
+    when: never
+  - !reference [.except_mergequeue]
+
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy
     when: always
@@ -769,13 +775,13 @@ workflow:
 
 .if_windows_installer_changes: &if_windows_installer_changes
   changes:
-      paths:
-        - tools/windows/DatadogAgentInstaller/**/*
-        - .gitlab/e2e_install_packages/windows.yml
-        - test/new-e2e/tests/windows/install-test/**/*
-        - test/new-e2e/tests/windows/domain-test/**/*
-        - tasks/msi.py
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    paths:
+      - tools/windows/DatadogAgentInstaller/**/*
+      - .gitlab/e2e_install_packages/windows.yml
+      - test/new-e2e/tests/windows/install-test/**/*
+      - test/new-e2e/tests/windows/domain-test/**/*
+      - tasks/msi.py
+    compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
 .except_windows_installer_changes:
   - <<: *if_windows_installer_changes

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -2,7 +2,7 @@ single-machine-performance-regression_detector:
   stage: functional_test
   timeout: 1h10m
   rules:
-    - !reference [.except_main_or_release_branch]
+    - !reference [.except_release_branch]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -26,6 +26,9 @@ single-machine-performance-regression_detector:
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   script:
+    # This job must run on the `main` branch for compatibility with github's required
+    # branch protection rules. This is a no-op for the `main` branch.
+    - $CI_COMMIT_BRANCH == "main" && echo "No-op for main branch" && exit 0
     # Ensure output files exist for artifact downloads step
     - mkdir outputs # Also needed for smp job sync step
     # Compute merge base of current commit and `main`

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -190,7 +190,7 @@ single-machine-performance-regression_detector:
 single-machine-performance-regression_detector-pr-comment:
   stage: functional_test
   rules:
-    - !reference [.except_main_or_release_branch]
+    - !reference [.except_release_branch]
     - when: always
   image:
     name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"


### PR DESCRIPTION
### What does this PR do?
Github's branch protection seems to not include jobs that don't run on `main`. 
SMP is making this job required soon (planned tomorrow) and this change should allow this job name to show up correctly in github and allow it to be a required check.

### Motivation
SMP is making this job required soon (planned tomorrow) and this change should allow this job name to show up correctly in github and allow it to be a required check.

### Describe how to test/QA your changes
n/a

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->