### PR TITLE
[Backport 7.60.x] [ksm] Do not initialize API server client in Configure() when fetching pods from Kubelet

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -42,6 +42,13 @@ func NewExtendedPodFactory(client *apiserver.APIClient) customresource.RegistryF
 	}
 }
 
+// NewExtendedPodFactoryForKubelet returns a new Pod metric family generator
+// factory meant to be used when pods are collected from the Kubelet.
+func NewExtendedPodFactoryForKubelet() customresource.RegistryFactory {
+	// No need to set an API server client, because we're collecting from the Kubelet.
+	return &extendedPodFactory{}
+}
+
 type extendedPodFactory struct {
 	client interface{}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -278,31 +278,47 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	builder := kubestatemetrics.New()
 	builder.WithUsingAPIServerCache(k.instance.UseAPIServerCache)
 
-	// Due to how init is done, we cannot use GetAPIClient in `Run()` method
-	// So we are waiting for a reasonable amount of time here in case.
-	// We cannot wait forever as there's no way to be notified of shutdown
-	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
-	defer apiCancel()
-	c, err := apiserver.WaitForAPIClient(apiCtx)
-	if err != nil {
-		return err
-	}
+	k.configurePodCollection(builder, k.instance.Collectors)
 
-	// Discover resources that are currently available
-	resources, err := discoverResources(c.Cl.Discovery())
-	if err != nil {
-		return err
-	}
+	var collectors []string
+	var apiServerClient *apiserver.APIClient
+	var resources []*v1.APIResourceList
 
-	// Prepare the collectors for the resources specified in the configuration file.
-	collectors, err := filterUnknownCollectors(k.instance.Collectors, resources)
-	if err != nil {
-		return err
-	}
+	switch k.instance.PodCollectionMode {
+	case nodeKubeletPodCollection:
+		// In this case we don't need to set up anything related to the API
+		// server.
+		collectors = []string{"pods"}
+	case defaultPodCollection, clusterUnassignedPodCollection:
+		// Due to how init is done, we cannot use GetAPIClient in `Run()` method
+		// So we are waiting for a reasonable amount of time here in case.
+		// We cannot wait forever as there's no way to be notified of shutdown
+		apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
+		defer apiCancel()
+		apiServerClient, err = apiserver.WaitForAPIClient(apiCtx)
+		if err != nil {
+			return err
+		}
 
-	// Enable the KSM default collectors if the config collectors list is empty.
-	if len(collectors) == 0 {
-		collectors = options.DefaultResources.AsSlice()
+		// Discover resources that are currently available
+		resources, err = discoverResources(apiServerClient.Cl.Discovery())
+		if err != nil {
+			return err
+		}
+
+		// Prepare the collectors for the resources specified in the configuration file.
+		collectors, err = filterUnknownCollectors(k.instance.Collectors, resources)
+		if err != nil {
+			return err
+		}
+
+		// Enable the KSM default collectors if the config collectors list is empty.
+		if len(collectors) == 0 {
+			collectors = options.DefaultResources.AsSlice()
+		}
+
+		builder.WithKubeClient(apiServerClient.InformerCl)
+		builder.WithVPAClient(apiServerClient.VPAInformerClient)
 	}
 
 	// Enable exposing resource annotations explicitly for kube_<resource>_annotations metadata metrics.
@@ -335,10 +351,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	builder.WithFamilyGeneratorFilter(allowDenyList)
 
-	builder.WithKubeClient(c.InformerCl)
-
-	builder.WithVPAClient(c.VPAInformerClient)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	k.cancel = cancel
 	builder.WithContext(ctx)
@@ -354,7 +366,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	// configure custom resources required for extended features and
 	// compatibility across deprecated/removed versions of APIs
-	cr := k.discoverCustomResources(c, collectors, resources)
+	cr := k.discoverCustomResources(apiServerClient, collectors, resources)
 	builder.WithGenerateCustomResourceStoresFunc(builder.GenerateCustomResourceStoresFunc)
 	builder.WithCustomResourceStoreFactories(cr.factories...)
 	builder.WithCustomResourceClients(cr.clients)
@@ -374,8 +386,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	if err := builder.WithEnabledResources(cr.collectors); err != nil {
 		return err
 	}
-
-	k.configurePodCollection(builder, collectors)
 
 	// Start the collection process
 	k.allStores = builder.BuildStores()
@@ -432,6 +442,15 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 	for _, c := range collectors {
 		if extended, ok := extendedCollectors[c]; ok {
 			collectors = append(collectors, extended)
+		}
+	}
+
+	if k.instance.PodCollectionMode == nodeKubeletPodCollection {
+		return customResources{
+			collectors: collectors,
+			factories: []customresource.RegistryFactory{
+				customresources.NewExtendedPodFactoryForKubelet(),
+			},
 		}
 	}
 

--- a/releasenotes-dca/notes/ksm-pods-in-nodes-improve-configuration-4161b4d778f7a2e3.yaml
+++ b/releasenotes-dca/notes/ksm-pods-in-nodes-improve-configuration-4161b4d778f7a2e3.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue in the KSM check when it's configured with the option
+    ``pod_collection_mode`` set to ``node_kubelet``. Previously, the check could
+    fail to start if there was a timeout while contacting the API server. This
+    issue has now been resolved.


### PR DESCRIPTION

### What does this PR do?

Backport #31177 to 7.60.x.
The automatic backport failed and I needed to solved a minor conflict: https://github.com/DataDog/datadog-agent/pull/31177#issuecomment-2483853963

### Describe how to test/QA your changes

The error should no longer appear (notice that it didn't alway appear, only when there's a timeout which shouldn't be so frequent).

I deployed in one cluster and didn't see the error. But I'll monitor our infra as we deploy to make sure it doesn't appear anywhere.