### PR TITLE
Capture additional entries from the event log

### DIFF
--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -31,7 +31,7 @@ var (
 
 	eventLogChannelsToExport = map[string]string{
 		"System":      "Event/System/Provider[@Name=\"Service Control Manager\"]",
-		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\" or @Name=\"DatadogAgent\"]",
+		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\" or @Name=\"DatadogAgent\" or @Name=\".NET Runtime\" or @Name=\"Application Error\"]",
 		"Microsoft-Windows-WMI-Activity/Operational": "*",
 	}
 	execTimeout = 30 * time.Second

--- a/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
+++ b/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    On Windows, agent flares now include event logs for .NET applications
+    On Windows, agent flares now include event logs for .NET applications.

--- a/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
+++ b/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    On Windows, agent flares now include event logs for .NET applications.
+    On Windows, Agent flares now include event logs for .NET applications.

--- a/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
+++ b/releasenotes/notes/add-events-to-flare-b10cb7bf1aaf4d50.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, agent flares now include event logs for .NET applications


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Captures additional entries from the event log, relevant to .NET applications:
 - .NET Runtime: contains information about profiler misconfiguration and managed crashes
 - Application Error: contains information about native crashes

### Motivation

Most .NET support tickets include an agent flare. Currently we have to ask the customer to manually collect this information, it would be very useful for us to have it included in the flare.

### Describe how to test/QA your changes

Tested the flare locally to make sure it contains the new event logs entries.

### Possible Drawbacks / Trade-offs

Possible risks:
 - Capturing sensitive information: the ".NET Runtime" event contains the crashing stacktrace. However this is generally not considered a sensitive information. The "Application Error" event only contains the faulting module, exception code, and instruction pointer, so no risk there.
 - Volume of data: ".NET Runtime "will load one event every time a .NET application is successfully instrumented. We'll get two events (.NET Runtime and Application Error) every time a .NET application crashes. As a .NET developer, on a typical day I have ~10 events, 100 on a busy day. On the absolute worst day I have 1244 events (I was trying to launch an application in loops to reproduce a race condition, so this is not representative)

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->