### PR TITLE
[CWS] Add x86 syscall tester to .gitignore

### DIFF
--- a/pkg/security/tests/syscall_tester/.gitignore
+++ b/pkg/security/tests/syscall_tester/.gitignore
@@ -1,4 +1,5 @@
 go/ebpf_probe.o
 bin/syscall_go_tester
 bin/syscall_tester
+bin/syscall_x86_tester
 bin/syscall_tester.d


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add `syscall_x86_tester` binary to `.gitignore`.

### Motivation

This binary was missing in #31215.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->