### PR TITLE
Add foundations for Windows FIPS flavor

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -37,6 +37,7 @@
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
       -e API_KEY_ORG2=${API_KEY_ORG2}
       -e OMNIBUS_GIT_CACHE_DIR=${Env:TEMP}/${CI_PIPELINE_ID}/omnibus-git-cache
+      -e AGENT_FLAVOR=${AGENT_FLAVOR}
       registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       c:\mnt\tasks\winbuildscripts\buildwin.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -64,6 +65,19 @@ windows_msi_and_bosh_zip_x64-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
   timeout: 2h
+
+windows_msi_and_bosh_zip_x64-a7-fips:
+  extends: .windows_main_agent_base
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  variables:
+    ARCH: "x64"
+    AGENT_FLAVOR: fips
+  before_script:
+    - set RELEASE_VERSION $RELEASE_VERSION_7
+  timeout: 2h
+
 
 # cloudfoundry IoT build for Windows
 windows_zip_agent_binaries_x64-a7:

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -53,6 +53,7 @@ ALL_TAGS = {
     "zlib",
     "zstd",
     "test",  # used for unit-tests
+    "goexperiment.systemcrypto",  # used for FIPS mode
 }
 
 ### Tag inclusion lists

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -724,11 +724,3 @@ def mod_diffs(_, targets):
                 print(f"  - Version {version} in:")
                 for path in paths:
                     print(f"    * {path}")
-
-
-def repo_go_version():
-    """
-    Returns the go version specified in the .go-version file
-    """
-    with open('.go-version') as f:
-        return f.read().strip()

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -724,3 +724,11 @@ def mod_diffs(_, targets):
                 print(f"  - Version {version} in:")
                 for path in paths:
                     print(f"    * {path}")
+
+
+def repo_go_version():
+    """
+    Returns the go version specified in the .go-version file
+    """
+    with open('.go-version') as f:
+        return f.read().strip()

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -77,9 +77,15 @@ def _get_env(ctx, major_version='7', release_version='nightly'):
     env['PACKAGE_VERSION'] = get_version(
         ctx, include_git=True, url_safe=True, major_version=major_version, include_pipeline_id=True
     )
-    env['AGENT_INSTALLER_OUTPUT_DIR'] = f'{BUILD_OUTPUT_DIR}'
-    env['NUGET_PACKAGES_DIR'] = f'{NUGET_PACKAGES_DIR}'
+    env['AGENT_FLAVOR'] = os.getenv("AGENT_FLAVOR", "")
+    env['AGENT_INSTALLER_OUTPUT_DIR'] = BUILD_OUTPUT_DIR
+    env['NUGET_PACKAGES_DIR'] = NUGET_PACKAGES_DIR
+
     return env
+
+
+def _is_fips_mode(env):
+    return env['AGENT_FLAVOR'] == "fips"
 
 
 def _msbuild_configuration(debug=False):
@@ -264,6 +270,14 @@ def _build_msi(ctx, env, outdir, name, allowlist):
     sign_file(ctx, out_file)
 
 
+def _msi_output_name(env):
+    flavorPart = ""
+    if _is_fips_mode(env):
+        flavorPart = "fips-"
+    msi_name = f"datadog-agent-{flavorPart}{env['PACKAGE_VERSION']}-1-x86_64"
+    return msi_name
+
+
 @task
 def build(ctx, vstudio_root=None, arch="x64", major_version='7', release_version='nightly', debug=False):
     """
@@ -301,7 +315,7 @@ def build(ctx, vstudio_root=None, arch="x64", major_version='7', release_version
 
     # Run WiX to turn the WXS into an MSI
     with timed("Building MSI"):
-        msi_name = f"datadog-agent-{env['PACKAGE_VERSION']}-1-x86_64"
+        msi_name = _msi_output_name(env)
         _build_msi(ctx, env, build_outdir, msi_name, DATADOG_AGENT_MSI_ALLOW_LIST)
 
         # And copy it to the final output path as a build artifact

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -271,11 +271,10 @@ def _build_msi(ctx, env, outdir, name, allowlist):
 
 
 def _msi_output_name(env):
-    flavorPart = ""
     if _is_fips_mode(env):
-        flavorPart = "fips-"
-    msi_name = f"datadog-agent-{flavorPart}{env['PACKAGE_VERSION']}-1-x86_64"
-    return msi_name
+        return f"datadog-fips-agent-{env['PACKAGE_VERSION']}-1-x86_64"
+    else:
+        return f"datadog-agent-{env['PACKAGE_VERSION']}-1-x86_64"
 
 
 @task

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -6,7 +6,8 @@ from invoke import task
 from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.flavor import AgentFlavor
-from tasks.go import deps, repo_go_version
+from tasks.go import deps
+from tasks.libs.common.check_tools_version import expected_go_repo_v
 from tasks.libs.common.omnibus import (
     install_dir_for_project,
     omnibus_compute_cache_key,
@@ -144,7 +145,7 @@ def get_omnibus_env(
             #       available at that time.
             #       Comments from the Linux FIPS PR discussed wanting to centralize
             #       the msgo root logic, so this can be updated then.
-            go_version = repo_go_version()
+            go_version = expected_go_repo_v()
             env['MSGO_ROOT'] = f'C:\\msgo\\{go_version}\\go'
             gobinpath = f"{env['MSGO_ROOT']}\\bin\\go.exe"
             if not os.path.exists(gobinpath):

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -688,6 +688,7 @@ def build(
     with_unit_test=False,
     ebpf_compiler='clang',
     static=False,
+    fips_mode=False,
 ):
     """
     Build the system-probe
@@ -714,6 +715,7 @@ def build(
         strip_binary=strip_binary,
         arch=arch,
         static=static,
+        fips_mode=fips_mode,
     )
 
 

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -13,11 +13,16 @@ if "%OMNIBUS_TARGET%" == "" set OMNIBUS_TARGET=main
 if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--flavor iot
 if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_ARGS=--target-project dogstatsd
 if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --target-project agent-binaries
+if "%AGENT_FLAVOR%" == "fips" set OMNIBUS_ARGS=--flavor fips
 
 if DEFINED GOMODCACHE set OMNIBUS_ARGS=%OMNIBUS_ARGS% --go-mod-cache %GOMODCACHE%
 if DEFINED USE_S3_CACHING set OMNIBUS_ARGS=%OMNIBUS_ARGS% %USE_S3_CACHING%
 
-SET PATH=%PATH%;%GOPATH%/bin
+set REPO_ROOT=%~p0\..\..
+pushd .
+cd %REPO_ROOT% || exit /b 100
+
+SET PATH=%PATH%;%GOPATH%\bin
 
 @echo GOPATH %GOPATH%
 @echo PATH %PATH%
@@ -32,25 +37,21 @@ if "%TARGET_ARCH%" == "x64" (
     call ridk enable
 )
 
-set REPO_ROOT=%~p0\..\..
-pushd .
-cd %REPO_ROOT% || exit /b 101
 
+pip3 install -r requirements.txt || exit /b 120
 
-pip3 install -r requirements.txt || exit /b 102
-
-inv -e deps || exit /b 103
+inv -e deps || exit /b 130
 if "%GO_VERSION_CHECK%" == "true" (
-    inv -e check-go-version || exit /b 104
+    inv -e check-go-version || exit /b 140
 )
 
-@echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
-inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 105
+@echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --release-version %RELEASE_VERSION%"
+inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --release-version %RELEASE_VERSION% || exit /b 150
 
 REM only build MSI for main targets for now.
 if "%OMNIBUS_TARGET%" == "main" (
-    @echo "inv -e msi.build --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%
-    inv -e msi.build --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 106
+    @echo "inv -e msi.build --release-version %RELEASE_VERSION%
+    inv -e msi.build --release-version %RELEASE_VERSION% || exit /b 160
 )
 
 REM Build the OCI package for the Agent 7 only.

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
@@ -34,10 +34,10 @@ namespace WixSetup.Datadog_Agent
             _agentVersion = agentVersion;
         }
 
-        public string ProductFullName => "Datadog Agent FIPS";
+        public string ProductFullName => "Datadog FIPS Agent";
         public Guid UpgradeCode => new("de421174-9615-4fe9-b8a8-2b3f123bdc4f");
-        public string ProductDescription => $"Datadog Agent FIPS {_agentVersion.PackageVersion}";
-        public string PackageOutFileName => $"datadog-agent-fips-{_agentVersion.PackageVersion}-1-x86_64";
+        public string ProductDescription => $"Datadog FIPS Agent {_agentVersion.PackageVersion}";
+        public string PackageOutFileName => $"datadog-fips-agent-{_agentVersion.PackageVersion}-1-x86_64";
     }
 
     internal class BaseAgent : IAgentFlavor

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace WixSetup.Datadog_Agent
+{
+    internal static class AgentFlavorFactory
+    {
+        public static IAgentFlavor New(AgentVersion agentVersion)
+        {
+            var flavor = Environment.GetEnvironmentVariable("AGENT_FLAVOR");
+
+            return flavor switch
+            {
+                "fips" => new FIPSAgent(agentVersion),
+                "base" => new BaseAgent(agentVersion),
+                _ => new BaseAgent(agentVersion) // Default to BaseAgent if no valid value is provided
+            };
+        }
+    }
+
+    internal interface IAgentFlavor
+    {
+        string ProductFullName { get; }
+        Guid UpgradeCode { get; }
+        string ProductDescription { get; }
+        string PackageOutFileName { get; }
+    }
+
+    internal class FIPSAgent : IAgentFlavor
+    {
+        private readonly AgentVersion _agentVersion;
+
+        public FIPSAgent(AgentVersion agentVersion)
+        {
+            _agentVersion = agentVersion;
+        }
+
+        public string ProductFullName => "Datadog Agent FIPS";
+        public Guid UpgradeCode => new("de421174-9615-4fe9-b8a8-2b3f123bdc4f");
+        public string ProductDescription => $"Datadog Agent FIPS {_agentVersion.PackageVersion}";
+        public string PackageOutFileName => $"datadog-agent-fips-{_agentVersion.PackageVersion}-1-x86_64";
+    }
+
+    internal class BaseAgent : IAgentFlavor
+    {
+        private readonly AgentVersion _agentVersion;
+
+        public BaseAgent(AgentVersion agentVersion)
+        {
+            _agentVersion = agentVersion;
+        }
+
+        public string ProductFullName => "Datadog Agent";
+        public Guid UpgradeCode => new("0c50421b-aefb-4f15-a809-7af256d608a5");
+        public string ProductDescription => $"Datadog Agent {_agentVersion.PackageVersion}";
+        public string PackageOutFileName => $"datadog-agent-{_agentVersion.PackageVersion}-1-x86_64";
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -16,15 +16,12 @@ namespace WixSetup.Datadog_Agent
         private const string CompanyFullName = "Datadog, Inc.";
 
         // Product
-        private const string ProductFullName = "Datadog Agent";
-        private const string ProductDescription = "Datadog Agent {0}";
         private const string ProductHelpUrl = @"https://help.datadoghq.com/hc/en-us";
         private const string ProductAboutUrl = @"https://www.datadoghq.com/about/";
         private const string ProductComment = @"Copyright 2015 - Present Datadog";
         private const string ProductContact = @"https://www.datadoghq.com/about/contact/";
 
         // same value for all versions; must not be changed
-        private static readonly Guid ProductUpgradeCode = new("0c50421b-aefb-4f15-a809-7af256d608a5");
         private static readonly string ProductLicenceRtfFilePath = Path.Combine("assets", "LICENSE.rtf");
         private static readonly string ProductIconFilePath = Path.Combine("assets", "project.ico");
         private static readonly string InstallerBackgroundImagePath = Path.Combine("assets", "dialog_background.bmp");
@@ -40,6 +37,7 @@ namespace WixSetup.Datadog_Agent
         private readonly AgentVersion _agentVersion;
         private readonly AgentCustomActions _agentCustomActions = new();
         private readonly AgentInstallerUI _agentInstallerUi;
+        private readonly IAgentFlavor _agentFlavor;
 
         public AgentInstaller()
         : this(null)
@@ -60,11 +58,13 @@ namespace WixSetup.Datadog_Agent
 
             _agentBinaries = new AgentBinaries(BinSource, InstallerSource);
             _agentInstallerUi = new AgentInstallerUI(this, _agentCustomActions);
+            _agentFlavor = AgentFlavorFactory.New(_agentVersion);
         }
 
         public Project Configure()
         {
-            var project = new ManagedProject("Datadog Agent",
+
+            var project = new ManagedProject(_agentFlavor.ProductFullName,
                 // Use 2 LaunchConditions, one for server versions,
                 // one for client versions.
                 MinimumSupportedWindowsVersion.WindowsServer2016 |
@@ -145,9 +145,9 @@ namespace WixSetup.Datadog_Agent
             project
                 .SetCustomActions(_agentCustomActions)
                 .SetProjectInfo(
-                    upgradeCode: ProductUpgradeCode,
-                    name: ProductFullName,
-                    description: string.Format(ProductDescription, _agentVersion.Version),
+                    upgradeCode: _agentFlavor.UpgradeCode,
+                    name: _agentFlavor.ProductFullName,
+                    description: _agentFlavor.ProductDescription,
                     // This version is overridden below because SetProjectInfo throws an Exception if Revision is != 0
                     version: new Version(
                         _agentVersion.Version.Major,
@@ -156,7 +156,7 @@ namespace WixSetup.Datadog_Agent
                         0)
                 )
                 .SetControlPanelInfo(
-                    name: ProductFullName,
+                    name: _agentFlavor.ProductFullName,
                     manufacturer: CompanyFullName,
                     readme: ProductHelpUrl,
                     comment: ProductComment,
@@ -220,7 +220,7 @@ namespace WixSetup.Datadog_Agent
                 // Set custom output directory (WixSharp defaults to current directory)
                 project.OutDir = Environment.GetEnvironmentVariable("AGENT_MSI_OUTDIR");
             }
-            project.OutFileName = $"datadog-agent-{_agentVersion.PackageVersion}-1-x86_64";
+            project.OutFileName = _agentFlavor.PackageOutFileName;
             project.Package.AttributesDefinition = $"Comments={ProductComment}";
 
             // clear default media as we will add it via MediaTemplate


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add support for `fips` flavor to Windows omnibus build and MSI
- Use `MSGO_ROOT` env var to point to msgo installation

Adds a new package job to build the `fips` flavor. The MSI has a new upgrade code, so is a wholly separate "product" from the regular Agent. This means you will need to uninstall one to install the other.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1193
Support FIPS Windows builds

follow up to https://github.com/DataDog/datadog-agent/pull/31004

### Describe how to test/QA your changes
changes affect an unreleased build, testing to be done with E2E tests in future PRs

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Details on package names, preventing simultaneous install with regular agent, etc, to be handled in future PRs

requires build image with msgo installed: https://github.com/DataDog/datadog-agent-buildimages/pull/720