### PR TITLE
[CWS] sbom: debug log messages when no container PID was found

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -45,6 +45,8 @@ const SBOMSource = "runtime-security-agent"
 
 const maxSBOMGenerationRetries = 3
 
+var errNoProcessForContainerID = errors.New("found no running process matching the given container ID")
+
 // SBOM defines an SBOM
 type SBOM struct {
 	sync.RWMutex
@@ -242,7 +244,11 @@ func (r *Resolver) Start(ctx context.Context) error {
 				if err := retry.Do(func() error {
 					return r.analyzeWorkload(sbom)
 				}, retry.Attempts(maxSBOMGenerationRetries), retry.Delay(200*time.Millisecond)); err != nil {
-					seclog.Warnf("%s", err.Error())
+					if errors.Is(err, errNoProcessForContainerID) {
+						seclog.Debugf("Couldn't generate SBOM for '%s': %v", sbom.ContainerID, err)
+					} else {
+						seclog.Warnf("Failed to generate SBOM for '%s': %v", sbom.ContainerID, err)
+					}
 				}
 			}
 		}
@@ -344,7 +350,7 @@ func (r *Resolver) doScan(sbom *SBOM) (*trivy.Report, error) {
 		return nil, lastErr
 	}
 	if !scanned {
-		return nil, fmt.Errorf("couldn't generate sbom: all root candidates failed")
+		return nil, errNoProcessForContainerID
 	}
 	return report, nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Mark as debug the log messages corresponding to errors indicating that we failed to retrieve the container PIDs.
This kind of errors is expected to happen when trying to generate SBOM data for a container that has already stopped.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->