### PR TITLE
[SDBM-1330] Prevent failures when collecting Oracle metrics with big execution plan

### DIFF
--- a/pkg/collector/corechecks/oracle/statements.go
+++ b/pkg/collector/corechecks/oracle/statements.go
@@ -226,7 +226,7 @@ type PlanDefinition struct {
 	PlanStepId       int64   `json:"id"`
 	ParentId         int64   `json:"parent_id"`
 	Depth            int64   `json:"depth"`
-	Position         int64   `json:"position"`
+	Position         uint64  `json:"position"`
 	SearchColumns    int64   `json:"search_columns,omitempty"`
 	Cost             float64 `json:"cost"`
 	Cardinality      float64 `json:"cardinality,omitempty"`
@@ -299,7 +299,7 @@ type PlanStepRows struct {
 	PlanStepId       sql.NullInt64   `db:"ID"`
 	ParentId         sql.NullInt64   `db:"PARENT_ID"`
 	Depth            sql.NullInt64   `db:"DEPTH"`
-	Position         sql.NullInt64   `db:"POSITION"`
+	Position         *uint64         `db:"POSITION"`
 	SearchColumns    sql.NullInt64   `db:"SEARCH_COLUMNS"`
 	Cost             sql.NullFloat64 `db:"COST"`
 	Cardinality      sql.NullFloat64 `db:"CARDINALITY"`
@@ -701,8 +701,8 @@ func (c *Check) StatementMetrics() (int, error) {
 								if stepRow.Depth.Valid {
 									stepPayload.Depth = stepRow.Depth.Int64
 								}
-								if stepRow.Position.Valid {
-									stepPayload.Position = stepRow.Position.Int64
+								if stepRow.Position != nil {
+									stepPayload.Position = *stepRow.Position
 								}
 								if stepRow.SearchColumns.Valid {
 									stepPayload.SearchColumns = stepRow.SearchColumns.Int64

--- a/releasenotes/notes/fix-oracle-execution-plan-collection-ed04a62d8349eb67.yaml
+++ b/releasenotes/notes/fix-oracle-execution-plan-collection-ed04a62d8349eb67.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix Oracle execution plan collection failing because of out of bound position column. 
+    This could happen when the execution plan was too big.

--- a/releasenotes/notes/fix-oracle-execution-plan-collection-ed04a62d8349eb67.yaml
+++ b/releasenotes/notes/fix-oracle-execution-plan-collection-ed04a62d8349eb67.yaml
@@ -8,5 +8,4 @@
 ---
 fixes:
   - |
-    Fix Oracle execution plan collection failing because of out of bound position column. 
-    This could happen when the execution plan was too big.
+    Fix Oracle execution plan collection failures caused by an out-of-range position column, which can occur if the execution plan is excessively large.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Sometimes, when fetching the execution plan, the query result will fail to be serialized in Go because the plan position would be too big for int64. I've replaced the type to uint64 to prevent those crashes.
This is an example of error messages:
```
2024-11-14 21:42:59 UTC | CORE | ERROR | (pkg/collector/corechecks/oracle/statements.go:825 in StatementMetrics) | agent>  failed getting execution plan sql: Scan error on column index 11, name "POSITION": converting driver.Value type string ("18446744073709551615") to a int64: value out of range SELECT /* DD */
  child_number,
	timestamp,
	operation,
	options,
	object_name,
	object_type,
	object_alias,
	optimizer,
	id,
	parent_id,
	depth,
	position,
	....
```

### Motivation

### Describe how to test/QA your changes
Collect Oracle plan as usual and check that everything is working. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->