### PR TITLE
Revert usm: Refactor GoTLS monitor with new uprobe attacher (#29309)

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -11,22 +11,34 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"sync"
 	"time"
+	"unsafe"
 
+	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 const (
@@ -49,15 +61,76 @@ const (
 	GoTLSAttacherName = "go-tls"
 )
 
+type uprobesInfo struct {
+	functionInfo string
+	returnInfo   string
+}
+
+var functionToProbes = map[string]uprobesInfo{
+	bininspect.ReadGoTLSFunc: {
+		functionInfo: connReadProbe,
+		returnInfo:   connReadRetProbe,
+	},
+	bininspect.WriteGoTLSFunc: {
+		functionInfo: connWriteProbe,
+		returnInfo:   connWriteRetProbe,
+	},
+	bininspect.CloseGoTLSFunc: {
+		functionInfo: connCloseProbe,
+	},
+}
+
+var functionsConfig = map[string]bininspect.FunctionConfiguration{
+	bininspect.WriteGoTLSFunc: {
+		IncludeReturnLocations: true,
+		ParamLookupFunction:    lookup.GetWriteParams,
+	},
+	bininspect.ReadGoTLSFunc: {
+		IncludeReturnLocations: true,
+		ParamLookupFunction:    lookup.GetReadParams,
+	},
+	bininspect.CloseGoTLSFunc: {
+		IncludeReturnLocations: false,
+		ParamLookupFunction:    lookup.GetCloseParams,
+	},
+}
+
+var structFieldsLookupFunctions = map[bininspect.FieldIdentifier]bininspect.StructLookupFunction{
+	bininspect.StructOffsetTLSConn:     lookup.GetTLSConnInnerConnOffset,
+	bininspect.StructOffsetTCPConn:     lookup.GetTCPConnInnerConnOffset,
+	bininspect.StructOffsetNetConnFd:   lookup.GetConnFDOffset,
+	bininspect.StructOffsetNetFdPfd:    lookup.GetNetFD_PFDOffset,
+	bininspect.StructOffsetPollFdSysfd: lookup.GetFD_SysfdOffset,
+}
+
 type pid = uint32
 
 // goTLSProgram contains implementation for go-TLS.
 type goTLSProgram struct {
-	attacher  *uprobes.UprobeAttacher
-	inspector *goTLSBinaryInspector
-	cfg       *config.Config
-	procMon   *monitor.ProcessMonitor
+	wg      sync.WaitGroup
+	done    chan struct{}
+	cfg     *config.Config
+	manager *manager.Manager
+
+	// Path to the process/container's procfs
+	procRoot string
+
+	// eBPF map holding the result of binary analysis, indexed by binaries'
+	// inodes.
+	offsetsDataMap *ebpf.Map
+
+	// binAnalysisMetric handles telemetry on the time spent doing binary
+	// analysis
+	binAnalysisMetric *libtelemetry.Counter
+
+	// binNoSymbolsMetric counts Golang binaries without symbols.
+	binNoSymbolsMetric *libtelemetry.Counter
+
+	registry *utils.FileRegistry
 }
+
+// Validate that goTLSProgram implements the Attacher interface.
+var _ utils.Attacher = &goTLSProgram{}
 
 var goTLSSpec = &protocols.ProtocolSpec{
 	Maps: []*manager.Map{
@@ -109,56 +182,14 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 			return nil, errors.New("goTLS support requires runtime-compilation or CO-RE to be enabled")
 		}
 
-		attacherCfg := uprobes.AttacherConfig{
-			EbpfConfig: &c.Config,
-			Rules: []*uprobes.AttachRule{{
-				Targets: uprobes.AttachToExecutable,
-				ProbesSelector: []manager.ProbesSelector{
-					&manager.AllOf{
-						Selectors: []manager.ProbesSelector{
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connReadProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connReadRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connWriteProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connWriteRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connCloseProbe}},
-						},
-					},
-				},
-				ProbeOptionsOverride: map[string]uprobes.ProbeOptions{
-					connReadProbe:     {IsManualReturn: false, Symbol: bininspect.ReadGoTLSFunc},
-					connReadRetProbe:  {IsManualReturn: true, Symbol: bininspect.ReadGoTLSFunc},
-					connWriteProbe:    {IsManualReturn: false, Symbol: bininspect.WriteGoTLSFunc},
-					connWriteRetProbe: {IsManualReturn: true, Symbol: bininspect.WriteGoTLSFunc},
-					connCloseProbe:    {IsManualReturn: false, Symbol: bininspect.CloseGoTLSFunc},
-				},
-			}},
-			ExcludeTargets:                 uprobes.ExcludeInternal,
-			PerformInitialScan:             false,
-			EnablePeriodicScanNewProcesses: false,
-		}
-
-		if c.GoTLSExcludeSelf {
-			attacherCfg.ExcludeTargets |= uprobes.ExcludeSelf
-		}
-
-		inspector := &goTLSBinaryInspector{
-			structFieldsLookupFunctions: structFieldsLookupFunctions,
-			paramLookupFunctions:        paramLookupFunctions,
-			binAnalysisMetric:           libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
-			binNoSymbolsMetric:          libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
-		}
-
-		procMon := monitor.GetProcessMonitor()
-		attacher, err := uprobes.NewUprobeAttacher(consts.USMModuleName, GoTLSAttacherName, attacherCfg, m, nil, inspector, procMon)
-		if err != nil {
-			return nil, fmt.Errorf("cannot create uprobe attacher: %w", err)
-		}
-
 		return &goTLSProgram{
-			cfg:       c,
-			inspector: inspector,
-			attacher:  attacher,
-			procMon:   procMon,
+			done:               make(chan struct{}),
+			cfg:                c,
+			manager:            m,
+			procRoot:           c.ProcRoot,
+			binAnalysisMetric:  libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
+			binNoSymbolsMetric: libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
+			registry:           utils.NewFileRegistry(consts.USMModuleName, "go-tls"),
 		}, nil
 	}
 }
@@ -185,21 +216,48 @@ func (p *goTLSProgram) ConfigureOptions(_ *manager.Manager, options *manager.Opt
 func (p *goTLSProgram) PreStart(m *manager.Manager) error {
 	var err error
 
-	p.inspector.offsetsDataMap, _, err = m.GetMap(offsetsDataMap)
+	p.offsetsDataMap, _, err = m.GetMap(offsetsDataMap)
 	if err != nil {
 		return fmt.Errorf("could not get offsets_data map: %s", err)
 	}
 
-	err = p.attacher.Start()
-	if err != nil {
-		return fmt.Errorf("could not start attacher: %w", err)
-	}
+	procMonitor := monitor.GetProcessMonitor()
+	cleanupExec := procMonitor.SubscribeExec(p.handleProcessStart)
+	cleanupExit := procMonitor.SubscribeExit(p.handleProcessExit)
+
+	p.wg.Add(1)
+	go func() {
+		processSync := time.NewTicker(scanTerminatedProcessesInterval)
+
+		defer func() {
+			processSync.Stop()
+			cleanupExec()
+			cleanupExit()
+			procMonitor.Stop()
+			p.registry.Clear()
+			p.wg.Done()
+		}()
+
+		for {
+			select {
+			case <-p.done:
+				return
+			case <-processSync.C:
+				processSet := p.registry.GetRegisteredProcesses()
+				deletedPids := monitor.FindDeletedProcesses(processSet)
+				for deletedPid := range deletedPids {
+					_ = p.registry.Unregister(deletedPid)
+				}
+			}
+		}
+	}()
 
 	return nil
 }
 
-// PostStart is a no-op
+// PostStart registers the goTLS program to the attacher list.
 func (p *goTLSProgram) PostStart(*manager.Manager) error {
+	utils.AddAttacher(consts.USMModuleName, p.Name(), p)
 	return nil
 }
 
@@ -211,11 +269,28 @@ func (p *goTLSProgram) GetStats() *protocols.ProtocolStats {
 	return nil
 }
 
-// Stop terminates the uprobe attacher for GoTLS programs.
+// Stop terminates goTLS main goroutine.
 func (p *goTLSProgram) Stop(*manager.Manager) {
-	p.procMon.Stop()
-	p.attacher.Stop()
+	close(p.done)
+	// Waiting for the main event loop to finish.
+	p.wg.Wait()
 }
+
+var (
+	internalProcessRegex = regexp.MustCompile("datadog-agent/.*/((process|security|trace)-agent|system-probe|agent)")
+)
+
+// DetachPID detaches the provided PID from the eBPF program.
+func (p *goTLSProgram) DetachPID(pid uint32) error {
+	return p.registry.Unregister(pid)
+}
+
+var (
+	// ErrSelfExcluded is returned when the PID is the same as the agent's PID.
+	ErrSelfExcluded = errors.New("self-excluded")
+	// ErrInternalDDogProcessRejected is returned when the PID is an internal datadog process.
+	ErrInternalDDogProcessRejected = errors.New("internal datadog process rejected")
+)
 
 // GoTLSAttachPID attaches Go TLS hooks on the binary of process with
 // provided PID, if Go TLS is enabled.
@@ -224,7 +299,7 @@ func GoTLSAttachPID(pid pid) error {
 		return errors.New("GoTLS is not enabled")
 	}
 
-	err := goTLSSpec.Instance.(*goTLSProgram).attacher.AttachPID(pid)
+	err := goTLSSpec.Instance.(*goTLSProgram).AttachPID(pid)
 	if errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
 		// The process monitor has attached the process before us.
 		return nil
@@ -240,5 +315,183 @@ func GoTLSDetachPID(pid pid) error {
 		return errors.New("GoTLS is not enabled")
 	}
 
-	return goTLSSpec.Instance.(*goTLSProgram).attacher.DetachPID(pid)
+	return goTLSSpec.Instance.(*goTLSProgram).DetachPID(pid)
+}
+
+// AttachPID attaches the provided PID to the eBPF program.
+func (p *goTLSProgram) AttachPID(pid uint32) error {
+	if p.cfg.GoTLSExcludeSelf && pid == uint32(os.Getpid()) {
+		return ErrSelfExcluded
+	}
+
+	pidAsStr := strconv.FormatUint(uint64(pid), 10)
+	exePath := filepath.Join(p.procRoot, pidAsStr, "exe")
+
+	binPath, err := os.Readlink(exePath)
+	if err != nil {
+		return err
+	}
+
+	// Check if the process is datadog's internal process, if so, we don't want to hook the process.
+	if internalProcessRegex.MatchString(binPath) {
+		if log.ShouldLog(seelog.DebugLvl) {
+			log.Debugf("ignoring pid %d, as it is an internal datadog component (%q)", pid, binPath)
+		}
+		return ErrInternalDDogProcessRejected
+	}
+
+	// Check go process
+	probeList := make([]manager.ProbeIdentificationPair, 0)
+	return p.registry.Register(binPath, pid, registerCBCreator(p.manager, p.offsetsDataMap, &probeList, p.binAnalysisMetric, p.binNoSymbolsMetric),
+		unregisterCBCreator(p.manager, &probeList, p.offsetsDataMap),
+		utils.IgnoreCB)
+}
+
+func registerCBCreator(mgr *manager.Manager, offsetsDataMap *ebpf.Map, probeIDs *[]manager.ProbeIdentificationPair, binAnalysisMetric, binNoSymbolsMetric *libtelemetry.Counter) func(path utils.FilePath) error {
+	return func(filePath utils.FilePath) error {
+		start := time.Now()
+
+		f, err := os.Open(filePath.HostPath)
+		if err != nil {
+			return fmt.Errorf("could not open file %s, %w", filePath.HostPath, err)
+		}
+		defer f.Close()
+
+		elfFile, err := safeelf.NewFile(f)
+		if err != nil {
+			return fmt.Errorf("file %s could not be parsed as an ELF file: %w", filePath.HostPath, err)
+		}
+
+		inspectionResult, err := bininspect.InspectNewProcessBinary(elfFile, functionsConfig, structFieldsLookupFunctions)
+		if err != nil {
+			if errors.Is(err, safeelf.ErrNoSymbols) {
+				binNoSymbolsMetric.Add(1)
+			}
+			return fmt.Errorf("error extracting inspectoin data from %s: %w", filePath.HostPath, err)
+		}
+
+		if err := addInspectionResultToMap(offsetsDataMap, filePath.ID, inspectionResult); err != nil {
+			return fmt.Errorf("failed adding inspection rules: %w", err)
+		}
+
+		pIDs, err := attachHooks(mgr, inspectionResult, filePath.HostPath, filePath.ID)
+		if err != nil {
+			removeInspectionResultFromMap(offsetsDataMap, filePath.ID)
+			return fmt.Errorf("error while attaching hooks to %s: %w", filePath.HostPath, err)
+		}
+		*probeIDs = pIDs
+
+		elapsed := time.Since(start)
+
+		binAnalysisMetric.Add(elapsed.Milliseconds())
+		log.Debugf("attached hooks on %s (%v) in %s", filePath.HostPath, filePath.ID, elapsed)
+		return nil
+	}
+}
+
+func (p *goTLSProgram) handleProcessExit(pid pid) {
+	_ = p.DetachPID(pid)
+}
+
+func (p *goTLSProgram) handleProcessStart(pid pid) {
+	_ = p.AttachPID(pid)
+}
+
+// addInspectionResultToMap runs a binary inspection and adds the result to the
+// map that's being read by the probes, indexed by the binary's inode number `ino`.
+func addInspectionResultToMap(offsetsDataMap *ebpf.Map, binID utils.PathIdentifier, result *bininspect.Result) error {
+	offsetsData, err := inspectionResultToProbeData(result)
+	if err != nil {
+		return fmt.Errorf("error while parsing inspection result: %w", err)
+	}
+
+	key := &gotls.TlsBinaryId{
+		Id_major: unix.Major(binID.Dev),
+		Id_minor: unix.Minor(binID.Dev),
+		Ino:      binID.Inode,
+	}
+	if err := offsetsDataMap.Put(unsafe.Pointer(key), unsafe.Pointer(&offsetsData)); err != nil {
+		return fmt.Errorf("could not write binary inspection result to map for binID %v: %w", binID, err)
+	}
+
+	return nil
+}
+
+func removeInspectionResultFromMap(offsetsDataMap *ebpf.Map, binID utils.PathIdentifier) {
+	key := &gotls.TlsBinaryId{
+		Id_major: unix.Major(binID.Dev),
+		Id_minor: unix.Minor(binID.Dev),
+		Ino:      binID.Inode,
+	}
+	if err := offsetsDataMap.Delete(unsafe.Pointer(key)); err != nil {
+		log.Errorf("could not remove inspection result from map for ino %v: %s", binID, err)
+	}
+}
+
+func attachHooks(mgr *manager.Manager, result *bininspect.Result, binPath string, binID utils.PathIdentifier) ([]manager.ProbeIdentificationPair, error) {
+	uid := getUID(binID)
+	probeIDs := make([]manager.ProbeIdentificationPair, 0)
+
+	for function, uprobes := range functionToProbes {
+		if functionsConfig[function].IncludeReturnLocations {
+			if uprobes.returnInfo == "" {
+				return nil, fmt.Errorf("function %q configured to include return locations but no return uprobes found in config", function)
+			}
+			for i, offset := range result.Functions[function].ReturnLocations {
+				returnProbeID := manager.ProbeIdentificationPair{
+					EBPFFuncName: uprobes.returnInfo,
+					UID:          makeReturnUID(uid, i),
+				}
+				newProbe := &manager.Probe{
+					ProbeIdentificationPair: returnProbeID,
+					BinaryPath:              binPath,
+					// Each return probe needs to have a unique uid value,
+					// so add the index to the binary UID to make an overall UID.
+					UprobeOffset: offset,
+				}
+				if err := mgr.AddHook("", newProbe); err != nil {
+					return nil, fmt.Errorf("could not add return hook to function %q in offset %d due to: %w", function, offset, err)
+				}
+				probeIDs = append(probeIDs, returnProbeID)
+				ddebpf.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, "usm_gotls")
+			}
+		}
+
+		if uprobes.functionInfo != "" {
+			probeID := manager.ProbeIdentificationPair{
+				EBPFFuncName: uprobes.functionInfo,
+				UID:          uid,
+			}
+
+			newProbe := &manager.Probe{
+				BinaryPath:              binPath,
+				UprobeOffset:            result.Functions[function].EntryLocation,
+				ProbeIdentificationPair: probeID,
+			}
+			if err := mgr.AddHook("", newProbe); err != nil {
+				return nil, fmt.Errorf("could not add hook for %q in offset %d due to: %w", uprobes.functionInfo, result.Functions[function].EntryLocation, err)
+			}
+			probeIDs = append(probeIDs, probeID)
+			ddebpf.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, "usm_gotls")
+		}
+	}
+
+	return probeIDs, nil
+}
+
+func unregisterCBCreator(mgr *manager.Manager, probeIDs *[]manager.ProbeIdentificationPair, offsetsDataMap *ebpf.Map) func(path utils.FilePath) error {
+	return func(path utils.FilePath) error {
+		if len(*probeIDs) == 0 {
+			return nil
+		}
+		removeInspectionResultFromMap(offsetsDataMap, path.ID)
+		for _, probeID := range *probeIDs {
+			err := mgr.DetachHook(probeID)
+			if err != nil {
+				log.Errorf("failed detaching hook %s: %s", probeID.UID, err)
+			}
+		}
+		log.Debugf("detached hooks on ino %v", path.ID)
+		return nil
+	}
 }

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -10,152 +10,12 @@ package usm
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
-	"time"
 	"unsafe"
 
-	"github.com/cilium/ebpf"
-	"golang.org/x/sys/unix"
-
-	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup"
-	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
-
-var paramLookupFunctions = map[string]bininspect.ParameterLookupFunction{
-	bininspect.WriteGoTLSFunc: lookup.GetWriteParams,
-	bininspect.ReadGoTLSFunc:  lookup.GetReadParams,
-	bininspect.CloseGoTLSFunc: lookup.GetCloseParams,
-}
-
-var structFieldsLookupFunctions = map[bininspect.FieldIdentifier]bininspect.StructLookupFunction{
-	bininspect.StructOffsetTLSConn:     lookup.GetTLSConnInnerConnOffset,
-	bininspect.StructOffsetTCPConn:     lookup.GetTCPConnInnerConnOffset,
-	bininspect.StructOffsetNetConnFd:   lookup.GetConnFDOffset,
-	bininspect.StructOffsetNetFdPfd:    lookup.GetNetFD_PFDOffset,
-	bininspect.StructOffsetPollFdSysfd: lookup.GetFD_SysfdOffset,
-}
-
-// goTLSBinaryInspector is a BinaryInspector that inspects Go binaries, dealing with the specifics of Go binaries
-// such as the argument passing convention and the lack of uprobes
-type goTLSBinaryInspector struct {
-	structFieldsLookupFunctions map[bininspect.FieldIdentifier]bininspect.StructLookupFunction
-	paramLookupFunctions        map[string]bininspect.ParameterLookupFunction
-
-	// eBPF map holding the result of binary analysis, indexed by binaries'
-	// inodes.
-	offsetsDataMap *ebpf.Map
-
-	// binAnalysisMetric handles telemetry on the time spent doing binary
-	// analysis
-	binAnalysisMetric *libtelemetry.Counter
-
-	// binNoSymbolsMetric counts Golang binaries without symbols.
-	binNoSymbolsMetric *libtelemetry.Counter
-}
-
-// Ensure goTLSBinaryInspector implements BinaryInspector
-var _ uprobes.BinaryInspector = &goTLSBinaryInspector{}
-
-// Inspect extracts the metadata required to attach to a Go binary from the ELF file at the given path.
-func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.SymbolRequest) (map[string]bininspect.FunctionMetadata, error) {
-	start := time.Now()
-
-	path := fpath.HostPath
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("could not open file %s, %w", path, err)
-	}
-	defer f.Close()
-
-	elfFile, err := safeelf.NewFile(f)
-	if err != nil {
-		return nil, fmt.Errorf("file %s could not be parsed as an ELF file: %w", path, err)
-	}
-
-	functionsConfig := make(map[string]bininspect.FunctionConfiguration, len(requests))
-	for _, req := range requests {
-		lookupFunc, ok := p.paramLookupFunctions[req.Name]
-		if !ok {
-			return nil, fmt.Errorf("no parameter lookup function found for function %s", req.Name)
-		}
-
-		functionsConfig[req.Name] = bininspect.FunctionConfiguration{
-			IncludeReturnLocations: req.IncludeReturnLocations,
-			ParamLookupFunction:    lookupFunc,
-		}
-	}
-
-	inspectionResult, err := bininspect.InspectNewProcessBinary(elfFile, functionsConfig, p.structFieldsLookupFunctions)
-	if err != nil {
-		if errors.Is(err, safeelf.ErrNoSymbols) {
-			p.binNoSymbolsMetric.Add(1)
-		}
-		return nil, fmt.Errorf("error extracting inspection data from %s: %w", path, err)
-	}
-
-	if err := p.addInspectionResultToMap(fpath.ID, inspectionResult); err != nil {
-		return nil, fmt.Errorf("failed adding inspection rules: %w", err)
-	}
-
-	elapsed := time.Since(start)
-	p.binAnalysisMetric.Add(elapsed.Milliseconds())
-
-	return inspectionResult.Functions, nil
-}
-
-// Cleanup removes the inspection result for the binary at the given path from the map.
-func (p *goTLSBinaryInspector) Cleanup(fpath utils.FilePath) {
-	if p.offsetsDataMap == nil {
-		log.Warn("offsetsDataMap is nil, cannot remove inspection result")
-		return
-	}
-
-	binID := fpath.ID
-	key := &gotls.TlsBinaryId{
-		Id_major: unix.Major(binID.Dev),
-		Id_minor: unix.Minor(binID.Dev),
-		Ino:      binID.Inode,
-	}
-	if err := p.offsetsDataMap.Delete(unsafe.Pointer(key)); err != nil {
-		// Ignore errors for non-existing keys: if the inspect process fails, we won't have added the key to the map
-		// but the deactivation callback (which calls Cleanup and thus this method) will still be called. So it's normal
-		// to not find the key in the map. We report other errors though.
-		if !errors.Is(err, unix.ENOENT) {
-			log.Errorf("could not remove binary inspection result from map for binID %v: %v", binID, err)
-		}
-	}
-}
-
-// addInspectionResultToMap runs a binary inspection and adds the result to the
-// map that's being read by the probes, indexed by the binary's inode number `ino`.
-func (p *goTLSBinaryInspector) addInspectionResultToMap(binID utils.PathIdentifier, result *bininspect.Result) error {
-	if p.offsetsDataMap == nil {
-		return errors.New("offsetsDataMap is nil, cannot write inspection result")
-	}
-
-	offsetsData, err := inspectionResultToProbeData(result)
-	if err != nil {
-		return fmt.Errorf("error while parsing inspection result: %w", err)
-	}
-
-	key := &gotls.TlsBinaryId{
-		Id_major: unix.Major(binID.Dev),
-		Id_minor: unix.Minor(binID.Dev),
-		Ino:      binID.Inode,
-	}
-	if err := p.offsetsDataMap.Put(unsafe.Pointer(key), unsafe.Pointer(&offsetsData)); err != nil {
-		return fmt.Errorf("could not write binary inspection result to map for binID %v: %w", binID, err)
-	}
-
-	return nil
-}
 
 func inspectionResultToProbeData(result *bininspect.Result) (gotls.TlsOffsetsData, error) {
 	closeConnPointer, err := getConnPointer(result, bininspect.CloseGoTLSFunc)
@@ -360,6 +220,10 @@ func getReturnError(result *bininspect.Result, funcName string) (gotls.Location,
 	default:
 		return gotls.Location{}, fmt.Errorf("unknown abi %q", result.ABI)
 	}
+}
+
+func makeReturnUID(uid string, returnNumber int) string {
+	return fmt.Sprintf("%s_%x", uid, returnNumber)
 }
 
 func boolToBinary(value bool) uint8 {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reverts #29309. Some minor changes made in that PR have been kept to avoid conflicts (e.g., using a constant for the `utils.WaitForProgramToBeTraced` test calls instead of a hardcoded string) as they were changed too by subsequent PRs.

### Motivation

Fix for incident 32654, avoid issues for 7.61 until this is more tested.

### Describe how to test/QA your changes

Unit tests, revert was also tested in staging to ensure it fixed the observed issues.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Tested in load-testing environment against 7.59 for validation:


![Screenshot 2024-11-26 at 16 43 59](https://github.com/user-attachments/assets/2d0d8956-2004-4490-adc3-29dbd27093e3)

![Screenshot 2024-11-26 at 16 44 04](https://github.com/user-attachments/assets/2337092a-845a-419a-9e79-2cb322fcbdc8)
![Uploading Screenshot 2024-11-26 at 16.44.16.png…]()


