### PR TITLE
[ASCII-2536] remove subscribers functionality from remote tagger

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -353,9 +353,8 @@ func (t *remoteTagger) DogstatsdCardinality() types.TagCardinality {
 	return t.dogstatsdCardinality
 }
 
-// Subscribe returns a channel that receives a slice of events whenever an entity is
-// added, modified or deleted. It can send an initial burst of events only to the new
-// subscriber, without notifying all of the others.
+// Subscribe currently returns a non-nil error indicating that the method is not supported
+// for remote tagger. Currently, there are no use cases for client subscribing to remote tagger events
 func (t *remoteTagger) Subscribe(string, *types.Filter) (types.Subscription, error) {
 	return nil, errors.New("subscription to the remote tagger is not currently supported")
 }

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -354,10 +354,9 @@ func (t *remoteTagger) DogstatsdCardinality() types.TagCardinality {
 }
 
 // Subscribe returns a channel that receives a slice of events whenever an entity is
-// added, modified or deleted. It can send an initial burst of events only to the new
-// subscriber, without notifying all of the others.
-func (t *remoteTagger) Subscribe(subscriptionID string, filter *types.Filter) (types.Subscription, error) {
-	return t.store.subscribe(subscriptionID, filter)
+// Agents running the remote tagger don't have the ability to subscribe to events, as they are the ones receiving the events.
+func (t *remoteTagger) Subscribe(string, *types.Filter) (types.Subscription, error) {
+	return nil, nil
 }
 
 func (t *remoteTagger) run() {

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -354,9 +354,10 @@ func (t *remoteTagger) DogstatsdCardinality() types.TagCardinality {
 }
 
 // Subscribe returns a channel that receives a slice of events whenever an entity is
-// Agents running the remote tagger don't have the ability to subscribe to events, as they are the ones receiving the events.
+// added, modified or deleted. It can send an initial burst of events only to the new
+// subscriber, without notifying all of the others.
 func (t *remoteTagger) Subscribe(string, *types.Filter) (types.Subscription, error) {
-	return nil, nil
+	return nil, errors.New("subscription to the remote tagger is not currently supported")
 }
 
 func (t *remoteTagger) run() {

--- a/comp/core/tagger/impl-remote/tagstore.go
+++ b/comp/core/tagger/impl-remote/tagstore.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	genericstore "github.com/DataDog/datadog-agent/comp/core/tagger/generic_store"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/subscriber"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 )
@@ -23,17 +22,15 @@ type tagStore struct {
 	telemetry map[string]float64
 	cfg       config.Component
 
-	subscriptionManager subscriber.SubscriptionManager
-	telemetryStore      *telemetry.Store
+	telemetryStore *telemetry.Store
 }
 
 func newTagStore(cfg config.Component, telemetryStore *telemetry.Store) *tagStore {
 	return &tagStore{
-		store:               genericstore.NewObjectStore[*types.Entity](),
-		telemetry:           make(map[string]float64),
-		cfg:                 cfg,
-		subscriptionManager: subscriber.NewSubscriptionManager(telemetryStore),
-		telemetryStore:      telemetryStore,
+		store:          genericstore.NewObjectStore[*types.Entity](),
+		telemetry:      make(map[string]float64),
+		cfg:            cfg,
+		telemetryStore: telemetryStore,
 	}
 }
 
@@ -61,8 +58,6 @@ func (s *tagStore) processEvents(events []types.EntityEvent, replace bool) error
 			s.store.Unset(event.Entity.ID)
 		}
 	}
-
-	s.notifySubscribers(events)
 
 	return nil
 }
@@ -101,30 +96,8 @@ func (s *tagStore) collectTelemetry() {
 	}
 }
 
-func (s *tagStore) subscribe(subscriptionID string, filter *types.Filter) (types.Subscription, error) {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
-	events := make([]types.EntityEvent, 0, s.store.Size())
-
-	s.store.ForEach(nil, func(_ types.EntityID, e *types.Entity) {
-		events = append(events, types.EntityEvent{
-			EventType: types.EventTypeAdded,
-			Entity:    *e,
-		})
-	})
-
-	return s.subscriptionManager.Subscribe(subscriptionID, filter, events)
-}
-
-func (s *tagStore) notifySubscribers(events []types.EntityEvent) {
-	s.subscriptionManager.Notify(events)
-}
-
 // reset clears the local store, preparing it to be re-initialized from a fresh
-// stream coming from the remote source. It also notifies all subscribers that
-// entities have been deleted before re-adding them. In practice, a remote
-// tagger is not expected to have subscribers though.
+// stream coming from the remote source.
 // NOTE: caller must ensure that it holds s.mutex's lock, as this func does not
 // do it on its own.
 func (s *tagStore) reset() {
@@ -140,8 +113,6 @@ func (s *tagStore) reset() {
 			Entity:    types.Entity{ID: e.ID},
 		})
 	})
-
-	s.notifySubscribers(events)
 
 	s.store = genericstore.NewObjectStore[*types.Entity]()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes subscriber functionality from the remote tagger and their dependencies 

The subscribe method is called in the tagger server, which is only use for core Agent that runs the local tagger 
https://github.com/DataDog/datadog-agent/blob/043922b67eb043ad69e26bb889890d2bd8a95f5d/comp/core/tagger/server/server.go#L61

### Motivation

Continue reducing the size of the remote tagger

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->