### PR TITLE
Implement missing config methods for nodetreemodel

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -82,6 +82,9 @@ type Reader interface {
 	// OnUpdate adds a callback to the list receivers to be called each time a value is change in the configuration
 	// by a call to the 'Set' method. The configuration will sequentially call each receiver.
 	OnUpdate(callback NotificationReceiver)
+
+	// Stringify stringifies the config
+	Stringify(source Source) string
 }
 
 // Writer is a subset of Config that only allows writing the configuration

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -92,7 +92,6 @@ type Writer interface {
 	Set(key string, value interface{}, source Source)
 	SetWithoutSource(key string, value interface{})
 	UnsetForSource(key string, source Source)
-	CopyConfig(cfg Config)
 }
 
 // ReaderWriter is a subset of Config that allows reading and writing the configuration

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -835,6 +835,11 @@ func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) 
 	return &config
 }
 
+// Stringify stringifies the config, but only for nodetremodel with the test build tag
+func (c *safeConfig) Stringify(source Source) string {
+	return "safeConfig{...}"
+}
+
 // CopyConfig copies the given config to the receiver config. This should only be used in tests as replacing
 // the global config reference is unsafe.
 func (c *safeConfig) CopyConfig(cfg Config) {

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -836,7 +836,7 @@ func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) 
 }
 
 // Stringify stringifies the config, but only for nodetremodel with the test build tag
-func (c *safeConfig) Stringify(source Source) string {
+func (c *safeConfig) Stringify(_ Source) string {
 	return "safeConfig{...}"
 }
 

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -840,26 +840,6 @@ func (c *safeConfig) Stringify(source Source) string {
 	return "safeConfig{...}"
 }
 
-// CopyConfig copies the given config to the receiver config. This should only be used in tests as replacing
-// the global config reference is unsafe.
-func (c *safeConfig) CopyConfig(cfg Config) {
-	c.Lock()
-	defer c.Unlock()
-
-	if cfg, ok := cfg.(*safeConfig); ok {
-		c.Viper = cfg.Viper
-		c.configSources = cfg.configSources
-		c.envPrefix = cfg.envPrefix
-		c.envKeyReplacer = cfg.envKeyReplacer
-		c.proxies = cfg.proxies
-		c.configEnvVars = cfg.configEnvVars
-		c.unknownKeys = cfg.unknownKeys
-		c.notificationReceivers = cfg.notificationReceivers
-		return
-	}
-	panic("Replacement config must be an instance of safeConfig")
-}
-
 // GetProxies returns the proxy settings from the configuration
 func (c *safeConfig) GetProxies() *Proxy {
 	c.Lock()

--- a/pkg/config/model/viper_test.go
+++ b/pkg/config/model/viper_test.go
@@ -249,26 +249,6 @@ func TestCheckKnownKey(t *testing.T) {
 	assert.Contains(t, config.unknownKeys, "foobar")
 }
 
-func TestCopyConfig(t *testing.T) {
-	config := NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
-	config.SetDefault("baz", "qux")
-	config.Set("foo", "bar", SourceFile)
-	config.BindEnv("xyz", "XXYYZZ")
-	config.SetKnown("tyu")
-	config.OnUpdate(func(_ string, _, _ any) {})
-
-	backup := NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
-	backup.CopyConfig(config)
-
-	assert.Equal(t, "qux", backup.Get("baz"))
-	assert.Equal(t, "bar", backup.Get("foo"))
-	t.Setenv("XXYYZZ", "value")
-	assert.Equal(t, "value", backup.Get("xyz"))
-	assert.True(t, backup.IsKnown("tyu"))
-	// can't compare function pointers directly so just check the number of callbacks
-	assert.Len(t, backup.(*safeConfig).notificationReceivers, 1, "notification receivers should be copied")
-}
-
 func TestExtraConfig(t *testing.T) {
 	config := NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -689,26 +689,6 @@ func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) 
 	return &config
 }
 
-// CopyConfig copies the given config to the receiver config. This should only be used in tests as replacing
-// the global config reference is unsafe.
-func (c *ntmConfig) CopyConfig(cfg model.Config) {
-	c.Lock()
-	defer c.Unlock()
-	c.logErrorNotImplemented("CopyConfig")
-	if cfg, ok := cfg.(*ntmConfig); ok {
-		// TODO: Probably a bug, should be a deep copy, add a test and verify
-		c.root = cfg.root
-		c.envPrefix = cfg.envPrefix
-		c.envKeyReplacer = cfg.envKeyReplacer
-		c.proxies = cfg.proxies
-		c.configEnvVars = cfg.configEnvVars
-		c.unknownKeys = cfg.unknownKeys
-		c.notificationReceivers = cfg.notificationReceivers
-		return
-	}
-	panic("Replacement config must be an instance of ntmConfig")
-}
-
 // ExtraConfigFilesUsed returns the additional config files used
 func (c *ntmConfig) ExtraConfigFilesUsed() []string {
 	c.Lock()

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -305,6 +305,18 @@ func (c *ntmConfig) BuildSchema() {
 	}
 }
 
+// Stringify stringifies the config, but only with the test build tag
+func (c *ntmConfig) Stringify(source model.Source) string {
+	c.Lock()
+	defer c.Unlock()
+	// only does anything if the build tag "test" is enabled
+	text, err := c.toDebugString(source)
+	if err != nil {
+		return fmt.Sprintf("Stringify error: %s", err)
+	}
+	return text
+}
+
 func (c *ntmConfig) isReady() bool {
 	return c.ready.Load()
 }

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -498,10 +498,21 @@ func (c *ntmConfig) UnmarshalKey(key string, _rawVal interface{}, _opts ...viper
 }
 
 // MergeConfig merges in another config
-func (c *ntmConfig) MergeConfig(_in io.Reader) error {
+func (c *ntmConfig) MergeConfig(in io.Reader) error {
 	c.Lock()
 	defer c.Unlock()
-	return c.logErrorNotImplemented("MergeConfig")
+
+	content, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	other := newInnerNode(nil)
+	if err = c.readConfigurationContent(other, content); err != nil {
+		return err
+	}
+
+	return c.root.Merge(other)
 }
 
 // MergeFleetPolicy merges the configuration from the reader given with an existing config

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -494,7 +494,7 @@ func (c *ntmConfig) UnmarshalKey(key string, _rawVal interface{}, _opts ...viper
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	return c.logErrorNotImplemented("UnmarshalKey")
+	return fmt.Errorf("nodetreemodel.UnmarshalKey not available, use pkg/config/structure.UnmarshalKey instead")
 }
 
 // MergeConfig merges in another config
@@ -642,11 +642,9 @@ func (c *ntmConfig) ConfigFileUsed() string {
 	return c.configFile
 }
 
-// SetTypeByDefaultValue enables typing using default values
+// SetTypeByDefaultValue is a no-op
 func (c *ntmConfig) SetTypeByDefaultValue(_in bool) {
-	c.Lock()
-	defer c.Unlock()
-	c.logErrorNotImplemented("SetTypeByDefaultValue")
+	// do nothing: nodetreemodel always does this conversion
 }
 
 // BindEnvAndSetDefault binds an environment variable and sets a default for the given key
@@ -684,7 +682,6 @@ func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) 
 		envTransform:       make(map[string]func(string) interface{}),
 	}
 
-	config.SetTypeByDefaultValue(true)
 	config.SetConfigName(name)
 	config.SetEnvPrefix(envPrefix)
 	config.SetEnvKeyReplacer(envKeyReplacer)

--- a/pkg/config/nodetreemodel/debug_string.go
+++ b/pkg/config/nodetreemodel/debug_string.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !test
+// +build !test
+
+package nodetreemodel
+
+import "github.com/DataDog/datadog-agent/pkg/config/model"
+
+func (c *ntmConfig) toDebugString(_ model.Source) (string, error) {
+	// don't show any data outside of tests, that way we don't have to worry about scrubbing
+	return "nodeTreeModelConfig{...}", nil
+}

--- a/pkg/config/nodetreemodel/debug_string_testonly.go
+++ b/pkg/config/nodetreemodel/debug_string_testonly.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+// +build test
+
+package nodetreemodel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func (c *ntmConfig) toDebugString(source model.Source) (string, error) {
+	var node Node
+	switch source {
+	case "root":
+		node = c.root
+	case model.SourceEnvVar:
+		node = c.envs
+	case model.SourceDefault:
+		node = c.defaults
+	case model.SourceFile:
+		node = c.file
+	default:
+		return "", fmt.Errorf("invalid source: %s", source)
+	}
+	lines, err := debugTree(node, 0)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func debugTree(n Node, depth int) ([]string, error) {
+	padding := strings.Repeat("  ", depth)
+	if n == nil {
+		return []string{fmt.Sprintf("%s%v", padding, "<nil>")}, nil
+	}
+	if leaf, ok := n.(LeafNode); ok {
+		val := leaf.Get()
+		source := leaf.Source()
+		return []string{fmt.Sprintf("%sval:%v, source:%s", padding, val, source)}, nil
+	}
+	inner, ok := n.(InnerNode)
+	if !ok {
+		return nil, fmt.Errorf("unknown node type: %T", n)
+	}
+	keys := inner.ChildrenKeys()
+	result := []string{}
+	for _, key := range keys {
+		msg := fmt.Sprintf("%s%s", padding, key)
+		child, _ := n.GetChild(key)
+		rest, err := debugTree(child, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, append([]string{msg}, rest...)...)
+	}
+	return result, nil
+}

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -60,7 +60,7 @@ func (c *ntmConfig) ReadConfig(in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if err := c.readConfigurationContent(content); err != nil {
+	if err := c.readConfigurationContent(c.file, content); err != nil {
 		return err
 	}
 	return c.mergeAllLayers()
@@ -71,15 +71,15 @@ func (c *ntmConfig) readInConfig(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return c.readConfigurationContent(content)
+	return c.readConfigurationContent(c.file, content)
 }
 
-func (c *ntmConfig) readConfigurationContent(content []byte) error {
+func (c *ntmConfig) readConfigurationContent(target InnerNode, content []byte) error {
 	var obj map[string]interface{}
 	if err := yaml.Unmarshal(content, &obj); err != nil {
 		return err
 	}
-	c.warnings = append(c.warnings, loadYamlInto(c.defaults, c.file, obj, "")...)
+	c.warnings = append(c.warnings, loadYamlInto(c.defaults, target, obj, "")...)
 	return nil
 }
 

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -369,13 +369,6 @@ func (t *teeConfig) Stringify(source model.Source) string {
 	return t.baseline.Stringify(source)
 }
 
-// CopyConfig copies the given config to the receiver config. This should only be used in tests as replacing
-// the global config reference is unsafe.
-func (t *teeConfig) CopyConfig(cfg model.Config) {
-	t.baseline.CopyConfig(cfg)
-	t.compare.CopyConfig(cfg)
-}
-
 func (t *teeConfig) GetProxies() *model.Proxy {
 	return t.baseline.GetProxies()
 }

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -364,6 +364,11 @@ func (t *teeConfig) Object() model.Reader {
 	return t.baseline
 }
 
+// Stringify stringifies the config
+func (t *teeConfig) Stringify(source model.Source) string {
+	return t.baseline.Stringify(source)
+}
+
 // CopyConfig copies the given config to the receiver config. This should only be used in tests as replacing
 // the global config reference is unsafe.
 func (t *teeConfig) CopyConfig(cfg model.Config) {


### PR DESCRIPTION
### What does this PR do?

Handle the following unimplemented methods, by either implementing or removing:
- MergeConfig
- UnmarshalKey
- SetTypeByDefaultValue
- CopyConfig

### Motivation

Removing dependency on viper

### Describe how to test/QA your changes

Changes covered by tests. Primary behavior is gated behind an environment variable.

### Possible Drawbacks / Trade-offs

### Additional Notes
