### PR TITLE
[CWS] Disable unused registry event types v2

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -18,9 +18,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 
 	"golang.org/x/sys/windows"
 )
@@ -40,9 +42,10 @@ func createTestProbe() (*WindowsProbe, error) {
 	if err != nil {
 		return nil, err
 	}
-	wp.isRenameEnabled = true
-	wp.isDeleteEnabled = true
-	wp.isWriteEnabled = true
+
+	wp.enabledEventTypes[model.FileRenameEventType.String()] = true
+	wp.enabledEventTypes[model.DeleteFileEventType.String()] = true
+	wp.enabledEventTypes[model.WriteFileEventType.String()] = true
 
 	err = wp.Init()
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -106,11 +106,8 @@ type WindowsProbe struct {
 	// actions
 	processKiller *ProcessKiller
 
-	// enabled probes
-	isRenameEnabled           bool
-	isWriteEnabled            bool
-	isDeleteEnabled           bool
-	isChangePermissionEnabled bool
+	enabledEventTypes map[string]bool
+
 	// channel handling.  Currently configurable, but should probably be set
 	// to false with a configurable size value
 	blockonchannelsend bool
@@ -318,16 +315,16 @@ func (p *WindowsProbe) reconfigureProvider() error {
 			idClose,
 		}
 
-		if p.isWriteEnabled {
+		if p.enabledEventTypes[model.WriteFileEventType.String()] {
 			fileIDs = append(fileIDs, idWrite)
 		}
-		if p.isRenameEnabled {
+		if p.enabledEventTypes[model.FileRenameEventType.String()] {
 			fileIDs = append(fileIDs, idRename, idRenamePath, idRename29)
 		}
-		if p.isDeleteEnabled {
+		if p.enabledEventTypes[model.DeleteFileEventType.String()] {
 			fileIDs = append(fileIDs, idSetDelete, idDeletePath)
 		}
-		if p.isChangePermissionEnabled {
+		if p.enabledEventTypes[model.ChangePermissionEventType.String()] {
 			fileIDs = append(fileIDs, idObjectPermsChange)
 		}
 
@@ -361,6 +358,22 @@ func (p *WindowsProbe) reconfigureProvider() error {
 		// try masking on create & create_new_file
 		// given the current requirements, I think we can _probably_ just do create_new_file
 		cfg.MatchAnyKeyword = 0xF7E3
+
+		regIDs := []uint16{}
+		if p.enabledEventTypes[model.CreateRegistryKeyEventType.String()] {
+			regIDs = append(regIDs, idRegCreateKey)
+		}
+		if p.enabledEventTypes[model.OpenRegistryKeyEventType.String()] {
+			regIDs = append(regIDs, idRegOpenKey)
+		}
+		if p.enabledEventTypes[model.DeleteRegistryKeyEventType.String()] {
+			regIDs = append(regIDs, idRegDeleteKey)
+		}
+		if p.enabledEventTypes[model.SetRegistryKeyValueEventType.String()] {
+			regIDs = append(regIDs, idRegSetValueKey)
+		}
+
+		cfg.EnabledIDs = regIDs
 	})
 
 	if p.auditSession != nil {
@@ -453,11 +466,9 @@ func (p *WindowsProbe) auditEtw(ecb etwCallback) error {
 		case etw.DDGUID(p.auditguid):
 			switch e.EventHeader.EventDescriptor.ID {
 			case idObjectPermsChange:
-				if p.isChangePermissionEnabled {
-					if pc, err := p.parseObjectPermsChange(e); err == nil {
-						log.Infof("Received objectPermsChange event %d %s\n", e.EventHeader.EventDescriptor.ID, pc)
-						ecb(pc, e.EventHeader.ProcessID)
-					}
+				if pc, err := p.parseObjectPermsChange(e); err == nil {
+					log.Infof("Received objectPermsChange event %d %s\n", e.EventHeader.EventDescriptor.ID, pc)
+					ecb(pc, e.EventHeader.ProcessID)
 				}
 			}
 		}
@@ -1253,6 +1264,8 @@ func initializeWindowsProbe(config *config.Config, opts Opts) (*WindowsProbe, er
 
 		discardedFileHandles: dfh,
 
+		enabledEventTypes: make(map[string]bool),
+
 		approvers: make(map[eval.Field][]approver),
 
 		volumeMap: make(map[string]string),
@@ -1306,23 +1319,11 @@ func NewWindowsProbe(probe *Probe, config *config.Config, opts Opts, telemetry t
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
 func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
-	p.isWriteEnabled = false
-	p.isRenameEnabled = false
-	p.isDeleteEnabled = false
-	p.isChangePermissionEnabled = false
+	clear(p.enabledEventTypes)
 	p.currentEventTypes = rs.GetEventTypes()
 
 	for _, eventType := range p.currentEventTypes {
-		switch eventType {
-		case model.FileRenameEventType.String():
-			p.isRenameEnabled = true
-		case model.WriteFileEventType.String():
-			p.isWriteEnabled = true
-		case model.DeleteFileEventType.String():
-			p.isDeleteEnabled = true
-		case model.ChangePermissionEventType.String():
-			p.isChangePermissionEnabled = true
-		}
+		p.enabledEventTypes[eventType] = true
 	}
 
 	ars, err := kfilters.NewApplyRuleSetReport(p.config.Probe, rs)

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -467,7 +467,7 @@ func (p *WindowsProbe) auditEtw(ecb etwCallback) error {
 			switch e.EventHeader.EventDescriptor.ID {
 			case idObjectPermsChange:
 				if pc, err := p.parseObjectPermsChange(e); err == nil {
-					log.Infof("Received objectPermsChange event %d %s\n", e.EventHeader.EventDescriptor.ID, pc)
+					log.Tracef("Received objectPermsChange event %d %s\n", e.EventHeader.EventDescriptor.ID, pc)
 					ecb(pc, e.EventHeader.ProcessID)
 				}
 			}

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -106,16 +105,16 @@ type WindowsProbe struct {
 	// actions
 	processKiller *ProcessKiller
 
-	enabledEventTypes map[string]bool
+	enabledEventTypesLock sync.RWMutex
+	enabledEventTypes     map[string]bool
 
 	// channel handling.  Currently configurable, but should probably be set
 	// to false with a configurable size value
 	blockonchannelsend bool
 
 	// approvers
-	currentEventTypes []string
-	approvers         map[eval.Field][]approver
-	approverLock      sync.RWMutex
+	approvers    map[eval.Field][]approver
+	approverLock sync.RWMutex
 }
 
 type writeRateLimiterKey struct {
@@ -315,6 +314,7 @@ func (p *WindowsProbe) reconfigureProvider() error {
 			idClose,
 		}
 
+		// reconfigureProvider should be called with the enabledEventTypesLock held for reading
 		if p.enabledEventTypes[model.WriteFileEventType.String()] {
 			fileIDs = append(fileIDs, idWrite)
 		}
@@ -360,6 +360,7 @@ func (p *WindowsProbe) reconfigureProvider() error {
 		cfg.MatchAnyKeyword = 0xF7E3
 
 		regIDs := []uint16{}
+		// reconfigureProvider should be called with the enabledEventTypesLock held for reading
 		if p.enabledEventTypes[model.CreateRegistryKeyEventType.String()] {
 			regIDs = append(regIDs, idRegCreateKey)
 		}
@@ -445,8 +446,10 @@ func (p *WindowsProbe) approve(field eval.Field, eventType string, value string)
 
 	approvers, exists := p.approvers[field]
 	if !exists {
+		p.enabledEventTypesLock.RLock()
+		defer p.enabledEventTypesLock.RUnlock()
 		// no approvers, so no filtering for this field, except if no rule for this event type
-		return slices.Contains(p.currentEventTypes, eventType)
+		return p.enabledEventTypes[eventType]
 	}
 
 	for _, approver := range approvers {
@@ -1319,12 +1322,12 @@ func NewWindowsProbe(probe *Probe, config *config.Config, opts Opts, telemetry t
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
 func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
+	p.enabledEventTypesLock.Lock()
 	clear(p.enabledEventTypes)
-	p.currentEventTypes = rs.GetEventTypes()
-
-	for _, eventType := range p.currentEventTypes {
+	for _, eventType := range rs.GetEventTypes() {
 		p.enabledEventTypes[eventType] = true
 	}
+	p.enabledEventTypesLock.Unlock()
 
 	ars, err := kfilters.NewApplyRuleSetReport(p.config.Probe, rs)
 	if err != nil {
@@ -1334,7 +1337,6 @@ func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 	// remove old approvers
 	p.approverLock.Lock()
 	defer p.approverLock.Unlock()
-
 	clear(p.approvers)
 
 	for eventType, report := range ars.Policies {
@@ -1343,6 +1345,8 @@ func (p *WindowsProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRe
 		}
 	}
 
+	p.enabledEventTypesLock.RLock()
+	defer p.enabledEventTypesLock.RUnlock()
 	if err := p.reconfigureProvider(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reconfigure ETW to only get registry events for which we have agent rules to match against.

The initial PR (#31047) was reverted (#31106) because it introduced a deadlock in the `ApplyRuleSet` function, this PR has this fixed.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->