### PR TITLE
[CWS] Fix ptrace issues and add tests

### DIFF
--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -324,6 +324,7 @@ struct ptrace_event_t {
     u32 request;
     u32 pid;
     u64 addr;
+    u32 ns_pid;
 };
 
 struct syscall_monitor_event_t {

--- a/pkg/security/ebpf/c/include/hooks/ptrace.h
+++ b/pkg/security/ebpf/c/include/hooks/ptrace.h
@@ -11,6 +11,7 @@ HOOK_SYSCALL_ENTRY3(ptrace, u32, request, pid_t, pid, void *, addr) {
         .ptrace = {
             .request = request,
             .pid = 0, // 0 in case the root ns pid resolution failed
+            .ns_pid = (u32)pid,
             .addr = (u64)addr,
         }
     };
@@ -59,6 +60,7 @@ int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
         .request = syscall->ptrace.request,
         .pid = syscall->ptrace.pid,
         .addr = syscall->ptrace.addr,
+        .ns_pid = syscall->ptrace.ns_pid,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -156,6 +156,7 @@ struct syscall_cache_t {
             u32 request;
             u32 pid;
             u64 addr;
+            u32 ns_pid;
         } ptrace;
 
         struct {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1073,14 +1073,42 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode ptrace event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
+
 		// resolve tracee process context
 		var pce *model.ProcessCacheEntry
-		if event.PTrace.PID == 0 { // pid can be 0 for a PTRACE_TRACEME request
+		if event.PTrace.Request == unix.PTRACE_TRACEME { // pid can be 0 for a PTRACE_TRACEME request
 			pce = newPlaceholderProcessCacheEntryPTraceMe()
+		} else if event.PTrace.PID == 0 && event.PTrace.NSPID == 0 {
+			seclog.Errorf("ptrace event without any PID to resolve")
+			return
 		} else {
-			pce = p.Resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID, 0, false, newEntryCb)
+			pidToResolve := event.PTrace.PID
+
+			if pidToResolve == 0 { // resolve the PID given as argument instead
+				if event.ContainerContext.ContainerID == "" {
+					pidToResolve = event.PTrace.NSPID
+				} else {
+					// 1. get the pid namespace of the tracer
+					ns, err := utils.GetProcessPidNamespace(event.ProcessContext.Process.Pid)
+					if err != nil {
+						seclog.Errorf("Failed to resolve PID namespace: %v", err)
+						return
+					}
+
+					// 2. find the host pid matching the arg pid with he tracer namespace
+					pid, err := utils.FindPidNamespace(event.PTrace.NSPID, ns)
+					if err != nil {
+						seclog.Warnf("Failed to resolve tracee PID namespace: %v", err)
+						return
+					}
+
+					pidToResolve = pid
+				}
+			}
+
+			pce = p.Resolvers.ProcessResolver.Resolve(pidToResolve, pidToResolve, 0, false, newEntryCb)
 			if pce == nil {
-				pce = model.NewPlaceholderProcessCacheEntry(event.PTrace.PID, event.PTrace.PID, false)
+				pce = model.NewPlaceholderProcessCacheEntry(pidToResolve, pidToResolve, false)
 			}
 		}
 		event.PTrace.Tracee = &pce.ProcessContext

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -538,6 +538,7 @@ type PTraceEvent struct {
 
 	Request uint32          `field:"request"` // SECLDoc[request] Definition:`ptrace request` Constants:`Ptrace constants`
 	PID     uint32          `field:"-"`
+	NSPID   uint32          `field:"-"`
 	Address uint64          `field:"-"`
 	Tracee  *ProcessContext `field:"tracee"` // process context of the tracee
 }

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -833,14 +833,15 @@ func (e *PTraceEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, err
 	}
 
-	if len(data)-read < 16 {
+	if len(data)-read < 20 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.Request = binary.NativeEndian.Uint32(data[read : read+4])
 	e.PID = binary.NativeEndian.Uint32(data[read+4 : read+8])
 	e.Address = binary.NativeEndian.Uint64(data[read+8 : read+16])
-	return read + 16, nil
+	e.NSPID = binary.NativeEndian.Uint32(data[read+16 : read+20])
+	return read + 20, nil
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -895,10 +895,24 @@ func newMProtectEventSerializer(e *model.Event) *MProtectEventSerializer {
 }
 
 func newPTraceEventSerializer(e *model.Event) *PTraceEventSerializer {
+	if e.PTrace.Tracee == nil {
+		return nil
+	}
+
+	fakeTraceeEvent := &model.Event{
+		BaseEvent: model.BaseEvent{
+			FieldHandlers:  e.FieldHandlers,
+			ProcessContext: e.PTrace.Tracee,
+			ContainerContext: &model.ContainerContext{
+				ContainerID: e.PTrace.Tracee.ContainerID,
+			},
+		},
+	}
+
 	return &PTraceEventSerializer{
 		Request: model.PTraceRequest(e.PTrace.Request).String(),
 		Address: fmt.Sprintf("0x%x", e.PTrace.Address),
-		Tracee:  newProcessContextSerializer(e.PTrace.Tracee, e),
+		Tracee:  newProcessContextSerializer(e.PTrace.Tracee, fakeTraceeEvent),
 	}
 }
 

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -24,8 +25,16 @@ func TestPTraceEvent(t *testing.T) {
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:         "test_ptrace",
+			ID:         "test_ptrace_cont",
 			Expression: `ptrace.request == PTRACE_CONT && ptrace.tracee.file.name == "syscall_tester"`,
+		},
+		{
+			ID:         "test_ptrace_me",
+			Expression: `ptrace.request == PTRACE_TRACEME && process.file.name == "syscall_tester"`,
+		},
+		{
+			ID:         "test_ptrace_attach",
+			Expression: `ptrace.request == PTRACE_ATTACH && ptrace.tracee.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -40,18 +49,18 @@ func TestPTraceEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.Run(t, "ptrace", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	test.Run(t, "ptrace-cont", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		args := []string{"ptrace-traceme"}
 		envs := []string{}
 
-		test.WaitSignal(t, func() error {
+		err := test.GetEventSent(t, func() error {
 			cmd := cmdFunc(syscallTester, args, envs)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 
 			return nil
-		}, func(event *model.Event, _ *rules.Rule) {
+		}, func(_ *rules.Rule, event *model.Event) bool {
 			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
 
@@ -59,6 +68,63 @@ func TestPTraceEvent(t *testing.T) {
 			assert.Equal(t, value.(bool), false)
 
 			test.validatePTraceSchema(t, event)
-		})
+			return true
+		}, time.Second*3, "test_ptrace_cont")
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	test.Run(t, "ptrace-me", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		args := []string{"ptrace-traceme"}
+		envs := []string{}
+
+		err := test.GetEventSent(t, func() error {
+			cmd := cmdFunc(syscallTester, args, envs)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("%s: %w", out, err)
+			}
+
+			return nil
+		}, func(_ *rules.Rule, event *model.Event) bool {
+			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
+			assert.Equal(t, uint64(0), event.PTrace.Address, "wrong address")
+
+			value, _ := event.GetFieldValue("event.async")
+			assert.Equal(t, value.(bool), false)
+
+			test.validatePTraceSchema(t, event)
+			return true
+		}, time.Second*3, "test_ptrace_me")
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	test.Run(t, "ptrace-attach", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		args := []string{"ptrace-attach"}
+		envs := []string{}
+
+		err := test.GetEventSent(t, func() error {
+			cmd := cmdFunc(syscallTester, args, envs)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("%s: %w", out, err)
+			}
+
+			return nil
+		}, func(_ *rules.Rule, event *model.Event) bool {
+			assert.Equal(t, "ptrace", event.GetType(), "wrong event type")
+			assert.Equal(t, uint64(0), event.PTrace.Address, "wrong address")
+			assert.Equal(t, event.PTrace.Tracee.PPid, event.PTrace.Tracee.Parent.Pid, "tracee wrong ppid / parent pid")
+
+			value, _ := event.GetFieldValue("event.async")
+			assert.Equal(t, value.(bool), false)
+
+			test.validatePTraceSchema(t, event)
+			return true
+		}, time.Second*3, "test_ptrace_attach")
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -185,6 +185,19 @@ int ptrace_traceme() {
     return EXIT_SUCCESS;
 }
 
+int ptrace_attach() {
+    int child = fork();
+    if (child == 0) {
+        for (int i = 0; i < 20; i++) {
+            sleep(1);
+        }
+    } else {
+        ptrace(PTRACE_ATTACH, child, 0, NULL);
+        wait(NULL);
+    }
+    return EXIT_SUCCESS;
+}
+
 int test_signal_sigusr(int child, int sig) {
     int do_fork = child == 0;
     if (do_fork) {
@@ -885,6 +898,8 @@ int main(int argc, char **argv) {
             exit_code = span_exec(sub_argc, sub_argv);
         } else if (strcmp(cmd, "ptrace-traceme") == 0) {
             exit_code = ptrace_traceme();
+        } else if (strcmp(cmd, "ptrace-attach") == 0) {
+            exit_code = ptrace_attach();
         } else if (strcmp(cmd, "span-open") == 0) {
             exit_code = span_open(sub_argc, sub_argv);
         } else if (strcmp(cmd, "pipe-chown") == 0) {


### PR DESCRIPTION
### What does this PR do?

Our ptrace support had 2 issues:

1. the kernel hook to resolve the tracee host PID is not always reached (for at least PTRACE_ATTACH/PTRACE_SEIZE). This resulted in a empty tracee context.

This PR fix it by returning the pid arg in case the callpath doesn't resolve it. We now fallback to proc to resolve the tracee host pid.

2. the tracee process context was resolved regarding the tracer, not the tracee. So, all the resolved metadata (as well as its process lineage) were wrong.

We now resolve it properly.

The PR also add two more tests.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->