### PR TITLE
usm: go-tls: Add periodic process check

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
@@ -243,16 +244,36 @@ func (p *goTLSProgram) PreStart(m *manager.Manager) error {
 			case <-p.done:
 				return
 			case <-processSync.C:
-				processSet := p.registry.GetRegisteredProcesses()
-				deletedPids := monitor.FindDeletedProcesses(processSet)
-				for deletedPid := range deletedPids {
-					_ = p.registry.Unregister(deletedPid)
-				}
+				p.sync()
+				p.registry.Log()
 			}
 		}
 	}()
 
 	return nil
+}
+
+func (p *goTLSProgram) sync() {
+	deletionCandidates := p.registry.GetRegisteredProcesses()
+
+	_ = kernel.WithAllProcs(p.procRoot, func(pid int) error {
+		if _, ok := deletionCandidates[uint32(pid)]; ok {
+			// We have previously hooked into this process and it remains active,
+			// so we remove it from the deletionCandidates list, and move on to the next PID
+			delete(deletionCandidates, uint32(pid))
+			return nil
+		}
+
+		// This is a new PID so we attempt to attach SSL probes to it
+		_ = p.AttachPID(uint32(pid))
+		return nil
+	})
+
+	// At this point all entries from deletionCandidates are no longer alive, so
+	// we should detach our SSL probes from them
+	for pid := range deletionCandidates {
+		p.handleProcessExit(pid)
+	}
 }
 
 // PostStart registers the goTLS program to the attacher list.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a periodic check for new process to go-tls similar to the one used by istio and nodejs.  This is to have a safety net to ensure that we don't missing hooking a program even if we happen to miss exec events in some case.

### Motivation

https://datadoghq.atlassian.net/browse/USMON-694

### Describe how to test/QA your changes

Manually tested by disabling the `handleProcessExec` and `handleProcessExit` callbacks in `process_monitor.go` (to ensure that no events are received) and checking that Go processes are still attached and detached (after the expected delay) using the debug level system-probe logs.

### Possible Drawbacks / Trade-offs

### Additional Notes

No significant increase seen in CPU load in load test. The new sync func takes about 4ms of CPU time per minute.

[Load test results against 7.60-rc6](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=vincent-gotls2-base&tpl_var_client-service%5B0%5D=golang-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=vincent-gotls2-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm-test-env-sso&tpl_var_server-service%5B0%5D=golang-httpbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1732722036988&to_ts=1732725607409&live=false)

[Profile from load test focusing on the sync function](https://dddev.datadoghq.com/profiling/comparison?query=service%3Asystem-probe%20kube_cluster_name%3Ausm-test-env-sso%20agent-env%3Avincent-gotls1-new&compare_end_A=1732724553950&compare_end_B=1732724553950&compare_query_A=service%3Asystem-probe%20kube_cluster_name%3Ausm-test-env-sso%20agent-env%3Avincent-gotls2-base&compare_query_B=service%3Asystem-probe%20kube_cluster_name%3Ausm-test-env-sso%20agent-env%3Avincent-gotls2-new&compare_start_A=1732722229396.7715&compare_start_B=1732722235514.0188&compareValuesMode=absolute&comparisonViz=flamegraph&my_code=disabled&op_filter=focus_on%28function%3A%22%28%2AgoTLSProgram%29.sync%22%29&profile_type=cpu-time&viz=flame_graph&zoom_B=1999006758&start=1732715565307&end=1732722765307&paused=true)

[Profile from staging cluster focusing on the sync function](https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Asystem-probe%20kube_cluster_name%3Aoddish-c%20version%3A7.61.0-devel_git.530.d19135f&compare_end_A=1732553400000&compare_end_B=1732802958352&compare_query_A=service%3Asystem-probe%20kube_cluster_name%3Aoddish-c%20version%3A7.60.0-rc.5&compare_start_A=1732546320000&compare_start_B=1732799358352&compareValuesMode=absolute&my_code=disabled&op_filter=focus_on%28function%3A%22%28%2AgoTLSProgram%29.sync%22%29&profile_type=cpu-time&viz=flame_graph&start=1732802007724&end=1732802907724&paused=true)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->