### PR TITLE
Revert "[NPM] Allow safely overriding connections check interval"

### DIFF
--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -82,12 +82,6 @@ const (
 
 	// DefaultProcessDiscoveryHintFrequency is the default frequency in terms of number of checks which we send a process discovery hint
 	DefaultProcessDiscoveryHintFrequency = 60
-
-	// DefaultConnectionsMinCheckInterval is the minimum interval allowed for the connections check
-	DefaultConnectionsMinCheckInterval = 5 * time.Second
-
-	// DefaultConnectionsMaxCheckInterval is the maximum interval allowed for the connections check
-	DefaultConnectionsMaxCheckInterval = 5 * time.Minute
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -178,7 +172,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 		"DD_PROCESS_ADDITIONAL_ENDPOINTS",
 	)
 	procBindEnvAndSetDefault(config, "process_config.events_additional_endpoints", make(map[string][]string))
-	procBindEnvAndSetDefault(config, "process_config.intervals.connections", 30*time.Second)
+	config.SetKnown("process_config.intervals.connections")
 	procBindEnvAndSetDefault(config, "process_config.expvar_port", DefaultProcessExpVarPort)
 	procBindEnvAndSetDefault(config, "process_config.log_file", DefaultProcessAgentLogFile)
 	procBindEnvAndSetDefault(config, "process_config.internal_profiling.enabled", false)

--- a/pkg/process/checks/interval.go
+++ b/pkg/process/checks/interval.go
@@ -23,6 +23,8 @@ const (
 	//nolint:revive // TODO(PROC) Fix revive linter
 	RTContainerCheckDefaultInterval = 2 * time.Second
 	//nolint:revive // TODO(PROC) Fix revive linter
+	ConnectionsCheckDefaultInterval = 30 * time.Second
+	//nolint:revive // TODO(PROC) Fix revive linter
 	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
 
 	discoveryMinInterval = 10 * time.Minute
@@ -36,6 +38,7 @@ const (
 	configRTProcessInterval   = configIntervals + "process_realtime"
 	configContainerInterval   = configIntervals + "container"
 	configRTContainerInterval = configIntervals + "container_realtime"
+	configConnectionsInterval = configIntervals + "connections"
 )
 
 var (
@@ -44,6 +47,7 @@ var (
 		RTProcessCheckName:     RTProcessCheckDefaultInterval,
 		ContainerCheckName:     ContainerCheckDefaultInterval,
 		RTContainerCheckName:   RTContainerCheckDefaultInterval,
+		ConnectionsCheckName:   ConnectionsCheckDefaultInterval,
 		DiscoveryCheckName:     ProcessDiscoveryCheckDefaultInterval,
 		ProcessEventsCheckName: pkgconfigsetup.DefaultProcessEventsCheckInterval,
 	}
@@ -53,6 +57,7 @@ var (
 		RTProcessCheckName:   configRTProcessInterval,
 		ContainerCheckName:   configContainerInterval,
 		RTContainerCheckName: configRTContainerInterval,
+		ConnectionsCheckName: configConnectionsInterval,
 	}
 )
 
@@ -82,21 +87,6 @@ func GetInterval(cfg pkgconfigmodel.Reader, checkName string) time.Duration {
 				pkgconfigsetup.DefaultProcessEventsMinCheckInterval.String(), pkgconfigsetup.DefaultProcessEventsCheckInterval.String())
 		}
 		return eventsInterval
-	case ConnectionsCheckName:
-		connectionsInterval := cfg.GetDuration("process_config.intervals.connections")
-		minInterval := pkgconfigsetup.DefaultConnectionsMinCheckInterval
-		if connectionsInterval < minInterval {
-			connectionsInterval = minInterval
-			_ = log.Warnf("Invalid interval for connections check (< %s) using default value of %s",
-				minInterval.String(), minInterval.String())
-		}
-		maxInterval := pkgconfigsetup.DefaultConnectionsMaxCheckInterval
-		if connectionsInterval > maxInterval {
-			connectionsInterval = maxInterval
-			_ = log.Warnf("Invalid interval for connections check (> %s) using default value of %s",
-				maxInterval.String(), maxInterval.String())
-		}
-		return connectionsInterval
 
 	default:
 		defaultInterval := defaultIntervals[checkName]

--- a/pkg/process/checks/interval_test.go
+++ b/pkg/process/checks/interval_test.go
@@ -41,6 +41,11 @@ func TestLegacyIntervalDefault(t *testing.T) {
 			checkName:        RTProcessCheckName,
 			expectedInterval: RTProcessCheckDefaultInterval,
 		},
+		{
+			name:             "connections default",
+			checkName:        ConnectionsCheckName,
+			expectedInterval: ConnectionsCheckDefaultInterval,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := configmock.New(t)
@@ -76,6 +81,11 @@ func TestLegacyIntervalOverride(t *testing.T) {
 			name:      "process rt default",
 			setting:   "process_config.intervals.process_realtime",
 			checkName: RTProcessCheckName,
+		},
+		{
+			name:      "connections default",
+			setting:   "process_config.intervals.connections",
+			checkName: ConnectionsCheckName,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,39 +147,4 @@ func TestProcessEventsInterval(t *testing.T) {
 			assert.Equal(t, tc.expectedInterval, GetInterval(cfg, ProcessEventsCheckName))
 		})
 	}
-}
-
-func TestConnectionsInterval(t *testing.T) {
-	for _, tc := range []struct {
-		name             string
-		interval         time.Duration
-		expectedInterval time.Duration
-	}{
-		{
-			name:             "allowed interval",
-			interval:         2 * time.Minute,
-			expectedInterval: 2 * time.Minute,
-		},
-		{
-			name:             "below minimum",
-			interval:         0,
-			expectedInterval: pkgconfigsetup.DefaultConnectionsMinCheckInterval,
-		},
-		{
-			name:             "above maximum",
-			interval:         2 * time.Hour,
-			expectedInterval: pkgconfigsetup.DefaultConnectionsMaxCheckInterval,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := configmock.New(t)
-			cfg.SetWithoutSource("process_config.intervals.connections", tc.interval)
-
-			assert.Equal(t, tc.expectedInterval, GetInterval(cfg, ConnectionsCheckName))
-		})
-	}
-	t.Run("default", func(t *testing.T) {
-		cfg := configmock.New(t)
-		assert.Equal(t, 30*time.Second, GetInterval(cfg, ConnectionsCheckName))
-	})
 }


### PR DESCRIPTION
Reverts DataDog/datadog-agent#31044

This change actually changed the type of the config which will make testing changing the interval difficult depending on which version is running. I'm going to rework it so it's still passed as an integer in seconds (old) instead of a duration (new)