### PR TITLE
[tagger/fake] Simplify implementation

### DIFF
--- a/comp/core/tagger/impl/fake_tagger.go
+++ b/comp/core/tagger/impl/fake_tagger.go
@@ -21,16 +21,14 @@ import (
 
 // FakeTagger is a fake implementation of the tagger interface
 type FakeTagger struct {
-	errors         map[string]error
-	store          *tagstore.TagStore
-	telemetryStore *telemetry.Store
+	errors map[string]error
+	store  *tagstore.TagStore
 }
 
-func newFakeTagger(telemetryStore *telemetry.Store) *FakeTagger {
+func newFakeTagger() *FakeTagger {
 	return &FakeTagger{
-		errors:         make(map[string]error),
-		store:          tagstore.NewTagStore(telemetryStore),
-		telemetryStore: telemetryStore,
+		errors: make(map[string]error),
+		store:  tagstore.NewTagStore(nil),
 	}
 }
 
@@ -72,8 +70,9 @@ func (f *FakeTagger) ReplayTagger() tagger.ReplayTagger {
 }
 
 // GetTaggerTelemetryStore returns tagger telemetry store
+// The fake tagger returns nil as it doesn't use telemetry
 func (f *FakeTagger) GetTaggerTelemetryStore() *telemetry.Store {
-	return f.telemetryStore
+	return nil
 }
 
 // Tag fake implementation

--- a/comp/core/tagger/impl/fake_tagger.go
+++ b/comp/core/tagger/impl/fake_tagger.go
@@ -8,7 +8,6 @@ package taggerimpl
 import (
 	"context"
 	"strconv"
-	"sync"
 
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -25,7 +24,6 @@ type FakeTagger struct {
 	errors         map[string]error
 	store          *tagstore.TagStore
 	telemetryStore *telemetry.Store
-	sync.RWMutex
 }
 
 func newFakeTagger(telemetryStore *telemetry.Store) *FakeTagger {
@@ -53,20 +51,6 @@ func (f *FakeTagger) SetTags(entityID types.EntityID, source string, low, orch, 
 // SetGlobalTags allows to set tags in store for the global entity
 func (f *FakeTagger) SetGlobalTags(low, orch, high, std []string) {
 	f.SetTags(taggercommon.GetGlobalEntityID(), "static", low, orch, high, std)
-}
-
-// SetTagsFromInfo allows to set tags from list of TagInfo
-func (f *FakeTagger) SetTagsFromInfo(tags []*types.TagInfo) {
-	f.store.ProcessTagInfo(tags)
-}
-
-// SetError allows to set an error to be returned when `Tag` or `AccumulateTagsFor` is called
-// for this entity and cardinality
-func (f *FakeTagger) SetError(entityID types.EntityID, cardinality types.TagCardinality, err error) {
-	f.Lock()
-	defer f.Unlock()
-
-	f.errors[f.getKey(entityID, cardinality)] = err
 }
 
 // Tagger interface

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -142,7 +142,7 @@ func NewTaggerClient(params tagger.Params, cfg config.Component, wmeta workloadm
 	var err error
 	telemetryStore := telemetry.NewStore(telemetryComp)
 	if params.UseFakeTagger {
-		defaultTagger = newFakeTagger(telemetryStore)
+		defaultTagger = newFakeTagger()
 	} else {
 		defaultTagger, err = newLocalTagger(cfg, wmeta, telemetryStore)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR simplifies the fake tagger implementation. This will help us in a following PR to delete some unwanted dependencies from the tagger mock.

In particular, this PR deletes a couple of functions that were never called and deletes the telemetry store from the fake tagger implementation as we don't really need it in this context.

### Describe how to test/QA your changes

Covered by unit and e2e tests.