### PR TITLE
[CWS] custom events cleanup

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -63,6 +63,7 @@ const (
 	EBPFLessHelloMessageRuleID = "ebpfless_hello_msg"
 	// EBPFLessHelloMessageRuleDesc is the rule description for the hello msg event
 	EBPFLessHelloMessageRuleDesc = "Hello message received"
+
 	// InternalCoreDumpRuleID internal core dump
 	InternalCoreDumpRuleID = "internal_core_dump"
 	// InternalCoreDumpRuleDesc internal core dump

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -19,11 +19,6 @@ const (
 	// ServiceName is the service tag of the custom event types defined in this package
 	ServiceName = "runtime-security-agent"
 
-	// LostEventsRuleID is the rule ID for the lost_events_* events
-	LostEventsRuleID = "lost_events"
-	//LostEventsRuleDesc is the rule description for the lost_events_* events
-	LostEventsRuleDesc = "Lost events"
-
 	// RulesetLoadedRuleID is the rule ID for the ruleset_loaded events
 	RulesetLoadedRuleID = "ruleset_loaded"
 	// RulesetLoadedRuleDesc is the rule description for the ruleset_loaded events
@@ -103,7 +98,6 @@ func NewCustomRule(id eval.RuleID, description string) *rules.Rule {
 // AllCustomRuleIDs returns the list of custom rule IDs
 func AllCustomRuleIDs() []string {
 	return []string{
-		LostEventsRuleID,
 		RulesetLoadedRuleID,
 		AbnormalPathRuleID,
 		SelfTestRuleID,

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -20,55 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-// EventLostRead is the event used to report lost events detected from user space
-// easyjson:json
-type EventLostRead struct {
-	events.CustomEventCommonFields
-	Name string  `json:"map"`
-	Lost float64 `json:"lost"`
-}
-
-// ToJSON marshal using json format
-func (e EventLostRead) ToJSON() ([]byte, error) {
-	return utils.MarshalEasyJSON(e)
-}
-
-// NewEventLostReadEvent returns the rule and a populated custom event for a lost_events_read event
-func NewEventLostReadEvent(acc *events.AgentContainerContext, mapName string, lost float64) (*rules.Rule, *events.CustomEvent) {
-	evt := EventLostRead{
-		Name: mapName,
-		Lost: lost,
-	}
-	evt.FillCustomEventCommonFields(acc)
-
-	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
-}
-
-// EventLostWrite is the event used to report lost events detected from kernel space
-// easyjson:json
-type EventLostWrite struct {
-	events.CustomEventCommonFields
-	Name string            `json:"map"`
-	Lost map[string]uint64 `json:"per_event"`
-}
-
-// ToJSON marshal using json format
-func (e EventLostWrite) ToJSON() ([]byte, error) {
-	return utils.MarshalEasyJSON(e)
-}
-
-// NewEventLostWriteEvent returns the rule and a populated custom event for a lost_events_write event
-func NewEventLostWriteEvent(acc *events.AgentContainerContext, mapName string, perEventPerCPU map[string]uint64) (*rules.Rule, *events.CustomEvent) {
-	evt := EventLostWrite{
-		Name: mapName,
-		Lost: perEventPerCPU,
-	}
-	evt.FillCustomEventCommonFields(acc)
-
-	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
-}
-
-
 // AbnormalEvent is used to report that a path resolution failed for a suspicious reason
 // easyjson:json
 type AbnormalEvent struct {

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
@@ -42,7 +41,7 @@ func NewEventLostReadEvent(acc *events.AgentContainerContext, mapName string, lo
 	}
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomLostReadEventType, evt)
+	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
 }
 
 // EventLostWrite is the event used to report lost events detected from kernel space
@@ -66,17 +65,9 @@ func NewEventLostWriteEvent(acc *events.AgentContainerContext, mapName string, p
 	}
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomLostWriteEventType, evt)
+	return events.NewCustomRule(events.LostEventsRuleID, events.LostEventsRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
 }
 
-func errorToEventType(err error) model.EventType {
-	switch err.(type) {
-	case dentry.ErrTruncatedParents, dentry.ErrTruncatedParentsERPC:
-		return model.CustomTruncatedParentsEventType
-	default:
-		return model.UnknownEventType
-	}
-}
 
 // AbnormalEvent is used to report that a path resolution failed for a suspicious reason
 // easyjson:json
@@ -105,7 +96,7 @@ func NewAbnormalEvent(acc *events.AgentContainerContext, id string, description 
 		return evt
 	}
 
-	return events.NewCustomRule(id, description), events.NewCustomEventLazy(errorToEventType(err), marshalerCtor)
+	return events.NewCustomRule(id, description), events.NewCustomEventLazy(model.CustomEventType, marshalerCtor)
 }
 
 // EBPFLessHelloMsgEvent defines a hello message
@@ -146,5 +137,5 @@ func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.H
 
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.EBPFLessHelloMessageRuleID, events.EBPFLessHelloMessageRuleDesc), events.NewCustomEvent(model.UnknownEventType, evt)
+	return events.NewCustomRule(events.EBPFLessHelloMessageRuleID, events.EBPFLessHelloMessageRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
 }

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -23,7 +23,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *EventLostWrite) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *EBPFLessHelloMsgEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -42,23 +42,32 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 			continue
 		}
 		switch key {
-		case "map":
-			out.Name = string(in.String())
-		case "per_event":
+		case "nsid":
+			out.NSID = uint64(in.Uint64())
+		case "workload_container":
+			easyjsonF8f9ddd1Decode(in, &out.Container)
+		case "args":
 			if in.IsNull() {
 				in.Skip()
+				out.EntrypointArgs = nil
 			} else {
-				in.Delim('{')
-				out.Lost = make(map[string]uint64)
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v1 uint64
-					v1 = uint64(in.Uint64())
-					(out.Lost)[key] = v1
+				in.Delim('[')
+				if out.EntrypointArgs == nil {
+					if !in.IsDelim(']') {
+						out.EntrypointArgs = make([]string, 0, 4)
+					} else {
+						out.EntrypointArgs = []string{}
+					}
+				} else {
+					out.EntrypointArgs = (out.EntrypointArgs)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v1 string
+					v1 = string(in.String())
+					out.EntrypointArgs = append(out.EntrypointArgs, v1)
 					in.WantComma()
 				}
-				in.Delim('}')
+				in.Delim(']')
 			}
 		case "date":
 			if data := in.Raw(); in.Ok() {
@@ -86,39 +95,53 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in EventLostWrite) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in EBPFLessHelloMsgEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	{
-		const prefix string = ",\"map\":"
+	if in.NSID != 0 {
+		const prefix string = ",\"nsid\":"
+		first = false
 		out.RawString(prefix[1:])
-		out.String(string(in.Name))
+		out.Uint64(uint64(in.NSID))
 	}
-	{
-		const prefix string = ",\"per_event\":"
-		out.RawString(prefix)
-		if in.Lost == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
-			out.RawString(`null`)
+	if true {
+		const prefix string = ",\"workload_container\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.RawByte('{')
-			v2First := true
-			for v2Name, v2Value := range in.Lost {
-				if v2First {
-					v2First = false
-				} else {
+			out.RawString(prefix)
+		}
+		easyjsonF8f9ddd1Encode(out, in.Container)
+	}
+	if len(in.EntrypointArgs) != 0 {
+		const prefix string = ",\"args\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v2, v3 := range in.EntrypointArgs {
+				if v2 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v2Name))
-				out.RawByte(':')
-				out.Uint64(uint64(v2Value))
+				out.String(string(v3))
 			}
-			out.RawByte('}')
+			out.RawByte(']')
 		}
 	}
 	{
 		const prefix string = ",\"date\":"
-		out.RawString(prefix)
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
 		out.Raw((in.Timestamp).MarshalJSON())
 	}
 	{
@@ -139,12 +162,12 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
+func (v EBPFLessHelloMsgEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *EventLostWrite) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *EBPFLessHelloMsgEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
 }
 func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jlexer.Lexer, out *events.AgentContainerContext) {
@@ -201,247 +224,6 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jw
 		out.Uint64(uint64(in.CreatedAt))
 	}
 	out.RawByte('}')
-}
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *EventLostRead) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "map":
-			out.Name = string(in.String())
-		case "lost":
-			out.Lost = float64(in.Float64())
-		case "date":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Timestamp).UnmarshalJSON(data))
-			}
-		case "service":
-			out.Service = string(in.String())
-		case "container":
-			if in.IsNull() {
-				in.Skip()
-				out.AgentContainerContext = nil
-			} else {
-				if out.AgentContainerContext == nil {
-					out.AgentContainerContext = new(events.AgentContainerContext)
-				}
-				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in EventLostRead) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"map\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Name))
-	}
-	{
-		const prefix string = ",\"lost\":"
-		out.RawString(prefix)
-		out.Float64(float64(in.Lost))
-	}
-	{
-		const prefix string = ",\"date\":"
-		out.RawString(prefix)
-		out.Raw((in.Timestamp).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"service\":"
-		out.RawString(prefix)
-		out.String(string(in.Service))
-	}
-	{
-		const prefix string = ",\"container\":"
-		out.RawString(prefix)
-		if in.AgentContainerContext == nil {
-			out.RawString("null")
-		} else {
-			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *EventLostRead) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
-}
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *EBPFLessHelloMsgEvent) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "nsid":
-			out.NSID = uint64(in.Uint64())
-		case "workload_container":
-			easyjsonF8f9ddd1Decode(in, &out.Container)
-		case "args":
-			if in.IsNull() {
-				in.Skip()
-				out.EntrypointArgs = nil
-			} else {
-				in.Delim('[')
-				if out.EntrypointArgs == nil {
-					if !in.IsDelim(']') {
-						out.EntrypointArgs = make([]string, 0, 4)
-					} else {
-						out.EntrypointArgs = []string{}
-					}
-				} else {
-					out.EntrypointArgs = (out.EntrypointArgs)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v3 string
-					v3 = string(in.String())
-					out.EntrypointArgs = append(out.EntrypointArgs, v3)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "date":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Timestamp).UnmarshalJSON(data))
-			}
-		case "service":
-			out.Service = string(in.String())
-		case "container":
-			if in.IsNull() {
-				in.Skip()
-				out.AgentContainerContext = nil
-			} else {
-				if out.AgentContainerContext == nil {
-					out.AgentContainerContext = new(events.AgentContainerContext)
-				}
-				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in EBPFLessHelloMsgEvent) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.NSID != 0 {
-		const prefix string = ",\"nsid\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Uint64(uint64(in.NSID))
-	}
-	if true {
-		const prefix string = ",\"workload_container\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		easyjsonF8f9ddd1Encode(out, in.Container)
-	}
-	if len(in.EntrypointArgs) != 0 {
-		const prefix string = ",\"args\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v4, v5 := range in.EntrypointArgs {
-				if v4 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v5))
-			}
-			out.RawByte(']')
-		}
-	}
-	{
-		const prefix string = ",\"date\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Raw((in.Timestamp).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"service\":"
-		out.RawString(prefix)
-		out.String(string(in.Service))
-	}
-	{
-		const prefix string = ",\"container\":"
-		out.RawString(prefix)
-		if in.AgentContainerContext == nil {
-			out.RawString("null")
-		} else {
-			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v EBPFLessHelloMsgEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *EBPFLessHelloMsgEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
 }
 func easyjsonF8f9ddd1Decode(in *jlexer.Lexer, out *struct {
 	ID             string `json:"id,omitempty"`
@@ -532,7 +314,7 @@ func easyjsonF8f9ddd1Encode(out *jwriter.Writer, in struct {
 	}
 	out.RawByte('}')
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *AbnormalEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *AbnormalEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -589,7 +371,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in AbnormalEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in AbnormalEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -631,10 +413,10 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AbnormalEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -580,7 +580,7 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 	return n, nil
 }
 
-func (p *EBPFProbe) onEventLost(perfMapName string, perEvent map[string]uint64) {
+func (p *EBPFProbe) onEventLost(_ string, perEvent map[string]uint64) {
 	// snapshot traced cgroups if a CgroupTracing event was lost
 	if p.probe.IsActivityDumpEnabled() && perEvent[model.CgroupTracingEventType.String()] > 0 {
 		p.profileManagers.SnapshotTracedCgroups()

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -581,12 +581,6 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 }
 
 func (p *EBPFProbe) onEventLost(perfMapName string, perEvent map[string]uint64) {
-	if p.config.RuntimeSecurity.InternalMonitoringEnabled {
-		p.probe.DispatchCustomEvent(
-			NewEventLostWriteEvent(p.GetAgentContainerContext(), perfMapName, perEvent),
-		)
-	}
-
 	// snapshot traced cgroups if a CgroupTracing event was lost
 	if p.probe.IsActivityDumpEnabled() && perEvent[model.CgroupTracingEventType.String()] > 0 {
 		p.profileManagers.SnapshotTracedCgroups()

--- a/pkg/security/probe/selftests/self_tests.go
+++ b/pkg/security/probe/selftests/self_tests.go
@@ -61,7 +61,7 @@ func NewSelfTestEvent(acc *events.AgentContainerContext, success []eval.RuleID, 
 	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.SelfTestRuleID, events.SelfTestRuleDesc),
-		events.NewCustomEvent(model.CustomSelfTestEventType, evt)
+		events.NewCustomEvent(model.CustomEventType, evt)
 }
 
 // SetOnNewPoliciesReadyCb implements the PolicyProvider interface

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -363,7 +363,7 @@ func newRuleSetLoadedEvent(acc *events.AgentContainerContext, policies []*Policy
 	evt.FillCustomEventCommonFields(acc)
 
 	return events.NewCustomRule(events.RulesetLoadedRuleID, events.RulesetLoadedRuleDesc),
-		events.NewCustomEvent(model.CustomRulesetLoadedEventType, evt)
+		events.NewCustomEvent(model.CustomEventType, evt)
 }
 
 // newHeartbeatEvents returns the rule (e.g. heartbeat) and a populated custom event for a heartbeat event
@@ -382,7 +382,7 @@ func newHeartbeatEvents(acc *events.AgentContainerContext, policies []*policy) (
 			Policy: &policyState,
 		}
 		evt.FillCustomEventCommonFields(acc)
-		evts = append(evts, events.NewCustomEvent(model.CustomHeartbeatEventType, evt))
+		evts = append(evts, events.NewCustomEvent(model.CustomEventType, evt))
 	}
 
 	return events.NewCustomRule(events.HeartbeatRuleID, events.HeartbeatRuleDesc),

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -119,20 +119,8 @@ const (
 	// LastApproverEventType is the last event that accepts approvers
 	LastApproverEventType = SpliceEventType
 
-	// CustomLostReadEventType is the custom event used to report lost events detected in user space
-	CustomLostReadEventType EventType = iota
-	// CustomLostWriteEventType is the custom event used to report lost events detected in kernel space
-	CustomLostWriteEventType
-	// CustomRulesetLoadedEventType is the custom event used to report that a new ruleset was loaded
-	CustomRulesetLoadedEventType
-	// CustomHeartbeatEventType is the custom event used to report a heartbeat event
-	CustomHeartbeatEventType
-	// CustomForkBombEventType is the custom event used to report the detection of a fork bomb
-	CustomForkBombEventType
-	// CustomTruncatedParentsEventType is the custom event used to report that the parents of a path were truncated
-	CustomTruncatedParentsEventType
-	// CustomSelfTestEventType is the custom event used to report the results of a self test run
-	CustomSelfTestEventType
+	// CustomEventType represents a custom event type
+	CustomEventType EventType = iota
 
 	// CreateNewFileEventType event
 	CreateNewFileEventType
@@ -243,18 +231,8 @@ func (t EventType) String() string {
 		return "ondemand"
 	case RawPacketEventType:
 		return "packet"
-	case CustomLostReadEventType:
-		return "lost_events_read"
-	case CustomLostWriteEventType:
-		return "lost_events_write"
-	case CustomRulesetLoadedEventType:
-		return "ruleset_loaded"
-	case CustomForkBombEventType:
-		return "fork_bomb"
-	case CustomTruncatedParentsEventType:
-		return "truncated_parents"
-	case CustomSelfTestEventType:
-		return "self_test"
+	case CustomEventType:
+		return "custom_event"
 	case CreateNewFileEventType:
 		return "create"
 	case DeleteFileEventType:

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -119,20 +119,8 @@ const (
 	// LastApproverEventType is the last event that accepts approvers
 	LastApproverEventType = SpliceEventType
 
-	// CustomLostReadEventType is the custom event used to report lost events detected in user space
-	CustomLostReadEventType EventType = iota
-	// CustomLostWriteEventType is the custom event used to report lost events detected in kernel space
-	CustomLostWriteEventType
-	// CustomRulesetLoadedEventType is the custom event used to report that a new ruleset was loaded
-	CustomRulesetLoadedEventType
-	// CustomHeartbeatEventType is the custom event used to report a heartbeat event
-	CustomHeartbeatEventType
-	// CustomForkBombEventType is the custom event used to report the detection of a fork bomb
-	CustomForkBombEventType
-	// CustomTruncatedParentsEventType is the custom event used to report that the parents of a path were truncated
-	CustomTruncatedParentsEventType
-	// CustomSelfTestEventType is the custom event used to report the results of a self test run
-	CustomSelfTestEventType
+	// CustomEventType represents a custom event type
+	CustomEventType EventType = iota
 
 	// CreateNewFileEventType event
 	CreateNewFileEventType
@@ -243,18 +231,8 @@ func (t EventType) String() string {
 		return "ondemand"
 	case RawPacketEventType:
 		return "packet"
-	case CustomLostReadEventType:
-		return "lost_events_read"
-	case CustomLostWriteEventType:
-		return "lost_events_write"
-	case CustomRulesetLoadedEventType:
-		return "ruleset_loaded"
-	case CustomForkBombEventType:
-		return "fork_bomb"
-	case CustomTruncatedParentsEventType:
-		return "truncated_parents"
-	case CustomSelfTestEventType:
-		return "self_test"
+	case CustomEventType:
+		return "custom_event"
 	case CreateNewFileEventType:
 		return "create"
 	case DeleteFileEventType:

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -58,14 +58,12 @@ func TestEventRulesetLoaded(t *testing.T) {
 			// force a reload
 			return syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
 		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
-			assert.Equal(t, events.RulesetLoadedRuleID, rule.ID, "wrong rule")
-
 			test.cws.SendStats()
 
 			assert.Equal(t, count+1, test.statsdClient.Get(key))
 
 			return validateRuleSetLoadedSchema(t, customEvent)
-		}, 20*time.Second, model.CustomRulesetLoadedEventType)
+		}, 20*time.Second, model.CustomEventType, events.RulesetLoadedRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,11 +91,8 @@ func TestEventHeartbeatSent(t *testing.T) {
 			// force a reload
 			return syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
 		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
-
-			isHeartbeatEvent := events.HeartbeatRuleID == rule.ID
-
-			return validateHeartbeatSchema(t, customEvent) && isHeartbeatEvent
-		}, 80*time.Second, model.CustomHeartbeatEventType)
+			return validateHeartbeatSchema(t, customEvent)
+		}, 80*time.Second, model.CustomEventType, events.HeartbeatRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -323,9 +318,8 @@ func truncatedParents(t *testing.T, staticOpts testOpts, dynamicOpts dynamicTest
 		}
 		return f.Close()
 	}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
-		assert.Equal(t, events.AbnormalPathRuleID, rule.ID, "wrong rule")
 		return true
-	}, getEventTimeout, model.CustomTruncatedParentsEventType)
+	}, getEventTimeout, model.CustomEventType, events.AbnormalPathRuleID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -320,7 +320,7 @@ func (tm *testModule) RegisterRuleEventHandler(cb onRuleHandler) {
 	tm.eventHandlers.Unlock()
 }
 
-func (tm *testModule) GetCustomEventSent(tb testing.TB, action func() error, cb func(rule *rules.Rule, event *events.CustomEvent) bool, timeout time.Duration, eventType model.EventType) error {
+func (tm *testModule) GetCustomEventSent(tb testing.TB, action func() error, cb func(rule *rules.Rule, event *events.CustomEvent) bool, timeout time.Duration, eventType model.EventType, ruleID string) error {
 	tb.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -328,7 +328,7 @@ func (tm *testModule) GetCustomEventSent(tb testing.TB, action func() error, cb 
 	message := make(chan ActionMessage, 1)
 
 	tm.RegisterCustomSendEventHandler(func(rule *rules.Rule, event *events.CustomEvent) {
-		if event.GetEventType() != eventType {
+		if event.GetEventType() != eventType || rule.ID != ruleID {
 			return
 		}
 

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -277,9 +277,8 @@ func TestAnomalyDetection(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -309,11 +308,9 @@ func TestAnomalyDetection(t *testing.T) {
 			// don't do anything
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection.")
-			}
+			t.Fatal("Should not had receive any anomaly detection.")
 			return false
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-dns", func(t *testing.T) {
@@ -345,9 +342,8 @@ func TestAnomalyDetection(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -381,11 +377,9 @@ func TestAnomalyDetection(t *testing.T) {
 			// don't do anything
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection.")
-			}
+			t.Fatal("Should not had receive any anomaly detection.")
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
 
@@ -466,11 +460,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*5, model.DNSEventType)
+		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-warmed-up-autolearned-1", func(t *testing.T) {
@@ -479,11 +471,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-warmed-up-not-autolearned-1", func(t *testing.T) {
@@ -492,9 +482,8 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Error(err)
 		}
@@ -512,11 +501,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*5, model.DNSEventType)
+		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	// already sleep for timeout for warmup period + 2sec spare (5s)
@@ -527,11 +514,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-warmed-up-autolearned-bis-2", func(t *testing.T) {
@@ -540,11 +525,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-warmed-up-autolearned-bis-1", func(t *testing.T) {
@@ -553,11 +536,9 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			if r.Rule.ID == events.AnomalyDetectionRuleID {
-				t.Fatal("Should not had receive any anomaly detection during warm up.")
-			}
+			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
 
@@ -636,7 +617,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-reinsertion-dns", func(t *testing.T) {
@@ -670,7 +651,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("anomaly-detection-stable-period-process", func(t *testing.T) {
@@ -699,9 +680,8 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -737,9 +717,8 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1040,9 +1019,8 @@ func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 		_, err = cmd.CombinedOutput()
 		return err
 	}, func(r *rules.Rule, event *events.CustomEvent) bool {
-		assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 		return true
-	}, time.Second*3, model.ExecEventType)
+	}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1128,7 +1106,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	selector := fakeManualResolver.GetContainerSelector(dockerInstanceV1.containerID)
@@ -1147,9 +1125,8 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1173,9 +1150,8 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.ExecEventType)
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1189,7 +1165,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("life-cycle-v1-stable-v2-process", func(t *testing.T) {
@@ -1200,7 +1176,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
@@ -1220,7 +1196,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 }
 
@@ -1304,7 +1280,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	time.Sleep(time.Second * 10) // waiting for the stable period
@@ -1317,9 +1293,8 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1344,9 +1319,8 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*3, model.DNSEventType)
+		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1363,7 +1337,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	t.Run("life-cycle-v1-stable-v2-dns", func(t *testing.T) {
@@ -1374,7 +1348,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
@@ -1394,7 +1368,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
 
@@ -1479,7 +1453,7 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	selector := fakeManualResolver.GetContainerSelector(dockerInstanceV1.containerID)
@@ -1498,9 +1472,8 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1524,9 +1497,8 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1570,9 +1542,8 @@ func TestSecurityProfileLifeCycleEvictitonProcess(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1660,7 +1631,7 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 
 	selector := fakeManualResolver.GetContainerSelector(dockerInstanceV1.containerID)
@@ -1679,9 +1650,8 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1705,9 +1675,8 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1751,9 +1720,8 @@ func TestSecurityProfileLifeCycleEvictitonDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.DNSEventType)
+		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1841,7 +1809,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	selector := fakeManualResolver.GetContainerSelector(dockerInstanceV1.containerID)
@@ -1862,7 +1830,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	fakeManualResolver.SpecifyNextSelector(&cgroupModel.WorkloadSelector{
@@ -1885,7 +1853,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	fakeManualResolver.SpecifyNextSelector(&cgroupModel.WorkloadSelector{
@@ -1908,7 +1876,7 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 
 	if err := test.SetProfileVersionState(&cgroupModel.WorkloadSelector{
@@ -1926,9 +1894,8 @@ func TestSecurityProfileLifeCycleEvictitonProcessUnstable(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2055,8 +2022,8 @@ func TestSecurityProfilePersistence(t *testing.T) {
 			dockerInstance2.Command("getent", []string{}, []string{}).CombinedOutput()
 			return nil
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			return assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
-		}, time.Second*2, model.ExecEventType)
+			return true
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2068,9 +2035,8 @@ func TestSecurityProfilePersistence(t *testing.T) {
 			_, err := dockerInstance2.Command("/bin/echo", []string{"aaa"}, []string{}).CombinedOutput()
 			return err
 		}, func(r *rules.Rule, event *events.CustomEvent) bool {
-			assert.NotEqual(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return false
-		}, time.Second*2, model.ExecEventType)
+		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
 			if otherErr, ok := err.(ErrTimeout); !ok {
 				t.Fatal(otherErr)


### PR DESCRIPTION
### What does this PR do?

Cleanup PR which:

- merge all custom event types into a single one (no need to have both event types AND rule ID for each of them)
- adapt/simplify test helpers to filter custom events with wanted rule ID
- remove dead custom events code (CustomForkBombEventType / CustomTruncatedParentsEventType)
- remove both CustomLostReadEventType (wich was not used at all) and CustomLostWriteEventType (disabled by default and not used, we use metrics instead)

### Motivation

Do some cleanup

### Describe how to test/QA your changes

Launch tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->