### PR TITLE
[CWS] cleanup the CWS config in `quality_gate_idle_all_features`

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
@@ -33,7 +33,7 @@ network_path:
     enabled: true
 
 runtime_security_config:
-  ## Set to true to enable Threat Detection
+  ## Set to true to enable CWS
   enabled: true
 
 cluster_checks:

--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/security-agent.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/security-agent.yaml
@@ -1,13 +1,11 @@
 # Per https://docs.datadoghq.com/security/cloud_security_management/setup/agent/linux/
+
 runtime_security_config:
-  ## @param enabled - boolean - optional - default: false
-  ## Set to true to enable Threat Detection
+  # Set to true to enable CWS
   enabled: true
 
 compliance_config:
-  ## @param enabled - boolean - optional - default: false
-  ## Set to true to enable CIS benchmarks for Misconfigurations.
-  #
+  # Set to true to enable CIS benchmarks for Misconfigurations (CSPM).
   enabled: true
   host_benchmarks:
     enabled: true

--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/system-probe.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/system-probe.yaml
@@ -1,10 +1,5 @@
 # Per https://docs.datadoghq.com/security/cloud_security_management/setup/agent/linux/
 
 runtime_security_config:
-  ## @param enabled - boolean - optional - default: false
-  ## Set to true to enable Threat Detection
+  # Set to true to enable CWS
   enabled: true
-
-  remote_configuration:
-    ## @param enabled - boolean - optional - default: false
-    enabled: true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make it clearer in SMP quality gates idle all features that runtime_security_config is enabling CWS, and removes the CWS remote config specific flag (since it's enabled by default anyway, and remote config is disabled in SMP runs).

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->