### PR TITLE
[CWS] fix `TestLoaderCompile` build

### DIFF
--- a/pkg/network/tracer/connection/dump.go
+++ b/pkg/network/tracer/connection/dump.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-
 func dumpMapsHandler(w io.Writer, _ *manager.Manager, mapName string, currentMap *ebpf.Map) {
 	switch mapName {
 

--- a/pkg/security/ebpf/compile_test.go
+++ b/pkg/security/ebpf/compile_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLoaderCompile(t *testing.T) {
 	ebpftest.TestBuildMode(t, ebpftest.RuntimeCompiled, "", func(t *testing.T) {
-		_, err := sysconfig.New("")
+		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 		cfg, err := config.NewConfig()
 		require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

The `TestLoaderCompile` was not building because of a missing argument to `sysconfig.New`. This PR fixes this. Please note that this test is currently not run in the CI (because of the `linux_bpf` build tag).

This PR also fixes a small gofmt issue that this fix uncovered.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->