### PR TITLE
Deflake TestExtractExtractPodDisruptionBudgetStatus

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/poddisruptionbudget_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/poddisruptionbudget_test.go
@@ -327,6 +327,7 @@ func TestExtractPodDisruptionBudget(t *testing.T) {
 }
 
 func TestExtractExtractPodDisruptionBudgetStatus(t *testing.T) {
+	t0 := time.Now()
 	for name, tc := range map[string]struct {
 		in     *policyv1.PodDisruptionBudgetStatus
 		expect *model.PodDisruptionBudgetStatus
@@ -344,7 +345,7 @@ func TestExtractExtractPodDisruptionBudgetStatus(t *testing.T) {
 		},
 		"full": {
 			in: &policyv1.PodDisruptionBudgetStatus{
-				DisruptedPods:      map[string]metav1.Time{"liborio": metav1.NewTime(time.Now())},
+				DisruptedPods:      map[string]metav1.Time{"liborio": metav1.NewTime(t0)},
 				DisruptionsAllowed: 4,
 				CurrentHealthy:     5,
 				DesiredHealthy:     6,
@@ -354,14 +355,14 @@ func TestExtractExtractPodDisruptionBudgetStatus(t *testing.T) {
 						Type:               "regular",
 						Status:             metav1.ConditionUnknown,
 						ObservedGeneration: 2,
-						LastTransitionTime: metav1.NewTime(time.Now()),
+						LastTransitionTime: metav1.NewTime(t0),
 						Reason:             "why not",
 						Message:            "instant",
 					},
 				},
 			},
 			expect: &model.PodDisruptionBudgetStatus{
-				DisruptedPods:      map[string]int64{"liborio": time.Now().Unix()},
+				DisruptedPods:      map[string]int64{"liborio": t0.Unix()},
 				DisruptionsAllowed: 4,
 				CurrentHealthy:     5,
 				DesiredHealthy:     6,
@@ -370,7 +371,7 @@ func TestExtractExtractPodDisruptionBudgetStatus(t *testing.T) {
 					{
 						Type:               "regular",
 						Status:             string(metav1.ConditionUnknown),
-						LastTransitionTime: time.Now().Unix(),
+						LastTransitionTime: t0.Unix(),
 						Reason:             "why not",
 						Message:            "instant",
 					},


### PR DESCRIPTION
Since we expect timestamps to be the same actually assign the same value instead betting on not crossing seconds boundary between `time.Now()` calls.
### What does this PR do?

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes