### PR TITLE
move service discovery to simpler sysprobe client

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux.go
@@ -8,12 +8,16 @@
 package servicediscovery
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"time"
 
+	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/servicetype"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	processnet "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,38 +28,56 @@ func init() {
 }
 
 type linuxImpl struct {
-	getSysProbeClient processnet.SysProbeUtilGetter
-	time              timer
+	getDiscoveryServices func(client *http.Client) (*model.ServicesResponse, error)
+	time                 timer
 
 	ignoreCfg map[string]bool
 
 	ignoreProcs       map[int]bool
 	aliveServices     map[int]*serviceInfo
 	potentialServices map[int]*serviceInfo
+
+	sysProbeClient *http.Client
 }
 
 func newLinuxImpl(ignoreCfg map[string]bool) (osImpl, error) {
 	return &linuxImpl{
-		getSysProbeClient: processnet.GetRemoteSystemProbeUtil,
-		time:              realTime{},
-		ignoreCfg:         ignoreCfg,
-		ignoreProcs:       make(map[int]bool),
-		aliveServices:     make(map[int]*serviceInfo),
-		potentialServices: make(map[int]*serviceInfo),
+		getDiscoveryServices: getDiscoveryServices,
+		time:                 realTime{},
+		ignoreCfg:            ignoreCfg,
+		ignoreProcs:          make(map[int]bool),
+		aliveServices:        make(map[int]*serviceInfo),
+		potentialServices:    make(map[int]*serviceInfo),
+		sysProbeClient:       sysprobeclient.Get(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
 	}, nil
 }
 
-func (li *linuxImpl) DiscoverServices() (*discoveredServices, error) {
-	socket := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
-	sysProbe, err := li.getSysProbeClient(socket)
+func getDiscoveryServices(client *http.Client) (*model.ServicesResponse, error) {
+	url := sysprobeclient.ModuleURL(sysconfig.DiscoveryModule, "/services")
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, errWithCode{
-			err:  err,
-			code: errorCodeSystemProbeConn,
-		}
+		return nil, err
 	}
 
-	response, err := sysProbe.GetDiscoveryServices()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got non-success status code: url: %s, status_code: %d", req.URL, resp.StatusCode)
+	}
+
+	res := &model.ServicesResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (li *linuxImpl) DiscoverServices() (*discoveredServices, error) {
+	response, err := li.getDiscoveryServices(li.sysProbeClient)
 	if err != nil {
 		return nil, errWithCode{
 			err:  err,

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -7,15 +7,22 @@
 package languagedetection
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"regexp"
 	"runtime"
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
+	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/internal/detectors"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
-	"github.com/DataDog/datadog-agent/pkg/process/net"
+	languagepb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/languagedetection"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -140,15 +147,8 @@ func DetectLanguage(procs []languagemodels.Process, sysprobeConfig model.Reader)
 		}()
 
 		log.Trace("[language detection] Requesting language from system probe")
-		util, err := net.GetRemoteSystemProbeUtil(
-			sysprobeConfig.GetString("system_probe_config.sysprobe_socket"),
-		)
-		if err != nil {
-			log.Warn("[language detection] Failed to request language:", err)
-			return langs
-		}
-
-		privilegedLangs, err := util.DetectLanguage(unknownPids)
+		sysprobeClient := sysprobeclient.Get(sysprobeConfig.GetString("system_probe_config.sysprobe_socket"))
+		privilegedLangs, err := detectLanguage(sysprobeClient, unknownPids)
 		if err != nil {
 			log.Warn("[language detection] Failed to request language:", err)
 			return langs
@@ -159,6 +159,49 @@ func DetectLanguage(procs []languagemodels.Process, sysprobeConfig model.Reader)
 		}
 	}
 	return langs
+}
+
+func detectLanguage(client *http.Client, pids []int32) ([]languagemodels.Language, error) {
+	procs := make([]*languagepb.Process, len(pids))
+	for i, pid := range pids {
+		procs[i] = &languagepb.Process{Pid: pid}
+	}
+	reqBytes, err := proto.Marshal(&languagepb.DetectLanguageRequest{Processes: procs})
+	if err != nil {
+		return nil, err
+	}
+
+	url := sysprobeclient.ModuleURL(sysconfig.LanguageDetectionModule, "/detect")
+	req, err := http.NewRequest(http.MethodGet, url, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resProto languagepb.DetectLanguageResponse
+	err = proto.Unmarshal(resBody, &resProto)
+	if err != nil {
+		return nil, err
+	}
+
+	langs := make([]languagemodels.Language, len(pids))
+	for i, lang := range resProto.Languages {
+		langs[i] = languagemodels.Language{
+			Name:    languagemodels.LanguageName(lang.Name),
+			Version: lang.Version,
+		}
+	}
+	return langs, nil
 }
 
 func privilegedLanguageDetectionEnabled(sysProbeConfig model.Reader) bool {

--- a/pkg/languagedetection/detector_linux_test.go
+++ b/pkg/languagedetection/detector_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -10,7 +10,6 @@ package net
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -18,15 +17,11 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"google.golang.org/protobuf/proto"
 
-	discoverymodel "github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	netEncoding "github.com/DataDog/datadog-agent/pkg/network/encoding/unmarshal"
 	nppayload "github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	procEncoding "github.com/DataDog/datadog-agent/pkg/process/encoding"
 	reqEncoding "github.com/DataDog/datadog-agent/pkg/process/encoding/request"
-	languagepb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/languagedetection"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -285,73 +280,6 @@ func (r *RemoteSysProbeUtil) Register(clientID string) error {
 	}
 
 	return nil
-}
-
-//nolint:revive // TODO(PROC) Fix revive linter
-func (r *RemoteSysProbeUtil) DetectLanguage(pids []int32) ([]languagemodels.Language, error) {
-	procs := make([]*languagepb.Process, len(pids))
-	for i, pid := range pids {
-		procs[i] = &languagepb.Process{Pid: pid}
-	}
-	reqBytes, err := proto.Marshal(&languagepb.DetectLanguageRequest{Processes: procs})
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodGet, languageDetectionURL, bytes.NewBuffer(reqBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := r.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	resBody, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var resProto languagepb.DetectLanguageResponse
-	err = proto.Unmarshal(resBody, &resProto)
-	if err != nil {
-		return nil, err
-	}
-
-	langs := make([]languagemodels.Language, len(pids))
-	for i, lang := range resProto.Languages {
-		langs[i] = languagemodels.Language{
-			Name:    languagemodels.LanguageName(lang.Name),
-			Version: lang.Version,
-		}
-	}
-	return langs, nil
-}
-
-// GetDiscoveryServices returns service information from system-probe.
-func (r *RemoteSysProbeUtil) GetDiscoveryServices() (*discoverymodel.ServicesResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, discoveryServicesURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got non-success status code: path %s, url: %s, status_code: %d", r.path, discoveryServicesURL, resp.StatusCode)
-	}
-
-	res := &discoverymodel.ServicesResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
-		return nil, err
-	}
-	return res, nil
 }
 
 func (r *RemoteSysProbeUtil) init() error {

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -18,15 +18,13 @@ import (
 )
 
 const (
-	pingURL              = "http://unix/" + string(sysconfig.PingModule) + "/ping/"
-	tracerouteURL        = "http://unix/" + string(sysconfig.TracerouteModule) + "/traceroute/"
-	connectionsURL       = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/connections"
-	networkIDURL         = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
-	procStatsURL         = "http://unix/" + string(sysconfig.ProcessModule) + "/stats"
-	registerURL          = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/register"
-	statsURL             = "http://unix/debug/stats"
-	languageDetectionURL = "http://unix/" + string(sysconfig.LanguageDetectionModule) + "/detect"
-	discoveryServicesURL = "http://unix/" + string(sysconfig.DiscoveryModule) + "/services"
+	pingURL        = "http://unix/" + string(sysconfig.PingModule) + "/ping/"
+	tracerouteURL  = "http://unix/" + string(sysconfig.TracerouteModule) + "/traceroute/"
+	connectionsURL = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/connections"
+	networkIDURL   = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
+	procStatsURL   = "http://unix/" + string(sysconfig.ProcessModule) + "/stats"
+	registerURL    = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/register"
+	statsURL       = "http://unix/debug/stats"
 )
 
 // CheckPath is used in conjunction with calling the stats endpoint, since we are calling this

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -12,8 +12,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	discoverymodel "github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	nppayload "github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
@@ -61,16 +59,6 @@ func (r *RemoteSysProbeUtil) GetProcStats(_ []int32) (*model.ProcStatsWithPermBy
 //nolint:revive // TODO(PROC) Fix revive linter
 func (r *RemoteSysProbeUtil) Register(_ string) error {
 	return ErrNotImplemented
-}
-
-// DetectLanguage is not supported
-func (r *RemoteSysProbeUtil) DetectLanguage([]int32) ([]languagemodels.Language, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetDiscoveryServices is not supported
-func (r *RemoteSysProbeUtil) GetDiscoveryServices() (*discoverymodel.ServicesResponse, error) {
-	return nil, ErrNotImplemented
 }
 
 // GetPing is not supported

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -17,15 +17,12 @@ import (
 )
 
 const (
-	connectionsURL       = "http://localhost:3333/" + string(sysconfig.NetworkTracerModule) + "/connections"
-	networkIDURL         = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
-	registerURL          = "http://localhost:3333/" + string(sysconfig.NetworkTracerModule) + "/register"
-	languageDetectionURL = "http://localhost:3333/" + string(sysconfig.LanguageDetectionModule) + "/detect"
-	statsURL             = "http://localhost:3333/debug/stats"
-	tracerouteURL        = "http://localhost:3333/" + string(sysconfig.TracerouteModule) + "/traceroute/"
+	connectionsURL = "http://localhost:3333/" + string(sysconfig.NetworkTracerModule) + "/connections"
+	networkIDURL   = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
+	registerURL    = "http://localhost:3333/" + string(sysconfig.NetworkTracerModule) + "/register"
+	statsURL       = "http://localhost:3333/debug/stats"
+	tracerouteURL  = "http://localhost:3333/" + string(sysconfig.TracerouteModule) + "/traceroute/"
 
-	// discovery* is not used on Windows, the value is added to avoid a compilation error
-	discoveryServicesURL = "http://localhost:3333/" + string(sysconfig.DiscoveryModule) + "/services"
 	// procStatsURL is not used in windows, the value is added to avoid compilation error in windows
 	procStatsURL = "http://localhost:3333/" + string(sysconfig.ProcessModule) + "stats"
 	// pingURL is not used in windows, the value is added to avoid compilation error in windows

--- a/pkg/process/net/mocks/sys_probe_util.go
+++ b/pkg/process/net/mocks/sys_probe_util.go
@@ -3,10 +3,7 @@
 package mocks
 
 import (
-	languagemodels "github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	mock "github.com/stretchr/testify/mock"
-
-	model "github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
 
 	payload "github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 
@@ -26,64 +23,6 @@ type SysProbeUtil_Expecter struct {
 
 func (_m *SysProbeUtil) EXPECT() *SysProbeUtil_Expecter {
 	return &SysProbeUtil_Expecter{mock: &_m.Mock}
-}
-
-// DetectLanguage provides a mock function with given fields: pids
-func (_m *SysProbeUtil) DetectLanguage(pids []int32) ([]languagemodels.Language, error) {
-	ret := _m.Called(pids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DetectLanguage")
-	}
-
-	var r0 []languagemodels.Language
-	var r1 error
-	if rf, ok := ret.Get(0).(func([]int32) ([]languagemodels.Language, error)); ok {
-		return rf(pids)
-	}
-	if rf, ok := ret.Get(0).(func([]int32) []languagemodels.Language); ok {
-		r0 = rf(pids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]languagemodels.Language)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func([]int32) error); ok {
-		r1 = rf(pids)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// SysProbeUtil_DetectLanguage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DetectLanguage'
-type SysProbeUtil_DetectLanguage_Call struct {
-	*mock.Call
-}
-
-// DetectLanguage is a helper method to define mock.On call
-//   - pids []int32
-func (_e *SysProbeUtil_Expecter) DetectLanguage(pids interface{}) *SysProbeUtil_DetectLanguage_Call {
-	return &SysProbeUtil_DetectLanguage_Call{Call: _e.mock.On("DetectLanguage", pids)}
-}
-
-func (_c *SysProbeUtil_DetectLanguage_Call) Run(run func(pids []int32)) *SysProbeUtil_DetectLanguage_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]int32))
-	})
-	return _c
-}
-
-func (_c *SysProbeUtil_DetectLanguage_Call) Return(_a0 []languagemodels.Language, _a1 error) *SysProbeUtil_DetectLanguage_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *SysProbeUtil_DetectLanguage_Call) RunAndReturn(run func([]int32) ([]languagemodels.Language, error)) *SysProbeUtil_DetectLanguage_Call {
-	_c.Call.Return(run)
-	return _c
 }
 
 // GetConnections provides a mock function with given fields: clientID
@@ -140,63 +79,6 @@ func (_c *SysProbeUtil_GetConnections_Call) Return(_a0 *process.Connections, _a1
 }
 
 func (_c *SysProbeUtil_GetConnections_Call) RunAndReturn(run func(string) (*process.Connections, error)) *SysProbeUtil_GetConnections_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetDiscoveryServices provides a mock function with given fields:
-func (_m *SysProbeUtil) GetDiscoveryServices() (*model.ServicesResponse, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetDiscoveryServices")
-	}
-
-	var r0 *model.ServicesResponse
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.ServicesResponse, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() *model.ServicesResponse); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.ServicesResponse)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// SysProbeUtil_GetDiscoveryServices_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDiscoveryServices'
-type SysProbeUtil_GetDiscoveryServices_Call struct {
-	*mock.Call
-}
-
-// GetDiscoveryServices is a helper method to define mock.On call
-func (_e *SysProbeUtil_Expecter) GetDiscoveryServices() *SysProbeUtil_GetDiscoveryServices_Call {
-	return &SysProbeUtil_GetDiscoveryServices_Call{Call: _e.mock.On("GetDiscoveryServices")}
-}
-
-func (_c *SysProbeUtil_GetDiscoveryServices_Call) Run(run func()) *SysProbeUtil_GetDiscoveryServices_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *SysProbeUtil_GetDiscoveryServices_Call) Return(_a0 *model.ServicesResponse, _a1 error) *SysProbeUtil_GetDiscoveryServices_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *SysProbeUtil_GetDiscoveryServices_Call) RunAndReturn(run func() (*model.ServicesResponse, error)) *SysProbeUtil_GetDiscoveryServices_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/process/net/shared.go
+++ b/pkg/process/net/shared.go
@@ -10,8 +10,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	discoverymodel "github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	nppayload "github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
@@ -25,8 +23,6 @@ type SysProbeUtil interface {
 	GetProcStats(pids []int32) (*model.ProcStatsWithPermByPID, error)
 	Register(clientID string) error
 	GetNetworkID() (string, error)
-	DetectLanguage(pids []int32) ([]languagemodels.Language, error)
-	GetDiscoveryServices() (*discoverymodel.ServicesResponse, error)
 	GetPing(clientID string, host string, count int, interval time.Duration, timeout time.Duration) ([]byte, error)
 	GetTraceroute(clientID string, host string, port uint16, protocol nppayload.Protocol, maxTTL uint8, timeout time.Duration) ([]byte, error)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moves service discovery and language detection to use the simpler system-probe client.

### Motivation

Split PR from https://github.com/DataDog/datadog-agent/pull/30936

### Describe how to test/QA your changes

Tested manually and on staging

### Possible Drawbacks / Trade-offs

### Additional Notes
Stacked PR on top of #31293 

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->