### PR TITLE
[ksm] Do not initialize API server client in Configure() when fetching pods from Kubelet

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -42,6 +42,13 @@ func NewExtendedPodFactory(client *apiserver.APIClient) customresource.RegistryF
 	}
 }
 
+// NewExtendedPodFactoryForKubelet returns a new Pod metric family generator
+// factory meant to be used when pods are collected from the Kubelet.
+func NewExtendedPodFactoryForKubelet() customresource.RegistryFactory {
+	// No need to set an API server client, because we're collecting from the Kubelet.
+	return &extendedPodFactory{}
+}
+
 type extendedPodFactory struct {
 	client clientset.Interface
 }

--- a/releasenotes-dca/notes/ksm-pods-in-nodes-improve-configuration-4161b4d778f7a2e3.yaml
+++ b/releasenotes-dca/notes/ksm-pods-in-nodes-improve-configuration-4161b4d778f7a2e3.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue in the KSM check when it's configured with the option
+    ``pod_collection_mode`` set to ``node_kubelet``. Previously, the check could
+    fail to start if there was a timeout while contacting the API server. This
+    issue has now been resolved.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the KSM check when configured with `pod_collection_mode` set to `node_kubelet`. 

In particular, the check can fail to start due to a timeout in the `Configure` function, resulting in the following error message:
```
Could not configure check kubernetes_state_core: unable to perform resource discovery: Get "https://172.17.0.1:443/api?timeout=10s": context deadline exceeded
```

With `pod_collection_mode` set to `node_kubelet`, the KSM check does not require an API server client or resource discovery, as it relies on the kubelet instead. This PR resolves the issue by ensuring that the API server is not initialized when `node_kubelet` is the configured pod collection mode.


### Describe how to test/QA your changes

The error should no longer appear (notice that it didn't alway appear, only when there's a timeout which shouldn't be so frequent).

I deployed in one cluster and didn't see the error. But I'll monitor our infra as we deploy to make sure it doesn't appear anywhere.