### PR TITLE
[CWS] extract rule filter model to its own package

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -33,7 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/utils"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	secl "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -134,7 +134,7 @@ func xccdfEnabled() bool {
 }
 
 var defaultSECLRuleFilter = sync.OnceValues(func() (*secl.SECLRuleFilter, error) {
-	ruleFilterModel, err := rules.NewRuleFilterModel(nil, "")
+	ruleFilterModel, err := filtermodel.NewRuleFilterModel(nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default SECL rule filter: %w", err)
 	}
@@ -422,7 +422,7 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 }
 
 func (a *Agent) runAptConfigurationExport(ctx context.Context) {
-	ruleFilterModel, err := rules.NewRuleFilterModel(nil, "")
+	ruleFilterModel, err := filtermodel.NewRuleFilterModel(nil, "")
 	if err != nil {
 		log.Errorf("failed to run apt configuration export: %v", err)
 		return

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/rconfig"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/autosuppression"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/monitor"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -131,7 +132,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 		ruleFilters = append(ruleFilters, agentVersionFilter)
 	}
 
-	ruleFilterModel, err := NewRuleFilterModel(e.probe.Config, e.probe.Origin())
+	ruleFilterModel, err := filtermodel.NewRuleFilterModel(e.probe.Config, e.probe.Origin())
 	if err != nil {
 		return fmt.Errorf("failed to create rule filter: %w", err)
 	}

--- a/pkg/security/rules/filtermodel/rule_filters_model.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package rules holds rules related files
-package rules
+// Package filtermodel holds rules related files
+package filtermodel
 
 import (
 	"reflect"

--- a/pkg/security/rules/filtermodel/rule_filters_model_linux.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_linux.go
@@ -5,8 +5,8 @@
 
 //go:build linux
 
-// Package rules holds rules related files
-package rules
+// Package filtermodel holds rules related files
+package filtermodel
 
 import (
 	"os"

--- a/pkg/security/rules/filtermodel/rule_filters_model_other.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_other.go
@@ -5,8 +5,8 @@
 
 //go:build !linux
 
-// Package rules holds rules related files
-package rules
+// Package filtermodel holds rules related files
+package filtermodel
 
 import (
 	"os"

--- a/pkg/security/tests/rule_filters_test.go
+++ b/pkg/security/tests/rule_filters_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
-	rulesmodule "github.com/DataDog/datadog-agent/pkg/security/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ func TestSECLRuleFilter(t *testing.T) {
 		Code:         kernel.Kernel5_9,
 	}
 
-	m, err := rulesmodule.NewRuleFilterModel(nil, "")
+	m, err := filtermodel.NewRuleFilterModel(nil, "")
 	assert.NoError(t, err)
 	m.Version = kv
 	seclRuleFilter := rules.NewSECLRuleFilter(m)


### PR DESCRIPTION
### What does this PR do?

This PR moves the fitler model code to its own package. The goal being to limit the inclusion of the CWS whole engine code from the compliance code that uses this filter model.

### Motivation

### Describe how to test/QA your changes

This PR is only moving stuff around, it is covered by tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->