### PR TITLE
[SMP] Lower quality gate bounds

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -34,7 +34,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "425.0 MiB"
+      upper_bound: "388.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -34,7 +34,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "388.0 MiB"
+      upper_bound: "390.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -45,7 +45,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "740.0 MiB"
+      upper_bound: "738.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -45,7 +45,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "770.0 MiB"
+      upper_bound: "735.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -45,7 +45,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "735.0 MiB"
+      upper_bound: "740.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
### What does this PR do?

Lowers the `quality_gate_idle` experiment memory bound from `425 MiB` to `390 MiB`. Also lowers the `quality_gate_idle_all_features` memory bound from `770 MiB` to `738 MiB`

### Motivation

Reduce agent resource usage as a result of the efforts from [#incident-32196](https://app.datadoghq.com/incidents/32196). There is more information on how we got to these new bounds in this [notebook](https://app.datadoghq.com/notebook/10521523/nov-18-picking-a-new-agent-idle-quality-gate?notebookType=rte).

### Describe how to test/QA your changes

n/a

### Possible Drawbacks / Trade-offs

Less headroom for features.

### Additional Notes
