### PR TITLE
Disable lost-bytes check for 1000ms latency experiment

### DIFF
--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -32,8 +32,9 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
-    description: "Allowable bytes not polled by log Agent"
-    bounds:
-      series: lost_bytes
-      upper_bound: 0KiB
+  # Temporarily disable as we expect this to be failing, but not for long.
+  # - name: lost_bytes
+  #   description: "Allowable bytes not polled by log Agent"
+  #   bounds:
+  #     series: lost_bytes
+  #     upper_bound: 0KiB


### PR DESCRIPTION
### What does this PR do?

While we expect Agent to eventually not lose bytes in this configuration we see that this check is regularly failing. Commented out, will be re-enabled in the near-term as a part of work to dynamically scale senders.
