### PR TITLE
Specifically provide CPU, memory allotments in quality gates

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -9,6 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 1GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -9,6 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 1GiB
 
   environment:
     DD_API_KEY: 00000001


### PR DESCRIPTION
### What does this PR do?

This commit places specific CPU and memory limits on our idle quality gate experiments. 

### Motivation

By default the target has the runner's full allotment of resources and as we have asserted a bound on memory it makes sense to bound the memory available to the target to more closely mimic deploy conditions.

### Additional Notes

REF https://github.com/DataDog/datadog-agent/pull/31326 
REF https://github.com/DataDog/datadog-agent/pull/31246
