### PR TITLE
[ebpfless] Refactor TCP Seq logic to include sequence bump from SYN and FIN 

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -536,7 +536,7 @@ func TestConnRefusedSyn(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      1,
+		TCPClosed:      0,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }
@@ -569,7 +569,7 @@ func TestConnRefusedSynAck(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      1,
+		TCPClosed:      0,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -25,10 +25,14 @@ var statsTelemetry = struct {
 	missedTCPConnections telemetry.Counter
 	missingTCPFlags      telemetry.Counter
 	tcpSynAndFin         telemetry.Counter
+	tcpRstAndSyn         telemetry.Counter
+	tcpRstAndFin         telemetry.Counter
 }{
 	telemetry.NewCounter(ebpflessModuleName, "missed_tcp_connections", []string{}, "Counter measuring the number of TCP connections where we missed the SYN handshake"),
 	telemetry.NewCounter(ebpflessModuleName, "missing_tcp_flags", []string{}, "Counter measuring packets encountered with none of SYN, FIN, ACK, RST set"),
 	telemetry.NewCounter(ebpflessModuleName, "tcp_syn_and_fin", []string{}, "Counter measuring packets encountered with SYN+FIN together"),
+	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_syn", []string{}, "Counter measuring packets encountered with RST+SYN together"),
+	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_fin", []string{}, "Counter measuring packets encountered with RST+FIN together"),
 }
 
 const tcpSeqMidpoint = 0x80000000
@@ -85,6 +89,9 @@ func isSeqBefore(prev, cur uint32) bool {
 	diff := cur - prev
 	// constrain the maximum difference to half the number space
 	return diff > 0 && diff < tcpSeqMidpoint
+}
+func isSeqBeforeEq(prev, cur uint32) bool {
+	return prev == cur || isSeqBefore(prev, cur)
 }
 
 func debugPacketDir(pktType uint8) string {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1163,7 +1163,9 @@ func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {
 			return cs.DPort == uint16(remotePort)
 		})
 
-		assert.Len(ct, outgoing, 1)
+		if !assert.Len(ct, outgoing, 1) {
+			return
+		}
 		assert.Equal(ct, bytesSent, int(outgoing[0].Monotonic.SentBytes))
 	}, 3*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

1. Replaces `payloadSeq` logic with`calcNextSeq` which slightly simplifies retransmit logic in the next PR, #31397.
    The difference is, `calcNextSeq` includes the increment to Seq that happens when the SYN or FIN flags are set
3. TCP reset only counts as a closed connection if it got opened to begin with, this fixes a couple tests regarding that.
4. Adds some more telemetry via `checkInvalidTcp` for unusual TCP packets

### Motivation

This refactor gets rid of an off-by-one correction and is useful for the upcoming TCP retransmit PR

### Describe how to test/QA your changes

Tracer should still pass the same tests as before.

To run this PR's ebpfless tests:

```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->