### PR TITLE
[CONTP-493] Exclude cluster-agent unittest from mac os runner

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command_test.go
+++ b/cmd/cluster-agent/subcommands/start/command_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows && kubeapiserver
+//go:build !darwin && !windows && kubeapiserver
 
 package start
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Exclude cmd/cluster-agent/subcommands/start unit test from mac os runner

### Motivation
A failed test was reported
Test name: cmd/cluster-agent/subcommands/start.TestMain
CI Job: tests_macos

### Describe how to test/QA your changes
Run test in local mac env, it should be excluded. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->