### PR TITLE
Revert "[test-infra-definitions][automated] Bump test-infra-definitions (#31299)"

### DIFF
--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -4,4 +4,4 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: bef3516a51ab
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 7cd5e8a62570

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -60,7 +60,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20241121090639-bef3516a51ab
+	github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570
 	github.com/aws/aws-sdk-go-v2 v1.32.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.40
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.164.2

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -16,8 +16,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20241121090639-bef3516a51ab h1:abQ5giOKHmI2oC1ADgF/z3yZJhkMIiC6t+D/BDnW2+w=
-github.com/DataDog/test-infra-definitions v0.0.0-20241121090639-bef3516a51ab/go.mod h1:l0n0FQYdWWQxbI5a2EkuynRQIteUQcYOaOhdxD9TvJs=
+github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570 h1:vVkrzQIPIhgxZP+GMd+9UhILnZTj1Uf4wZlxhcDGysA=
+github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570/go.mod h1:l0n0FQYdWWQxbI5a2EkuynRQIteUQcYOaOhdxD9TvJs=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reverts #31299 (commit [8f120bb](https://github.com/DataDog/datadog-agent/commit/8f120bb64c18b60081dd15c564202dbe8564d924) on `main`).

### Motivation

It broke the [new-e2e-containers](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/715135034) job, especially the `TestKindSuite`, `TestKindSuite/TestDogstatsdInAgent` and `TestKindSuite/TestDogstatsdInAgent/metric___custom.metric` tests.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->