### PR TITLE
fix(installer): Forward hostname from daemon to installer

### DIFF
--- a/pkg/fleet/env/env_test.go
+++ b/pkg/fleet/env/env_test.go
@@ -37,7 +37,8 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationNotSet,
 				},
-				Tags: []string{},
+				Tags:     []string{},
+				Hostname: "",
 			},
 		},
 		{
@@ -68,6 +69,7 @@ func TestFromEnv(t *testing.T) {
 				envAgentUserName:                              "customuser",
 				envTags:                                       "k1:v1,k2:v2",
 				envExtraTags:                                  "k3:v3,k4:v4",
+				envHostname:                                   "hostname",
 			},
 			expected: &Env{
 				APIKey:               "123456",
@@ -111,7 +113,8 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationEnabledAll,
 				},
-				Tags: []string{"k1:v1", "k2:v2", "k3:v3", "k4:v4"},
+				Tags:     []string{"k1:v1", "k2:v2", "k3:v3", "k4:v4"},
+				Hostname: "hostname",
 			},
 		},
 		{
@@ -167,6 +170,7 @@ func TestFromEnv(t *testing.T) {
 				DefaultPackagesInstallOverride: map[string]bool{},
 				DefaultPackagesVersionOverride: map[string]string{},
 				Tags:                           []string{},
+				Hostname:                       "",
 			},
 		},
 	}
@@ -234,7 +238,8 @@ func TestToEnv(t *testing.T) {
 					"dotnet": "latest",
 					"ruby":   "1.2",
 				},
-				Tags: []string{"k1:v1", "k2:v2"},
+				Tags:     []string{"k1:v1", "k2:v2"},
+				Hostname: "hostname",
 			},
 			expected: []string{
 				"DD_API_KEY=123456",
@@ -259,6 +264,7 @@ func TestToEnv(t *testing.T) {
 				"DD_INSTALLER_DEFAULT_PKG_VERSION_PACKAGE=1.2.3",
 				"DD_INSTALLER_DEFAULT_PKG_VERSION_ANOTHER_PACKAGE=4.5.6",
 				"DD_TAGS=k1:v1,k2:v2",
+				"DD_HOSTNAME=hostname",
 			},
 		},
 	}

--- a/pkg/fleet/internal/cdn/cdn_http.go
+++ b/pkg/fleet/internal/cdn/cdn_http.go
@@ -23,6 +23,7 @@ type cdnHTTP struct {
 	client              *remoteconfig.HTTPClient
 	currentRootsVersion uint64
 	hostTagsGetter      hostTagsGetter
+	env                 *env.Env
 }
 
 func newCDNHTTP(env *env.Env, configDBPath string) (CDN, error) {
@@ -39,6 +40,7 @@ func newCDNHTTP(env *env.Env, configDBPath string) (CDN, error) {
 		client:              client,
 		currentRootsVersion: 1,
 		hostTagsGetter:      newHostTagsGetter(env),
+		env:                 env,
 	}, nil
 }
 
@@ -134,6 +136,6 @@ func (c *cdnHTTP) get(ctx context.Context) ([][]byte, error) {
 
 	return getOrderedScopedLayers(
 		files,
-		getScopeExprVars(ctx, c.hostTagsGetter),
+		getScopeExprVars(c.env, c.hostTagsGetter),
 	)
 }

--- a/pkg/fleet/internal/cdn/cdn_rc.go
+++ b/pkg/fleet/internal/cdn/cdn_rc.go
@@ -32,6 +32,7 @@ type cdnRC struct {
 	configDBPath        string
 	firstRequest        bool
 	hostTagsGetter      hostTagsGetter
+	env                 *env.Env
 }
 
 // newCDNRC creates a new CDN with RC: it fetches the configuration from the remote config service instead of cloudfront
@@ -86,6 +87,7 @@ func newCDNRC(env *env.Env, configDBPath string) (CDN, error) {
 		configDBPath:        configDBPathTemp,
 		firstRequest:        true,
 		hostTagsGetter:      ht,
+		env:                 env,
 	}
 	service.Start()
 	return cdn, nil
@@ -192,7 +194,7 @@ func (c *cdnRC) get(ctx context.Context) ([][]byte, error) {
 	}
 	return getOrderedScopedLayers(
 		files,
-		getScopeExprVars(ctx, c.hostTagsGetter),
+		getScopeExprVars(c.env, c.hostTagsGetter),
 	)
 }
 

--- a/pkg/fleet/internal/cdn/scope_expression.go
+++ b/pkg/fleet/internal/cdn/scope_expression.go
@@ -6,12 +6,11 @@
 package cdn
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
 
-	pkghostname "github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/fleet/env"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/expr-lang/expr"
 )
@@ -112,14 +111,9 @@ func getOrderedScopedLayers(configs map[string][]byte, env map[string]interface{
 	return layers, nil
 }
 
-func getScopeExprVars(ctx context.Context, hostTagsGetter hostTagsGetter) map[string]interface{} {
-	// TODO(baptiste): This should be passed from the daemon to the executable like tags
-	hostname, err := pkghostname.Get(ctx)
-	if err != nil {
-		hostname = "unknown"
-	}
+func getScopeExprVars(env *env.Env, hostTagsGetter hostTagsGetter) map[string]interface{} {
 	return map[string]interface{}{
-		"hostname":          hostname,
+		"hostname":          env.Hostname,
 		"installer_version": version.AgentVersion, // AgentVersion evaluates to the installer version here
 
 		"tags": hostTagsGetter.get(),


### PR DESCRIPTION
### What does this PR do?
Forward hostname from installer daemon to installer binary

### Motivation

### Describe how to test/QA your changes
Tested manually on a VM, hostname is indeed used in the CDN

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->