### PR TITLE
Set resource allocations for all SMP experiments

### DIFF
--- a/test/regression/cases/basic_py_check/experiment.yaml
+++ b/test/regression/cases/basic_py_check/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 000001

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 30g
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 30g
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 30g
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 30g
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_tree/experiment.yaml
+++ b/test/regression/cases/file_tree/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001
@@ -37,4 +39,3 @@ target:
     DD_PROFILING_EXECUTION_TRACE_ENABLED: true
     DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
     DD_PROFILING_WAIT_PROFILE: true
-

--- a/test/regression/cases/otel_to_otel_logs/experiment.yaml
+++ b/test/regression/cases/otel_to_otel_logs/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/otel_to_otel_logs/experiment.yaml
+++ b/test/regression/cases/otel_to_otel_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 8GiB
+  memory_allotment: 24GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/otel_to_otel_logs/experiment.yaml
+++ b/test/regression/cases/otel_to_otel_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 4GiB
+  memory_allotment: 8GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/pycheck_lots_of_tags/experiment.yaml
+++ b/test/regression/cases/pycheck_lots_of_tags/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 000001

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 1GiB
+  memory_allotment: 500MiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/experiment.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/tcp_syslog_to_blackhole/experiment.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
+  cpu_allotment: 8
+  memory_allotment: 4GiB
 
   environment:
     DD_API_KEY: 00000001


### PR DESCRIPTION
### What does this PR do?

This commit builds on the insight in #31333, setting allocations for all experiments. I further drop the allocation for quality-gate-idle as the bound there can be more tight.

### Additional Notes

REF #31326
REF #31246

