### PR TITLE
[SVLS-6016] Filter high cardinality tags from the metric agent

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -193,8 +193,8 @@ func setupMetricAgent(tags map[string]string, tagger tagger.Component) *metrics.
 		SketchesBucketOffset: time.Second * 0,
 		Tagger:               tagger,
 	}
-	// we don't want to add the container_id tag to metrics for cardinality reasons
-	tags = serverlessInitTag.WithoutContainerID(tags)
+	// we don't want to add certain tags to metrics for cardinality reasons
+	tags = serverlessInitTag.WithoutHighCardinalityTags(tags)
 	metricAgent.Start(5*time.Second, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
 	metricAgent.SetExtraTags(serverlessTag.MapToArray(tags))
 	return metricAgent

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -62,11 +62,15 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string, versionMode string) 
 	return tagsMap
 }
 
-// WithoutContainerID creates a new tag map without the `container_id` tag
-func WithoutContainerID(tags map[string]string) map[string]string {
+// WithoutHihCardinalityTags creates a new tag map without high cardinality tags we use on traces
+func WithoutHighCardinalityTags(tags map[string]string) map[string]string {
 	newTags := make(map[string]string, len(tags))
 	for k, v := range tags {
-		if k != "container_id" {
+		if k != "container_id" &&
+			k != "gcr.container_id" &&
+			k != "gcrfx.container_id" &&
+			k != "replica_name" &&
+			k != "aca.replica.name" {
 			newTags[k] = v
 		}
 	}

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -104,3 +104,9 @@ func TestDdTags(t *testing.T) {
 	assert.Equal(t, "value5", mergedTags["key5"])
 	assert.Equal(t, "value6", mergedTags["key6"])
 }
+
+func TestWithoutHighCardinalityTags(t *testing.T) {
+	tags := map[string]string{"key1": "value1", "key2": "value2", "container_id": "abc", "replica_name": "abc"}
+	filteredTags := WithoutHighCardinalityTags(tags)
+	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, filteredTags)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
It filters high cardinality tags when setting up the metric agent in serverless-init. 

### Motivation
We recently added a tag that was not filtered and is adding to custom metric costs.

### Describe how to test/QA your changes
Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->