### PR TITLE
[CWS] add pool layer of events used in fallback and snapshot

### DIFF
--- a/pkg/security/probe/model_ebpf.go
+++ b/pkg/security/probe/model_ebpf.go
@@ -10,7 +10,6 @@ package probe
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/rawpacket"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
@@ -49,24 +48,5 @@ func NewEBPFModel(probe *EBPFProbe) *model.Model {
 func newEBPFEvent(fh *EBPFFieldHandlers) *model.Event {
 	event := model.NewFakeEvent()
 	event.FieldHandlers = fh
-	return event
-}
-
-// newEBPFEventFromPCE returns a new event from a process cache entry
-func newEBPFEventFromPCE(entry *model.ProcessCacheEntry, fh *EBPFFieldHandlers) *model.Event {
-	eventType := model.ExecEventType
-	if !entry.IsExec {
-		eventType = model.ForkEventType
-	}
-
-	event := newEBPFEvent(fh)
-	event.Type = uint32(eventType)
-	event.TimestampRaw = uint64(time.Now().UnixNano())
-	event.ProcessCacheEntry = entry
-	event.ProcessContext = &entry.ProcessContext
-	event.Exec.Process = &entry.Process
-	event.ProcessContext.Process.ContainerID = entry.ContainerID
-	event.ProcessContext.Process.CGroup = entry.CGroup
-
 	return event
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a pool of `*model.Event` to be used by the `newEBPFEventFromPCE` in snapshot and fallback from map/proc paths. The goal here is to reduce the allocation caused by those code paths.

### Motivation



### Describe how to test/QA your changes

Covered by unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->