### PR TITLE
usm: Revisit map size

### DIFF
--- a/pkg/network/ebpf/c/protocols/sockfd.h
+++ b/pkg/network/ebpf/c/protocols/sockfd.h
@@ -11,10 +11,10 @@
 // sockfd_lookup_light function calls, so they can be accessed by the corresponding kretprobe.
 // * Key is the pid_tgid;
 // * Value the socket FD;
-BPF_HASH_MAP(sockfd_lookup_args, __u64, __u32, 1024)
+BPF_HASH_MAP(sockfd_lookup_args, __u64, __u32, 10000)
 
-BPF_HASH_MAP(tuple_by_pid_fd, pid_fd_t, conn_tuple_t, 1024)
-
-BPF_HASH_MAP(pid_fd_by_tuple, conn_tuple_t, pid_fd_t, 1024)
+// Size 0 indicates we set override it in the user mode
+BPF_HASH_MAP(tuple_by_pid_fd, pid_fd_t, conn_tuple_t, 0)
+BPF_HASH_MAP(pid_fd_by_tuple, conn_tuple_t, pid_fd_t, 0)
 
 #endif


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set size of the maps `tuple_by_pid_fd`, `pid_fd_by_tuple` to 0, to indicate the user mode is overriding the map size.
Also, increases the size of `sockfd_lookup_args` to 10k, to have more room for entries.

### Motivation

For `tuple_by_pid_fd`, `pid_fd_by_tuple`, to better reflect size of the maps.

For `sockfd_lookup_args`, the map is used to cache arguments between a kprobe to its kretprobe
It is likely that ebpf-check is not able to report true numbers on how much the map is full, so we don't have true measurement for the utilization of the map. However, the map costs us 0.095MB, and bumping it to 0.9MB (10K entries vs 1K), is negligible, but gives us more room in case we're missing an issue.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->