### PR TITLE
feat(upgrade): Add test to upgrade from current 6 to stable 7

### DIFF
--- a/.gitlab/kitchen_testing/new-e2e_testing.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing.yml
@@ -27,26 +27,14 @@
     TARGETS: ./tests/agent-platform/upgrade
     TEAM: agent-build-and-releases
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
+    FROM_CURRENT_TO_STABLE: false
   parallel:
     matrix:
       - START_MAJOR_VERSION: [5, 6]
         END_MAJOR_VERSION: [6]
   script:
     - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME)
-    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
-
-.new-e2e_script_upgrade7:
-  variables:
-    TARGETS: ./tests/agent-platform/upgrade
-    TEAM: agent-build-and-releases
-    EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --arch $E2E_ARCH --flavor $FLAVOR
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [5, 6, 7]
-        END_MAJOR_VERSION: [7]
-  script:
-    - export DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/aws_ssm_get_wrapper.sh $INSTALL_SCRIPT_API_KEY_SSM_NAME )
-    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION
+    - inv -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION --from-current-to-stable $FROM_CURRENT_TO_STABLE
 
 .new-e2e_rpm:
   variables:

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -84,3 +84,19 @@ new-e2e-agent-platform-install-script-upgrade6-amazonlinux-x64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-upgrade7-amazonlinux-x64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_script_upgrade6
+    - .new-e2e_os_amazonlinux
+    - .new-e2e_amazonlinux_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+    FROM_CURRENT_TO_STABLE: true
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -96,5 +96,7 @@ new-e2e-agent-platform-install-script-upgrade7-amazonlinux-x64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-    START_MAJOR_VERSION: 6
-    END_MAJOR_VERSION: 7
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/amazonlinux.yml
@@ -96,7 +96,5 @@ new-e2e-agent-platform-install-script-upgrade7-amazonlinux-x64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
+    START_MAJOR_VERSION: 6
+    END_MAJOR_VERSION: 7

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -63,10 +63,8 @@ new-e2e-agent-platform-install-script-upgrade7-centos-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
+    START_MAJOR_VERSION: 6
+    END_MAJOR_VERSION: 7
 
 .new-e2e_centos6_a6_x86_64:
   variables:

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -63,8 +63,11 @@ new-e2e-agent-platform-install-script-upgrade7-centos-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-    START_MAJOR_VERSION: 6
-    END_MAJOR_VERSION: 7
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]
+
 
 .new-e2e_centos6_a6_x86_64:
   variables:

--- a/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/centos.yml
@@ -52,6 +52,22 @@ new-e2e-agent-platform-install-script-upgrade6-centos-x86_64:
   variables:
     FLAVOR: datadog-agent
 
+new-e2e-agent-platform-install-script-upgrade7-centos-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_script_upgrade6
+    - .new-e2e_os_centos
+    - .new-e2e_centos_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+    FROM_CURRENT_TO_STABLE: true
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]
+
 .new-e2e_centos6_a6_x86_64:
   variables:
     E2E_ARCH: x86_64

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -120,5 +120,8 @@ new-e2e-agent-platform-install-script-upgrade7-debian-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-    START_MAJOR_VERSION: 6
-    END_MAJOR_VERSION: 7
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]
+

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -108,3 +108,19 @@ new-e2e-agent-platform-install-script-upgrade6-debian-x86_64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-upgrade7-debian-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_script_upgrade6
+    - .new-e2e_os_debian
+    - .new-e2e_debian_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+    FROM_CURRENT_TO_STABLE: true
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/debian.yml
@@ -120,7 +120,5 @@ new-e2e-agent-platform-install-script-upgrade7-debian-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
+    START_MAJOR_VERSION: 6
+    END_MAJOR_VERSION: 7

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -59,6 +59,9 @@ new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-    START_MAJOR_VERSION: 6
-    END_MAJOR_VERSION: 7
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]
+
 

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -16,6 +16,17 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_suse_rpm_testing_x64-a6"]
 
+new-e2e-agent-platform-install-script-suse-a6-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_install_script
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+
 new-e2e-agent-platform-package-signing-suse-a6-x86_64:
   stage: kitchen_testing
   extends:

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -58,6 +58,18 @@ new-e2e-agent-platform-install-script-upgrade6-suse-x86_64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_script_upgrade6
+    - .new-e2e_os_suse
+    - .new-e2e_suse_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+    FROM_CURRENT_TO_STABLE: true
   parallel:
     matrix:
       - START_MAJOR_VERSION: [6]

--- a/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/suse.yml
@@ -16,17 +16,6 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs: ["deploy_suse_rpm_testing_x64-a6"]
 
-new-e2e-agent-platform-install-script-suse-a6-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_install_script
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-
 new-e2e-agent-platform-package-signing-suse-a6-x86_64:
   stage: kitchen_testing
   extends:
@@ -48,17 +37,6 @@ new-e2e-agent-platform-step-by-step-suse-a6-x86_64:
   variables:
     FLAVOR: datadog-agent
 
-new-e2e-agent-platform-install-script-upgrade6-suse-x86_64:
-  stage: kitchen_testing
-  extends:
-    - .new_e2e_template
-    - .new-e2e_script_upgrade6
-    - .new-e2e_os_suse
-    - .new-e2e_suse_a6_x86_64
-    - .new-e2e_agent_a6
-  variables:
-    FLAVOR: datadog-agent
-
 new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
   stage: kitchen_testing
   extends:
@@ -70,7 +48,6 @@ new-e2e-agent-platform-install-script-upgrade7-suse-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
+    START_MAJOR_VERSION: 6
+    END_MAJOR_VERSION: 7
+

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -112,7 +112,5 @@ new-e2e-agent-platform-install-script-upgrade7-ubuntu-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-  parallel:
-    matrix:
-      - START_MAJOR_VERSION: [6]
-        END_MAJOR_VERSION: [7]
+    START_MAJOR_VERSION: 6
+    END_MAJOR_VERSION: 7

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -100,3 +100,19 @@ new-e2e-agent-platform-install-script-upgrade6-ubuntu-x86_64:
     - .new-e2e_agent_a6
   variables:
     FLAVOR: datadog-agent
+
+new-e2e-agent-platform-install-script-upgrade7-ubuntu-x86_64:
+  stage: kitchen_testing
+  extends:
+    - .new_e2e_template
+    - .new-e2e_script_upgrade6
+    - .new-e2e_os_ubuntu
+    - .new-e2e_ubuntu_a6_x86_64
+    - .new-e2e_agent_a6
+  variables:
+    FLAVOR: datadog-agent
+    FROM_CURRENT_TO_STABLE: true
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]

--- a/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/new-e2e_testing/ubuntu.yml
@@ -112,5 +112,8 @@ new-e2e-agent-platform-install-script-upgrade7-ubuntu-x86_64:
   variables:
     FLAVOR: datadog-agent
     FROM_CURRENT_TO_STABLE: true
-    START_MAJOR_VERSION: 6
-    END_MAJOR_VERSION: 7
+  parallel:
+    matrix:
+      - START_MAJOR_VERSION: [6]
+        END_MAJOR_VERSION: [7]
+

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -56,6 +56,7 @@ def run(
     cache=False,
     junit_tar="",
     test_run_name="",
+    from_current_to_stable="",
 ):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
@@ -92,7 +93,7 @@ def run(
         test_run_arg = f"-run {test_run_name}"
 
     cmd = f'gotestsum --format {gotestsum_format} '
-    cmd += '{junit_file_flag} --packages="{packages}" -- -ldflags="-X {REPO_PATH}/test/new-e2e/tests/containers.GitCommit={commit}" {verbose} -mod={go_mod} -vet=off -timeout {timeout} -tags "{go_build_tags}" {nocache} {run} {skip} {test_run_arg} -args {osversion} {platform} {major_version} {arch} {flavor} {cws_supported_osversion} {src_agent_version} {dest_agent_version} {keep_stacks} {extra_flags}'
+    cmd += '{junit_file_flag} --packages="{packages}" -- -ldflags="-X {REPO_PATH}/test/new-e2e/tests/containers.GitCommit={commit}" {verbose} -mod={go_mod} -vet=off -timeout {timeout} -tags "{go_build_tags}" {nocache} {run} {skip} {test_run_arg} -args {osversion} {platform} {major_version} {arch} {flavor} {cws_supported_osversion} {src_agent_version} {dest_agent_version} {keep_stacks} {extra_flags} {from_current_to_stable}'
 
     args = {
         "go_mod": "mod",
@@ -116,6 +117,7 @@ def run(
         "dest_agent_version": f"-dest-agent-version {dest_agent_version}" if dest_agent_version else '',
         "keep_stacks": '-keep-stacks' if keep_stacks else '',
         "extra_flags": extra_flags,
+        "from_current_to_stable": "-from-current-to-stable" if from_current_to_stable == "true" else '',
     }
 
     test_res = test_flavor(

--- a/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
+++ b/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
@@ -123,7 +123,6 @@ func (is *upgradeSuite) UpgradeAgentVersion(VMclient *common.TestClient, toCurre
 		install.Unix(is.T(), VMclient, installparams.WithArch(*architecture), installparams.WithFlavor(*flavorName), installparams.WithMajorVersion(is.destVersion), installparams.WithUpgrade(true))
 	} else {
 		install.Unix(is.T(), VMclient, installparams.WithArch(*architecture), installparams.WithFlavor(*flavorName), installparams.WithMajorVersion(is.destVersion), installparams.WithUpgrade(true), installparams.WithPipelineID(""))
-
 	}
 	_, err := VMclient.SvcManager.Restart("datadog-agent")
 	require.NoError(is.T(), err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Add a feature in the TestUpgrade. This test currently upgrade from a stable version to the current one built in the pipeline. On the Agent 6 branch it's not possible upgrade on Agen7 this way as we don't build it. So I added the possibility to upgrade from the current built Agent 6 version to the stable Agent 7 one. And I added this test for each OS
- Remove the `new-e2e-agent-platform-install-script-upgrade6-suse-x86_64: [5, 6]` as we cannot install agent5 on `suse`

### Motivation
Have a test to validate customers can still upgrade from the version we deliver to Agent 7

### Describe how to test/QA your changes
This is an automated test, if job is green it's ok

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->