### PR TITLE
fix(coverage): Pass the coverage flag in macos tests

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -22,7 +22,7 @@ tests_macos:
     - python3 -m pip install -r tasks/libs/requirements-github.txt --break-system-packages
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" = "true" ]]; then FAST_TESTS_FLAG="--fast-tests true"; fi
-    - inv -e github.trigger-macos --workflow-type "test" --datadog-agent-ref "$CI_COMMIT_SHA" --version-cache "$VERSION_CACHE_CONTENT" $FAST_TESTS_FLAG --test-washer $COVERAGE_CACHE_FLAG
+    - inv -e github.trigger-macos --workflow-type "test" --datadog-agent-ref "$CI_COMMIT_SHA" --version-cache "$VERSION_CACHE_CONTENT" $FAST_TESTS_FLAG --test-washer
   timeout: 6h
   after_script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-*-repacked.tgz"
@@ -51,7 +51,7 @@ tests_macos:
     - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
-    - inv -e test --rerun-fails=2 --race --profile --cpus 12 --save-result-json $TEST_OUTPUT_FILE --junit-tar "junit-${CI_JOB_NAME}.tgz" $FAST_TESTS_FLAG --test-washer
+    - inv -e test --rerun-fails=2 --race --profile --cpus 12 --save-result-json $TEST_OUTPUT_FILE --junit-tar "junit-${CI_JOB_NAME}.tgz" $FAST_TESTS_FLAG --test-washer --coverage
     - inv -e invoke-unit-tests
   artifacts:
     expire_in: 2 weeks


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The coverage upload currently fails in macos because the `coverage.out` file is not generated, see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/716918465

### Motivation
tech debt

### Describe how to test/QA your changes
The macos_test codecov upload is [passing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/717476268)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->