### PR TITLE
[CI] Make the technical lint jobs run at pipeline start

### DIFF
--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -3,6 +3,7 @@
   stage: lint
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
+  needs: []
 
 lint_licenses:
   extends: .lint
@@ -46,19 +47,16 @@ lint_components:
 
 lint_python:
   extends: .lint
-  needs: []
   script:
     - inv -e linter.python
 
 lint_update_go:
   extends: .lint
-  needs: []
   script:
     - inv -e linter.update-go
 
 validate_modules:
   extends: .lint
-  needs: []
   script:
     - inv -e modules.validate
     - inv -e modules.validate-used-by-otel


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR make the technical linters runs at the start of all pipelines.

### Motivation

The jobs don't need any job to run before, so we can add a `needs: []` to them.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->