### PR TITLE
Refreshing trace secrets from the CLI

### DIFF
--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -8,6 +8,7 @@ package secret
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -68,12 +69,45 @@ func showSecretInfo(config config.Component, _ log.Component) error {
 }
 
 func secretRefresh(config config.Component, _ log.Component) error {
+	fmt.Println("Agent refresh:")
 	res, err := callIPCEndpoint(config, "agent/secret/refresh")
 	if err != nil {
 		return err
 	}
 	fmt.Println(string(res))
+
+	if config.GetBool("apm_config.enabled") {
+		fmt.Println("APM agent refresh:")
+		res, err = traceAgentSecretRefresh(config)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(res))
+	}
 	return nil
+}
+
+func traceAgentSecretRefresh(conf config.Component) ([]byte, error) {
+	err := apiutil.SetAuthToken(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	port := conf.GetInt("apm_config.debug.port")
+	if port <= 0 {
+		return nil, fmt.Errorf("invalid apm_config.debug.port -- %d", port)
+	}
+
+	c := apiutil.GetClient(false)
+	c.Timeout = conf.GetDuration("server_timeout") * time.Second
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/secret/refresh", port)
+	res, err := apiutil.DoGet(c, url, apiutil.CloseConnection)
+	if err != nil {
+		return nil, fmt.Errorf("could not contact trace-agent: %s", err)
+	}
+
+	return res, nil
 }
 
 func callIPCEndpoint(config config.Component, endpointURL string) ([]byte, error) {

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logtracefx "github.com/DataDog/datadog-agent/comp/core/log/fx-trace"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -137,6 +138,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 			return acfg, nil
 		}),
 		fxutil.ProvideOptional[coreconfig.Component](),
+		fxutil.ProvideNoneOptional[secrets.Component](),
 		workloadmetafx.Module(workloadmeta.Params{
 			AgentType:  workloadmeta.NodeAgent,
 			InitHelper: common.GetWorkloadmetaInit(),

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	traceagent "github.com/DataDog/datadog-agent/comp/trace/agent/def"
@@ -38,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
@@ -59,6 +61,7 @@ type dependencies struct {
 	Shutdowner fx.Shutdowner
 
 	Config             config.Component
+	Secrets            optional.Option[secrets.Component]
 	Context            context.Context
 	Params             *Params
 	TelemetryCollector telemetry.TelemetryCollector
@@ -86,6 +89,7 @@ type component struct {
 
 	cancel             context.CancelFunc
 	config             config.Component
+	secrets            optional.Option[secrets.Component]
 	params             *Params
 	tagger             tagger.Component
 	telemetryCollector telemetry.TelemetryCollector
@@ -107,6 +111,7 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 	c = component{
 		cancel:             cancel,
 		config:             deps.Config,
+		secrets:            deps.Secrets,
 		params:             deps.Params,
 		telemetryCollector: deps.TelemetryCollector,
 		tagger:             deps.Tagger,

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -6,6 +6,7 @@
 package agentimpl
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -69,6 +70,26 @@ func runAgentSidekicks(ag component) error {
 		log.Errorf("could not set auth token: %s", err)
 	} else {
 		ag.Agent.DebugServer.AddRoute("/config", ag.config.GetConfigHandler())
+	}
+	if secrets, ok := ag.secrets.Get(); ok {
+		// Adding a route to trigger a secrets refresh from the CLI.
+		// TODO - components: the secrets comp already export a route but it requires the API component which is not
+		// used by the trace agent. This should be removed once the trace-agent is fully componentize.
+		ag.Agent.DebugServer.AddRoute("/secret/refresh", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if apiutil.Validate(w, req) != nil {
+				return
+			}
+
+			res, err := secrets.Refresh()
+			if err != nil {
+				log.Errorf("error while refresing secrets: %s", err)
+				w.Header().Set("Content-Type", "application/json")
+				body, _ := json.Marshal(map[string]string{"error": err.Error()})
+				http.Error(w, string(body), http.StatusInternalServerError)
+				return
+			}
+			w.Write([]byte(res))
+		}))
 	}
 
 	api.AttachEndpoint(api.Endpoint{

--- a/comp/trace/bundle_test.go
+++ b/comp/trace/bundle_test.go
@@ -17,6 +17,7 @@ import (
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
@@ -62,6 +63,7 @@ func TestMockBundleDependencies(t *testing.T) {
 		fx.Provide(func() context.Context { return context.TODO() }), // fx.Supply(ctx) fails with a missing type error.
 		fx.Supply(core.BundleParams{}),
 		coreconfig.MockModule(),
+		fxutil.ProvideNoneOptional[secrets.Component](),
 		telemetryimpl.MockModule(),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		workloadmetafx.Module(workloadmeta.NewParams()),

--- a/pkg/util/fxutil/provide_optional.go
+++ b/pkg/util/fxutil/provide_optional.go
@@ -16,3 +16,10 @@ func ProvideOptional[T any]() fx.Option {
 		return optional.NewOption[T](actualType)
 	})
 }
+
+// ProvideNoneOptional provide a none optional for the type
+func ProvideNoneOptional[T any]() fx.Option {
+	return fx.Provide(func() optional.Option[T] {
+		return optional.NewNoneOption[T]()
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Refreshing trace secrets from the CLI.

### Describe how to test/QA your changes

Manuall QA of the entire refresh mechanism is being done (host linux/windows, k8s and eks). This will lead to the API key refresh behavior to be a public preview.