### PR TITLE
[FA] Check fleet files for systemd condition

### DIFF
--- a/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
@@ -2,7 +2,8 @@
 Description=Datadog Security Agent Experiment
 After=network.target
 BindsTo=datadog-agent-exp.service
-ConditionPathExists=/etc/datadog-agent/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
+ConditionPathExists=|/etc/datadog-packages/datadog-agent/experiment/security-agent.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/service/embedded/datadog-agent-security.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-security.service
@@ -2,7 +2,8 @@
 Description=Datadog Security Agent
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
-ConditionPathExists=/etc/datadog-agent/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
+ConditionPathExists=|/etc/datadog-packages/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
@@ -3,7 +3,8 @@ Description=Datadog System Probe Experiment
 Requires=sys-kernel-debug.mount
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
-ConditionPathExists=/etc/datadog-agent/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
+ConditionPathExists=|/etc/datadog-packages/datadog-agent/experiment/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe.service
@@ -4,7 +4,8 @@ Requires=sys-kernel-debug.mount
 Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
-ConditionPathExists=/etc/datadog-agent/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
+ConditionPathExists=|/etc/datadog-packages/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -736,7 +736,7 @@ func (c *LocalCDN) AddLayer(name string, content string) error {
 
 	layerPath := filepath.Join(c.DirPath, name)
 
-	jsonContent := fmt.Sprintf(`{"name": "%s","config": {%s}}`, name, content)
+	jsonContent := fmt.Sprintf(`{"name": "%s", %s}`, name, content)
 
 	_, err := c.host.remote.WriteFile(layerPath, []byte(jsonContent))
 	require.NoError(c.host.t, err)

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -465,7 +465,7 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
     }
   }
 `)
-	hash := "abcdef" // TODO: fixme
+	hash := "4681728e9932105c5eea80056151172764d99e348d09a78158874389d25f3c00"
 	timestamp = s.host.LastJournaldTimestamp()
 	s.mustStartConfigExperiment(localCDN.DirPath, datadogAgent, hash)
 	// Assert the successful start of the experiment

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -386,7 +386,7 @@ func (s *upgradeScenarioSuite) TestUpgradeSuccessfulWithUmask() {
 
 func (s *upgradeScenarioSuite) TestConfigUpgradeSuccessful() {
 	localCDN := host.NewLocalCDN(s.host)
-	localCDN.AddLayer("config", "\"log_level\": \"debug\"")
+	localCDN.AddLayer("config", "\"config\": {\"log_level\": \"debug\"}")
 	s.RunInstallScript(
 		"DD_REMOTE_UPDATES=true",
 		"DD_REMOTE_POLICIES=true",
@@ -409,9 +409,115 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeSuccessful() {
 	s.executeConfigGoldenPath(localCDN.DirPath, "c78c5e96820c89c6cbc178ddba4ce20a167138a3a580ed4637369a9c5ed804c3")
 }
 
+func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
+	localCDN := host.NewLocalCDN(s.host)
+	localCDN.AddLayer("config", "\"config\": {\"log_level\": \"debug\"}")
+	timestamp := s.host.LastJournaldTimestamp()
+	s.RunInstallScript(
+		"DD_REMOTE_UPDATES=true",
+		"DD_REMOTE_POLICIES=true",
+		fmt.Sprintf("DD_INSTALLER_DEBUG_CDN_LOCAL_DIR_PATH=%s", localCDN.DirPath),
+	)
+	defer s.Purge()
+
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.WaitForUnitActive(
+		"datadog-agent.service",
+		"datadog-agent-trace.service",
+		"datadog-agent-process.service",
+		"datadog-installer.service",
+	)
+	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
+	// Make sure security agent and system probe are disabled
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Skipped(probeUnit).
+			Skipped(securityUnit),
+		),
+	)
+
+	state := s.host.State()
+	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", "/etc/datadog-packages/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
+
+	// Enables security agent & sysprobe
+	localCDN.AddLayer("config", `
+  "config": {
+    "sbom": {
+      "container_image": {
+        "enabled": true
+      },
+      "host": {
+        "enabled": true
+      }
+    }
+  },
+  "security_agent": {
+    "runtime_security_config": {
+      "enabled": true
+    },
+    "compliance_config": {
+      "enabled": true
+    }
+  },
+  "system_probe": {
+    "runtime_security_config": {
+      "enabled": true
+    }
+  }
+`)
+	hash := "abcdef" // TODO: fixme
+	timestamp = s.host.LastJournaldTimestamp()
+	s.mustStartConfigExperiment(localCDN.DirPath, datadogAgent, hash)
+	// Assert the successful start of the experiment
+	s.host.WaitForUnitActivating(agentUnitXP)
+	s.host.WaitForFileExists(false, "/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
+
+	// Assert experiment is running
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnit).
+			Stopped(traceUnit).
+			Stopped(processUnit),
+		).
+		Unordered(host.SystemdEvents().
+			Starting(agentUnitXP).
+			Started(traceUnitXP).
+			Started(processUnitXP).
+			Started(securityUnitXP).
+			Started(probeUnitXP),
+		),
+	)
+
+	timestamp = s.host.LastJournaldTimestamp()
+	s.mustPromoteConfigExperiment(localCDN.DirPath, datadogAgent)
+	s.host.WaitForUnitActive(agentUnit)
+
+	// Assert experiment is promoted
+	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
+		Unordered(host.SystemdEvents().
+			Stopped(agentUnitXP).
+			Stopped(processUnitXP).
+			Stopped(traceUnitXP).
+			Stopped(securityUnitXP).
+			Stopped(probeUnitXP),
+		).
+		Unordered(host.SystemdEvents().
+			Started(agentUnit).
+			Stopped(processUnit).
+			Stopped(traceUnit).
+			Started(securityUnit).
+			Started(probeUnit),
+		),
+	)
+
+	state = s.host.State()
+	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
+}
+
 func (s *upgradeScenarioSuite) TestUpgradeConfigFromExistingExperiment() {
 	localCDN := host.NewLocalCDN(s.host)
-	localCDN.AddLayer("config", "\"log_level\": \"debug\"")
+	localCDN.AddLayer("config", "\"config\": {\"log_level\": \"debug\"}")
 	s.RunInstallScript(
 		"DD_REMOTE_UPDATES=true",
 		"DD_REMOTE_POLICIES=true",
@@ -445,7 +551,7 @@ func (s *upgradeScenarioSuite) TestUpgradeConfigFromExistingExperiment() {
 
 func (s *upgradeScenarioSuite) TestUpgradeConfigFailure() {
 	localCDN := host.NewLocalCDN(s.host)
-	localCDN.AddLayer("config", "\"log_level\": \"debug\"")
+	localCDN.AddLayer("config", "\"config\": {\"log_level\": \"debug\"}")
 	s.RunInstallScript(
 		"DD_REMOTE_UPDATES=true",
 		"DD_REMOTE_POLICIES=true",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update the `ConditionPathExists` systemd condition to a `OR` condition between the classic file (`system-probe.yaml` or `security-agent.yaml`), and the file managed by fleet.

That way, we can start the system-probe with fleet even if there was no `system-probe.yaml` at first.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->