### PR TITLE
[CWS] allow using ebpfless mode of CWS without using the config flag

### DIFF
--- a/cmd/system-probe/modules/eventmonitor_linux.go
+++ b/cmd/system-probe/modules/eventmonitor_linux.go
@@ -10,12 +10,12 @@ package modules
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	netconfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	usmstate "github.com/DataDog/datadog-agent/pkg/network/usm/state"
 	procmon "github.com/DataDog/datadog-agent/pkg/process/monitor"
+	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 )
 
 // EventMonitor - Event monitor Factory
@@ -24,7 +24,7 @@ var EventMonitor = module.Factory{
 	ConfigNamespaces: eventMonitorModuleConfigNamespaces,
 	Fn:               createEventMonitorModule,
 	NeedsEBPF: func() bool {
-		return !pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled")
+		return !secconfig.IsEBPFLessModeEnabled()
 	},
 }
 

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -123,7 +123,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
 
 	// CWS -eBPF Less
-	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.enabled", false)
+	cfg.BindEnv("runtime_security_config.ebpfless.enabled")
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", constants.DefaultEBPFLessProbeAddr)
 
 	// CWS - IMDS

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -507,6 +507,7 @@ func IsEBPFLessModeEnabled() bool {
 	const cfgKey = "runtime_security_config.ebpfless.enabled"
 	// by default on fargate, we enable ebpfless mode
 	if !pkgconfigsetup.SystemProbe().IsSet(cfgKey) && fargate.IsFargateInstance() {
+		seclog.Infof("Fargate instance detected, enabling CWS ebpfless mode")
 		pkgconfigsetup.SystemProbe().Set(cfgKey, true, pkgconfigmodel.SourceAgentRuntime)
 	}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 )
 
 const (
@@ -454,7 +455,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		UserSessionsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
 
 		// ebpf less
-		EBPFLessEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.ebpfless.enabled"),
+		EBPFLessEnabled: IsEBPFLessModeEnabled(),
 		EBPFLessSocket:  pkgconfigsetup.SystemProbe().GetString("runtime_security_config.ebpfless.socket"),
 
 		// IMDS
@@ -497,6 +498,19 @@ func isRemoteConfigEnabled() bool {
 	}
 
 	return false
+}
+
+// IsEBPFLessModeEnabled returns true if the ebpfless mode is enabled
+// it's based on the configuration itself, but will default on true if
+// running on fargate
+func IsEBPFLessModeEnabled() bool {
+	const cfgKey = "runtime_security_config.ebpfless.enabled"
+	// by default on fargate, we enable ebpfless mode
+	if !pkgconfigsetup.SystemProbe().IsSet(cfgKey) && fargate.IsFargateInstance() {
+		pkgconfigsetup.SystemProbe().Set(cfgKey, true, pkgconfigmodel.SourceAgentRuntime)
+	}
+
+	return pkgconfigsetup.SystemProbe().GetBool(cfgKey)
 }
 
 // GetAnomalyDetectionMinimumStablePeriod returns the minimum stable period for a given event type


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows the CWS ebpfless mode to be a tiny bit more clever. Instead of only using the `ebpfless.enabled` config flag, we now also take into account if running on fargate. In the case where the config is not set, we will default to true on fargate (where eBPF is not supported).

### Motivation

### Describe how to test/QA your changes

Already covered by tests (e2e) and manual testing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->