### PR TITLE
[e2e] Update datadog-cilium integration versions used in Agent install E2E tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_integration.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_integration.go
@@ -23,48 +23,48 @@ func CheckIntegrationInstall(t *testing.T, client *TestClient) {
 	freezeContent, err := client.FileManager.ReadFile(requirementIntegrationPath)
 	require.NoError(t, err)
 
-	freezeContent = ciliumRegex.ReplaceAll(freezeContent, []byte("datadog-cilium==2.2.1"))
+	freezeContent = ciliumRegex.ReplaceAll(freezeContent, []byte("datadog-cilium==4.0.0"))
 	_, err = client.FileManager.WriteFile(requirementIntegrationPath, freezeContent)
 	require.NoError(t, err)
 
 	t.Run("install-uninstall package", func(tt *testing.T) {
-		installIntegration(tt, client, "datadog-cilium==2.2.1")
+		installIntegration(tt, client, "datadog-cilium==4.0.0")
 
 		freezeRequirement := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.Contains(tt, freezeRequirement, "datadog-cilium==2.2.1", "before removal integration should be in freeze")
+		require.Contains(tt, freezeRequirement, "datadog-cilium==4.0.0", "before removal integration should be in freeze")
 
 		client.AgentClient.Integration(agentclient.WithArgs([]string{"remove", "-r", "datadog-cilium"}))
 
 		freezeRequirementNew := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.NotContains(tt, freezeRequirementNew, "datadog-cilium==2.2.1", "after removal integration should not be in freeze")
+		require.NotContains(tt, freezeRequirementNew, "datadog-cilium==4.0.0", "after removal integration should not be in freeze")
 	})
 
 	t.Run("upgrade a package", func(tt *testing.T) {
-		installIntegration(tt, client, "datadog-cilium==2.2.1")
+		installIntegration(tt, client, "datadog-cilium==4.0.0")
 
 		freezeRequirement := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.NotContains(tt, freezeRequirement, "datadog-cilium==2.3.0", "before update integration should not be in 2.3.0")
+		require.NotContains(tt, freezeRequirement, "datadog-cilium==5.0.0", "before update integration should not be in 5.0.0")
 
-		installIntegration(tt, client, "datadog-cilium==2.3.0")
+		installIntegration(tt, client, "datadog-cilium==5.0.0")
 
 		freezeRequirementNew := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.Contains(tt, freezeRequirementNew, "datadog-cilium==2.3.0", "after update integration should be in 2.3.0")
+		require.Contains(tt, freezeRequirementNew, "datadog-cilium==5.0.0", "after update integration should be in 5.0.0")
 	})
 
 	t.Run("downgrade a package", func(tt *testing.T) {
-		installIntegration(tt, client, "datadog-cilium==2.3.0")
+		installIntegration(tt, client, "datadog-cilium==5.0.0")
 
 		freezeRequirement := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.NotContains(tt, freezeRequirement, "datadog-cilium==2.2.1", "before downgrade integration should not be in 2.2.1")
+		require.NotContains(tt, freezeRequirement, "datadog-cilium==4.0.0", "before downgrade integration should not be in 4.0.0")
 
-		installIntegration(tt, client, "datadog-cilium==2.2.1")
+		installIntegration(tt, client, "datadog-cilium==4.0.0")
 
 		freezeRequirementNew := client.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
-		require.Contains(tt, freezeRequirementNew, "datadog-cilium==2.2.1", "after downgrade integration should be in 2.2.1")
+		require.Contains(tt, freezeRequirementNew, "datadog-cilium==4.0.0", "after downgrade integration should be in 4.0.0")
 	})
 
 	t.Run("downgrade to older version than shipped", func(tt *testing.T) {
-		_, err := client.AgentClient.IntegrationWithError(agentclient.WithArgs([]string{"install", "-r", "datadog-cilium==2.2.0"}))
+		_, err := client.AgentClient.IntegrationWithError(agentclient.WithArgs([]string{"install", "-r", "datadog-cilium==3.6.0"}))
 		require.Error(tt, err, "should raise error when trying to install version older than the one shipped")
 	})
 }


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates the version

### Motivation

The tests broke today when using very old versions of the integration.

### Describe how to test/QA your changes

Check the `new-e2e-agent-platform-install-script` test jobs, they should succeed.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a