### PR TITLE
ensure remote tagger do not block when starting

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -186,15 +186,6 @@ func (t *remoteTagger) Start(ctx context.Context) error {
 
 	t.client = pb.NewAgentSecureClient(t.conn)
 
-	err = t.startTaggerStream(noTimeout)
-	if err != nil {
-		// tagger stopped before being connected
-		if errors.Is(err, errTaggerStreamNotStarted) {
-			return nil
-		}
-		return err
-	}
-
 	t.log.Info("remote tagger initialized successfully")
 
 	go t.run()

--- a/comp/core/tagger/impl-remote/remote_test.go
+++ b/comp/core/tagger/impl-remote/remote_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package remotetaggerimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+)
+
+func TestStart(t *testing.T) {
+	grpcServer, authToken, err := grpc.NewMockGrpcSecureServer("5001")
+	require.NoError(t, err)
+	defer grpcServer.Stop()
+
+	params := tagger.RemoteParams{
+		RemoteFilter: types.NewMatchAllFilter(),
+		RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
+		RemoteTokenFetcher: func(config.Component) func() (string, error) {
+			return func() (string, error) {
+				return authToken, nil
+			}
+		},
+	}
+
+	cfg := configmock.New(t)
+	log := logmock.New(t)
+	telemetry := nooptelemetry.GetCompatComponent()
+
+	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	require.NoError(t, err)
+	err = remoteTagger.Start(context.TODO())
+	require.NoError(t, err)
+	remoteTagger.Stop()
+}
+
+func TestStartDoNotBlockIfServerIsNotAvailable(t *testing.T) {
+	params := tagger.RemoteParams{
+		RemoteFilter: types.NewMatchAllFilter(),
+		RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
+		RemoteTokenFetcher: func(config.Component) func() (string, error) {
+			return func() (string, error) {
+				return "something", nil
+			}
+		},
+	}
+
+	cfg := configmock.New(t)
+	log := logmock.New(t)
+	telemetry := nooptelemetry.GetCompatComponent()
+
+	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	require.NoError(t, err)
+	err = remoteTagger.Start(context.TODO())
+	require.NoError(t, err)
+	remoteTagger.Stop()
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ensure the remote tagger do not block during the boot process of the application

### Motivation

The function `startTaggerStream` was called twice. One in the `Start` function, and another time in the `run` function in a separate Go routine.

The problem is that if the first call to `startTaggerStream` inside the `Start` function is not able to connect to the server it will block the boot process forever. Since we already call `startTaggerStream` inside the `run` function on a separate goroutine and in a loop we can safely remove the call to `startTaggerStream` inside the `Start` function.

Code for the `run` function:

```go
func (t *remoteTagger) run() {
	for {
		select {
		case <-t.telemetryTicker.C:
			t.store.collectTelemetry()
			continue
		case <-t.ctx.Done():
			return
		default:
		}

		if t.stream == nil {
			if err := t.startTaggerStream(noTimeout); err != nil {
				t.log.Warnf("error received trying to start stream with target %q: %s", t.options.Target, err)
				continue
			}
		}

		var response *pb.StreamTagsResponse
		err := grpcutil.DoWithTimeout(func() error {
			var err error
			response, err = t.stream.Recv()
			return err
		}, streamRecvTimeout)
		if err != nil {
			t.streamCancel()

			t.telemetryStore.ClientStreamErrors.Inc()

			// when Recv() returns an error, the stream is aborted
			// and the contents of our store are considered out of
			// sync and therefore no longer valid, so the tagger
			// can no longer be considered ready, and the stream
			// must be re-established.
			t.ready = false
			t.stream = nil

			t.log.Warnf("error received from remote tagger: %s", err)

			continue
		}

		t.telemetryStore.Receives.Inc()

		err = t.processResponse(response)
		if err != nil {
			t.log.Warnf("error processing event received from remote tagger: %s", err)
			continue
		}
	}
}
```


### Describe how to test/QA your changes

Added naive unit tests that test the main thread is not blocked

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->