### PR TITLE
discovery: Report PHP DDService name

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/php_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/php_test.go
@@ -15,9 +15,10 @@ import (
 
 func TestServiceNameFromCLI(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		expected string
+		name              string
+		args              []string
+		expected          string
+		expectedDDService string
 	}{
 		{
 			name:     "should return laravel for artisan commands",
@@ -25,14 +26,20 @@ func TestServiceNameFromCLI(t *testing.T) {
 			expected: "laravel",
 		},
 		{
-			name:     "should return service_name for php -ddatadog.service=service_name",
-			args:     []string{"php", "-ddatadog.service=service_name", "server.php"},
-			expected: "service_name",
+			name:              "should return service_name for php -ddatadog.service=service_name",
+			args:              []string{"php", "-ddatadog.service=service_name", "server.php"},
+			expectedDDService: "service_name",
 		},
 		{
-			name:     "should return service_name for php -d datadog.service=service_name",
-			args:     []string{"php", "-d", "datadog.service=service_name", "server.php"},
-			expected: "service_name",
+			name:              "should return service_name for php -d datadog.service=service_name",
+			args:              []string{"php", "-d", "datadog.service=service_name", "server.php"},
+			expectedDDService: "service_name",
+		},
+		{
+			name:              "should return both laravel and dd service",
+			args:              []string{"php", "-ddatadog.service=foo", "artisan", "serve"},
+			expected:          "laravel",
+			expectedDDService: "foo",
 		},
 		{
 			name:     "artisan command with -x flag",
@@ -60,6 +67,7 @@ func TestServiceNameFromCLI(t *testing.T) {
 			} else {
 				require.False(t, ok)
 			}
+			require.Equal(t, tt.expectedDDService, value.DDService)
 		})
 	}
 }

--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -453,7 +453,8 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"swoole-server.php",
 			},
 			lang:                  language.PHP,
-			expectedGeneratedName: "foo",
+			expectedDDService:     "foo",
+			expectedGeneratedName: "php",
 		},
 		{
 			name: "PHP with version number",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The name provided by the PHP -ddatadog.service= parameter should be reported as the DDService name and not as the generated name. This makes it similar to the implementation for Java.

### Motivation

Noticed while working on reporting of source of generated service name.

### Describe how to test/QA your changes

Automated tests are included in the PR.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->