### PR TITLE
Add a basic e2e test JMXFetch

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -277,6 +277,7 @@ new-e2e-aml:
     - deploy_deb_testing-a7_x64
     - deploy_windows_testing-a7
     - qa_agent
+    - qa_agent_jmx
     - qa_dca
   rules:
     - !reference [.on_aml_or_e2e_changes]

--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -175,6 +175,15 @@ func (agent *agentCommandRunner) StatusWithError(commandArgs ...agentclient.Agen
 	}, err
 }
 
+// JMX run the jmx command and returns a Status struct and error
+func (agent *agentCommandRunner) JMX(commandArgs ...agentclient.AgentArgsOption) (*agentclient.Status, error) {
+	status, err := agent.executeCommandWithError("jmx", commandArgs...)
+
+	return &agentclient.Status{
+		Content: status,
+	}, err
+}
+
 // waitForReadyTimeout blocks up to timeout waiting for agent to be ready.
 // Retries every 100 ms up to timeout.
 // Returns error on failure.

--- a/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
@@ -59,6 +59,9 @@ type Agent interface {
 
 	// StatusWithError runs status command and returns a Status struct and error
 	StatusWithError(commandArgs ...AgentArgsOption) (*Status, error)
+
+	// JMX run the jmx command and returns a Status struct and error
+	JMX(commandArgs ...AgentArgsOption) (*Status, error)
 }
 
 // Status contains the Agent status content

--- a/test/new-e2e/tests/agent-metrics-logs/jmxfetch/docs.go
+++ b/test/new-e2e/tests/agent-metrics-logs/jmxfetch/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package jmxfetch contains e2e tests for the JMXFetch.
+package jmxfetch

--- a/test/new-e2e/tests/agent-metrics-logs/jmxfetch/jmxfetch_nix_test.go
+++ b/test/new-e2e/tests/agent-metrics-logs/jmxfetch/jmxfetch_nix_test.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package jmxfetch
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/docker"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/jmxfetch"
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/DataDog/test-infra-definitions/components/docker"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/docker-labels.yaml
+var jmxFetchADLabels string
+
+var jmxFetchADLabelsDockerComposeManifest = docker.ComposeInlineManifest{
+	Name:    "jmx-test-app-labels",
+	Content: pulumi.String(jmxFetchADLabels),
+}
+
+type jmxfetchNixTest struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestJMXFetchNix(t *testing.T) {
+	t.Parallel()
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(
+		awsdocker.Provisioner(
+			awsdocker.WithAgentOptions(
+				dockeragentparams.WithLogs(),
+				dockeragentparams.WithJMX(),
+				dockeragentparams.WithExtraComposeInlineManifest(
+					jmxfetch.DockerComposeManifest,
+					jmxFetchADLabelsDockerComposeManifest,
+				),
+			)))}
+
+	e2e.Run(t,
+		&jmxfetchNixTest{},
+		suiteParams...,
+	)
+}
+
+func (j *jmxfetchNixTest) Test_FakeIntakeReceivesJMXFetchMetrics() {
+	metricNames := []string{
+		"test.e2e.jmxfetch.counter_100",
+		"test.e2e.jmxfetch.gauge_200",
+		"test.e2e.jmxfetch.increment_counter",
+	}
+	start := time.Now()
+	j.EventuallyWithT(func(c *assert.CollectT) {
+		for _, metricName := range metricNames {
+			metrics, err := j.Env().FakeIntake.Client().
+				FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
+			assert.NoError(c, err)
+			assert.NotEmpty(j.T(), metrics, "no metrics found for", metricName)
+		}
+	}, 5*time.Minute, 10*time.Second)
+	j.T().Logf("Started: %v and took %v", start, time.Since(start))
+
+	// Helpful debug when things fail
+	if j.T().Failed() {
+		names, err := j.Env().FakeIntake.Client().GetMetricNames()
+		assert.NoError(j.T(), err)
+		for _, name := range names {
+			j.T().Logf("Got metric: %q", name)
+		}
+		for _, metricName := range metricNames {
+			tjc, err := j.Env().FakeIntake.Client().FilterMetrics(metricName)
+			assert.NoError(j.T(), err)
+			assert.NotEmpty(j.T(), tjc, "Filter metrics was empty for", metricName)
+			if len(tjc) > 0 {
+				for _, point := range tjc[0].Points {
+					j.T().Logf("Found metrics: %q \n%v - %v \n%q", tjc[0].Metric, point, point.Value, tjc[0].Type)
+				}
+			}
+		}
+	}
+}
+
+func (j *jmxfetchNixTest) TestJMXListCollectedWithRateMetrics() {
+	status, err := j.Env().Agent.Client.JMX(agentclient.WithArgs([]string{"list", "collected", "with-rate-metrics"}))
+	require.NoError(j.T(), err)
+	assert.NotEmpty(j.T(), status.Content)
+
+	lines := strings.Split(status.Content, "\n")
+	var consoleReporterOut []string
+	var foundShouldBe100, foundShouldBe200, foundIncrementCounter bool
+	for _, line := range lines {
+		if strings.Contains(line, "ConsoleReporter") {
+			consoleReporterOut = append(consoleReporterOut, line)
+			if strings.Contains(line, "dd.test.sample:name=default,type=simple") {
+				if strings.Contains(line, "ShouldBe100") {
+					foundShouldBe100 = true
+				}
+				if strings.Contains(line, "ShouldBe200") {
+					foundShouldBe200 = true
+				}
+				if strings.Contains(line, "IncrementCounter") {
+					foundIncrementCounter = true
+				}
+			}
+		}
+	}
+
+	assert.NotEmpty(j.T(), consoleReporterOut, "Did not find ConsoleReporter output in status")
+	assert.True(j.T(), foundShouldBe100,
+		"Did not find bean name: dd.test.sample:name=default,type=simple - Attribute name: ShouldBe100  - Attribute type: java.lang.Integer")
+	assert.True(j.T(), foundShouldBe200,
+		"Did not find bean name: dd.test.sample:name=default,type=simple - Attribute name: ShouldBe200  - Attribute type: java.lang.Double")
+	assert.True(j.T(), foundIncrementCounter,
+		"Did not find bean name: dd.test.sample:name=default,type=simple - Attribute name: IncrementCounter  - Attribute type: java.lang.Integer")
+
+	// Helpful debug when things fail
+	if j.T().Failed() {
+		for _, line := range consoleReporterOut {
+			j.T().Log(line)
+		}
+	}
+}

--- a/test/new-e2e/tests/agent-metrics-logs/jmxfetch/testdata/docker-labels.yaml
+++ b/test/new-e2e/tests/agent-metrics-logs/jmxfetch/testdata/docker-labels.yaml
@@ -1,0 +1,43 @@
+---
+services:
+
+  jmx-test-app:
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "test": {
+            "init_config": {
+              "is_jmx": true,
+              "collect_default_metrics": true,
+              "new_gc_metrics": true,
+              "conf": [
+                {
+                  "include": {
+                    "domain": "dd.test.sample",
+                    "type": "simple",
+                    "attribute": {
+                      "ShouldBe100": {
+                        "metric_type": "gauge",
+                        "alias": "test.e2e.jmxfetch.counter_100"
+                      },
+                      "ShouldBe200": {
+                        "metric_type": "gauge",
+                        "alias": "test.e2e.jmxfetch.gauge_200"
+                      },
+                      "IncrementCounter": {
+                        "metric_type": "counter",
+                        "alias": "test.e2e.jmxfetch.increment_counter"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": "9010"
+              }
+            ]
+          }
+        }


### PR DESCRIPTION
### What does this PR do?

Adds a test for JMXFetch and also the Agent command `jmx list collected with-rate-metrics`.

### Motivation

I want to reduce the amount of manual QA we do for JMXFetch.

### Describe how to test/QA your changes

Check the tests in `new-e2e-aml` pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->