### PR TITLE
Enable requesting flares with profiles via Remote Config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -319,6 +319,7 @@
 /comp/core/configsync @DataDog/agent-configuration
 /comp/core/flare @DataDog/agent-configuration
 /comp/core/gui @DataDog/agent-configuration
+/comp/core/profiler @DataDog/agent-configuration
 /comp/core/secrets @DataDog/agent-configuration
 /comp/core/settings @DataDog/agent-configuration
 /comp/core/status @DataDog/agent-configuration

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -34,7 +34,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	flareprofilerdef "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	flareprofilerfx "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	coresettings "github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
@@ -124,6 +125,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					defaultpaths.DogstatsDLogFile,
 					defaultpaths.StreamlogsLogFile,
 				)),
+				flareprofilerfx.Module(),
 				// workloadmeta setup
 				wmcatalog.GetCatalog(),
 				workloadmetafx.Module(workloadmeta.Params{
@@ -188,7 +190,7 @@ func makeFlare(flareComp flare.Component,
 	cliParams *cliParams,
 	_ option.Option[workloadmeta.Component],
 	_ tagger.Component,
-	flareprofiler flareprofiler.Component) error {
+	flareprofiler flareprofilerdef.Component) error {
 	var (
 		profile flaretypes.ProfileData
 		err     error

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -10,9 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -20,14 +18,12 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamlogs"
-	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager/diagnosesendermanagerimpl"
 	authtokenimpl "github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector"
@@ -37,7 +33,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	profiler "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	profilerfx "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	coresettings "github.com/DataDog/datadog-agent/comp/core/settings"
+	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -130,6 +130,17 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					AgentType:  workloadmeta.NodeAgent,
 					InitHelper: common.GetWorkloadmetaInit(),
 				}),
+				fx.Provide(func(config config.Component) coresettings.Params {
+					return coresettings.Params{
+						// A settings object is required to populate some dependencies, but
+						// no values are valid since the flare runs by default in a separate
+						// process from the main agent.
+						Settings: map[string]coresettings.RuntimeSetting{},
+						Config:   config,
+					}
+				}),
+				settingsimpl.Module(),
+				profilerfx.Module(),
 				localTaggerfx.Module(tagger.Params{}),
 				autodiscoveryimpl.Module(),
 				fx.Supply(option.None[collector.Component]()),
@@ -171,145 +182,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{flareCmd}
 }
 
-func readProfileData(seconds int) (flare.ProfileData, error) {
-	type agentProfileCollector func(service string) error
-
-	pdata := flare.ProfileData{}
-	c := util.GetClient(false)
-
-	type pprofGetter func(path string) ([]byte, error)
-
-	tcpGet := func(portConfig string, onHTTPS bool) pprofGetter {
-		endpoint := url.URL{
-			Scheme: "http",
-			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(pkgconfigsetup.Datadog().GetInt(portConfig))),
-			Path:   "/debug/pprof",
-		}
-		if onHTTPS {
-			endpoint.Scheme = "https"
-		}
-
-		return func(path string) ([]byte, error) {
-			return util.DoGet(c, endpoint.String()+path, util.LeaveConnectionOpen)
-		}
-	}
-
-	serviceProfileCollector := func(get func(url string) ([]byte, error), seconds int) agentProfileCollector {
-		return func(service string) error {
-			fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from %s.", seconds, service))
-			for _, prof := range []struct{ name, path string }{
-				{
-					// 1st heap profile
-					name: service + "-1st-heap.pprof",
-					path: "/heap",
-				},
-				{
-					// CPU profile
-					name: service + "-cpu.pprof",
-					path: fmt.Sprintf("/profile?seconds=%d", seconds),
-				},
-				{
-					// 2nd heap profile
-					name: service + "-2nd-heap.pprof",
-					path: "/heap",
-				},
-				{
-					// mutex profile
-					name: service + "-mutex.pprof",
-					path: "/mutex",
-				},
-				{
-					// goroutine blocking profile
-					name: service + "-block.pprof",
-					path: "/block",
-				},
-				{
-					// Trace
-					name: service + ".trace",
-					path: fmt.Sprintf("/trace?seconds=%d", seconds),
-				},
-			} {
-				b, err := get(prof.path)
-				if err != nil {
-					return err
-				}
-				pdata[prof.name] = b
-			}
-			return nil
-		}
-	}
-
-	agentCollectors := map[string]agentProfileCollector{
-		"core":           serviceProfileCollector(tcpGet("expvar_port", false), seconds),
-		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port", false), seconds),
-	}
-
-	if pkgconfigsetup.Datadog().GetBool("process_config.enabled") ||
-		pkgconfigsetup.Datadog().GetBool("process_config.container_collection.enabled") ||
-		pkgconfigsetup.Datadog().GetBool("process_config.process_collection.enabled") {
-
-		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port", false), seconds)
-	}
-
-	if pkgconfigsetup.Datadog().GetBool("apm_config.enabled") {
-		traceCpusec := pkgconfigsetup.Datadog().GetInt("apm_config.receiver_timeout")
-		if traceCpusec > seconds {
-			// do not exceed requested duration
-			traceCpusec = seconds
-		} else if traceCpusec <= 0 {
-			// default to 4s as maximum connection timeout of trace-agent HTTP server is 5s by default
-			traceCpusec = 4
-		}
-
-		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port", true), traceCpusec)
-	}
-
-	if pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enabled") {
-		client := &http.Client{
-			Transport: &http.Transport{
-				DialContext: sysprobeclient.DialContextFunc(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
-			},
-		}
-
-		sysProbeGet := func() pprofGetter {
-			return func(path string) ([]byte, error) {
-				var buf bytes.Buffer
-				pprofURL := sysprobeclient.DebugURL("/pprof" + path)
-				req, err := http.NewRequest(http.MethodGet, pprofURL, &buf)
-				if err != nil {
-					return nil, err
-				}
-
-				res, err := client.Do(req)
-				if err != nil {
-					return nil, err
-				}
-				defer res.Body.Close()
-
-				return io.ReadAll(res.Body)
-			}
-		}
-
-		agentCollectors["system-probe"] = serviceProfileCollector(sysProbeGet(), seconds)
-	}
-
-	var errs error
-	for name, callback := range agentCollectors {
-		if err := callback(name); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error collecting %s agent profile: %v", name, err))
-		}
-	}
-
-	return pdata, errs
-}
-
 func makeFlare(flareComp flare.Component,
 	lc log.Component,
 	config config.Component,
 	_ sysprobeconfig.Component,
 	cliParams *cliParams,
 	_ option.Option[workloadmeta.Component],
-	_ tagger.Component) error {
+	_ tagger.Component,
+	profiler profiler.Component) error {
 	var (
 		profile flare.ProfileData
 		err     error
@@ -359,8 +239,13 @@ func makeFlare(flareComp flare.Component,
 			ProfileBlockingRate:  cliParams.profileBlockingRate,
 		}
 
+		logFunc := func(s string, params ...interface{}) error {
+			fmt.Fprintln(color.Output, color.BlueString(s, params...))
+			return nil
+		}
+
 		err = settings.ExecWithRuntimeProfilingSettings(func() {
-			if profile, err = readProfileData(cliParams.profiling); err != nil {
+			if profile, err = profiler.ReadProfileData(cliParams.profiling, logFunc); err != nil {
 				fmt.Fprintln(color.Output, color.YellowString(fmt.Sprintf("Could not collect performance profile data: %s", err)))
 			}
 		}, profilingOpts, c)

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -23,7 +23,7 @@ import (
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	profiler "github.com/DataDog/datadog-agent/comp/core/profiler/def"
 	profilerfx "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
-	profilerimpl "github.com/DataDog/datadog-agent/comp/core/profiler/impl"
+	profilermock "github.com/DataDog/datadog-agent/comp/core/profiler/mock"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
@@ -76,7 +76,7 @@ func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, tcp
 	var err error
 	t := c.T()
 
-	handler := profilerimpl.NewMockHandler()
+	handler := profilermock.NewMockHandler()
 	tcpServer = httptest.NewServer(handler)
 	tcpTLSServer = httptest.NewTLSServer(handler)
 	if runtime.GOOS == "linux" {

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	profiler "github.com/DataDog/datadog-agent/comp/core/profiler/def"
 	profilerfx "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	profilerimpl "github.com/DataDog/datadog-agent/comp/core/profiler/impl"
@@ -152,7 +152,7 @@ func (c *commandTestSuite) TestReadProfileData() {
 	data, err := profiler.ReadProfileData(10, func(string, ...interface{}) error { return nil })
 	require.NoError(t, err)
 
-	expected := flare.ProfileData{
+	expected := flaretypes.ProfileData{
 		"core-1st-heap.pprof":           []byte("heap_profile"),
 		"core-2nd-heap.pprof":           []byte("heap_profile"),
 		"core-block.pprof":              []byte("block"),
@@ -179,7 +179,7 @@ func (c *commandTestSuite) TestReadProfileData() {
 		"trace.trace":                   []byte("trace"),
 	}
 	if runtime.GOOS != "darwin" {
-		maps.Copy(expected, flare.ProfileData{
+		maps.Copy(expected, flaretypes.ProfileData{
 			"system-probe-1st-heap.pprof": []byte("heap_profile"),
 			"system-probe-2nd-heap.pprof": []byte("heap_profile"),
 			"system-probe-block.pprof":    []byte("block"),
@@ -220,7 +220,7 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 	require.Error(t, err)
 	require.Regexp(t, "^* error collecting trace agent profile: ", err.Error())
 
-	expected := flare.ProfileData{
+	expected := flaretypes.ProfileData{
 		"core-1st-heap.pprof":           []byte("heap_profile"),
 		"core-2nd-heap.pprof":           []byte("heap_profile"),
 		"core-block.pprof":              []byte("block"),
@@ -241,7 +241,7 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 		"security-agent.trace":          []byte("trace"),
 	}
 	if runtime.GOOS != "darwin" {
-		maps.Copy(expected, flare.ProfileData{
+		maps.Copy(expected, flaretypes.ProfileData{
 			"system-probe-1st-heap.pprof": []byte("heap_profile"),
 			"system-probe-2nd-heap.pprof": []byte("heap_profile"),
 			"system-probe-block.pprof":    []byte("block"),

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -65,6 +65,7 @@ import (
 	lsof "github.com/DataDog/datadog-agent/comp/core/lsof/fx"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
+	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	remoteagentregistryfx "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/fx"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -345,6 +346,7 @@ func getSharedFxOption() fx.Option {
 			defaultpaths.StreamlogsLogFile,
 		)),
 		core.Bundle(),
+		flareprofiler.Module(),
 		lsof.Module(),
 		// Enable core agent specific features like persistence-to-disk
 		forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithFeatures(defaultforwarder.CoreFeatures))),

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -65,6 +65,7 @@ import (
 	lsof "github.com/DataDog/datadog-agent/comp/core/lsof/fx"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
+	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	remoteagentregistryfx "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/fx"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -346,6 +347,7 @@ func getSharedFxOption() fx.Option {
 		)),
 		core.Bundle(),
 		lsof.Module(),
+		flareprofiler.Module(),
 		// Enable core agent specific features like persistence-to-disk
 		forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithFeatures(defaultforwarder.CoreFeatures))),
 		// workloadmeta setup

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -65,7 +65,6 @@ import (
 	lsof "github.com/DataDog/datadog-agent/comp/core/lsof/fx"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
-	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	remoteagentregistryfx "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/fx"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -347,7 +346,6 @@ func getSharedFxOption() fx.Option {
 		)),
 		core.Bundle(),
 		lsof.Module(),
-		flareprofiler.Module(),
 		// Enable core agent specific features like persistence-to-disk
 		forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithFeatures(defaultforwarder.CoreFeatures))),
 		// workloadmeta setup

--- a/comp/README.md
+++ b/comp/README.md
@@ -167,6 +167,10 @@ Package lsof provides a flare file with data about files opened by the agent pro
 Package pid writes the current PID to a file, ensuring that the file
 doesn't exist or doesn't contain a PID for a running process.
 
+### [comp/core/profiler](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/profiler)
+
+Package profiler provides a flare folder containing the output of various agent's pprof servers
+
 ### [comp/core/remoteagentregistry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/remoteagentregistry)
 
 Package remoteagentregistry provides an integration point for remote agents to register and be able to report their

--- a/comp/README.md
+++ b/comp/README.md
@@ -169,6 +169,8 @@ doesn't exist or doesn't contain a PID for a running process.
 
 ### [comp/core/profiler](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/profiler)
 
+*Datadog Team*: agent-configuration
+
 Package profiler provides a flare folder containing the output of various agent's pprof servers
 
 ### [comp/core/remoteagentregistry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/remoteagentregistry)

--- a/comp/core/flare/component.go
+++ b/comp/core/flare/component.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
-	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -37,6 +36,5 @@ func Module(params Params) fxutil.Module {
 
 	return fxutil.Component(
 		fx.Provide(newFlare),
-		fx.Supply(params),
-		flareprofiler.Module())
+		fx.Supply(params))
 }

--- a/comp/core/flare/component.go
+++ b/comp/core/flare/component.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -32,7 +33,10 @@ type Component interface {
 
 // Module defines the fx options for this component.
 func Module(params Params) fxutil.Module {
+	var fbf types.FlareBuilderFactory = helpers.NewFlareBuilder
+
 	return fxutil.Component(
 		fx.Provide(newFlare),
-		fx.Supply(params))
+		fx.Supply(params),
+		fx.Supply(fbf))
 }

--- a/comp/core/flare/component.go
+++ b/comp/core/flare/component.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
+	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -26,7 +27,7 @@ type Component interface {
 	// Create creates a new flare locally and returns the path to the flare file.
 	//
 	// If providerTimeout is 0 or negative, the timeout from the configuration will be used.
-	Create(pdata ProfileData, providerTimeout time.Duration, ipcError error) (string, error)
+	Create(pdata types.ProfileData, providerTimeout time.Duration, ipcError error) (string, error)
 	// Send sends a flare archive to Datadog.
 	Send(flarePath string, caseID string, email string, source helpers.FlareSource) (string, error)
 }
@@ -38,5 +39,6 @@ func Module(params Params) fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newFlare),
 		fx.Supply(params),
-		fx.Supply(fbf))
+		fx.Supply(fbf),
+		flareprofiler.Module())
 }

--- a/comp/core/flare/component.go
+++ b/comp/core/flare/component.go
@@ -34,11 +34,9 @@ type Component interface {
 
 // Module defines the fx options for this component.
 func Module(params Params) fxutil.Module {
-	var fbf types.FlareBuilderFactory = helpers.NewFlareBuilder
 
 	return fxutil.Component(
 		fx.Provide(newFlare),
 		fx.Supply(params),
-		fx.Supply(fbf),
 		flareprofiler.Module())
 }

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -38,9 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
-// ProfileData maps (pprof) profile names to the profile data.
-type ProfileData map[string][]byte
-
 type dependencies struct {
 	fx.In
 
@@ -145,7 +142,7 @@ func (f *flare) onAgentTaskEvent(taskType rcclienttypes.TaskType, task rcclientt
 }
 
 func (f *flare) createAndReturnFlarePath(w http.ResponseWriter, r *http.Request) {
-	var profile ProfileData
+	var profile types.ProfileData
 
 	if r.Body != http.NoBody {
 		body, err := io.ReadAll(r.Body)
@@ -201,7 +198,7 @@ func (f *flare) Send(flarePath string, caseID string, email string, source helpe
 // Create creates a new flare and returns the path to the final archive file.
 //
 // If providerTimeout is 0 or negative, the timeout from the configuration will be used.
-func (f *flare) Create(pdata ProfileData, providerTimeout time.Duration, ipcError error) (string, error) {
+func (f *flare) Create(pdata types.ProfileData, providerTimeout time.Duration, ipcError error) (string, error) {
 	return f.create(types.FlareArgs{}, providerTimeout, ipcError, pdata)
 }
 
@@ -209,10 +206,10 @@ func (f *flare) Create(pdata ProfileData, providerTimeout time.Duration, ipcErro
 //
 // If providerTimeout is 0 or negative, the timeout from the configuration will be used.
 func (f *flare) CreateWithArgs(flareArgs types.FlareArgs, providerTimeout time.Duration, ipcError error) (string, error) {
-	return f.create(flareArgs, providerTimeout, ipcError, ProfileData{})
+	return f.create(flareArgs, providerTimeout, ipcError, types.ProfileData{})
 }
 
-func (f *flare) create(flareArgs types.FlareArgs, providerTimeout time.Duration, ipcError error, pdata ProfileData) (string, error) {
+func (f *flare) create(flareArgs types.FlareArgs, providerTimeout time.Duration, ipcError error, pdata types.ProfileData) (string, error) {
 	if providerTimeout <= 0 {
 		providerTimeout = f.config.GetDuration("flare_provider_timeout")
 	}

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -38,7 +38,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
-var flareBuilderFactory types.FlareBuilderFactory = helpers.NewFlareBuilder
+// FlareBuilderFactory creates an instance of FlareBuilder
+type flareBuilderFactory func(localFlare bool, flareArgs types.FlareArgs) (types.FlareBuilder, error)
+
+var fbFactory flareBuilderFactory = helpers.NewFlareBuilder
 
 type dependencies struct {
 	fx.In
@@ -213,7 +216,7 @@ func (f *flare) create(flareArgs types.FlareArgs, providerTimeout time.Duration,
 		providerTimeout = f.config.GetDuration("flare_provider_timeout")
 	}
 
-	fb, err := flareBuilderFactory(f.params.local, flareArgs)
+	fb, err := fbFactory(f.params.local, flareArgs)
 	if err != nil {
 		return "", err
 	}

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -31,20 +31,25 @@ import (
 	mockTagger "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+
+	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
+
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestFlareCreation(t *testing.T) {
-	realProvider := types.NewFiller(func(_ types.FlareBuilder) error { return nil })
-
+func getFlare(t *testing.T, overrides map[string]interface{}, fillers ...fx.Option) *flare {
+	fillerModule := fxutil.Component(fillers...)
 	fakeTagger := mockTagger.SetupFakeTagger(t)
-
-	f := newFlare(
+	return newFlare(
 		fxutil.Test[dependencies](
 			t,
 			fx.Provide(func() log.Component { return logmock.New(t) }),
 			config.MockModule(),
+			fx.Replace(config.MockParams{
+				Overrides: overrides,
+			}),
 			secretsimpl.MockModule(),
 			nooptelemetry.Module(),
 			hostnameimpl.MockModule(),
@@ -57,45 +62,40 @@ func TestFlareCreation(t *testing.T) {
 			fx.Provide(func(ac autodiscovery.Mock) autodiscovery.Component { return ac.(autodiscovery.Component) }),
 			fx.Provide(func() mockTagger.Mock { return fakeTagger }),
 			fx.Provide(func() tagger.Component { return fakeTagger }),
-			// provider a nil FlareFiller
-			fx.Provide(fx.Annotate(
-				func() *types.FlareFiller { return nil },
-				fx.ResultTags(`group:"flare"`),
-			)),
-			// provider a real FlareFiller
-			fx.Provide(fx.Annotate(
-				func() *types.FlareFiller { return realProvider },
-				fx.ResultTags(`group:"flare"`),
-			)),
+			fx.Supply(helpers.CreateFlareBuilderMockFactory(t)),
+			fillerModule,
 		),
+	).Comp.(*flare)
+}
+func TestFlareCreation(t *testing.T) {
+	realProvider := types.NewFiller(func(_ types.FlareBuilder) error { return nil })
+
+	flare := getFlare(
+		t,
+		map[string]interface{}{},
+		// provider a nil FlareFiller
+		fx.Provide(fx.Annotate(
+			func() *types.FlareFiller { return nil },
+			fx.ResultTags(`group:"flare"`),
+		)),
+		// provider a real FlareFiller
+		fx.Provide(fx.Annotate(
+			func() *types.FlareFiller { return realProvider },
+			fx.ResultTags(`group:"flare"`),
+		)),
 	)
 
-	assert.GreaterOrEqual(t, len(f.Comp.(*flare).providers), 1)
-	assert.NotContains(t, f.Comp.(*flare).providers, nil)
+	assert.GreaterOrEqual(t, len(flare.providers), 1)
+	assert.NotContains(t, flare.providers, nil)
 }
 
 func TestRunProviders(t *testing.T) {
 	firstStarted := make(chan struct{}, 1)
 	var secondDone atomic.Bool
 
-	fakeTagger := mockTagger.SetupFakeTagger(t)
-
-	deps := fxutil.Test[dependencies](
+	flare := getFlare(
 		t,
-		fx.Provide(func() log.Component { return logmock.New(t) }),
-		config.MockModule(),
-		secretsimpl.MockModule(),
-		nooptelemetry.Module(),
-		hostnameimpl.MockModule(),
-		demultiplexerimpl.MockModule(),
-		fx.Provide(func() Params { return Params{} }),
-		collector.NoneModule(),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-		autodiscoveryimpl.MockModule(),
-		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: scheduler.NewController()}),
-		fx.Provide(func(ac autodiscovery.Mock) autodiscovery.Component { return ac.(autodiscovery.Component) }),
-		fx.Provide(func() mockTagger.Mock { return fakeTagger }),
-		fx.Provide(func() tagger.Component { return fakeTagger }),
+		map[string]interface{}{},
 		// provider a nil FlareFiller
 		fx.Provide(fx.Annotate(
 			func() *types.FlareFiller { return nil },
@@ -123,13 +123,12 @@ func TestRunProviders(t *testing.T) {
 	)
 
 	cliProviderTimeout := time.Nanosecond
-	f := newFlare(deps)
 
 	fb, err := helpers.NewFlareBuilder(false, flarebuilder.FlareArgs{})
 	require.NoError(t, err)
 
 	start := time.Now()
-	f.Comp.(*flare).runProviders(fb, cliProviderTimeout)
+	flare.runProviders(fb, cliProviderTimeout)
 	// ensure that providers are actually started
 	<-firstStarted
 	elapsed := time.Since(start)
@@ -137,4 +136,73 @@ func TestRunProviders(t *testing.T) {
 	// ensure that we're not blocking for the slow provider
 	assert.Less(t, elapsed, 5*time.Second)
 	assert.False(t, secondDone.Load())
+}
+
+func TestAgentTaskFlareArgs(t *testing.T) {
+	type rcSettings struct {
+		duration  time.Duration
+		blockRate int
+		mutexFrac int
+	}
+
+	enabledDefaults := rcSettings{
+		duration:  40 * time.Second,
+		blockRate: 123,
+		mutexFrac: 456,
+	}
+
+	disabledDefaults := rcSettings{}
+
+	testCfg := map[string]interface{}{
+		"site":                                "localhost", // Provide extra guarantees we don't try to send the flare off the box
+		"flare.rc_profiling.profile_duration": enabledDefaults.duration,
+		"flare.rc_profiling.blocking_rate":    enabledDefaults.blockRate,
+		"flare.rc_profiling.mutex_fraction":   enabledDefaults.mutexFrac,
+	}
+
+	scenarios := []struct {
+		name        string
+		task        string
+		expSettings rcSettings
+	}{
+		{
+			name:        "Test profiling enabled",
+			task:        "{\"args\":{\"case_id\":\"22420\",\"enable_profiling\":\"true\",\"user_handle\":\"no-reply@datadoghq.com\"},\"task_type\":\"flare\",\"uuid\":\"a_uuid\"}",
+			expSettings: enabledDefaults,
+		},
+		{
+			name:        "Test profiling disabled",
+			task:        "{\"args\":{\"case_id\":\"22420\",\"enable_profiling\":\"false\",\"user_handle\":\"no-reply@datadoghq.com\"},\"task_type\":\"flare\",\"uuid\":\"a_uuid\"}",
+			expSettings: disabledDefaults,
+		},
+		{
+			name:        "Test profiling invalid",
+			task:        "{\"args\":{\"case_id\":\"22420\",\"enable_profiling\":\"1\",\"user_handle\":\"no-reply@datadoghq.com\"},\"task_type\":\"flare\",\"uuid\":\"a_uuid\"}",
+			expSettings: disabledDefaults,
+		},
+		{
+			name:        "Test profiling not present",
+			task:        "{\"args\":{\"case_id\":\"22420\",\"user_handle\":\"no-reply@datadoghq.com\"},\"task_type\":\"flare\",\"uuid\":\"a_uuid\"}",
+			expSettings: disabledDefaults,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			flare := getFlare(t, testCfg)
+
+			flare.providers = []*types.FlareFiller{
+				types.NewFiller(func(fb types.FlareBuilder) error {
+					assert.Equal(t, s.expSettings.duration, fb.GetFlareArgs().ProfileDuration)
+					assert.Equal(t, s.expSettings.blockRate, fb.GetFlareArgs().ProfileBlockingRate)
+					assert.Equal(t, s.expSettings.mutexFrac, fb.GetFlareArgs().ProfileMutexFraction)
+					return nil
+				}),
+			}
+			atc, err := rcclienttypes.ParseConfigAgentTask([]byte(s.task), state.Metadata{})
+			assert.NoError(t, err)
+
+			flare.onAgentTaskEvent(rcclienttypes.TaskFlare, atc)
+		})
+	}
 }

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -62,10 +62,17 @@ func getFlare(t *testing.T, overrides map[string]interface{}, fillers ...fx.Opti
 			fx.Provide(func(ac autodiscovery.Mock) autodiscovery.Component { return ac.(autodiscovery.Component) }),
 			fx.Provide(func() mockTagger.Mock { return fakeTagger }),
 			fx.Provide(func() tagger.Component { return fakeTagger }),
-			fx.Supply(helpers.CreateFlareBuilderMockFactory(t)),
 			fillerModule,
 		),
 	).Comp.(*flare)
+}
+
+func setupMockBuilder(t *testing.T) func() {
+	flareBuilderFactory = helpers.CreateFlareBuilderMockFactory(t)
+
+	return func() {
+		flareBuilderFactory = helpers.NewFlareBuilder
+	}
 }
 func TestFlareCreation(t *testing.T) {
 	realProvider := types.NewFiller(func(_ types.FlareBuilder) error { return nil })
@@ -139,6 +146,8 @@ func TestRunProviders(t *testing.T) {
 }
 
 func TestAgentTaskFlareArgs(t *testing.T) {
+	defer setupMockBuilder(t)()
+
 	type rcSettings struct {
 		duration  time.Duration
 		blockRate int

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -67,11 +67,14 @@ func getFlare(t *testing.T, overrides map[string]interface{}, fillers ...fx.Opti
 	).Comp.(*flare)
 }
 
+// CreateFlareBuilderMockFactory generates a FlareBuilderFactory that will output mocked builders when called.
 func setupMockBuilder(t *testing.T) func() {
-	flareBuilderFactory = helpers.CreateFlareBuilderMockFactory(t)
+	fbFactory = func(localFlare bool, flareArgs types.FlareArgs) (types.FlareBuilder, error) {
+		return helpers.NewFlareBuilderMockWithArgs(t, localFlare, flareArgs), nil
+	}
 
 	return func() {
-		flareBuilderFactory = helpers.NewFlareBuilder
+		fbFactory = helpers.NewFlareBuilder
 	}
 }
 func TestFlareCreation(t *testing.T) {

--- a/comp/core/flare/flareimpl/mock.go
+++ b/comp/core/flare/flareimpl/mock.go
@@ -17,6 +17,7 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -44,7 +45,7 @@ func (fc *MockFlare) handlerFunc(w http.ResponseWriter, _ *http.Request) {
 }
 
 // Create mocks the flare create function
-func (fc *MockFlare) Create(_ flare.ProfileData, _ time.Duration, _ error) (string, error) {
+func (fc *MockFlare) Create(_ flaretypes.ProfileData, _ time.Duration, _ error) (string, error) {
 	return "a string", nil
 }
 

--- a/comp/core/flare/helpers/builder_mock.go
+++ b/comp/core/flare/helpers/builder_mock.go
@@ -59,13 +59,6 @@ func createMock(t *testing.T, local bool, args types.FlareArgs) *FlareBuilderMoc
 	return fb
 }
 
-// CreateFlareBuilderMockFactory generates a FlareBuilderFactory that will output mocked builders when called.
-func CreateFlareBuilderMockFactory(t *testing.T) types.FlareBuilderFactory {
-	return func(localFlare bool, flareArgs types.FlareArgs) (types.FlareBuilder, error) {
-		return NewFlareBuilderMockWithArgs(t, localFlare, flareArgs), nil
-	}
-}
-
 func (m *FlareBuilderMock) filePath(path ...string) string {
 	return filepath.Join(
 		append(

--- a/comp/core/flare/helpers/builder_mock.go
+++ b/comp/core/flare/helpers/builder_mock.go
@@ -8,6 +8,7 @@
 package helpers
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ import (
 
 // FlareBuilderMock offers all the helpers to test flare providers.
 type FlareBuilderMock struct {
-	Fb   types.FlareBuilder
+	types.FlareBuilder
 	Root string
 	t    *testing.T
 }
@@ -30,18 +31,39 @@ type FlareBuilderMock struct {
 // 'local' relates to where the flare is currently created. Flare created from the Agent process are not local. Flares
 // created directly from the CLI are local. Almost every flare Provider shouldn't care where the flare is being built.
 func NewFlareBuilderMock(t *testing.T, local bool) *FlareBuilderMock {
+	return createMock(t, local, types.FlareArgs{})
+}
+
+// NewFlareBuilderMockWithArgs return a FlareBuilderMock to test flare providers.
+//
+// 'local' relates to where the flare is currently created. Flare created from the Agent process are not local. Flares
+// created directly from the CLI are local. Almost every flare Provider shouldn't care where the flare is being built.
+//
+// FlareArgs will be made available to callers of GetFlareArgs()
+func NewFlareBuilderMockWithArgs(t *testing.T, local bool, args types.FlareArgs) *FlareBuilderMock {
+	return createMock(t, local, args)
+}
+
+func createMock(t *testing.T, local bool, args types.FlareArgs) *FlareBuilderMock {
 	root := t.TempDir()
 
-	builder, err := newBuilder(root, "test-hostname", local, types.FlareArgs{})
+	builder, err := newBuilder(root, "test-hostname", local, args)
 	require.NoError(t, err)
 
 	fb := &FlareBuilderMock{
-		Fb:   builder,
-		Root: builder.flareDir,
-		t:    t,
+		FlareBuilder: builder,
+		Root:         builder.flareDir,
+		t:            t,
 	}
 	t.Cleanup(func() { builder.logFile.Close() })
 	return fb
+}
+
+// CreateFlareBuilderMockFactory generates a FlareBuilderFactory that will output mocked builders when called.
+func CreateFlareBuilderMockFactory(t *testing.T) types.FlareBuilderFactory {
+	return func(localFlare bool, flareArgs types.FlareArgs) (types.FlareBuilder, error) {
+		return NewFlareBuilderMockWithArgs(t, localFlare, flareArgs), nil
+	}
 }
 
 func (m *FlareBuilderMock) filePath(path ...string) string {
@@ -82,4 +104,10 @@ func (m *FlareBuilderMock) AssertFileContentMatch(pattern string, paths ...strin
 // AssertNoFileExists asserts that a file does not exists within the flare
 func (m *FlareBuilderMock) AssertNoFileExists(paths ...string) bool {
 	return assert.NoFileExists(m.t, m.filePath(paths...))
+}
+
+// Save overrides the underlying flarebuilder method to a no-op. This helps
+// ensure tests do not attempt to further process the temporary flare.
+func (m *FlareBuilderMock) Save() (string, error) {
+	return "", errors.New("Unimplemented")
 }

--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -23,9 +23,6 @@ type ProfileData map[string][]byte
 // see the aliased type for the full description
 type FlareBuilder = flarebuilder.FlareBuilder
 
-// FlareBuilderFactory creates an instance of FlareBuilder
-type FlareBuilderFactory func(localFlare bool, flareArgs FlareArgs) (FlareBuilder, error)
-
 // FlareArgs contains the args passed in by the caller to the flare generation process
 // see the aliased type for the full description
 type FlareArgs = flarebuilder.FlareArgs

--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -16,6 +16,9 @@ import (
 	flarebuilder "github.com/DataDog/datadog-agent/comp/core/flare/builder"
 )
 
+// ProfileData maps (pprof) profile names to the profile data.
+type ProfileData map[string][]byte
+
 // FlareBuilder contains all the helpers to add files to a flare archive.
 // see the aliased type for the full description
 type FlareBuilder = flarebuilder.FlareBuilder

--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -20,6 +20,9 @@ import (
 // see the aliased type for the full description
 type FlareBuilder = flarebuilder.FlareBuilder
 
+// FlareBuilderFactory creates an instance of FlareBuilder
+type FlareBuilderFactory func(localFlare bool, flareArgs FlareArgs) (FlareBuilder, error)
+
 // FlareArgs contains the args passed in by the caller to the flare generation process
 // see the aliased type for the full description
 type FlareArgs = flarebuilder.FlareArgs

--- a/comp/core/profiler/def/component.go
+++ b/comp/core/profiler/def/component.go
@@ -8,9 +8,9 @@ package profiler
 
 // team: agent-shared-components
 
-import "github.com/DataDog/datadog-agent/comp/core/flare"
+import flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 
 // Component is the component type
 type Component interface {
-	ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flare.ProfileData, error)
+	ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flaretypes.ProfileData, error)
 }

--- a/comp/core/profiler/def/component.go
+++ b/comp/core/profiler/def/component.go
@@ -6,7 +6,7 @@
 // Package profiler provides a flare folder containing the output of various agent's pprof servers
 package profiler
 
-// team: agent-shared-components
+// team: agent-configuration
 
 import flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 

--- a/comp/core/profiler/def/component.go
+++ b/comp/core/profiler/def/component.go
@@ -12,5 +12,13 @@ import flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 
 // Component is the component type
 type Component interface {
+	// Gathers and returns pprof server output for a variety of agent services.
+	//
+	// Will always attempt to read the pprof of core-agent and security-agent, and will optionally try to read information for
+	// process-agent, trace-agent, and system-probe if those systems are detected as enabled.
+	//
+	// This function is exposed via the public api to support the flare generation cli command. While the goal
+	// is to move the profiling component completely into a flare provider, the existing architecture
+	// expects an explicit and pre-emptive profiling run before the flare logic is properly called.
 	ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flaretypes.ProfileData, error)
 }

--- a/comp/core/profiler/def/component.go
+++ b/comp/core/profiler/def/component.go
@@ -12,7 +12,7 @@ import flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 
 // Component is the component type
 type Component interface {
-	// Gathers and returns pprof server output for a variety of agent services.
+	// ReadPofileData Gathers and returns pprof server output for a variety of agent services.
 	//
 	// Will always attempt to read the pprof of core-agent and security-agent, and will optionally try to read information for
 	// process-agent, trace-agent, and system-probe if those systems are detected as enabled.

--- a/comp/core/profiler/def/component.go
+++ b/comp/core/profiler/def/component.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package profiler provides a flare folder containing the output of various agent's pprof servers
+package profiler
+
+// team: agent-shared-components
+
+import "github.com/DataDog/datadog-agent/comp/core/flare"
+
+// Component is the component type
+type Component interface {
+	ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flare.ProfileData, error)
+}

--- a/comp/core/profiler/fx/fx.go
+++ b/comp/core/profiler/fx/fx.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the profiler component
+package fx
+
+import (
+	profilerimpl "github.com/DataDog/datadog-agent/comp/core/profiler/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(profilerimpl.NewComponent),
+	)
+}

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -1,0 +1,331 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package profilerimpl implements the profiler component interface
+package profilerimpl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/flare"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	profilercomp "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	"github.com/DataDog/datadog-agent/comp/core/settings"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// Requires defines the dependencies for the profiler component
+type Requires struct {
+	compdef.In
+
+	SettingsComponent settings.Component
+	Config            config.Component
+	SysProbeConfig    sysprobeconfig.Component
+}
+
+// Provides defines the output of the profiler component
+type Provides struct {
+	compdef.Out
+
+	Comp          profilercomp.Component
+	FlareProvider flaretypes.Provider
+}
+
+type profiler struct {
+	settingsComponent settings.Component
+	cfg               config.Component
+	sysProbeCfg       sysprobeconfig.Component
+}
+
+// Gathers and returns pprof server output for a variety of agent services.
+//
+// Will always attempt to read the pprof of core-agent and security-agent, and will optionally try to read information for
+// process-agent, trace-agent, and system-probe if those systems are detected as enabled.
+//
+// This function is exposed via the public api to support the flare generation cli command. While the goal
+// is to move the profiling component completely into a flare provider, the existing architecture
+// expects an explicit and pre-emptive profiling run before the flare logic is properly called.
+func (p profiler) ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flare.ProfileData, error) {
+	type agentProfileCollector func(service string) error
+
+	pdata := flare.ProfileData{}
+	c := util.GetClient(false)
+
+	type pprofGetter func(path string) ([]byte, error)
+	tcpGet := func(portConfig string, onHTTPS bool) pprofGetter {
+		endpoint := url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(p.cfg.GetInt(portConfig))),
+			Path:   "/debug/pprof",
+		}
+		if onHTTPS {
+			endpoint.Scheme = "https"
+		}
+		return func(path string) ([]byte, error) {
+			return util.DoGet(c, endpoint.String()+path, util.LeaveConnectionOpen)
+		}
+	}
+
+	serviceProfileCollector := func(get func(url string) ([]byte, error), seconds int) agentProfileCollector {
+		return func(service string) error {
+			_ = logFunc("Getting a %ds profile snapshot from %s.", seconds, service)
+
+			for _, prof := range []struct{ name, path string }{
+				{
+					// 1st heap profile
+					name: service + "-1st-heap.pprof",
+					path: "/heap",
+				},
+				{
+					// CPU profile
+					name: service + "-cpu.pprof",
+					path: fmt.Sprintf("/profile?seconds=%d", seconds),
+				},
+				{
+					// 2nd heap profile
+					name: service + "-2nd-heap.pprof",
+					path: "/heap",
+				},
+				{
+					// mutex profile
+					name: service + "-mutex.pprof",
+					path: "/mutex",
+				},
+				{
+					// goroutine blocking profile
+					name: service + "-block.pprof",
+					path: "/block",
+				},
+				{
+					// Trace
+					name: service + ".trace",
+					path: fmt.Sprintf("/trace?seconds=%d", seconds),
+				},
+			} {
+				b, err := get(prof.path)
+				if err != nil {
+					return err
+				}
+				pdata[prof.name] = b
+			}
+			return nil
+		}
+	}
+
+	agentCollectors := map[string]agentProfileCollector{}
+	if p.coreAgentEnabled() {
+		agentCollectors["core"] = serviceProfileCollector(tcpGet("expvar_port", false), seconds)
+	}
+
+	if p.securityAgentEnabled() {
+		agentCollectors["security-agent"] = serviceProfileCollector(tcpGet("security_agent.expvar_port", false), seconds)
+	}
+
+	if p.processAgentEnabled() {
+		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port", false), seconds)
+	}
+
+	if p.apmEnabled() {
+		traceCpusec := p.apmTraceSeconds(seconds)
+		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port", true), traceCpusec)
+	}
+
+	if p.sysProbeEnabled() {
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: sysprobeclient.DialContextFunc(p.sysProbeCfg.GetString("system_probe_config.sysprobe_socket")),
+			},
+		}
+
+		sysProbeGet := func() pprofGetter {
+			return func(path string) ([]byte, error) {
+				var buf bytes.Buffer
+				pprofURL := sysprobeclient.DebugURL("/pprof" + path)
+				req, err := http.NewRequest(http.MethodGet, pprofURL, &buf)
+				if err != nil {
+					return nil, err
+				}
+
+				res, err := client.Do(req)
+				if err != nil {
+					return nil, err
+				}
+				defer res.Body.Close()
+
+				return io.ReadAll(res.Body)
+			}
+		}
+
+		agentCollectors["system-probe"] = serviceProfileCollector(sysProbeGet(), seconds)
+	}
+
+	var errs error
+	for name, callback := range agentCollectors {
+		if err := callback(name); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error collecting %s agent profile: %v", name, err))
+		}
+	}
+
+	return pdata, errs
+}
+
+func (p profiler) setProfilerSetting(settingName string, newValue int, fb flaretypes.FlareBuilder) func() {
+	oldValue, err := p.settingsComponent.GetRuntimeSetting(settingName)
+	if err != nil {
+		_ = fb.Logf("Unable to access %s setting, ignoring value provided by flare args: %v", settingName, err)
+
+		return nil
+	} else if newValue <= 0 || newValue == oldValue {
+		return nil
+	}
+
+	err = p.settingsComponent.SetRuntimeSetting(settingName, newValue, model.SourceAgentRuntime)
+	if err != nil {
+		_ = fb.Logf("Unable to set the %s: %v", settingName, err)
+	}
+
+	return func() {
+		nErr := p.settingsComponent.SetRuntimeSetting(settingName, oldValue, model.SourceAgentRuntime)
+		if nErr != nil {
+			_ = fb.Logf("Unable to reset the %s back to its original value: %v", settingName, nErr)
+		}
+	}
+}
+
+// Currently flare args are only populated (and this function is only enabled) via
+// the RC flare generation flow. The goal is to shift other flare generation flows
+// to utilize this provider over time, which will require additional plumbing. For
+// example, the flare api call must be expanded to take in an optional profile duration
+// before the cli command can be fully ported over.
+func (p profiler) fillFlare(fb flaretypes.FlareBuilder) error {
+	duration := fb.GetFlareArgs().ProfileDuration
+
+	if duration <= 0 {
+		_ = fb.Logf("Profiling retrieval has been disabled via an unset duration, exiting profile flare filler")
+		return nil
+	}
+
+	blockingRate := fb.GetFlareArgs().ProfileBlockingRate
+	bDeferFunc := p.setProfilerSetting("runtime_block_profile_rate", blockingRate, fb)
+	if bDeferFunc != nil {
+		defer bDeferFunc()
+	}
+
+	mutexFraction := fb.GetFlareArgs().ProfileMutexFraction
+	mDeferFunc := p.setProfilerSetting("runtime_mutex_profile_fraction", mutexFraction, fb)
+	if mDeferFunc != nil {
+		defer mDeferFunc()
+	}
+
+	pdata, err := p.ReadProfileData(int(duration.Seconds()), fb.Logf)
+
+	// For legacy reasons it's not unexpected to get partial errors from ReadProfileData, record them in the logs
+	// and persist whatever data we did get
+	if err != nil {
+		_ = fb.Logf("Errors encountered generating flare profiles: %s", err)
+	}
+	for name, data := range pdata {
+		fb.AddFileWithoutScrubbing(filepath.Join("profiles", name), data)
+	}
+
+	return nil
+}
+
+// Currently the core agent is always considered enabled
+func (profiler) coreAgentEnabled() bool {
+	return true
+}
+
+// Currently the security agent is always considered enabled
+func (profiler) securityAgentEnabled() bool {
+	return true
+}
+
+func (p profiler) processAgentEnabled() bool {
+	return p.cfg.GetBool("process_config.enabled") ||
+		p.cfg.GetBool("process_config.container_collection.enabled") ||
+		p.cfg.GetBool("process_config.process_collection.enabled")
+}
+
+func (p profiler) apmEnabled() bool {
+	return p.cfg.GetBool("apm_config.enabled")
+}
+
+func (p profiler) sysProbeEnabled() bool {
+	return p.sysProbeCfg.GetBool("system_probe_config.enabled")
+}
+
+func (p profiler) timeout(fb flaretypes.FlareBuilder) time.Duration {
+	d := fb.GetFlareArgs().ProfileDuration
+	if d <= 0 {
+		return 0
+	}
+	var timeout time.Duration
+
+	// pprof's /profile + /trace both require [duration] seconds to track, so each agent requires
+	// at least 2*[duration] of runtime
+	if p.coreAgentEnabled() {
+		timeout += 2 * d
+	}
+	if p.securityAgentEnabled() {
+		timeout += 2 * d
+	}
+	if p.processAgentEnabled() {
+		timeout += 2 * d
+	}
+	if p.apmEnabled() {
+		apmSeconds := p.apmTraceSeconds(int(d.Seconds()))
+		timeout += 2 * (time.Duration(apmSeconds) * time.Second)
+	}
+	if p.sysProbeEnabled() {
+		timeout += 2 * d
+	}
+
+	processOverhead := p.cfg.GetDuration("flare.profile_overhead_runtime")
+
+	return timeout + processOverhead
+}
+
+func (p profiler) apmTraceSeconds(seconds int) int {
+	traceCpusec := p.cfg.GetInt("apm_config.receiver_timeout")
+	if traceCpusec > seconds {
+		// do not exceed requested duration
+		traceCpusec = seconds
+	} else if traceCpusec <= 0 {
+		// default to 4s as maximum connection timeout of trace-agent HTTP server is 5s by default
+		traceCpusec = 4
+	}
+
+	return traceCpusec
+}
+
+// NewComponent creates a new Profiler component
+func NewComponent(req Requires) (Provides, error) {
+	p := profiler{
+		settingsComponent: req.SettingsComponent,
+		cfg:               req.Config,
+		sysProbeCfg:       req.SysProbeConfig,
+	}
+	return Provides{
+		Comp:          p,
+		FlareProvider: flaretypes.NewProviderWithTimeout(p.fillFlare, p.timeout),
+	}, nil
+}

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -22,7 +22,6 @@ import (
 	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	profilercomp "github.com/DataDog/datadog-agent/comp/core/profiler/def"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -63,10 +62,10 @@ type profiler struct {
 // This function is exposed via the public api to support the flare generation cli command. While the goal
 // is to move the profiling component completely into a flare provider, the existing architecture
 // expects an explicit and pre-emptive profiling run before the flare logic is properly called.
-func (p profiler) ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flare.ProfileData, error) {
+func (p profiler) ReadProfileData(seconds int, logFunc func(log string, params ...interface{}) error) (flaretypes.ProfileData, error) {
 	type agentProfileCollector func(service string) error
 
-	pdata := flare.ProfileData{}
+	pdata := flaretypes.ProfileData{}
 	c := util.GetClient(false)
 
 	type pprofGetter func(path string) ([]byte, error)
@@ -200,6 +199,7 @@ func (p profiler) setProfilerSetting(settingName string, newValue int, fb flaret
 	err = p.settingsComponent.SetRuntimeSetting(settingName, newValue, model.SourceAgentRuntime)
 	if err != nil {
 		_ = fb.Logf("Unable to set the %s: %v", settingName, err)
+		return nil
 	}
 
 	return func() {

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -54,7 +54,7 @@ type profiler struct {
 	sysProbeCfg       sysprobeconfig.Component
 }
 
-// Gathers and returns pprof server output for a variety of agent services.
+// ReadProfileData gathers and returns pprof server output for a variety of agent services.
 //
 // Will always attempt to read the pprof of core-agent and security-agent, and will optionally try to read information for
 // process-agent, trace-agent, and system-probe if those systems are detected as enabled.

--- a/comp/core/profiler/impl/profiler_mock.go
+++ b/comp/core/profiler/impl/profiler_mock.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package profilerimpl
+
+import (
+	"net/http"
+)
+
+// NewMockHandler provides a standard handler that will mimic the endpoints the profiler will scan for pprof data
+// Can be injected directly in to an httptest server
+func NewMockHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/debug/pprof/heap":
+			w.Write([]byte("heap_profile"))
+		case "/debug/pprof/profile":
+			time := r.URL.Query()["seconds"][0]
+			w.Write([]byte(time + "_sec_cpu_pprof"))
+		case "/debug/pprof/mutex":
+			w.Write([]byte("mutex"))
+		case "/debug/pprof/block":
+			w.Write([]byte("block"))
+		case "/debug/stats": // only for system-probe
+			w.WriteHeader(200)
+		case "/debug/pprof/trace":
+			w.Write([]byte("trace"))
+		default:
+			w.WriteHeader(500)
+		}
+	})
+}

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 	profilerdef "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	profilermock "github.com/DataDog/datadog-agent/comp/core/profiler/mock"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 
@@ -30,7 +31,7 @@ import (
 )
 
 func createGenericConfig(t *testing.T) model.Config {
-	handler := NewMockHandler()
+	handler := profilermock.NewMockHandler()
 
 	server := httptest.NewServer(handler)
 

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -1,0 +1,256 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profilerimpl
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
+	profilerdef "github.com/DataDog/datadog-agent/comp/core/profiler/def"
+	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+
+	configcomponent "github.com/DataDog/datadog-agent/comp/core/config"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func createGenericConfig(t *testing.T) model.Config {
+	handler := NewMockHandler()
+
+	server := httptest.NewServer(handler)
+
+	t.Cleanup(func() {
+		if server != nil {
+			server.Close()
+			server = nil
+		}
+	})
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port := u.Port()
+
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("expvar_port", port)
+	mockConfig.SetWithoutSource("apm_config.debug.port", port)
+	mockConfig.SetWithoutSource("process_config.expvar_port", port)
+	mockConfig.SetWithoutSource("security_agent.expvar_port", port)
+
+	mockConfig.SetWithoutSource("process_config.enabled", false)
+	mockConfig.SetWithoutSource("process_config.container_collection.enabled", false)
+	mockConfig.SetWithoutSource("process_config.process_collection.enabled", false)
+	mockConfig.SetWithoutSource("apm_config.enabled", false)
+	mockConfig.SetWithoutSource("system_probe_config.enabled", false)
+
+	return mockConfig
+}
+
+type reqs struct {
+	fx.In
+
+	Comp profilerdef.Component
+}
+
+func getProfiler(t testing.TB, overrideConfig map[string]interface{}, overrideSysProbe map[string]interface{}) profiler {
+	deps := fxutil.Test[reqs](
+		t,
+		core.MockBundle(),
+		fx.Replace(configcomponent.MockParams{
+			Overrides: overrideConfig,
+		}),
+		fx.Replace(sysprobeconfigimpl.MockParams{
+			Overrides: overrideSysProbe,
+		}),
+		settingsimpl.MockModule(),
+		fxutil.ProvideComponentConstructor(NewComponent),
+	)
+
+	return deps.Comp.(profiler)
+}
+
+func TestProfileSetting(t *testing.T) {
+
+	scenarios := []struct {
+		name     string
+		newVal   int
+		oldVal   int
+		expVal   int
+		expDefer bool
+	}{
+		{
+			name:     "Base case - no change",
+			newVal:   0,
+			oldVal:   10,
+			expVal:   10,
+			expDefer: false,
+		},
+		{
+			name:     "Same value - no change",
+			newVal:   10,
+			oldVal:   10,
+			expVal:   10,
+			expDefer: false,
+		},
+		{
+			name:     "Overwrite value",
+			newVal:   20,
+			oldVal:   10,
+			expVal:   20,
+			expDefer: true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			fb := helpers.NewFlareBuilderMockWithArgs(t, true, types.FlareArgs{})
+			profiler := getProfiler(t, map[string]interface{}{}, map[string]interface{}{})
+			profiler.settingsComponent.SetRuntimeSetting("runtime_block_profile_rate", s.oldVal, model.SourceDefault)
+
+			deferFunc := profiler.setProfilerSetting("runtime_block_profile_rate", s.newVal, fb)
+			curVal, _ := profiler.settingsComponent.GetRuntimeSetting("runtime_block_profile_rate")
+			assert.Equal(t, s.expVal, curVal)
+
+			if s.expDefer {
+				assert.NotNil(t, deferFunc)
+			} else {
+				assert.Nil(t, deferFunc)
+			}
+			if deferFunc != nil {
+				deferFunc()
+			}
+
+			curVal, _ = profiler.settingsComponent.GetRuntimeSetting("runtime_block_profile_rate")
+			assert.Equal(t, s.oldVal, curVal)
+		})
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	baseTimeout := 10 * time.Minute
+
+	scenarios := []struct {
+		name            string
+		extraCfgs       map[string]interface{}
+		extraSysCfgs    map[string]interface{}
+		profileDuration time.Duration
+		expTimeout      time.Duration
+	}{
+		{
+			name:            "Base Enabled Case",
+			extraCfgs:       map[string]interface{}{},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 4*(10*time.Second),
+		},
+		{
+			name:            "Base Disabled Case",
+			extraCfgs:       map[string]interface{}{},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 0,
+			expTimeout:      0,
+		},
+		{
+			name: "APM Enabled, Default Runtime",
+			extraCfgs: map[string]interface{}{
+				"apm_config.enabled": true,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 4*(10*time.Second) + 2*(4*time.Second), // APM default runtime has a ceiling of 4
+		},
+		{
+			name: "APM Enabled, Small Runtime",
+			extraCfgs: map[string]interface{}{
+				"apm_config.enabled":          true,
+				"apm_config.receiver_timeout": 20,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 6*(10*time.Second), // APM timeout is floored to the profile duration
+		},
+		{
+			name: "APM Enabled, Large Runtime",
+			extraCfgs: map[string]interface{}{
+				"apm_config.enabled":          true,
+				"apm_config.receiver_timeout": 5,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 4*(10*time.Second) + 2*(5*time.Second), // APM timeout is the ceiling, limiting profile duration
+		},
+		{
+			name: "Process Agent Enabled",
+			extraCfgs: map[string]interface{}{
+				"process_config.enabled": true,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 6*(10*time.Second),
+		},
+		{
+			name: "Process Agent Enabled, Alternate Setting",
+			extraCfgs: map[string]interface{}{
+				"process_config.process_collection.enabled": true,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 6*(10*time.Second),
+		},
+		{
+			name:      "SysProbe Enabled",
+			extraCfgs: map[string]interface{}{},
+			extraSysCfgs: map[string]interface{}{
+				"system_probe_config.enabled": true,
+			},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 6*(10*time.Second),
+		},
+		{
+			name: "Everything Enabled",
+			extraCfgs: map[string]interface{}{
+				"process_config.container_collection.enabled": true,
+				"apm_config.enabled":                          true,
+				"apm_config.receiver_timeout":                 10,
+			},
+			extraSysCfgs: map[string]interface{}{
+				"system_probe_config.enabled": true,
+			},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 10*(10*time.Second),
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			cfg := createGenericConfig(t)
+			cfg.SetWithoutSource("flare.profile_overhead_runtime", baseTimeout)
+			fArgs := types.FlareArgs{
+				ProfileDuration: s.profileDuration,
+			}
+			for k, v := range s.extraCfgs {
+				cfg.SetWithoutSource(k, v)
+			}
+			fb := helpers.NewFlareBuilderMockWithArgs(t, true, fArgs)
+			profiler := getProfiler(t, cfg.AllSettings(), s.extraSysCfgs)
+
+			timeout := profiler.timeout(fb)
+
+			assert.Equal(t, s.expTimeout, timeout)
+		})
+	}
+}

--- a/comp/core/profiler/mock/profiler_mock.go
+++ b/comp/core/profiler/mock/profiler_mock.go
@@ -5,7 +5,8 @@
 
 //go:build test
 
-package profilerimpl
+// Package mock defines useful entities for mocking the flare profiler and its operations
+package mock
 
 import (
 	"net/http"

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
@@ -148,7 +148,7 @@ func TestFlareProvider(t *testing.T) {
 	fb := helpers.NewFlareBuilderMock(t, false)
 	fb.AssertNoFileExists("test-agent/test_file.yaml")
 
-	err = flareProvider.FlareFiller.Callback(fb.Fb)
+	err = flareProvider.FlareFiller.Callback(fb)
 	require.NoError(t, err)
 	fb.AssertFileExists("test-agent/test_file.yaml")
 	fb.AssertFileContent("test_content", "test-agent/test_file.yaml")

--- a/comp/core/settings/settingsimpl/settings_mock.go
+++ b/comp/core/settings/settingsimpl/settings_mock.go
@@ -31,12 +31,16 @@ type MockProvides struct {
 	Comp settings.Component
 }
 
-type mock struct{}
+type mock struct {
+	rtSettings map[string]interface{}
+}
 
 func newMock() MockProvides {
-	m := mock{}
+	m := mock{
+		rtSettings: map[string]interface{}{},
+	}
 	return MockProvides{
-		Comp: m,
+		Comp: &m,
 	}
 }
 
@@ -46,12 +50,17 @@ func (m mock) RuntimeSettings() map[string]settings.RuntimeSetting {
 }
 
 // GetRuntimeSetting returns the value of a runtime configurable setting
-func (m mock) GetRuntimeSetting(string) (interface{}, error) {
+func (m mock) GetRuntimeSetting(key string) (interface{}, error) {
+	v, found := m.rtSettings[key]
+	if found {
+		return v, nil
+	}
 	return nil, nil
 }
 
 // SetRuntimeSetting changes the value of a runtime configurable setting
-func (m mock) SetRuntimeSetting(string, interface{}, model.Source) error {
+func (m *mock) SetRuntimeSetting(key string, v interface{}, _ model.Source) error {
+	m.rtSettings[key] = v
 	return nil
 }
 

--- a/comp/logs/agent/flare/flare_controller_test.go
+++ b/comp/logs/agent/flare/flare_controller_test.go
@@ -25,7 +25,7 @@ func TestFillFlare(t *testing.T) {
 
 	fc.SetAllFiles([]string{file.Name()})
 
-	fc.FillFlare(f.Fb)
+	fc.FillFlare(f)
 	f.AssertFileExists("logs_file_permissions.log")
 	f.AssertFileContent(file.Name()+" "+fi.Mode().String(), "logs_file_permissions.log")
 }
@@ -46,7 +46,7 @@ func TestNonexistantFile(t *testing.T) {
 	name := "file.log"
 
 	fc.SetAllFiles([]string{name})
-	fc.FillFlare(f.Fb)
+	fc.FillFlare(f)
 
 	fi, err := os.Stat(name)
 	if fi != nil {

--- a/comp/metadata/host/hostimpl/host_test.go
+++ b/comp/metadata/host/hostimpl/host_test.go
@@ -105,7 +105,7 @@ func TestFlareProvider(t *testing.T) {
 
 	hostProvider := ret.Comp.(*host)
 	fbMock := flarehelpers.NewFlareBuilderMock(t, false)
-	hostProvider.fillFlare(fbMock.Fb)
+	hostProvider.fillFlare(fbMock)
 
 	fbMock.AssertFileExists(filepath.Join("metadata", "host.json"))
 }

--- a/comp/metadata/internal/util/inventory_payload_test.go
+++ b/comp/metadata/internal/util/inventory_payload_test.go
@@ -108,12 +108,12 @@ func TestFillFlare(t *testing.T) {
 	i := getTestInventoryPayload(t, nil)
 
 	i.Enabled = false
-	i.fillFlare(f.Fb)
+	i.fillFlare(f)
 	f.AssertFileExists("metadata", "inventory", "test.json")
 	f.AssertFileContent("inventory metadata is disabled", "metadata", "inventory", "test.json")
 
 	i.Enabled = true
-	i.fillFlare(f.Fb)
+	i.fillFlare(f)
 	f.AssertFileExists("metadata", "inventory", "test.json")
 	f.AssertFileContent("{\n    \"test\": true\n}", "metadata", "inventory", "test.json")
 }

--- a/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
+++ b/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
@@ -140,7 +140,7 @@ func TestOTelExtFlareBuilder(t *testing.T) {
 
 	// Fill the flare
 	f := helpers.NewFlareBuilderMock(t, false)
-	col.fillFlare(f.Fb)
+	col.fillFlare(f)
 
 	f.AssertFileExists("otel", "otel-response.json")
 

--- a/comp/process/agent/flare_test.go
+++ b/comp/process/agent/flare_test.go
@@ -22,6 +22,6 @@ func TestFillFlare(t *testing.T) {
 
 	fc := NewFlareHelper([]checks.Check{check})
 
-	fc.FillFlare(f.Fb)
+	fc.FillFlare(f)
 	f.AssertFileExists("process_check_output.json")
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -360,7 +360,10 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// flare configs
 	config.BindEnvAndSetDefault("flare_provider_timeout", 10*time.Second)
-	config.BindEnvAndSetDefault("flare.rc_profiling_runtime", 60*time.Second)
+	config.BindEnvAndSetDefault("flare.rc_profiling.profile_duration", 30*time.Second)
+	config.BindEnvAndSetDefault("flare.profile_overhead_runtime", 10*time.Second)
+	config.BindEnvAndSetDefault("flare.rc_profiling.blocking_rate", 0)
+	config.BindEnvAndSetDefault("flare.rc_profiling.mutex_fraction", 0)
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -69,7 +69,7 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mock := flarehelpers.NewFlareBuilderMock(t, test.local)
-			createSecurityAgentArchive(mock.Fb, logFilePath, statusComponent)
+			createSecurityAgentArchive(mock, logFilePath, statusComponent)
 
 			for _, f := range test.expectedFiles {
 				mock.AssertFileExists(f)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -50,7 +50,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	GetConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
+	GetConfigFiles(mock, searchPaths{"": "./test/confd"})
 
 	mock.AssertFileExists("etc", "datadog.yaml")
 	mock.AssertFileExists("etc", "system-probe.yaml")
@@ -60,7 +60,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 	configmock.New(t)
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	GetConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
+	GetConfigFiles(mock, searchPaths{"": "./test/confd"})
 
 	mock.AssertFileExists("etc/confd/test.yaml")
 	mock.AssertFileExists("etc/confd/test.Yml")
@@ -71,7 +71,7 @@ func TestIncludeConfigFilesWithPrefix(t *testing.T) {
 	configmock.New(t)
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	GetConfigFiles(mock.Fb, searchPaths{"prefix": "./test/confd"})
+	GetConfigFiles(mock, searchPaths{"prefix": "./test/confd"})
 
 	mock.AssertFileExists("etc/confd/prefix/test.yaml")
 	mock.AssertFileExists("etc/confd/prefix/test.Yml")
@@ -91,7 +91,7 @@ func TestRegistryJSON(t *testing.T) {
 	confMock.SetWithoutSource("logs_config.run_path", filepath.Dir(srcDir))
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	getRegistryJSON(mock.Fb)
+	getRegistryJSON(mock)
 
 	mock.AssertFileContent("mockfilecontent", "registry.json")
 }
@@ -172,7 +172,7 @@ func TestVersionHistory(t *testing.T) {
 	confMock.SetWithoutSource("run_path", filepath.Dir(srcDir))
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	getVersionHistory(mock.Fb)
+	getVersionHistory(mock)
 
 	mock.AssertFileContent("mockfilecontent", "version-history.json")
 }
@@ -269,7 +269,7 @@ func TestProcessAgentChecks(t *testing.T) {
 
 	t.Run("without process-agent running", func(t *testing.T) {
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getChecksFromProcessAgent(mock.Fb, func() (string, error) { return "fake:1337", nil })
+		getChecksFromProcessAgent(mock, func() (string, error) { return "fake:1337", nil })
 
 		mock.AssertFileContentMatch("error: process-agent is not running or is unreachable: error collecting data for 'process_discovery_check_output.json': .*", "process_check_output.json")
 	})
@@ -300,7 +300,7 @@ func TestProcessAgentChecks(t *testing.T) {
 		setupIPCAddress(t, configmock.New(t), srv.URL)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getChecksFromProcessAgent(mock.Fb, getProcessAPIAddressPort)
+		getChecksFromProcessAgent(mock, getProcessAPIAddressPort)
 
 		mock.AssertFileContent(string(expectedProcessesJSON), "process_check_output.json")
 		mock.AssertFileContent(string(expectedContainersJSON), "container_check_output.json")

--- a/releasenotes/notes/enable-profiler-in-rc-flares-f56b8ccacf8f4e8f.yaml
+++ b/releasenotes/notes/enable-profiler-in-rc-flares-f56b8ccacf8f4e8f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added capability to generate profiling data in a flare 
+    requested via Remote Config


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Enables profiling collection for flares generated by way of Remote Config. 

To support this, a new profiler component has been added as a flare filler. This component can be optionally disabled in flare runs when the FlareArgs.ProfileDuration value is set to 0, and will transiently set the `runtime_block_profile_rate` and `runtime_mutex_profile_fraction` runtime settings to align with FlareArgs.ProfileBlockingRate and FlareArgs.ProfileMutexFraction respectively. 

The core logic of the profiler is an almost-exact mirror of the profiling functionality previously found in the flare cli subcommand. To minimize shifting architecture, the flare cli command will directly call this functionality exposed in the profiler rather than utilize the profiler's flareFiller logic.  

The RC Agent Task, upon detecting a new `enable_profiling` boolean flag, will populate reasonable default profiling args and make them accessible to the profiler. These defaults can be changed via the undocumented config settings `flare.rc_...`

### Motivation

### Describe how to test/QA your changes
Existing CLI flare generation saw some underlying architecture changes, but should be completely unchanged from a functional perspective. Running the `datadog-agent flare` cli command with and without the various profiling options should generate the same output and the same flare contents as before. 

Remote config flare generation can be prompted by navigating to https://{{ddog_site}}/fleet, selecting the host to generate the flare, navigating to support -> send support ticket, and sending the support ticket with debug mode enabled. There is a somewhat decent automatic test spread confirming that the various permutations of RC task args will populate the flare filler with the correct values, but it is important to test that 
1. The flare generation correctly identifies the agents to profile, such as active system-probe components or active process agents. 
2. Flare generation is within the flare provider timeout threshold. Providers that get timed out generate a log of the format "flare provider '%s' skipped after %s". Providers that finish successfully (whether or not the timeout message appeared) show debug logs of the format "flare provider '%s' completed in %s".
3. RC flares generated with default settings are identical to flares created with the `datadog-agent flare -p 30` cli command
4. Flares are successfully uploaded to the support ticket requested, which will be visible in the RC UI.
5. Log output during flare generation, both in the agent.log and in the flare_creation.log, is clear and helpful


### Possible Drawbacks / Trade-offs
Gathering profiling information in the flare can drastically increase generation times. In some system setups, profiling can currently take up to an additional 5 minutes on the default settings.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->