### PR TITLE
Revert "[CWS] Disable unused registry event types (#31047)"

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -18,11 +18,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 
 	"golang.org/x/sys/windows"
 )
@@ -42,10 +40,9 @@ func createTestProbe() (*WindowsProbe, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	wp.enabledEventTypes[model.FileRenameEventType.String()] = true
-	wp.enabledEventTypes[model.DeleteFileEventType.String()] = true
-	wp.enabledEventTypes[model.WriteFileEventType.String()] = true
+	wp.isRenameEnabled = true
+	wp.isDeleteEnabled = true
+	wp.isWriteEnabled = true
 
 	err = wp.Init()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This reverts commit 846e066983d9fd5ffc333e5fdc6d22a5fb8cb669 (#31047).

### Motivation

This PR broke the `new-e2e-windows-service-test`, `new-e2e-windows-service-test-nofim`, and `new-e2e-cws: [--run TestAgentWindowsSuite]` jobs.

### Describe how to test/QA your changes

Run full pipeline on the revert PR: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/49098843

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->