### PR TITLE
Moving the check for java.io.tmpdir so that it always happens for JMXFetch

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -240,15 +240,6 @@ func (j *JMXFetch) Start(manage bool) error {
 			log.Warnf("Java option -XX:MaxRAMPercentage will not take effect since either -Xmx or XX:MaxHeapSize is already present. These options override MaxRAMPercentage.")
 			passOption = false
 		}
-		if !strings.Contains(javaOptions, "java.io.tmpdir") {
-			javaTmpDir := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "jmxfetch")
-			if err := os.MkdirAll(javaTmpDir, 0755); err != nil {
-				log.Warnf("Failed to create jmxfetch temporary directory %s: %v", javaTmpDir, err)
-			} else {
-				javaTmpDirOpt := fmt.Sprintf(" -Djava.io.tmpdir=%s", javaTmpDir)
-				javaOptions += javaTmpDirOpt
-			}
-		}
 		if maxHeapSizeAsPercentRAM < 0.00 || maxHeapSizeAsPercentRAM > 100.0 {
 			log.Warnf("The value for MaxRAMPercentage must be between 0.0 and 100.0 for the option to take effect")
 			passOption = false
@@ -277,6 +268,16 @@ func (j *JMXFetch) Start(manage bool) error {
 		// Specify the initial memory allocation pool for the JVM
 		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
 			javaOptions += defaultJvmInitialMemoryAllocation
+		}
+	}
+
+	if !strings.Contains(javaOptions, "java.io.tmpdir") {
+		javaTmpDir := filepath.Join(pkgconfigsetup.Datadog().GetString("run_path"), "jmxfetch")
+		if err := os.MkdirAll(javaTmpDir, 0755); err != nil {
+			log.Warnf("Failed to create jmxfetch temporary directory %s: %v", javaTmpDir, err)
+		} else {
+			javaTmpDirOpt := fmt.Sprintf(" -Djava.io.tmpdir=%s", javaTmpDir)
+			javaOptions += javaTmpDirOpt
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This fixes the bug in #31075 where JMXFetch would only use a temp directory if run in a container.

### Motivation

We want JMXFetch to always use a temp directory that it can write an execute in.

### Describe how to test/QA your changes

Install the Agent on a host that has:

- Java installed
- Docker installed

Make sure that `/tmp` has the permissions `noexec` on the entire directory.

The run the following Docker compose file:


```yaml
---
services:
  jmx-test-app:
    image: ghcr.io/datadog/apps-jmx-test-app:main
    container_name: jmx-test-app
    environment:
      HOST_NAME: "localhost"
    ports:
      - "9010:9010"
    labels:
      com.datadoghq.ad.checks: |
        {
          "test": {
            "init_config": {
              "is_jmx": true,
              "collect_default_metrics": true,
              "new_gc_metrics": true
            },
            "instances": [
              {
                "host": "localhost",
                "port": "9010"
              }
            ]
          }
        }
```

### Possible Drawbacks / Trade-offs

None
