### PR TITLE
[pkg/networkpath] Skip Test_createRawTCPSyn and Test_createRawTCPSynBuffer on macOS

### DIFF
--- a/pkg/networkpath/traceroute/tcp/utils_test.go
+++ b/pkg/networkpath/traceroute/tcp/utils_test.go
@@ -10,6 +10,7 @@ package tcp
 import (
 	"net"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/google/gopacket"
@@ -28,6 +29,10 @@ var (
 )
 
 func Test_createRawTCPSyn(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Test_createRawTCPSyn is broken on macOS")
+	}
+
 	srcIP := net.ParseIP("1.2.3.4")
 	dstIP := net.ParseIP("5.6.7.8")
 	srcPort := uint16(12345)
@@ -58,6 +63,10 @@ func Test_createRawTCPSyn(t *testing.T) {
 }
 
 func Test_createRawTCPSynBuffer(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Test_createRawTCPSyn is broken on macOS")
+	}
+
 	srcIP := net.ParseIP("1.2.3.4")
 	dstIP := net.ParseIP("5.6.7.8")
 	srcPort := uint16(12345)


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Skips the `Test_createRawTCPSyn` and `Test_createRawTCPSynBuffer` tests on macOS (#incident-32860).

### Motivation

Remove broken tests while they are investigated.

### Describe how to test/QA your changes

macOS unit test jobs in CI should pass.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a