### PR TITLE
[EBPF] gpu: mark TestVectorAddProgramDetected as flaky

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
@@ -151,6 +152,8 @@ func (v *gpuSuite) TestGPUSysprobeEndpointIsResponding() {
 }
 
 func (v *gpuSuite) TestVectorAddProgramDetected() {
+	flake.Mark(v.T())
+
 	_ = v.runCudaDockerWorkload()
 
 	v.EventuallyWithT(func(c *assert.CollectT) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR marks the TestVectorAddProgramDetected as flaky

### Motivation

Avoid main failures. For some reason sometimes the vectorAdd program is not finding the GPU.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->