### PR TITLE
[ASCII-2533] ensure the remote tagger do no timeout if is not able to connect to the core agent

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -186,8 +186,7 @@ func (t *remoteTagger) Start(ctx context.Context) error {
 
 	t.client = pb.NewAgentSecureClient(t.conn)
 
-	timeout := time.Duration(t.cfg.GetInt("remote_tagger_timeout_seconds")) * time.Second
-	err = t.startTaggerStream(timeout)
+	err = t.startTaggerStream(noTimeout)
 	if err != nil {
 		// tagger stopped before being connected
 		if errors.Is(err, errTaggerStreamNotStarted) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1085,7 +1085,6 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("win_skip_com_init", false)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
-	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
 
 	// Configuration for TLS for outgoing connections
 	config.BindEnvAndSetDefault("min_tls_version", "tlsv1.2")

--- a/releasenotes/notes/remove-remote-tagger-timeout-configuration-91a32b8468ff64e1.yaml
+++ b/releasenotes/notes/remove-remote-tagger-timeout-configuration-91a32b8468ff64e1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+     The remote tagger will attempt to connect to the core agent indefinitely until it is successful. 
+     The ``remote_tagger_timeout_seconds`` configuration is removed, and the timeout is no longer configurable.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ensure the remote tagger does not timeout when attempting to connect to the core Agent. 

This is particualrly important for the `trace-agent` and `security-agent` that now are using the remote tagger https://github.com/DataDog/datadog-agent/pull/31096 and the `system-probe` is planning to https://github.com/DataDog/datadog-agent/pull/30852.

### Motivation

Avoid sub-process crashing because the remote tagger is not able to connect to the core Agent. We now try without out limit, and during the time the remote tagger is not able to establish a connection users of the remote tagger will get a degraded experience, but not crash the process. 

I removed the `remote_tagger_timeout_seconds` configuration option. According to Metabase only 30 Agents (1.16%) are not using the default value (30 seconds) https://metabase-analytics.us1.prod.dog/dashboard/43351-agent-config?date_filter=past1days&exclude_billing_plans=&org_tier=&org_type=&org_id=&config_path_prefix=&config_path=remote_tagger_timeout_seconds

### Describe how to test/QA your changes
Start the trace-agent, _without_ having a core-agent running, and ensure the trace-agent doesn't crash.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->