### PR TITLE
[CWS] improve clean up of old persisted profiles in directory provider

### DIFF
--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -338,6 +338,7 @@ func (dp *DirectoryProvider) onHandleFilesFromWatcher() {
 	dp.newFilesLock.Lock()
 	defer dp.newFilesLock.Unlock()
 
+	var filesToCleanup []string
 	for file := range dp.newFiles {
 		if err := dp.loadProfile(file); err != nil {
 			if errors.Is(err, cgroupModel.ErrNoImageProvided) {
@@ -346,8 +347,12 @@ func (dp *DirectoryProvider) onHandleFilesFromWatcher() {
 				seclog.Warnf("couldn't load new profile %s: %v", file, err)
 			}
 
-			continue
+			filesToCleanup = append(filesToCleanup, file)
 		}
+	}
+
+	if len(filesToCleanup) != 0 {
+		dp.OnLocalStorageCleanup(filesToCleanup)
 	}
 
 	dp.newFiles = make(map[string]bool)

--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -239,12 +239,9 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 	dp.Lock()
 
 	// prioritize a persited profile over activity dumps
-	if existingProfile, ok := dp.profileMapping[profileManagerSelector]; ok {
-		if existingProfile.selector.Tag == "*" && profile.Selector.GetImageTag() != "*" {
-			seclog.Debugf("ignoring %s: a persisted profile already exists for workload %s", profilePath, profileManagerSelector.String())
-			dp.Unlock()
-			return nil
-		}
+	if _, ok := dp.profileMapping[profileManagerSelector]; ok {
+		dp.Unlock()
+		return fmt.Errorf("ignoring %s: a persisted profile already exists for workload %s", profilePath, profileManagerSelector.String())
 	}
 
 	// update profile mapping


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR implements multiple clean up improvements to the security profiles directory provider code:
- we now remove persisted profiles when we are not able to read them (parsing error, no image tag or name etc)
- when adding a new profile to the mapping we never overwrite a previously existing profile but instead return an error. Mixed with the previous change this will trigger a disk removal of the new profile.

This last point is especially important: currently when the watcher sees a modification to the disk it lists all the profiles from the directory, and loads all profiles that are not in the mapping. This includes old profiles that were in the mapping at one point but had been overwritten.

### Motivation

### Describe how to test/QA your changes

Covered by unit tests + multiple staging deployments

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->