### PR TITLE
[ebpfless] Refactor TCP Seq logic to include sequence bump from SYN and FIN

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -61,6 +61,35 @@ func NewTCPProcessor() *TCPProcessor { //nolint:revive // TODO
 	}
 }
 
+// calcNextSeq returns the seq "after" this segment, aka, what the ACK will be once this segment is received
+func calcNextSeq(tcp *layers.TCP, payloadLen uint16) uint32 {
+	nextSeq := tcp.Seq + uint32(payloadLen)
+	if tcp.SYN || tcp.FIN {
+		nextSeq++
+	}
+	return nextSeq
+}
+
+func checkInvalidTcp(tcp *layers.TCP) bool {
+	noFlagsCombo := !tcp.SYN && !tcp.FIN && !tcp.ACK && !tcp.RST
+	if noFlagsCombo {
+		// no flags at all (I think this can happen for expanding the TCP window sometimes?)
+		statsTelemetry.missingTCPFlags.Inc()
+		return true
+	} else if tcp.SYN && tcp.FIN {
+		statsTelemetry.tcpSynAndFin.Inc()
+		return true
+	} else if tcp.RST && tcp.SYN {
+		statsTelemetry.tcpRstAndSyn.Inc()
+		return true
+	} else if tcp.RST && tcp.FIN {
+		statsTelemetry.tcpRstAndFin.Inc()
+		return true
+	}
+
+	return false
+}
+
 func (t *TCPProcessor) updateSynFlag(conn *network.ConnectionStats, st *connectionState, pktType uint8, tcp *layers.TCP, payloadLen uint16) { //nolint:revive // TODO
 	if tcp.RST {
 		return
@@ -85,14 +114,14 @@ func (t *TCPProcessor) updateSynFlag(conn *network.ConnectionStats, st *connecti
 // updateTcpStats is designed to mirror the stat tracking in the windows driver's handleFlowProtocolTcp
 // https://github.com/DataDog/datadog-windows-filter/blob/d7560d83eb627117521d631a4c05cd654a01987e/ddfilter/flow/flow_tcp.c#L91
 func (t *TCPProcessor) updateTcpStats(conn *network.ConnectionStats, st *connectionState, pktType uint8, tcp *layers.TCP, payloadLen uint16) { //nolint:revive // TODO
-	payloadSeq := tcp.Seq + uint32(payloadLen)
+	nextSeq := calcNextSeq(tcp, payloadLen)
 
 	if pktType == unix.PACKET_OUTGOING {
 		conn.Monotonic.SentPackets++
-		if !st.hasSentPacket || isSeqBefore(st.maxSeqSent, payloadSeq) {
+		if !st.hasSentPacket || isSeqBefore(st.maxSeqSent, nextSeq) {
 			st.hasSentPacket = true
 			conn.Monotonic.SentBytes += uint64(payloadLen)
-			st.maxSeqSent = payloadSeq
+			st.maxSeqSent = nextSeq
 		}
 
 		ackOutdated := !st.hasLocalAck || isSeqBefore(st.lastLocalAck, tcp.Ack)
@@ -100,9 +129,9 @@ func (t *TCPProcessor) updateTcpStats(conn *network.ConnectionStats, st *connect
 			// wait until data comes in via SynStateAcked
 			if st.hasLocalAck && st.remoteSynState == SynStateAcked {
 				ackDiff := tcp.Ack - st.lastLocalAck
-				// if this is ack'ing a fin packet, there is an extra sequence number to cancel out
-				isFinAck := st.hasRemoteFin && tcp.Ack == st.remoteFinSeq+1
+				isFinAck := st.hasRemoteFin && tcp.Ack == st.remoteFinSeq
 				if isFinAck {
+					// if this is ack'ing a fin packet, there is an extra sequence number to cancel out
 					ackDiff--
 				}
 				conn.Monotonic.RecvBytes += uint64(ackDiff)
@@ -123,21 +152,21 @@ func (t *TCPProcessor) updateTcpStats(conn *network.ConnectionStats, st *connect
 }
 
 func (t *TCPProcessor) updateFinFlag(conn *network.ConnectionStats, st *connectionState, pktType uint8, tcp *layers.TCP, payloadLen uint16) {
-	payloadSeq := tcp.Seq + uint32(payloadLen)
+	nextSeq := calcNextSeq(tcp, payloadLen)
 	// update FIN sequence numbers
 	if tcp.FIN {
 		if pktType == unix.PACKET_OUTGOING {
 			st.hasLocalFin = true
-			st.localFinSeq = payloadSeq
+			st.localFinSeq = nextSeq
 		} else {
 			st.hasRemoteFin = true
-			st.remoteFinSeq = payloadSeq
+			st.remoteFinSeq = nextSeq
 		}
 	}
 
 	// if both fins have been sent and ack'd, then mark the connection closed
-	localFinIsAcked := st.hasLocalFin && isSeqBefore(st.localFinSeq, st.lastRemoteAck)
-	remoteFinIsAcked := st.hasRemoteFin && isSeqBefore(st.remoteFinSeq, st.lastLocalAck)
+	localFinIsAcked := st.hasLocalFin && isSeqBeforeEq(st.localFinSeq, st.lastRemoteAck)
+	remoteFinIsAcked := st.hasRemoteFin && isSeqBeforeEq(st.remoteFinSeq, st.lastLocalAck)
 	if st.tcpState == ConnStatEstablished && localFinIsAcked && remoteFinIsAcked {
 		*st = connectionState{
 			tcpState: ConnStatClosed,
@@ -156,11 +185,13 @@ func (t *TCPProcessor) updateRstFlag(conn *network.ConnectionStats, st *connecti
 		reason = syscall.ECONNREFUSED
 	}
 
+	if st.tcpState == ConnStatEstablished {
+		conn.Monotonic.TCPClosed++
+	}
 	*st = connectionState{
 		tcpState: ConnStatClosed,
 	}
 	conn.TCPFailures[uint16(reason)]++
-	conn.Monotonic.TCPClosed++
 }
 
 // Process handles a TCP packet, calculating stats and keeping track of its state according to the
@@ -179,15 +210,7 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, pktType uint8, ip4
 	})
 
 	// skip invalid packets we don't recognize:
-	noFlagsCombo := !tcp.SYN && !tcp.FIN && !tcp.ACK && !tcp.RST
-	if noFlagsCombo {
-		// no flags at all (I think this can happen for expanding the TCP window sometimes?)
-		statsTelemetry.missingTCPFlags.Inc()
-		return nil
-	}
-	synFinCombo := tcp.SYN && tcp.FIN
-	if synFinCombo {
-		statsTelemetry.tcpSynAndFin.Inc()
+	if checkInvalidTcp(tcp) {
 		return nil
 	}
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -536,7 +536,7 @@ func TestConnRefusedSyn(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      1,
+		TCPClosed:      0,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }
@@ -569,7 +569,7 @@ func TestConnRefusedSynAck(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      1,
+		TCPClosed:      0,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -25,10 +25,14 @@ var statsTelemetry = struct {
 	missedTCPConnections telemetry.Counter
 	missingTCPFlags      telemetry.Counter
 	tcpSynAndFin         telemetry.Counter
+	tcpRstAndSyn         telemetry.Counter
+	tcpRstAndFin         telemetry.Counter
 }{
 	telemetry.NewCounter(ebpflessModuleName, "missed_tcp_connections", []string{}, "Counter measuring the number of TCP connections where we missed the SYN handshake"),
 	telemetry.NewCounter(ebpflessModuleName, "missing_tcp_flags", []string{}, "Counter measuring packets encountered with none of SYN, FIN, ACK, RST set"),
 	telemetry.NewCounter(ebpflessModuleName, "tcp_syn_and_fin", []string{}, "Counter measuring packets encountered with SYN+FIN together"),
+	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_syn", []string{}, "Counter measuring packets encountered with RST+SYN together"),
+	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_fin", []string{}, "Counter measuring packets encountered with RST+FIN together"),
 }
 
 const tcpSeqMidpoint = 0x80000000
@@ -85,6 +89,9 @@ func isSeqBefore(prev, cur uint32) bool {
 	diff := cur - prev
 	// constrain the maximum difference to half the number space
 	return diff > 0 && diff < tcpSeqMidpoint
+}
+func isSeqBeforeEq(prev, cur uint32) bool {
+	return prev == cur || isSeqBefore(prev, cur)
 }
 
 func debugPacketDir(pktType uint8) string {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

1. Deletes the `payloadSeq` logic in favor of `calcNextSeq` which is more standard.
2. TCP reset only counts as a closed connection if it got opened to begin with, this fixes a couple tests regarding that.
3. Adds some more telemetry via `checkInvalidTcp` for unusual TCP packets

### Motivation

This refactor gets rid of an off-by-one correction and is useful for the upcoming TCP retransmit PR

### Describe how to test/QA your changes

Tracer should still pass the same tests as before.

To run this PR's ebpfless tests:

```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->