### PR TITLE
fix(rpm_test): Set 6 as default agent version

### DIFF
--- a/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
+++ b/test/new-e2e/tests/agent-platform/rpm/rpm_test.go
@@ -31,7 +31,7 @@ var (
 	osVersion    = flag.String("osversion", "", "os version to test")
 	platform     = flag.String("platform", "", "platform to test")
 	architecture = flag.String("arch", "", "architecture to test (x86_64, arm64)")
-	majorVersion = flag.String("major-version", "7", "major version to test (6, 7)")
+	majorVersion = flag.String("major-version", "6", "major version to test (6, 7)")
 )
 
 type rpmTestSuite struct {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force the default version of agent to `6` in the rpm_test, because the `new-e2e-agent-platform-rpm-centos6-a6-x86_64` is [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/708272269) on `6.53.x`, trying to install an Agent 7 (line 306)

### Motivation
The `new-e2e-agent-platform-rpm-centos6-a6-x86_64` was not having the `--major-version 6` passed as argument. To not impact the configuration I just changed the default value as we are building for Agent 6.

### Describe how to test/QA your changes
The test `new-e2e-agent-platform-rpm-centos6-a6-x86_64` is [passing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/708203886)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->