### PR TITLE
Bump windows docker memory for linter

### DIFF
--- a/.gitlab/lint/windows.yml
+++ b/.gitlab/lint/windows.yml
@@ -13,7 +13,7 @@
     # it would leave 6Gb free but we could not fit another job with these 6Gb remaining.
     - >
       docker run --rm
-      -m 16384M
+      -m 24576M
       --storage-opt "size=50GB"
       -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We recently bumped size of Windows runner after seeing flakiness coming from lack of memory on linter job. We should now bump the parameters on docker run to specify how much memory the linter can use

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->