### PR TITLE
(fleet) move /opt/datadog-installer/tmp to /opt/datadog-packages/tmp

### DIFF
--- a/pkg/fleet/installer/repository/repositories.go
+++ b/pkg/fleet/installer/repository/repositories.go
@@ -58,8 +58,8 @@ func (r *Repositories) loadRepositories() (map[string]*Repository, error) {
 			// Temporary dir created by Repositories.MkdirTemp, ignore
 			continue
 		}
-		if d.Name() == "run" {
-			// run dir, ignore
+		if d.Name() == "run" || d.Name() == "tmp" {
+			// run/tmp dir, ignore
 			continue
 		}
 		repo := r.newRepository(d.Name())

--- a/pkg/fleet/installer/repository/repositories_test.go
+++ b/pkg/fleet/installer/repository/repositories_test.go
@@ -68,10 +68,14 @@ func TestLoadRepositories(t *testing.T) {
 
 	os.Mkdir(path.Join(rootDir, "datadog-agent"), 0755)
 	os.Mkdir(path.Join(rootDir, tempDirPrefix+"2394812349"), 0755)
+	os.Mkdir(path.Join(rootDir, "run"), 0755)
+	os.Mkdir(path.Join(rootDir, "tmp"), 0755)
 
 	repositories, err := NewRepositories(rootDir, runDir).loadRepositories()
 	assert.NoError(t, err)
 	assert.Len(t, repositories, 1)
 	assert.Contains(t, repositories, "datadog-agent")
 	assert.NotContains(t, repositories, tempDirPrefix+"2394812349")
+	assert.NotContains(t, repositories, "run")
+	assert.NotContains(t, repositories, "tmp")
 }

--- a/pkg/fleet/installer/service/datadog_installer.go
+++ b/pkg/fleet/installer/service/datadog_installer.go
@@ -108,13 +108,13 @@ func SetupInstaller(ctx context.Context) (err error) {
 	}
 	// Enforce that the directory exists. It should be created by the bootstrapper but
 	// older versions don't do it
-	err = os.MkdirAll("/opt/datadog-installer/tmp", 0755)
+	err = os.MkdirAll("/opt/datadog-packages/tmp", 0755)
 	if err != nil {
-		return fmt.Errorf("error creating /opt/datadog-installer/tmp: %w", err)
+		return fmt.Errorf("error creating /opt/datadog-packages/tmp: %w", err)
 	}
-	err = os.Chown("/opt/datadog-installer/tmp", ddAgentUID, ddAgentGID)
+	err = os.Chown("/opt/datadog-packages/tmp", ddAgentUID, ddAgentGID)
 	if err != nil {
-		return fmt.Errorf("error changing owner of /opt/datadog-installer/tmp: %w", err)
+		return fmt.Errorf("error changing owner of /opt/datadog-packages/tmp: %w", err)
 	}
 	// Create installer path symlink
 	err = os.Symlink("/opt/datadog-packages/datadog-installer/stable/bin/installer/installer", "/usr/bin/datadog-installer")

--- a/pkg/fleet/internal/paths/installer_paths.go
+++ b/pkg/fleet/internal/paths/installer_paths.go
@@ -16,7 +16,7 @@ const (
 	// LocksPath is the path to the packages locks directory.
 	LocksPath = "/opt/datadog-packages/run/locks"
 	// RootTmpDir is the temporary path where the bootstrapper will be extracted to.
-	RootTmpDir = "/opt/datadog-installer/tmp"
+	RootTmpDir = "/opt/datadog-packages/tmp"
 	// DefaultUserConfigsDir is the default Agent configuration directory.
 	DefaultUserConfigsDir = "/etc"
 	// StableInstallerPath is the path to the stable installer binary.

--- a/test/new-e2e/tests/installer/unix/package_installer_test.go
+++ b/test/new-e2e/tests/installer/unix/package_installer_test.go
@@ -40,7 +40,7 @@ func (s *packageInstallerSuite) TestInstall() {
 	state.AssertDirExists("/opt/datadog-packages/run/locks", 0777, "root", "root")
 
 	state.AssertDirExists("/opt/datadog-installer", 0755, "root", "root")
-	state.AssertDirExists("/opt/datadog-installer/tmp", 0755, "dd-agent", "dd-agent")
+	state.AssertDirExists("/opt/datadog-packages/tmp", 0755, "dd-agent", "dd-agent")
 	state.AssertDirExists("/opt/datadog-packages", 0755, "root", "root")
 	state.AssertDirExists("/opt/datadog-packages/datadog-installer", 0755, "root", "root")
 


### PR DESCRIPTION
This PR migrates  `/opt/datadog-installer/tmp` to `/opt/datadog-packages/tmp`. This fully removes the use of `/opt/datadog-installer`, simplifying our file layout.

### Describe how to test/QA your changes

