### PR TITLE
chore(installer): Add default build tags

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -114,6 +114,9 @@ DOGSTATSD_TAGS = {"containerd", "docker", "kubelet", "podman", "zlib", "zstd"}
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
 IOT_AGENT_TAGS = {"jetson", "otlp", "systemd", "zlib", "zstd"}
 
+# INSTALLER_TAGS lists the tags needed when building the installer
+INSTALLER_TAGS = {"docker", "ec2", "gce", "kubelet"}
+
 # PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
 PROCESS_AGENT_TAGS = AGENT_TAGS.union({"fargateprocess"}).difference({"otlp", "python", "trivy"})
 
@@ -185,6 +188,7 @@ build_tags = {
         "cluster-agent": CLUSTER_AGENT_TAGS,
         "cluster-agent-cloudfoundry": CLUSTER_AGENT_CLOUDFOUNDRY_TAGS,
         "dogstatsd": DOGSTATSD_TAGS,
+        "installer": INSTALLER_TAGS,
         "process-agent": PROCESS_AGENT_TAGS,
         "security-agent": SECURITY_AGENT_TAGS,
         "serverless": SERVERLESS_TAGS,

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -41,7 +41,7 @@ def build(
 
     build_include = (
         get_default_build_tags(
-            build="updater",
+            build="installer",
         )  # TODO/FIXME: Arch not passed to preserve build tags. Should this be fixed?
         if build_include is None
         else filter_incompatible_tags(build_include.split(","))


### PR DESCRIPTION
### What does this PR do?
Adds the following default build tags for the installer:
- docker
- ec2
- gce
- kubelet

This is so the installer can retrieve tags from these environments and use them to compute whether or not a policy should be applied.

### Motivation
Retrieving host tags

### Describe how to test/QA your changes
QA-ed manually on these environments: we do receive the tags!

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->