### PR TITLE
[ha-agent] Consume RC HA_AGENT

### DIFF
--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -7,8 +7,10 @@ package haagentimpl
 
 import (
 	"context"
+	"encoding/json"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"go.uber.org/atomic"
 )
@@ -46,4 +48,30 @@ func (h *haAgentImpl) SetLeader(leaderAgentHostname string) {
 		return
 	}
 	h.isLeader.Store(agentHostname == leaderAgentHostname)
+}
+
+func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	h.log.Debugf("Updates received: count=%d", len(updates))
+
+	for configPath, rawConfig := range updates {
+		h.log.Debugf("Received config %s: %s", configPath, string(rawConfig.Config))
+		haAgentMsg := haAgentConfig{}
+		err := json.Unmarshal(rawConfig.Config, &haAgentMsg)
+		if err != nil {
+			h.log.Warnf("Skipping invalid HA_AGENT update %s: %v", configPath, err)
+			applyStateCallback(configPath, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: "error unmarshalling payload",
+			})
+			continue
+		}
+
+		h.SetLeader(haAgentMsg.Leader)
+
+		h.log.Debugf("Processed config %s: %v", configPath, haAgentMsg)
+
+		applyStateCallback(configPath, state.ApplyStatus{
+			State: state.ApplyStateUnacknowledged,
+		})
+	}
 }

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -65,6 +65,15 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			})
 			continue
 		}
+		if haAgentMsg.Group != h.GetGroup() {
+			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected group %s, got %s",
+				configPath, h.GetGroup(), haAgentMsg.Group)
+			applyStateCallback(configPath, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: "group does not match",
+			})
+			continue
+		}
 
 		h.SetLeader(haAgentMsg.Leader)
 

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -80,7 +80,7 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 		h.log.Debugf("Processed config %s: %v", configPath, haAgentMsg)
 
 		applyStateCallback(configPath, state.ApplyStatus{
-			State: state.ApplyStateUnacknowledged,
+			State: state.ApplyStateAcknowledged,
 		})
 	}
 }

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -117,7 +117,7 @@ func Test_haAgentImpl_onHaAgentUpdate(t *testing.T) {
 			},
 			expectedApplyID: testConfigID,
 			expectedApplyStatus: state.ApplyStatus{
-				State: state.ApplyStateUnacknowledged,
+				State: state.ApplyStateAcknowledged,
 			},
 		},
 		{

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -8,8 +8,15 @@ package haagentimpl
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 )
+
+var testConfigID = "datadog/2/HA_AGENT/group-62345762794c0c0b/65f17d667fb50f8ae28a3c858bdb1be9ea994f20249c119e007c520ac115c807"
 
 func Test_Enabled(t *testing.T) {
 	tests := []struct {
@@ -34,7 +41,7 @@ func Test_Enabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			haAgent := newTestHaAgentComponent(t, tt.configs)
+			haAgent := newTestHaAgentComponent(t, tt.configs).Comp
 			assert.Equal(t, tt.expectedEnabled, haAgent.Enabled())
 		})
 	}
@@ -44,7 +51,7 @@ func Test_GetGroup(t *testing.T) {
 	agentConfigs := map[string]interface{}{
 		"ha_agent.group": "my-group-01",
 	}
-	haAgent := newTestHaAgentComponent(t, agentConfigs)
+	haAgent := newTestHaAgentComponent(t, agentConfigs).Comp
 	assert.Equal(t, "my-group-01", haAgent.GetGroup())
 }
 
@@ -52,11 +59,99 @@ func Test_IsLeader_SetLeader(t *testing.T) {
 	agentConfigs := map[string]interface{}{
 		"hostname": "my-agent-hostname",
 	}
-	haAgent := newTestHaAgentComponent(t, agentConfigs)
+	haAgent := newTestHaAgentComponent(t, agentConfigs).Comp
 
 	haAgent.SetLeader("another-agent")
 	assert.False(t, haAgent.IsLeader())
 
 	haAgent.SetLeader("my-agent-hostname")
 	assert.True(t, haAgent.IsLeader())
+}
+
+func Test_RCListener(t *testing.T) {
+	tests := []struct {
+		name             string
+		configs          map[string]interface{}
+		expectRCListener bool
+	}{
+		{
+			name: "enabled",
+			configs: map[string]interface{}{
+				"ha_agent.enabled": true,
+			},
+			expectRCListener: true,
+		},
+		{
+			name: "disabled",
+			configs: map[string]interface{}{
+				"ha_agent.enabled": false,
+			},
+			expectRCListener: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provides := newTestHaAgentComponent(t, tt.configs)
+			if tt.expectRCListener {
+				assert.NotNil(t, provides.RCListener.ListenerProvider)
+			} else {
+				assert.Nil(t, provides.RCListener.ListenerProvider)
+			}
+		})
+	}
+}
+
+func Test_haAgentImpl_onHaAgentUpdate(t *testing.T) {
+
+	tests := []struct {
+		name                string
+		updates             map[string]state.RawConfig
+		expectedApplyID     string
+		expectedApplyStatus state.ApplyStatus
+	}{
+		{
+			name: "successful update",
+			updates: map[string]state.RawConfig{
+				testConfigID: {Config: []byte(`{"group":"group01","leader":"ha-agent1"}`)},
+			},
+			expectedApplyID: testConfigID,
+			expectedApplyStatus: state.ApplyStatus{
+				State: state.ApplyStateUnacknowledged,
+			},
+		},
+		{
+			name: "invalid payload",
+			updates: map[string]state.RawConfig{
+				testConfigID: {Config: []byte(`invalid-json`)},
+			},
+			expectedApplyID: testConfigID,
+			expectedApplyStatus: state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: "error unmarshalling payload",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentConfigs := map[string]interface{}{
+				"hostname": "my-agent-hostname",
+			}
+			agentConfigComponent := fxutil.Test[config.Component](t, fx.Options(
+				config.MockModule(),
+				fx.Replace(config.MockParams{Overrides: agentConfigs}),
+			))
+
+			h := newHaAgentImpl(logmock.New(t), newHaAgentConfigs(agentConfigComponent))
+
+			var applyID string
+			var applyStatus state.ApplyStatus
+			applyFunc := func(id string, status state.ApplyStatus) {
+				applyID = id
+				applyStatus = status
+			}
+			h.onHaAgentUpdate(tt.updates, applyFunc)
+			assert.Equal(t, tt.expectedApplyID, applyID)
+			assert.Equal(t, tt.expectedApplyStatus, applyStatus)
+		})
+	}
 }

--- a/comp/haagent/impl/haagent_testutils_test.go
+++ b/comp/haagent/impl/haagent_testutils_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 )
 
-func newTestHaAgentComponent(t *testing.T, agentConfigs map[string]interface{}) haagent.Component {
+func newTestHaAgentComponent(t *testing.T, agentConfigs map[string]interface{}) Provides {
 	logComponent := logmock.New(t)
 	agentConfigComponent := fxutil.Test[config.Component](t, fx.Options(
 		config.MockModule(),
@@ -30,8 +29,5 @@ func newTestHaAgentComponent(t *testing.T, agentConfigs map[string]interface{}) 
 
 	provides, err := NewComponent(requires)
 	require.NoError(t, err)
-
-	comp := provides.Comp
-	require.NotNil(t, comp)
-	return comp
+	return provides
 }

--- a/comp/haagent/impl/rcpayload.go
+++ b/comp/haagent/impl/rcpayload.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package haagentimpl
+
+type haAgentConfig struct {
+	Group  string `json:"group"`
+	Leader string `json:"leader"`
+}

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -32,6 +32,7 @@ var validProducts = map[string]struct{}{
 	ProductTesting1:                     {},
 	ProductTesting2:                     {},
 	ProductOrchestratorK8sCRDs:          {},
+	ProductHaAgent:                      {},
 }
 
 const (
@@ -87,4 +88,6 @@ const (
 	ProductTesting2 = "TESTING2"
 	// ProductOrchestratorK8sCRDs receives values for k8s crds
 	ProductOrchestratorK8sCRDs = "ORCHESTRATOR_K8S_CRDS"
+	// ProductHaAgent is the HA Agent product
+	ProductHaAgent = "HA_AGENT"
 )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[ha-agent] Consume RC HA_AGENT

### Motivation

Need for HA Agent feature.

### Describe how to test/QA your changes

1/ Run Agent with HA Agent feature enabled:
```
ha_agent:
  enabled: true
  group: my-group01
```

2/ Write messages from backend to HA_AGENT RC product

3/ Check in logs that the RC listener for HA_AGENT is receiving the msg



### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->