### PR TITLE
Use Set for gauge calls

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -470,7 +470,7 @@ AND status = 'ACTIVE'`)
 	}
 	sendMetricWithDefaultTags(c, gauge, "dd.oracle.activity.time_ms", float64(time.Since(start).Milliseconds()))
 	TlmOracleActivityLatency.Observe(float64(time.Since(start).Milliseconds()))
-	TlmOracleActivitySamplesCount.Add(float64(len(sessionRows)))
+	TlmOracleActivitySamplesCount.Set(float64(len(sessionRows)))
 
 	sender.Commit()
 

--- a/pkg/collector/corechecks/oracle/statements.go
+++ b/pkg/collector/corechecks/oracle/statements.go
@@ -871,7 +871,7 @@ func (c *Check) StatementMetrics() (int, error) {
 	TlmOracleStatementMetricsLatency.Observe(float64(time.Since(start).Milliseconds()))
 	if c.config.ExecutionPlans.Enabled {
 		sendMetricWithDefaultTags(c, gauge, "dd.oracle.plan_errors.count", float64(planErrors))
-		TlmOracleStatementMetricsErrorCount.Add(float64(planErrors))
+		TlmOracleStatementMetricsErrorCount.Set(float64(planErrors))
 	}
 	sender.Commit()
 

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -728,7 +728,7 @@ func EmitAgentTelemetry(checkName *C.char, metricName *C.char, metricValue C.dou
 	case "gauge":
 		gauge := lazyInitTelemetryGauge(goCheckName, goMetricName)
 		if gauge != nil {
-			gauge.Add(goMetricValue)
+			gauge.Set(goMetricValue)
 		}
 	default:
 		log.Warnf("EmitAgentTelemetry: unsupported metric type %s requested by %s for %s", goMetricType, goCheckName, goMetricName)

--- a/releasenotes/notes/fix-gauge-method-d53690032d05460f.yaml
+++ b/releasenotes/notes/fix-gauge-method-d53690032d05460f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Corrects the method call for gauges to be Set instead of Add.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes the method call for gauges to be `Set` rather than `Add`

### Motivation
`Add` causes the gauge to constantly rise with each call.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->