### PR TITLE
make sure `inv  agent.build` does not bundle additional agents by default

### DIFF
--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -12,7 +12,7 @@
     - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true  # Allow failure, we can't remove parent folders of datadog-agent
   script:
     - inv check-go-version
-    - inv -e system-probe.build --strip-object-files --no-bundle
+    - inv -e system-probe.build --strip-object-files
     # fail if references to glibc >= 2.18
     - objdump -p $CI_PROJECT_DIR/$SYSTEM_PROBE_BINARIES_DIR/system-probe | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1
     - inv -e system-probe.save-build-outputs $CI_PROJECT_DIR/sysprobe-build-outputs.tar.xz

--- a/.run/Build process-agent.run.xml
+++ b/.run/Build process-agent.run.xml
@@ -12,7 +12,7 @@
     <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
-      <env name="BUILD_COMMAND" value="inv process-agent.build --no-bundle --build-exclude=systemd" />
+      <env name="BUILD_COMMAND" value="inv process-agent.build --build-exclude=systemd" />
       <env name="SCRIPT_TO_RUN" value=".run/build.sh" />
     </envs>
     <method v="2" />

--- a/.run/Build system-probe.run.xml
+++ b/.run/Build system-probe.run.xml
@@ -13,7 +13,7 @@
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
       <env name="SCRIPT_TO_RUN" value=".run/build.sh" />
-      <env name="BUILD_COMMAND" value="invoke system-probe.build --no-bundle" />
+      <env name="BUILD_COMMAND" value="invoke system-probe.build" />
     </envs>
     <method v="2" />
   </configuration>

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -52,7 +52,7 @@ Also note that the trace agent needs to be built and run separately. For more in
 We use `pkg-config` to make compilers and linkers aware of Python. The required .pc files are
 provided automatically when building python through omnibus.
 
-As an option, the Agent can combines multiple functionalities into a single binary to reduce
+As an option, the Agent can combine multiple functionalities into a single binary to reduce
 the space used on disk. The `DD_BUNDLED_AGENT` environment variable is used to select
 which functionality to enable. For instance, if set to `process-agent`, it will act as the process Agent.
 If the environment variable is not defined, the process name is used as a fallback.

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -52,7 +52,7 @@ Also note that the trace agent needs to be built and run separately. For more in
 We use `pkg-config` to make compilers and linkers aware of Python. The required .pc files are
 provided automatically when building python through omnibus.
 
-By default, the Agent combines multiple functionalities into a single binary to reduce
+As an option, the Agent can combines multiple functionalities into a single binary to reduce
 the space used on disk. The `DD_BUNDLED_AGENT` environment variable is used to select
 which functionality to enable. For instance, if set to `process-agent`, it will act as the process Agent.
 If the environment variable is not defined, the process name is used as a fallback.

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -76,22 +76,6 @@ To disable bundling entirely:
 deva agent.build --bundle agent
 ```
 
-One binary per Agent can still be built by using its own invoke task and passing the
-`--no-bundle` argument:
-- The 'main' Agent: https://github.com/DataDog/datadog-agent/blob/main/tasks/agent.py
-- The process Agent: https://github.com/DataDog/datadog-agent/blob/main/tasks/process_agent.py
-- The trace Agent: https://github.com/DataDog/datadog-agent/blob/main/tasks/trace_agent.py
-- The cluster Agent: https://github.com/DataDog/datadog-agent/blob/main/tasks/cluster_agent.py
-- The security Agent: https://github.com/DataDog/datadog-agent/blob/main/tasks/security_agent.py
-- The system probe: https://github.com/DataDog/datadog-agent/blob/main/tasks/system_probe.py
-
-So to build the process Agent as a standalone self contained executable:
-
-```
-deva process-agent.build --no-bundle
-```
-
-
 ## Testing Agent changes in containerized environments
 
 Building an Agent Docker image from scratch through an embedded build is a slow process.

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -150,7 +150,7 @@ build do
       if windows_target?
         command "invoke -e system-probe.build", env: env
       elsif linux_target?
-        command "invoke -e system-probe.build-sysprobe-binary --install-path=#{install_dir} --no-bundle", env: env
+        command "invoke -e system-probe.build-sysprobe-binary --install-path=#{install_dir}", env: env
       end
     end
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -134,7 +134,7 @@ build do
 
   # Process agent
   if not bundled_agents.include? "process-agent"
-    command "invoke -e process-agent.build --install-path=#{install_dir} --major-version #{major_version_arg} --flavor #{flavor_arg} --no-bundle", :env => env
+    command "invoke -e process-agent.build --install-path=#{install_dir} --major-version #{major_version_arg} --flavor #{flavor_arg}", :env => env
   end
 
   if windows_target?
@@ -173,7 +173,7 @@ build do
   secagent_support = (not heroku_target?) and (not windows_target? or (ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?))
   if secagent_support
     if not bundled_agents.include? "security-agent"
-      command "invoke -e security-agent.build --install-path=#{install_dir} --major-version #{major_version_arg} --no-bundle", :env => env
+      command "invoke -e security-agent.build --install-path=#{install_dir} --major-version #{major_version_arg}", :env => env
     end
     if windows_target?
       copy 'bin/security-agent/security-agent.exe', "#{install_dir}/bin/agent"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -37,8 +37,6 @@ BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "agent")
 AGENT_TAG = "datadog/agent:master"
 
-BUNDLED_AGENTS = {}
-
 if sys.platform == "win32":
     # Our `ridk enable` toolchain puts Ruby's bin dir at the front of the PATH
     # This dir contains `aws.rb` which will execute if we just call `aws`,
@@ -188,7 +186,7 @@ def build(
             out="cmd/agent/rsrc.syso",
         )
     else:
-        bundled_agents += bundle or BUNDLED_AGENTS.get(flavor, [])
+        bundled_agents += bundle
 
     if flavor.is_iot():
         # Iot mode overrides whatever passed through `--build-exclude` and `--build-include`

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -37,11 +37,7 @@ BIN_DIR = os.path.join(".", "bin")
 BIN_PATH = os.path.join(BIN_DIR, "agent")
 AGENT_TAG = "datadog/agent:master"
 
-BUNDLED_AGENTS = {
-    # system-probe requires a working compilation environment for eBPF so we do not
-    # enable it by default but we enable it in the released artifacts.
-    AgentFlavor.base: ["process-agent", "trace-agent", "security-agent"],
-}
+BUNDLED_AGENTS = {}
 
 if sys.platform == "win32":
     # Our `ridk enable` toolchain puts Ruby's bin dir at the front of the PATH

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -186,7 +186,7 @@ def build(
             out="cmd/agent/rsrc.syso",
         )
     else:
-        bundled_agents += bundle
+        bundled_agents += bundle or []
 
     if flavor.is_iot():
         # Iot mode overrides whatever passed through `--build-exclude` and `--build-include`

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1326,7 +1326,7 @@ def build(
 
     build_task = "build-sysprobe-binary" if component == "system-probe" else "build"
     cc.exec(
-        f"cd {CONTAINER_AGENT_PATH} && git config --global --add safe.directory {CONTAINER_AGENT_PATH} && inv {inv_echo} {component}.{build_task} --no-bundle --arch={arch_obj.name}",
+        f"cd {CONTAINER_AGENT_PATH} && git config --global --add safe.directory {CONTAINER_AGENT_PATH} && inv {inv_echo} {component}.{build_task} --arch={arch_obj.name}",
     )
 
     cc.exec(f"tar cf {CONTAINER_AGENT_PATH}/kmt-deps/{stack}/build-embedded-dir.tar {EMBEDDED_SHARE_DIR}")

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -6,7 +6,6 @@ import tempfile
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.agent import build as agent_build
 from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
@@ -28,21 +27,10 @@ def build(
     incremental_build=False,
     major_version='7',
     go_mod="mod",
-    bundle=True,
 ):
     """
     Build the process agent
     """
-    if bundle and sys.platform != "win32":
-        return agent_build(
-            ctx,
-            race=race,
-            build_include=build_include,
-            build_exclude=build_exclude,
-            flavor=flavor,
-            major_version=major_version,
-            go_mod=go_mod,
-        )
 
     flavor = AgentFlavor[flavor]
     if flavor.is_ot():

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -13,7 +13,6 @@ from subprocess import check_output
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from tasks.agent import build as agent_build
 from tasks.agent import generate_config
 from tasks.build_tags import get_default_build_tags
 from tasks.go import run_golangci_lint
@@ -60,18 +59,10 @@ def build(
     go_mod="mod",
     skip_assets=False,
     static=False,
-    bundle=True,
 ):
     """
     Build the security agent
     """
-    if bundle and sys.platform != "win32":
-        return agent_build(
-            ctx,
-            install_path=install_path,
-            race=race,
-            go_mod=go_mod,
-        )
 
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, static=static, install_path=install_path)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -19,10 +19,7 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from tasks.agent import BUNDLED_AGENTS
-from tasks.agent import build as agent_build
 from tasks.build_tags import UNIT_TEST_TAGS, get_default_build_tags
-from tasks.flavor import AgentFlavor
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.common.color import color_message
 from tasks.libs.common.git import get_commit_sha
@@ -685,7 +682,6 @@ def build(
     strip_object_files=False,
     strip_binary=False,
     with_unit_test=False,
-    bundle=True,
     ebpf_compiler='clang',
     static=False,
 ):
@@ -712,7 +708,6 @@ def build(
         race=race,
         incremental_build=incremental_build,
         strip_binary=strip_binary,
-        bundle=bundle,
         arch=arch,
         static=static,
     )
@@ -740,19 +735,8 @@ def build_sysprobe_binary(
     install_path=None,
     bundle_ebpf=False,
     strip_binary=False,
-    bundle=True,
     static=False,
 ) -> None:
-    if bundle and not is_windows:
-        return agent_build(
-            ctx,
-            race=race,
-            major_version=major_version,
-            go_mod=go_mod,
-            bundle_ebpf=bundle_ebpf,
-            bundle=BUNDLED_AGENTS[AgentFlavor.base] + ["system-probe"],
-        )
-
     arch_obj = Arch.from_str(arch)
 
     ldflags, gcflags, env = get_build_flags(

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -3,7 +3,6 @@ import sys
 
 from invoke import Exit, task
 
-from tasks.agent import build as agent_build
 from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
@@ -23,22 +22,10 @@ def build(
     install_path=None,
     major_version='7',
     go_mod="mod",
-    bundle=False,
 ):
     """
     Build the trace agent.
     """
-
-    if bundle:
-        return agent_build(
-            ctx,
-            race=race,
-            build_include=build_include,
-            build_exclude=build_exclude,
-            flavor=flavor,
-            major_version=major_version,
-            go_mod=go_mod,
-        )
 
     flavor = AgentFlavor[flavor]
     if flavor.is_ot():


### PR DESCRIPTION
### What does this PR do?

Currently when you run `inv -e agent.build` it builds bundled agent containing the process-agent, the trace-agent and the security-agent. Since this is not the configuration we ship to customers it can be error-prone. This PR makes sure by default no bundling is done.

This PR also removes the bundling option for system-probe, which is never used and can't be used since the system-probe requires a different build env.

### Motivation

Make sure people using `inv agent.build` get something similar to customers

### Describe how to test/QA your changes

This should mostly impact dev builds, I checked all CI builds and all those that end up in the shipped packages are manually overriding the bundle option today.

During QA week: you should validate that in the packages the different agents are not bundled version but correctly unbundled ones. (including checking for heroku since the setup is kind of strange).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->