### PR TITLE
Drop `idle` experiment memory allocation to 400MiB

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 500MiB
+  memory_allotment: 415MiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 8
-  memory_allotment: 415MiB
+  memory_allotment: 400MiB
 
   environment:
     DD_API_KEY: 00000001


### PR DESCRIPTION
### Motivation

This commit drops the memory allocated to Agent in its idle default configuration from 500MiB to 415MiB. We observe the running consumption as closer to 415MiB after a 30 minute run.

