### PR TITLE
usm: Enable event monitor if USM needs it

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -51,6 +52,15 @@ func adjustUSM(cfg model.Config) {
 		applyDefault(cfg, spNS("process_service_inference", "enabled"), true)
 	} else {
 		applyDefault(cfg, spNS("process_service_inference", "enabled"), false)
+	}
+
+	// Similar to the checkin in adjustNPM(). The process event data stream and USM have the same
+	// minimum kernel version requirement, but USM's check for that is done
+	// later.  This check here prevents the EventMonitorModule from getting
+	// enabled on unsupported kernels by load() in config.go.
+	if cfg.GetBool(smNS("enable_event_stream")) && !ProcessEventDataStreamSupported() {
+		log.Warn("disabling USM event stream as it is not supported for this kernel version")
+		cfg.Set(smNS("enable_event_stream"), false, model.SourceAgentRuntime)
 	}
 
 	applyDefault(cfg, spNS("process_service_inference", "use_windows_service_name"), true)

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -137,6 +137,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(secNS("enabled")) ||
 		cfg.GetBool(secNS("fim_enabled")) ||
 		cfg.GetBool(evNS("process.enabled")) ||
+		(usmEnabled && cfg.GetBool(smNS("enable_event_stream"))) ||
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled")) ||
 			gpuEnabled) {
 		c.EnabledModules[EventMonitorModule] = struct{}{}

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -24,6 +24,7 @@ func TestEventMonitor(t *testing.T) {
 
 	for i, tc := range []struct {
 		cws, fim, processEvents, networkEvents, gpu bool
+		usmEvents                                   bool
 		enabled                                     bool
 	}{
 		{cws: false, fim: false, processEvents: false, networkEvents: false, enabled: false},
@@ -43,6 +44,7 @@ func TestEventMonitor(t *testing.T) {
 		{cws: true, fim: true, processEvents: false, networkEvents: true, enabled: true},
 		{cws: true, fim: true, processEvents: true, networkEvents: true, enabled: true},
 		{cws: false, fim: false, processEvents: false, networkEvents: false, gpu: true, enabled: true},
+		{usmEvents: true, enabled: true},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Logf("%+v\n", tc)
@@ -52,6 +54,8 @@ func TestEventMonitor(t *testing.T) {
 			t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", strconv.FormatBool(tc.networkEvents))
 			t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", strconv.FormatBool(tc.networkEvents))
 			t.Setenv("DD_GPU_MONITORING_ENABLED", strconv.FormatBool(tc.gpu))
+			t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", strconv.FormatBool(tc.usmEvents))
+			t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_EVENT_STREAM", strconv.FormatBool(tc.usmEvents))
 
 			cfg, err := New("/doesnotexist", "")
 			t.Logf("%+v\n", cfg)


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If all options other than USM which need the event stream (including `network_process.enabled`) are explicitly disabled, the event monitor module is not enabled even if USM needs it.  Add the USM event stream configuration as a condition for enabling the event monitor module.

### Motivation

Reported as found during manual experimentation during investigation of an incident.

### Describe how to test/QA your changes

Automated tests have been updated.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->