### PR TITLE
[CWS] Fix a ptrace test and add Centos7 support

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1084,7 +1084,8 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			pidToResolve := event.PTrace.PID
 
 			if pidToResolve == 0 { // resolve the PID given as argument instead
-				if event.ContainerContext.ContainerID == "" {
+				containerID := p.fieldHandlers.ResolveContainerID(event, event.ContainerContext)
+				if containerID == "" && event.PTrace.Request != unix.PTRACE_ATTACH {
 					pidToResolve = event.PTrace.NSPID
 				} else {
 					// 1. get the pid namespace of the tracer

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1088,20 +1088,11 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 				if containerID == "" && event.PTrace.Request != unix.PTRACE_ATTACH {
 					pidToResolve = event.PTrace.NSPID
 				} else {
-					// 1. get the pid namespace of the tracer
-					ns, err := utils.GetProcessPidNamespace(event.ProcessContext.Process.Pid)
+					pid, err := utils.TryToResolveTraceePid(event.ProcessContext.Process.Pid, event.PTrace.NSPID)
 					if err != nil {
-						seclog.Errorf("Failed to resolve PID namespace: %v", err)
+						seclog.Errorf("PTrace err: %v", err)
 						return
 					}
-
-					// 2. find the host pid matching the arg pid with he tracer namespace
-					pid, err := utils.FindPidNamespace(event.PTrace.NSPID, ns)
-					if err != nil {
-						seclog.Warnf("Failed to resolve tracee PID namespace: %v", err)
-						return
-					}
-
 					pidToResolve = pid
 				}
 			}

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -102,7 +102,7 @@ func TestPTraceEvent(t *testing.T) {
 	})
 
 	test.Run(t, "ptrace-attach", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		args := []string{"ptrace-attach"}
+		args := []string{"sleep", "2", ";", "ptrace-attach"}
 		envs := []string{}
 
 		err := test.GetEventSent(t, func() error {
@@ -122,7 +122,7 @@ func TestPTraceEvent(t *testing.T) {
 
 			test.validatePTraceSchema(t, event)
 			return true
-		}, time.Second*3, "test_ptrace_attach")
+		}, time.Second*6, "test_ptrace_attach")
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -188,11 +188,10 @@ int ptrace_traceme() {
 int ptrace_attach() {
     int child = fork();
     if (child == 0) {
-        for (int i = 0; i < 20; i++) {
-            sleep(1);
-        }
+        sleep(2);
     } else {
         ptrace(PTRACE_ATTACH, child, 0, NULL);
+        sleep(2); // sleep here to let the agent resolve the pid namespace on procfs
         wait(NULL);
     }
     return EXIT_SUCCESS;

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -188,11 +188,11 @@ int ptrace_traceme() {
 int ptrace_attach() {
     int child = fork();
     if (child == 0) {
-        sleep(5);
+        sleep(3);
     } else {
         ptrace(PTRACE_ATTACH, child, 0, NULL);
-        sleep(5); // sleep here to let the agent resolve the pid namespace on procfs
         wait(NULL);
+        sleep(3); // sleep here to let the agent resolve the pid namespace on procfs
     }
     return EXIT_SUCCESS;
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -188,10 +188,10 @@ int ptrace_traceme() {
 int ptrace_attach() {
     int child = fork();
     if (child == 0) {
-        sleep(2);
+        sleep(5);
     } else {
         ptrace(PTRACE_ATTACH, child, 0, NULL);
-        sleep(2); // sleep here to let the agent resolve the pid namespace on procfs
+        sleep(5); // sleep here to let the agent resolve the pid namespace on procfs
         wait(NULL);
     }
     return EXIT_SUCCESS;

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -515,8 +515,7 @@ func FindTraceesByTracerPid(pid uint32) ([]uint32, error) {
 }
 
 var isNsPidAvailable = sync.OnceValue(func() bool {
-	selfStatus := filepath.Join(kernel.ProcFSRoot(), "self", "status")
-	content, err := os.ReadFile(selfStatus)
+	content, err := os.ReadFile("/proc/self/status")
 	if err != nil {
 		return false
 	}

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -549,19 +549,19 @@ func TryToResolveTraceePid(hostTracerPID, NsTraceePid uint32) (uint32, error) {
 			return 0, fmt.Errorf("Failed to resolve tracee PID namespace: %v", err)
 		}
 		return pid, nil
-	} else {
-		/*
-		   Otherwise, we look at all process matching the tracer PID. And as a tracer can attach
-		   to multiple tracees, we return a result only if we found only one.
-		*/
-
-		traceePids, err := FindTraceesByTracerPid(hostTracerPID)
-		if err != nil {
-			return 0, fmt.Errorf("Failed to find tracee pids matching tracer pid: %v", err)
-		}
-		if len(traceePids) == 1 {
-			return traceePids[0], nil
-		}
 	}
+
+	/*
+	   Otherwise, we look at all process matching the tracer PID. And as a tracer can attach
+	   to multiple tracees, we return a result only if we found only one.
+	*/
+	traceePids, err := FindTraceesByTracerPid(hostTracerPID)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to find tracee pids matching tracer pid: %v", err)
+	}
+	if len(traceePids) == 1 {
+		return traceePids[0], nil
+	}
+
 	return 0, errors.New("Unable to resolve host tracee PID")
 }

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -468,3 +468,101 @@ func FindPidNamespace(nspid uint32, ns uint64) (uint32, error) {
 	}
 	return 0, errors.New("PID not found")
 }
+
+// GetTracerPid returns the tracer pid of the the givent root pid
+func GetTracerPid(pid uint32) (uint32, error) {
+	statusFile := StatusPath(pid)
+	content, err := os.ReadFile(statusFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read status file: %w", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "TracerPid:") {
+			// Remove "NSpid:" prefix and trim spaces
+			line = strings.TrimPrefix(line, "TracerPid:")
+			line = strings.TrimSpace(line)
+
+			tracerPid, err := strconv.ParseUint(line, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse TracerPid value: %w", err)
+			}
+			return uint32(tracerPid), nil
+		}
+	}
+	return 0, fmt.Errorf("TracerPid field not found")
+}
+
+// FindTraceesByTracerPid returns the process list being trced by the given tracer host PID
+func FindTraceesByTracerPid(pid uint32) ([]uint32, error) {
+	procPids, err := process.Pids()
+	if err != nil {
+		return nil, err
+	}
+
+	traceePids := []uint32{}
+	for _, procPid := range procPids {
+		tracerPid, err := GetTracerPid(uint32(procPid))
+		if err != nil {
+			continue
+		}
+		if tracerPid == pid {
+			traceePids = append(traceePids, uint32(procPid))
+		}
+	}
+	return traceePids, nil
+}
+
+var isNsPidAvailable = sync.OnceValue(func() bool {
+	selfStatus := filepath.Join(kernel.ProcFSRoot(), "self", "status")
+	content, err := os.ReadFile(selfStatus)
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "NSpid:") {
+			return true
+		}
+	}
+	return false
+})
+
+// TryToResolveTraceePid tries to resolve and returnt the HOST tracee PID, given the HOST tracer PID and the namespaced tracee PID.
+func TryToResolveTraceePid(hostTracerPID, NsTraceePid uint32) (uint32, error) {
+	// Look if the NSpid status field is available or not (it should be, except for Centos7).
+	if isNsPidAvailable() {
+		/*
+		   If it's available, we will search for an host pid having the same PID namespace as the
+		   tracer, and having the corresponding NS PID in its status field
+		*/
+
+		// 1. get the pid namespace of the tracer
+		ns, err := GetProcessPidNamespace(hostTracerPID)
+		if err != nil {
+			return 0, fmt.Errorf("Failed to resolve PID namespace: %v", err)
+		}
+
+		// 2. find the host pid matching the arg pid with he tracer namespace
+		pid, err := FindPidNamespace(NsTraceePid, ns)
+		if err != nil {
+			return 0, fmt.Errorf("Failed to resolve tracee PID namespace: %v", err)
+		}
+		return pid, nil
+	} else {
+		/*
+		   Otherwise, we look at all process matching the tracer PID. And as a tracer can attach
+		   to multiple tracees, we return a result only if we found only one.
+		*/
+
+		traceePids, err := FindTraceesByTracerPid(hostTracerPID)
+		if err != nil {
+			return 0, fmt.Errorf("Failed to find tracee pids matching tracer pid: %v", err)
+		}
+		if len(traceePids) == 1 {
+			return traceePids[0], nil
+		}
+	}
+	return 0, errors.New("Unable to resolve host tracee PID")
+}


### PR DESCRIPTION
### What does this PR do?

Ptrace tests were failing on the KTM for 3 reasons, this PR fixes them all:

1. A race was present on tests, leading to fail to resolve the tracer PID namespace on procfs. Resolved by adding a sleep in the tracee and tracer.
2. On some kernels, the container ID is not resolved in the callpath of `PTRACE_ATTACH`. Resolved by forcing a namespace resolution for `PTRACE_ATTACH` requests, even for host PID.
3. On Centos7, proc status does not contains the `NSpid` field, breaking the proc resolution. Partially resolved by adding another fallback for Centos7, trying to use the `TracerPid` field instead.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->