### PR TITLE
Don't build containers based on debian packages

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -33,7 +33,7 @@
 # context
 .docker_build_artifact:
   before_script:
-    - mv $OMNIBUS_PACKAGE_DIR/*.deb $BUILD_CONTEXT
+    - mv $OMNIBUS_PACKAGE_DIR/*.xz $BUILD_CONTEXT
 
 .docker_build_job_definition_amd64:
   extends: .docker_build_job_definition
@@ -56,12 +56,12 @@ docker_build_agent7:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: agent_deb-x64-a7
+    - job: datadog-agent-7-x64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
+    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
 
 single_machine_performance-amd64-a7:
   extends: .docker_publish_job_definition
@@ -82,12 +82,12 @@ docker_build_agent7_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: agent_deb-arm64-a7
+    - job: datadog-agent-7-arm64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
+    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
@@ -96,12 +96,12 @@ docker_build_agent7_jmx:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: agent_deb-x64-a7
+    - job: datadog-agent-7-x64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
 
 docker_build_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -109,12 +109,12 @@ docker_build_agent7_jmx_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: agent_deb-arm64-a7
+    - job: datadog-agent-7-arm64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
 
 # build agent7 UA image
 docker_build_ot_agent7:
@@ -123,12 +123,12 @@ docker_build_ot_agent7:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: ot_agent_deb-x64-a7
+    - job: datadog-ot-agent-7-x64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_amd64.deb
+    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
 
 docker_build_ot_agent7_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -136,12 +136,12 @@ docker_build_ot_agent7_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: ot_agent_deb-arm64-a7
+    - job: datadog-ot-agent-7-arm64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_arm64.deb
+    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
 
 # build agent7 jmx image
 docker_build_ot_agent7_jmx:
@@ -150,12 +150,12 @@ docker_build_ot_agent7_jmx:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: ot_agent_deb-x64-a7
+    - job: datadog-ot-agent-7-x64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_amd64.deb
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
 
 docker_build_ot_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -163,12 +163,12 @@ docker_build_ot_agent7_jmx_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   needs:
-    - job: ot_agent_deb-arm64-a7
+    - job: datadog-ot-agent-7-arm64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent_7*_arm64.deb
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
 
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /output
 ENV S6_VERSION="v2.2.0.3"
 ENV JUST_CONTAINERS_DOWNLOAD_LOCATION=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL:+${GENERAL_ARTIFACTS_CACHE_BUCKET_URL}/s6-overlay}
 ENV JUST_CONTAINERS_DOWNLOAD_LOCATION=${JUST_CONTAINERS_DOWNLOAD_LOCATION:-https://github.com/just-containers/s6-overlay/releases/download}
-RUN apt install --no-install-recommends -y curl ca-certificates maven
+RUN apt install --no-install-recommends -y curl ca-certificates maven xz-utils
 RUN S6ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "amd64" || echo "aarch64") && curl -L ${JUST_CONTAINERS_DOWNLOAD_LOCATION}/${S6_VERSION}/s6-overlay-${S6ARCH}.tar.gz -o /output/s6.tgz
 COPY s6.$TARGETARCH.sha256 /output/s6.$TARGETARCH.sha256
 # To calculate S6_SHA256SUM for a specific version, run:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -40,7 +40,7 @@ FROM baseimage AS extract
 ARG TARGETARCH
 ARG WITH_JMX
 ARG PYTHON_VERSION
-ARG DD_AGENT_ARTIFACT=datadog-agent*_$TARGETARCH.deb
+ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
 ARG GENERAL_ARTIFACTS_CACHE_BUCKET_URL
 
 # copy everything - globbing with args wont work
@@ -65,9 +65,9 @@ RUN echo "$(cat /output/s6.$TARGETARCH.sha256) /output/s6.tgz" | sha256sum -c - 
 #   - static libraries                   # FIXME: move upstream
 #   - jmxfetch on nojmx build
 
-RUN find / -maxdepth 1 -type f -name "datadog-*_$TARGETARCH.deb" ! -name "$DD_AGENT_ARTIFACT" -exec rm {} \;
+RUN find / -maxdepth 1 -type f -name "datadog-*-$TARGETARCH.tar.xz" ! -name "$DD_AGENT_ARTIFACT" -exec rm {} \;
 
-RUN find / -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec dpkg -x {} . \; \
+RUN find / -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
  && rm -rf usr etc/init lib \
     opt/datadog-agent/sources \
     opt/datadog-agent/embedded/share/doc \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -69,6 +69,7 @@ RUN find / -maxdepth 1 -type f -name "datadog-*-$TARGETARCH.tar.xz" ! -name "$DD
 
 RUN find / -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
  && rm -rf usr etc/init lib \
+    go/ \
     opt/datadog-agent/sources \
     opt/datadog-agent/embedded/share/doc \
     opt/datadog-agent/embedded/share/man \

--- a/omnibus/config/software/datadog-agent-prepare.rb
+++ b/omnibus/config/software/datadog-agent-prepare.rb
@@ -16,7 +16,6 @@ build do
     %w{embedded/lib embedded/bin embedded/etc bin}.each do |dir|
       dir_fullpath = File.expand_path(File.join(install_dir, dir))
       FileUtils.mkdir_p(dir_fullpath)
-      FileUtils.touch(File.join(dir_fullpath, ".gitkeep"))
     end
 
     # Add a README for the embedded environment's configuration folder


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Instead of relying on the debian package only to extract it, we can use the unpackaged build artifact and extract it directly.

### Motivation

This makes the container based jobs (and their dependencies) start about 3.5 minutes earlier, which is a nice little improvement.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->