### PR TITLE
fix(installer): Only override agent environment when installing the injector for Docker

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -121,38 +121,6 @@ func (a *apmInjectorInstaller) Finish(err error) {
 func (a *apmInjectorInstaller) Setup(ctx context.Context) error {
 	var err error
 
-	// Set up defaults for agent sockets
-	if err := a.configureSocketsEnv(ctx); err != nil {
-		return err
-	}
-	// Symlinks for sysvinit
-	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent-trace"); err != nil && !os.IsExist(err) {
-		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent-trace: %w", envFilePath, err)
-	}
-	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
-		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent: %w", envFilePath, err)
-	}
-	systemdRunning, err := isSystemdRunning()
-	if err != nil {
-		return fmt.Errorf("failed to check if systemd is running: %w", err)
-	}
-	if systemdRunning {
-		if err := addSystemDEnvOverrides(ctx, agentUnit); err != nil {
-			return err
-		}
-		if err := addSystemDEnvOverrides(ctx, agentExp); err != nil {
-			return err
-		}
-		if err := addSystemDEnvOverrides(ctx, traceAgentUnit); err != nil {
-			return err
-		}
-		if err := addSystemDEnvOverrides(ctx, traceAgentExp); err != nil {
-			return err
-		}
-		if err := systemdReload(ctx); err != nil {
-			return err
-		}
-	}
 	if err := setupAppArmor(ctx); err != nil {
 		return err
 	}
@@ -213,6 +181,10 @@ func (a *apmInjectorInstaller) Instrument(ctx context.Context) (retErr error) {
 		return fmt.Errorf("DD_APM_INSTRUMENTATION_ENABLED is set to docker but docker is not installed")
 	}
 	if shouldInstrumentDocker(a.envs) && dockerIsInstalled {
+		// Set up defaults for agent sockets -- requires an agent restart
+		if err := a.configureSocketsEnv(ctx); err != nil {
+			return err
+		}
 		a.cleanups = append(a.cleanups, a.dockerConfigInstrument.cleanup)
 		rollbackDocker, err := a.instrumentDocker(ctx)
 		if err != nil {

--- a/pkg/fleet/installer/service/apm_sockets.go
+++ b/pkg/fleet/installer/service/apm_sockets.go
@@ -86,6 +86,36 @@ func (a *apmInjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr 
 	if err := os.Chmod(envFilePath, 0644); err != nil {
 		return fmt.Errorf("error changing permissions of %s: %w", envFilePath, err)
 	}
+
+	// Symlinks for sysvinit
+	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent-trace"); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent-trace: %w", envFilePath, err)
+	}
+	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent: %w", envFilePath, err)
+	}
+	systemdRunning, err := isSystemdRunning()
+	if err != nil {
+		return fmt.Errorf("failed to check if systemd is running: %w", err)
+	}
+	if systemdRunning {
+		if err := addSystemDEnvOverrides(ctx, agentUnit); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, agentExp); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, traceAgentUnit); err != nil {
+			return err
+		}
+		if err := addSystemDEnvOverrides(ctx, traceAgentExp); err != nil {
+			return err
+		}
+		if err := systemdReload(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?
Reduce error surface by only override agent environment if we're installing the injector for Docker. Agent environment override is only needed to specify the APM socket paths -- which we don't need outside of Docker.

### Motivation

### Describe how to test/QA your changes
Covered by E2E tests & tested manually

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->