### PR TITLE
Change viper.AllKeys to use a WRLock instead of a RLock

### DIFF
--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -310,8 +310,8 @@ func (c *safeConfig) IsSet(key string) bool {
 }
 
 func (c *safeConfig) AllKeysLowercased() []string {
-	c.RLock()
-	defer c.RUnlock()
+	c.Lock()
+	defer c.Unlock()
 	return c.Viper.AllKeys()
 }
 


### PR DESCRIPTION
### What does this PR do?

The previous PR https://github.com/DataDog/datadog-agent/pull/30723 fixed a map iteration bug in viper, but it missed one case, which is now being handled here.

When viper builds the collection of keys and/or settings, it does so by flattening each layer into a single map. Because this operation is modifying the map being built, AND viper will mistakingly treat leaf nodes with map values as though they were inner nodes of the config, this needs to be locked with a WRLock. This PR fixes the case where `AllKeys()` is called simultaneously by multiple threads by using a WRLock in that methods a well.

### Motivation

Properly handle concurrency in viper.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
