### PR TITLE
[CONTP-48] Cluster Agent consistent tagging via global tags fix

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -193,7 +193,7 @@ func run(
 	}
 
 	var clusterCheckHandler *clusterchecks.Handler
-	clusterCheckHandler, err = setupClusterCheck(mainCtx, ac)
+	clusterCheckHandler, err = setupClusterCheck(mainCtx, ac, taggerComp)
 	if err == nil {
 		api.ModifyAPIRouter(func(r *mux.Router) {
 			dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
@@ -300,8 +300,8 @@ func initializeBBSCache(ctx context.Context) error {
 	}
 }
 
-func setupClusterCheck(ctx context.Context, ac autodiscovery.Component) (*clusterchecks.Handler, error) {
-	handler, err := clusterchecks.NewHandler(ac)
+func setupClusterCheck(ctx context.Context, ac autodiscovery.Component, tagger tagger.Component) (*clusterchecks.Handler, error) {
+	handler, err := clusterchecks.NewHandler(ac, tagger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -387,7 +387,7 @@ func start(log log.Component,
 
 	if config.GetBool("cluster_checks.enabled") {
 		// Start the cluster check Autodiscovery
-		clusterCheckHandler, err := setupClusterCheck(mainCtx, ac)
+		clusterCheckHandler, err := setupClusterCheck(mainCtx, ac, taggerComp)
 		if err == nil {
 			api.ModifyAPIRouter(func(r *mux.Router) {
 				dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
@@ -549,8 +549,8 @@ func start(log log.Component,
 	return nil
 }
 
-func setupClusterCheck(ctx context.Context, ac autodiscovery.Component) (*clusterchecks.Handler, error) {
-	handler, err := clusterchecks.NewHandler(ac)
+func setupClusterCheck(ctx context.Context, ac autodiscovery.Component, tagger tagger.Component) (*clusterchecks.Handler, error) {
+	handler, err := clusterchecks.NewHandler(ac, tagger)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -225,8 +225,10 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 	}
 
 	// static tags for ECS and EKS Fargate containers
-	for tag, value := range c.staticTags {
-		tagList.AddLow(tag, value)
+	for tag, valueList := range c.staticTags {
+		for _, value := range valueList {
+			tagList.AddLow(tag, value)
+		}
 	}
 
 	// gpu tags from container resource requests
@@ -399,8 +401,10 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 	}
 
 	// static tags for EKS Fargate pods
-	for tag, value := range c.staticTags {
-		tagList.AddLow(tag, value)
+	for tag, valueList := range c.staticTags {
+		for _, value := range valueList {
+			tagList.AddLow(tag, value)
+		}
 	}
 
 	low, orch, high, standard := tagList.Compute()

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -57,7 +57,7 @@ type WorkloadMetaCollector struct {
 	containerEnvAsTags    map[string]string
 	containerLabelsAsTags map[string]string
 
-	staticTags                    map[string]string
+	staticTags                    map[string][]string // for ECS and EKS Fargate
 	k8sResourcesAnnotationsAsTags map[string]map[string]string
 	k8sResourcesLabelsAsTags      map[string]map[string]string
 	globContainerLabels           map[string]glob.Glob
@@ -91,42 +91,51 @@ func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags
 
 // Run runs the continuous event watching loop and sends new tags to the
 // tagger based on the events sent by the workloadmeta.
-func (c *WorkloadMetaCollector) Run(ctx context.Context) {
-	c.collectStaticGlobalTags(ctx)
+func (c *WorkloadMetaCollector) Run(ctx context.Context, datadogConfig config.Component) {
+	c.collectStaticGlobalTags(ctx, datadogConfig)
 	c.stream(ctx)
 }
 
-func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context) {
+func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, datadogConfig config.Component) {
 	c.staticTags = util.GetStaticTags(ctx)
 	if _, exists := c.staticTags[clusterTagNamePrefix]; flavor.GetFlavor() == flavor.ClusterAgent && !exists {
 		// If we are running the cluster agent, we want to set the kube_cluster_name tag as a global tag if we are able
 		// to read it, for the instances where we are running in an environment where hostname cannot be detected.
 		if cluster := clustername.GetClusterNameTagValue(ctx, ""); cluster != "" {
 			if c.staticTags == nil {
-				c.staticTags = make(map[string]string, 1)
+				c.staticTags = make(map[string][]string, 1)
 			}
-			c.staticTags[clusterTagNamePrefix] = cluster
+			if _, exists := c.staticTags[clusterTagNamePrefix]; !exists {
+				c.staticTags[clusterTagNamePrefix] = []string{}
+			}
+			c.staticTags[clusterTagNamePrefix] = append(c.staticTags[clusterTagNamePrefix], cluster)
 		}
 	}
-	if len(c.staticTags) > 0 {
-		tags := taglist.NewTagList()
+	// These are the global tags that should only be applied to the internal global entity
+	// Whereas the static tags are applied to containers and pods directly as well.
+	globalEnvTags := util.GetGlobalEnvTags(datadogConfig)
 
-		for tag, value := range c.staticTags {
-			tags.AddLow(tag, value)
+	tagList := taglist.NewTagList()
+
+	for _, tags := range []map[string][]string{c.staticTags, globalEnvTags} {
+		for tagKey, valueList := range tags {
+			for _, value := range valueList {
+				tagList.AddLow(tagKey, value)
+			}
 		}
-
-		low, orch, high, standard := tags.Compute()
-		c.tagProcessor.ProcessTagInfo([]*types.TagInfo{
-			{
-				Source:               staticSource,
-				EntityID:             common.GetGlobalEntityID(),
-				HighCardTags:         high,
-				OrchestratorCardTags: orch,
-				LowCardTags:          low,
-				StandardTags:         standard,
-			},
-		})
 	}
+
+	low, orch, high, standard := tagList.Compute()
+	c.tagProcessor.ProcessTagInfo([]*types.TagInfo{
+		{
+			Source:               staticSource,
+			EntityID:             common.GetGlobalEntityID(),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+		},
+	})
 }
 
 func (c *WorkloadMetaCollector) stream(ctx context.Context) {

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -111,7 +111,7 @@ func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, dat
 			c.staticTags[clusterTagNamePrefix] = append(c.staticTags[clusterTagNamePrefix], cluster)
 		}
 	}
-	// These are the global tags that should only be applied to the internal global entity
+	// These are the global tags that should only be applied to the internal global entity on DCA.
 	// Whereas the static tags are applied to containers and pods directly as well.
 	globalEnvTags := util.GetGlobalEnvTags(datadogConfig)
 

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -116,7 +116,7 @@ func TestHandleKubePod(t *testing.T) {
 
 	tests := []struct {
 		name                          string
-		staticTags                    map[string]string
+		staticTags                    map[string][]string
 		k8sResourcesAnnotationsAsTags map[string]map[string]string
 		k8sResourcesLabelsAsTags      map[string]map[string]string
 		pod                           workloadmeta.KubernetesPod
@@ -789,8 +789,8 @@ func TestHandleKubePod(t *testing.T) {
 		},
 		{
 			name: "static tags",
-			staticTags: map[string]string{
-				"eks_fargate_node": "foobar",
+			staticTags: map[string][]string{
+				"eks_fargate_node": {"foobar"},
 			},
 			pod: workloadmeta.KubernetesPod{
 				EntityID: podEntityID,
@@ -961,7 +961,7 @@ func TestHandleKubePodWithoutPvcAsTags(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		staticTags          map[string]string
+		staticTags          map[string][]string
 		labelsAsTags        map[string]string
 		annotationsAsTags   map[string]string
 		nsLabelsAsTags      map[string]string
@@ -1117,7 +1117,7 @@ func TestHandleKubePodNoContainerName(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		staticTags          map[string]string
+		staticTags          map[string][]string
 		labelsAsTags        map[string]string
 		annotationsAsTags   map[string]string
 		nsLabelsAsTags      map[string]string
@@ -1617,7 +1617,7 @@ func TestHandleContainer(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		staticTags   map[string]string
+		staticTags   map[string][]string
 		labelsAsTags map[string]string
 		envAsTags    map[string]string
 		container    workloadmeta.Container
@@ -2098,8 +2098,8 @@ func TestHandleContainer(t *testing.T) {
 		},
 		{
 			name: "static tags",
-			staticTags: map[string]string{
-				"eks_fargate_node": "foobar",
+			staticTags: map[string][]string{
+				"eks_fargate_node": {"foobar"},
 			},
 			container: workloadmeta.Container{
 				EntityID: entityID,

--- a/comp/core/tagger/impl/local_tagger.go
+++ b/comp/core/tagger/impl/local_tagger.go
@@ -60,7 +60,7 @@ func (t *localTagger) Start(ctx context.Context) error {
 	)
 
 	go t.tagStore.Run(t.ctx)
-	go t.collector.Run(t.ctx)
+	go t.collector.Run(t.ctx, t.cfg)
 
 	return nil
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
@@ -13,13 +13,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestIsolateCheckSuccessful(t *testing.T) {
-	testDispatcher := newDispatcher()
+	fakeTagger := mock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
 	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
 	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
@@ -99,7 +101,8 @@ func TestIsolateCheckSuccessful(t *testing.T) {
 }
 
 func TestIsolateNonExistentCheckFails(t *testing.T) {
-	testDispatcher := newDispatcher()
+	fakeTagger := mock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
 	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
 	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
@@ -177,7 +180,8 @@ func TestIsolateNonExistentCheckFails(t *testing.T) {
 }
 
 func TestIsolateCheckOnlyOneRunnerFails(t *testing.T) {
-	testDispatcher := newDispatcher()
+	fakeTagger := mock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
 	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
@@ -34,12 +36,21 @@ type dispatcher struct {
 	rebalancingPeriod             time.Duration
 }
 
-func newDispatcher() *dispatcher {
+func newDispatcher(tagger tagger.Component) *dispatcher {
 	d := &dispatcher{
 		store: newClusterStore(),
 	}
 	d.nodeExpirationSeconds = pkgconfigsetup.Datadog().GetInt64("cluster_checks.node_expiration_timeout")
-	d.extraTags = pkgconfigsetup.Datadog().GetStringSlice("cluster_checks.extra_tags")
+
+	// Attach the cluster agent's global tags to all dispatched checks
+	// as defined in the tagger's workloadmeta collector
+	var err error
+	d.extraTags, err = tagger.GlobalTags(types.LowCardinality)
+	if err != nil {
+		log.Warnf("Cannot get global tags from the tagger: %v", err)
+	} else {
+		log.Debugf("Adding global tags to cluster check dispatcher: %v", d.extraTags)
+	}
 
 	excludedChecks := pkgconfigsetup.Datadog().GetStringSlice("cluster_checks.exclude_checks")
 	// This option will almost always be empty
@@ -77,7 +88,6 @@ func newDispatcher() *dispatcher {
 		return d
 	}
 
-	var err error
 	d.clcRunnersClient, err = clusteragent.GetCLCRunnerClient()
 	if err != nil {
 		log.Warnf("Cannot create CLC runners client, advanced dispatching will be disabled: %v", err)

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -1377,7 +1378,8 @@ func TestRebalance(t *testing.T) {
 				checkMetricSamplesWeight = originalMetricSamplesWeight
 			}()
 
-			dispatcher := newDispatcher()
+			fakeTagger := mock.SetupFakeTagger(t)
+			dispatcher := newDispatcher(fakeTagger)
 
 			// prepare store
 			dispatcher.store.active = true
@@ -1433,7 +1435,8 @@ func TestMoveCheck(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			dispatcher := newDispatcher()
+			fakeTagger := mock.SetupFakeTagger(t)
+			dispatcher := newDispatcher(fakeTagger)
 
 			// setup check id
 			id := checkid.BuildID(tc.check.config.Name, tc.check.config.FastDigest(), tc.check.config.Instances[0], tc.check.config.InitConfig)
@@ -1477,7 +1480,8 @@ func TestCalculateAvg(t *testing.T) {
 		checkMetricSamplesWeight = originalMetricSamplesWeight
 	}()
 
-	testDispatcher := newDispatcher()
+	fakeTagger := mock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
 
 	// The busyness of this node is 3 (1 + 2)
 	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "")
@@ -1518,7 +1522,8 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	//   other tests specific for the checksDistribution struct that test more
 	//   complex scenarios.
 
-	testDispatcher := newDispatcher()
+	fakeTagger := mock.SetupFakeTagger(t)
+	testDispatcher := newDispatcher(fakeTagger)
 
 	testDispatcher.store.active = true
 	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "")

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -59,7 +60,7 @@ type Handler struct {
 
 // NewHandler returns a populated Handler
 // It will hook on the specified AutoConfig instance at Start
-func NewHandler(ac pluggableAutoConfig) (*Handler, error) {
+func NewHandler(ac pluggableAutoConfig, tagger tagger.Component) (*Handler, error) {
 	if ac == nil {
 		return nil, errors.New("empty autoconfig object")
 	}
@@ -68,7 +69,7 @@ func NewHandler(ac pluggableAutoConfig) (*Handler, error) {
 		leaderStatusFreq: 5 * time.Second,
 		warmupDuration:   pkgconfigsetup.Datadog().GetDuration("cluster_checks.warmup_duration") * time.Second,
 		leadershipChan:   make(chan state, 1),
-		dispatcher:       newDispatcher(),
+		dispatcher:       newDispatcher(tagger),
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("leader_election") {

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	taggerMock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
@@ -138,6 +139,7 @@ func TestUpdateLeaderIP(t *testing.T) {
 func TestHandlerRun(t *testing.T) {
 	dummyT := &testing.T{}
 	ac := &mockedPluggableAutoConfig{}
+	fakeTagger := taggerMock.SetupFakeTagger(t)
 	ac.Test(t)
 	le := &fakeLeaderEngine{
 		err: errors.New("failing"),
@@ -154,7 +156,7 @@ func TestHandlerRun(t *testing.T) {
 		leaderStatusFreq:     100 * time.Millisecond,
 		warmupDuration:       250 * time.Millisecond,
 		leadershipChan:       make(chan state, 1),
-		dispatcher:           newDispatcher(),
+		dispatcher:           newDispatcher(fakeTagger),
 		leaderStatusCallback: le.get,
 		leaderForwarder:      api.NewLeaderForwarder(testPort, 10),
 	}

--- a/pkg/config/utils/tags.go
+++ b/pkg/config/utils/tags.go
@@ -28,3 +28,17 @@ func GetConfiguredTags(c pkgconfigmodel.Reader, includeDogstatsd bool) []string 
 
 	return combined
 }
+
+// GetConfiguredDCATags returns list of tags from a configuration, based on
+// `cluster_checks.extra_tags` (DD_CLUSTER_CHECKS_EXTRA_TAGS) and
+// `orchestrator_explorer.extra_tags (DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS).
+func GetConfiguredDCATags(c pkgconfigmodel.Reader) []string {
+	clusterCheckTags := c.GetStringSlice("cluster_checks.extra_tags")
+	orchestratorTags := c.GetStringSlice("orchestrator_explorer.extra_tags")
+
+	combined := make([]string, 0, len(clusterCheckTags)+len(orchestratorTags))
+	combined = append(combined, clusterCheckTags...)
+	combined = append(combined, orchestratorTags...)
+
+	return combined
+}

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -83,17 +83,18 @@ func GetStaticTags(ctx context.Context) map[string][]string {
 }
 
 // GetGlobalEnvTags is similar to GetStaticTags, but returning a map[string][]string containing
-// <key>:<value> pairs for all global environment tags. This includes DD_TAGS and DD_EXTRA_TAGS always,
-// and DD_CLUSTER_CHECKS_EXTRA_TAGS and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS when on Cluster Agent
+// <key>:<value> pairs for all global environment tags on the cluster agent. This includes:
+// DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
 func GetGlobalEnvTags(config model.Reader) map[string][]string {
+	if flavor.GetFlavor() != flavor.ClusterAgent {
+		return nil
+	}
 
 	// DD_TAGS / DD_EXTRA_TAGS
 	tags := configUtils.GetConfiguredTags(config, false)
 
 	// DD_CLUSTER_CHECKS_EXTRA_TAGS / DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
-	if flavor.GetFlavor() == flavor.ClusterAgent {
-		tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
-	}
+	tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
 
 	if tags == nil {
 		return nil

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -70,19 +72,44 @@ func GetStaticTagsSlice(ctx context.Context) []string {
 	return tags
 }
 
-// GetStaticTags is similar to GetStaticTagsSlice, but returning a map[string]string containing
+// GetStaticTags is similar to GetStaticTagsSlice, but returning a map[string][]string containing
 // <key>:<value> pairs for tags.  Tags not matching this pattern are omitted.
-func GetStaticTags(ctx context.Context) map[string]string {
+func GetStaticTags(ctx context.Context) map[string][]string {
 	tags := GetStaticTagsSlice(ctx)
 	if tags == nil {
 		return nil
 	}
+	return sliceToMap(tags)
+}
 
-	rv := make(map[string]string, len(tags))
+// GetGlobalEnvTags is similar to GetStaticTags, but returning a map[string][]string containing
+// <key>:<value> pairs for all global environment tags. This includes DD_TAGS and DD_EXTRA_TAGS always,
+// and DD_CLUSTER_CHECKS_EXTRA_TAGS and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS when on Cluster Agent
+func GetGlobalEnvTags(config model.Reader) map[string][]string {
+
+	// DD_TAGS / DD_EXTRA_TAGS
+	tags := configUtils.GetConfiguredTags(config, false)
+
+	// DD_CLUSTER_CHECKS_EXTRA_TAGS / DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
+	}
+
+	if tags == nil {
+		return nil
+	}
+	return sliceToMap(tags)
+}
+
+func sliceToMap(tags []string) map[string][]string {
+	rv := make(map[string][]string, len(tags))
 	for _, t := range tags {
 		tagParts := strings.SplitN(t, ":", 2)
 		if len(tagParts) == 2 {
-			rv[tagParts[0]] = tagParts[1]
+			if _, ok := rv[tagParts[0]]; !ok {
+				rv[tagParts[0]] = []string{}
+			}
+			rv[tagParts[0]] = append(rv[tagParts[0]], tagParts[1])
 		}
 	}
 	return rv

--- a/pkg/util/static_tags_test.go
+++ b/pkg/util/static_tags_test.go
@@ -108,10 +108,7 @@ func TestExtraGlobalEnvTags(t *testing.T) {
 	t.Run("Agent extraGlobalTags", func(t *testing.T) {
 		flavor.SetFlavor(flavor.DefaultAgent)
 		globalTags := GetGlobalEnvTags(mockConfig)
-		assert.Equal(t, map[string][]string{
-			"some":  {"tag"},
-			"extra": {"tag"},
-		}, globalTags)
+		assert.Equal(t, map[string][]string(nil), globalTags)
 	})
 
 	t.Run("ClusterAgent extraGlobalTags", func(t *testing.T) {

--- a/pkg/util/static_tags_test.go
+++ b/pkg/util/static_tags_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func TestStaticTags(t *testing.T) {
@@ -26,10 +27,10 @@ func TestStaticTags(t *testing.T) {
 		mockConfig.SetWithoutSource("tags", []string{"some:tag", "another:tag", "nocolon"})
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background())
-		assert.Equal(t, map[string]string{
-			"some":             "tag",
-			"another":          "tag",
-			"eks_fargate_node": "eksnode",
+		assert.Equal(t, map[string][]string{
+			"some":             {"tag"},
+			"another":          {"tag"},
+			"eks_fargate_node": {"eksnode"},
 		}, staticTags)
 	})
 
@@ -39,10 +40,10 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		defer mockConfig.SetWithoutSource("extra_tags", []string{})
 		staticTags := GetStaticTags(context.Background())
-		assert.Equal(t, map[string]string{
-			"some":             "tag",
-			"extra":            "tag",
-			"eks_fargate_node": "eksnode",
+		assert.Equal(t, map[string][]string{
+			"some":             {"tag"},
+			"extra":            {"tag"},
+			"eks_fargate_node": {"eksnode"},
 		}, staticTags)
 	})
 
@@ -50,9 +51,9 @@ func TestStaticTags(t *testing.T) {
 		mockConfig.SetWithoutSource("tags", []string{"kube_cluster_name:foo"})
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background())
-		assert.Equal(t, map[string]string{
-			"eks_fargate_node":  "eksnode",
-			"kube_cluster_name": "foo",
+		assert.Equal(t, map[string][]string{
+			"eks_fargate_node":  {"eksnode"},
+			"kube_cluster_name": {"foo"},
 		}, staticTags)
 	})
 }
@@ -89,5 +90,38 @@ func TestStaticTagsSlice(t *testing.T) {
 			"extra:tag",
 			"eks_fargate_node:eksnode",
 		}, staticTags)
+	})
+}
+
+func TestExtraGlobalEnvTags(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("tags", []string{"some:tag", "nocolon"})
+	mockConfig.SetWithoutSource("extra_tags", []string{"extra:tag", "missingcolon"})
+	mockConfig.SetWithoutSource("cluster_checks.extra_tags", []string{"cluster:tag", "nocolon"})
+	mockConfig.SetWithoutSource("orchestrator_explorer.extra_tags", []string{"orch:tag", "missingcolon"})
+
+	recordFlavor := flavor.GetFlavor()
+	defer func() {
+		flavor.SetFlavor(recordFlavor)
+	}()
+
+	t.Run("Agent extraGlobalTags", func(t *testing.T) {
+		flavor.SetFlavor(flavor.DefaultAgent)
+		globalTags := GetGlobalEnvTags(mockConfig)
+		assert.Equal(t, map[string][]string{
+			"some":  {"tag"},
+			"extra": {"tag"},
+		}, globalTags)
+	})
+
+	t.Run("ClusterAgent extraGlobalTags", func(t *testing.T) {
+		flavor.SetFlavor(flavor.ClusterAgent)
+		globalTags := GetGlobalEnvTags(mockConfig)
+		assert.Equal(t, map[string][]string{
+			"some":    {"tag"},
+			"extra":   {"tag"},
+			"cluster": {"tag"},
+			"orch":    {"tag"},
+		}, globalTags)
 	})
 }

--- a/releasenotes/notes/unify-cluster-check-tag-0a8e854517742c0f.yaml
+++ b/releasenotes/notes/unify-cluster-check-tag-0a8e854517742c0f.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Cluster check tagging has been unified across all different environments.
+    Now, DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
+    will apply to all cluster check data, including when executing on the Cluster Agent itself, or when
+    dispatched to execute on the Node Agent or Cluster Checks Runner.

--- a/releasenotes/notes/unify-cluster-check-tag-0a8e854517742c0f.yaml
+++ b/releasenotes/notes/unify-cluster-check-tag-0a8e854517742c0f.yaml
@@ -8,7 +8,4 @@
 ---
 enhancements:
   - |
-    Cluster check tagging has been unified across all different environments.
-    Now, DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
-    will apply to all cluster check data, including when executing on the Cluster Agent itself, or when
-    dispatched to execute on the Node Agent or Cluster Checks Runner.
+    Standardized cluster check tagging across all environments, allowing DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, and DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS to apply to all cluster check data when operating on the Cluster Agent, Node Agent, or Cluster Checks Runner.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR unifies the way that data is tagged from cluster checks. All data from a cluster check (including those that are technically not cluster checks but still executed on the DCA on the cluster level such as KSM check) will receive the global tags defined on the cluster agent (DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS).

### Motivation

Simplify the way users interact with cluster check tags. Currently we have 4 different environment variables that apply differently for some checks (KSM, Orchestrator, others) and also differently depending on where the check is executed (DCA, Node Agent, CLC runner).

### Describe how to test/QA your changes

#### Case 1: DCA w/o CLC

1. Deploy the Agent
```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: <INSERT_CLUSTER_NAME>
  clusterChecks:
    enabled: true
  kubeStateMetricsCore:
    enabled: true
    # useClusterCheckRunners: true
  envDict:
    DD_TAGS: "source:node-tags"
    DD_EXTRA_TAGS: "source:node-extra"
    DD_CLUSTER_CHECKS_EXTRA_TAGS: "source:node-cluster_extra"       # Note: should never see these
    DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS: "source:node-orch_extra"   # Note: should never see these
agents:
  image:
    tag: <INSERT_RC_TAG>
# clusterChecksRunner:
#   replicas: 1
#   enabled: true
#   image:
#     tag: <INSERT_RC_TAG>
clusterAgent:
  envDict:
    DD_TAGS: "source:dca-tags"
    DD_EXTRA_TAGS: "source:dca-extra"
    DD_CLUSTER_CHECKS_EXTRA_TAGS: "source:dca-cluster_extra"
    DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS: "source:dca-orch_extra"
  image:
    tag: <INSERT_RC_TAG>
  enabled: true
  replicas: 1
```
2. Deploy the nginx service with an autodiscovery http check
```
apiVersion: v1
kind: Service
metadata:
    name: my-nginx
    labels:
        run: my-nginx
        tags.datadoghq.com/env: "prod"
        tags.datadoghq.com/service: "my-nginx"
        tags.datadoghq.com/version: "1.19.0"
    annotations:
      ad.datadoghq.com/service.checks: |
        {
          "http_check": {
            "init_config": {},
            "instances": [
              {
                "url":"http://%%host%%",
                "name":"My Nginx",
                "timeout":1
              }
            ]
          }
        }        
spec:
    ports:
        - port: 80
          protocol: TCP
    selector:
        run: my-nginx
```

3. Verify Global Tags are set
```
k exec -it datadog-agent-linux-cluster-agent-xxxxx -- agent tagger-list
=== Entity internal://global-entity-id ===
== Source workloadmeta-static =
=Tags: [kube_cluster_name:gabedos-cluster source:dca-cluster_extra source:dca-extra source:dca-orch_extra source:dca-tags]
===

k exec -it datadog-agent-linux-xxxxx -- agent tagger-list
=== Entity internal://global-entity-id ===
== Source workloadmeta-static =
=Tags: []  # Update: we should expect no tags on the node agent.
===
```

4. Confirm the following metrics tags:
- `network.http.cant_connect` should contain all of the cluster agent tags and *not the node agent tags*. The check is dispatched from the cluster agent where the DCA global tags are added to the check config. The node agent tags are not added to these metrics. This is the expected behavior from before this PR. This is because node agent host tags are attached via a separate process for metrics specifically originated from node agent checks.
- `kubernetes_state.deployment.count` should contain only the DCA tags since it's executed on the cluster agent.
- `check_run.kube_apiserver_controlplane.up.ok` should contain both the DCA tags and Node Agent tags because the metric is produced from the kube_apiserver check that run on both the DCA and Node Agent. 
- `container.cpu.limit` should contain just the Node Agent tags. This is a sanity check that extra tags aren't being applied in the wrong places.

<img width="1205" alt="After-DCA-no-CLC" src="https://github.com/user-attachments/assets/6198a5ab-c226-4232-91b1-53c4ac3c2f0b">

#### DCA w/ CLC

1. Deploy the Agent. Uncomment out the KSM UseClusterCheckRunners and the clusterChecksRunners in the `linux.yaml` from above.
2. Deploy the nginx service from above.
3. Confirm the following metrics:
- `network.http.cant_connect`: This one will be different. The check is now being executed on the clusterChecksRunner which will not have the Node Agent tags. When the DCA creates and dispatches a check config it will attach its own global tags.
- `kubernetes_state.deployment.count`: DCA tags only
- `check_run.kube_apiserver_controlplane.up.ok`: DCA + Node tags
- `container.cpu.limit`: Node tags only

<img width="1204" alt="After-DCA-with-CLC" src="https://github.com/user-attachments/assets/6e333885-4e16-491f-9f49-bb1faae473d4">

4. Confirm the following events tags:

Go to the Events Management Explorer and search for events created by your cluster. This will just be a lot of pod creations. Click on them and you should see all of the cluster-agent tags as well as the node-agent tags. We expect both because the orchestrator check runs on both the node-agent and the cluster-agent. They detected the same event and send data to the datadog backend with their own tags and they end up being merged together into one entity.

<img width="1084" alt="OrchestratorPage" src="https://github.com/user-attachments/assets/a0ae6c4e-c909-4ac1-b3b2-fc6c3e1b210a">

### Possible Drawbacks / Trade-offs

Since these are low cardinality global tags, we don't expect to see a significant change in the number of unique metrics for customer billing.

This does in some ways limit the flexibility for some customers. For instance, they will not be able to use DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS to just add tags to the events emitted by the orchestrator check. Instead, the tag will be attached to all data from the cluster agent. This makes the tagging interface much simpler for customers. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->