### PR TITLE
Fix large number of active session history rows

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -216,7 +216,7 @@ func sendPayload(c *Check, sessionRows []OracleActivityRow, timestamp float64) e
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) SampleSession() error {
 	activeSessionHistory := c.config.QuerySamples.ActiveSessionHistory
-	if activeSessionHistory && c.lastSampleId == 0 {
+	if activeSessionHistory {
 		err := getWrapper(c, &c.lastSampleId, "SELECT /* DD */ MAX(sample_id) FROM v$active_session_history")
 		return err
 	}

--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -20,121 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ActivitySnapshot is a payload containing database activity samples. It is parsed from the intake payload.
-// easyjson:json
-type ActivitySnapshot struct {
-	Metadata
-	// Tags should be part of the common Metadata struct but because Activity payloads use a string array
-	// and samples use a comma-delimited list of tags in a single string, both flavors have to be handled differently
-	Tags               []string            `json:"ddtags,omitempty"`
-	CollectionInterval float64             `json:"collection_interval,omitempty"`
-	OracleActivityRows []OracleActivityRow `json:"oracle_activity,omitempty"`
-}
-
-//nolint:revive // TODO(DBM) Fix revive linter
-type RowMetadata struct {
-	Commands       []string `json:"dd_commands,omitempty"`
-	Tables         []string `json:"dd_tables,omitempty"`
-	Comments       []string `json:"dd_comments,omitempty"`
-	QueryTruncated string   `json:"query_truncated,omitempty"`
-}
-
-// Metadata contains the metadata fields common to all events processed
-type Metadata struct {
-	Timestamp      float64 `json:"timestamp,omitempty"`
-	Host           string  `json:"host,omitempty"`
-	Source         string  `json:"ddsource,omitempty"`
-	DBMType        string  `json:"dbm_type,omitempty"`
-	DDAgentVersion string  `json:"ddagentversion,omitempty"`
-}
-
-//nolint:revive // TODO(DBM) Fix revive linter
-type OracleSQLRow struct {
-	SQLID                  string `json:"sql_id,omitempty"`
-	ForceMatchingSignature uint64 `json:"force_matching_signature,omitempty"`
-	SQLPlanHashValue       uint64 `json:"sql_plan_hash_value,omitempty"`
-	SQLExecStart           string `json:"sql_exec_start,omitempty"`
-}
-
-//nolint:revive // TODO(DBM) Fix revive linter
-type OracleActivityRow struct {
-	Now           string `json:"now"`
-	SessionID     uint64 `json:"sid,omitempty"`
-	SessionSerial uint64 `json:"serial,omitempty"`
-	User          string `json:"user,omitempty"`
-	Status        string `json:"status"`
-	OsUser        string `json:"os_user,omitempty"`
-	Process       string `json:"process,omitempty"`
-	Client        string `json:"client,omitempty"`
-	Port          string `json:"port,omitempty"`
-	Program       string `json:"program,omitempty"`
-	Type          string `json:"type,omitempty"`
-	OracleSQLRow
-	Module                string `json:"module,omitempty"`
-	Action                string `json:"action,omitempty"`
-	ClientInfo            string `json:"client_info,omitempty"`
-	LogonTime             string `json:"logon_time,omitempty"`
-	ClientIdentifier      string `json:"client_identifier,omitempty"`
-	BlockingInstance      uint64 `json:"blocking_instance,omitempty"`
-	BlockingSession       uint64 `json:"blocking_session,omitempty"`
-	FinalBlockingInstance uint64 `json:"final_blocking_instance,omitempty"`
-	FinalBlockingSession  uint64 `json:"final_blocking_session,omitempty"`
-	WaitEvent             string `json:"wait_event,omitempty"`
-	WaitEventClass        string `json:"wait_event_class,omitempty"`
-	WaitTimeMicro         uint64 `json:"wait_time_micro,omitempty"`
-	Statement             string `json:"statement,omitempty"`
-	PdbName               string `json:"pdb_name,omitempty"`
-	CdbName               string `json:"cdb_name,omitempty"`
-	QuerySignature        string `json:"query_signature,omitempty"`
-	CommandName           string `json:"command_name,omitempty"`
-	PreviousSQL           bool   `json:"previous_sql,omitempty"`
-	OpFlags               uint64 `json:"op_flags,omitempty"`
-	RowMetadata
-}
-
-//nolint:revive // TODO(DBM) Fix revive linter
-type OracleActivityRowDB struct {
-	Now                        string         `db:"NOW"`
-	UtcMs                      float64        `db:"UTC_MS"`
-	SessionID                  uint64         `db:"SID"`
-	SessionSerial              uint64         `db:"SERIAL#"`
-	User                       sql.NullString `db:"USERNAME"`
-	Status                     string         `db:"STATUS"`
-	OsUser                     sql.NullString `db:"OSUSER"`
-	Process                    sql.NullString `db:"PROCESS"`
-	Client                     sql.NullString `db:"MACHINE"`
-	Port                       sql.NullInt64  `db:"PORT"`
-	Program                    sql.NullString `db:"PROGRAM"`
-	Type                       sql.NullString `db:"TYPE"`
-	SQLID                      sql.NullString `db:"SQL_ID"`
-	ForceMatchingSignature     *string        `db:"FORCE_MATCHING_SIGNATURE"`
-	SQLPlanHashValue           *uint64        `db:"SQL_PLAN_HASH_VALUE"`
-	SQLExecStart               sql.NullString `db:"SQL_EXEC_START"`
-	SQLAddress                 sql.NullString `db:"SQL_ADDRESS"`
-	PrevSQLID                  sql.NullString `db:"PREV_SQL_ID"`
-	PrevForceMatchingSignature *string        `db:"PREV_FORCE_MATCHING_SIGNATURE"`
-	PrevSQLPlanHashValue       *uint64        `db:"PREV_SQL_PLAN_HASH_VALUE"`
-	PrevSQLExecStart           sql.NullString `db:"PREV_SQL_EXEC_START"`
-	PrevSQLAddress             sql.NullString `db:"PREV_SQL_ADDRESS"`
-	Module                     sql.NullString `db:"MODULE"`
-	Action                     sql.NullString `db:"ACTION"`
-	ClientInfo                 sql.NullString `db:"CLIENT_INFO"`
-	LogonTime                  sql.NullString `db:"LOGON_TIME"`
-	ClientIdentifier           sql.NullString `db:"CLIENT_IDENTIFIER"`
-	OpFlags                    uint64         `db:"OP_FLAGS"`
-	BlockingInstance           *uint64        `db:"BLOCKING_INSTANCE"`
-	BlockingSession            *uint64        `db:"BLOCKING_SESSION"`
-	FinalBlockingInstance      *uint64        `db:"FINAL_BLOCKING_INSTANCE"`
-	FinalBlockingSession       *uint64        `db:"FINAL_BLOCKING_SESSION"`
-	WaitEvent                  sql.NullString `db:"EVENT"`
-	WaitEventClass             sql.NullString `db:"WAIT_CLASS"`
-	WaitTimeMicro              *uint64        `db:"WAIT_TIME_MICRO"`
-	Statement                  sql.NullString `db:"SQL_FULLTEXT"`
-	PrevSQLFullText            sql.NullString `db:"PREV_SQL_FULLTEXT"`
-	PdbName                    sql.NullString `db:"PDB_NAME"`
-	CommandName                sql.NullString `db:"COMMAND_NAME"`
-}
-
 // Converts sql types to Go native types
 func (c *Check) getSQLRow(SQLID sql.NullString, forceMatchingSignature *string, SQLPlanHashValue *uint64, SQLExecStart sql.NullString) (OracleSQLRow, error) {
 	SQLRow := OracleSQLRow{}
@@ -216,9 +101,15 @@ func sendPayload(c *Check, sessionRows []OracleActivityRow, timestamp float64) e
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) SampleSession() error {
 	activeSessionHistory := c.config.QuerySamples.ActiveSessionHistory
-	if activeSessionHistory {
-		err := getWrapper(c, &c.lastSampleId, "SELECT /* DD */ MAX(sample_id) FROM v$active_session_history")
-		return err
+	if activeSessionHistory && c.lastSampleID == 0 {
+		err := getWrapper(c, &c.lastSampleID, "SELECT /* DD */ NVL(MAX(sample_id),0) FROM v$active_session_history")
+		if err != nil {
+			return err
+		}
+		if c.lastSampleID == 0 {
+			log.Infof("%s no active session history samples found", c.logPrompt)
+			return nil
+		}
 	}
 	start := time.Now()
 	copy(c.lastOracleActivityRows, []OracleActivityRow{})
@@ -250,7 +141,7 @@ AND status = 'ACTIVE'`)
 
 	var err error
 	if activeSessionHistory {
-		err = selectWrapper(c, &sessionSamples, activityQuery, maxSQLTextLength, c.lastSampleId)
+		err = selectWrapper(c, &sessionSamples, activityQuery, maxSQLTextLength, c.lastSampleID)
 	} else {
 		err = selectWrapper(c, &sessionSamples, activityQuery, maxSQLTextLength, maxSQLTextLength)
 	}
@@ -272,6 +163,10 @@ AND status = 'ACTIVE'`)
 	var lastNow string
 	for _, sample := range sessionSamples {
 		var sessionRow OracleActivityRow
+
+		if activeSessionHistory && sample.SampleID > c.lastSampleID {
+			c.lastSampleID = sample.SampleID
+		}
 
 		sessionRow.Now = sample.Now
 		if lastNow != sessionRow.Now && lastNow != "" {

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -114,6 +114,11 @@ func TestActiveSessionHistory(t *testing.T) {
 	c, _ := newDefaultCheck(t, "", "")
 	defer c.Teardown()
 
+	var count uint64
+	getWrapper(&c, &count, "SELECT BANNER FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
+	if count == 0 {
+		t.Skip("Active Session History is only available in Oracle Enterprise Edition")
+	}
 	c.dbmEnabled = true
 	c.config.QuerySamples.ActiveSessionHistory = true
 
@@ -122,7 +127,7 @@ func TestActiveSessionHistory(t *testing.T) {
 
 	err = c.SampleSession()
 	require.NoError(t, err, "activity sample failed")
-	prevSamplId := c.lastSampleId
+	prevSamplId := c.lastSampleID
 
 	conn, err := getSysConnection(t)
 	require.NoError(t, err)
@@ -146,5 +151,5 @@ END;`
 	err = c.SampleSession()
 	require.NoError(t, err, "activity sample failed")
 
-	assert.Greater(t, c.lastSampleId, prevSamplId, "sample id should have increased")
+	assert.Greater(t, c.lastSampleID, prevSamplId, "sample id should have increased")
 }

--- a/pkg/collector/corechecks/oracle/activity_queries.go
+++ b/pkg/collector/corechecks/oracle/activity_queries.go
@@ -220,6 +220,7 @@ AND s.command = comm.command_type(+)`
 const activityQueryActiveSessionHistory = `SELECT /*+ push_pred(sq) */ /* DD_ACTIVITY_SAMPLING */
 	cast (sample_time as date) now,
 	(CAST(sample_time_utc AS DATE) - TO_DATE('1970-01-01', 'YYYY-MM-DD')) * 86400000 as utc_ms,
+	s.sample_id sample_id,
 	s.session_id sid,
 	s.session_serial# serial#,
 	sess.username,

--- a/pkg/collector/corechecks/oracle/activity_structs.go
+++ b/pkg/collector/corechecks/oracle/activity_structs.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import "database/sql"
+
+// ActivitySnapshot is a payload containing database activity samples. It is parsed from the intake payload.
+// easyjson:json
+type ActivitySnapshot struct {
+	Metadata
+	// Tags should be part of the common Metadata struct but because Activity payloads use a string array
+	// and samples use a comma-delimited list of tags in a single string, both flavors have to be handled differently
+	Tags               []string            `json:"ddtags,omitempty"`
+	CollectionInterval float64             `json:"collection_interval,omitempty"`
+	OracleActivityRows []OracleActivityRow `json:"oracle_activity,omitempty"`
+}
+
+//nolint:revive // TODO(DBM) Fix revive linter
+type RowMetadata struct {
+	Commands       []string `json:"dd_commands,omitempty"`
+	Tables         []string `json:"dd_tables,omitempty"`
+	Comments       []string `json:"dd_comments,omitempty"`
+	QueryTruncated string   `json:"query_truncated,omitempty"`
+}
+
+// Metadata contains the metadata fields common to all events processed
+type Metadata struct {
+	Timestamp      float64 `json:"timestamp,omitempty"`
+	Host           string  `json:"host,omitempty"`
+	Source         string  `json:"ddsource,omitempty"`
+	DBMType        string  `json:"dbm_type,omitempty"`
+	DDAgentVersion string  `json:"ddagentversion,omitempty"`
+}
+
+//nolint:revive // TODO(DBM) Fix revive linter
+type OracleSQLRow struct {
+	SQLID                  string `json:"sql_id,omitempty"`
+	ForceMatchingSignature uint64 `json:"force_matching_signature,omitempty"`
+	SQLPlanHashValue       uint64 `json:"sql_plan_hash_value,omitempty"`
+	SQLExecStart           string `json:"sql_exec_start,omitempty"`
+}
+
+//nolint:revive // TODO(DBM) Fix revive linter
+type OracleActivityRow struct {
+	Now           string `json:"now"`
+	SessionID     uint64 `json:"sid,omitempty"`
+	SessionSerial uint64 `json:"serial,omitempty"`
+	User          string `json:"user,omitempty"`
+	Status        string `json:"status"`
+	OsUser        string `json:"os_user,omitempty"`
+	Process       string `json:"process,omitempty"`
+	Client        string `json:"client,omitempty"`
+	Port          string `json:"port,omitempty"`
+	Program       string `json:"program,omitempty"`
+	Type          string `json:"type,omitempty"`
+	OracleSQLRow
+	Module                string `json:"module,omitempty"`
+	Action                string `json:"action,omitempty"`
+	ClientInfo            string `json:"client_info,omitempty"`
+	LogonTime             string `json:"logon_time,omitempty"`
+	ClientIdentifier      string `json:"client_identifier,omitempty"`
+	BlockingInstance      uint64 `json:"blocking_instance,omitempty"`
+	BlockingSession       uint64 `json:"blocking_session,omitempty"`
+	FinalBlockingInstance uint64 `json:"final_blocking_instance,omitempty"`
+	FinalBlockingSession  uint64 `json:"final_blocking_session,omitempty"`
+	WaitEvent             string `json:"wait_event,omitempty"`
+	WaitEventClass        string `json:"wait_event_class,omitempty"`
+	WaitTimeMicro         uint64 `json:"wait_time_micro,omitempty"`
+	Statement             string `json:"statement,omitempty"`
+	PdbName               string `json:"pdb_name,omitempty"`
+	CdbName               string `json:"cdb_name,omitempty"`
+	QuerySignature        string `json:"query_signature,omitempty"`
+	CommandName           string `json:"command_name,omitempty"`
+	PreviousSQL           bool   `json:"previous_sql,omitempty"`
+	OpFlags               uint64 `json:"op_flags,omitempty"`
+	RowMetadata
+}
+
+//nolint:revive // TODO(DBM) Fix revive linter
+type OracleActivityRowDB struct {
+	SampleID                   uint64         `db:"SAMPLE_ID"`
+	Now                        string         `db:"NOW"`
+	UtcMs                      float64        `db:"UTC_MS"`
+	SessionID                  uint64         `db:"SID"`
+	SessionSerial              uint64         `db:"SERIAL#"`
+	User                       sql.NullString `db:"USERNAME"`
+	Status                     string         `db:"STATUS"`
+	OsUser                     sql.NullString `db:"OSUSER"`
+	Process                    sql.NullString `db:"PROCESS"`
+	Client                     sql.NullString `db:"MACHINE"`
+	Port                       sql.NullInt64  `db:"PORT"`
+	Program                    sql.NullString `db:"PROGRAM"`
+	Type                       sql.NullString `db:"TYPE"`
+	SQLID                      sql.NullString `db:"SQL_ID"`
+	ForceMatchingSignature     *string        `db:"FORCE_MATCHING_SIGNATURE"`
+	SQLPlanHashValue           *uint64        `db:"SQL_PLAN_HASH_VALUE"`
+	SQLExecStart               sql.NullString `db:"SQL_EXEC_START"`
+	SQLAddress                 sql.NullString `db:"SQL_ADDRESS"`
+	PrevSQLID                  sql.NullString `db:"PREV_SQL_ID"`
+	PrevForceMatchingSignature *string        `db:"PREV_FORCE_MATCHING_SIGNATURE"`
+	PrevSQLPlanHashValue       *uint64        `db:"PREV_SQL_PLAN_HASH_VALUE"`
+	PrevSQLExecStart           sql.NullString `db:"PREV_SQL_EXEC_START"`
+	PrevSQLAddress             sql.NullString `db:"PREV_SQL_ADDRESS"`
+	Module                     sql.NullString `db:"MODULE"`
+	Action                     sql.NullString `db:"ACTION"`
+	ClientInfo                 sql.NullString `db:"CLIENT_INFO"`
+	LogonTime                  sql.NullString `db:"LOGON_TIME"`
+	ClientIdentifier           sql.NullString `db:"CLIENT_IDENTIFIER"`
+	OpFlags                    uint64         `db:"OP_FLAGS"`
+	BlockingInstance           *uint64        `db:"BLOCKING_INSTANCE"`
+	BlockingSession            *uint64        `db:"BLOCKING_SESSION"`
+	FinalBlockingInstance      *uint64        `db:"FINAL_BLOCKING_INSTANCE"`
+	FinalBlockingSession       *uint64        `db:"FINAL_BLOCKING_SESSION"`
+	WaitEvent                  sql.NullString `db:"EVENT"`
+	WaitEventClass             sql.NullString `db:"WAIT_CLASS"`
+	WaitTimeMicro              *uint64        `db:"WAIT_TIME_MICRO"`
+	Statement                  sql.NullString `db:"SQL_FULLTEXT"`
+	PrevSQLFullText            sql.NullString `db:"PREV_SQL_FULLTEXT"`
+	PdbName                    sql.NullString `db:"PDB_NAME"`
+	CommandName                sql.NullString `db:"COMMAND_NAME"`
+}

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -113,7 +113,7 @@ type Check struct {
 	openMode                                string
 	legacyIntegrationCompatibilityMode      bool
 	clock                                   clock.Clock
-	lastSampleId                            uint64
+	lastSampleID                            uint64
 }
 
 type vDatabase struct {

--- a/pkg/collector/corechecks/oracle/sql/user/grants.sql
+++ b/pkg/collector/corechecks/oracle/sql/user/grants.sql
@@ -39,6 +39,7 @@ declare
     'v_$dataguard_stats',
     'v_$transaction',
     'v_$locked_object',
+    'v_$active_session_history',
     'dba_objects',
     'cdb_data_files',
     'dba_data_files'
@@ -56,9 +57,7 @@ begin
         command := 'grant select on ' || array(i) || ' to &&user with grant option';
       end if;
       begin
-         dbms_output.disable;
          execute immediate command;
-         dbms_output.enable;
       exception
          when others then
             null;

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -8,6 +8,7 @@
 package oracle
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/config"
+	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -120,6 +122,13 @@ func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
 	default:
 		return handleRealConnection(useDefaultUser)
 	}
+}
+
+func getSysConnection(t *testing.T) (*sql.DB, error) {
+	connection := getConnectData(t, useSysUser)
+	databaseUrl := go_ora.BuildUrl(connection.Server, connection.Port, connection.ServiceName, connection.Username, connection.Password, nil)
+	conn, err := sql.Open("oracle", databaseUrl)
+	return conn, err
 }
 
 func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {

--- a/releasenotes/notes/oracle-ash-many-rows-b8fe482335e392fa.yaml
+++ b/releasenotes/notes/oracle-ash-many-rows-b8fe482335e392fa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix excessive number of rows coming from active session history.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix limit when selecting active session history samples on Oracle.

### Motivation

The limit didn't work properly so the whole session history was selected.

The [feature](https://github.com/DataDog/datadog-agent/pull/28729) was introduced in `7.58.0`.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->