### PR TITLE
Enable ReceiveResourceSpansV2 by default in OTel Agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -175,8 +175,13 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	if addr := ddc.Traces.Endpoint; addr != "" {
 		pkgconfig.Set("apm_config.apm_dd_url", addr, pkgconfigmodel.SourceFile)
 	}
-	if ddc.Traces.ComputeTopLevelBySpanKind {
-		pkgconfig.Set("apm_config.features", []string{"enable_otlp_compute_top_level_by_span_kind"}, pkgconfigmodel.SourceFile)
+
+	if pkgconfig.Get("apm_config.features") == nil {
+		apmConfigFeatures := []string{"enable_receive_resource_spans_v2"}
+		if ddc.Traces.ComputeTopLevelBySpanKind {
+			apmConfigFeatures = append(apmConfigFeatures, "enable_otlp_compute_top_level_by_span_kind")
+		}
+		pkgconfig.Set("apm_config.features", apmConfigFeatures, pkgconfigmodel.SourceDefault)
 	}
 
 	return pkgconfig, nil

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -55,7 +55,7 @@ func (suite *ConfigTestSuite) TestAgentConfig() {
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, 10, c.Get("apm_config.trace_buffer"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, nil, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2"}, c.Get("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
@@ -77,7 +77,8 @@ func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, true, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"},
+		c.Get("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
@@ -102,7 +103,7 @@ func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, true, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
 
 	// log_level from datadog.yaml takes precedence -> more verbose
 	assert.Equal(t, "debug", c.Get("log_level"))
@@ -123,6 +124,38 @@ func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlKeysAvailable() {
 	assert.Equal(t, "https://localhost:7777", c.GetString("otelcollector.extension_url"))
 	assert.Equal(t, 5009, c.GetInt("agent_ipc.port"))
 	assert.Equal(t, 60, c.GetInt("agent_ipc.config_refresh_interval"))
+}
+
+func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromDatadogYaml() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	ddFileName := "testdata/datadog_apm_config_features.yaml"
+	c, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	assert.Equal(t, []string{"test1", "test2"}, c.GetStringSlice("apm_config.features"))
+}
+
+func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromEnv() {
+	t := suite.T()
+	fileName := "testdata/config_default.yaml"
+	oldval, exists := os.LookupEnv("DD_APM_FEATURES")
+	os.Setenv("DD_APM_FEATURES", "test1,test2")
+	defer func() {
+		if !exists {
+			os.Unsetenv("DD_APM_FEATURES")
+		} else {
+			os.Setenv("DD_APM_FEATURES", oldval)
+		}
+	}()
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	if err != nil {
+		t.Errorf("Failed to load agent config: %v", err)
+	}
+
+	assert.Equal(t, []string{"test1", "test2"}, c.GetStringSlice("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestLogLevelPrecedence() {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -141,11 +141,7 @@ func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromDatadogYaml() {
 func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromEnv() {
 	t := suite.T()
 	fileName := "testdata/config_default.yaml"
-	oldval, _ := os.LookupEnv("DD_APM_FEATURES")
 	t.Setenv("DD_APM_FEATURES", "test1,test2")
-	defer func() {
-		t.Setenv("DD_APM_FEATURES", oldval)
-	}()
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	if err != nil {
 		t.Errorf("Failed to load agent config: %v", err)

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -141,14 +141,10 @@ func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromDatadogYaml() {
 func (suite *ConfigTestSuite) TestAgentConfigSetAPMFeaturesFromEnv() {
 	t := suite.T()
 	fileName := "testdata/config_default.yaml"
-	oldval, exists := os.LookupEnv("DD_APM_FEATURES")
-	os.Setenv("DD_APM_FEATURES", "test1,test2")
+	oldval, _ := os.LookupEnv("DD_APM_FEATURES")
+	t.Setenv("DD_APM_FEATURES", "test1,test2")
 	defer func() {
-		if !exists {
-			os.Unsetenv("DD_APM_FEATURES")
-		} else {
-			os.Setenv("DD_APM_FEATURES", oldval)
-		}
+		t.Setenv("DD_APM_FEATURES", oldval)
 	}()
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	if err != nil {

--- a/cmd/otel-agent/config/testdata/datadog_apm_config_features.yaml
+++ b/cmd/otel-agent/config/testdata/datadog_apm_config_features.yaml
@@ -1,0 +1,10 @@
+api_key: deadbeef
+
+log_level: debug
+
+otelcollector:
+  enabled: true
+  extension_url: "https://localhost:7777"
+
+apm_config:
+  features: ["test1", "test2"]

--- a/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
+++ b/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    The `enable_receive_resource_spans_v2` flag now defaults to true in Converged Agent. This enables the refactored
+    version of the span receiver in trace agent, which gives a 10% performance and deprecates some functionality:
+    - No longer check for information about the resource in HTTP headers (ContainerID, Lang, LangVersion, Interpreter, LangVendor).
+    - No longer check for resource-related values (container, env, hostname) in span attributes - behaviour which did not follow OTel spec

--- a/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
+++ b/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
@@ -2,6 +2,6 @@
 other:
   - |
     The `enable_receive_resource_spans_v2` flag now defaults to true in Converged Agent. This enables the refactored
-    version of the OTLP span receiver in trace agent, which gives a 10% performance and deprecates some functionality:
-    - No longer check for information about the resource in HTTP headers (ContainerID, Lang, LangVersion, Interpreter, LangVendor).
-    - No longer check for resource-related values (container, env, hostname) in span attributes - behaviour which did not follow OTel spec
+    version of the OTLP span receiver in trace agent, improves performance by 10%, and deprecates the following functionality:
+    - No longer checks for information about the resource in HTTP headers (ContainerID, Lang, LangVersion, Interpreter, LangVendor).
+    - No longer checks for resource-related values (container, env, hostname) in span attributes. This previous behavior did not follow the OTel spec.

--- a/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
+++ b/releasenotes/notes/enable-receiveresourcespansv2-by-default-in-otel-agent-b7ce3ca53203203d.yaml
@@ -2,6 +2,6 @@
 other:
   - |
     The `enable_receive_resource_spans_v2` flag now defaults to true in Converged Agent. This enables the refactored
-    version of the span receiver in trace agent, which gives a 10% performance and deprecates some functionality:
+    version of the OTLP span receiver in trace agent, which gives a 10% performance and deprecates some functionality:
     - No longer check for information about the resource in HTTP headers (ContainerID, Lang, LangVersion, Interpreter, LangVendor).
     - No longer check for resource-related values (container, env, hostname) in span attributes - behaviour which did not follow OTel spec


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enable refactored implementation of trace agent OTLPReceiver by default for converged agent customers. The v1 logic will be deprecated eventually.

If DD_APM_FEATURES or apm_features.config are specified manually and do not include `enable_receive_resource_spans_v2`, the new logic will be disabled.

### Motivation

### Describe how to test/QA your changes

Run otel-agent with no apm_features configured; verify that the new logic is enabled (e.g. by sending spans with container ID in span attributes instead of resource attributes and verifying that that container ID doesn't get used). Then, run otel-agent with DD_APM_FEATURES specified to exclude `enable_receive_resource_spans_v2` and verify that the new logic is disabled.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->