### PR TITLE
[usm] Create entry in `connection_protocol` only if needed

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -124,16 +124,7 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         bpf_map_delete_elem(&connection_states, &skb_tup);
     }
 
-    protocol_stack_t *stack = get_or_create_protocol_stack(&skb_tup);
-    if (!stack) {
-        // should never happen, but it is required by the eBPF verifier
-        return;
-    }
-
-    // This is used to signal the tracer program that this protocol stack
-    // is also shared with our USM program for the purposes of deletion.
-    // For more context refer to the comments in `delete_protocol_stack`
-    stack->flags |= FLAG_USM_ENABLED;
+    protocol_stack_t *stack = get_protocol_stack_if_exists(&skb_tup);
 
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     if (tcp_termination) {
@@ -157,6 +148,16 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         log_debug("[protocol_dispatcher_entrypoint]: %p Classifying protocol as: %d", skb, cur_fragment_protocol);
         // If there has been a change in the classification, save the new protocol.
         if (cur_fragment_protocol != PROTOCOL_UNKNOWN) {
+            stack = get_or_create_protocol_stack(&skb_tup);
+            if (!stack) {
+                // should never happen, but it is required by the eBPF verifier
+                return;
+            }
+
+            // This is used to signal the tracer program that this protocol stack
+            // is also shared with our USM program for the purposes of deletion.
+            // For more context refer to the comments in `delete_protocol_stack`
+            set_protocol_flag(stack, FLAG_USM_ENABLED);
             set_protocol(stack, cur_fragment_protocol);
         }
     }

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -124,7 +124,7 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         bpf_map_delete_elem(&connection_states, &skb_tup);
     }
 
-    protocol_stack_t *stack = get_protocol_stack(&skb_tup);
+    protocol_stack_t *stack = get_or_create_protocol_stack(&skb_tup);
     if (!stack) {
         // should never happen, but it is required by the eBPF verifier
         return;

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -147,7 +147,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
         return;
     }
 
-    protocol_stack_t *protocol_stack = get_protocol_stack(&usm_ctx->tuple);
+    protocol_stack_t *protocol_stack = get_or_create_protocol_stack(&usm_ctx->tuple);
     if (!protocol_stack) {
         return;
     }
@@ -206,7 +206,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_queues
         goto next_program;
     }
 
-    protocol_stack_t *protocol_stack = get_protocol_stack(&usm_ctx->tuple);
+    protocol_stack_t *protocol_stack = get_or_create_protocol_stack(&usm_ctx->tuple);
     if (!protocol_stack) {
         return;
     }
@@ -229,7 +229,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_dbs(st
         goto next_program;
     }
 
-    protocol_stack_t *protocol_stack = get_protocol_stack(&usm_ctx->tuple);
+    protocol_stack_t *protocol_stack = get_or_create_protocol_stack(&usm_ctx->tuple);
     if (!protocol_stack) {
         return;
     }
@@ -246,7 +246,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_grpc(s
         return;
     }
 
-    protocol_stack_t *protocol_stack = get_protocol_stack(&usm_ctx->tuple);
+    protocol_stack_t *protocol_stack = get_or_create_protocol_stack(&usm_ctx->tuple);
     if (!protocol_stack) {
         return;
     }

--- a/pkg/network/ebpf/c/protocols/classification/routing.h
+++ b/pkg/network/ebpf/c/protocols/classification/routing.h
@@ -55,6 +55,11 @@ static __always_inline void init_routing_cache(usm_context_t *usm_ctx, protocol_
     usm_ctx->routing_skip_layers = 0;
     usm_ctx->routing_current_program = CLASSIFICATION_PROG_UNKNOWN;
 
+    // No protocol stack, nothing to mark for skipping
+    if (!stack) {
+        return;
+    }
+
     // We skip a given layer in two cases:
     // 1) If the protocol for that layer is known
     // 2) If there are no programs registered for that layer

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -44,7 +44,6 @@ static __always_inline protocol_stack_t* get_or_create_protocol_stack(conn_tuple
 
     // this code path is executed once during the entire connection lifecycle
     protocol_stack_wrapper_t empty_wrapper = {0};
-    empty_wrapper.updated = bpf_ktime_get_ns();
 
     // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
     // and do not provide any useful signal since the key is expected to be present sometimes.

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -23,6 +23,14 @@ static __always_inline protocol_stack_t* __get_protocol_stack_if_exists(conn_tup
     return &wrapper->stack;
 }
 
+// Returns the protocol_stack_t associated with the given connection tuple.
+// If the tuple is not found, returns NULL.
+static __always_inline protocol_stack_t* get_protocol_stack_if_exists(conn_tuple_t* tuple) {
+    conn_tuple_t normalized_tup = *tuple;
+    normalize_tuple(&normalized_tup);
+    return __get_protocol_stack_if_exists(&normalized_tup);
+}
+
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;
     normalize_tuple(&normalized_tup);

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -31,7 +31,9 @@ static __always_inline protocol_stack_t* get_protocol_stack_if_exists(conn_tuple
     return __get_protocol_stack_if_exists(&normalized_tup);
 }
 
-static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
+// Returns the protocol_stack_t associated with the given connection tuple.
+// If the tuple is not found, creates a new entry and returns it.
+static __always_inline protocol_stack_t* get_or_create_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;
     normalize_tuple(&normalized_tup);
     protocol_stack_wrapper_t* wrapper = bpf_map_lookup_elem(&connection_protocol, &normalized_tup);
@@ -63,7 +65,7 @@ static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tu
 }
 
 __maybe_unused static __always_inline void update_protocol_stack(conn_tuple_t* skb_tup, protocol_t cur_fragment_protocol) {
-    protocol_stack_t *stack = get_protocol_stack(skb_tup);
+    protocol_stack_t *stack = get_or_create_protocol_stack(skb_tup);
     if (!stack) {
         return;
     }

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -51,7 +51,7 @@ static __always_inline protocol_stack_t* get_or_create_protocol_stack(conn_tuple
     // EBUSY can be returned if a program tries to access an already held bucket lock
     // https://elixir.bootlin.com/linux/latest/source/kernel/bpf/hashtab.c#L164
     // Before kernel version 6.7 it was possible for a program to get interrupted before disabling
-    // interrupts for acquring the bucket spinlock but after marking a bucket as busy.
+    // interrupts for acquiring the bucket spinlock but after marking a bucket as busy.
     // https://github.com/torvalds/linux/commit/d35381aa73f7e1e8b25f3ed5283287a64d9ddff5
     // As such a program running from an irq context would falsely see a bucket as busy in certain cases
     // as explained in the linked commit message.

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -15,7 +15,7 @@ static __always_inline bool is_protocol_classification_supported() {
     return val > 0;
 }
 
-static __always_inline protocol_stack_t* __get_protocol_stack(conn_tuple_t* tuple) {
+static __always_inline protocol_stack_t* __get_protocol_stack_if_exists(conn_tuple_t* tuple) {
     protocol_stack_wrapper_t *wrapper = bpf_map_lookup_elem(&connection_protocol, tuple);
     if (!wrapper) {
         return NULL;
@@ -51,7 +51,7 @@ static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tu
     // above scenario.
     // However the EBUSY error does not carry any signal for us since this is caused by a kernel bug.
     bpf_map_update_with_telemetry(connection_protocol, &normalized_tup, &empty_wrapper, BPF_NOEXIST, -EEXIST, -EBUSY);
-    return __get_protocol_stack(&normalized_tup);
+    return __get_protocol_stack_if_exists(&normalized_tup);
 }
 
 __maybe_unused static __always_inline void update_protocol_stack(conn_tuple_t* skb_tup, protocol_t cur_fragment_protocol) {

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -20,6 +20,7 @@ static __always_inline protocol_stack_t* __get_protocol_stack_if_exists(conn_tup
     if (!wrapper) {
         return NULL;
     }
+    wrapper->updated = bpf_ktime_get_ns();
     return &wrapper->stack;
 }
 

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -37,10 +37,9 @@ static __always_inline protocol_stack_t* get_protocol_stack_if_exists(conn_tuple
 static __always_inline protocol_stack_t* get_or_create_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;
     normalize_tuple(&normalized_tup);
-    protocol_stack_wrapper_t* wrapper = bpf_map_lookup_elem(&connection_protocol, &normalized_tup);
+    protocol_stack_t *wrapper = __get_protocol_stack_if_exists(&normalized_tup);
     if (wrapper) {
-        wrapper->updated = bpf_ktime_get_ns();
-        return &wrapper->stack;
+        return wrapper;
     }
 
     // this code path is executed once during the entire connection lifecycle

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -72,7 +72,7 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     normalized_tuple.pid = 0;
     normalized_tuple.netns = 0;
 
-    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
+    protocol_stack_t *stack = get_or_create_protocol_stack(&normalized_tuple);
     if (!stack) {
         return;
     }
@@ -166,7 +166,7 @@ static __always_inline void tls_dispatch_kafka(struct pt_regs *ctx)
         return;
     }
 
-    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
+    protocol_stack_t *stack = get_or_create_protocol_stack(&normalized_tuple);
     if (!stack) {
         return;
     }
@@ -182,7 +182,7 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, boo
     normalized_tuple.pid = 0;
     normalized_tuple.netns = 0;
 
-    protocol_stack_t *stack = get_protocol_stack(&normalized_tuple);
+    protocol_stack_t *stack = get_or_create_protocol_stack(&normalized_tuple);
     if (!stack) {
         return;
     }

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -38,9 +38,6 @@ static __always_inline void http_process(http_event_t *event, skb_info_t *skb_in
 /* this function is called by all TLS hookpoints (OpenSSL, GnuTLS and GoTLS, JavaTLS) and */
 /* it's used for classify the subset of protocols that is supported by `classify_protocol_for_dispatcher` */
 static __always_inline void classify_decrypted_payload(protocol_stack_t *stack, conn_tuple_t *t, void *buffer, size_t len) {
-    // we're in the context of TLS hookpoints, thus the protocol is TLS.
-    set_protocol(stack, PROTOCOL_TLS);
-
     if (is_protocol_layer_known(stack, LAYER_APPLICATION)) {
         // No classification is needed.
         return;
@@ -76,6 +73,9 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
     if (!stack) {
         return;
     }
+
+    // we're in the context of TLS hookpoints, thus the protocol is TLS.
+    set_protocol(stack, PROTOCOL_TLS);
 
     const __u32 zero = 0;
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -182,10 +182,10 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, boo
     normalized_tuple.pid = 0;
     normalized_tuple.netns = 0;
 
-    protocol_stack_t *stack = get_or_create_protocol_stack(&normalized_tuple);
-    if (!stack) {
-        return;
-    }
+    // Using __get_protocol_stack_if_exists as `conn_tuple_copy` is already normalized.
+    protocol_stack_t *stack = __get_protocol_stack_if_exists(&normalized_tuple);
+    // No need to explicitly checking if the stack is NULL, as `get_protocol_from_stack` will return PROTOCOL_UNKNOWN
+    // and then we will return from the function as we will hit the default case of the switch statement.
 
     protocol_prog_t prog;
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -116,6 +116,8 @@ static __always_inline void update_protocol_classification_information(conn_tupl
     }
 
     conn_tuple_copy = *cached_skb_conn_tup_ptr;
+    normalize_tuple(&conn_tuple_copy);
+    // Using __get_protocol_stack_if_exists as `conn_tuple_copy` is already normalized.
     protocol_stack = __get_protocol_stack_if_exists(&conn_tuple_copy);
     set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     mark_protocol_direction(t, &conn_tuple_copy, protocol_stack);

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -105,6 +105,7 @@ static __always_inline void update_protocol_classification_information(conn_tupl
     conn_tuple_copy.pid = 0;
     normalize_tuple(&conn_tuple_copy);
 
+    // Using __get_protocol_stack_if_exists as `conn_tuple_copy` is already normalized.
     protocol_stack_t *protocol_stack = __get_protocol_stack_if_exists(&conn_tuple_copy);
     set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     mark_protocol_direction(t, &conn_tuple_copy, protocol_stack);

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -105,7 +105,7 @@ static __always_inline void update_protocol_classification_information(conn_tupl
     conn_tuple_copy.pid = 0;
     normalize_tuple(&conn_tuple_copy);
 
-    protocol_stack_t *protocol_stack = __get_protocol_stack(&conn_tuple_copy);
+    protocol_stack_t *protocol_stack = __get_protocol_stack_if_exists(&conn_tuple_copy);
     set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     mark_protocol_direction(t, &conn_tuple_copy, protocol_stack);
     merge_protocol_stacks(&stats->protocol_stack, protocol_stack);
@@ -116,7 +116,7 @@ static __always_inline void update_protocol_classification_information(conn_tupl
     }
 
     conn_tuple_copy = *cached_skb_conn_tup_ptr;
-    protocol_stack = __get_protocol_stack(&conn_tuple_copy);
+    protocol_stack = __get_protocol_stack_if_exists(&conn_tuple_copy);
     set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     mark_protocol_direction(t, &conn_tuple_copy, protocol_stack);
     merge_protocol_stacks(&stats->protocol_stack, protocol_stack);

--- a/pkg/network/tracer/tracer_testutil.go
+++ b/pkg/network/tracer/tracer_testutil.go
@@ -7,7 +7,11 @@
 
 package tracer
 
-import "github.com/DataDog/datadog-agent/pkg/network/usm"
+import (
+	"github.com/cilium/ebpf"
+
+	"github.com/DataDog/datadog-agent/pkg/network/usm"
+)
 
 // RemoveClient stops tracking stateful data for a given client
 func (t *Tracer) RemoveClient(clientID string) {
@@ -17,4 +21,9 @@ func (t *Tracer) RemoveClient(clientID string) {
 // USMMonitor returns the USM monitor field
 func (t *Tracer) USMMonitor() *usm.Monitor {
 	return t.usmMonitor
+}
+
+// GetMap returns the map with the given name
+func (t *Tracer) GetMap(name string) (*ebpf.Map, error) {
+	return t.ebpfTracer.GetMap(name)
 }

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -23,7 +23,9 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/cilium/ebpf"
 	gorilla "github.com/gorilla/mux"
 	redis2 "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	netlink "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/amqp"
@@ -698,6 +701,94 @@ func TestFullMonitorWithTracer(t *testing.T) {
 	t.Cleanup(tr.Stop)
 
 	require.NoError(t, tr.RegisterClient(clientID))
+}
+
+func testUnclassifiedProtocol(t *testing.T, tr *tracer.Tracer, clientHost, targetHost, serverHost string) {
+	defaultDialer := &net.Dialer{
+		LocalAddr: &net.TCPAddr{
+			IP: net.ParseIP(clientHost),
+		},
+	}
+
+	serverAddress := net.JoinHostPort(serverHost, rawTrafficPort)
+	targetAddress := net.JoinHostPort(targetHost, rawTrafficPort)
+
+	server := tracertestutil.NewTCPServerOnAddress(serverAddress, func(c net.Conn) {
+		_, _ = io.Copy(c, c)
+	})
+	require.NoError(t, server.Run())
+	t.Cleanup(server.Shutdown)
+
+	tests := []protocolClassificationAttributes{
+		{
+			name: "unsupported TCP protocol",
+			context: testContext{
+				serverPort:    rawTrafficPort,
+				serverAddress: serverAddress,
+				targetAddress: targetAddress,
+				extras:        make(map[string]interface{}),
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				c, err := defaultDialer.Dial("tcp", ctx.targetAddress)
+				require.NoError(t, err)
+				ctx.extras["client"] = c
+
+				const inputText = "Hello, World!"
+				_, err = c.Write([]byte(inputText))
+				require.NoError(t, err)
+				n, err := c.Read(make([]byte, len(inputText)))
+				require.NoError(t, err)
+				require.Equal(t, len(inputText), n)
+
+			},
+			validation: func(t *testing.T, ctx testContext, tr *tracer.Tracer) {
+				m, err := tr.GetMap(probes.ConnectionProtocolMap)
+				require.NoError(t, err)
+
+				client := ctx.extras["client"].(net.Conn)
+				defer client.Close()
+				localAddrString, _, err := net.SplitHostPort(client.LocalAddr().(*net.TCPAddr).String())
+				require.NoError(t, err)
+				localAddr, err := netip.ParseAddr(localAddrString)
+				require.NoError(t, err)
+				remoteAddrString, _, err := net.SplitHostPort(client.RemoteAddr().(*net.TCPAddr).String())
+				require.NoError(t, err)
+				remoteAddr, err := netip.ParseAddr(remoteAddrString)
+				require.NoError(t, err)
+
+				ll, lh := util.ToLowHighIP(localAddr)
+				rl, rh := util.ToLowHighIP(remoteAddr)
+				key := netebpf.ConnTuple{
+					Saddr_h:  lh,
+					Saddr_l:  ll,
+					Daddr_h:  rh,
+					Daddr_l:  rl,
+					Sport:    uint16(client.LocalAddr().(*net.TCPAddr).Port),
+					Dport:    uint16(client.RemoteAddr().(*net.TCPAddr).Port),
+					Metadata: uint32(netebpf.TCP),
+				}
+				inverseKey := netebpf.ConnTuple{
+					Saddr_h:  key.Daddr_h,
+					Saddr_l:  key.Daddr_l,
+					Daddr_h:  key.Saddr_h,
+					Daddr_l:  key.Saddr_l,
+					Sport:    key.Dport,
+					Dport:    key.Sport,
+					Metadata: key.Metadata,
+				}
+				value := netebpf.ProtocolStackWrapper{}
+				keyExistence := m.Lookup(unsafe.Pointer(&key), unsafe.Pointer(&value))
+				require.ErrorIs(t, keyExistence, ebpf.ErrKeyNotExist)
+				keyExistence = m.Lookup(unsafe.Pointer(&inverseKey), unsafe.Pointer(&value))
+				require.ErrorIs(t, keyExistence, ebpf.ErrKeyNotExist)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testProtocolClassificationInner(t, tt, tr)
+		})
+	}
 }
 
 func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost, targetHost, serverHost string) {
@@ -2371,6 +2462,10 @@ func testProtocolClassificationLinux(t *testing.T, tr *tracer.Tracer, clientHost
 		name     string
 		testFunc func(t *testing.T, tr *tracer.Tracer, clientHost, targetHost, serverHost string)
 	}{
+		{
+			name:     "unclassified",
+			testFunc: testUnclassifiedProtocol,
+		},
 		{
 			name:     "kafka",
 			testFunc: testKafkaProtocolClassification,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the current codebase to generate an entry in the `connection_protocol` map only when a connection was classified.

### Motivation

* The map has high utilization rate in production clusters. Once the map is full, we cannot insert new values, and then USM can suffer from inaccuracies when decoding a protocol, and NPM can report wrong protocol for the connection. 
* Reduce pressure on the `connection_protocol` map, but creating an entry only when needed (= when a connection is classified and supported).
* Don't generate entries on `tls_finish` callback.

### Describe how to test/QA your changes

#### UTs
Added a new test to ensure an unclassified connection does not create an entry in the map.
The test passes on the branch but fails on `main` branch prior to the change.
Test `TestUSMSuite/.*/TestProtocolClassification/.*/unclassified`

Other classification tests are passing.

#### Dogfooding

Ran on `oddish-c` without impacting the accuracy or yielding any error.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->