### PR TITLE
CONTP-358: feat(unified-origin-detection): add  dd.internal.card:none support

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -458,6 +458,15 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 			}
 		}
 	default:
+		// Disable origin detection if cardinality is none
+		// TODO: The `none` cardinality should be directly supported by the Tagger.
+		if originInfo.Cardinality == "none" {
+			originInfo.ContainerIDFromSocket = packets.NoOrigin
+			originInfo.PodUID = ""
+			originInfo.ContainerID = ""
+			return
+		}
+
 		// Tag using Local Data
 		if originInfo.ContainerIDFromSocket != packets.NoOrigin && len(originInfo.ContainerIDFromSocket) > containerIDFromSocketCutIndex {
 			containerID := originInfo.ContainerIDFromSocket[containerIDFromSocketCutIndex:]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add support for `none` cardinality for Unified Origin Detection. This setting is mainly used when sending metrics with the `dd.internal.card:none` tag. We are not re-using the `dogstatsd_origin_optout_enabled` but are leaving it for Legacy Origin Detection.

### Motivation

This is needed in case we want to even avoid `low` tags for some very high cardinality metrics.

### Describe how to test/QA your changes

Unit tests covers the change.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We will work again on this in the future to have `none` cardinality being better supported by the Tagger, to still be able to have global tags in the metrics.

Regarding the `changelog/no-changelog` label. As this is not yet an externally supported feature, we are not putting any changelog.