### PR TITLE
Remove PYTHON_VERSION from Docker image building

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -61,7 +61,7 @@ docker_build_agent7:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
 
 single_machine_performance-amd64-a7:
   extends: .docker_publish_job_definition
@@ -87,7 +87,7 @@ docker_build_agent7_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
@@ -101,7 +101,7 @@ docker_build_agent7_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
 
 docker_build_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -114,7 +114,7 @@ docker_build_agent7_jmx_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
 
 # build agent7 UA image
 docker_build_ot_agent7:
@@ -128,7 +128,7 @@ docker_build_ot_agent7:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
+    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
 
 docker_build_ot_agent7_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -141,7 +141,7 @@ docker_build_ot_agent7_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta
-    BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
+    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
 
 # build agent7 jmx image
 docker_build_ot_agent7_jmx:
@@ -155,7 +155,7 @@ docker_build_ot_agent7_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-amd64.tar.xz
 
 docker_build_ot_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -168,7 +168,7 @@ docker_build_ot_agent7_jmx_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-ot-beta-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-ot-agent-7*-arm64.tar.xz
 
 # build the cluster-agent image
 docker_build_cluster_agent_amd64:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -39,7 +39,6 @@ RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sy
 FROM baseimage AS extract
 ARG TARGETARCH
 ARG WITH_JMX
-ARG PYTHON_VERSION
 ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
 ARG GENERAL_ARTIFACTS_CACHE_BUCKET_URL
 
@@ -75,25 +74,6 @@ RUN find / -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
     opt/datadog-agent/embedded/share/man \
     # self-test certificates that are detected (false positive) as private keys
     opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
- && if [ "$PYTHON_VERSION" = "2" ]; then \
-        rm -rf \
-            opt/datadog-agent/embedded/bin/2to3-3* \
-            opt/datadog-agent/embedded/bin/easy_install-3* \
-            opt/datadog-agent/embedded/bin/idle* \
-            opt/datadog-agent/embedded/bin/pip3* \
-            opt/datadog-agent/embedded/bin/pydoc* \
-            opt/datadog-agent/embedded/bin/python3* \
-            opt/datadog-agent/embedded/bin/pyvenv* \
-            opt/datadog-agent/embedded/include/python3* \
-            opt/datadog-agent/embedded/lib/*python3* || true ;\
-    fi \
- && if [ "$PYTHON_VERSION" = "3" ]; then \
-        rm -rf \
-            opt/datadog-agent/embedded/bin/pip2* \
-            opt/datadog-agent/embedded/bin/python2* \
-            opt/datadog-agent/embedded/include/python2* \
-            opt/datadog-agent/embedded/lib/*python2* || true ;\
-    fi \
  && find opt/datadog-agent/ -iname "*.a" -delete \
  && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi \
  && mkdir conf.d checks.d
@@ -116,11 +96,9 @@ RUN if [ -n "$WITH_JMX" ]; then cd /opt/bouncycastle-fips && mvn dependency:copy
 FROM baseimage AS release
 LABEL maintainer="Datadog <package@datadoghq.com>"
 ARG WITH_JMX
-ARG PYTHON_VERSION
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA
 ENV DOCKER_DD_AGENT=true \
-    DD_PYTHON_VERSION=$PYTHON_VERSION \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
     CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
     # Pass envvar variables to agents
@@ -201,13 +179,6 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
 #   (see PR https://github.com/DataDog/documentation/pull/21889)
 # * https://datadoghq.atlassian.net/wiki/spaces/TS/pages/2615709591/Why+the+containerized+Agent+runs+as+root#Agent-user
 RUN [ "$(getent passwd dd-agent | cut -d: -f 3)" -eq 100 ]
-
-# Update links to python binaries
-RUN if [ -n "$PYTHON_VERSION" ]; then \
-  ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/python \
-  && ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION}-config /opt/datadog-agent/embedded/bin/python-config \
-  && ln -sfn /opt/datadog-agent/embedded/bin/pip${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/pip ; \
-  fi
 
 # Override the exit script by ours to fix --pid=host operations
 RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 
 from invoke import task
-from invoke.exceptions import Exit, ParseError
+from invoke.exceptions import Exit
 
 from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.devcontainer import run_on_devcontainer
@@ -359,15 +359,10 @@ def system_tests(_):
 
 
 @task
-def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False, tag=None, push=False):
+def image_build(ctx, arch='amd64', base_dir="omnibus", skip_tests=False, tag=None, push=False):
     """
     Build the docker image
     """
-    BOTH_VERSIONS = ["both", "2+3"]
-    VALID_VERSIONS = ["2", "3"] + BOTH_VERSIONS
-    if python_version not in VALID_VERSIONS:
-        raise ParseError("provided python_version is invalid")
-
     build_context = "Dockerfiles/agent"
     base_dir = base_dir or os.environ["OMNIBUS_BASE_DIR"]
     pkg_dir = os.path.join(base_dir, 'pkg')
@@ -386,8 +381,6 @@ def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_
         tag = AGENT_TAG
 
     common_build_opts = f"-t {tag} -f {dockerfile_path}"
-    if python_version not in BOTH_VERSIONS:
-        common_build_opts = f"{common_build_opts} --build-arg PYTHON_VERSION={python_version}"
 
     # Build with the testing target
     if not skip_tests:


### PR DESCRIPTION
### What does this PR do?

Clean up references to PYTHON_VERSION when building Agent images.

### Motivation

Cleanup, as it's no longer needed now that we don't have Agent 6 on main.

### Describe how to test/QA your changes

Done with:

- Diffing the files in the container before and after the change (only the `python-config` link was dropped, see below).
- Ran e2e tests via integrations-core's tooling (`ddev env run -a registry.ddbuild.io/ci/datadog-agent/agent:v49956016-d72dbc8d-7-amd64`, etc.) 

### Possible Drawbacks / Trade-offs

### Additional Notes

The only difference in the files included in the image is that we lose the link of `python-config` -> `python3-config`. This should generally not be needed (more so given that a default python install won't attempt to create it).