### PR TITLE
[CWS] make windows self test run from outside of system-probe

### DIFF
--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -9,6 +9,7 @@ package selftests
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -37,7 +38,7 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.device_path =~ "%s" && process.pid == %d`, basename, filepath.ToSlash(devicePath), os.Getpid()),
+		Expression: fmt.Sprintf(`create.file.name == "%s" && create.file.device_path =~ "%s"`, basename, filepath.ToSlash(devicePath)),
 		Silent:     true,
 	}
 }
@@ -46,12 +47,21 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 func (o *WindowsCreateFileSelfTest) GenerateEvent() error {
 	o.isSuccess = false
 
-	file, err := os.Create(o.filename)
-	if err != nil {
+	cmd := exec.Command(
+		"powershell",
+		"-c",
+		"New-Item",
+		"-Path",
+		o.filename,
+		"-ItemType",
+		"file",
+	)
+	if err := cmd.Run(); err != nil {
 		log.Debugf("error creating file: %v", err)
 		return err
 	}
-	return file.Close()
+
+	return os.Remove(o.filename)
 }
 
 // HandleEvent handles self test events

--- a/pkg/security/probe/selftests/open_registry_key_windows.go
+++ b/pkg/security/probe/selftests/open_registry_key_windows.go
@@ -10,14 +10,12 @@ package selftests
 
 import (
 	"fmt"
-	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"golang.org/x/sys/windows/registry"
 )
 
 // WindowsOpenRegistryKeyTest defines a windows open registry key self test
@@ -33,7 +31,7 @@ func (o *WindowsOpenRegistryKeyTest) GetRuleDefinition() *rules.RuleDefinition {
 
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
-		Expression: fmt.Sprintf(`open.registry.key_name == "%s" && process.pid == %d`, filepath.Base(o.keyPath), os.Getpid()),
+		Expression: fmt.Sprintf(`open.registry.key_name == "%s"`, filepath.Base(o.keyPath)),
 		Silent:     true,
 	}
 }
@@ -42,12 +40,20 @@ func (o *WindowsOpenRegistryKeyTest) GetRuleDefinition() *rules.RuleDefinition {
 func (o *WindowsOpenRegistryKeyTest) GenerateEvent() error {
 	o.isSuccess = false
 
-	key, err := registry.OpenKey(registry.LOCAL_MACHINE, o.keyPath, registry.READ)
-	if err != nil {
+	path := fmt.Sprintf("Registry::HKEY_LOCAL_MACHINE:\\%s", o.keyPath)
+
+	cmd := exec.Command(
+		"powershell",
+		"-c",
+		"Get-ItemProperty",
+		"-Path",
+		path,
+	)
+	if err := cmd.Run(); err != nil {
 		log.Debugf("error opening registry key: %v", err)
 		return err
 	}
-	defer key.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We ignore events coming from system-probe pid itself. As such self tests won't work if you just open a file as-is, you need to go through another process. This is already done on linux, this PR does the same for windows.

### Motivation

### Describe how to test/QA your changes

No agent impact expected, this should fix the new-e2e cws windows test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->