### PR TITLE
[e2e] add local host provisioner based on podman

### DIFF
--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -4,4 +4,4 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 047dd64128b6
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 7cd5e8a62570

--- a/.gitlab/common/test_infra_version.yml
+++ b/.gitlab/common/test_infra_version.yml
@@ -4,4 +4,4 @@ variables:
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   # Make sure to update test-infra-definitions version in go.mod as well
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 7cd5e8a62570
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 047dd64128b6

--- a/test/new-e2e/examples/agentenv_metrics_test.go
+++ b/test/new-e2e/examples/agentenv_metrics_test.go
@@ -46,6 +46,5 @@ func (v *fakeintakeSuiteMetrics) Test3_FakeIntakeReceivesSystemUptimeHigherThanZ
 		metrics, err := v.Env().FakeIntake.Client().FilterMetrics("system.uptime", client.WithMetricValueHigherThan(0))
 		assert.NoError(c, err)
 		assert.Greater(c, len(metrics), 0, "no 'system.uptime' with value higher than 0 yet")
-		assert.Greater(c, len(metrics), 0, "no 'system.load.1' metrics yet")
 	}, 5*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/examples/vm_localpodman_test.go
+++ b/test/new-e2e/examples/vm_localpodman_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	localhost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/local/host"
+)
+
+type vmLocalPodmanSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestVMLocalPodmanSuite runs tests for the VM interface provisioned on a local podman managed container.
+func TestVMLocalPodmanSuite(t *testing.T) {
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(localhost.PodmanProvisioner())}
+
+	e2e.Run(t, &vmLocalPodmanSuite{}, suiteParams...)
+}
+
+func (v *vmLocalPodmanSuite) TestExecute() {
+	vm := v.Env().RemoteHost
+
+	out, err := vm.Execute("whoami")
+	v.Require().NoError(err)
+	v.Require().NotEmpty(out)
+}
+
+func (v *vmLocalPodmanSuite) TestFakeIntakeReceivesSystemLoadMetric() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		metrics, err := v.Env().FakeIntake.Client().FilterMetrics("system.load.1")
+		assert.NoError(c, err)
+		assert.Greater(c, len(metrics), 0, "no 'system.load.1' metrics yet")
+	}, 5*time.Minute, 10*time.Second)
+}
+
+func (v *vmLocalPodmanSuite) TestFakeIntakeReceivesSystemUptimeHigherThanZero() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		metrics, err := v.Env().FakeIntake.Client().FilterMetrics("system.uptime", client.WithMetricValueHigherThan(0))
+		assert.NoError(c, err)
+		assert.Greater(c, len(metrics), 0, "no 'system.uptime' with value higher than 0 yet")
+	}, 5*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/examples/vm_test.go
+++ b/test/new-e2e/examples/vm_test.go
@@ -6,15 +6,12 @@
 package examples
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
 )
-
-var devMode = flag.Bool("devmode", false, "enable dev mode")
 
 type vmSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -23,9 +20,6 @@ type vmSuite struct {
 // TestVMSuite runs tests for the VM interface to ensure its implementation is correct.
 func TestVMSuite(t *testing.T) {
 	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake())}
-	if *devMode {
-		suiteParams = append(suiteParams, e2e.WithDevMode())
-	}
 
 	e2e.Run(t, &vmSuite{}, suiteParams...)
 }

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -60,7 +60,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570
+	github.com/DataDog/test-infra-definitions v0.0.0-20241127134930-047dd64128b6
 	github.com/aws/aws-sdk-go-v2 v1.32.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.40
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.164.2
@@ -78,7 +78,7 @@ require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.16.1
 	github.com/pulumi/pulumi-eks/sdk/v2 v2.7.8 // indirect
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.17.1
-	github.com/pulumi/pulumi/sdk/v3 v3.137.0
+	github.com/pulumi/pulumi/sdk/v3 v3.140.0
 	github.com/samber/lo v1.47.0
 	github.com/stretchr/testify v1.9.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -303,8 +303,9 @@ require (
 	github.com/pulumi/pulumi-azure-native-sdk/authorization/v2 v2.67.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.56.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.67.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v2 v2.73.1 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.67.0 // indirect
-	github.com/pulumi/pulumi-azure-native-sdk/v2 v2.67.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/v2 v2.73.1 // indirect
 	github.com/pulumi/pulumi-gcp/sdk/v6 v6.67.1 // indirect
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.38.0 // indirect
 	github.com/twinj/uuid v0.0.0-20151029044442-89173bcdda19 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -16,8 +16,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570 h1:vVkrzQIPIhgxZP+GMd+9UhILnZTj1Uf4wZlxhcDGysA=
-github.com/DataDog/test-infra-definitions v0.0.0-20241115164330-7cd5e8a62570/go.mod h1:l0n0FQYdWWQxbI5a2EkuynRQIteUQcYOaOhdxD9TvJs=
+github.com/DataDog/test-infra-definitions v0.0.0-20241127134930-047dd64128b6 h1:7Cy8Iju8X6XdwqXyTrkke1ULq/yEikXVEwAgg4yCGFg=
+github.com/DataDog/test-infra-definitions v0.0.0-20241127134930-047dd64128b6/go.mod h1:YYNx5mySRiinvCoTQIkToR8PcBXpxrRIW/HqmTw9XAY=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
@@ -415,10 +415,12 @@ github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.56.0 h1:MFOd6X9FPlixzriy
 github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.56.0/go.mod h1:453Ff5wNscroYfq+zxME7Nbt7HdZv+dh0zLZwLyGBws=
 github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.67.0 h1:jvruQQSO1ESk7APFQ3mAge7C9SWKU9nbBHrilcyeSGU=
 github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.67.0/go.mod h1:d5nmekK1mrjM9Xo/JGGVlAs7mqqftBo3DmKji+1zbmw=
+github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v2 v2.73.1 h1:rkNZDAik+qlIhbmFoa09ln/oJMXey5+olw8ShmljgXc=
+github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v2 v2.73.1/go.mod h1:P/N/xG2lVxsHdspmKjH+d8d4ln+2arXBmOl3zhjWnnw=
 github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.67.0 h1:r26Xl6FdOJnbLs1ny9ekuRjFxAocZK8jS8SLrgXKEFE=
 github.com/pulumi/pulumi-azure-native-sdk/network/v2 v2.67.0/go.mod h1:8yXZtmHe2Zet5pb8gZ7D730d0VAm4kYUdwCj7sjhz6g=
-github.com/pulumi/pulumi-azure-native-sdk/v2 v2.67.0 h1:FgfXLypiQ/DKWRPQpyNaftXcGl5HVgA93msBZTQ6Ddk=
-github.com/pulumi/pulumi-azure-native-sdk/v2 v2.67.0/go.mod h1:0y4wJUCX1eA3ZSn0jJIRXtHeJA7qgbPfkrR9qvj+5D4=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.73.1 h1:yzXxwwq3tHdtSOi5vjKmKXq7HyKvDaKulF53MFTMbh8=
+github.com/pulumi/pulumi-azure-native-sdk/v2 v2.73.1/go.mod h1:ChjIUNDNeN6jI33ZOivHUFqM6purDiLP01mghMGe1Fs=
 github.com/pulumi/pulumi-command/sdk v1.0.1 h1:ZuBSFT57nxg/fs8yBymUhKLkjJ6qmyN3gNvlY/idiN0=
 github.com/pulumi/pulumi-command/sdk v1.0.1/go.mod h1:C7sfdFbUIoXKoIASfXUbP/U9xnwPfxvz8dBpFodohlA=
 github.com/pulumi/pulumi-docker/sdk/v4 v4.5.5 h1:7OjAfgLz5PAy95ynbgPAlWls5WBe4I/QW/61TdPWRlQ=
@@ -437,8 +439,8 @@ github.com/pulumi/pulumi-random/sdk/v4 v4.16.6 h1:M9BSF13bQxj74C61nBTVITrsgT6oRR
 github.com/pulumi/pulumi-random/sdk/v4 v4.16.6/go.mod h1:l5ew7S/G1GspPLH9KeWXqxQ4ZmS2hh2sEMv3bW9M3yc=
 github.com/pulumi/pulumi-tls/sdk/v4 v4.11.1 h1:tXemWrzeVTqG8zq6hBdv1TdPFXjgZ+dob63a/6GlF1o=
 github.com/pulumi/pulumi-tls/sdk/v4 v4.11.1/go.mod h1:hODo3iEmmXDFOXqPK+V+vwI0a3Ww7BLjs5Tgamp86Ng=
-github.com/pulumi/pulumi/sdk/v3 v3.137.0 h1:bxhYpOY7Z4xt+VmezEpHuhjpOekkaMqOjzxFg/1OhCw=
-github.com/pulumi/pulumi/sdk/v3 v3.137.0/go.mod h1:PvKsX88co8XuwuPdzolMvew5lZV+4JmZfkeSjj7A6dI=
+github.com/pulumi/pulumi/sdk/v3 v3.140.0 h1:+Z/RBvdYg7tBNkBwk4p/FzlV7niBT3TbLAICq/Y0LDU=
+github.com/pulumi/pulumi/sdk/v3 v3.140.0/go.mod h1:PvKsX88co8XuwuPdzolMvew5lZV+4JmZfkeSjj7A6dI=
 github.com/pulumiverse/pulumi-time/sdk v0.1.0 h1:xfi9HKDgV+GgDxQ23oSv9KxC3DQqViGTcMrJICRgJv0=
 github.com/pulumiverse/pulumi-time/sdk v0.1.0/go.mod h1:NUa1zA74DF002WrM6iF111A6UjX9knPpXufVRvBwNyg=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/test/new-e2e/pkg/environments/local/host/podman.go
+++ b/test/new-e2e/pkg/environments/local/host/podman.go
@@ -1,0 +1,182 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package localhost contains the provisioner for the local Host based environments
+package localhost
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/resources/local"
+
+	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
+	localpodman "github.com/DataDog/test-infra-definitions/scenarios/local/podman"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	provisionerBaseID = "local-host-"
+	defaultName       = "podman-host"
+)
+
+// ProvisionerParams contains all the parameters needed to create the environment
+type ProvisionerParams struct {
+	name              string
+	agentOptions      []agentparams.Option
+	fakeintakeOptions []fakeintake.Option
+	extraConfigParams runner.ConfigMap
+}
+
+func newProvisionerParams() *ProvisionerParams {
+	return &ProvisionerParams{
+		name:              defaultName,
+		agentOptions:      []agentparams.Option{},
+		fakeintakeOptions: []fakeintake.Option{},
+		extraConfigParams: runner.ConfigMap{},
+	}
+}
+
+// ProvisionerOption is a function that modifies the ProvisionerParams
+type ProvisionerOption func(*ProvisionerParams) error
+
+// WithName sets the name of the provisioner
+func WithName(name string) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.name = name
+		return nil
+	}
+}
+
+// WithAgentOptions adds options to the agent
+func WithAgentOptions(opts ...agentparams.Option) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.agentOptions = opts
+		return nil
+	}
+}
+
+// WithoutFakeIntake removes the fake intake
+func WithoutFakeIntake() ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.fakeintakeOptions = nil
+		return nil
+	}
+}
+
+// WithoutAgent removes the agent
+func WithoutAgent() ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.agentOptions = nil
+		return nil
+	}
+}
+
+// WithExtraConfigParams adds extra config parameters to the environment
+func WithExtraConfigParams(configMap runner.ConfigMap) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.extraConfigParams = configMap
+		return nil
+	}
+}
+
+// PodmanProvisionerNoAgentNoFakeIntake wraps Provisioner with hardcoded WithoutAgent and WithoutFakeIntake options.
+func PodmanProvisionerNoAgentNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Host] {
+	mergedOpts := make([]ProvisionerOption, 0, len(opts)+2)
+	mergedOpts = append(mergedOpts, opts...)
+	mergedOpts = append(mergedOpts, WithoutAgent(), WithoutFakeIntake())
+
+	return PodmanProvisioner(mergedOpts...)
+}
+
+// PodmanProvisionerNoFakeIntake wraps Provisioner with hardcoded WithoutFakeIntake option.
+func PodmanProvisionerNoFakeIntake(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Host] {
+	mergedOpts := make([]ProvisionerOption, 0, len(opts)+1)
+	mergedOpts = append(mergedOpts, opts...)
+	mergedOpts = append(mergedOpts, WithoutFakeIntake())
+
+	return PodmanProvisioner(mergedOpts...)
+}
+
+// PodmanProvisioner creates a new provisioner
+func PodmanProvisioner(opts ...ProvisionerOption) e2e.TypedProvisioner[environments.Host] {
+	// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
+	// and it's easy to forget about it, leading to hard to debug issues.
+	params := newProvisionerParams()
+	_ = optional.ApplyOptions(params, opts)
+
+	provisioner := e2e.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.Host) error {
+		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
+		// and it's easy to forget about it, leading to hard to debug issues.
+		params := newProvisionerParams()
+		_ = optional.ApplyOptions(params, opts)
+
+		return PodmanRunFunc(ctx, env, params)
+	}, params.extraConfigParams)
+
+	return provisioner
+}
+
+// PodmanRunFunc is the Pulumi run function that runs the provisioner
+func PodmanRunFunc(ctx *pulumi.Context, env *environments.Host, params *ProvisionerParams) error {
+	localEnv, err := local.NewEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+
+	vm, err := localpodman.NewVM(localEnv, params.name)
+	if err != nil {
+		return err
+	}
+
+	err = vm.Export(ctx, &env.RemoteHost.HostOutput)
+	if err != nil {
+		return err
+	}
+
+	if params.fakeintakeOptions != nil {
+		fakeIntake, err := fakeintakeComp.NewLocalDockerFakeintake(&localEnv, "fakeintake")
+		if err != nil {
+			return err
+		}
+		err = fakeIntake.Export(ctx, &env.FakeIntake.FakeintakeOutput)
+		if err != nil {
+			return err
+		}
+
+		if params.agentOptions != nil {
+			newOpts := []agentparams.Option{agentparams.WithFakeintake(fakeIntake)}
+			params.agentOptions = append(newOpts, params.agentOptions...)
+		}
+	} else {
+		env.FakeIntake = nil
+	}
+
+	if params.agentOptions != nil {
+		agentOptions := []agentparams.Option{agentparams.WithHostname("localdocker-vm")}
+		agentOptions = append(agentOptions, params.agentOptions...)
+		agent, err := agent.NewHostAgent(&localEnv, vm, agentOptions...)
+		if err != nil {
+			return err
+		}
+		err = agent.Export(ctx, &env.Agent.HostAgentOutput)
+		if err != nil {
+			return err
+		}
+	} else {
+		env.Agent = nil
+	}
+
+	// explicit set the updater as nil as we do not use it
+	env.Updater = nil
+
+	return nil
+}

--- a/test/new-e2e/pkg/environments/local/kubernetes/kind.go
+++ b/test/new-e2e/pkg/environments/local/kubernetes/kind.go
@@ -131,7 +131,7 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 		return err
 	}
 
-	kindCluster, err := kubeComp.NewLocalKindCluster(&localEnv, localEnv.CommonNamer().ResourceName("kind"), params.name, localEnv.KubernetesVersion())
+	kindCluster, err := kubeComp.NewLocalKindCluster(&localEnv, params.name, localEnv.KubernetesVersion())
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/pkg/environments/local/kubernetes/kind.go
+++ b/test/new-e2e/pkg/environments/local/kubernetes/kind.go
@@ -131,7 +131,7 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 		return err
 	}
 
-	kindCluster, err := kubeComp.NewLocalKindCluster(&localEnv, params.name, localEnv.KubernetesVersion())
+	kindCluster, err := kubeComp.NewLocalKindCluster(&localEnv, localEnv.CommonNamer().ResourceName("kind"), params.name, localEnv.KubernetesVersion())
 	if err != nil {
 		return err
 	}
@@ -150,8 +150,6 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 	}
 
 	if params.fakeintakeOptions != nil {
-		fakeintakeOpts := []fakeintake.Option{fakeintake.WithLoadBalancer()}
-		params.fakeintakeOptions = append(fakeintakeOpts, params.fakeintakeOptions...)
 		fakeIntake, err := fakeintakeComp.NewLocalDockerFakeintake(&localEnv, "fakeintake")
 		if err != nil {
 			return err

--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -13,6 +13,7 @@ import (
 	infraaws "github.com/DataDog/test-infra-definitions/resources/aws"
 	infraazure "github.com/DataDog/test-infra-definitions/resources/azure"
 	infragcp "github.com/DataDog/test-infra-definitions/resources/gcp"
+	infralocal "github.com/DataDog/test-infra-definitions/resources/local"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 
@@ -62,6 +63,9 @@ const (
 	GCPPrivateKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infragcp.DDInfraDefaultPrivateKeyPath
 	// GCPPrivateKeyPassword pulumi config paramater name
 	GCPPrivateKeyPassword = commonconfig.DDInfraConfigNamespace + ":" + infragcp.DDInfraDefaultPrivateKeyPassword
+
+	// LocalPublicKeyPath pulumi config paramater name
+	LocalPublicKeyPath = commonconfig.DDInfraConfigNamespace + ":" + infralocal.DDInfraDefaultPublicKeyPath
 )
 
 // ConfigMap type alias to auto.ConfigMap
@@ -124,7 +128,7 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 	cm.Set(InfraEnvironmentVariables, profile.EnvironmentNames(), false)
 	params := map[parameters.StoreKey][]string{
 		parameters.KeyPairName:        {AWSKeyPairName},
-		parameters.PublicKeyPath:      {AWSPublicKeyPath, AzurePublicKeyPath, GCPPublicKeyPath},
+		parameters.PublicKeyPath:      {AWSPublicKeyPath, AzurePublicKeyPath, GCPPublicKeyPath, LocalPublicKeyPath},
 		parameters.PrivateKeyPath:     {AWSPrivateKeyPath, AzurePrivateKeyPath, GCPPrivateKeyPath},
 		parameters.ExtraResourcesTags: {InfraExtraResourcesTags},
 		parameters.PipelineID:         {AgentPipelineID},

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -46,6 +46,7 @@ func Test_BuildStackParameters(t *testing.T) {
 		"ddinfra:gcp/defaultPublicKeyPath":      auto.ConfigValue{Value: "public_key_path", Secret: false},
 		"ddinfra:gcp/defaultPrivateKeyPath":     auto.ConfigValue{Value: "private_key_path", Secret: false},
 		"ddinfra:gcp/defaultPrivateKeyPassword": auto.ConfigValue{Value: "private_key_password", Secret: true},
+		"ddinfra:local/defaultPublicKeyPath":    auto.ConfigValue{Value: "public_key_path", Secret: false},
 		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 		"ddagent:commit_sha":                    auto.ConfigValue{Value: "commit_sha", Secret: false},
 		"ddagent:majorVersion":                  auto.ConfigValue{Value: "major_version", Secret: false},

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -85,7 +85,7 @@ func NewHost(context e2e.Context, hostOutput remote.HostOutput) (*Host, error) {
 	host := &Host{
 		context:              context,
 		username:             hostOutput.Username,
-		host:                 fmt.Sprintf("%s:%d", hostOutput.Address, 22),
+		host:                 fmt.Sprintf("%s:%d", hostOutput.Address, hostOutput.Port),
 		privateKey:           privateSSHKey,
 		privateKeyPassphrase: []byte(privateKeyPassword),
 		buildCommand:         buildCommandFactory(hostOutput.OSFamily),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add support to run e2e tests targeting host environments using a local container provisioned by podman

### Motivation

This should reduce the dev loop when writing or debugging tests targeting an host environment, allowing to run them locally.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This PR requires installing podman, I will update the setup on test-infra side to install it. In the meantime you can follow [podman installation instructions](https://podman.io/docs/installation)

This provisioner has a bug with `UpdateEnv` I am investigating