### PR TITLE
[tagger] Delete unused config param

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -132,7 +132,7 @@ func NewRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.C
 			TokenFetcher: params.RemoteTokenFetcher(cfg),
 		},
 		cfg:            cfg,
-		store:          newTagStore(cfg, telemetryStore),
+		store:          newTagStore(telemetryStore),
 		telemetryStore: telemetryStore,
 		filter:         params.RemoteFilter,
 		log:            log,

--- a/comp/core/tagger/impl-remote/tagstore.go
+++ b/comp/core/tagger/impl-remote/tagstore.go
@@ -8,7 +8,6 @@ package remotetaggerimpl
 import (
 	"sync"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	genericstore "github.com/DataDog/datadog-agent/comp/core/tagger/generic_store"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/subscriber"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -21,17 +20,15 @@ type tagStore struct {
 	mutex     sync.RWMutex
 	store     types.ObjectStore[*types.Entity]
 	telemetry map[string]float64
-	cfg       config.Component
 
 	subscriptionManager subscriber.SubscriptionManager
 	telemetryStore      *telemetry.Store
 }
 
-func newTagStore(cfg config.Component, telemetryStore *telemetry.Store) *tagStore {
+func newTagStore(telemetryStore *telemetry.Store) *tagStore {
 	return &tagStore{
 		store:               genericstore.NewObjectStore[*types.Entity](),
 		telemetry:           make(map[string]float64),
-		cfg:                 cfg,
 		subscriptionManager: subscriber.NewSubscriptionManager(telemetryStore),
 		telemetryStore:      telemetryStore,
 	}

--- a/comp/core/tagger/impl-remote/tagstore_test.go
+++ b/comp/core/tagger/impl-remote/tagstore_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -50,8 +49,7 @@ func TestProcessEvent_AddAndModify(t *testing.T) {
 	}
 	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)
-	cfg := configmock.New(t)
-	store := newTagStore(cfg, telemetryStore)
+	store := newTagStore(telemetryStore)
 	store.processEvents(events, false)
 
 	entity := store.getEntity(entityID)
@@ -88,8 +86,7 @@ func TestProcessEvent_AddAndDelete(t *testing.T) {
 
 	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)
-	cfg := configmock.New(t)
-	store := newTagStore(cfg, telemetryStore)
+	store := newTagStore(telemetryStore)
 	store.processEvents(events, false)
 
 	entity := store.getEntity(entityID)
@@ -103,9 +100,8 @@ func TestProcessEvent_AddAndDelete(t *testing.T) {
 
 func TestProcessEvent_Replace(t *testing.T) {
 	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
-	cfg := configmock.New(t)
 	telemetryStore := taggerTelemetry.NewStore(tel)
-	store := newTagStore(cfg, telemetryStore)
+	store := newTagStore(telemetryStore)
 
 	store.processEvents([]types.EntityEvent{
 		{

--- a/comp/core/tagger/impl/fake_tagger.go
+++ b/comp/core/tagger/impl/fake_tagger.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
@@ -29,10 +28,10 @@ type FakeTagger struct {
 	sync.RWMutex
 }
 
-func newFakeTagger(cfg config.Component, telemetryStore *telemetry.Store) *FakeTagger {
+func newFakeTagger(telemetryStore *telemetry.Store) *FakeTagger {
 	return &FakeTagger{
 		errors:         make(map[string]error),
-		store:          tagstore.NewTagStore(cfg, telemetryStore),
+		store:          tagstore.NewTagStore(telemetryStore),
 		telemetryStore: telemetryStore,
 	}
 }

--- a/comp/core/tagger/impl/local_tagger.go
+++ b/comp/core/tagger/impl/local_tagger.go
@@ -41,7 +41,7 @@ type localTagger struct {
 
 func newLocalTagger(cfg config.Component, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (tagger.Component, error) {
 	return &localTagger{
-		tagStore:       tagstore.NewTagStore(cfg, telemetryStore),
+		tagStore:       tagstore.NewTagStore(telemetryStore),
 		workloadStore:  wmeta,
 		telemetryStore: telemetryStore,
 		cfg:            cfg,

--- a/comp/core/tagger/impl/replay_tagger.go
+++ b/comp/core/tagger/impl/replay_tagger.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
@@ -31,9 +30,9 @@ type replayTagger struct {
 	telemetryStore  *telemetry.Store
 }
 
-func newReplayTagger(cfg config.Component, telemetryStore *telemetry.Store) tagger.ReplayTagger {
+func newReplayTagger(telemetryStore *telemetry.Store) tagger.ReplayTagger {
 	return &replayTagger{
-		store:          tagstore.NewTagStore(cfg, telemetryStore),
+		store:          tagstore.NewTagStore(telemetryStore),
 		telemetryStore: telemetryStore,
 	}
 }

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -100,7 +100,6 @@ type TaggerWrapper struct {
 	defaultTagger tagger.Component
 
 	wmeta         workloadmeta.Component
-	cfg           config.Component
 	datadogConfig datadogConfig
 
 	checksCardinality          types.TagCardinality
@@ -143,7 +142,7 @@ func NewTaggerClient(params tagger.Params, cfg config.Component, wmeta workloadm
 	var err error
 	telemetryStore := telemetry.NewStore(telemetryComp)
 	if params.UseFakeTagger {
-		defaultTagger = newFakeTagger(cfg, telemetryStore)
+		defaultTagger = newFakeTagger(telemetryStore)
 	} else {
 		defaultTagger, err = newLocalTagger(cfg, wmeta, telemetryStore)
 	}
@@ -207,7 +206,7 @@ func (t *TaggerWrapper) Stop() error {
 
 // ReplayTagger returns the replay tagger instance
 func (t *TaggerWrapper) ReplayTagger() tagger.ReplayTagger {
-	return newReplayTagger(t.cfg, t.telemetryStore)
+	return newReplayTagger(t.telemetryStore)
 }
 
 // GetTaggerTelemetryStore returns tagger telemetry store

--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	genericstore "github.com/DataDog/datadog-agent/comp/core/tagger/generic_store"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/subscriber"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -45,22 +44,20 @@ type TagStore struct {
 
 	clock clock.Clock
 
-	cfg            config.Component
 	telemetryStore *telemetry.Store
 }
 
 // NewTagStore creates new LocalTaggerTagStore.
-func NewTagStore(cfg config.Component, telemetryStore *telemetry.Store) *TagStore {
-	return newTagStoreWithClock(cfg, clock.New(), telemetryStore)
+func NewTagStore(telemetryStore *telemetry.Store) *TagStore {
+	return newTagStoreWithClock(clock.New(), telemetryStore)
 }
 
-func newTagStoreWithClock(cfg config.Component, clock clock.Clock, telemetryStore *telemetry.Store) *TagStore {
+func newTagStoreWithClock(clock clock.Clock, telemetryStore *telemetry.Store) *TagStore {
 	return &TagStore{
 		telemetry:           make(map[string]map[string]float64),
 		store:               genericstore.NewObjectStore[EntityTags](),
 		subscriptionManager: subscriber.NewSubscriptionManager(telemetryStore),
 		clock:               clock,
-		cfg:                 cfg,
 		telemetryStore:      telemetryStore,
 	}
 }

--- a/comp/core/tagger/tagstore/tagstore_bench_test.go
+++ b/comp/core/tagger/tagstore/tagstore_bench_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -48,7 +47,7 @@ func init() {
 func BenchmarkTagStoreThroughput(b *testing.B) {
 	tel := fxutil.Test[telemetry.Component](b, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)
-	store := NewTagStore(configmock.New(b), telemetryStore)
+	store := NewTagStore(telemetryStore)
 
 	doneCh := make(chan struct{})
 	pruneTicker := time.NewTicker(time.Second)
@@ -95,7 +94,7 @@ func BenchmarkTagStore_processTagInfo(b *testing.B) {
 	tel := fxutil.Test[telemetry.Component](b, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)
 
-	store := NewTagStore(configmock.New(b), telemetryStore)
+	store := NewTagStore(telemetryStore)
 
 	for i := 0; i < b.N; i++ {
 		processRandomTagInfoBatch(store)

--- a/comp/core/tagger/tagstore/tagstore_test.go
+++ b/comp/core/tagger/tagstore/tagstore_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -37,8 +36,7 @@ func (s *StoreTestSuite) SetupTest() {
 	// set the mock clock to the current time
 	s.clock.Add(time.Since(time.Unix(0, 0)))
 
-	mockConfig := configmock.New(s.T())
-	s.tagstore = newTagStoreWithClock(mockConfig, s.clock, telemetryStore)
+	s.tagstore = newTagStoreWithClock(s.clock, telemetryStore)
 }
 
 func (s *StoreTestSuite) TestIngest() {
@@ -491,8 +489,7 @@ func TestSubscribe(t *testing.T) {
 	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)
 	clock := clock.NewMock()
-	mockConfig := configmock.New(t)
-	store := newTagStoreWithClock(mockConfig, clock, telemetryStore)
+	store := newTagStoreWithClock(clock, telemetryStore)
 
 	collectors.CollectorPriorities["source2"] = types.ClusterOrchestrator
 	collectors.CollectorPriorities["source"] = types.NodeRuntime


### PR DESCRIPTION
### What does this PR do?

This PR deletes unused code in the tagger.
The config param was stored in some structs that don't use it.

### Describe how to test/QA your changes

Unit and e2e tests are enough.