### PR TITLE
[PROCS-4575] Split the ECS-EC2 process check running into the core agent into a separate suite

### DIFF
--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -87,13 +87,24 @@ func (s *ECSEC2Suite) TestProcessCheck() {
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
 }
 
-func (s *ECSEC2Suite) TestProcessCheckInCoreAgent() {
+// ECSEC2CoreAgentSuite runs the same test as ECSEC2Suite but with the process check running in the core agent
+// This is duplicated as the tests have been flaky. This may be due to how pulumi is handling the provisioning of
+// ecs tasks.
+type ECSEC2CoreAgentSuite struct {
+	ECSEC2Suite
+}
+
+func TestECSEC2CoreAgentSuite(t *testing.T) {
+	t.Parallel()
+	s := ECSEC2CoreAgentSuite{}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
+		e2e.NewTypedPulumiProvisioner("ecsEC2CoreAgentCPUStress", ecsEC2CPUStressProvisioner(true), nil))}
+
+	e2e.Run(t, &s, e2eParams...)
+}
+
+func (s *ECSEC2CoreAgentSuite) TestProcessCheckInCoreAgent() {
 	t := s.T()
-
-	s.UpdateEnv(e2e.NewTypedPulumiProvisioner("ecsEC2CPUStress", ecsEC2CPUStressProvisioner(true), nil))
-
-	// Flush fake intake to remove any payloads which may have
-	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	var payloads []*aggregator.ProcessPayload
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
### What does this PR do?
Moves the ECS-EC2 process checks running into the core agent into its own test suite. 

### Motivation
The test has been flaky. Currently we suspect that the containers may not be properly updated when updating the env between tests in ECS. Agent Devx is working on adding additional test logging to better troubleshoot these issues in the future.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->