### PR TITLE
chore: disable remote agent registry support by default

### DIFF
--- a/comp/api/api/apiimpl/grpc.go
+++ b/comp/api/api/apiimpl/grpc.go
@@ -187,6 +187,10 @@ func (s *serverSecure) WorkloadmetaStreamEntities(in *pb.WorkloadmetaStreamReque
 }
 
 func (s *serverSecure) RegisterRemoteAgent(_ context.Context, in *pb.RegisterRemoteAgentRequest) (*pb.RegisterRemoteAgentResponse, error) {
+	if s.remoteAgentRegistry == nil {
+		return nil, status.Error(codes.Unimplemented, "remote agent registry not enabled")
+	}
+
 	registration := rarproto.ProtobufToRemoteAgentRegistration(in)
 	recommendedRefreshIntervalSecs, err := s.remoteAgentRegistry.RegisterRemoteAgent(registration)
 	if err != nil {

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry.go
@@ -44,6 +44,11 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) Provides {
+	enabled := reqs.Config.GetBool("remote_agent_registry.enabled")
+	if !enabled {
+		return Provides{}
+	}
+
 	ra := newRemoteAgent(reqs)
 
 	return Provides{

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1011,6 +1011,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.recovery_interval", time.Duration(0))
 
 	// Remote agents
+	config.BindEnvAndSetDefault("remote_agent_registry.enabled", false)
 	config.BindEnvAndSetDefault("remote_agent_registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.recommended_refresh_interval", time.Duration(10*time.Second))


### PR DESCRIPTION
### What does this PR do?

This PR disables support for the "remote agent registry" by default through the introduction of a new configuration setting, `remote_agent_registry.enabled`, which controls whether or not the registry is enabled (duh).

When the registry is disabled, remote agents will receive an error when attempting to register themselves that indicates that RAR is not enabled.

### Motivation

We want to gate this behavior somewhat while we flesh out its long-term design and security posture.

### Describe how to test/QA your changes

```shell
# Build the Agent and the `remote-agent` tool:
inv agent.build
inv agent.build-remote-agent

# In another shell, run the Agent.
# 
# We override `cmd_port` in our configuration to `6001` to avoid conflicts with
# any local Datadog Agent that's running, which will matter for running the
# commands further down.
bin/agent/agent -c bin/agent/dist run

# Check the Agent's status output, and observe that there's no `Remote Agents` section
# since RAR is now disabled by default:
bin/agent/agent -c bin/agent/dist status

# Run the `remote-agent` binary, pretending to be a remote agent.
#
# With the default Agent configuration, RAR is disabled, and so the client should
# an error that states "remote agent registry not enabled", like so:
# 
# ... failed to register remote agent: ... remote agent registry not enabled
bin/remote-agent -agent-id remote-agent-1 -display-name="Remote Agent #1" \
                 -listen-addr 127.0.0.1:13580 \
                 -agent-ipc-address localhost:6001 \
                 -agent-auth-token-file bin/agent/dist/auth_token

# Update your Agent configuration to set `remote_agent_registry.enabled` to `true`,
# and restart the Agent. Check its status again, and observe that there's now a
# `Remote Agents` section which indicates no remote agents are registered:
bin/agent/agent -c bin/agent/dist status

# We'll also now try to register the remote again (using the same `bin/remote-agent`
# command from before) which should end up showing something along these lines:
# 
# ... Registered with Core Agent. Recommended refresh interval of 10 seconds.

# Finally, check the Agent's status one last time, and observe that now there is an
# entry in the `Remote Agents` section for our local remote agent, Remote Agent #1:
bin/agent/agent -c bin/agent/dist status
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes

N/A