### PR TITLE
Introduce a quality gate experiment for "usual" logs tailing

### DIFF
--- a/test/regression/cases/quality_gate_logs/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/cases/quality_gate_logs/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/smp-shared/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
@@ -10,7 +10,6 @@ dd_url: http://127.0.0.1:9091
 logs_enabled: true
 logs_config:
   logs_dd_url: 127.0.0.1:9092
-  file_scan_period: 1
   logs_no_ssl: true
   force_use_http: true
 

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -1,0 +1,38 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 30g
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: total_rss_bytes
+      upper_bound: 1GiB
+
+  - name: lost_bytes
+    description: "Allowable bytes not polled by log Agent"
+    bounds:
+      series: lost_bytes
+      upper_bound: 0KiB

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -1,4 +1,4 @@
-optimization_goal: egress_throughput
+optimization_goal: cpu
 erratic: false
 
 target:

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 30g
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -29,7 +29,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: 1GiB
+      upper_bound: 440MiB
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_logs/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_logs/lading/lading.yaml
@@ -1,0 +1,27 @@
+generator:
+  - file_gen:
+      logrotate_fs:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          constant: 500KiB
+        concurrent_logs: 2
+        maximum_bytes_per_log: 50MiB
+        total_rotations: 5
+        max_depth: 0
+        variant: "ascii"
+        maximum_prebuild_cache_size_bytes: 300MiB
+        mount_point: /smp-shared
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 75
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
### What does this PR do?

This commit introduces a quality gates experiments meant to demonstrate that logs Agent will not lose logs and will not consume too much memory when operating in a "usual" logs tailing situation. Logs are produced in two sources at 500 KiB/second and rotate 5 total times at 50 MiB. Intake latency is 75ms.

### Motivation

Protect the 'usual' logs tailing scenario from performance regression. 

### Additional Notes

Exact details may change once we haggle some with AML.
