### PR TITLE
fix(ci): [agent6] Fix ASC `new-e2e` tests

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
@@ -7,18 +7,25 @@
 package check
 
 import (
+	_ "embed"
 	"fmt"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type baseCheckSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
+
+//go:embed fixtures/hello.yaml
+var customCheckYaml []byte
+
+//go:embed fixtures/hello.py
+var customCheckPython []byte
 
 func (v *baseCheckSuite) TestCheckDisk() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"disk"}))
@@ -43,8 +50,7 @@ func (v *baseCheckSuite) TestCustomCheck() {
 
 func (v *baseCheckSuite) TestCheckRate() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
+	data := parseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 
@@ -59,8 +65,7 @@ func (v *baseCheckSuite) TestCheckTimes() {
 	times := 10
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
 
-	data := parseCheckOutput([]byte(check))
-	require.NotNil(v.T(), data)
+	data := parseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 

--- a/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_nix_test.go
@@ -7,7 +7,6 @@
 package check
 
 import (
-	_ "embed"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -20,12 +19,6 @@ import (
 type linuxCheckSuite struct {
 	baseCheckSuite
 }
-
-//go:embed fixtures/hello.yaml
-var customCheckYaml []byte
-
-//go:embed fixtures/hello.py
-var customCheckPython []byte
 
 func TestLinuxCheckSuite(t *testing.T) {
 	e2e.Run(t, &linuxCheckSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(

--- a/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_win_test.go
@@ -21,13 +21,14 @@ type windowsCheckSuite struct {
 }
 
 func TestWindowsCheckSuite(t *testing.T) {
-	t.Skip("not working because of the following error: unable to import module 'hello': source code string cannot contain null bytes")
-
+	t.Parallel()
 	e2e.Run(t, &windowsCheckSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 			awshost.WithAgentOptions(
 				agentparams.WithFile("C:/ProgramData/Datadog/conf.d/hello.d/conf.yaml", string(customCheckYaml), true),
 				agentparams.WithFile("C:/ProgramData/Datadog/checks.d/hello.py", string(customCheckPython), true),
-			))))
+			),
+		),
+	))
 }

--- a/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.py
+++ b/test/new-e2e/tests/agent-subcommands/check/fixtures/hello.py
@@ -13,7 +13,7 @@ __version__ = "1.0.0"
 # flake8: noqa
 class HelloCheck(AgentCheck):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(HelloCheck, self).__init__(*args, **kwargs)
         self.value = 123
 
     def check(self, instance):

--- a/test/new-e2e/tests/agent-subcommands/health/health_commont_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_commont_test.go
@@ -6,23 +6,26 @@
 package health
 
 import (
-	"testing"
+	"net/http"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 
 	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type baseHealthSuite struct {
 	e2e.BaseSuite[environments.Host]
-}
-
-func TestSubcommandSuite(t *testing.T) {
-	e2e.Run(t, &baseHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
+	descriptor os.Descriptor
 }
 
 // section contains the content status of a specific section (e.g. Forwarder)
@@ -41,4 +44,41 @@ func (v *baseHealthSuite) TestDefaultInstallHealthy() {
 
 	assert.NoError(v.T(), err)
 	assert.Contains(v.T(), output, "Agent health: PASS")
+}
+
+func (v *baseHealthSuite) TestDefaultInstallUnhealthy() {
+	// the fakeintake says that any API key is invalid by sending a 403 code
+	override := api.ResponseOverride{
+		Endpoint:   "/api/v1/validate",
+		StatusCode: 403,
+		Method:     http.MethodGet,
+		Body:       []byte("invalid API key"),
+	}
+	err := v.Env().FakeIntake.Client().ConfigureOverride(override)
+	require.NoError(v.T(), err)
+
+	// restart the agent, which validates the key using the fakeintake at startup
+	v.UpdateEnv(awshost.Provisioner(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
+		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\nforwarder_apikey_validation_interval: 1")),
+	))
+
+	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
+		// forwarder should be unhealthy because the key is invalid
+		_, err = v.Env().Agent.Client.Health()
+		assert.ErrorContains(collect, err, "Agent health: FAIL")
+		assert.ErrorContains(collect, err, "=== 1 unhealthy components ===\nforwarder")
+	}, time.Second*30, time.Second)
+
+	// the fakeintake now says that the api key is valid
+	override.StatusCode = 200
+	override.Body = []byte("valid API key")
+	err = v.Env().FakeIntake.Client().ConfigureOverride(override)
+	require.NoError(v.T(), err)
+
+	// the agent will check every minute if the key is valid, so wait at most 1m30
+	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
+		_, err = v.Env().Agent.Client.Health()
+		assert.NoError(collect, err)
+	}, time.Second*90, 3*time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_commont_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_commont_test.go
@@ -6,26 +6,23 @@
 package health
 
 import (
-	"net/http"
+	"testing"
 	"time"
 
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 
 	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type baseHealthSuite struct {
 	e2e.BaseSuite[environments.Host]
-	descriptor os.Descriptor
+}
+
+func TestSubcommandSuite(t *testing.T) {
+	e2e.Run(t, &baseHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }
 
 // section contains the content status of a specific section (e.g. Forwarder)
@@ -44,41 +41,4 @@ func (v *baseHealthSuite) TestDefaultInstallHealthy() {
 
 	assert.NoError(v.T(), err)
 	assert.Contains(v.T(), output, "Agent health: PASS")
-}
-
-func (v *baseHealthSuite) TestDefaultInstallUnhealthy() {
-	// the fakeintake says that any API key is invalid by sending a 403 code
-	override := api.ResponseOverride{
-		Endpoint:   "/api/v1/validate",
-		StatusCode: 403,
-		Method:     http.MethodGet,
-		Body:       []byte("invalid API key"),
-	}
-	err := v.Env().FakeIntake.Client().ConfigureOverride(override)
-	require.NoError(v.T(), err)
-
-	// restart the agent, which validates the key using the fakeintake at startup
-	v.UpdateEnv(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
-		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\nforwarder_apikey_validation_interval: 1")),
-	))
-
-	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
-		// forwarder should be unhealthy because the key is invalid
-		_, err = v.Env().Agent.Client.Health()
-		assert.ErrorContains(collect, err, "Agent health: FAIL")
-		assert.ErrorContains(collect, err, "=== 1 unhealthy components ===\nforwarder")
-	}, time.Second*30, time.Second)
-
-	// the fakeintake now says that the api key is valid
-	override.StatusCode = 200
-	override.Body = []byte("valid API key")
-	err = v.Env().FakeIntake.Client().ConfigureOverride(override)
-	require.NoError(v.T(), err)
-
-	// the agent will check every minute if the key is valid, so wait at most 1m30
-	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
-		_, err = v.Env().Agent.Client.Health()
-		assert.NoError(collect, err)
-	}, time.Second*90, 3*time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -8,11 +8,11 @@ package health
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/stretchr/testify/assert"
 )
 
 type linuxHealthSuite struct {
@@ -20,29 +20,9 @@ type linuxHealthSuite struct {
 }
 
 func TestLinuxHealthSuite(t *testing.T) {
-	e2e.Run(t, &linuxHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
-}
-
-func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
-	// the fakeintake says that any API key is invalid by sending a 403 code
-	override := api.ResponseOverride{
-		Endpoint:    "/api/v1/validate",
-		StatusCode:  403,
-		ContentType: "text/plain",
-		Body:        []byte("invalid API key"),
-	}
-	v.Env().FakeIntake.Client().ConfigureOverride(override)
-
-	// restart the agent, which validates the key using the fakeintake at startup
-	v.UpdateEnv(awshost.Provisioner(
-		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n")),
-	))
-
-	// agent should be unhealthy because the key is invalid
-	_, err := v.Env().Agent.Client.Health()
-	if err == nil {
-		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
-		return
-	}
-	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
+	t.Parallel()
+	suite := &linuxHealthSuite{baseHealthSuite{descriptor: os.UbuntuDefault}}
+	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
+	)))
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -14,15 +14,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type linuxHealthSuite struct {
 	baseHealthSuite
-	descriptor os.Descriptor
 }
 
 func TestLinuxHealthSuite(t *testing.T) {
@@ -42,8 +39,7 @@ func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
 
 	// restart the agent, which validates the key using the fakeintake at startup
 	v.UpdateEnv(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
-		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\nforwarder_apikey_validation_interval: 1")),
+		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n")),
 	))
 
 	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -8,11 +8,11 @@ package health
 import (
 	"testing"
 
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
 )
 
 type linuxHealthSuite struct {
@@ -20,9 +20,29 @@ type linuxHealthSuite struct {
 }
 
 func TestLinuxHealthSuite(t *testing.T) {
-	t.Parallel()
-	suite := &linuxHealthSuite{baseHealthSuite{descriptor: os.UbuntuDefault}}
-	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
-	)))
+	e2e.Run(t, &linuxHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
+}
+
+func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
+	// the fakeintake says that any API key is invalid by sending a 403 code
+	override := api.ResponseOverride{
+		Endpoint:    "/api/v1/validate",
+		StatusCode:  403,
+		ContentType: "text/plain",
+		Body:        []byte("invalid API key"),
+	}
+	v.Env().FakeIntake.Client().ConfigureOverride(override)
+
+	// restart the agent, which validates the key using the fakeintake at startup
+	v.UpdateEnv(awshost.Provisioner(
+		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n")),
+	))
+
+	// agent should be unhealthy because the key is invalid
+	_, err := v.Env().Agent.Client.Health()
+	if err == nil {
+		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
+		return
+	}
+	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -6,17 +6,23 @@
 package health
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type linuxHealthSuite struct {
 	baseHealthSuite
+	descriptor os.Descriptor
 }
 
 func TestLinuxHealthSuite(t *testing.T) {
@@ -26,23 +32,24 @@ func TestLinuxHealthSuite(t *testing.T) {
 func (v *linuxHealthSuite) TestDefaultInstallUnhealthy() {
 	// the fakeintake says that any API key is invalid by sending a 403 code
 	override := api.ResponseOverride{
-		Endpoint:    "/api/v1/validate",
-		StatusCode:  403,
-		ContentType: "text/plain",
-		Body:        []byte("invalid API key"),
+		Endpoint:   "/api/v1/validate",
+		StatusCode: 403,
+		Method:     http.MethodGet,
+		Body:       []byte("invalid API key"),
 	}
-	v.Env().FakeIntake.Client().ConfigureOverride(override)
+	err := v.Env().FakeIntake.Client().ConfigureOverride(override)
+	require.NoError(v.T(), err)
 
 	// restart the agent, which validates the key using the fakeintake at startup
 	v.UpdateEnv(awshost.Provisioner(
-		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n")),
+		awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
+		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\nforwarder_apikey_validation_interval: 1")),
 	))
 
-	// agent should be unhealthy because the key is invalid
-	_, err := v.Env().Agent.Client.Health()
-	if err == nil {
-		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
-		return
-	}
-	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
+	require.EventuallyWithT(v.T(), func(collect *assert.CollectT) {
+		// forwarder should be unhealthy because the key is invalid
+		_, err = v.Env().Agent.Client.Health()
+		assert.ErrorContains(collect, err, "Agent health: FAIL")
+		assert.ErrorContains(collect, err, "=== 1 unhealthy components ===\nforwarder")
+	}, time.Second*30, time.Second)
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -8,13 +8,11 @@ package health
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/fakeintake/api"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
 
 type windowsHealthSuite struct {
@@ -22,27 +20,9 @@ type windowsHealthSuite struct {
 }
 
 func TestWindowsHealthSuite(t *testing.T) {
-	e2e.Run(t, &windowsHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
-}
-
-func (v *windowsHealthSuite) TestDefaultInstallUnhealthy() {
-	// the fakeintake says that any API key is invalid by sending a 403 code
-	override := api.ResponseOverride{
-		Endpoint:    "/api/v1/validate",
-		StatusCode:  403,
-		ContentType: "text/plain",
-		Body:        []byte("invalid API key"),
-	}
-	v.Env().FakeIntake.Client().ConfigureOverride(override)
-	// restart the agent, which validates the key using the fakeintake at startup
-	v.UpdateEnv(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
-		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n"))))
-
-	// agent should be unhealthy because the key is invalid
-	_, err := v.Env().Agent.Client.Health()
-	if err == nil {
-		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
-		return
-	}
-	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
+	t.Parallel()
+	suite := &windowsHealthSuite{baseHealthSuite{descriptor: os.WindowsDefault}}
+	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
+	)))
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -6,6 +6,7 @@
 package health
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -30,12 +31,13 @@ func TestWindowsHealthSuite(t *testing.T) {
 func (v *windowsHealthSuite) TestDefaultInstallUnhealthy() {
 	// the fakeintake says that any API key is invalid by sending a 403 code
 	override := api.ResponseOverride{
-		Endpoint:    "/api/v1/validate",
-		StatusCode:  403,
-		ContentType: "text/plain",
-		Body:        []byte("invalid API key"),
+		Endpoint:   "/api/v1/validate",
+		StatusCode: 403,
+		Method:     http.MethodGet,
+		Body:       []byte("invalid API key"),
 	}
-	v.Env().FakeIntake.Client().ConfigureOverride(override)
+	err := v.Env().FakeIntake.Client().ConfigureOverride(override)
+	require.NoError(v.T(), err)
 	// restart the agent, which validates the key using the fakeintake at startup
 	v.UpdateEnv(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n"))))

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -8,11 +8,13 @@ package health
 import (
 	"testing"
 
-	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
-
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/assert"
 )
 
 type windowsHealthSuite struct {
@@ -20,9 +22,27 @@ type windowsHealthSuite struct {
 }
 
 func TestWindowsHealthSuite(t *testing.T) {
-	t.Parallel()
-	suite := &windowsHealthSuite{baseHealthSuite{descriptor: os.WindowsDefault}}
-	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
-	)))
+	e2e.Run(t, &windowsHealthSuite{}, e2e.WithProvisioner(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)))))
+}
+
+func (v *windowsHealthSuite) TestDefaultInstallUnhealthy() {
+	// the fakeintake says that any API key is invalid by sending a 403 code
+	override := api.ResponseOverride{
+		Endpoint:    "/api/v1/validate",
+		StatusCode:  403,
+		ContentType: "text/plain",
+		Body:        []byte("invalid API key"),
+	}
+	v.Env().FakeIntake.Client().ConfigureOverride(override)
+	// restart the agent, which validates the key using the fakeintake at startup
+	v.UpdateEnv(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+		awshost.WithAgentOptions(agentparams.WithAgentConfig("log_level: info\n"))))
+
+	// agent should be unhealthy because the key is invalid
+	_, err := v.Env().Agent.Client.Health()
+	if err == nil {
+		assert.Fail(v.T(), "agent expected to be unhealthy, but no error found!")
+		return
+	}
+	assert.Contains(v.T(), err.Error(), "Agent health: FAIL")
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix ASC `new-e2e` tests:
- Use correct syntax and output format for custom check on `subcommand` test (see https://github.com/DataDog/datadog-agent/pull/30095)
- Sync api override and message check in TestHealthSuite (see https://github.com/DataDog/datadog-agent/pull/29429)

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-455

### Describe how to test/QA your changes
`e2e` stage is [passing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines?page=1&scope=all&ref=nschweitzer%2Fsubcommand)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->