### PR TITLE
[CWS] Remove `connect.server.*` secl field aliases

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -524,10 +524,6 @@ A connect was executed
 | [`connect.addr.is_public`](#common-ipportcontext-is_public-doc) | Whether the IP address belongs to a public network |
 | [`connect.addr.port`](#common-ipportcontext-port-doc) | Port number |
 | [`connect.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
-| [`connect.server.addr.family`](#connect-server-addr-family-doc) | Server address family |
-| [`connect.server.addr.ip`](#common-ipportcontext-ip-doc) | IP address |
-| [`connect.server.addr.is_public`](#common-ipportcontext-is_public-doc) | Whether the IP address belongs to a public network |
-| [`connect.server.addr.port`](#common-ipportcontext-port-doc) | Port number |
 
 ### Event `dns`
 
@@ -2144,8 +2140,8 @@ Type: IP/CIDR
 
 Definition: IP address
 
-`*.ip` has 7 possible prefixes:
-`bind.addr` `connect.addr` `connect.server.addr` `network.destination` `network.source` `packet.destination` `packet.source`
+`*.ip` has 6 possible prefixes:
+`bind.addr` `connect.addr` `network.destination` `network.source` `packet.destination` `packet.source`
 
 
 ### `*.is_exec` {#common-process-is_exec-doc}
@@ -2171,8 +2167,8 @@ Type: bool
 
 Definition: Whether the IP address belongs to a public network
 
-`*.is_public` has 7 possible prefixes:
-`bind.addr` `connect.addr` `connect.server.addr` `network.destination` `network.source` `packet.destination` `packet.source`
+`*.is_public` has 6 possible prefixes:
+`bind.addr` `connect.addr` `network.destination` `network.source` `packet.destination` `packet.source`
 
 
 ### `*.is_thread` {#common-process-is_thread-doc}
@@ -2368,8 +2364,8 @@ Type: int
 
 Definition: Port number
 
-`*.port` has 7 possible prefixes:
-`bind.addr` `connect.addr` `connect.server.addr` `network.destination` `network.source` `packet.destination` `packet.source`
+`*.port` has 6 possible prefixes:
+`bind.addr` `connect.addr` `network.destination` `network.source` `packet.destination` `packet.source`
 
 
 ### `*.ppid` {#common-process-ppid-doc}
@@ -2669,13 +2665,6 @@ Definition: UID argument of the syscall
 Type: int
 
 Definition: Address family
-
-
-
-### `connect.server.addr.family` {#connect-server-addr-family-doc}
-Type: int
-
-Definition: Server address family
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -1839,26 +1839,6 @@
           "name": "connect.retval",
           "definition": "Return value of the syscall",
           "property_doc_link": "common-syscallevent-retval-doc"
-        },
-        {
-          "name": "connect.server.addr.family",
-          "definition": "Server address family",
-          "property_doc_link": "connect-server-addr-family-doc"
-        },
-        {
-          "name": "connect.server.addr.ip",
-          "definition": "IP address",
-          "property_doc_link": "common-ipportcontext-ip-doc"
-        },
-        {
-          "name": "connect.server.addr.is_public",
-          "definition": "Whether the IP address belongs to a public network",
-          "property_doc_link": "common-ipportcontext-is_public-doc"
-        },
-        {
-          "name": "connect.server.addr.port",
-          "definition": "Port number",
-          "property_doc_link": "common-ipportcontext-port-doc"
         }
       ]
     },
@@ -8370,7 +8350,6 @@
       "prefixes": [
         "bind.addr",
         "connect.addr",
-        "connect.server.addr",
         "network.destination",
         "network.source",
         "packet.destination",
@@ -8432,7 +8411,6 @@
       "prefixes": [
         "bind.addr",
         "connect.addr",
-        "connect.server.addr",
         "network.destination",
         "network.source",
         "packet.destination",
@@ -9128,7 +9106,6 @@
       "prefixes": [
         "bind.addr",
         "connect.addr",
-        "connect.server.addr",
         "network.destination",
         "network.source",
         "packet.destination",
@@ -9731,18 +9708,6 @@
       "link": "connect-addr-family-doc",
       "type": "int",
       "definition": "Address family",
-      "prefixes": [
-        "connect"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "connect.server.addr.family",
-      "link": "connect-server-addr-family-doc",
-      "type": "int",
-      "definition": "Server address family",
       "prefixes": [
         "connect"
       ],

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -999,42 +999,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
-	case "connect.server.addr.family":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return int(ev.Connect.AddrFamily)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "connect.server.addr.ip":
-		return &eval.CIDREvaluator{
-			EvalFnc: func(ctx *eval.Context) net.IPNet {
-				ev := ctx.Event.(*Event)
-				return ev.Connect.Addr.IPNet
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
-	case "connect.server.addr.is_public":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveIsIPPublic(ev, &ev.Connect.Addr)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-		}, nil
-	case "connect.server.addr.port":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ev := ctx.Event.(*Event)
-				return int(ev.Connect.Addr.Port)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-		}, nil
 	case "container.created_at":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -20172,10 +20136,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"connect.addr.is_public",
 		"connect.addr.port",
 		"connect.retval",
-		"connect.server.addr.family",
-		"connect.server.addr.ip",
-		"connect.server.addr.is_public",
-		"connect.server.addr.port",
 		"container.created_at",
 		"container.id",
 		"container.runtime",
@@ -21692,14 +21652,6 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return int(ev.Connect.Addr.Port), nil
 	case "connect.retval":
 		return int(ev.Connect.SyscallEvent.Retval), nil
-	case "connect.server.addr.family":
-		return int(ev.Connect.AddrFamily), nil
-	case "connect.server.addr.ip":
-		return ev.Connect.Addr.IPNet, nil
-	case "connect.server.addr.is_public":
-		return ev.FieldHandlers.ResolveIsIPPublic(ev, &ev.Connect.Addr), nil
-	case "connect.server.addr.port":
-		return int(ev.Connect.Addr.Port), nil
 	case "container.created_at":
 		return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)), nil
 	case "container.id":
@@ -28394,14 +28346,6 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "connect", nil
 	case "connect.retval":
 		return "connect", nil
-	case "connect.server.addr.family":
-		return "connect", nil
-	case "connect.server.addr.ip":
-		return "connect", nil
-	case "connect.server.addr.is_public":
-		return "connect", nil
-	case "connect.server.addr.port":
-		return "connect", nil
 	case "container.created_at":
 		return "", nil
 	case "container.id":
@@ -31222,14 +31166,6 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "connect.addr.port":
 		return reflect.Int, nil
 	case "connect.retval":
-		return reflect.Int, nil
-	case "connect.server.addr.family":
-		return reflect.Int, nil
-	case "connect.server.addr.ip":
-		return reflect.Struct, nil
-	case "connect.server.addr.is_public":
-		return reflect.Bool, nil
-	case "connect.server.addr.port":
 		return reflect.Int, nil
 	case "container.created_at":
 		return reflect.Int, nil
@@ -34565,40 +34501,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Connect.SyscallEvent.Retval"}
 		}
 		ev.Connect.SyscallEvent.Retval = int64(rv)
-		return nil
-	case "connect.server.addr.family":
-		rv, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Connect.AddrFamily"}
-		}
-		if rv < 0 || rv > math.MaxUint16 {
-			return &eval.ErrValueOutOfRange{Field: "Connect.AddrFamily"}
-		}
-		ev.Connect.AddrFamily = uint16(rv)
-		return nil
-	case "connect.server.addr.ip":
-		rv, ok := value.(net.IPNet)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Connect.Addr.IPNet"}
-		}
-		ev.Connect.Addr.IPNet = rv
-		return nil
-	case "connect.server.addr.is_public":
-		rv, ok := value.(bool)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Connect.Addr.IsPublic"}
-		}
-		ev.Connect.Addr.IsPublic = rv
-		return nil
-	case "connect.server.addr.port":
-		rv, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Connect.Addr.Port"}
-		}
-		if rv < 0 || rv > math.MaxUint16 {
-			return &eval.ErrValueOutOfRange{Field: "Connect.Addr.Port"}
-		}
-		ev.Connect.Addr.Port = uint16(rv)
 		return nil
 	case "container.created_at":
 		if ev.BaseEvent.ContainerContext == nil {

--- a/pkg/security/secl/model/field_accessors_unix.go
+++ b/pkg/security/secl/model/field_accessors_unix.go
@@ -946,38 +946,6 @@ func (ev *Event) GetConnectRetval() int64 {
 	return ev.Connect.SyscallEvent.Retval
 }
 
-// GetConnectServerAddrFamily returns the value of the field, resolving if necessary
-func (ev *Event) GetConnectServerAddrFamily() uint16 {
-	if ev.GetEventType().String() != "connect" {
-		return uint16(0)
-	}
-	return ev.Connect.AddrFamily
-}
-
-// GetConnectServerAddrIp returns the value of the field, resolving if necessary
-func (ev *Event) GetConnectServerAddrIp() net.IPNet {
-	if ev.GetEventType().String() != "connect" {
-		return net.IPNet{}
-	}
-	return ev.Connect.Addr.IPNet
-}
-
-// GetConnectServerAddrIsPublic returns the value of the field, resolving if necessary
-func (ev *Event) GetConnectServerAddrIsPublic() bool {
-	if ev.GetEventType().String() != "connect" {
-		return false
-	}
-	return ev.FieldHandlers.ResolveIsIPPublic(ev, &ev.Connect.Addr)
-}
-
-// GetConnectServerAddrPort returns the value of the field, resolving if necessary
-func (ev *Event) GetConnectServerAddrPort() uint16 {
-	if ev.GetEventType().String() != "connect" {
-		return uint16(0)
-	}
-	return ev.Connect.Addr.Port
-}
-
 // GetContainerCreatedAt returns the value of the field, resolving if necessary
 func (ev *Event) GetContainerCreatedAt() int {
 	if ev.BaseEvent.ContainerContext == nil {

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -299,7 +299,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 	case "connect":
 		_ = ev.FieldHandlers.ResolveIsIPPublic(ev, &ev.Connect.Addr)
-		_ = ev.FieldHandlers.ResolveIsIPPublic(ev, &ev.Connect.Addr)
 	case "dns":
 	case "exec":
 		if ev.Exec.Process.IsNotKworker() {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -645,8 +645,9 @@ type BindEvent struct {
 // ConnectEvent represents a connect event
 type ConnectEvent struct {
 	SyscallEvent
-	Addr       IPPortContext `field:"addr;server.addr"`               // Connection address
-	AddrFamily uint16        `field:"addr.family;server.addr.family"` // SECLDoc[addr.family] Definition:`Address family` SECLDoc[server.addr.family] Definition:`Server address family`
+
+	Addr       IPPortContext `field:"addr"`        // Connection address
+	AddrFamily uint16        `field:"addr.family"` // SECLDoc[addr.family] Definition:`Address family`
 }
 
 // NetDevice represents a network device

--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -30,11 +30,11 @@ func TestConnectEvent(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet",
-			Expression: `connect.server.addr.family == AF_INET && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.family == AF_INET && process.file.name == "syscall_tester"`,
 		},
 		{
 			ID:         "test_connect_af_inet6",
-			Expression: `connect.server.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
 		},
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove `connect.server.*` secl field aliases, only keeping the `connect.addr` prefix.

### Motivation

- Make secl syntax match the connect(2) man page documentation
- Avoid having two different fields that resolve to the same data

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->