### PR TITLE
Making sure that JMX images are available for e2e tests to run

### DIFF
--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -17,6 +17,23 @@ qa_agent:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
+qa_agent_jmx:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_agent7_jmx
+    - docker_build_agent7_jmx_arm64
+    - docker_build_agent7_windows1809_jmx
+    - docker_build_agent7_windows2022_jmx
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-winltsc2022-amd64
+    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-jmx
+
 qa_agent_ot:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -79,6 +79,7 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_agent
+    - qa_agent_jmx
     - qa_dca
     - qa_dogstatsd
 


### PR DESCRIPTION
### What does this PR do?

Updates the gitlab pipelines to make sure the JMX Docker image is published for QA.

### Motivation

These images are needed for running e2e tests that check JMX working correctly.

### Describe how to test/QA your changes

Check pipelines worked as expected.
