### PR TITLE
[SBOM] Re-use `ErrorCallback` WalkOption in post-analysis steps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1061,7 +1061,7 @@ replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20
 // Pull in replacements needed by upstream Trivy
 replace (
 	// Maps to Trivy fork https://github.com/DataDog/trivy/commits/use-fs-main-dd/
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20240925151901-6736b8661190
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20241126101205-8517f9b946f4
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	// testcontainers-go has a bug with versions v0.25.0 and v0.26.0
 	// ref: https://github.com/testcontainers/testcontainers-go/issues/1782

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.21.0 h1:/Dp1WBvekdus
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.21.0/go.mod h1:asNuwNy1O2HbadkcZVuqmFGonfEzXS/SBvOo8V1MJvQ=
 github.com/DataDog/sketches-go v1.4.6 h1:acd5fb+QdUzGrosfNLwrIhqyrbMORpvBy7mE+vHlT3I=
 github.com/DataDog/sketches-go v1.4.6/go.mod h1:7Y8GN8Jf66DLyDhc94zuWA3uHEt/7ttt8jHOBWWrSOg=
-github.com/DataDog/trivy v0.0.0-20240925151901-6736b8661190 h1:JDfYwI7ELSnWDgn0hj7afbByrLbFtztkvgQf69H+fv4=
-github.com/DataDog/trivy v0.0.0-20240925151901-6736b8661190/go.mod h1:hLiUAm3v175M5jWbq34TdGmX6mvHIJY7FMuZ3wBugtw=
+github.com/DataDog/trivy v0.0.0-20241126101205-8517f9b946f4 h1:UVL5oU/8o0JhEv8Js6qxJgiqeV+PzPw/aldojyexS/U=
+github.com/DataDog/trivy v0.0.0-20241126101205-8517f9b946f4/go.mod h1:hLiUAm3v175M5jWbq34TdGmX6mvHIJY7FMuZ3wBugtw=
 github.com/DataDog/viper v1.13.5 h1:SZMcyMknYQN2jRY/40A16gUXexlNJOI8sDs1cWZnI64=
 github.com/DataDog/viper v1.13.5/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Bump trivy in order to re-use existing `ErrCallback` WalkOption when walking a filesystem in post-analysis steps. 

### Motivation

The goal is to re-use the option set by the agent here
https://github.com/DataDog/datadog-agent/blob/50a93b76d2742ad731d51d52f121bb327fecd55d/pkg/util/trivy/trivy.go#L109-L116

to properly ignore `os.ErrNotExist` errors occuring when walking the filesystem in trivy post-analysis steps (e.g. when running the dpkg analyzer).

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->