### PR TITLE
Remove the AppArmor only when the injector package is removed

### DIFF
--- a/pkg/fleet/installer/service/apm_inject.go
+++ b/pkg/fleet/installer/service/apm_inject.go
@@ -157,6 +157,11 @@ func (a *apmInjectorInstaller) Remove(ctx context.Context) (err error) {
 		return fmt.Errorf("error removing install scripts: %w", err)
 	}
 
+	err = removeAppArmor(ctx)
+	if err != nil {
+		return fmt.Errorf("error removing AppArmor profile: %w", err)
+	}
+
 	return a.Uninstrument(ctx)
 }
 
@@ -214,8 +219,6 @@ func (a *apmInjectorInstaller) Uninstrument(ctx context.Context) error {
 		dockerErr := a.uninstrumentDocker(ctx)
 		errs = append(errs, dockerErr)
 	}
-	appArmorErr := removeAppArmor(ctx)
-	errs = append(errs, appArmorErr)
 
 	return multierr.Combine(errs...)
 }

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -346,6 +346,9 @@ func (s *packageApmInjectSuite) TestUninstrument() {
 	state.AssertDirExists("/opt/datadog-packages/datadog-apm-inject/stable", 0755, "root", "root")
 	s.assertLDPreloadNotInstrumented()
 	s.assertDockerdNotInstrumented()
+	if s.os == e2eos.Ubuntu2204 || s.os == e2eos.Debian12 {
+		s.assertAppArmorProfile() // AppArmor profile should still be there
+	}
 }
 
 func (s *packageApmInjectSuite) TestInstrumentScripts() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove the AppArmor only when the injector package is removed, not when the instrumentation is disabled.

It was causing issues because the AppArmor profile was not restored when the instrumentation was re-enabled.

AppArmor support was added in https://github.com/DataDog/datadog-agent/pull/29697

### Motivation

### Describe how to test/QA your changes
Tested manually on a vm & by E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->