### PR TITLE
[POC] leverage dd csi plugin in DCA autoinstrumentation and config webhooks

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -528,7 +528,7 @@ func (w *Webhook) newInjector(startTime time.Time, pod *corev1.Pod, opts ...inje
 	}
 
 	return newInjector(startTime, w.config.containerRegistry, w.config.injectorImageTag, opts...).
-		podMutator(w.config.version)
+		podMutator(w.config.version, w.config.csiEnabled)
 }
 
 func initContainerIsSidecar(container *corev1.Container) bool {
@@ -726,7 +726,7 @@ func (w *Webhook) injectAutoInstruConfig(pod *corev1.Pod, config extractedPodLib
 			containerMutators:     containerMutators,
 			initContainerMutators: initContainerMutators,
 			podMutators:           []podMutator{configInjector.podMutator(lib.lang)},
-		}).mutatePod(pod); err != nil {
+		}, w.config.csiEnabled).mutatePod(pod); err != nil {
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
 			lastError = err
 			continue

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -35,6 +35,7 @@ type webhookConfig struct {
 	languageDetectionEnabled          bool
 	languageDetectionReportingEnabled bool
 	injectAutoDetectedLibraries       bool
+	csiEnabled                        bool
 	// keep pointers to bool to differentiate between unset and false
 	// for backward compatibility with the previous implementation.
 	// TODO: remove the pointers when the backward compatibility is not needed anymore.
@@ -64,6 +65,7 @@ func retrieveConfig(datadogConfig config.Component, injectionFilter mutatecommon
 		languageDetectionEnabled:          datadogConfig.GetBool("language_detection.enabled"),
 		languageDetectionReportingEnabled: datadogConfig.GetBool("language_detection.reporting.enabled"),
 		injectAutoDetectedLibraries:       datadogConfig.GetBool("admission_controller.auto_instrumentation.inject_auto_detected_libraries"),
+		csiEnabled:                        datadogConfig.GetBool("csi_driver.enabled"),
 
 		asmEnabled:       getOptionalBoolValue(datadogConfig, "admission_controller.auto_instrumentation.asm.enabled"),
 		iastEnabled:      getOptionalBoolValue(datadogConfig, "admission_controller.auto_instrumentation.iast.enabled"),

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -620,6 +620,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// We use a long timeout here since the metadata and token API can be very slow sometimes.
 	config.BindEnvAndSetDefault("ibm_metadata_timeout", 5) // value in seconds
 
+	// CSI Driver Config
+	config.BindEnvAndSetDefault("csi_driver.enabled", false)
+
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR is a POC that modified the cluster agent admission controller so that it leverages the existence of a datadog CSI driver in order to:
- eliminate the injection of apm ssi init containers (except for the injector init container) ==> results in minimising the pod startup time for APM SSI
- replace injected hostpath volumes in the autoinstrumentation and config webhooks by using datadog csi volumes (of type apm, socket or local)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->