### PR TITLE
[CWS] small optimization to the user path computation on windows

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -761,7 +761,13 @@ func (wp *WindowsProbe) convertDrivePath(devicefilename string) (string, error) 
 	pathchunks := strings.SplitN(devicefilename, "\\", 4)
 	if len(pathchunks) > 2 {
 		if strings.EqualFold(pathchunks[1], "device") {
-			pathchunks[2] = wp.volumeMap[strings.ToLower(pathchunks[2])]
+			// first try a direct match, to avoid the `strings.ToLower` call
+			replaced, ok := wp.volumeMap[pathchunks[2]]
+			if !ok {
+				// then try a case insensitive match
+				replaced = wp.volumeMap[strings.ToLower(pathchunks[2])]
+			}
+			pathchunks[2] = replaced
 			return filepath.Join(pathchunks[2:]...), nil
 		}
 	}
@@ -823,7 +829,9 @@ func (wp *WindowsProbe) initializeVolumeMap() error {
 				if len(paths) > 2 {
 					// the \Device leads to the first entry being empty
 					if strings.EqualFold(paths[1], "device") {
-						wp.volumeMap[strings.ToLower(paths[2])] = drive
+						device := paths[2]
+						wp.volumeMap[device] = drive                  // device as-is for direct match
+						wp.volumeMap[strings.ToLower(device)] = drive // lower case for slower fallback
 					}
 				}
 			}

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -758,7 +758,7 @@ func (wp *WindowsProbe) parseNameDeleteArgs(e *etw.DDEventRecord) (*nameDeleteAr
 // nolint: unused
 func (wp *WindowsProbe) convertDrivePath(devicefilename string) (string, error) {
 	// filepath doesn't seem to like the \Device\HarddiskVolume1 format
-	pathchunks := strings.Split(devicefilename, "\\")
+	pathchunks := strings.SplitN(devicefilename, "\\", 4)
 	if len(pathchunks) > 2 {
 		if strings.EqualFold(pathchunks[1], "device") {
 			pathchunks[2] = wp.volumeMap[strings.ToLower(pathchunks[2])]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

For every windows event, we try to compute the user path from the device path. This is memory intensive (because of case insensitiveness and because we need to allocate yet another string).

### Motivation

### Describe how to test/QA your changes

code is unit tested

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->