### PR TITLE
[backport 7.60.x] Revert usm: Refactor GoTLS monitor with new uprobe attacher (#29309)

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -8,24 +8,36 @@
 package usm
 
 import (
+	"debug/elf"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"sync"
 	"time"
+	"unsafe"
 
+	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -43,20 +55,78 @@ const (
 	connWriteProbe    = "uprobe__crypto_tls_Conn_Write"
 	connWriteRetProbe = "uprobe__crypto_tls_Conn_Write__return"
 	connCloseProbe    = "uprobe__crypto_tls_Conn_Close"
-
-	// GoTLSAttacherName holds the name used for the uprobe attacher of go-tls programs. Used for tests.
-	GoTLSAttacherName = "go-tls"
 )
+
+type uprobesInfo struct {
+	functionInfo string
+	returnInfo   string
+}
+
+var functionToProbes = map[string]uprobesInfo{
+	bininspect.ReadGoTLSFunc: {
+		functionInfo: connReadProbe,
+		returnInfo:   connReadRetProbe,
+	},
+	bininspect.WriteGoTLSFunc: {
+		functionInfo: connWriteProbe,
+		returnInfo:   connWriteRetProbe,
+	},
+	bininspect.CloseGoTLSFunc: {
+		functionInfo: connCloseProbe,
+	},
+}
+
+var functionsConfig = map[string]bininspect.FunctionConfiguration{
+	bininspect.WriteGoTLSFunc: {
+		IncludeReturnLocations: true,
+		ParamLookupFunction:    lookup.GetWriteParams,
+	},
+	bininspect.ReadGoTLSFunc: {
+		IncludeReturnLocations: true,
+		ParamLookupFunction:    lookup.GetReadParams,
+	},
+	bininspect.CloseGoTLSFunc: {
+		IncludeReturnLocations: false,
+		ParamLookupFunction:    lookup.GetCloseParams,
+	},
+}
+
+var structFieldsLookupFunctions = map[bininspect.FieldIdentifier]bininspect.StructLookupFunction{
+	bininspect.StructOffsetTLSConn:     lookup.GetTLSConnInnerConnOffset,
+	bininspect.StructOffsetTCPConn:     lookup.GetTCPConnInnerConnOffset,
+	bininspect.StructOffsetNetConnFd:   lookup.GetConnFDOffset,
+	bininspect.StructOffsetNetFdPfd:    lookup.GetNetFD_PFDOffset,
+	bininspect.StructOffsetPollFdSysfd: lookup.GetFD_SysfdOffset,
+}
 
 type pid = uint32
 
 // goTLSProgram contains implementation for go-TLS.
 type goTLSProgram struct {
-	attacher  *uprobes.UprobeAttacher
-	inspector *goTLSBinaryInspector
-	cfg       *config.Config
-	procMon   *monitor.ProcessMonitor
+	wg      sync.WaitGroup
+	done    chan struct{}
+	cfg     *config.Config
+	manager *manager.Manager
+
+	// Path to the process/container's procfs
+	procRoot string
+
+	// eBPF map holding the result of binary analysis, indexed by binaries'
+	// inodes.
+	offsetsDataMap *ebpf.Map
+
+	// binAnalysisMetric handles telemetry on the time spent doing binary
+	// analysis
+	binAnalysisMetric *libtelemetry.Counter
+
+	// binNoSymbolsMetric counts Golang binaries without symbols.
+	binNoSymbolsMetric *libtelemetry.Counter
+
+	registry *utils.FileRegistry
 }
+
+// Validate that goTLSProgram implements the Attacher interface.
+var _ utils.Attacher = &goTLSProgram{}
 
 var goTLSSpec = &protocols.ProtocolSpec{
 	Maps: []*manager.Map{
@@ -108,56 +178,14 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 			return nil, errors.New("goTLS support requires runtime-compilation or CO-RE to be enabled")
 		}
 
-		attacherCfg := uprobes.AttacherConfig{
-			EbpfConfig: &c.Config,
-			Rules: []*uprobes.AttachRule{{
-				Targets: uprobes.AttachToExecutable,
-				ProbesSelector: []manager.ProbesSelector{
-					&manager.AllOf{
-						Selectors: []manager.ProbesSelector{
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connReadProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connReadRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connWriteProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connWriteRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: connCloseProbe}},
-						},
-					},
-				},
-				ProbeOptionsOverride: map[string]uprobes.ProbeOptions{
-					connReadProbe:     {IsManualReturn: false, Symbol: bininspect.ReadGoTLSFunc},
-					connReadRetProbe:  {IsManualReturn: true, Symbol: bininspect.ReadGoTLSFunc},
-					connWriteProbe:    {IsManualReturn: false, Symbol: bininspect.WriteGoTLSFunc},
-					connWriteRetProbe: {IsManualReturn: true, Symbol: bininspect.WriteGoTLSFunc},
-					connCloseProbe:    {IsManualReturn: false, Symbol: bininspect.CloseGoTLSFunc},
-				},
-			}},
-			ExcludeTargets:                 uprobes.ExcludeInternal,
-			PerformInitialScan:             false,
-			EnablePeriodicScanNewProcesses: false,
-		}
-
-		if c.GoTLSExcludeSelf {
-			attacherCfg.ExcludeTargets |= uprobes.ExcludeSelf
-		}
-
-		inspector := &goTLSBinaryInspector{
-			structFieldsLookupFunctions: structFieldsLookupFunctions,
-			paramLookupFunctions:        paramLookupFunctions,
-			binAnalysisMetric:           libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
-			binNoSymbolsMetric:          libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
-		}
-
-		procMon := monitor.GetProcessMonitor()
-		attacher, err := uprobes.NewUprobeAttacher(GoTLSAttacherName, attacherCfg, m, nil, inspector, procMon)
-		if err != nil {
-			return nil, fmt.Errorf("cannot create uprobe attacher: %w", err)
-		}
-
 		return &goTLSProgram{
-			cfg:       c,
-			inspector: inspector,
-			attacher:  attacher,
-			procMon:   procMon,
+			done:               make(chan struct{}),
+			cfg:                c,
+			manager:            m,
+			procRoot:           c.ProcRoot,
+			binAnalysisMetric:  libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
+			binNoSymbolsMetric: libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
+			registry:           utils.NewFileRegistry("go-tls"),
 		}, nil
 	}
 }
@@ -184,21 +212,48 @@ func (p *goTLSProgram) ConfigureOptions(_ *manager.Manager, options *manager.Opt
 func (p *goTLSProgram) PreStart(m *manager.Manager) error {
 	var err error
 
-	p.inspector.offsetsDataMap, _, err = m.GetMap(offsetsDataMap)
+	p.offsetsDataMap, _, err = m.GetMap(offsetsDataMap)
 	if err != nil {
 		return fmt.Errorf("could not get offsets_data map: %s", err)
 	}
 
-	err = p.attacher.Start()
-	if err != nil {
-		return fmt.Errorf("could not start attacher: %w", err)
-	}
+	procMonitor := monitor.GetProcessMonitor()
+	cleanupExec := procMonitor.SubscribeExec(p.handleProcessStart)
+	cleanupExit := procMonitor.SubscribeExit(p.handleProcessExit)
+
+	p.wg.Add(1)
+	go func() {
+		processSync := time.NewTicker(scanTerminatedProcessesInterval)
+
+		defer func() {
+			processSync.Stop()
+			cleanupExec()
+			cleanupExit()
+			procMonitor.Stop()
+			p.registry.Clear()
+			p.wg.Done()
+		}()
+
+		for {
+			select {
+			case <-p.done:
+				return
+			case <-processSync.C:
+				processSet := p.registry.GetRegisteredProcesses()
+				deletedPids := monitor.FindDeletedProcesses(processSet)
+				for deletedPid := range deletedPids {
+					_ = p.registry.Unregister(deletedPid)
+				}
+			}
+		}
+	}()
 
 	return nil
 }
 
-// PostStart is a no-op
+// PostStart registers the goTLS program to the attacher list.
 func (p *goTLSProgram) PostStart(*manager.Manager) error {
+	utils.AddAttacher(p.Name(), p)
 	return nil
 }
 
@@ -210,11 +265,28 @@ func (p *goTLSProgram) GetStats() *protocols.ProtocolStats {
 	return nil
 }
 
-// Stop terminates the uprobe attacher for GoTLS programs.
+// Stop terminates goTLS main goroutine.
 func (p *goTLSProgram) Stop(*manager.Manager) {
-	p.procMon.Stop()
-	p.attacher.Stop()
+	close(p.done)
+	// Waiting for the main event loop to finish.
+	p.wg.Wait()
 }
+
+var (
+	internalProcessRegex = regexp.MustCompile("datadog-agent/.*/((process|security|trace)-agent|system-probe|agent)")
+)
+
+// DetachPID detaches the provided PID from the eBPF program.
+func (p *goTLSProgram) DetachPID(pid uint32) error {
+	return p.registry.Unregister(pid)
+}
+
+var (
+	// ErrSelfExcluded is returned when the PID is the same as the agent's PID.
+	ErrSelfExcluded = errors.New("self-excluded")
+	// ErrInternalDDogProcessRejected is returned when the PID is an internal datadog process.
+	ErrInternalDDogProcessRejected = errors.New("internal datadog process rejected")
+)
 
 // GoTLSAttachPID attaches Go TLS hooks on the binary of process with
 // provided PID, if Go TLS is enabled.
@@ -223,7 +295,7 @@ func GoTLSAttachPID(pid pid) error {
 		return errors.New("GoTLS is not enabled")
 	}
 
-	err := goTLSSpec.Instance.(*goTLSProgram).attacher.AttachPID(pid)
+	err := goTLSSpec.Instance.(*goTLSProgram).AttachPID(pid)
 	if errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
 		// The process monitor has attached the process before us.
 		return nil
@@ -239,5 +311,183 @@ func GoTLSDetachPID(pid pid) error {
 		return errors.New("GoTLS is not enabled")
 	}
 
-	return goTLSSpec.Instance.(*goTLSProgram).attacher.DetachPID(pid)
+	return goTLSSpec.Instance.(*goTLSProgram).DetachPID(pid)
+}
+
+// AttachPID attaches the provided PID to the eBPF program.
+func (p *goTLSProgram) AttachPID(pid uint32) error {
+	if p.cfg.GoTLSExcludeSelf && pid == uint32(os.Getpid()) {
+		return ErrSelfExcluded
+	}
+
+	pidAsStr := strconv.FormatUint(uint64(pid), 10)
+	exePath := filepath.Join(p.procRoot, pidAsStr, "exe")
+
+	binPath, err := utils.ResolveSymlink(exePath)
+	if err != nil {
+		return err
+	}
+
+	// Check if the process is datadog's internal process, if so, we don't want to hook the process.
+	if internalProcessRegex.MatchString(binPath) {
+		if log.ShouldLog(seelog.DebugLvl) {
+			log.Debugf("ignoring pid %d, as it is an internal datadog component (%q)", pid, binPath)
+		}
+		return ErrInternalDDogProcessRejected
+	}
+
+	// Check go process
+	probeList := make([]manager.ProbeIdentificationPair, 0)
+	return p.registry.Register(binPath, pid, registerCBCreator(p.manager, p.offsetsDataMap, &probeList, p.binAnalysisMetric, p.binNoSymbolsMetric),
+		unregisterCBCreator(p.manager, &probeList, p.offsetsDataMap),
+		utils.IgnoreCB)
+}
+
+func registerCBCreator(mgr *manager.Manager, offsetsDataMap *ebpf.Map, probeIDs *[]manager.ProbeIdentificationPair, binAnalysisMetric, binNoSymbolsMetric *libtelemetry.Counter) func(path utils.FilePath) error {
+	return func(filePath utils.FilePath) error {
+		start := time.Now()
+
+		f, err := os.Open(filePath.HostPath)
+		if err != nil {
+			return fmt.Errorf("could not open file %s, %w", filePath.HostPath, err)
+		}
+		defer f.Close()
+
+		elfFile, err := elf.NewFile(f)
+		if err != nil {
+			return fmt.Errorf("file %s could not be parsed as an ELF file: %w", filePath.HostPath, err)
+		}
+
+		inspectionResult, err := bininspect.InspectNewProcessBinary(elfFile, functionsConfig, structFieldsLookupFunctions)
+		if err != nil {
+			if errors.Is(err, elf.ErrNoSymbols) {
+				binNoSymbolsMetric.Add(1)
+			}
+			return fmt.Errorf("error extracting inspectoin data from %s: %w", filePath.HostPath, err)
+		}
+
+		if err := addInspectionResultToMap(offsetsDataMap, filePath.ID, inspectionResult); err != nil {
+			return fmt.Errorf("failed adding inspection rules: %w", err)
+		}
+
+		pIDs, err := attachHooks(mgr, inspectionResult, filePath.HostPath, filePath.ID)
+		if err != nil {
+			removeInspectionResultFromMap(offsetsDataMap, filePath.ID)
+			return fmt.Errorf("error while attaching hooks to %s: %w", filePath.HostPath, err)
+		}
+		*probeIDs = pIDs
+
+		elapsed := time.Since(start)
+
+		binAnalysisMetric.Add(elapsed.Milliseconds())
+		log.Debugf("attached hooks on %s (%v) in %s", filePath.HostPath, filePath.ID, elapsed)
+		return nil
+	}
+}
+
+func (p *goTLSProgram) handleProcessExit(pid pid) {
+	_ = p.DetachPID(pid)
+}
+
+func (p *goTLSProgram) handleProcessStart(pid pid) {
+	_ = p.AttachPID(pid)
+}
+
+// addInspectionResultToMap runs a binary inspection and adds the result to the
+// map that's being read by the probes, indexed by the binary's inode number `ino`.
+func addInspectionResultToMap(offsetsDataMap *ebpf.Map, binID utils.PathIdentifier, result *bininspect.Result) error {
+	offsetsData, err := inspectionResultToProbeData(result)
+	if err != nil {
+		return fmt.Errorf("error while parsing inspection result: %w", err)
+	}
+
+	key := &gotls.TlsBinaryId{
+		Id_major: unix.Major(binID.Dev),
+		Id_minor: unix.Minor(binID.Dev),
+		Ino:      binID.Inode,
+	}
+	if err := offsetsDataMap.Put(unsafe.Pointer(key), unsafe.Pointer(&offsetsData)); err != nil {
+		return fmt.Errorf("could not write binary inspection result to map for binID %v: %w", binID, err)
+	}
+
+	return nil
+}
+
+func removeInspectionResultFromMap(offsetsDataMap *ebpf.Map, binID utils.PathIdentifier) {
+	key := &gotls.TlsBinaryId{
+		Id_major: unix.Major(binID.Dev),
+		Id_minor: unix.Minor(binID.Dev),
+		Ino:      binID.Inode,
+	}
+	if err := offsetsDataMap.Delete(unsafe.Pointer(key)); err != nil {
+		log.Errorf("could not remove inspection result from map for ino %v: %s", binID, err)
+	}
+}
+
+func attachHooks(mgr *manager.Manager, result *bininspect.Result, binPath string, binID utils.PathIdentifier) ([]manager.ProbeIdentificationPair, error) {
+	uid := getUID(binID)
+	probeIDs := make([]manager.ProbeIdentificationPair, 0)
+
+	for function, uprobes := range functionToProbes {
+		if functionsConfig[function].IncludeReturnLocations {
+			if uprobes.returnInfo == "" {
+				return nil, fmt.Errorf("function %q configured to include return locations but no return uprobes found in config", function)
+			}
+			for i, offset := range result.Functions[function].ReturnLocations {
+				returnProbeID := manager.ProbeIdentificationPair{
+					EBPFFuncName: uprobes.returnInfo,
+					UID:          makeReturnUID(uid, i),
+				}
+				newProbe := &manager.Probe{
+					ProbeIdentificationPair: returnProbeID,
+					BinaryPath:              binPath,
+					// Each return probe needs to have a unique uid value,
+					// so add the index to the binary UID to make an overall UID.
+					UprobeOffset: offset,
+				}
+				if err := mgr.AddHook("", newProbe); err != nil {
+					return nil, fmt.Errorf("could not add return hook to function %q in offset %d due to: %w", function, offset, err)
+				}
+				probeIDs = append(probeIDs, returnProbeID)
+				ddebpf.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, "usm_gotls")
+			}
+		}
+
+		if uprobes.functionInfo != "" {
+			probeID := manager.ProbeIdentificationPair{
+				EBPFFuncName: uprobes.functionInfo,
+				UID:          uid,
+			}
+
+			newProbe := &manager.Probe{
+				BinaryPath:              binPath,
+				UprobeOffset:            result.Functions[function].EntryLocation,
+				ProbeIdentificationPair: probeID,
+			}
+			if err := mgr.AddHook("", newProbe); err != nil {
+				return nil, fmt.Errorf("could not add hook for %q in offset %d due to: %w", uprobes.functionInfo, result.Functions[function].EntryLocation, err)
+			}
+			probeIDs = append(probeIDs, probeID)
+			ddebpf.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, "usm_gotls")
+		}
+	}
+
+	return probeIDs, nil
+}
+
+func unregisterCBCreator(mgr *manager.Manager, probeIDs *[]manager.ProbeIdentificationPair, offsetsDataMap *ebpf.Map) func(path utils.FilePath) error {
+	return func(path utils.FilePath) error {
+		if len(*probeIDs) == 0 {
+			return nil
+		}
+		removeInspectionResultFromMap(offsetsDataMap, path.ID)
+		for _, probeID := range *probeIDs {
+			err := mgr.DetachHook(probeID)
+			if err != nil {
+				log.Errorf("failed detaching hook %s: %s", probeID.UID, err)
+			}
+		}
+		log.Debugf("detached hooks on ino %v", path.ID)
+		return nil
+	}
 }

--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -8,154 +8,14 @@
 package usm
 
 import (
-	"debug/elf"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
-	"time"
 	"unsafe"
 
-	"github.com/cilium/ebpf"
-	"golang.org/x/sys/unix"
-
-	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup"
-	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-var paramLookupFunctions = map[string]bininspect.ParameterLookupFunction{
-	bininspect.WriteGoTLSFunc: lookup.GetWriteParams,
-	bininspect.ReadGoTLSFunc:  lookup.GetReadParams,
-	bininspect.CloseGoTLSFunc: lookup.GetCloseParams,
-}
-
-var structFieldsLookupFunctions = map[bininspect.FieldIdentifier]bininspect.StructLookupFunction{
-	bininspect.StructOffsetTLSConn:     lookup.GetTLSConnInnerConnOffset,
-	bininspect.StructOffsetTCPConn:     lookup.GetTCPConnInnerConnOffset,
-	bininspect.StructOffsetNetConnFd:   lookup.GetConnFDOffset,
-	bininspect.StructOffsetNetFdPfd:    lookup.GetNetFD_PFDOffset,
-	bininspect.StructOffsetPollFdSysfd: lookup.GetFD_SysfdOffset,
-}
-
-// goTLSBinaryInspector is a BinaryInspector that inspects Go binaries, dealing with the specifics of Go binaries
-// such as the argument passing convention and the lack of uprobes
-type goTLSBinaryInspector struct {
-	structFieldsLookupFunctions map[bininspect.FieldIdentifier]bininspect.StructLookupFunction
-	paramLookupFunctions        map[string]bininspect.ParameterLookupFunction
-
-	// eBPF map holding the result of binary analysis, indexed by binaries'
-	// inodes.
-	offsetsDataMap *ebpf.Map
-
-	// binAnalysisMetric handles telemetry on the time spent doing binary
-	// analysis
-	binAnalysisMetric *libtelemetry.Counter
-
-	// binNoSymbolsMetric counts Golang binaries without symbols.
-	binNoSymbolsMetric *libtelemetry.Counter
-}
-
-// Ensure goTLSBinaryInspector implements BinaryInspector
-var _ uprobes.BinaryInspector = &goTLSBinaryInspector{}
-
-// Inspect extracts the metadata required to attach to a Go binary from the ELF file at the given path.
-func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requests []uprobes.SymbolRequest) (map[string]bininspect.FunctionMetadata, error) {
-	start := time.Now()
-
-	path := fpath.HostPath
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("could not open file %s, %w", path, err)
-	}
-	defer f.Close()
-
-	elfFile, err := elf.NewFile(f)
-	if err != nil {
-		return nil, fmt.Errorf("file %s could not be parsed as an ELF file: %w", path, err)
-	}
-
-	functionsConfig := make(map[string]bininspect.FunctionConfiguration, len(requests))
-	for _, req := range requests {
-		lookupFunc, ok := p.paramLookupFunctions[req.Name]
-		if !ok {
-			return nil, fmt.Errorf("no parameter lookup function found for function %s", req.Name)
-		}
-
-		functionsConfig[req.Name] = bininspect.FunctionConfiguration{
-			IncludeReturnLocations: req.IncludeReturnLocations,
-			ParamLookupFunction:    lookupFunc,
-		}
-	}
-
-	inspectionResult, err := bininspect.InspectNewProcessBinary(elfFile, functionsConfig, p.structFieldsLookupFunctions)
-	if err != nil {
-		if errors.Is(err, elf.ErrNoSymbols) {
-			p.binNoSymbolsMetric.Add(1)
-		}
-		return nil, fmt.Errorf("error extracting inspection data from %s: %w", path, err)
-	}
-
-	if err := p.addInspectionResultToMap(fpath.ID, inspectionResult); err != nil {
-		return nil, fmt.Errorf("failed adding inspection rules: %w", err)
-	}
-
-	elapsed := time.Since(start)
-	p.binAnalysisMetric.Add(elapsed.Milliseconds())
-
-	return inspectionResult.Functions, nil
-}
-
-// Cleanup removes the inspection result for the binary at the given path from the map.
-func (p *goTLSBinaryInspector) Cleanup(fpath utils.FilePath) {
-	if p.offsetsDataMap == nil {
-		log.Warn("offsetsDataMap is nil, cannot remove inspection result")
-		return
-	}
-
-	binID := fpath.ID
-	key := &gotls.TlsBinaryId{
-		Id_major: unix.Major(binID.Dev),
-		Id_minor: unix.Minor(binID.Dev),
-		Ino:      binID.Inode,
-	}
-	if err := p.offsetsDataMap.Delete(unsafe.Pointer(key)); err != nil {
-		// Ignore errors for non-existing keys: if the inspect process fails, we won't have added the key to the map
-		// but the deactivation callback (which calls Cleanup and thus this method) will still be called. So it's normal
-		// to not find the key in the map. We report other errors though.
-		if !errors.Is(err, unix.ENOENT) {
-			log.Errorf("could not remove binary inspection result from map for binID %v: %v", binID, err)
-		}
-	}
-}
-
-// addInspectionResultToMap runs a binary inspection and adds the result to the
-// map that's being read by the probes, indexed by the binary's inode number `ino`.
-func (p *goTLSBinaryInspector) addInspectionResultToMap(binID utils.PathIdentifier, result *bininspect.Result) error {
-	if p.offsetsDataMap == nil {
-		return errors.New("offsetsDataMap is nil, cannot write inspection result")
-	}
-
-	offsetsData, err := inspectionResultToProbeData(result)
-	if err != nil {
-		return fmt.Errorf("error while parsing inspection result: %w", err)
-	}
-
-	key := &gotls.TlsBinaryId{
-		Id_major: unix.Major(binID.Dev),
-		Id_minor: unix.Minor(binID.Dev),
-		Ino:      binID.Inode,
-	}
-	if err := p.offsetsDataMap.Put(unsafe.Pointer(key), unsafe.Pointer(&offsetsData)); err != nil {
-		return fmt.Errorf("could not write binary inspection result to map for binID %v: %w", binID, err)
-	}
-
-	return nil
-}
 
 func inspectionResultToProbeData(result *bininspect.Result) (gotls.TlsOffsetsData, error) {
 	closeConnPointer, err := getConnPointer(result, bininspect.CloseGoTLSFunc)
@@ -360,6 +220,10 @@ func getReturnError(result *bininspect.Result, funcName string) (gotls.Location,
 	default:
 		return gotls.Location{}, fmt.Errorf("unknown abi %q", result.ABI)
 	}
+}
+
+func makeReturnUID(uid string, returnNumber int) string {
+	return fmt.Sprintf("%s_%x", uid, returnNumber)
 }
 
 func boolToBinary(value bool) uint8 {

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -543,7 +543,7 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 			})
 			monitor := newKafkaMonitor(t, cfg)
 			if tls && cfg.EnableGoTLSSupport {
-				utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 			tt.testBody(t, &tt.context, monitor)
 		})
@@ -1141,7 +1141,7 @@ func testKafkaFetchRaw(t *testing.T, tls bool, apiVersion int) {
 
 	monitor := newKafkaMonitor(t, getDefaultTestConfiguration(tls))
 	if tls {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyPid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyPid, utils.ManualTracingFallbackEnabled)
 	}
 
 	for _, tt := range tests {
@@ -1366,7 +1366,7 @@ func testKafkaProduceRaw(t *testing.T, tls bool, apiVersion int) {
 
 	monitor := newKafkaMonitor(t, getDefaultTestConfiguration(tls))
 	if tls {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyPid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyPid, utils.ManualTracingFallbackEnabled)
 	}
 
 	for _, tt := range tests {

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -486,27 +486,27 @@ func testHTTP2GoTLSAttachProbes(t *testing.T, cfg *config.Config) {
 			t.Skip("GoTLS not supported for this setup")
 		}
 
-		t.Run("new process", func(tt *testing.T) {
-			testHTTPGoTLSCaptureNewProcess(tt, cfg, true)
+		t.Run("new process", func(t *testing.T) {
+			testHTTPGoTLSCaptureNewProcess(t, cfg, true)
 		})
-		t.Run("already running process", func(tt *testing.T) {
-			testHTTPGoTLSCaptureAlreadyRunning(tt, cfg, true)
+		t.Run("already running process", func(t *testing.T) {
+			testHTTPGoTLSCaptureAlreadyRunning(t, cfg, true)
 		})
 	})
 }
 
 func TestHTTP2GoTLSAttachProbes(t *testing.T) {
 	t.Run("netlink",
-		func(tt *testing.T) {
+		func(t *testing.T) {
 			cfg := config.New()
 			cfg.EnableUSMEventStream = false
-			testHTTP2GoTLSAttachProbes(tt, cfg)
+			testHTTP2GoTLSAttachProbes(t, cfg)
 		})
 	t.Run("event stream",
-		func(tt *testing.T) {
+		func(t *testing.T) {
 			cfg := config.New()
 			cfg.EnableUSMEventStream = true
-			testHTTP2GoTLSAttachProbes(tt, cfg)
+			testHTTP2GoTLSAttachProbes(t, cfg)
 		})
 }
 
@@ -561,7 +561,7 @@ func TestOldConnectionRegression(t *testing.T) {
 		usmMonitor := setupUSMTLSMonitor(t, cfg)
 
 		// Ensure this test program is being traced
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
 
 		// The HTTPServer used here effectively works as an "echo" servers and
 		// returns back in the response whatever it received in the request
@@ -632,7 +632,7 @@ func TestLimitListenerRegression(t *testing.T) {
 		usmMonitor := setupUSMTLSMonitor(t, cfg)
 
 		// Ensure this test program is being traced
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
 
 		// Issue multiple HTTP requests
 		for i := 0; i < 10; i++ {
@@ -692,7 +692,7 @@ func testHTTPGoTLSCaptureNewProcess(t *testing.T, cfg *config.Config, isHTTP2 bo
 
 	// spin-up goTLS client and issue requests after initialization
 	command, runRequests := gotlstestutil.NewGoTLSClient(t, serverAddr, expectedOccurrences, isHTTP2)
-	utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, command.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, "go-tls", command.Process.Pid, utils.ManualTracingFallbackEnabled)
 	runRequests()
 	checkRequests(t, usmMonitor, expectedOccurrences, reqs, isHTTP2)
 }
@@ -729,7 +729,7 @@ func testHTTPGoTLSCaptureAlreadyRunning(t *testing.T, cfg *config.Config, isHTTP
 		reqs[req] = false
 	}
 
-	utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, command.Process.Pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, "go-tls", command.Process.Pid, utils.ManualTracingFallbackEnabled)
 	issueRequestsFn()
 	checkRequests(t, usmMonitor, expectedOccurrences, reqs, isHTTP2)
 }

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -190,7 +190,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 
 	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
 	if isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", os.Getpid(), utils.ManualTracingFallbackEnabled)
 	}
 
 	tests := []postgresParsingTestAttributes{

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2409,11 +2409,11 @@ func testProtocolClassificationLinux(t *testing.T, tr *tracer.Tracer, clientHost
 // Wraps the call to the Go-TLS attach function and waits for the program to be traced.
 func goTLSAttachPID(t *testing.T, pid int) {
 	t.Helper()
-	if utils.IsProgramTraced(usm.GoTLSAttacherName, pid) {
+	if utils.IsProgramTraced("go-tls", pid) {
 		return
 	}
 	require.NoError(t, usm.GoTLSAttachPID(uint32(pid)))
-	utils.WaitForProgramsToBeTraced(t, usm.GoTLSAttacherName, pid, utils.ManualTracingFallbackEnabled)
+	utils.WaitForProgramsToBeTraced(t, "go-tls", pid, utils.ManualTracingFallbackEnabled)
 }
 
 // goTLSDetachPID detaches the Go-TLS monitoring from the given PID.
@@ -2422,13 +2422,13 @@ func goTLSDetachPID(t *testing.T, pid int) {
 	t.Helper()
 
 	// The program is not traced; nothing to do.
-	if !utils.IsProgramTraced(usm.GoTLSAttacherName, pid) {
+	if !utils.IsProgramTraced("go-tls", pid) {
 		return
 	}
 
 	require.NoError(t, usm.GoTLSDetachPID(uint32(pid)))
 
 	require.Eventually(t, func() bool {
-		return !utils.IsProgramTraced(usm.GoTLSAttacherName, pid)
+		return !utils.IsProgramTraced("go-tls", pid)
 	}, 5*time.Second, 100*time.Millisecond, "process %v is still traced by Go-TLS after detaching", pid)
 }

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -121,7 +121,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 
 	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 	// c is a stream endpoint
 	// a + b are unary endpoints
@@ -449,7 +449,7 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 
 	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	// Random string generation is an heavy operation, and it's proportional for the length (15MB)

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -151,7 +151,7 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	clients := getHTTP2UnixClientArray(2, unixPath)
@@ -213,7 +213,7 @@ func (s *usmHTTP2Suite) TestSimpleHTTP2() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	tests := []struct {
@@ -401,7 +401,7 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 		t.Run(tt.name, func(t *testing.T) {
 			monitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			tt.runClients(t, 1)
@@ -456,7 +456,7 @@ func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 
 	monitor := setupUSMTLSMonitor(t, cfg)
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 
 	const (
@@ -522,7 +522,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
 	if s.isTLS {
-		utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+		utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
 	tests := []struct {
 		name              string
@@ -1320,7 +1320,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)
@@ -1406,7 +1406,7 @@ func (s *usmHTTP2Suite) TestRemainderTable() {
 		t.Run(tt.name, func(t *testing.T) {
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)
@@ -1476,7 +1476,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 		t.Run(tt.name, func(t *testing.T) {
 			usmMonitor := setupUSMTLSMonitor(t, cfg)
 			if s.isTLS {
-				utils.WaitForProgramsToBeTraced(t, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
+				utils.WaitForProgramsToBeTraced(t, "go-tls", proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
 
 			c := dialHTTP2Server(t)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?


This PR backports the revert of #29309 to 7.60

### Motivation

Follow up to incident 32654

### Describe how to test/QA your changes

Tested in unit tests, revert also tested on staging.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

As this revert didn't apply cleanly, pasting here the changes with respect to the commit immediately previous to  5e69839

Command:

``` 
git diff 5e69839^..HEAD -- pkg/network/usm/{ebpf_gotls*,kafka_monitor_test,monitor_tls_tests,postgres_monitor_test,usm_grpc_monitor_test,usm_http2_monitor_test,tests/tracer_usm_linux_test}.go
```


```diff 
diff --git a/pkg/network/usm/kafka_monitor_test.go b/pkg/network/usm/kafka_monitor_test.go
index 0330b943eb..47eb33f1c1 100644
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -34,6 +34,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -122,7 +123,11 @@ func TestKafkaProtocolParsing(t *testing.T) {
 	serverHost := "127.0.0.1"
 	require.NoError(t, kafka.RunServer(t, serverHost, kafkaPort))
 
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	if !prebuilt.IsDeprecated() {
+		modes = append(modes, ebpftest.Prebuilt)
+	}
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
 		suite.Run(t, new(KafkaProtocolParsingSuite))
 	})
 }
@@ -1681,7 +1686,11 @@ func newKafkaMonitor(t *testing.T, cfg *config.Config) *Monitor {
 func TestLoadKafkaBinary(t *testing.T) {
 	skipTestIfKernelNotSupported(t)
 
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	if !prebuilt.IsDeprecated() {
+		modes = append(modes, ebpftest.Prebuilt)
+	}
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
 		t.Run("debug", func(t *testing.T) {
 			loadKafkaBinary(t, true)
 		})
diff --git a/pkg/network/usm/postgres_monitor_test.go b/pkg/network/usm/postgres_monitor_test.go
index 94a188ab4d..3df6d1754e 100644
--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -103,7 +104,11 @@ type postgresProtocolParsingSuite struct {
 func TestPostgresMonitoring(t *testing.T) {
 	skipTestIfKernelNotSupported(t)
 
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	if !prebuilt.IsDeprecated() {
+		modes = append(modes, ebpftest.Prebuilt)
+	}
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
 		suite.Run(t, new(postgresProtocolParsingSuite))
 	})
 }
diff --git a/pkg/network/usm/usm_grpc_monitor_test.go b/pkg/network/usm/usm_grpc_monitor_test.go
index 35ae34a9d4..fa67bde4ad 100644
--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -56,7 +57,12 @@ func TestGRPCScenarios(t *testing.T) {
 		t.Skipf("HTTP2 monitoring can not run on kernel before %v", http2.MinimumKernelVersion)
 	}
 
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	if !prebuilt.IsDeprecated() {
+		modes = append(modes, ebpftest.Prebuilt)
+	}
+
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
 		for _, tc := range []struct {
 			name  string
 			isTLS bool
diff --git a/pkg/network/usm/usm_http2_monitor_test.go b/pkg/network/usm/usm_http2_monitor_test.go
index 46c3188b09..90fe72a2a5 100644
--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -35,6 +35,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -93,7 +94,12 @@ func skipIfKernelNotSupported(t *testing.T) {
 
 func TestHTTP2Scenarios(t *testing.T) {
 	skipIfKernelNotSupported(t)
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
+	if !prebuilt.IsDeprecated() {
+		modes = append(modes, ebpftest.Prebuilt)
+	}
+
+	ebpftest.TestBuildModes(t, modes, "", func(t *testing.T) {
 		for _, tc := range []struct {
 			name  string
 			isTLS bool
```

These changes are only in the test files, and they all come from https://github.com/DataDog/datadog-agent/commit/98f3964d72b1015f4d10f0e795bc63e6821a7b91