### PR TITLE
[Backport 7.60.x] [EBPF] attacher: Fix cleanup of uprobes (#31419)

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -301,9 +301,9 @@ type UprobeAttacher struct {
 	// inspector is used  extract the metadata from the binaries
 	inspector BinaryInspector
 
-	// pathToAttachedProbes maps a filesystem path to the probes attached to it.
+	// fileIDToAttachedProbes maps a filesystem path to the probes attached to it.
 	// Used to detach them once the path is no longer used.
-	pathToAttachedProbes map[string][]manager.ProbeIdentificationPair
+	fileIDToAttachedProbes map[utils.PathIdentifier][]manager.ProbeIdentificationPair
 
 	// onAttachCallback is a callback that is called whenever a probe is attached
 	onAttachCallback AttachCallback
@@ -344,15 +344,15 @@ func NewUprobeAttacher(name string, config AttacherConfig, mgr ProbeManager, onA
 	}
 
 	ua := &UprobeAttacher{
-		name:                 name,
-		config:               config,
-		fileRegistry:         utils.NewFileRegistry(name),
-		manager:              mgr,
-		onAttachCallback:     onAttachCallback,
-		pathToAttachedProbes: make(map[string][]manager.ProbeIdentificationPair),
-		done:                 make(chan struct{}),
-		inspector:            inspector,
-		processMonitor:       processMonitor,
+		name:                   name,
+		config:                 config,
+		fileRegistry:           utils.NewFileRegistry(name),
+		manager:                mgr,
+		onAttachCallback:       onAttachCallback,
+		fileIDToAttachedProbes: make(map[utils.PathIdentifier][]manager.ProbeIdentificationPair),
+		done:                   make(chan struct{}),
+		inspector:              inspector,
+		processMonitor:         processMonitor,
 	}
 
 	utils.AddAttacher(name, ua)
@@ -839,7 +839,7 @@ func (ua *UprobeAttacher) attachProbeSelector(selector manager.ProbesSelector, f
 			}
 
 			ebpf.AddProgramNameMapping(newProbe.ID(), newProbe.EBPFFuncName, ua.name)
-			ua.pathToAttachedProbes[fpath.HostPath] = append(ua.pathToAttachedProbes[fpath.HostPath], newProbeID)
+			ua.fileIDToAttachedProbes[fpath.ID] = append(ua.fileIDToAttachedProbes[fpath.ID], newProbeID)
 
 			if ua.onAttachCallback != nil {
 				ua.onAttachCallback(newProbe, &fpath)
@@ -889,13 +889,14 @@ func (ua *UprobeAttacher) computeSymbolsToRequest(rules []*AttachRule) ([]Symbol
 }
 
 func (ua *UprobeAttacher) detachFromBinary(fpath utils.FilePath) error {
-	for _, probeID := range ua.pathToAttachedProbes[fpath.HostPath] {
+	for _, probeID := range ua.fileIDToAttachedProbes[fpath.ID] {
 		err := ua.manager.DetachHook(probeID)
 		if err != nil {
 			return fmt.Errorf("error detaching probe %+v: %w", probeID, err)
 		}
 	}
 
+	delete(ua.fileIDToAttachedProbes, fpath.ID)
 	ua.inspector.Cleanup(fpath)
 
 	return nil

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -473,8 +474,13 @@ func TestAttachToBinaryAndDetach(t *testing.T) {
 	require.NoError(t, err)
 	mockMan.AssertExpectations(t)
 
+	// FileRegistry calls the detach callback without host path. Replicate that here.
+	detachPath := utils.FilePath{
+		ID: target.ID,
+	}
+
 	mockMan.On("DetachHook", expectedProbe.ProbeIdentificationPair).Return(nil)
-	err = ua.detachFromBinary(target)
+	err = ua.detachFromBinary(detachPath)
 	require.NoError(t, err)
 	inspector.AssertExpectations(t)
 	mockMan.AssertExpectations(t)
@@ -735,6 +741,18 @@ func TestUprobeAttacher(t *testing.T) {
 
 	require.NotNil(t, mainProbe)
 	require.Equal(t, uint32(cmd.Process.Pid), mainProbe.fpath.PID)
+
+	require.True(t, connectProbe.probe.IsRunning())
+	require.True(t, mainProbe.probe.IsRunning())
+
+	// Kill the process to trigger the detach
+	cmd.Process.Kill()
+
+	// Ensure probes are correctly detached
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.False(c, connectProbe.probe.IsRunning())
+		assert.False(c, mainProbe.probe.IsRunning())
+	}, 1*time.Second, 10*time.Millisecond)
 }
 
 func launchProcessMonitor(t *testing.T, useEventStream bool) *monitor.ProcessMonitor {


### PR DESCRIPTION
(cherry picked from commit c45797dc794766d4bbddf89181cc6cd3322e751d)

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Backports #31419 to 7.60.x

### Motivation

Avoid issues with uprobe cleanup on other users of the uprobe attacher. Related to incident 32654.

### Describe how to test/QA your changes

Tested in staging to validate that the issue was resolved, and added extra unit tests to ensure correct behavior.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->