### PR TITLE
[CWS] add `prepare_secagent_ebpf_functional_tests*` jobs to merge queue

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -76,7 +76,6 @@ prepare_sysprobe_ebpf_functional_tests_x64:
 .prepare_secagent_ebpf_functional_tests:
   stage: source_test
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_deps", "go_tools_deps"]
   artifacts:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We recently faced a conflict resulting in some main CI jobs failing and requiring a revert https://github.com/DataDog/datadog-agent/pull/31232. The goal of this PR is to prevent this from happening again in the future by adding the failing jobs to the merge queue pipeline. Those 2 jobs are only 5 minutes long so it should not increase the merge queue latency.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->