### PR TITLE
discovery: Enable if USM is enabled

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -23,6 +23,8 @@ func adjustUSM(cfg model.Config) {
 		applyDefault(cfg, netNS("enable_https_monitoring"), true)
 		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
 		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
+
+		applyDefault(cfg, discoveryNS("enabled"), true)
 	}
 
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))

--- a/cmd/system-probe/config/config_test.go
+++ b/cmd/system-probe/config/config_test.go
@@ -95,4 +95,21 @@ func TestEnableDiscovery(t *testing.T) {
 		cfg := mock.NewSystemProbe(t)
 		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
 	})
+
+	t.Run("default enabled with USM", func(t *testing.T) {
+		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+
+		cfg := mock.NewSystemProbe(t)
+		Adjust(cfg)
+		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
+	})
+
+	t.Run("force disabled with USM", func(t *testing.T) {
+		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+		t.Setenv("DD_DISCOVERY_ENABLED", "false")
+
+		cfg := mock.NewSystemProbe(t)
+		Adjust(cfg)
+		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
+	})
 }

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -405,7 +405,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(ccmNS, "enabled"), false)
 
 	// Discovery config
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "enabled"), false)
+	cfg.BindEnv(join(discoveryNS, "enabled"))
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_services"), []string{"datadog-agent", "trace-agent", "process-agent", "system-probe", "security-agent", "datadog-cluster-agent"})


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enable service discovery by default if USM is enabled.  This is a step towards enabling it by default without other conditions.

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1362

### Describe how to test/QA your changes

Unit tests updated.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->