### PR TITLE
add otel agent integration test to gitlab ci

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -11,7 +11,7 @@ integration_tests_otel:
     - !reference [.retrieve_linux_go_deps]
     - inv check-otel-build
     - inv check-otel-module-versions
-    - inv otel-agent.otel-agent-integration
+    - inv otel-agent.integration-test
   rules:
     - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
       when: never

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -11,6 +11,7 @@ integration_tests_otel:
     - !reference [.retrieve_linux_go_deps]
     - inv check-otel-build
     - inv check-otel-module-versions
+    - inv otel-agent.otel-agent-integration
   rules:
     - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
       when: never

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -69,3 +69,12 @@ def image_build(ctx, arch='amd64', base_version='latest', tag=OT_AGENT_TAG, push
 
     os.remove(os.path.join(build_context, BIN_NAME))
     os.remove(os.path.join(build_context, CFG_NAME))
+
+
+@task
+def otel_agent_integration(ctx):
+    """
+    Run the otel integration test
+    """
+    cmd = "go test -timeout 0s -tags kubelet,jmx,cri,otlp,zstd,zk,jetson,etcd,kubeapiserver,zlib,podman,netcgo,docker,oracle,python,consul,orchestrator,process,trivy,systemd,datadog.no_waf,apm,containerd,ec2,gce,test -run ^TestIntegration$ github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"
+    ctx.run(cmd)

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -72,7 +72,7 @@ def image_build(ctx, arch='amd64', base_version='latest', tag=OT_AGENT_TAG, push
 
 
 @task
-def otel_agent_integration(ctx):
+def integration_test(ctx):
     """
     Run the otel integration test
     """

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -76,8 +76,6 @@ def integration_test(ctx):
     """
     Run the otel integration test
     """
-    cmd = """go test -timeout 0s -tags kubelet,jmx,cri,otlp,zstd,zk,jetson,etcd,\
-            kubeapiserver,zlib,podman,netcgo,docker,oracle,python,consul,orchestrator,\
-            process,trivy,systemd,datadog.no_waf,apm,containerd,ec2,gce,test -run \
-            ^TestIntegration$ github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"""
+    cmd = """go test -timeout 0s -tags otlp,test -run ^TestIntegration$ \
+        github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"""
     ctx.run(cmd)

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -76,5 +76,8 @@ def integration_test(ctx):
     """
     Run the otel integration test
     """
-    cmd = "go test -timeout 0s -tags kubelet,jmx,cri,otlp,zstd,zk,jetson,etcd,kubeapiserver,zlib,podman,netcgo,docker,oracle,python,consul,orchestrator,process,trivy,systemd,datadog.no_waf,apm,containerd,ec2,gce,test -run ^TestIntegration$ github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"
+    cmd = """go test -timeout 0s -tags kubelet,jmx,cri,otlp,zstd,zk,jetson,etcd,\
+            kubeapiserver,zlib,podman,netcgo,docker,oracle,python,consul,orchestrator,\
+            process,trivy,systemd,datadog.no_waf,apm,containerd,ec2,gce,test -run \
+            ^TestIntegration$ github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"""
     ctx.run(cmd)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds the existing otel agent integration test to the gitlab pipeline

### Motivation
This test is not run on CI, see https://github.com/DataDog/datadog-agent/pull/31437 where I set this test to assert 0=1 and all pipelines passed

### Describe how to test/QA your changes
`inv otel-agent.integration-test`
### Possible Drawbacks / Trade-offs
more overhead on pipelines
### Additional Notes
Job passed on CI: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/719768933
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->