### PR TITLE
ci: Drop "go_mod_tidy_check" as an upstream dep for Agent build

### DIFF
--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -37,34 +37,23 @@
 .agent_build_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-x64",
-      "go_deps",
-      "generate_minimized_btfs_x64",
-    ]
+  needs: ["build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     PACKAGE_ARCH: amd64
-    DD_CC: 'x86_64-unknown-linux-gnu-gcc'
-    DD_CXX: 'x86_64-unknown-linux-gnu-g++'
-    DD_CMAKE_TOOLCHAIN: '/opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake'
+    DD_CC: "x86_64-unknown-linux-gnu-gcc"
+    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+    DD_CMAKE_TOOLCHAIN: "/opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake"
 
 .agent_build_arm64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs:
-    [
-      "go_mod_tidy_check",
-      "build_system-probe-arm64",
-      "go_deps",
-      "generate_minimized_btfs_arm64",
-    ]
+    ["build_system-probe-arm64", "go_deps", "generate_minimized_btfs_arm64"]
   variables:
     PACKAGE_ARCH: arm64
-    DD_CC: 'aarch64-unknown-linux-gnu-gcc'
-    DD_CXX: 'aarch64-unknown-linux-gnu-g++'
-    DD_CMAKE_TOOLCHAIN: '/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake'
+    DD_CC: "aarch64-unknown-linux-gnu-gcc"
+    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+    DD_CMAKE_TOOLCHAIN: "/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake"
 
 .agent_7_build:
   variables:
@@ -116,16 +105,16 @@ iot-agent-x64:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   variables:
-    DD_CC: 'x86_64-unknown-linux-gnu-gcc'
-    DD_CXX: 'x86_64-unknown-linux-gnu-g++'
+    DD_CC: "x86_64-unknown-linux-gnu-gcc"
+    DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 iot-agent-arm64:
   extends: .iot-agent-common
   tags: ["arch:arm64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   variables:
-    DD_CC: 'aarch64-unknown-linux-gnu-gcc'
-    DD_CXX: 'aarch64-unknown-linux-gnu-g++'
+    DD_CC: "aarch64-unknown-linux-gnu-gcc"
+    DD_CXX: "aarch64-unknown-linux-gnu-g++"
 
 iot-agent-armhf:
   extends: .iot-agent-common
@@ -169,8 +158,8 @@ dogstatsd-x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
-    DD_CC: 'x86_64-unknown-linux-gnu-gcc'
-    DD_CXX: 'x86_64-unknown-linux-gnu-g++'
+    DD_CC: "x86_64-unknown-linux-gnu-gcc"
+    DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 dogstatsd-arm64:
   extends: .dogstatsd_build_common
@@ -178,6 +167,5 @@ dogstatsd-arm64:
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_arm64", "go_deps"]
   variables:
-    DD_CC: 'aarch64-unknown-linux-gnu-gcc'
-    DD_CXX: 'aarch64-unknown-linux-gnu-g++'
-
+    DD_CC: "aarch64-unknown-linux-gnu-gcc"
+    DD_CXX: "aarch64-unknown-linux-gnu-g++"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `go_mod_tidy_check` from the upstream dependencies for the regression detector and quality gates.

### Motivation

This isn't strictly required, and we could start the build jobs earlier - ideally reducing the start-to-regression result duration.

[Looking at the Datadog app for this job we could save anywhere between 4 to ~8 minutes](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3A%22go_mod_tidy_check%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&fromUser=false&index=cipipeline&viz=distribution&start=1731600833238&end=1732205633238&paused=false).

### Describe how to test/QA your changes

If CI passes that should be sufficient.

### Possible Drawbacks / Trade-offs

### Additional Notes

This job is a dependency of a number of other build related jobs, which could also be removed for duration improvements (theoretically).

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->