### PR TITLE
[BARX-713] Use commit SHA in tag when publishing agent-dev images from main

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -18,6 +18,7 @@ dev_branch_multiarch-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
+    - !reference [.except_mergequeue]
     - if: '$CI_COMMIT_BRANCH == "main"'
       when: manual
       variables:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -21,10 +21,12 @@ dev_branch_multiarch-a7:
     - if: '$CI_COMMIT_BRANCH == "main"'
       when: manual
       variables:
-        IMAGE_TAG: '${CI_COMMIT_SHORT_SHA}'
+        IMAGE_TAG: "${CI_COMMIT_SHORT_SHA}"
+      allow_failure: true
     - when: manual
       variables:
-        IMAGE_TAG: '${CI_COMMIT_REF_SLUG}'
+        IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
+      allow_failure: true
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -208,4 +210,3 @@ dev_branch-ot:
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-7-ot-beta
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-arm64
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-7-ot-beta-jmx
-

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -17,7 +17,14 @@ dev_branch-dogstatsd:
 dev_branch_multiarch-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.manual]
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+      variables:
+        IMAGE_TAG: '${CI_COMMIT_SHORT_SHA}'
+    - when: manual
+      variables:
+        IMAGE_TAG: '${CI_COMMIT_REF_SLUG}'
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
@@ -28,9 +35,9 @@ dev_branch_multiarch-a7:
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3
+        IMG_DESTINATIONS: agent-dev:${IMAGE_TAG}-py3
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
+        IMG_DESTINATIONS: agent-dev:${IMAGE_TAG}-py3-jmx
 
 dev_branch_multiarch-dogstatsd:
   extends: .docker_publish_job_definition


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use the commit SHA when dev images are published off `main`

### Motivation

SMP has need to test images build off recent `main` commits, but existing publish jobs will overwrite the tag. This provides a more "immutable" option for SMP to use.

### Describe how to test/QA your changes

Trigger the job on `main`/dev branches.

### Possible Drawbacks / Trade-offs

Increasing the number of tags stored in the image registries.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->