### PR TITLE
discovery: Tweak Python name heuristics

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/python_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/python_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+
 package usm
 
 import (


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a couple of small improvements to the Python name heuristics based on real data seen during testing:

 - If the directory name is not useful ("/" or "bin"), for example, try falling back to the filename.

 - Ignore the -u flag while skipping arguments since some cases were seen with "python -u foo" which ended up not generating a name.

### Motivation

https://datadoghq.atlassian.net/browse/USMON-1356

### Describe how to test/QA your changes

Unit test cases added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->