### PR TITLE
Adjust Counter metric from monotonic (Prometheus-style) to Datadog-style Counter metric

### DIFF
--- a/comp/core/agenttelemetry/impl/sender.go
+++ b/comp/core/agenttelemetry/impl/sender.go
@@ -240,7 +240,7 @@ func (s *senderImpl) addMetricPayload(
 	metricType := metricFamily.GetType()
 	switch metricType {
 	case dto.MetricType_COUNTER:
-		payload.Type = "monotonic"
+		payload.Type = "counter"
 		payload.Value = metric.GetCounter().GetValue()
 	case dto.MetricType_GAUGE:
 		payload.Type = "gauge"

--- a/releasenotes/notes/agent-telemetry-prom2dd-counter-5cde7684d71e8a6d.yaml
+++ b/releasenotes/notes/agent-telemetry-prom2dd-counter-5cde7684d71e8a6d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Agent telemetry's original implementation did not reset counter type metrics on
+    each scrape. This caused the counter to be monotonically increasing. This fix
+    resets the counter metrics on each scrape.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Reset Counter-type metrics on each scrape to make its value change semantics matching Datadog Counter metrics.

### Motivation
Counter type metrics previously were reported AS IS from Prometheus client based telemetry. These metrics were monotonically grown and never reset. Which made it hard to query or plot the growth rates. It differs from Datadog-style metrics which are reset on each scrape.

### Describe how to test/QA your changes
`TestAdjustPrometheusCounterValue` is the Unit tests which test the change. Manual testing is not necessary.

### Possible Drawbacks / Trade-offs
There are compatibility challenges since overall telemetry could include pre-7.61 release style. Standard Datadog practice of metric rename is too disruptive since all counters may be affected but there are ways to mitigate this compatibility challenges which will be communicated OOTB.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->