### PR TITLE
fix: ECS_FARGATE activating when anything is placed in the value. Ins…

### DIFF
--- a/pkg/config/env/environment.go
+++ b/pkg/config/env/environment.go
@@ -62,7 +62,7 @@ func IsECS() bool {
 
 // IsECSFargate returns whether the Agent is running in ECS Fargate
 func IsECSFargate() bool {
-	return os.Getenv("ECS_FARGATE") != "" || os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE"
+	return os.Getenv("ECS_FARGATE") == "true" || os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE"
 }
 
 // IsHostProcAvailable returns whether host proc is available or not


### PR DESCRIPTION
…tead only on true.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Addresses the issue in: https://github.com/DataDog/datadog-agent/issues/31101

### Motivation
Ran into an issue where putting anything, including `false`, in the variable of `ECS_FARGATE` results into it is a ecs fargate agent... That's not what this should be.

### Describe how to test/QA your changes
Run without the environment variable `ECS_FARGATE` = No Fargate.
Run with the environment variable `ECS_FARGATE` empty = No Fargate.
Run with the environment variable `ECS_FARGATE` "true" = Fargate.
Run with the environment variable `ECS_FARGATE` "false" = No Fargate.
Run with the environment variable `ECS_FARGATE` "foo" = No Fargate.

### Possible Drawbacks / Trade-offs
This may be a breaking change, due to anyone that was using the `ECS_FARGATE` may still work, that is only if they put the string `true`. Otherwise, it may shutdown a lot of FARGATE services due to the change.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
None.