### PR TITLE
[NDM] Fix snmp walk command options

### DIFF
--- a/pkg/snmp/snmpparse/constants.go
+++ b/pkg/snmp/snmpparse/constants.go
@@ -19,10 +19,10 @@ var AuthOpts = NewOptions(OptPairs[gosnmp.SnmpV3AuthProtocol]{
 	{"", gosnmp.NoAuth},
 	{"MD5", gosnmp.MD5},
 	{"SHA", gosnmp.SHA},
-	{"SHA-224", gosnmp.SHA224},
-	{"SHA-256", gosnmp.SHA256},
-	{"SHA-384", gosnmp.SHA384},
-	{"SHA-512", gosnmp.SHA512},
+	{"SHA224", gosnmp.SHA224},
+	{"SHA256", gosnmp.SHA256},
+	{"SHA384", gosnmp.SHA384},
+	{"SHA512", gosnmp.SHA512},
 })
 
 // PrivOpts maps string names to gosnmp privacy protocols


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix snmp walk command options to use the same values as in the SNMP check config. If the command options doesn't match the config, the snmpwalk command will fail when trying to connect using the config values.

### Motivation

### Describe how to test/QA your changes
With an SNMP V3 config
```yaml
init_config:
  loader: core
  use_device_id_as_hostname: true
instances:
- ip_address: '10.0.0.1'
  snmp_version: 3 
  user: 'user'
  authProtocol: 'SHA256'
  authKey: 'fakeKey'
  privProtocol: 'AES256'
  privKey: 'fakePrivKey'
```
the following command should not fail with invalid options:
```
datadog-agent snmp walk 10.0.0.1
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->