### PR TITLE
fix(fakeintake): [agent6] Prevent publishing a `latest` fakeintake from `6.53.x`

### DIFF
--- a/.gitlab/dev_container_deploy/fakeintake.yml
+++ b/.gitlab/dev_container_deploy/fakeintake.yml
@@ -13,18 +13,3 @@ publish_fakeintake:
     IMG_DESTINATIONS: fakeintake:v${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: public
     IMG_SIGNING: "false"
-
-publish_fakeintake_latest:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.on_fakeintake_changes_on_main]
-  needs:
-    - job: docker_build_fakeintake
-      optional: false
-  variables:
-    IMG_SOURCES: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/fakeintake:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    IMG_DESTINATIONS: fakeintake:latest
-    IMG_REGISTRIES: public
-    IMG_SIGNING: "false"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent publishing a `latest` fakeintake from `6.53.x`, introduced in #30900

### Motivation
We should not publish a latest version from `6.53.x` branch
#incident-32523

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->