### PR TITLE
[CWS] Use ProcessCacheEntry cgroup context as event cgroup context

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -685,6 +685,9 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 		panic("should always return a process context")
 	}
 
+	// do the same with cgroup context
+	event.CGroupContext = event.ProcessCacheEntry.CGroup
+
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Copy the cgroup context of the process cache entry into the event cgroup context,
as it's currently done with process context.

### Motivation

Cgroup ID is empty if no `cgroup.id` field resolution is done.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->