### PR TITLE
[CWS] make sure `.gitkeep` is included in the go:embed of the syscall tester

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -109,7 +109,7 @@ func TestActionKill(t *testing.T) {
 				t.Error("signal timeout")
 			}
 			return nil
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "kill_action_usr2")
 		if err != nil {
@@ -123,7 +123,7 @@ func TestActionKill(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.signal == 'SIGUSR2')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
@@ -163,7 +163,7 @@ func TestActionKill(t *testing.T) {
 				t.Error("signal timeout")
 			}
 			return nil
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*5, "kill_action_kill")
 
@@ -178,7 +178,7 @@ func TestActionKill(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.signal == 'SIGKILL')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
@@ -239,7 +239,7 @@ func TestActionKillExcludeBinary(t *testing.T) {
 		}()
 
 		return nil
-	}, func(rule *rules.Rule, event *model.Event) bool {
+	}, func(_ *rules.Rule, _ *model.Event) bool {
 		return true
 	}, time.Second*5, "kill_action_kill_exclude")
 
@@ -315,7 +315,7 @@ func TestActionKillRuleSpecific(t *testing.T) {
 			t.Error("signal timeout")
 		}
 		return nil
-	}, func(rule *rules.Rule, event *model.Event) bool {
+	}, func(_ *rules.Rule, _ *model.Event) bool {
 		return true
 	}, time.Second*5, "kill_action_kill")
 
@@ -330,7 +330,7 @@ func TestActionKillRuleSpecific(t *testing.T) {
 		}
 		validateMessageSchema(t, string(msg.Data))
 
-		jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+		jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 			if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.signal == 'SIGKILL')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 				t.Errorf("element not found %s => %v", string(msg.Data), err)
 			}
@@ -353,7 +353,7 @@ func TestActionKillRuleSpecific(t *testing.T) {
 		}
 		validateMessageSchema(t, string(msg.Data))
 
-		jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+		jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 			if _, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions`); err == nil {
 				t.Errorf("unexpected rule action %s", string(msg.Data))
 			}
@@ -728,7 +728,7 @@ func TestActionHash(t *testing.T) {
 				done <- true
 			}()
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "hash_action")
 		})
 
@@ -739,7 +739,7 @@ func TestActionHash(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.state == 'Done')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
@@ -776,7 +776,7 @@ func TestActionHash(t *testing.T) {
 				done <- true
 			}()
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "hash_action")
 		})
 
@@ -787,7 +787,7 @@ func TestActionHash(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			jsonPathValidation(test, msg.Data, func(testMod *testModule, obj interface{}) {
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.state == 'Done')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -568,7 +568,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}
@@ -587,7 +587,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}
@@ -677,7 +677,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			cmd := dockerInstance2.Command("getconf", []string{"-a"}, []string{})
 			_, err := cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}
@@ -696,7 +696,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			cmd := dockerInstance2.Command("nslookup", []string{"foo.bar"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -50,7 +50,7 @@ func TestBindEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.Run(t, "bind-af-inet-any-success-tcp", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "bind-af-inet-any-success-tcp", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"bind", "AF_INET", "any", "tcp"}
 		envs := []string{}
 
@@ -61,7 +61,7 @@ func TestBindEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Bind.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
@@ -73,7 +73,7 @@ func TestBindEvent(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "bind-af-inet-any-success-udp", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "bind-af-inet-any-success-udp", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"bind", "AF_INET", "any", "udp"}
 		envs := []string{}
 
@@ -84,7 +84,7 @@ func TestBindEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Bind.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
@@ -96,7 +96,7 @@ func TestBindEvent(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "bind-af-inet6-any-success", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "bind-af-inet6-any-success", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"bind", "AF_INET6", "any"}
 		envs := []string{}
 
@@ -107,7 +107,7 @@ func TestBindEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET6), event.Bind.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
@@ -118,7 +118,7 @@ func TestBindEvent(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "bind-af-unknown-unix", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "bind-af-unknown-unix", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"bind", "AF_UNIX"}
 		envs := []string{}
 
@@ -129,7 +129,7 @@ func TestBindEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_UNIX), event.Bind.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(0), event.Bind.Addr.Port, "wrong address port")

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -47,7 +47,7 @@ func TestBPFEventLoad(t *testing.T) {
 	t.Run("prog_load", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfProgTypeKprobe), event.BPF.Program.Type, "wrong program type")
 
@@ -84,7 +84,7 @@ func TestBPFEventMap(t *testing.T) {
 	t.Run("map_lookup", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf", "-clone-bpf")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")
 
@@ -121,7 +121,7 @@ func TestBPFCwsMapConstant(t *testing.T) {
 	t.Run("map_lookup", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeArray), event.BPF.Map.Type, "wrong map type")
 

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -120,6 +120,7 @@ ExecStart=/usr/bin/touch %s`, testFile2)
 				return err
 			}
 			if err := os.Remove("/etc/systemd/system/cws-test.service"); err != nil {
+				return err
 			}
 			if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
 				return err
@@ -158,6 +159,7 @@ ExecStart=/usr/bin/touch %s`, testFile2)
 				return err
 			}
 			if err := os.Remove("/etc/systemd/system/cws-test.service"); err != nil {
+				return err
 			}
 			if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
 				return err

--- a/pkg/security/tests/chdir_test.go
+++ b/pkg/security/tests/chdir_test.go
@@ -69,7 +69,7 @@ func TestChdir(t *testing.T) {
 			defer f.Close()
 
 			return f.Chdir()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_chdir_rule")
 		})
 	})

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -57,7 +57,7 @@ func TestChmod(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o707)
 			assertInode(t, getInode(t, testFile), event.Chmod.File.Inode)
@@ -80,7 +80,7 @@ func TestChmod(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o757)
 			assertInode(t, getInode(t, testFile), event.Chmod.File.Inode)
@@ -106,7 +106,7 @@ func TestChmod(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o757)
 			assertInode(t, getInode(t, testFile), event.Chmod.File.Inode)
@@ -127,7 +127,7 @@ func TestChmod(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o717, "wrong mode")
 			assertInode(t, getInode(t, testFile), event.Chmod.File.Inode)

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -67,7 +67,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown", testFile, "100", "200")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(100), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(200), event.Chown.GID, "wrong user")
@@ -94,7 +94,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown", testFile, "101", "201")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(101), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(201), event.Chown.GID, "wrong user")
@@ -121,7 +121,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchownat", testFile, "102", "202")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(102), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(202), event.Chown.GID, "wrong user")
@@ -153,7 +153,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown", testSymlink, "103", "203")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(103), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(203), event.Chown.GID, "wrong user")
@@ -185,7 +185,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown32", testSymlink, "104", "204")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(204), event.Chown.GID, "wrong user")
@@ -213,7 +213,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown32", testFile, "105", "205")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(105), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(205), event.Chown.GID, "wrong user")
@@ -240,7 +240,7 @@ func TestChown32(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown32", testFile, "106", "206")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(106), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(206), event.Chown.GID, "wrong user")

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -113,7 +113,7 @@ func TestChown(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(101), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(201), event.Chown.GID, "wrong user")
@@ -184,7 +184,7 @@ func TestChown(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(103), event.Chown.UID, "wrong user")
 			assert.Equal(t, int64(203), event.Chown.GID, "wrong user")
@@ -255,7 +255,7 @@ func TestChown(t *testing.T) {
 		})
 	}))
 
-	test.Run(t, "pipe-chown-discarded", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "pipe-chown-discarded", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		_ = test.GetSignal(t, func() error {
 			syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 			if err != nil {
@@ -343,7 +343,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(testUID), event.Chown.UID, "wrong user")
 			assert.Equal(t, testUser, event.Chown.User, "wrong user")
@@ -368,7 +368,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(testUID), event.Chown.UID, "wrong user")
 			assert.Equal(t, testUser, event.Chown.User, "wrong user")
@@ -405,7 +405,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(testUID), event.Chown.UID, "wrong user")
 			assert.Equal(t, testUser, event.Chown.User, "wrong user")
@@ -430,7 +430,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(testUID), event.Chown.UID, "wrong user")
 			assert.Equal(t, testUser, event.Chown.User, "wrong user")
@@ -456,7 +456,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(testUID), event.Chown.UID, "wrong user")
 			assert.Equal(t, testUser, event.Chown.User, "wrong user")
@@ -482,7 +482,7 @@ func TestChownUserGroup(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(-1), event.Chown.UID, "wrong user")
 			assert.Equal(t, "", event.Chown.User, "wrong user")

--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -60,13 +60,13 @@ func TestConnectEvent(t *testing.T) {
 			defer wg.Done()
 			err := bindAndAcceptConnection("tcp", ":4242", done)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}()
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "tcp")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "connect", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Connect.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
@@ -88,13 +88,13 @@ func TestConnectEvent(t *testing.T) {
 			defer wg.Done()
 			err := bindAndAcceptConnection("udp", ":4242", done)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}()
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "udp")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "connect", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Connect.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
@@ -120,13 +120,13 @@ func TestConnectEvent(t *testing.T) {
 			defer wg.Done()
 			err := bindAndAcceptConnection("tcp", ":4242", done)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}()
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "tcp")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "connect", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET6), event.Connect.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
@@ -152,13 +152,13 @@ func TestConnectEvent(t *testing.T) {
 			defer wg.Done()
 			err := bindAndAcceptConnection("udp", ":4242", done)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}()
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "udp")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "connect", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET6), event.Connect.AddrFamily, "wrong address family")
 			assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -61,7 +61,7 @@ func TestContainerCreatedAt(t *testing.T) {
 	}
 	defer dockerWrapper.stop()
 
-	dockerWrapper.Run(t, "container-created-at", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	dockerWrapper.Run(t, "container-created-at", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("touch", []string{testFile}, nil)
 			return cmd.Run()
@@ -74,7 +74,7 @@ func TestContainerCreatedAt(t *testing.T) {
 		})
 	})
 
-	dockerWrapper.Run(t, "container-created-at-delay", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	dockerWrapper.Run(t, "container-created-at-delay", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("touch", []string{testFileDelay}, nil) // shouldn't trigger an event
 			if err := cmd.Run(); err != nil {
@@ -124,7 +124,7 @@ func TestContainerFlagsDocker(t *testing.T) {
 	}
 	defer dockerWrapper.stop()
 
-	dockerWrapper.Run(t, "container-runtime", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	dockerWrapper.Run(t, "container-runtime", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("touch", []string{testFile}, nil)
 			return cmd.Run()
@@ -167,7 +167,7 @@ func TestContainerFlagsPodman(t *testing.T) {
 	}
 	defer podmanWrapper.stop()
 
-	podmanWrapper.Run(t, "container-runtime", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	podmanWrapper.Run(t, "container-runtime", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("touch", []string{testFile}, nil)
 			return cmd.Run()

--- a/pkg/security/tests/ebpfless_test.go
+++ b/pkg/security/tests/ebpfless_test.go
@@ -59,7 +59,7 @@ func TestEBPFLessAttach(t *testing.T) {
 		go func() {
 			testFile, _, err := test.Path("test-ebpfless-attach")
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 			defer os.Remove(testFile)
 
@@ -90,14 +90,14 @@ func TestEBPFLessAttach(t *testing.T) {
 			}
 
 			// syscall tester to be reading to be tested
-			_ = <-sigCh
+			<-sigCh
 			if err = ptracer.Attach([]int{pid}, constants.DefaultEBPFLessProbeAddr, opts); err != nil {
 				fmt.Printf("unable to attach: %v", err)
 			}
 			doneCh <- true
 		}()
 		return nil
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_ebpfless_attach")
 	})
 

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -57,7 +57,7 @@ func TestEventRulesetLoaded(t *testing.T) {
 		err = test.GetCustomEventSent(t, func() error {
 			// force a reload
 			return syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
-		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, customEvent *events.CustomEvent) bool {
 			test.cws.SendStats()
 
 			assert.Equal(t, count+1, test.statsdClient.Get(key))
@@ -90,7 +90,7 @@ func TestEventHeartbeatSent(t *testing.T) {
 		err = test.GetCustomEventSent(t, func() error {
 			// force a reload
 			return syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
-		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, customEvent *events.CustomEvent) bool {
 			return validateHeartbeatSchema(t, customEvent)
 		}, 80*time.Second, model.CustomEventType, events.HeartbeatRuleID)
 		if err != nil {
@@ -140,7 +140,7 @@ func TestEventRaleLimiters(t *testing.T) {
 				t.Fatal(err)
 			}
 			return f.Close()
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "test_unique_id")
 		if err != nil {
@@ -156,7 +156,7 @@ func TestEventRaleLimiters(t *testing.T) {
 				timeoutCtx, t, syscallTester,
 				"open", testFile,
 			)
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "test_unique_id")
 		if err != nil {
@@ -170,7 +170,7 @@ func TestEventRaleLimiters(t *testing.T) {
 				t.Fatal(err)
 			}
 			return f.Close()
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "test_unique_id")
 		if err == nil {
@@ -191,7 +191,7 @@ func TestEventRaleLimiters(t *testing.T) {
 				t.Fatal(err)
 			}
 			return f.Close()
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "test_std")
 		if err != nil {
@@ -207,7 +207,7 @@ func TestEventRaleLimiters(t *testing.T) {
 				timeoutCtx, t, syscallTester,
 				"open", testFile,
 			)
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*3, "test_std")
 		if err == nil {
@@ -262,7 +262,7 @@ func TestEventIteratorRegister(t *testing.T) {
 	t.Run("std", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "span-exec", "123", "456", "/usr/bin/touch", testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_register_1")
 		})
 	})
@@ -274,7 +274,7 @@ func TestEventIteratorRegister(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_register_2")
 		})
 	})
@@ -317,7 +317,7 @@ func truncatedParents(t *testing.T, staticOpts testOpts, dynamicOpts dynamicTest
 			return err
 		}
 		return f.Close()
-	}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
+	}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 		return true
 	}, getEventTimeout, model.CustomEventType, events.AbnormalPathRuleID)
 	if err != nil {
@@ -330,7 +330,7 @@ func truncatedParents(t *testing.T, staticOpts testOpts, dynamicOpts dynamicTest
 			return err
 		}
 		return f.Close()
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		// check the length of the filepath that triggered the custom event
 		filepath, err := event.GetFieldValue("open.file.path")
 		if err == nil {

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -57,7 +57,7 @@ func TestBasicFileTest(t *testing.T) {
 			cmd := cmdFunc("powershell", inputargs, nil)
 			_ = cmd.Run()
 			return nil
-		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "create.file.name", "test.bad", event, "create.file.name file didn't match")
 		}))
 	})
@@ -94,7 +94,7 @@ func TestRenameFileEvent(t *testing.T) {
 	test.Run(t, "rename", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			return os.Rename("C:\\Temp\\test.bad", "C:\\Temp\\test.good")
-		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "rename.file.name", "test.bad", event, "rename.file.name file didn't match")
 			assertFieldEqualCaseInsensitve(t, event, "rename.file.destination.name", "test.good", event, "rename.file.destination.name file didn't match")
 		}))
@@ -131,7 +131,7 @@ func TestDeleteFileEvent(t *testing.T) {
 	test.Run(t, "delete", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			return os.Remove("C:\\Temp\\test.bad")
-		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "delete.file.name", "test.bad", event, "delete.file.name file didn't match")
 		}))
 	})
@@ -174,7 +174,7 @@ func TestWriteFileEvent(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "write.file.name", "test.bad", event, "write.file.name file didn't match")
 		}))
 	})
@@ -222,7 +222,7 @@ func TestWriteFileEventWithCreate(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateFileEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "write.file.name", "test.bad", "write.file.name file didn't match")
 		}))
 	})

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -165,7 +165,7 @@ func TestFilterOpenLeafDiscarder(t *testing.T) {
 			return err
 		}
 		return syscall.Close(fd)
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, eventType eval.EventType) bool {
 		if event == nil || (eventType != "open") {
 			return false
 		}
@@ -238,7 +238,7 @@ func TestFilterOpenLeafDiscarderActivityDump(t *testing.T) {
 			t.Fatal(err)
 		}
 		return nil
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, _ eval.EventType) bool {
 		e := event.(*model.Event)
 		if e == nil || e.GetEventType() != model.FileOpenEventType {
 			return false
@@ -299,7 +299,7 @@ func testFilterOpenParentDiscarder(t *testing.T, parents ...string) {
 			return err
 		}
 		return syscall.Close(fd)
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, eventType eval.EventType) bool {
 		if event == nil || (eventType != "open") {
 			return false
 		}
@@ -617,7 +617,7 @@ func TestFilterDiscarderMask(t *testing.T) {
 
 			testFile, testFilePtr, err = test.CreateWithOptions("test-mask", 98, 99, 0o447)
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
 		})
 
@@ -656,7 +656,7 @@ func TestFilterDiscarderMask(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
 		})
 	}))
@@ -698,7 +698,7 @@ func TestFilterRenameFileDiscarder(t *testing.T) {
 			return err
 		}
 		return syscall.Close(fd)
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, eventType eval.EventType) bool {
 		if event == nil || (eventType != "open") {
 			return false
 		}
@@ -784,7 +784,7 @@ func TestFilterRenameFolderDiscarder(t *testing.T) {
 			return err
 		}
 		return syscall.Close(fd)
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, eventType eval.EventType) bool {
 		if event == nil || (eventType != "open") {
 			return false
 		}
@@ -956,9 +956,9 @@ func TestFilterDiscarderRetention(t *testing.T) {
 			return err
 		}
 		return syscall.Close(fd)
-	}, func(event eval.Event, field eval.Field, eventType eval.EventType) bool {
+	}, func(event eval.Event, _ eval.Field, _ eval.EventType) bool {
 		e := event.(*model.Event)
-		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
+		if e == nil || e.GetEventType() != model.FileOpenEventType {
 			return false
 		}
 
@@ -1051,7 +1051,7 @@ func TestFilterBpfCmd(t *testing.T) {
 			return err
 		}
 		return nil
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_bpf_map_create")
 	})
 
@@ -1070,10 +1070,7 @@ func TestFilterBpfCmd(t *testing.T) {
 			return false
 		}
 		cmd := model.BPFCmd(uint64(cmdInt))
-		if assert.Equal(t, model.BpfMapCreateCmd, cmd, "should not get a bpf event with cmd other than BPF_MAP_CREATE") {
-			return false
-		}
-		return true
+		return !assert.Equal(t, model.BpfMapCreateCmd, cmd, "should not get a bpf event with cmd other than BPF_MAP_CREATE")
 	}, 1*time.Second, model.BPFEventType)
 	if err != nil {
 		if otherErr, ok := err.(ErrTimeout); !ok {
@@ -1122,7 +1119,7 @@ func TestFilterRuntimeDiscarded(t *testing.T) {
 	// unlink aren't discarded kernel side (inode invalidation) but should be discarded before the rule evaluation
 	err = test.GetSignal(t, func() error {
 		return os.Remove(testFile)
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(_ *model.Event, _ *rules.Rule) {
 		t.Errorf("shouldn't get an event")
 	})
 

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -56,7 +56,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testOrigExecutable, "/tmp/test1")
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig_exec")
 		})
 
@@ -72,14 +72,14 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 				t.Fatal(err)
 			}
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link_creation")
 		})
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testNewExecutable, "/tmp/test2")
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link_exec")
 		})
 	})
@@ -97,21 +97,21 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 				t.Fatal(err)
 			}
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link_creation")
 		})
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testOrigExecutable, "/tmp/test1")
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig_exec")
 		})
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testNewExecutable, "/tmp/test2")
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link_exec")
 		})
 	})
@@ -170,7 +170,7 @@ func TestHardLink(t *testing.T) {
 				t.Fatal(err)
 			}
 			return err
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link_creation")
 		})
 	})

--- a/pkg/security/tests/hash_test.go
+++ b/pkg/security/tests/hash_test.go
@@ -56,7 +56,7 @@ func TestHash(t *testing.T) {
 				return err
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(_ *model.Event, r *rules.Rule) {
 			assertTriggeredRule(t, r, "test_rule_hash_exec")
 		})
 	})
@@ -80,7 +80,7 @@ func TestHash(t *testing.T) {
 			syscall.Close(fd)
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(_ *model.Event, r *rules.Rule) {
 			assertTriggeredRule(t, r, "test_rule_hash_fifo")
 		})
 	})

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -148,7 +148,7 @@ func TestKworker(t *testing.T) {
 		}
 
 		return nil
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(_ *model.Event, r *rules.Rule) {
 		assert.Equal(t, "test_load_module_kworker", r.ID, "invalid rule triggered")
 	})
 }

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -56,7 +56,7 @@ func TestLink(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "link", event.GetType(), "wrong event type")
 			assertInode(t, getInode(t, testNewFile), event.Link.Source.Inode)
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
@@ -86,7 +86,7 @@ func TestLink(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "link", event.GetType(), "wrong event type")
 			assertInode(t, getInode(t, testNewFile), event.Link.Source.Inode)
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
@@ -145,7 +145,7 @@ func TestLink(t *testing.T) {
 				return fmt.Errorf("failed to create a link with io_uring: %d", ret)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "link", event.GetType(), "wrong event type")
 			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -55,7 +55,7 @@ func TestMacros(t *testing.T) {
 			return err
 		}
 		return os.Remove(testFile)
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "mkdir", event.GetType(), "wrong event type")
 	})
 }

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -26,6 +26,7 @@ const (
 	fakeGroupPath  = "/tmp/fake_group"
 )
 
+// SkipIfNotAvailable skips the test if not available for this platform
 func SkipIfNotAvailable(t *testing.T) {
 	match := func(list []string) bool {
 		var match bool

--- a/pkg/security/tests/misc_test.go
+++ b/pkg/security/tests/misc_test.go
@@ -51,7 +51,7 @@ func TestOsOrigin(t *testing.T) {
 			return err
 		}
 		return os.Remove(testFile)
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_origin")
 	})
 }
@@ -81,7 +81,7 @@ func TestHostname(t *testing.T) {
 			return err
 		}
 		return os.Remove(testFile)
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_hostname")
 	})
 }

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -47,7 +47,7 @@ func TestMMapEvent(t *testing.T) {
 				return fmt.Errorf("couldn't unmap memory segment: %w", err)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), event.MMap.Protection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
 
@@ -91,7 +91,7 @@ func TestMMapApproverZero(t *testing.T) {
 			return fmt.Errorf("couldn't unmap memory segment: %w", err)
 		}
 		return nil
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "mmap", event.GetType(), "wrong event type")
 		assert.Equal(t, uint64(unix.PROT_NONE), event.MMap.Protection&(unix.PROT_NONE), fmt.Sprintf("wrong protection: %s", model.Protection(event.MMap.Protection)))
 

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -592,7 +592,9 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 			fmt.Println(err)
 		}
 		commonCfgDir = cd
-		os.Chdir(commonCfgDir)
+		if err := os.Chdir(commonCfgDir); err != nil {
+			return nil, err
+		}
 	}
 
 	var proFile *os.File

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -104,7 +104,7 @@ func TestMount(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Chmod(file, 0707)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assert.Equal(t, file, event.Chmod.File.PathnameStr, "wrong path")
 		})
@@ -239,7 +239,7 @@ func TestMountPropagated(t *testing.T) {
 	t.Run("bind-mounted-chmod", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return os.Chmod(file, 0700)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assert.Equal(t, file, event.Chmod.File.PathnameStr, "wrong path")
 		})
@@ -359,7 +359,7 @@ func TestMountSnapshot(t *testing.T) {
 
 		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), dev, pid, "")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err)
 			return
 		}
 		assert.Equal(t, model.MountSourceMountID, mountSource)

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -48,7 +48,7 @@ func TestMProtectEvent(t *testing.T) {
 				return fmt.Errorf("couldn't mprotect segment: %w", err)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "mprotect", event.GetType(), "wrong event type")
 			assert.Equal(t, unix.PROT_READ|unix.PROT_WRITE, event.MProtect.VMProtection&(unix.PROT_READ|unix.PROT_WRITE), fmt.Sprintf("wrong initial protection: %s", model.Protection(event.MProtect.VMProtection)))
 			assert.Equal(t, unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC, event.MProtect.ReqProtection&(unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC), fmt.Sprintf("wrong requested protection: %s", model.Protection(event.MProtect.ReqProtection)))

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -67,7 +67,7 @@ func TestNetworkCIDR(t *testing.T) {
 				return err
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "dns", event.GetType(), "wrong event type")
 			assert.Equal(t, "google.com", event.DNS.Name, "wrong domain name")
 

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -74,7 +74,7 @@ func TestOnDemandOpen(t *testing.T) {
 			return err
 		}
 		return syscall.Close(int(fd))
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "ondemand", event.GetType(), "wrong event type")
 
 		value, _ := event.GetFieldValue("ondemand.arg2.str")
@@ -123,7 +123,7 @@ func TestOnDemandChdir(t *testing.T) {
 
 	test.WaitSignal(t, func() error {
 		return os.Chdir(testFolder)
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "ondemand", event.GetType(), "wrong event type")
 
 		value, _ := event.GetFieldValue("ondemand.arg1.str")
@@ -174,7 +174,7 @@ func TestOnDemandMprotect(t *testing.T) {
 			return fmt.Errorf("couldn't mprotect segment: %w", err)
 		}
 		return nil
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "ondemand", event.GetType(), "wrong event type")
 	})
 }

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -68,7 +68,7 @@ func TestOpen(t *testing.T) {
 				return error(errno)
 			}
 			return syscall.Close(int(fd))
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
@@ -91,7 +91,7 @@ func TestOpen(t *testing.T) {
 				return error(errno)
 			}
 			return syscall.Close(int(fd))
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
@@ -119,7 +119,7 @@ func TestOpen(t *testing.T) {
 				return error(errno)
 			}
 			return syscall.Close(int(fd))
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
@@ -139,7 +139,7 @@ func TestOpen(t *testing.T) {
 				return error(errno)
 			}
 			return syscall.Close(int(fd))
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
@@ -175,7 +175,7 @@ func TestOpen(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFileTrunc), event.Open.File.Inode, "wrong inode")
@@ -215,7 +215,7 @@ func TestOpen(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFileTrunc), event.Open.File.Inode, "wrong inode")
@@ -235,7 +235,7 @@ func TestOpen(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
 
@@ -261,7 +261,7 @@ func TestOpen(t *testing.T) {
 				return fmt.Errorf("OpenByHandleAt: %w", err)
 			}
 			return unix.Close(fdInt)
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertInode(t, event.Open.File.Inode, getInode(t, testFile))
@@ -281,7 +281,7 @@ func TestOpen(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
 		if err != nil {
@@ -324,7 +324,7 @@ func TestOpen(t *testing.T) {
 			}
 
 			return unix.Close(fd)
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			// O_LARGEFILE is added by io_uring during __io_openat_prep
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
@@ -366,7 +366,7 @@ func TestOpen(t *testing.T) {
 			}
 
 			return unix.Close(fd)
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			// O_LARGEFILE is added by io_uring during __io_openat_prep
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
@@ -419,7 +419,7 @@ func TestOpenMetadata(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertRights(t, event.Open.File.Mode, expectedMode)
 			assertInode(t, event.Open.File.Inode, getInode(t, testFile))
@@ -466,7 +466,7 @@ func TestOpenDiscarded(t *testing.T) {
 				return err
 			}
 			return unix.Close(fd)
-		}, func(e *model.Event, r *rules.Rule) {
+		}, func(_ *model.Event, _ *rules.Rule) {
 			t.Error("shouldn't have received an event")
 		})
 		if err == nil {
@@ -515,7 +515,7 @@ func TestOpenApproverZero(t *testing.T) {
 			return error(errno)
 		}
 		return syscall.Close(int(fd))
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "open", event.GetType(), "wrong event type")
 		assert.Equal(t, 0, int(event.Open.Flags), "wrong flags")
 		value, _ := event.GetFieldValue("event.async")

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -183,7 +183,7 @@ func TestOverlayFS(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 
@@ -197,7 +197,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -219,7 +219,7 @@ func TestOverlayFS(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 
@@ -233,7 +233,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -255,7 +255,7 @@ func TestOverlayFS(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 
@@ -269,7 +269,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -292,7 +292,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Rename(oldFile, newFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			success := true
 
 			if value, _ := event.GetFieldValue("rename.file.path"); value.(string) != oldFile {
@@ -317,7 +317,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(newFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -343,7 +343,7 @@ func TestOverlayFS(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_parent")
 		})
 
@@ -362,7 +362,7 @@ func TestOverlayFS(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_renamed_parent")
 		})
 	})
@@ -377,7 +377,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testDir)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("rmdir.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong rmdir inode")
@@ -395,7 +395,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Chmod(testFile, 0777)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("chmod.file.in_upper_layer")
 
@@ -409,7 +409,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -427,7 +427,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return syscall.Mkdir(testFile, 0777)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("mkdir.file.in_upper_layer")
 
@@ -441,7 +441,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("rmdir.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong rmdir inode")
@@ -459,7 +459,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Chtimes(testFile, time.Now(), time.Now())
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("utimes.file.in_upper_layer")
 
@@ -473,7 +473,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -491,7 +491,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Chown(testFile, os.Getuid(), os.Getgid())
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("chown.file.in_upper_layer")
 
@@ -505,7 +505,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -534,7 +534,7 @@ func TestOverlayFS(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("setxattr.file.in_upper_layer")
 
@@ -548,7 +548,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -566,7 +566,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Truncate(testFile, 0)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testFile)
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 
@@ -580,7 +580,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -603,7 +603,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Link(testSrc, testTarget)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inode = getInode(t, testSrc)
 			success := assert.Equal(t, inode, event.Link.Source.Inode, "wrong link source inode")
 
@@ -621,7 +621,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testSrc)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			success := assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
@@ -634,7 +634,7 @@ func TestOverlayFS(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testTarget)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -72,7 +72,7 @@ func TestProcess(t *testing.T) {
 			return err
 		}
 		return os.Remove(testFile)
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_rule")
 	})
 }
@@ -243,7 +243,7 @@ func TestProcessContext(t *testing.T) {
 			os.Remove(testFile)
 
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			t.Errorf("shouldn't get an event: got event: %s", test.debugEvent(event))
 		})
 		if err == nil {
@@ -264,7 +264,7 @@ func TestProcessContext(t *testing.T) {
 			os.Remove(testFile)
 
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_exec_time_2")
 		})
 	})
@@ -289,7 +289,7 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			return f.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqual(t, event, "process.file.path", executable)
 
 			assert.Equal(t, getInode(t, executable), event.ProcessContext.FileEvent.Inode, "wrong inode")
@@ -304,7 +304,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because "--password" is not a valid option for ls
 			_ = cmd.Run()
 			return nil
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, _ *rules.Rule) {
 			argv0, err := event.GetFieldValue("exec.argv0")
 			if err != nil {
 				t.Errorf("not able to get argv0")
@@ -373,7 +373,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := cmdFunc("ls", args, envs)
 			_ = cmd.Run()
 			return nil
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_envp", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -384,7 +384,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ll")
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_argv")
 		}))
 	})
@@ -395,7 +395,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ls", "--escape")
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_flags")
 		}))
 	})
@@ -406,7 +406,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "--block-size", "123")
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_options")
 		}))
 	})
@@ -427,7 +427,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, _ *rules.Rule) {
 			args, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -455,7 +455,7 @@ func TestProcessContext(t *testing.T) {
 		}))
 	})
 
-	test.Run(t, "args-overflow-list-50", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "args-overflow-list-50", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
 		// force seed to have something we can reproduce
@@ -472,7 +472,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			execArgs, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -505,7 +505,7 @@ func TestProcessContext(t *testing.T) {
 		}
 	})
 
-	test.Run(t, "args-overflow-list-500", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "args-overflow-list-500", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		envs := []string{"LD_LIBRARY_PATH=/tmp/lib"}
 
 		// force seed to have something we can reproduce
@@ -522,7 +522,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			execArgs, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -586,7 +586,7 @@ func TestProcessContext(t *testing.T) {
 			}
 			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, _ *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")
 			if err != nil {
 				t.Errorf("not able to get exec.envp")
@@ -637,7 +637,7 @@ func TestProcessContext(t *testing.T) {
 			}
 			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")
 			if err != nil {
 				t.Errorf("not able to get exec.envp")
@@ -818,7 +818,7 @@ func TestProcessContext(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "ancestors", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "ancestors", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		testFile, _, err := test.Path("test-process-ancestors")
 		if err != nil {
 			t.Fatal(err)
@@ -842,7 +842,7 @@ func TestProcessContext(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "parent", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "parent", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		testFile, _, err := test.Path("test-process-parent")
 		if err != nil {
 			t.Fatal(err)
@@ -867,7 +867,7 @@ func TestProcessContext(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "pid1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "pid1", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		SkipIfNotAvailable(t)
 
 		testFile, _, err := test.Path("test-process-pid1")
@@ -887,12 +887,12 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_pid1", rule.ID, "wrong rule triggered")
 		})
 	})
 
-	test.Run(t, "service-tag", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "service-tag", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		testFile, _, err := test.Path("test-event-service")
 		if err != nil {
 			t.Fatal(err)
@@ -919,7 +919,7 @@ func TestProcessContext(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "ancestors-args", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "ancestors-args", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		testFile, _, err := test.Path("test-ancestors-args")
 		if err != nil {
 			t.Fatal(err)
@@ -934,7 +934,7 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_ancestors_args", rule.ID, "wrong rule triggered")
 		})
 	})
@@ -985,7 +985,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := exec.Command(syscallTester, args...)
 			_ = cmd.Run()
 			return nil
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_ancestors_glob")
 		}))
 	})
@@ -999,7 +999,7 @@ func TestProcessContext(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 
 			return nil
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_self_exec")
 		}))
 	})
@@ -1032,7 +1032,7 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	testProcessContextRule := func(t *testing.T, ruleID, filename string) {
-		test.Run(t, ruleID, func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		test.Run(t, ruleID, func(t *testing.T, _ wrapperType, _ func(cmd string, args []string, envs []string) *exec.Cmd) {
 			testFile, _, err := test.Path(filename)
 			if err != nil {
 				t.Fatal(err)
@@ -1045,7 +1045,7 @@ func TestProcessContext(t *testing.T) {
 				}
 				f.Close()
 				return os.Remove(testFile)
-			}, func(event *model.Event, rule *rules.Rule) {
+			}, func(_ *model.Event, rule *rules.Rule) {
 				assert.Equal(t, ruleID, rule.ID, "wrong rule triggered")
 			})
 		})
@@ -1120,7 +1120,7 @@ func TestProcessExecCTime(t *testing.T) {
 
 		cmd := exec.Command(testFile, "/tmp/test")
 		return cmd.Run()
-	}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+	}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_exec_ctime", rule.ID, "wrong rule triggered")
 	}))
 }
@@ -1144,7 +1144,7 @@ func TestProcessPIDVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		cmd := exec.Command(executable, fmt.Sprintf("/proc/%d/maps", os.Getpid()))
 		return cmd.Run()
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_var", rule.ID, "wrong rule triggered")
 	})
 }
@@ -1229,7 +1229,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		filename1, _, err = test.Create("test-open")
 		return err
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_set_mutable_vars", rule.ID, "wrong rule triggered")
 	})
 	if err != nil {
@@ -1240,7 +1240,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		filename2, _, err = test.Create("test-open-2")
 		return err
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_modify_mutable_vars", rule.ID, "wrong rule triggered")
 	})
 	if err != nil {
@@ -1251,7 +1251,7 @@ func TestProcessScopedVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		filename3, _, err = test.Create("test-open-3")
 		return err
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_test_mutable_vars", rule.ID, "wrong rule triggered")
 	})
 	if err != nil {
@@ -1289,7 +1289,7 @@ func TestTimestampVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		filename1, _, err = test.Create("test-open")
 		return err
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_set_timestamp_var", rule.ID, "wrong rule triggered")
 	})
 	if err != nil {
@@ -1300,7 +1300,7 @@ func TestTimestampVariable(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		filename2, _, err = test.Create("test-open-2")
 		return err
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(_ *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_rule_test_timestamp_var", rule.ID, "wrong rule triggered")
 	})
 	if err != nil {
@@ -1334,7 +1334,7 @@ func TestProcessExec(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command("sh", "-c", executable+" /dev/null")
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqual(t, event, "exec.file.path", executable)
 			assertFieldIsOneOf(t, event, "process.parent.file.name", []string{"sh", "bash", "dash"}, "wrong process parent file name")
 			assertFieldStringArrayIndexedOneOf(t, event, "process.ancestors.file.name", 0, []string{"sh", "bash", "dash"})
@@ -1348,7 +1348,7 @@ func TestProcessExec(t *testing.T) {
 			args := []string{"exec-in-pthread", executable, "/dev/null"}
 			cmd := exec.Command(syscallTester, args...)
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqual(t, event, "exec.file.path", executable)
 			assertFieldEqual(t, event, "process.parent.file.name", "syscall_tester", "wrong process parent file name")
 		}))
@@ -1396,7 +1396,7 @@ func TestProcessMetadata(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testFile)
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assertRights(t, event.Exec.FileEvent.Mode, fileMode)
 			if !ebpfLessEnabled {
@@ -1418,7 +1418,7 @@ func TestProcessMetadata(t *testing.T) {
 			cmd := exec.Command(testFile)
 			cmd.SysProcAttr = attr
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
 			assert.Equal(t, 2001, int(event.Exec.Credentials.GID), "wrong gid")
@@ -1464,7 +1464,7 @@ func TestProcessExecExit(t *testing.T) {
 				return false
 			}
 
-			validate := test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			validate := test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 				validateProcessContextLineage(t, event)
 				validateProcessContextSECL(t, event)
 
@@ -1947,50 +1947,50 @@ func TestProcessBusybox(t *testing.T) {
 		return
 	}
 
-	wrapper.Run(t, "busybox-1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	wrapper.Run(t, "busybox-1", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("/usr/bin/whoami", nil, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_1", rule.ID, "wrong rule triggered")
 		})
 	})
 
-	wrapper.Run(t, "busybox-2", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	wrapper.Run(t, "busybox-2", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("/bin/sync", nil, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_2", rule.ID, "wrong rule triggered")
 		})
 	})
 
-	wrapper.Run(t, "busybox-3", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	wrapper.Run(t, "busybox-3", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("/bin/df", nil, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_3", rule.ID, "wrong rule triggered")
 		})
 	})
 
-	wrapper.Run(t, "busybox-4", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	wrapper.Run(t, "busybox-4", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("/bin/touch", []string{"/tmp/busybox-test"}, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_busybox_4", rule.ID, "wrong rule triggered")
 		})
 	})
@@ -2151,7 +2151,7 @@ chmod 755 pyscript.py
 	}
 
 	for _, test := range tests {
-		testModule.Run(t, test.name, func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testModule.Run(t, test.name, func(t *testing.T, _ wrapperType, _ func(cmd string, args []string, envs []string) *exec.Cmd) {
 			scriptLocation := filepath.Join(os.TempDir(), test.scriptName)
 			if scriptWriteErr := os.WriteFile(scriptLocation, []byte(test.executedScript), 0755); scriptWriteErr != nil {
 				t.Fatalf("could not write %s: %s", scriptLocation, scriptWriteErr)
@@ -2166,7 +2166,7 @@ chmod 755 pyscript.py
 				if scriptRunErr != nil {
 					t.Errorf("could not run %s: %s", scriptLocation, scriptRunErr)
 				}
-				t.Logf(string(output))
+				t.Log(string(output))
 
 				offsets, _ := p.GetOffsetConstants()
 				t.Logf("%s: %+v\n", constantfetch.OffsetNameLinuxBinprmStructFile, offsets[constantfetch.OffsetNameLinuxBinprmStructFile])
@@ -2322,7 +2322,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 			rule:                             filelessDetectionRule,
 			syscallTesterToRun:               "fileless",
 			syscallTesterScriptFilenameToRun: "",
-			check: func(event *model.Event, rule *rules.Rule) {
+			check: func(event *model.Event, _ *rules.Rule) {
 				assertFieldEqual(
 					t, event, "process.file.name", filelessExecutionFilenamePrefix, "process.file.name not matching",
 				)
@@ -2337,7 +2337,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 			rule:                             filelessWithInterpreterDetectionRule,
 			syscallTesterToRun:               "fileless",
 			syscallTesterScriptFilenameToRun: "script",
-			check: func(event *model.Event, rule *rules.Rule) {
+			check: func(event *model.Event, _ *rules.Rule) {
 				assertFieldEqual(t, event, "process.file.name", "memfd:script", "process.file.name not matching")
 			},
 		},
@@ -2388,7 +2388,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 
 					cmd := exec.Command(testFile)
 					return cmd.Run()
-				}, func(event *model.Event, rule *rules.Rule) {
+				}, func(event *model.Event, _ *rules.Rule) {
 					t.Errorf("shouldn't get an event: got event: %s", testModule.debugEvent(event))
 				})
 				if err == nil {

--- a/pkg/security/tests/process_windows_test.go
+++ b/pkg/security/tests/process_windows_test.go
@@ -34,7 +34,7 @@ func TestBasicTest(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(executable)
 			return cmd.Run()
-		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "exec.file.path", `c:\windows\system32\schtasks.exe`, "wrong exec file path")
 			assertFieldIsOneOf(t, event, "process.parent.file.name", []string{"testsuite.exe"}, "wrong process parent file name")
 		}))
@@ -57,7 +57,7 @@ func TestBasicTest(t *testing.T) {
 			// we will ignore the error.  The username & password arguments are invalid
 			_ = cmd.Run()
 			return nil
-		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, _ *rules.Rule) {
 			cmdline, err := event.GetFieldValue("exec.cmdline")
 			if err != nil {
 				t.Errorf("failed to get exec.cmdline: %v", err)

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -40,7 +40,7 @@ func TestPTraceEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.Run(t, "ptrace", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "ptrace", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"ptrace-traceme"}
 		envs := []string{}
 
@@ -51,7 +51,7 @@ func TestPTraceEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
 

--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -68,7 +68,7 @@ func TestBasicRegistryTestPowershell(t *testing.T) {
 			// we will ignore any error
 			_ = cmd.Run()
 			return nil
-		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "open.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})
@@ -116,7 +116,7 @@ func TestBasicRegistryTestRegExe(t *testing.T) {
 			// we will ignore any error
 			_ = cmd.Run()
 			return nil
-		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "create.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})
@@ -154,7 +154,7 @@ func TestBasicRegistryTestAPI(t *testing.T) {
 			}
 			return nil
 
-		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateRegistryEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqualCaseInsensitve(t, event, "create.registry.key_path", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`, "wrong registry key path")
 		}))
 	})

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -64,7 +64,7 @@ func TestRename(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertInode(t, event.Rename.New.Inode, getInode(t, testNewFile))
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -96,7 +96,7 @@ func TestRename(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertInode(t, event.Rename.New.Inode, getInode(t, testNewFile))
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -129,7 +129,7 @@ func TestRename(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertInode(t, event.Rename.New.Inode, getInode(t, testNewFile))
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -189,7 +189,7 @@ func TestRename(t *testing.T) {
 				return fmt.Errorf("failed to rename file with io_uring: %d", ret)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assert.Equal(t, getInode(t, testNewFile), event.Rename.New.Inode, "wrong inode")
 			assertFieldEqual(t, event, "rename.file.destination.inode", int(getInode(t, testNewFile)), "wrong inode")
@@ -248,7 +248,7 @@ func TestRenameInvalidate(t *testing.T) {
 	for i := 0; i != 5; i++ {
 		test.WaitSignal(t, func() error {
 			return os.Rename(testOldFile, testNewFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rename.file.destination.path", testNewFile)
 			test.validateRenameSchema(t, event)
@@ -318,7 +318,7 @@ func TestRenameReuseInode(t *testing.T) {
 		}
 
 		return f.Close()
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "open", event.GetType(), "wrong event type")
 	})
 
@@ -345,7 +345,7 @@ func TestRenameReuseInode(t *testing.T) {
 			return err
 		}
 		return f.Close()
-	}, func(event *model.Event, rule *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "open", event.GetType(), "wrong event type")
 		assertFieldEqual(t, event, "open.file.inode", int(testNewFileInode))
 		assertFieldEqual(t, event, "open.file.path", testReuseInodeFile)
@@ -390,7 +390,7 @@ func TestRenameFolder(t *testing.T) {
 				return err
 			}
 			return testFile.Close()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "open.file.path", filename)
 			test.validateOpenSchema(t, event)

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -58,7 +58,7 @@ func TestRmdir(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assertInode(t, event.Rmdir.File.Inode, inode)
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
@@ -88,7 +88,7 @@ func TestRmdir(t *testing.T) {
 				return error(err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assertInode(t, event.Rmdir.File.Inode, inode)
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
@@ -149,7 +149,7 @@ func TestRmdir(t *testing.T) {
 				return fmt.Errorf("failed to unlink file with io_uring: %d", ret)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
@@ -198,7 +198,7 @@ func TestRmdirInvalidate(t *testing.T) {
 					return error(errno)
 				}
 				return nil
-			}, func(event *model.Event, rule *rules.Rule) {
+			}, func(event *model.Event, _ *rules.Rule) {
 				assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 				assertFieldEqual(t, event, "rmdir.file.path", testFile)
 			})

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -66,7 +66,7 @@ func TestSBOM(t *testing.T) {
 	}
 	defer dockerWrapper.stop()
 
-	dockerWrapper.Run(t, "package-rule", func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
+	dockerWrapper.Run(t, "package-rule", func(t *testing.T, _ wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
 			retry.Do(func() error {
 				sbom := p.Resolvers.SBOMResolver.GetWorkload(dockerWrapper.containerID)

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -45,7 +45,7 @@ func validateMessageSchema(t *testing.T, msg string) bool {
 	if !validateStringSchema(t, msg, "file:///message.schema.json") {
 		return false
 	}
-	return validateUrlSchema(t, msg, upstreamEventSchema)
+	return validateURLSchema(t, msg, upstreamEventSchema)
 }
 
 //nolint:deadcode,unused
@@ -344,7 +344,7 @@ func validateStringSchema(t *testing.T, json string, path string) bool {
 }
 
 //nolint:deadcode,unused
-func validateUrlSchema(t *testing.T, json string, url string) bool {
+func validateURLSchema(t *testing.T, json string, url string) bool {
 	t.Helper()
 
 	documentLoader := gojsonschema.NewStringLoader(json)

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -277,7 +277,7 @@ func TestAnomalyDetection(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -308,7 +308,7 @@ func TestAnomalyDetection(t *testing.T) {
 		test.GetCustomEventSent(t, func() error {
 			// don't do anything
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection.")
 			return false
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -342,7 +342,7 @@ func TestAnomalyDetection(t *testing.T) {
 			cmd := dockerInstance.Command("nslookup", []string{"google.com"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -377,7 +377,7 @@ func TestAnomalyDetection(t *testing.T) {
 		test.GetCustomEventSent(t, func() error {
 			// don't do anything
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -460,7 +460,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance1.Command("nslookup", []string{"foo.bar"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -471,7 +471,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance1.Command("nslookup", []string{"foo.bar"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -482,7 +482,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance1.Command("nslookup", []string{"foo.baz"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -501,7 +501,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance2.Command("nslookup", []string{"foo.baz"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -514,7 +514,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance2.Command("nslookup", []string{"foo.bar"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -525,7 +525,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance2.Command("nslookup", []string{"foo.baz"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -536,7 +536,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd := testDockerInstance1.Command("nslookup", []string{"foo.baz"}, []string{})
 			cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -615,7 +615,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -649,7 +649,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			cmd := dockerInstance.Command("nslookup", []string{"google.fr"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -680,7 +680,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -717,7 +717,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			cmd := dockerInstance.Command("nslookup", []string{"google.fr"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -852,7 +852,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}
@@ -871,7 +871,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Fatal("Got a signal that should have been suppressed")
 			}
@@ -1019,7 +1019,7 @@ func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 		cmd := dockerInstance.Command("/bin/date", []string{"--help"}, []string{})
 		_, err = cmd.CombinedOutput()
 		return err
-	}, func(r *rules.Rule, event *events.CustomEvent) bool {
+	}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 		return true
 	}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	if err != nil {
@@ -1104,7 +1104,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -1125,7 +1125,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getent", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1150,7 +1150,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV2.Command("iconv", []string{"-l"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1163,7 +1163,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV2.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -1174,7 +1174,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV1.Command("iconv", []string{"-l"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -1194,7 +1194,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			cmd := dockerInstanceV1.Command("scanelf", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -1278,7 +1278,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.fr"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -1293,7 +1293,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.com"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1319,7 +1319,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV2.Command("nslookup", []string{"google.es"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1335,7 +1335,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV2.Command("nslookup", []string{"google.fr"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -1346,7 +1346,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.es"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -1366,7 +1366,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.co.uk"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -1453,7 +1453,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV1.Command("sleep", []string{"1"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// We shouldn't see anything: the profile is still learning
 			data, _ := event.MarshalJSON()
 			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
@@ -1471,7 +1471,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV1.Command("sleep", []string{"1"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// this time we shouldn't see anything new.
 			data, _ := event.MarshalJSON()
 			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
@@ -1485,7 +1485,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.com"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(r *rules.Rule, _ *events.CustomEvent) bool {
 			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			return true
 		}, time.Second*3, model.SyscallsEventType, events.AnomalyDetectionRuleID)
@@ -1513,7 +1513,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV2.Command("date", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(r *rules.Rule, _ *events.CustomEvent) bool {
 			// we should see an anomaly that will be inserted in the profile
 			assert.Equal(t, events.AnomalyDetectionRuleID, r.Rule.ID, "wrong custom event rule ID")
 			gotSyscallsEvent = true
@@ -1530,7 +1530,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV2.Command("date", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// this time we shouldn't see anything new.
 			data, _ := event.MarshalJSON()
 			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
@@ -1552,7 +1552,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.com"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// We shouldn't see anything: the profile is unstable
 			data, _ := event.MarshalJSON()
 			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
@@ -1640,7 +1640,7 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -1661,7 +1661,7 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getent", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1686,7 +1686,7 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 			cmd := dockerInstanceV2.Command("iconv", []string{"-l"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1731,7 +1731,7 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 			cmd := dockerInstanceV3.Command("getconf", []string{"-a"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1818,7 +1818,7 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.fr"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
@@ -1839,7 +1839,7 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 			cmd := dockerInstanceV1.Command("nslookup", []string{"google.com"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1864,7 +1864,7 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 			cmd := dockerInstanceV2.Command("nslookup", []string{"google.es"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1909,7 +1909,7 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 			cmd := dockerInstanceV3.Command("nslookup", []string{"google.fr"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -1996,7 +1996,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -2017,7 +2017,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			cmd := dockerInstanceV1.Command("getent", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -2040,7 +2040,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			cmd := dockerInstanceV2.Command("iconv", []string{"-l"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -2063,7 +2063,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			cmd := dockerInstanceV3.Command("getconf", []string{"-a"}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			t.Fatal(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
@@ -2083,7 +2083,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			cmd := dockerInstanceV3.Command("getent", []string{}, []string{})
 			_, _ = cmd.CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -2195,7 +2195,7 @@ func TestSecurityProfilePersistence(t *testing.T) {
 		err = test.GetEventSent(t, func() error {
 			_, err := dockerInstance2.Command("getconf", []string{"-a"}, []string{}).CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			t.Fatal("Got an event that should have been suppressed")
 			return false
 		}, time.Second*3, "test_autosuppression_exec")
@@ -2211,7 +2211,7 @@ func TestSecurityProfilePersistence(t *testing.T) {
 		err = test.GetCustomEventSent(t, func() error {
 			dockerInstance2.Command("getent", []string{}, []string{}).CombinedOutput()
 			return nil
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return true
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {
@@ -2224,7 +2224,7 @@ func TestSecurityProfilePersistence(t *testing.T) {
 		err = test.GetCustomEventSent(t, func() error {
 			_, err := dockerInstance2.Command("/bin/echo", []string{"aaa"}, []string{}).CombinedOutput()
 			return err
-		}, func(r *rules.Rule, event *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 		if err != nil {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -139,7 +139,7 @@ func TestSELinux(t *testing.T) {
 				return fmt.Errorf("failed to write to selinuxfs: %w", err)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			t.Errorf("expected error and got an event: %s", test.debugEvent(event))
 		})
 		if err == nil {

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -56,7 +56,7 @@ func fetchRealisticEventSerializerInner(tb testing.TB) *serializers.EventSeriali
 			return error(errno)
 		}
 		return syscall.Close(int(fd))
-	}, func(event *model.Event, r *rules.Rule) {
+	}, func(event *model.Event, _ *rules.Rule) {
 		workingEvent = event
 		assert.Equal(tb, "open", event.GetType(), "wrong event type")
 	})

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -45,7 +45,7 @@ func TestSignalEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.Run(t, "signal-sigusr1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "signal-sigusr1", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"signal", "sigusr1"}
 		envs := []string{}
 
@@ -56,7 +56,7 @@ func TestSignalEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGUSR1), event.Signal.Type, "wrong signal")
 			assert.Equal(t, int64(0), event.Signal.Retval, "wrong retval")
@@ -68,7 +68,7 @@ func TestSignalEvent(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "signal-eperm", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "signal-eperm", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"signal", "eperm"}
 		envs := []string{}
 
@@ -79,7 +79,7 @@ func TestSignalEvent(t *testing.T) {
 			}
 
 			return nil
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "signal", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(unix.SIGKILL), event.Signal.Type, "wrong signal")
 			assert.Equal(t, -int64(unix.EPERM), event.Signal.Retval, "wrong retval")

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -49,7 +49,7 @@ func TestSpan(t *testing.T) {
 
 	fakeTraceID128b := "136272290892501783905308705057321818530"
 
-	test.Run(t, "open", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "open", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		testFile, _, err := test.Path("test-span")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -42,7 +42,7 @@ func TestSpliceEvent(t *testing.T) {
 	t.Run("test_splice", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "splice")
-		}, func(event *model.Event, r *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")
 			assert.Equal(t, uint32(0), event.Splice.PipeExitFlag, "wrong pipe exit flag")

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 )
 
-//go:embed syscall_tester/bin
+//go:embed all:syscall_tester/bin
 var syscallTesterFS embed.FS
 
 func loadSyscallTester(t *testing.T, test *testModule, binary string) (string, error) {

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -144,7 +144,7 @@ func TestUnlink(t *testing.T) {
 				return fmt.Errorf("failed to unlink file with io_uring: %d", ret)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
@@ -193,7 +193,7 @@ func TestUnlinkInvalidate(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "unlink.file.path", testFile)
 		})

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -143,10 +143,10 @@ func TestUserGroup(t *testing.T) {
 				test.WaitSignals(t, func() error {
 					out, err := dockerWrapper.Command(testCommand.cmd[0], testCommand.cmd[1:], nil).CombinedOutput()
 					if err != nil {
-						t.Logf(string(out))
+						t.Log(string(out))
 					}
 					return err
-				}, func(event *model.Event, rule *rules.Rule) error {
+				}, func(_ *model.Event, rule *rules.Rule) error {
 					assertTriggeredRule(t, rule, testCommand.rules[i])
 					i++
 					if i < len(testCommand.rules) {

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -54,7 +54,7 @@ func TestUtimes(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(123), event.Utimes.Atime.Unix())
 			assert.Equal(t, int64(456), event.Utimes.Mtime.Unix())
@@ -95,7 +95,7 @@ func TestUtimes(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(111), event.Utimes.Atime.Unix())
 			assert.Equal(t, int64(222), event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond))
@@ -139,7 +139,7 @@ func TestUtimes(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(555), event.Utimes.Mtime.Unix())
 			assert.Equal(t, int64(666), event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond))
@@ -177,7 +177,7 @@ func TestUtimes(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assertNearTime(t, uint64(event.Utimes.Mtime.UnixNano()))
 			assertNearTime(t, uint64(event.Utimes.Atime.UnixNano()))

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -64,7 +64,7 @@ func TestSetXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
@@ -104,7 +104,7 @@ func TestSetXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
@@ -137,7 +137,7 @@ func TestSetXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
@@ -208,7 +208,7 @@ func TestRemoveXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
 			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
@@ -254,7 +254,7 @@ func TestRemoveXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
 			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
@@ -292,7 +292,7 @@ func TestRemoveXAttr(t *testing.T) {
 				return error(errno)
 			}
 			return nil
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, _ *rules.Rule) {
 			if event.GetType() != "removexattr" {
 				t.Errorf("expected removexattr event, got %s", event.GetType())
 			}


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The goal here is that even if syscall tester has not been built, the go embed still has a file to include. This is important for the CI since the linter needs a build to be possible, but it won't run so it's not an issue if the syscall tester binary is not present.

This PR also fixes the lint issues now reported by golangci-lint. Clearly this build issue was preventing it from running on `pkg/security/tests` files.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->