### PR TITLE
test(installer): Add E2E test for proxy setup

### DIFF
--- a/test/new-e2e/tests/installer/host/fixtures/squid.conf
+++ b/test/new-e2e/tests/installer/host/fixtures/squid.conf
@@ -1,0 +1,10 @@
+# Squid Configuration for Unrestricted Access
+
+# Define the HTTP port Squid will listen on
+http_port 3128
+
+# Allow all incoming connections
+acl all src all
+
+# Allow all access
+http_access allow all


### PR DESCRIPTION
### What does this PR do?
Follow-up of https://github.com/DataDog/datadog-agent/pull/31313 to add an E2E test

### Motivation

### Describe how to test/QA your changes
Only adding a test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->