### PR TITLE
BARX-632 - Change the agent image name in internal k8s rc deployment to otel flavour

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -23,7 +23,7 @@ rc_kubernetes_deploy:
     OPTION_AUTOMATIC_ROLLOUT: "true"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
-    AGENT_IMAGE_TAG: "${CI_COMMIT_REF_NAME}-otel-beta"
+    AGENT_IMAGE_TAG: "${CI_COMMIT_REF_NAME}-ot-beta"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -23,7 +23,7 @@ rc_kubernetes_deploy:
     OPTION_AUTOMATIC_ROLLOUT: "true"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
-    AGENT_IMAGE_TAG: $CI_COMMIT_REF_NAME
+    AGENT_IMAGE_TAG: "${CI_COMMIT_REF_NAME}-otel-beta"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - "inv pipeline.trigger-child-pipeline --project-name DataDog/k8s-datadog-agent-ops --git-ref main


### PR DESCRIPTION
### What does this PR do?

This PR changes the image tag used for the internal RC k8s deployments job, which is part of the Agent Release Candidate build pipeline, to `otel` flavour.

After the change the values set in the k8s-datadog-agent-ops PR will change from `tag:  7-60-1-rc-1-jmx` to `tag: 7-61-0-rc-1-ot-beta-jmx`

### Motivation

We want otel RC images to be the default ones for RC deployments to staging, so they can be tested continuously during the Agent QA period.

### Describe how to test/QA your changes

To be tested properly during 7.61.0 RC deployments. I did the manual check to see if the right image tag is set.