### PR TITLE
(fleet) move /etc/datadog-packages to /etc/datadog-agent/managed

### DIFF
--- a/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-exp.service
@@ -12,7 +12,7 @@ Type=oneshot
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 ExecStart=/bin/false
 ExecStop=/bin/false

--- a/pkg/fleet/installer/service/embedded/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-process-exp.service
@@ -9,7 +9,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/process-agent --cfgpath=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-process.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-process.service
@@ -9,7 +9,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/stable/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/process-agent --cfgpath=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-security-exp.service
@@ -3,14 +3,14 @@ Description=Datadog Security Agent Experiment
 After=network.target
 BindsTo=datadog-agent-exp.service
 ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
-ConditionPathExists=|/etc/datadog-packages/datadog-agent/experiment/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/security-agent start -c /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-security.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-security.service
@@ -3,14 +3,14 @@ Description=Datadog Security Agent
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
 ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
-ConditionPathExists=|/etc/datadog-packages/datadog-agent/stable/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/stable/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/security-agent start -c /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/stable/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe-exp.service
@@ -4,13 +4,13 @@ Requires=sys-kernel-debug.mount
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-packages/datadog-agent/experiment/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 Restart=on-failure
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-sysprobe.service
@@ -5,13 +5,13 @@ Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-packages/datadog-agent/stable/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 Restart=on-failure
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-trace-exp.service
@@ -8,7 +8,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-agent --config /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent-trace.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent-trace.service
@@ -9,7 +9,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/stable/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/trace-agent --config /etc/datadog-agent/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/stable/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/installer/service/embedded/datadog-agent.service
+++ b/pkg/fleet/installer/service/embedded/datadog-agent.service
@@ -11,7 +11,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/stable/run/agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-packages/datadog-agent/stable"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/stable/run/agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/pkg/fleet/internal/paths/installer_paths.go
+++ b/pkg/fleet/internal/paths/installer_paths.go
@@ -12,7 +12,7 @@ const (
 	// PackagesPath is the path to the packages directory.
 	PackagesPath = "/opt/datadog-packages"
 	// ConfigsPath is the path to the Fleet-managed configuration directory.
-	ConfigsPath = "/etc/datadog-packages"
+	ConfigsPath = "/etc/datadog-agent/managed"
 	// LocksPath is the path to the packages locks directory.
 	LocksPath = "/opt/datadog-packages/run/locks"
 	// RootTmpDir is the temporary path where the bootstrapper will be extracted to.

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -403,7 +403,7 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeSuccessful() {
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
 
 	state := s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", "/etc/datadog-packages/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/stable", "/etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
 
 	localCDN.UpdateLayer("config", "\"log_level\": \"error\"")
 	s.executeConfigGoldenPath(localCDN.DirPath, "c78c5e96820c89c6cbc178ddba4ce20a167138a3a580ed4637369a9c5ed804c3")
@@ -437,7 +437,7 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	)
 
 	state := s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", "/etc/datadog-packages/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/stable", "/etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
 
 	// Enables security agent & sysprobe
 	localCDN.AddLayer("config", `
@@ -511,8 +511,8 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	)
 
 	state = s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/stable", fmt.Sprintf("/etc/datadog-agent/managed/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-agent/managed/datadog-agent/%s", hash), "root", "root")
 }
 
 func (s *upgradeScenarioSuite) TestUpgradeConfigFromExistingExperiment() {
@@ -831,7 +831,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigStartExperiment(timestamp h
 	)
 
 	state := s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-agent/managed/datadog-agent/%s", hash), "root", "root")
 }
 
 func (s *upgradeScenarioSuite) assertSuccessfulConfigPromoteExperiment(timestamp host.JournaldTimestamp, hash string) {
@@ -852,8 +852,8 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigPromoteExperiment(timestamp
 	)
 
 	state := s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/stable", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-packages/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/stable", fmt.Sprintf("/etc/datadog-agent/managed/datadog-agent/%s", hash), "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/experiment", fmt.Sprintf("/etc/datadog-agent/managed/datadog-agent/%s", hash), "root", "root")
 }
 
 func (s *upgradeScenarioSuite) assertSuccessfulConfigStopExperiment(timestamp host.JournaldTimestamp) {
@@ -872,7 +872,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigStopExperiment(timestamp ho
 	)
 
 	state := s.host.State()
-	state.AssertSymlinkExists("/etc/datadog-packages/datadog-agent/experiment", "/etc/datadog-packages/datadog-agent/stable", "root", "root")
+	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/experiment", "/etc/datadog-agent/managed/datadog-agent/stable", "root", "root")
 }
 
 func (s *upgradeScenarioSuite) getInstallerStatus() installerStatus {


### PR DESCRIPTION
This PR moves /etc/datadog-packages to /etc/datadog-agent/managed. This simplifies our file layout and ensures customers can go back to a clean state after deleting that directory.

### Describe how to test/QA your changes

- e2e cover it