### PR TITLE
fix(ci): [agent6] Fix `new-e2e-process` test

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -189,6 +189,8 @@ func runCheck(log log.Component, cliParams *cliParams, ch checks.Check) error {
 
 	options := &checks.RunOptions{
 		RunStandard: true,
+		// disable chunking for all manual checks
+		NoChunking: true,
 	}
 
 	if cliParams.checkName == checks.RTName(ch.Name()) {

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -62,6 +62,7 @@ type Check interface {
 type RunOptions struct {
 	RunStandard bool
 	RunRealtime bool
+	NoChunking  bool
 }
 
 // RunResult is a result for a check run

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -7,6 +7,7 @@ package checks
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -118,6 +119,12 @@ func (c *ContainerCheck) Run(nextGroupID func() int32, options *RunOptions) (Run
 	if len(containers)%c.maxBatchSize != 0 {
 		groupSize++
 	}
+
+	// For no chunking, set groupsize as 1 to ensure one chunk
+	if options != nil && options.NoChunking {
+		groupSize = 1
+	}
+
 	chunked := chunkContainers(containers, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	groupID := nextGroupID()
@@ -144,7 +151,7 @@ func (c *ContainerCheck) Cleanup() {}
 
 // chunkContainers formats and chunks the ctrList into a slice of chunks using a specific number of chunks.
 func chunkContainers(containers []*model.Container, chunks int) [][]*model.Container {
-	perChunk := (len(containers) / chunks) + 1
+	perChunk := int(math.Ceil(float64(len(containers)) / float64(chunks)))
 	chunked := make([][]*model.Container, 0, chunks)
 	chunk := make([]*model.Container, 0, perChunk)
 

--- a/pkg/process/checks/container_check_test.go
+++ b/pkg/process/checks/container_check_test.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package checks
+
+import (
+	"testing"
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	proccontainersmocks "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
+)
+
+// Constant modeled after cacheValidityNoRT to allow for mocking containers functions
+const (
+	cacheValidityNoRTTest = 2 * time.Second
+)
+
+func containerCheckWithMockContainerProvider(t *testing.T) (*ContainerCheck, *proccontainersmocks.MockContainerProvider) {
+	mockCtrl := gomock.NewController(t)
+	containerProvider := proccontainersmocks.NewMockContainerProvider(mockCtrl)
+	sysInfo := &model.SystemInfo{
+		Cpus: []*model.CPUInfo{
+			{CoreId: "1"},
+			{CoreId: "2"},
+			{CoreId: "3"},
+			{CoreId: "4"},
+		},
+	}
+	hostInfo := &HostInfo{
+		SystemInfo: sysInfo,
+	}
+
+	return &ContainerCheck{
+		hostInfo:          hostInfo,
+		containerProvider: containerProvider,
+	}, containerProvider
+}
+
+func TestContainerCheckPayloads(t *testing.T) {
+	check, mockContainerProvider := containerCheckWithMockContainerProvider(t)
+	check.maxBatchSize = 2
+
+	// mock containers for testing
+	containers := []*model.Container{
+		{
+			Id: "container-1",
+			Addresses: []*model.ContainerAddr{
+				{Ip: "10.0.2.15", Port: 32769, Protocol: model.ConnectionType_tcp},
+				{Ip: "172.17.0.4", Port: 6379, Protocol: model.ConnectionType_tcp},
+			},
+		},
+		{
+			Id: "container-2",
+			Addresses: []*model.ContainerAddr{
+				{Ip: "172.17.0.2", Port: 80, Protocol: model.ConnectionType_tcp},
+			},
+		},
+		{
+			Id: "container-3",
+			Addresses: []*model.ContainerAddr{
+				{Ip: "172.17.0.3", Port: 88, Protocol: model.ConnectionType_tcp},
+			},
+		},
+	}
+
+	mockContainerProvider.EXPECT().GetContainers(cacheValidityNoRTTest, nil).Return(containers, nil, nil, nil)
+
+	// Test check runs without error using default chunk settings
+	result, err := check.Run(testGroupID(0), nil)
+	assert.NoError(t, err)
+
+	// Test that result has the proper number of chunks, and that those chunks are of the correct type
+	for _, elem := range result.Payloads() {
+		assert.IsType(t, &model.CollectorContainer{}, elem)
+		collectorContainers := elem.(*model.CollectorContainer)
+		resultContainers := collectorContainers.GetContainers()
+		for _, ctr := range resultContainers {
+			assert.Empty(t, ctr.Host)
+		}
+		if len(resultContainers) > check.maxBatchSize {
+			t.Errorf("Expected less than %d messages in chunk, got %d",
+				check.maxBatchSize, len(resultContainers))
+		}
+	}
+}
+
+func TestContainerCheckChunking(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		noChunking            bool
+		expectedPayloadLength int
+	}{
+		{
+			name:                  "Chunking",
+			noChunking:            false,
+			expectedPayloadLength: 2,
+		},
+		{
+			name:                  "No chunking",
+			noChunking:            true,
+			expectedPayloadLength: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			containerCheck, mockContainerProvider := containerCheckWithMockContainerProvider(t)
+
+			// Set small size per chunk to force chunking behavior
+			containerCheck.maxBatchSize = 1
+
+			// mock containers for testing
+			containers := []*model.Container{
+				{
+					Id: "container-1",
+					Addresses: []*model.ContainerAddr{
+						{Ip: "10.0.2.15", Port: 32769, Protocol: model.ConnectionType_tcp},
+						{Ip: "172.17.0.4", Port: 6379, Protocol: model.ConnectionType_tcp},
+					},
+				},
+				{
+					Id: "container-2",
+					Addresses: []*model.ContainerAddr{
+						{Ip: "172.17.0.2", Port: 80, Protocol: model.ConnectionType_tcp},
+					},
+				},
+			}
+			mockContainerProvider.EXPECT().GetContainers(cacheValidityNoRTTest, nil).Return(containers, nil, nil, nil)
+
+			// Test check runs without error and has correct number of chunks
+			actual, err := containerCheck.Run(testGroupID(0), getChunkingOption(tc.noChunking))
+			require.NoError(t, err)
+			assert.Len(t, actual.Payloads(), tc.expectedPayloadLength)
+		})
+	}
+}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"context"
 	"errors"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -369,6 +370,19 @@ func procsToStats(procs map[int32]*procutil.Process) map[int32]*procutil.Stats {
 func (p *ProcessCheck) Run(nextGroupID func() int32, options *RunOptions) (RunResult, error) {
 	if options == nil {
 		return p.run(nextGroupID(), false)
+	}
+
+	// For no chunking, set max batch size to max value to ensure one chunk
+	if options.NoChunking {
+		oldMaxBatchSize := p.maxBatchSize
+		oldMaxBatchBytes := p.maxBatchBytes
+		p.maxBatchSize = math.MaxInt
+		p.maxBatchBytes = math.MaxInt
+
+		defer func() {
+			p.maxBatchSize = oldMaxBatchSize
+			p.maxBatchBytes = oldMaxBatchBytes
+		}()
 	}
 
 	if options.RunStandard {

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -21,6 +21,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
+// Returns chunking and no chunking RunOptions
+func getChunkingOption(noChunking bool) *RunOptions {
+	return &RunOptions{RunStandard: true, NoChunking: noChunking}
+}
+
+func testGroupID(groupID int32) func() int32 {
+	return func() int32 {
+		return groupID
+	}
+}
+
 //nolint:deadcode,unused
 func procsToHash(procs []*procutil.Process) (procsByPid map[int32]*procutil.Process) {
 	procsByPid = make(map[int32]*procutil.Process)

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -88,7 +88,7 @@ func (d *ProcessDiscoveryCheck) ShouldSaveLastRun() bool { return true }
 
 // Run collects process metadata, and packages it into a CollectorProcessDiscovery payload to be sent.
 // It is a runtime error to call Run without first having called Init.
-func (d *ProcessDiscoveryCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResult, error) {
+func (d *ProcessDiscoveryCheck) Run(nextGroupID func() int32, options *RunOptions) (RunResult, error) {
 	if !d.initCalled {
 		return nil, fmt.Errorf("ProcessDiscoveryCheck.Run called before Init")
 	}
@@ -104,7 +104,15 @@ func (d *ProcessDiscoveryCheck) Run(nextGroupID func() int32, _ *RunOptions) (Ru
 		NumCpus:     calculateNumCores(d.info.SystemInfo),
 		TotalMemory: d.info.SystemInfo.TotalMemory,
 	}
-	procDiscoveryChunks := chunkProcessDiscoveries(pidMapToProcDiscoveries(procs, d.userProbe, d.scrubber), d.maxBatchSize)
+	procDiscoveries := pidMapToProcDiscoveries(procs, d.userProbe, d.scrubber)
+
+	// For no chunking, set max batch size as number of process discoveries to ensure one chunk
+	runMaxBatchSize := d.maxBatchSize
+	if options != nil && options.NoChunking {
+		runMaxBatchSize = len(procDiscoveries)
+	}
+
+	procDiscoveryChunks := chunkProcessDiscoveries(procDiscoveries, runMaxBatchSize)
 	payload := make([]model.MessageBody, len(procDiscoveryChunks))
 
 	groupID := nextGroupID()

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -7,20 +7,39 @@ package checks
 
 import (
 	"testing"
+	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil/mocks"
 )
 
-//nolint:revive // TODO(PROC) Fix revive linter
-func testGroupId(groupID int32) func() int32 {
-	return func() int32 {
-		return groupID
+func processDiscoveryCheckWithMockProbe(t *testing.T) (*ProcessDiscoveryCheck, *mocks.Probe) {
+	probe := mocks.NewProbe(t)
+	sysInfo := &model.SystemInfo{
+		Cpus: []*model.CPUInfo{
+			{CoreId: "1"},
+			{CoreId: "2"},
+			{CoreId: "3"},
+			{CoreId: "4"},
+		},
 	}
+	info := &HostInfo{
+		SystemInfo: sysInfo,
+	}
+
+	return &ProcessDiscoveryCheck{
+		probe:      probe,
+		scrubber:   procutil.NewDefaultDataScrubber(),
+		info:       info,
+		userProbe:  &LookupIdProbe{},
+		initCalled: true,
+	}, probe
 }
 
 func TestProcessDiscoveryCheck(t *testing.T) {
@@ -45,7 +64,7 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	)
 
 	// Test check runs without error
-	result, err := check.Run(testGroupId(0), nil)
+	result, err := check.Run(testGroupID(0), nil)
 	assert.NoError(t, err)
 
 	// Test that result has the proper number of chunks, and that those chunks are of the correct type
@@ -59,6 +78,50 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 			t.Errorf("Expected less than %d messages in chunk, got %d",
 				maxBatchSize, len(collectorProcDiscovery.ProcessDiscoveries))
 		}
+	}
+}
+
+func TestProcessDiscoveryCheckChunking(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		noChunking            bool
+		expectedPayloadLength int
+	}{
+		{
+			name:                  "Chunking",
+			noChunking:            false,
+			expectedPayloadLength: 5,
+		},
+		{
+			name:                  "No chunking",
+			noChunking:            true,
+			expectedPayloadLength: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			check, probe := processDiscoveryCheckWithMockProbe(t)
+
+			// Set small chunk size to force chunking behavior
+			check.maxBatchSize = 1
+
+			// mock processes
+			now := time.Now().Unix()
+			proc1 := makeProcessWithCreateTime(1, "git clone google.com", now)
+			proc2 := makeProcessWithCreateTime(2, "mine-bitcoins -all -x", now+1)
+			proc3 := makeProcessWithCreateTime(3, "foo --version", now+2)
+			proc4 := makeProcessWithCreateTime(4, "foo -bar -bim", now+3)
+			proc5 := makeProcessWithCreateTime(5, "datadog-process-agent --cfgpath datadog.conf", now+2)
+
+			processesByPid := map[int32]*procutil.Process{1: proc1, 2: proc2, 3: proc3, 4: proc4, 5: proc5}
+			probe.On("ProcessesByPID", mock.Anything, mock.Anything).
+				Return(processesByPid, nil)
+
+			// Test second check runs without error and has correct number of chunks
+			check.Run(testGroupID(0), getChunkingOption(tc.noChunking))
+			actual, err := check.Run(testGroupID(0), getChunkingOption(tc.noChunking))
+			require.NoError(t, err)
+			assert.Len(t, actual.Payloads(), tc.expectedPayloadLength)
+		})
 	}
 }
 

--- a/pkg/process/checks/process_events_linux_test.go
+++ b/pkg/process/checks/process_events_linux_test.go
@@ -249,7 +249,7 @@ func TestProcessEventsCheck(t *testing.T) {
 	events := make([]*payload.ProcessEvent, 0)
 	assert.Eventually(t, func() bool {
 		// Run the process_events check until all expected events are collected
-		msgs, err := check.Run(testGroupId(0), nil)
+		msgs, err := check.Run(testGroupID(0), nil)
 		require.NoError(t, err)
 
 		for _, msg := range msgs.Payloads() {

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -174,6 +174,51 @@ func TestProcessCheckSecondRun(t *testing.T) {
 	assert.Nil(t, actual.RealtimePayloads())
 }
 
+func TestProcessCheckChunking(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		noChunking            bool
+		expectedPayloadLength int
+	}{
+		{
+			name:                  "Chunking",
+			noChunking:            false,
+			expectedPayloadLength: 5,
+		},
+		{
+			name:                  "No chunking",
+			noChunking:            true,
+			expectedPayloadLength: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			processCheck, probe := processCheckWithMockProbe(t)
+
+			// Set small chunk size to force chunking behavior
+			processCheck.maxBatchBytes = 0
+			processCheck.maxBatchSize = 0
+
+			// mock processes
+			now := time.Now().Unix()
+			proc1 := makeProcessWithCreateTime(1, "git clone google.com", now)
+			proc2 := makeProcessWithCreateTime(2, "mine-bitcoins -all -x", now+1)
+			proc3 := makeProcessWithCreateTime(3, "foo --version", now+2)
+			proc4 := makeProcessWithCreateTime(4, "foo -bar -bim", now+3)
+			proc5 := makeProcessWithCreateTime(5, "datadog-process-agent --cfgpath datadog.conf", now+2)
+
+			processesByPid := map[int32]*procutil.Process{1: proc1, 2: proc2, 3: proc3, 4: proc4, 5: proc5}
+			probe.On("ProcessesByPID", mock.Anything, mock.Anything).
+				Return(processesByPid, nil)
+
+			// Test second check runs without error and has correct number of chunks
+			processCheck.Run(testGroupID(0), getChunkingOption(tc.noChunking))
+			actual, err := processCheck.Run(testGroupID(0), getChunkingOption(tc.noChunking))
+			require.NoError(t, err)
+			assert.Len(t, actual.Payloads(), tc.expectedPayloadLength)
+		})
+	}
+}
+
 func TestProcessCheckWithRealtime(t *testing.T) {
 	processCheck, probe := processCheckWithMockProbe(t)
 	proc1 := makeProcess(1, "git clone google.com")

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -116,6 +117,9 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 }
 
 func (s *windowsTestSuite) TestManualProcessCheck() {
+	// Responses with more than 100 processes end up being chunked, which fails JSON unmarshalling
+	// Fix tracked in https://datadoghq.atlassian.net/browse/PROCS-3613
+	flake.Mark(s.T())
 	check := s.Env().RemoteHost.
 		MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process --json")
 
@@ -125,7 +129,8 @@ func (s *windowsTestSuite) TestManualProcessCheck() {
 func (s *windowsTestSuite) TestManualProcessDiscoveryCheck() {
 	// Skipping due to flakiness
 	// Responses with more than 100 processes end up being chunked, which fails JSON unmarshalling
-
+	// Fix tracked in https://datadoghq.atlassian.net/browse/PROCS-3613
+	flake.Mark(s.T())
 	check := s.Env().RemoteHost.
 		MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process_discovery --json")
 	assertManualProcessDiscoveryCheck(s.T(), check, "MsMpEng.exe")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
fixes the [broken e2e process test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/710906417) on the `6.53.x` pipeline by backporting the following [fix from 7.57](https://github.com/DataDog/datadog-agent/pull/27906)


### Motivation
trying to fix the agent 6 pipeline to be able to release agent 6 independently ([BARX-704](https://datadoghq.atlassian.net/browse/BARX-704))

### Describe how to test/QA your changes
checked that the new-e2e-process test is passing 
[example of successful job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/713620345)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[BARX-704]: https://datadoghq.atlassian.net/browse/BARX-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ