### PR TITLE
[e2e] add stackid agent tag to docker, ecs, kind and eks provisioners

### DIFF
--- a/test/new-e2e/pkg/environments/aws/docker/host.go
+++ b/test/new-e2e/pkg/environments/aws/docker/host.go
@@ -204,7 +204,8 @@ func Run(ctx *pulumi.Context, env *environments.DockerHost, runParams RunParams)
 			params.agentOptions = append(params.agentOptions, dockeragentparams.WithExtraComposeManifest(dogstatsd.DockerComposeManifest.Name, dogstatsd.DockerComposeManifest.Content))
 			params.agentOptions = append(params.agentOptions, dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{"HOST_IP": host.Address}))
 		}
-		agent, err := agent.NewDockerAgent(&awsEnv, host, manager, params.agentOptions...)
+		agentOptions := append(params.agentOptions, dockeragentparams.WithTags([]string{fmt.Sprintf("stackid:%s", ctx.Stack())}))
+		agent, err := agent.NewDockerAgent(&awsEnv, host, manager, agentOptions...)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/pkg/environments/aws/ecs/ecs.go
+++ b/test/new-e2e/pkg/environments/aws/ecs/ecs.go
@@ -231,7 +231,9 @@ func Run(ctx *pulumi.Context, env *environments.ECS, params *ProvisionerParams) 
 			return err
 		}
 
-		_, err := agent.ECSLinuxDaemonDefinition(awsEnv, "ec2-linux-dd-agent", apiKeyParam.Name, fakeIntake, cluster.ClusterArn, params.agentOptions...)
+		// add stack-id to tags
+		agentOptions := append(params.agentOptions, ecsagentparams.WithTags([]string{fmt.Sprintf("stackid:%s", ctx.Stack())}))
+		_, err := agent.ECSLinuxDaemonDefinition(awsEnv, "ec2-linux-dd-agent", apiKeyParam.Name, fakeIntake, cluster.ClusterArn, agentOptions...)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/pkg/environments/aws/kubernetes/eks.go
+++ b/test/new-e2e/pkg/environments/aws/kubernetes/eks.go
@@ -111,7 +111,7 @@ func EKSRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 	workloadWithCRDDeps := []pulumi.Resource{cluster}
 	// Deploy the agent
 	if params.agentOptions != nil {
-		params.agentOptions = append(params.agentOptions, kubernetesagentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(cluster)), kubernetesagentparams.WithFakeintake(fakeIntake))
+		params.agentOptions = append(params.agentOptions, kubernetesagentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(cluster)), kubernetesagentparams.WithFakeintake(fakeIntake), kubernetesagentparams.WithTags([]string{fmt.Sprintf("stackid:%s", ctx.Stack())}))
 		kubernetesAgent, err := helm.NewKubernetesAgent(&awsEnv, "eks", cluster.KubeProvider, params.agentOptions...)
 		if err != nil {
 			return err

--- a/test/new-e2e/pkg/environments/aws/kubernetes/kind.go
+++ b/test/new-e2e/pkg/environments/aws/kubernetes/kind.go
@@ -139,7 +139,10 @@ agents:
   useHostNetwork: true
 `, kindClusterName)
 
-		newOpts := []kubernetesagentparams.Option{kubernetesagentparams.WithHelmValues(helmValues)}
+		newOpts := []kubernetesagentparams.Option{
+			kubernetesagentparams.WithHelmValues(helmValues),
+			kubernetesagentparams.WithTags([]string{fmt.Sprintf("stackid:%s", ctx.Stack())}),
+		}
 		params.agentOptions = append(newOpts, params.agentOptions...)
 		agent, err := helm.NewKubernetesAgent(&awsEnv, kindClusterName, kubeProvider, params.agentOptions...)
 		if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add stackid tag to agent config on docker, ecs, eks and kind environment

### Motivation

Helps investigating failing tests by allowing filtering metrics, that are redirected to dddev

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->