### PR TITLE
Add ASC as co-owners of the workloadmeta, tagger and autodicovery components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -308,10 +308,10 @@
 /comp/checks/agentcrashdetect @DataDog/windows-kernel-integrations
 /comp/checks/windowseventlog @DataDog/windows-agent
 /comp/checks/winregistry @DataDog/windows-agent
-/comp/core/autodiscovery @DataDog/container-platform
+/comp/core/autodiscovery @DataDog/container-platform @DataDog/agent-shared-components
 /comp/core/sysprobeconfig @DataDog/ebpf-platform
-/comp/core/tagger @DataDog/container-platform
-/comp/core/workloadmeta @DataDog/container-platform
+/comp/core/tagger @DataDog/container-platform @DataDog/agent-shared-components
+/comp/core/workloadmeta @DataDog/container-platform @DataDog/agent-shared-components
 /comp/metadata/packagesigning @DataDog/agent-delivery
 /comp/trace/etwtracer @DataDog/windows-agent
 /comp/autoscaling/datadogclient @DataDog/container-integrations

--- a/comp/README.md
+++ b/comp/README.md
@@ -113,7 +113,7 @@ Package agenttelemetry implements a component to generate Agent telemetry
 
 ### [comp/core/autodiscovery](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/autodiscovery)
 
-*Datadog Team*: container-platform
+*Datadog Team*: container-platform agent-shared-components
 
 Package autodiscovery provides the autodiscovery component for the Datadog Agent
 
@@ -185,7 +185,7 @@ component temporarily wraps pkg/config.
 
 ### [comp/core/tagger](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/tagger)
 
-*Datadog Team*: container-platform
+*Datadog Team*: container-platform agent-shared-components
 
 Package tagger provides the tagger interface for the Datadog Agent
 
@@ -195,7 +195,7 @@ Package telemetry implements a component for all agent telemetry.
 
 ### [comp/core/workloadmeta](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/workloadmeta)
 
-*Datadog Team*: container-platform
+*Datadog Team*: container-platform agent-shared-components
 
 Package workloadmeta provides the workloadmeta component for the Datadog Agent
 

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Component is the component type.
-// team: container-platform
+// team: container-platform agent-shared-components
 type Component interface {
 	AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)

--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
-// team: container-platform
+// team: container-platform agent-shared-components
 
 // ReplayTagger interface represent the tagger use for replaying dogstatsd events.
 type ReplayTagger interface {

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -6,7 +6,7 @@
 // Package workloadmeta provides the workloadmeta component for the Datadog Agent
 package workloadmeta
 
-// team: container-platform
+// team: container-platform agent-shared-components
 
 // Component is the component type.
 type Component interface {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add ASC as co-owner of the Autodiscovery, Workloadmeta and Tagger components

### Motivation
ASC has no say on what features must be implemented on those components, but I believe ASC could provide good feedback regarding the use of Fx. Especially, when it comes to these core components that are used so ubiquitous 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->