### PR TITLE
pkg/util/kernel: skip the sprintf + filepath join in `MountInfoPidPath`

### DIFF
--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -8,7 +8,6 @@
 package kernel
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,7 +19,7 @@ import (
 
 // MountInfoPidPath returns the path to the mountinfo file of a pid in /proc
 func MountInfoPidPath(pid int32) string {
-	return filepath.Join(ProcFSRoot(), fmt.Sprintf("/%d/mountinfo", pid))
+	return filepath.Join(ProcFSRoot(), strconv.FormatInt(int64(pid), 10), "mountinfo")
 }
 
 // ParseMountInfoFile collects the mounts for a specific process ID.


### PR DESCRIPTION
### What does this PR do?

This PR does a small optimization to `MountInfoPidPath` by:
- removing the filepath.Join + sprintf which is not useful (both are doing similar things here)
- fixing the double slash issue: basically the `filepath.Join` is `strings.Join` + `filepath.Clean`. The result of `strings.Join` will be something like `/proc//123/mountinfo` which will trigger the slow path of `filepath.Clean` (because of the double slash which will require a re-allocation to clean up).

[Example profile](https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20datacenter%3Aus1.ddbuild.io&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZNn-jnb5aJ6-AAAABhBWk5uLWpwOEFBQzM2S21jc0lRbEhRQUEAAAAkMDE5MzY3ZmEtNTdiZS00MTJhLWJkNGEtMTg0Y2M0YzQzNDI4AACP1g&my_code=disabled&profile_type=alloc-size&profileId=AZNn-jp8AAC36KmcsIQlHQAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1732613745707&to_ts=1732617345707&live=false) showing why this code path can be important 

### Motivation

### Describe how to test/QA your changes

This is covered by multiple tests downstream in multiple packages.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->