### PR TITLE
[CWS] fix tag resolver usage in windows functional tests

### DIFF
--- a/pkg/security/probe/opts_windows.go
+++ b/pkg/security/probe/opts_windows.go
@@ -9,6 +9,7 @@
 package probe
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
@@ -22,6 +23,9 @@ type Opts struct {
 
 	// EnvsVarResolutionEnabled defines if environment variables resolution is enabled
 	EnvsVarResolutionEnabled bool
+
+	// Tagger will override the default one. Mainly here for tests.
+	Tagger tags.Tagger
 
 	// this option for test purposes only; should never be true in main code
 	disableProcmon bool

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1296,7 +1296,11 @@ func NewWindowsProbe(probe *Probe, config *config.Config, opts Opts, telemetry t
 		return nil, err
 	}
 	p.probe = probe
-	p.Resolvers, err = resolvers.NewResolvers(config, p.statsdClient, probe.scrubber, telemetry)
+
+	resolversOpts := resolvers.Opts{
+		Tagger: probe.Opts.Tagger,
+	}
+	p.Resolvers, err = resolvers.NewResolvers(config, p.statsdClient, probe.scrubber, telemetry, resolversOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -9,8 +9,6 @@
 package model
 
 import (
-	"errors"
-	"fmt"
 	"sync"
 
 	"go.uber.org/atomic"
@@ -19,55 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
-
-var (
-	ErrNoImageProvided = errors.New("no image name provided") // ErrNoImageProvided is returned when no image name is provided
-)
-
-// WorkloadSelector is a selector used to uniquely indentify the image of a workload
-type WorkloadSelector struct {
-	Image string
-	Tag   string
-}
-
-// NewWorkloadSelector returns an initialized instance of a WorkloadSelector
-func NewWorkloadSelector(image string, tag string) (WorkloadSelector, error) {
-	if image == "" {
-		return WorkloadSelector{}, ErrNoImageProvided
-	} else if tag == "" {
-		tag = "latest"
-	}
-	return WorkloadSelector{
-		Image: image,
-		Tag:   tag,
-	}, nil
-}
-
-// IsReady returns true if the selector is ready
-func (ws *WorkloadSelector) IsReady() bool {
-	return len(ws.Image) != 0
-}
-
-// Match returns true if the input selector matches the current selector
-func (ws *WorkloadSelector) Match(selector WorkloadSelector) bool {
-	if ws.Tag == "*" || selector.Tag == "*" {
-		return ws.Image == selector.Image
-	}
-	return ws.Image == selector.Image && ws.Tag == selector.Tag
-}
-
-// String returns a string representation of a workload selector
-func (ws WorkloadSelector) String() string {
-	return fmt.Sprintf("[image_name:%s image_tag:%s]", ws.Image, ws.Tag)
-}
-
-// ToTags returns a string array representation of a workload selector
-func (ws WorkloadSelector) ToTags() []string {
-	return []string{
-		"image_name:" + ws.Image,
-		"image_tag:" + ws.Tag,
-	}
-}
 
 // CacheEntry cgroup resolver cache entry
 type CacheEntry struct {

--- a/pkg/security/resolvers/cgroup/model/types.go
+++ b/pkg/security/resolvers/cgroup/model/types.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+// Package model holds model related files
+package model
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNoImageProvided = errors.New("no image name provided") // ErrNoImageProvided is returned when no image name is provided
+)
+
+// WorkloadSelector is a selector used to uniquely indentify the image of a workload
+type WorkloadSelector struct {
+	Image string
+	Tag   string
+}
+
+// NewWorkloadSelector returns an initialized instance of a WorkloadSelector
+func NewWorkloadSelector(image string, tag string) (WorkloadSelector, error) {
+	if image == "" {
+		return WorkloadSelector{}, ErrNoImageProvided
+	} else if tag == "" {
+		tag = "latest"
+	}
+	return WorkloadSelector{
+		Image: image,
+		Tag:   tag,
+	}, nil
+}
+
+// IsReady returns true if the selector is ready
+func (ws *WorkloadSelector) IsReady() bool {
+	return len(ws.Image) != 0
+}
+
+// Match returns true if the input selector matches the current selector
+func (ws *WorkloadSelector) Match(selector WorkloadSelector) bool {
+	if ws.Tag == "*" || selector.Tag == "*" {
+		return ws.Image == selector.Image
+	}
+	return ws.Image == selector.Image && ws.Tag == selector.Tag
+}
+
+// String returns a string representation of a workload selector
+func (ws WorkloadSelector) String() string {
+	return fmt.Sprintf("[image_name:%s image_tag:%s]", ws.Image, ws.Tag)
+}
+
+// ToTags returns a string array representation of a workload selector
+func (ws WorkloadSelector) ToTags() []string {
+	return []string{
+		"image_name:" + ws.Image,
+		"image_tag:" + ws.Tag,
+	}
+}

--- a/pkg/security/resolvers/opts_windows.go
+++ b/pkg/security/resolvers/opts_windows.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package resolvers holds resolvers related files
+package resolvers
+
+import "github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
+
+// Opts defines common options
+type Opts struct {
+	Tagger tags.Tagger
+}

--- a/pkg/security/resolvers/resolvers_windows.go
+++ b/pkg/security/resolvers/resolvers_windows.go
@@ -29,13 +29,13 @@ type Resolvers struct {
 }
 
 // NewResolvers creates a new instance of Resolvers
-func NewResolvers(config *config.Config, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, telemetry telemetry.Component) (*Resolvers, error) {
+func NewResolvers(config *config.Config, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, telemetry telemetry.Component, opts Opts) (*Resolvers, error) {
 	processResolver, err := process.NewResolver(config, statsdClient, scrubber, process.NewResolverOpts())
 	if err != nil {
 		return nil, err
 	}
 
-	tagsResolver := tags.NewResolver(telemetry, nil)
+	tagsResolver := tags.NewResolver(telemetry, opts.Tagger)
 
 	userSessionsResolver, err := usersessions.NewResolver(config.RuntimeSecurity)
 	if err != nil {

--- a/pkg/security/tests/fake_tags_resolver.go
+++ b/pkg/security/tests/fake_tags_resolver.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux || windows
 
 // Package tests holds tests related files
 package tests

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -157,6 +157,12 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 			DontDiscardRuntime: true,
 		},
 	}
+	if opts.staticOpts.tagger != nil {
+		emopts.ProbeOpts.Tagger = opts.staticOpts.tagger
+	} else {
+		emopts.ProbeOpts.Tagger = NewFakeTaggerDifferentImageNames()
+	}
+
 	testMod.eventMonitor, err = eventmonitor.NewEventMonitor(emconfig, secconfig, emopts, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with the tag resolver in CWS functional tests for windows. On linux functional tests were already using a fake tag resolver but not on windows. When https://github.com/DataDog/datadog-agent/commit/2786875f1a233bf397f2590e83edde45ee429bc5 was merged, since the remote tagger was already disabled before, we no ended up with a nil pointer dereference.

This PR simply re-uses what is done on linux, but on windows this time.

This PR also removes the flake marker and mark the job as "allowed_to_fail". The goal here is to have the job run, collect information on flakyness across a few days, and then remove the "allowed_to_fail" 

### Motivation

### Describe how to test/QA your changes

This code is covered by tests (that are failing, which is why this PR exists in the first place), and it mostly touching test code.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->