### PR TITLE
[OTEL-2043] Pin otel collector version when checking otel module version

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -24,6 +24,7 @@ from invoke.exceptions import Exit
 from tasks.agent import integration_tests as agent_integration_tests
 from tasks.build_tags import compute_build_tags_for_flavor
 from tasks.cluster_agent import integration_tests as dca_integration_tests
+from tasks.collector import OCB_VERSION
 from tasks.coverage import PROFILE_COV, CodecovWorkaround
 from tasks.devcontainer import run_on_devcontainer
 from tasks.dogstatsd import integration_tests as dsd_integration_tests
@@ -50,7 +51,7 @@ GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
 WINDOWS_MAX_PACKAGES_NUMBER = 150
 TRIGGER_ALL_TESTS_PATHS = ["tasks/gotest.py", "tasks/build_tags.py", ".gitlab/source_test/*"]
 OTEL_UPSTREAM_GO_MOD_PATH = (
-    "https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/main/go.mod"
+    f"https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/v{OCB_VERSION}/go.mod"
 )
 
 


### PR DESCRIPTION
### What does this PR do?

Pin otel collector version in `inv check-otel-module-versions` to the current version in use in Agent, rather than pulling from the latest mainline head.

### Motivation

Prevent accidental breakage caused by upstream OTel change, e.g. #incident-29728.