### PR TITLE
ci(requirements): Remove unseless requirement installation

### DIFF
--- a/.gitlab/source_test/slack.yml
+++ b/.gitlab/source_test/slack.yml
@@ -9,8 +9,4 @@ slack_teams_channels_check:
     - !reference [.except_mergequeue]
     - when: on_success
   script:
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is 
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install codeowners -c tasks/libs/requirements-notifications.txt --break-system-packages
     - inv -e notify.check-teams


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove a `pip install` which is useless: `notify.check-teams` only needs `invoke` and `codeowners` that are already on the debian image used as part of the [base requirements](https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements.txt) from buildimage

### Motivation
Tidying for `deva` migration

### Describe how to test/QA your changes
The `slack_teams_channels_check` job is [passing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/712581410)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->