### PR TITLE
fix(kitchen): [agent6] Remove support of deprecated ubuntu release

### DIFF
--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -100,9 +100,6 @@ kitchen_test_system_probe_linux_x64_ec2:
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-22-04"
         KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
-      - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-23-04"
-        KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
 
 kitchen_test_system_probe_linux_arm64:
   extends:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove tests running on `ubuntu 23_04`

### Motivation
These release is not an LTS. As a consequence, the packages were moved out of standard bucket (see error [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/721802919)
```
       Err:3 http://ports.ubuntu.com/ubuntu-ports lunar-security Release
         404  Not Found [IP: 185.125.190.36 80]
```
Besides, the sysprobe tests should be replaced by a running version of KMT ones
https://datadoghq.atlassian.net/browse/ACIX-455


### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->