### PR TITLE
Do not validate signatures when an integration is manually installed in the E2E tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_integration.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_integration.go
@@ -80,7 +80,7 @@ func installIntegration(t *testing.T, client *TestClient, integration string) {
 	maxRetries := 6
 
 	err := backoff.Retry(func() error {
-		_, err := client.AgentClient.IntegrationWithError(agentclient.WithArgs([]string{"install", "-r", integration}))
+		_, err := client.AgentClient.IntegrationWithError(agentclient.WithArgs([]string{"install", "--unsafe-disable-verification", "-r", integration}))
 		return err
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), uint64(maxRetries)))
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Do not validate signatures when an integration is manually installed in the E2E tests

### Motivation

In #incident-32841, we started to face issues because the key that signed the version of the integration we were trying to install [got revoked](https://github.com/DataDog/integrations-core/pull/19146) (I left the team and I signed this version). Since we build the downloader from source, we started to pick up that change soon after the merge.

As discussed with @iliakur we can skip the signature validation, given this is already triple checked in the integration itself and we want to test the Agent here. 

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->