### PR TITLE
Use FinishedAt for `container.uptime` calculation if the container has stopped

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -266,17 +266,17 @@ func (c *collector) parsePodContainers(
 		}
 
 		containerState := workloadmeta.ContainerState{}
-		if st := container.State.Running; st != nil {
-			containerState.Running = true
-			containerState.Status = workloadmeta.ContainerStatusRunning
-			containerState.StartedAt = st.StartedAt
-			containerState.CreatedAt = st.StartedAt // CreatedAt not available
-		} else if st := container.State.Terminated; st != nil {
+		if st := container.Terminated(); st != nil {
 			containerState.Running = false
 			containerState.Status = workloadmeta.ContainerStatusStopped
 			containerState.CreatedAt = st.StartedAt
 			containerState.StartedAt = st.StartedAt
 			containerState.FinishedAt = st.FinishedAt
+		} else if st := container.Running(); st != nil {
+			containerState.Running = true
+			containerState.Status = workloadmeta.ContainerStatusRunning
+			containerState.StartedAt = st.StartedAt
+			containerState.CreatedAt = st.StartedAt // CreatedAt not available
 		}
 
 		// Kubelet considers containers without probe to be ready

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -320,6 +320,18 @@ type ContainerState struct {
 	ExitCode   *int64
 }
 
+// Uptime returns the duration the container has been running.
+// If the container has stopped, it returns the duration it was running.
+func (c ContainerState) Uptime() time.Duration {
+	if c.StartedAt.IsZero() {
+		return 0
+	}
+	if c.FinishedAt.IsZero() {
+		return time.Since(c.StartedAt)
+	}
+	return c.FinishedAt.Sub(c.StartedAt)
+}
+
 // String returns a string representation of ContainerState.
 func (c ContainerState) String(verbose bool) string {
 	var sb strings.Builder

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -127,7 +127,7 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 }
 
 func (p *Processor) processContainer(sender sender.Sender, tags []string, container *workloadmeta.Container, containerStats *metrics.ContainerStats) error {
-	if uptime := time.Since(container.State.StartedAt); uptime >= 0 {
+	if uptime := container.State.Uptime(); uptime >= 0 {
 		p.sendMetric(sender.Gauge, "container.uptime", pointer.Ptr(uptime.Seconds()), tags)
 	}
 

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -230,6 +230,30 @@ type ContainerStatus struct {
 	LastState    ContainerState `json:"lastState"`
 }
 
+// Running returns running state of the container.
+func (c *ContainerStatus) Running() *ContainerStateRunning {
+	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container:~:text=containerStatuses.lastState%20(-,ContainerState,-)
+	if c.LastState.Running != nil {
+		return c.LastState.Running
+	}
+	if c.State.Running != nil {
+		return c.State.Running
+	}
+	return nil
+}
+
+// Terminated returns terminated state of the container.
+func (c *ContainerStatus) Terminated() *ContainerStateTerminated {
+	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container:~:text=containerStatuses.lastState%20(-,ContainerState,-)
+	if c.LastState.Terminated != nil {
+		return c.LastState.Terminated
+	}
+	if c.State.Terminated != nil {
+		return c.State.Terminated
+	}
+	return nil
+}
+
 // IsPending returns if the container doesn't have an ID
 func (c *ContainerStatus) IsPending() bool {
 	return c.ID == ""


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use `finished at` for uptime calculation if the container has stopped

### Motivation

Currently, Agent calculates uptime by `now - started at`.
`now - started at` sometimes exceed `finished at - started at`.

`container.uptime` should be 60 seconds.

```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: restart-count-test
spec:
  containers:
    - name: startstop
      image: busybox
      command: ["sh", "-c", "sleep 60 && exit 1"]
EOF
```

`container.uptime` was 64 seconds.

![2024-11-16_10-51-41](https://github.com/user-attachments/assets/a31065d9-aec3-4685-9658-22a322cc701b)

`finishedAt: "2024-11-16T01:46:12Z" - startedAt: "2024-11-16T01:45:12Z" = 60 seconds` 

```
kubectl get pod restart-count-test -o yaml
....
  containerStatuses:
  - containerID: containerd://384db435a66e1fd719f717230a54c05d360418402c618878c21df55cba9383af
    image: docker.io/library/busybox:latest
    imageID: docker.io/library/busybox@sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
    lastState:
      terminated:
        containerID: containerd://384db435a66e1fd719f717230a54c05d360418402c618878c21df55cba9383af
        exitCode: 1
        finishedAt: "2024-11-16T01:46:12Z"
        reason: Error
        startedAt: "2024-11-16T01:45:12Z"
```

### Describe how to test/QA your changes


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->