### PR TITLE
usm: http2: Unify telemetry maps

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -101,16 +101,17 @@ static __always_inline void pktbuf_skip_preface(pktbuf_t pkt) {
 
 // Returns the telemetry pointer from the relevant map.
 static __always_inline void* get_telemetry(pktbuf_t pkt) {
-    const __u32 zero = 0;
+    const __u32 plaintext_ey = 0;
+    const __u32 tls_key = 1;
 
     pktbuf_map_lookup_option_t map_lookup_telemetry_array[] = {
         [PKTBUF_SKB] = {
             .map = &http2_telemetry,
-            .key = (void*)&zero,
+            .key = (void*)&plaintext_ey,
         },
         [PKTBUF_TLS] = {
-            .map = &tls_http2_telemetry,
-            .key = (void*)&zero,
+            .map = &http2_telemetry,
+            .key = (void*)&tls_key,
         },
     };
     return pktbuf_map_lookup(pkt, map_lookup_telemetry_array);

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -43,10 +43,8 @@ BPF_PERCPU_ARRAY_MAP(http2_scratch_buffer, http2_event_t, 1)
 /* Allocating a ctx on the heap, in order to save the ctx between the current stream. */
 BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, http2_ctx_t, 1)
 
-/* This map is used for telemetry in kernelspace
- * only key 0 is used
- * value is a http2 telemetry object
- */
+// This map is used to gather telemetry data from the eBPF programs. Key 0 is used for plaintext traffic,
+// and key 1 is used for encrypted traffic.
 BPF_ARRAY_MAP(http2_telemetry, http2_telemetry_t, 2)
 
 #endif

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -47,7 +47,6 @@ BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, http2_ctx_t, 1)
  * only key 0 is used
  * value is a http2 telemetry object
  */
-BPF_ARRAY_MAP(http2_telemetry, http2_telemetry_t, 1)
-BPF_ARRAY_MAP(tls_http2_telemetry, http2_telemetry_t, 1)
+BPF_ARRAY_MAP(http2_telemetry, http2_telemetry_t, 2)
 
 #endif

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -61,8 +61,6 @@ const (
 
 	// TelemetryMap is the name of the map used to retrieve plaintext metrics from the kernel
 	TelemetryMap = "http2_telemetry"
-	// TLSTelemetryMap is the name of the map used to retrieve metrics from the eBPF probes for TLS
-	TLSTelemetryMap = "tls_http2_telemetry"
 
 	tlsFirstFrameTailCall    = "uprobe__http2_tls_handle_first_frame"
 	tlsFilterTailCall        = "uprobe__http2_tls_filter"
@@ -316,13 +314,8 @@ func (p *Protocol) updateKernelTelemetry(mgr *manager.Manager) {
 		return
 	}
 
-	tlsMap, err := protocols.GetMap(mgr, TLSTelemetryMap)
-	if err != nil {
-		log.Warn(err)
-		return
-	}
-
-	var zero uint32
+	plaintextKey := uint32(0)
+	tlsKey := uint32(1)
 	http2Telemetry := &HTTP2Telemetry{}
 	ticker := time.NewTicker(30 * time.Second)
 
@@ -332,14 +325,14 @@ func (p *Protocol) updateKernelTelemetry(mgr *manager.Manager) {
 		for {
 			select {
 			case <-ticker.C:
-				if err := mp.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(http2Telemetry)); err != nil {
+				if err := mp.Lookup(unsafe.Pointer(&plaintextKey), unsafe.Pointer(http2Telemetry)); err != nil {
 					log.Errorf("unable to lookup %q map: %s", TelemetryMap, err)
 					return
 				}
 				p.http2Telemetry.update(http2Telemetry, false)
 
-				if err := tlsMap.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(http2Telemetry)); err != nil {
-					log.Errorf("unable to lookup %q map: %s", TLSTelemetryMap, err)
+				if err := mp.Lookup(unsafe.Pointer(&tlsKey), unsafe.Pointer(http2Telemetry)); err != nil {
+					log.Errorf("unable to lookup %q map: %s", TelemetryMap, err)
 					return
 				}
 				p.http2Telemetry.update(http2Telemetry, true)

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -59,7 +59,7 @@ const (
 	eosParserTailCall         = "socket__http2_eos_parser"
 	eventStream               = "http2"
 
-	// TelemetryMap is the name of the map used to retrieve plaintext metrics from the kernel
+	// TelemetryMap is the name of the map that collects telemetry for plaintext and TLS encrypted HTTP/2 traffic.
 	TelemetryMap = "http2_telemetry"
 
 	tlsFirstFrameTailCall    = "uprobe__http2_tls_handle_first_frame"

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1924,11 +1924,11 @@ func dialHTTP2Server(t *testing.T) net.Conn {
 // getHTTP2KernelTelemetry returns the HTTP2 kernel telemetry
 func getHTTP2KernelTelemetry(monitor *Monitor, isTLS bool) (*usmhttp2.HTTP2Telemetry, error) {
 	http2Telemetry := &usmhttp2.HTTP2Telemetry{}
-	var zero uint32
 
 	mapName := usmhttp2.TelemetryMap
+	key := uint32(0)
 	if isTLS {
-		mapName = usmhttp2.TLSTelemetryMap
+		key = uint32(1)
 	}
 
 	mp, _, err := monitor.ebpfProgram.GetMap(mapName)
@@ -1936,7 +1936,7 @@ func getHTTP2KernelTelemetry(monitor *Monitor, isTLS bool) (*usmhttp2.HTTP2Telem
 		return nil, fmt.Errorf("unable to get %q map: %s", mapName, err)
 	}
 
-	if err := mp.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(http2Telemetry)); err != nil {
+	if err := mp.Lookup(unsafe.Pointer(&key), unsafe.Pointer(http2Telemetry)); err != nil {
 		return nil, fmt.Errorf("unable to lookup %q map: %s", mapName, err)
 	}
 	return http2Telemetry, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Unifies http2 telemetry maps (plaintext + tls) into a single map

### Motivation

Each eBPF map has a minimum size in bytes. Having plaintext and tls map versions for telemetry introduced a waste in memory cost, and redundant code duplication. Instead of having 2 maps with a single entry each, we can have a single map with 2 entries.

### Describe how to test/QA your changes

There's an automated test `TestHTTP2KernelTelemetry()`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->