### PR TITLE
do not expect usm event stream if unsupported

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -786,6 +786,7 @@ workflow:
     when: never
 
 .system_probe_change_paths: &system_probe_change_paths
+  - cmd/system-probe/**/*
   - pkg/collector/corechecks/ebpf/**/*
   - pkg/collector/corechecks/servicediscovery/module/*
   - pkg/ebpf/**/*

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1344,7 +1344,8 @@ func TestUSMEventStream(t *testing.T) {
 		mock.NewSystemProbe(t)
 		cfg := New()
 
-		assert.True(t, cfg.EnableUSMEventStream)
+		expected := sysconfig.ProcessEventDataStreamSupported()
+		assert.Equal(t, expected, cfg.EnableUSMEventStream)
 	})
 
 	t.Run("via yaml", func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix config test when process event data stream is not supported

### Motivation

Failing tests on `main`

### Describe how to test/QA your changes

Fixed tests.

### Possible Drawbacks / Trade-offs

### Additional Notes

Added `cmd/system-probe` paths to trigger KMT. KMT tests did not run in #31420, which caused the original author to miss this.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->